### PR TITLE
fix(ci): correct release-plugin smoke-test hook list

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Smoke-test built scripts (self-contained, fail-open)
         run: |
           cd plugins/claude-code
-          for f in user-prompt-submit pre-tool-use post-tool-use sync; do
+          for f in session-start user-prompt-submit pre-tool-use post-tool-use stop; do
             test -f "scripts/$f.js" || { echo "::error::missing scripts/$f.js"; exit 1; }
           done
           # The hooks run on the user's machine with no node_modules; junk input


### PR DESCRIPTION
Projection of `ai-tc-oss-mirror#27`. The smoke test looped over `... post-tool-use sync` but there is no `sync` hook (hooks.json = SessionStart/UserPromptSubmit/PreToolUse/PostToolUse/Stop). The missing `scripts/sync.js` failed the plugin release before publish. Required in public because `release-plugin.yml` runs from here on the `plugin-v*` tag. Unblocks publishing `@akasecurity/plugin-claude-code`.