### PR TITLE
chore(release): 0.8.1 — plugin npm rename, CLI OIDC, marketplace routing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "aka",
       "source": {
         "source": "npm",
-        "package": "@akasecurity/plugin-claude-code"
+        "package": "@akasecurity/ai-tc-claude-code"
       },
       "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Local detection with inline warn/redact/block policies; every event is recorded to a local SQLite store on your machine.",
       "author": {

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the GitHub Release + move the cli-latest tag
+      id-token: write # OIDC trusted publishing to npm — no long-lived token
     steps:
       - uses: actions/checkout@v7
 
@@ -126,11 +127,14 @@ jobs:
           fi
           echo "✓ published CLI boots the bundled dashboard and serves /security"
 
-      - name: Publish to npm
+      # Publishes via npm OIDC trusted publishing: with `id-token: write` and a
+      # trusted publisher configured on npm for this repo + workflow, no
+      # NODE_AUTH_TOKEN/NPM_TOKEN is used, and provenance is attached automatically.
+      - name: Publish to npm (OIDC trusted publishing)
         if: github.event_name == 'push' || inputs.publish
         run: pnpm --filter @akasecurity/cli publish --no-git-checks
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
       # The install one-liners fetch the bootstrap scripts from the `cli-latest`
       # tag, so a successful publish must move it to this release commit.

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -77,7 +77,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build plugin (Turbo)
-        run: pnpm turbo run build --filter=@akasecurity/plugin-claude-code
+        run: pnpm turbo run build --filter=@akasecurity/ai-tc-claude-code
 
       - name: Verify tag matches manifest versions
         if: github.event_name == 'push'
@@ -103,11 +103,11 @@ jobs:
           echo "fail-open OK"
 
       - name: Pack tarball (release asset)
-        run: pnpm --filter @akasecurity/plugin-claude-code pack --pack-destination "$RUNNER_TEMP"
+        run: pnpm --filter @akasecurity/ai-tc-claude-code pack --pack-destination "$RUNNER_TEMP"
 
       - name: Publish to npm
         if: github.event_name == 'push' || inputs.publish
-        run: pnpm --filter @akasecurity/plugin-claude-code publish --no-git-checks
+        run: pnpm --filter @akasecurity/ai-tc-claude-code publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,65 @@
+# @akasecurity/cli — `aka`
+
+[![npm](https://img.shields.io/npm/v/@akasecurity/cli?style=flat-square&labelColor=232F3E&color=00E0B8)](https://www.npmjs.com/package/@akasecurity/cli)
+[![Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-232F3E?style=flat-square)](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)
+
+The `aka` command-line tool for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`) — an open-source, local-first control plane for coding agents. It inspects and governs the traffic of an agent session (prompts, tool calls, responses, file reads), scans each event against your rule packs, and records everything to a local SQLite store at `~/.aka/data/aka.db`.
+
+Everything runs on your machine. There's no account, no backend, and nothing leaves your computer to be scanned.
+
+## Install
+
+```bash
+npm install -g @akasecurity/cli
+```
+
+Or use the bootstrap installer (checks for Node, then installs):
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.ps1 | iex
+```
+
+Requires **Node.js 24+** (the CLI uses the built-in `node:sqlite`).
+
+## Quick start
+
+```bash
+aka init         # scaffold the local store at ~/.aka
+aka dashboard    # open the local web dashboard over your store
+```
+
+## What it does
+
+| Command          | What it does                                                     |
+| ---------------- | ---------------------------------------------------------------- |
+| `aka init`       | Create the local store and settings under `~/.aka`.              |
+| `aka dashboard`  | Launch the local web dashboard (findings, policies, exceptions). |
+| `aka scan`       | Scan working-tree source files for security flaws.               |
+| `aka detections` | List installed detection packs and available updates.            |
+| `aka exception`  | Manage exact-value exceptions that let a specific match through. |
+| `aka stats`      | Show detection activity and token/cost summaries from the store. |
+| `aka plugins`    | Optional hub to install agent plugins (e.g. Claude Code).        |
+
+Run `aka --help` for the full command list.
+
+## The Claude Code plugin
+
+The CLI gives you the dashboard, store, and scanning. To actually **intercept** a Claude Code session you also need the AKA plugin, which installs from the Claude Code plugin marketplace (not npm). With the CLI installed:
+
+```bash
+aka plugins install claude-code
+```
+
+This drives Claude Code to add the plugin for you (or prints the `/plugin` commands to run). See the [installation guide](https://akasecurity.github.io/ai-tc-docs/getting-started/installation/) for both components.
+
+## Docs
+
+Full documentation, architecture, and the built-in detection catalog live at **[akasecurity.github.io/ai-tc-docs](https://akasecurity.github.io/ai-tc-docs/)**.
+
+## License
+
+[Apache-2.0](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/akasecurity/ai-tc.git",

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,8 +1,14 @@
 import { existsSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import * as readline from 'node:readline/promises';
 import { parseArgs } from 'node:util';
 
-import { cliRecordedBy } from '@akasecurity/local-ops';
+import {
+  cliRecordedBy,
+  findAgent,
+  installedPluginVersions,
+  pluginRef,
+} from '@akasecurity/local-ops';
 import { DATA_FILE_MODE, openLocalDatabase } from '@akasecurity/persistence';
 import {
   bundledDetections,
@@ -14,13 +20,19 @@ import {
 import { defaultWorkspaceSettings } from '@akasecurity/schema';
 
 import { HOME_OPTION, homeBase } from '../lib/args.ts';
+import { runPlugins } from './plugins.ts';
 
 // `aka init` — scaffold the local AKA home: owner-only ~/.aka, a default
 // settings.json, and the SQLite store (openLocalDatabase creates the data dir,
 // applies migrations, and seeds the default per-category policies). Idempotent:
-// re-running re-applies no migration and re-seeds nothing.
+// re-running re-applies no migration and re-seeds nothing. Also checks for the
+// Claude Code plugin — the default install path — and offers to add it via the
+// marketplace when it's missing, so a CLI-first install ends up with both.
 export async function runInit(argv: string[]): Promise<void> {
-  const { values } = parseArgs({ args: argv, options: HOME_OPTION });
+  const { values } = parseArgs({
+    args: argv,
+    options: { ...HOME_OPTION, yes: { type: 'boolean', short: 'y' } },
+  });
   const home = homeBase(values.home);
 
   ensureDataDirSync(home);
@@ -68,4 +80,47 @@ export async function runInit(argv: string[]): Promise<void> {
         ? `  ⬆ ${String(updatesAvailable)} detection pack update(s) available — review with \`aka detections\`, apply with \`aka detections update --all\`\n`
         : ''),
   );
+
+  await offerPluginInstall(values.yes === true);
+}
+
+// The CLI alone only scans on demand (`aka scan`) — it doesn't see live agent
+// traffic. The Claude Code plugin is what does, so a CLI-first install (no
+// plugin yet) is offered the marketplace route here, mirroring the reverse
+// offer /aka:setup makes for the CLI after a plugin-first install.
+async function offerPluginInstall(autoYes: boolean): Promise<void> {
+  const agent = findAgent('claude-code');
+  const ref = agent ? pluginRef(agent) : undefined;
+  if (!agent || !ref) return;
+  if (installedPluginVersions().has(ref)) return;
+
+  const out = process.stdout;
+  if (!autoYes) {
+    if (!process.stdin.isTTY) {
+      out.write(
+        `\nNo Claude Code plugin detected. Install it via the marketplace:\n` +
+          `  /plugin marketplace add ${agent.marketplaceSource ?? ''}\n` +
+          `  /plugin install ${ref}\n` +
+          `Or re-run \`aka init --yes\` to install it automatically.\n`,
+      );
+      return;
+    }
+    if (
+      !(await confirm(`\nInstall the AKA Claude Code plugin now (via the marketplace)? [y/N] `))
+    ) {
+      out.write('Skipped. Install anytime with `aka plugins install claude-code`.\n');
+      return;
+    }
+  }
+  await runPlugins(['install', 'claude-code']);
+}
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(question)).trim().toLowerCase();
+    return answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-tc",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "packageManager": "pnpm@10.30.1",
   "type": "module",
   "engines": {

--- a/packages/local-ops/src/registry.ts
+++ b/packages/local-ops/src/registry.ts
@@ -29,10 +29,10 @@ export const AGENT_PLUGINS: readonly AgentPlugin[] = [
     sourceTool: 'claude-code',
     description:
       'Hooks Claude Code sessions to detect + redact sensitive data in prompts, responses, and file writes.',
-    npmPackage: '@akasecurity/plugin-claude-code',
-    pluginName: 'aka',
-    marketplace: 'ai-tc',
-    marketplaceSource: 'akasecurity/ai-tc',
+    npmPackage: '@akasecurity/ai-tc-claude-code',
+    pluginName: 'ai-tc',
+    marketplace: 'akasecurity',
+    marketplaceSource: 'akasecurity/marketplace',
   },
 ];
 

--- a/packages/local-ops/src/updates.test.ts
+++ b/packages/local-ops/src/updates.test.ts
@@ -8,8 +8,8 @@ function views(map: Record<string, string | null>): (pkg: string) => string | nu
 }
 
 const CLI = '@akasecurity/cli';
-const PLUGIN = '@akasecurity/plugin-claude-code';
-const REF = 'aka@ai-tc';
+const PLUGIN = '@akasecurity/ai-tc-claude-code';
+const REF = 'ai-tc@akasecurity';
 
 describe('gatherReport', () => {
   it('flags a CLI update when the registry is ahead of the installed version', () => {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -1,0 +1,46 @@
+# @akasecurity/ai-tc-claude-code — the `aka` plugin for Claude Code
+
+[![npm](https://img.shields.io/npm/v/@akasecurity/ai-tc-claude-code?style=flat-square&labelColor=232F3E&color=00E0B8)](https://www.npmjs.com/package/@akasecurity/ai-tc-claude-code)
+[![Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-232F3E?style=flat-square)](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)
+
+The Claude Code plugin for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`). It hooks into a Claude Code session and inspects its traffic — prompts, tool calls, tool results, file reads — scanning each event against your rule packs and applying inline **warn / redact / block** policies. Every event is recorded to a local SQLite store at `~/.aka/data/aka.db`.
+
+Detection runs entirely on your machine. There's no account and no backend — nothing leaves your computer to be scanned.
+
+## Install
+
+This package is distributed through the **Claude Code plugin marketplace**, not `npm install`. Add the marketplace and install the plugin from inside Claude Code:
+
+```text
+/plugin marketplace add akasecurity/marketplace
+/plugin install aka@akasecurity
+```
+
+Or let the `aka` CLI do it for you:
+
+```bash
+npm install -g @akasecurity/cli
+aka plugins install claude-code
+```
+
+Then run `aka init` to scaffold the local store, and `aka dashboard` to view findings.
+
+## What it registers
+
+The plugin installs Claude Code hooks that run locally with no `node_modules`, and fail open (a hook error never breaks your session):
+
+- **SessionStart** — snapshot the session context.
+- **UserPromptSubmit** — scan prompts before they reach the model.
+- **PreToolUse** — scan tool inputs (Bash, Edit, Write, WebFetch) before they run.
+- **PostToolUse** — scan tool outputs and file reads (Bash, Read, WebFetch) after they return.
+- **Stop** — reconcile token usage and finalize the session record.
+
+It also adds slash commands for reports and setup (`/aka:health`, `/aka:findings`, `/aka:dashboard`, and more).
+
+## Docs
+
+Full documentation and the built-in detection catalog live at **[akasecurity.github.io/ai-tc-docs](https://akasecurity.github.io/ai-tc-docs/)**.
+
+## License
+
+[Apache-2.0](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@akasecurity/plugin-claude-code",
-  "version": "0.8.0",
+  "name": "@akasecurity/ai-tc-claude-code",
+  "version": "0.8.1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
+  "license": "Apache-2.0",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Coordinated **0.8.1** release projection from the OSS mirror (PR #26 + #31).

## What ships
- Bump `@akasecurity/cli`, plugin, and root to **0.8.1** (lockstep).
- **Rename** plugin npm package `@akasecurity/plugin-claude-code` → **`@akasecurity/ai-tc-claude-code`** (same artifacts).
- CLI publish switches to **OIDC trusted publishing** (no long-lived token).
- Add npm README + Apache-2.0 `license` to cli and plugin.
- Route the plugin through the `akasecurity/marketplace` catalog (registry.ts, init.ts).

## Release steps after merge
1. Tag `cli-v0.8.1` → `release-cli.yml` publishes `@akasecurity/cli@0.8.1` via OIDC (first live OIDC run — dry-run first).
2. Tag `plugin-v0.8.1` → `release-plugin.yml` publishes `@akasecurity/ai-tc-claude-code@0.8.1` (new name, first release).
3. `npm deprecate @akasecurity/plugin-claude-code` → point to new name.