### PR TITLE
fix(ci): publish CLI via NPM_TOKEN (defer OIDC trusted publishing)

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -60,7 +60,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the GitHub Release + move the cli-latest tag
-      id-token: write # OIDC trusted publishing to npm — no long-lived token
     steps:
       - uses: actions/checkout@v7
 
@@ -127,14 +126,15 @@ jobs:
           fi
           echo "✓ published CLI boots the bundled dashboard and serves /security"
 
-      # Publishes via npm OIDC trusted publishing: with `id-token: write` and a
-      # trusted publisher configured on npm for this repo + workflow, no
-      # NODE_AUTH_TOKEN/NPM_TOKEN is used, and provenance is attached automatically.
-      - name: Publish to npm (OIDC trusted publishing)
+      # Publishes with the NPM_TOKEN automation token (2FA-bypass), matching the
+      # plugin release. OIDC trusted publishing is deferred until the npm-side
+      # trusted-publisher config for @akasecurity/cli is in place — then restore
+      # `id-token: write` above and swap this back to NPM_CONFIG_PROVENANCE.
+      - name: Publish to npm
         if: github.event_name == 'push' || inputs.publish
         run: pnpm --filter @akasecurity/cli publish --no-git-checks
         env:
-          NPM_CONFIG_PROVENANCE: 'true'
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # The install one-liners fetch the bootstrap scripts from the `cli-latest`
       # tag, so a successful publish must move it to this release commit.


### PR DESCRIPTION
The first cli-v0.8.1 run failed with npm 403 "OIDC permission denied" — the
npm-side trusted-publisher config for @akasecurity/cli isn't in place yet.
Fall back to the same NPM_TOKEN automation-token auth the plugin release uses:
drop id-token: write + NPM_CONFIG_PROVENANCE, set NODE_AUTH_TOKEN. Restore OIDC
once the trusted publisher is configured.