### PR TITLE
chore(cli): require Node >=24 via engines field

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,6 +10,9 @@
   "homepage": "https://github.com/akasecurity/ai-tc/tree/main/cli",
   "private": false,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "bin": {
     "aka": "./dist/cli.js"
   },


### PR DESCRIPTION
Adds `"engines": { "node": ">=24" }` to `@akasecurity/cli`.

The CLI bundles a dependency on the built-in `node:sqlite` module (Node 24+). With the repo's `engine-strict=true` (root `.npmrc`), declaring the constraint turns an old-Node install into an install-time `EBADENGINE` failure instead of a runtime crash. Matches the root package's `engines.node`.

Manual projection of the mirror change (`ai-tc-oss-mirror#25`); the mirror is the OSS source of truth, and this bridges the change into public until the one-way sync job lands. Required in public because the CLI release (`cli-v0.8.0`) is cut from this repo.