### PR TITLE
fix(plugin): address setup-triage review — drift gate, egress boundary, sentinel status

### DIFF
--- a/plugins/claude-code/src/triage/adapter.test.ts
+++ b/plugins/claude-code/src/triage/adapter.test.ts
@@ -127,6 +127,45 @@ describe('runApply — preview persists a plan and writes nothing', () => {
   });
 });
 
+describe('runApply — preview is a raw-free egress boundary by construction', () => {
+  const previewThrowing = async (runJudge: () => never): Promise<unknown> => {
+    const db = fakeDb();
+    try {
+      await runApply({
+        argv: [],
+        readStream: () => streamText(),
+        runJudge,
+        openDb: db.open,
+        now: () => 0,
+        createdBy: () => 'tester',
+        stdout: vi.fn(),
+        stderr: vi.fn(),
+      });
+    } catch (e) {
+      return e;
+    }
+    return undefined;
+  };
+
+  it('withholds a raw value that a downstream throw interpolated into its message', async () => {
+    const thrown = await previewThrowing(() => {
+      // A future/unexpected throw that echoes a raw hit value — the exact leak the
+      // boundary must contain regardless of which throw site produced it.
+      throw new Error(`judge blew up near ${RAW} — export KEY=${RAW}`);
+    });
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).not.toContain(RAW);
+    expect((thrown as Error).message).toMatch(/withheld/i);
+  });
+
+  it('passes a raw-free error message through unchanged (keeps useful diagnostics)', async () => {
+    const thrown = await previewThrowing(() => {
+      throw new Error('claude -p judge subprocess failed (exit 1)');
+    });
+    expect((thrown as Error).message).toBe('claude -p judge subprocess failed (exit 1)');
+  });
+});
+
 describe('runApply — confirm applies the persisted plan without re-judging', () => {
   it('applies exactly the previewed posture + entries and never reads the stream or judge', async () => {
     // 1. Preview writes a real plan file.
@@ -345,6 +384,155 @@ describe('runApply — confirm is atomic and reports what actually persisted', (
     expect(db.created).toEqual([]);
     expect(db.closed).toBe(1);
     expect(err.join('')).toMatch(/failed/i);
+  });
+});
+
+describe('runApply — confirm rejects a plan stale against the current store (drift gate)', () => {
+  const previewWith = async (posture: Record<string, ActionTaken>): Promise<string> => {
+    const db = fakeDb();
+    Object.assign(db.posture, posture);
+    const out: string[] = [];
+    await runApply({
+      argv: [],
+      readStream: () => streamText(),
+      runJudge: () => verdict(),
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    const path = planPathFromStdout(out);
+    written.push(path);
+    return path;
+  };
+
+  it('exits non-zero and writes NOTHING when a planned category drifted since preview', async () => {
+    // Preview snapshots `secret: block`; between preview and confirm the store
+    // changes it to `redact` (a CLI/web-ui edit) — applying the stale plan would
+    // silently act against a store the user never reviewed.
+    const path = await previewWith({ secret: 'block' });
+    const confirmDb = fakeDb();
+    confirmDb.posture.secret = 'redact';
+    const err: string[] = [];
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: confirmDb.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: vi.fn(),
+      stderr: (s) => err.push(s),
+    });
+    expect(code).toBe(1);
+    expect(err.join('')).toMatch(/store changed/i);
+    expect(err.join('')).toContain('secret');
+    // fail loud, NO write, handle closed exactly once
+    expect(confirmDb.posture).toEqual({ secret: 'redact' });
+    expect(confirmDb.created).toEqual([]);
+    expect(confirmDb.closed).toBe(1);
+  });
+
+  it('applies the plan when the store still matches the preview snapshot', async () => {
+    const path = await previewWith({ secret: 'block' });
+    const confirmDb = fakeDb();
+    confirmDb.posture.secret = 'block'; // unchanged since preview
+    const out: string[] = [];
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: confirmDb.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+    expect(out.join('')).toMatch(/applied/i);
+    // no drift → the write proceeded: one suppression row AND the posture overwrite
+    expect(confirmDb.created).toHaveLength(1);
+    expect(confirmDb.posture).toEqual({ secret: 'warn' });
+  });
+
+  it('treats a category ADDED to the store since preview as drift (undefined → value)', async () => {
+    // Preview saw NO row for `secret` (plan.current omits it); by confirm a row
+    // exists. This is the asymmetric case: current[secret] is undefined, the store
+    // now returns a value — it must count as drift, not be silently overwritten.
+    const path = await previewWith({});
+    const confirmDb = fakeDb();
+    confirmDb.posture.secret = 'block'; // row added after preview
+    const err: string[] = [];
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: confirmDb.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: vi.fn(),
+      stderr: (s) => err.push(s),
+    });
+    expect(code).toBe(1);
+    expect(err.join('')).toMatch(/store changed/i);
+    expect(confirmDb.created).toEqual([]);
+    expect(confirmDb.posture).toEqual({ secret: 'block' }); // untouched
+  });
+
+  it('fails loud (no write) if the drift read itself throws', async () => {
+    const path = await previewWith({ secret: 'block' });
+    // A store whose getCategoryAction throws — the drift gate must fail closed,
+    // not fall through to the write.
+    const created: unknown[] = [];
+    let closed = 0;
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: () => ({
+        policies: {
+          getCategoryAction: () => {
+            throw new Error('db read blew up');
+          },
+          upsertCategoryAction: () => {
+            created.push('posture');
+          },
+        },
+        exceptions: {
+          create: () => {
+            created.push('exception');
+            return Promise.resolve();
+          },
+        },
+        close: () => {
+          closed++;
+        },
+      }),
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: vi.fn(),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(1);
+    expect(created).toEqual([]);
+    expect(closed).toBe(1);
   });
 });
 

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -15,7 +15,7 @@
  * All IO (stream read, judge spawn, DB, clock, stdout/stderr) is injected so this
  * is unit-testable with fakes; the script wires the real implementations.
  */
-import type { ExceptionWriter } from '@akasecurity/plugin-sdk';
+import { assertRawFree, type ExceptionWriter } from '@akasecurity/plugin-sdk';
 import type {
   ActionTaken,
   DetectionCategory,
@@ -96,44 +96,72 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     return 0;
   }
 
-  const rec = deps.runJudge(hits);
-  const plan = planTriageWriteback(hits, rec);
-
-  // Read the store's current per-category action for the downgrade view.
-  // Read-only; retained in the plan file so confirm needn't re-read the DB.
-  const current: Partial<Record<DetectionCategory, ActionTaken>> = {};
-  const db = deps.openDb();
-  try {
-    for (const category of Object.keys(plan.posture) as DetectionCategory[]) {
-      const action = db.policies.getCategoryAction(category);
-      if (action !== undefined) current[category] = action;
-    }
-  } finally {
-    db.close();
-  }
-
-  deps.stdout(renderPosturePlan(plan.posture, current) + '\n\n');
-  deps.stdout(renderShowcase(plan.showcase) + '\n\n');
-  deps.stdout(renderSuppressionGate(plan.entries, plan.join) + '\n');
-  if (plan.skipped.length > 0) {
-    deps.stdout(
-      `\nSkipped (fail-secure): ${plan.skipped
-        .map((s) => `${s.category} — ${s.reason}`)
-        .join('; ')}\n`,
-    );
-  }
-  deps.stdout(`\nNotes: ${plan.notes}\n`);
-
-  // Persist the EXACT resolved raw-free plan the user is about to approve. The
-  // backstop (assertRawFree over the serialized doc) runs inside write().
+  // Preview egress boundary: everything below handles the raw hits, so any error
+  // it throws is scrubbed against the raw values before it can leave this process.
+  // A message that echoed a raw value is withheld wholesale; a clean one passes
+  // through unchanged. This is what lets the top-level apply-suppressions catch
+  // safely print err.message — the guarantee is enforced here, not by auditing
+  // every current throw site (a future throw is covered too). The scrub inherits
+  // assertRawFree's MIN_RAW_LEN floor (values shorter than 4 chars are not
+  // matched) — the same containment bound used at every other raw-egress
+  // checkpoint (plan-file backstop, reasoning/notes checks), not a weaker one.
   const rawValues = hits.map((h) => h.rawMatch);
-  const planPath = planIO.write(plan, current, rawValues);
-  deps.stdout(`\nPlan saved to: ${planPath}\n`);
-  deps.stdout(
-    `Re-run with: apply-suppressions.js --confirmed --plan ${planPath}\n` +
-      `(applies this exact plan — no re-scan, no re-judge; the file is deleted after apply)\n`,
-  );
-  return 0;
+  try {
+    const rec = deps.runJudge(hits);
+    const plan = planTriageWriteback(hits, rec);
+
+    // Read the store's current per-category action for the downgrade view.
+    // Read-only; retained in the plan file so confirm needn't re-read the DB.
+    const current: Partial<Record<DetectionCategory, ActionTaken>> = {};
+    const db = deps.openDb();
+    try {
+      for (const category of Object.keys(plan.posture) as DetectionCategory[]) {
+        const action = db.policies.getCategoryAction(category);
+        if (action !== undefined) current[category] = action;
+      }
+    } finally {
+      db.close();
+    }
+
+    deps.stdout(renderPosturePlan(plan.posture, current) + '\n\n');
+    deps.stdout(renderShowcase(plan.showcase) + '\n\n');
+    deps.stdout(renderSuppressionGate(plan.entries, plan.join) + '\n');
+    if (plan.skipped.length > 0) {
+      deps.stdout(
+        `\nSkipped (fail-secure): ${plan.skipped
+          .map((s) => `${s.category} — ${s.reason}`)
+          .join('; ')}\n`,
+      );
+    }
+    deps.stdout(`\nNotes: ${plan.notes}\n`);
+
+    // Persist the EXACT resolved raw-free plan the user is about to approve. The
+    // backstop (assertRawFree over the serialized doc) runs inside write().
+    const planPath = planIO.write(plan, current, rawValues);
+    deps.stdout(`\nPlan saved to: ${planPath}\n`);
+    deps.stdout(
+      `Re-run with: apply-suppressions.js --confirmed --plan ${planPath}\n` +
+        `(applies this exact plan — no re-scan, no re-judge; the file is deleted after apply)\n`,
+    );
+    return 0;
+  } catch (err) {
+    const original = err instanceof Error ? err.message : String(err);
+    // assertRawFree returns `original` when it holds no raw value, or throws
+    // RawEgressError when it does — in which case the whole message is withheld.
+    let safe: string;
+    try {
+      safe = assertRawFree(original, rawValues);
+    } catch {
+      safe =
+        'apply-suppressions preview failed (message withheld: it referenced a raw detected value)';
+    }
+    // Deliberately NOT chaining `err` as `cause`: the caught error is the very
+    // thing being scrubbed — its message/stack may carry the raw value, and a
+    // cause would re-expose it via util.inspect/loggers. Only the scrubbed
+    // message crosses this boundary.
+    // eslint-disable-next-line preserve-caught-error -- caught error may carry raw; see above
+    throw new Error(safe);
+  }
 }
 
 // CONFIRM: apply the persisted plan VERBATIM. No stream read, no judge. Any
@@ -169,6 +197,44 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
     closed = true;
     db.close();
   };
+
+  // Store-drift gate. The plan was approved against the per-category actions the
+  // preview captured in `plan.current`. If the store changed since (a CLI edit, a
+  // web-ui save, another wizard run), applying the plan blindly could turn an
+  // approved non-downgrade into a SILENT downgrade — the exact case the preview's
+  // renderPosturePlan WARNING exists to surface. Re-read each planned category and
+  // compare; on drift, fail loud with no write so the wizard routes to the floor
+  // fallback and the user re-previews against the store they can actually see.
+  // undefined (no row) compares equal on both sides, so an added/removed row
+  // counts as drift too. The read is same-process, immediately before the
+  // transactional write below; a concurrent edit landing in the sub-millisecond
+  // gap between them is an accepted residual window for this local single-user
+  // store, not covered here.
+  try {
+    const drifted: DetectionCategory[] = [];
+    for (const category of Object.keys(plan.posture) as DetectionCategory[]) {
+      if (db.policies.getCategoryAction(category) !== plan.current[category]) {
+        drifted.push(category);
+      }
+    }
+    if (drifted.length > 0) {
+      closeOnce();
+      deps.stderr(
+        `AKA apply-suppressions failed: the detection store changed since this plan was previewed ` +
+          `(${drifted.join(', ')}). Refusing to apply a stale plan — re-run /aka:setup to review ` +
+          `against the current store.\n`,
+      );
+      return 1;
+    }
+  } catch (err) {
+    closeOnce();
+    deps.stderr(
+      `AKA apply-suppressions failed: could not verify the plan against the current store ` +
+        `(${err instanceof Error ? err.message : 'read error'}). Refusing to apply.\n`,
+    );
+    return 1;
+  }
+
   try {
     const res = await performTriageWriteback(
       // The write only reads posture + entries; join/showcase/notes/skipped are

--- a/plugins/claude-code/src/triage/plan-file.test.ts
+++ b/plugins/claude-code/src/triage/plan-file.test.ts
@@ -54,7 +54,6 @@ describe('plan-file round-trip', () => {
 
     const back = readPlanFile(path);
     expect(back.version).toBe(PLAN_FILE_VERSION);
-    expect(back.token).toMatch(/\S/);
     expect(back.posture).toEqual(plan.posture);
     expect(back.entries).toEqual(plan.entries);
     expect(back.notes).toBe(plan.notes);
@@ -173,7 +172,6 @@ describe('deletePlanFile', () => {
 function readPlanFileDoc(plan: TriageWritebackPlan) {
   return {
     version: PLAN_FILE_VERSION,
-    token: 'test-token',
     posture: plan.posture,
     entries: plan.entries,
     showcase: plan.showcase,

--- a/plugins/claude-code/src/triage/plan-file.ts
+++ b/plugins/claude-code/src/triage/plan-file.ts
@@ -17,7 +17,6 @@
  * before anything touches disk: a leaked raw value fails the write
  * LOUDLY rather than persisting a secret to a temp file.
  */
-import { randomBytes } from 'node:crypto';
 import { mkdtempSync, readFileSync, rmdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
@@ -63,14 +62,11 @@ const JoinEntrySchema = z.object({
 
 // Bump when the on-disk shape changes; readPlanFile rejects any other version so
 // a stale file from an older plugin can never be replayed against newer apply
-// logic.
-export const PLAN_FILE_VERSION = 2;
+// logic. v3 dropped the unverified `token` field.
+export const PLAN_FILE_VERSION = 3;
 
 export const PersistedPlanSchema = z.object({
   version: z.literal(PLAN_FILE_VERSION),
-  // Opaque marker minted at persist time and carried through to confirm — a
-  // this-run integrity tag, not a security secret (the human gate is the guard).
-  token: z.string().min(1),
   // partialRecord (not record): a posture only covers the categories present in
   // the evidence, so an exhaustive-key record would reject every real plan.
   posture: z.partialRecord(DetectionCategory, BuiltinPolicyId),
@@ -78,8 +74,9 @@ export const PersistedPlanSchema = z.object({
   showcase: z.array(ShowcaseCategorySchema),
   join: z.array(JoinEntrySchema),
   notes: z.string(),
-  // The store's per-category action at preview time, retained so the confirm
-  // step can re-render the exact downgrade view without re-reading the DB.
+  // The store's per-category action at preview time. The downgrade view is
+  // rendered from it at PREVIEW (renderPosturePlan); confirm reads it back ONLY to
+  // compare against the live store and reject a stale plan (runConfirm's drift gate).
   current: z.partialRecord(DetectionCategory, ActionTaken),
 });
 export type PersistedPlan = z.infer<typeof PersistedPlanSchema>;
@@ -89,11 +86,9 @@ export type PersistedPlan = z.infer<typeof PersistedPlanSchema>;
 export function serializePlan(
   plan: TriageWritebackPlan,
   current: PersistedPlan['current'],
-  token: string,
 ): string {
   const doc: PersistedPlan = {
     version: PLAN_FILE_VERSION,
-    token,
     posture: plan.posture,
     entries: plan.entries,
     showcase: plan.showcase,
@@ -105,9 +100,8 @@ export function serializePlan(
 }
 
 export interface WritePlanDeps {
-  // Injectable for tests; default mints a fresh 0700 temp dir / random token.
+  // Injectable for tests; default mints a fresh 0700 temp dir.
   mkTempDir?: () => string;
-  mkToken?: () => string;
 }
 
 // Persist the resolved raw-free plan to a fresh temp file and return its path.
@@ -120,8 +114,7 @@ export function writePlanFile(
   rawValues: readonly string[],
   deps: WritePlanDeps = {},
 ): string {
-  const token = (deps.mkToken ?? (() => randomBytes(16).toString('hex')))();
-  const serialized = serializePlan(plan, current, token);
+  const serialized = serializePlan(plan, current);
   // Throws RawEgressError if any raw value survived into the document.
   assertRawFree(serialized, rawValues);
   const dir = (deps.mkTempDir ?? (() => mkdtempSync(join(tmpdir(), 'aka-plan-'))))();

--- a/plugins/claude-code/src/triage/writeback.test.ts
+++ b/plugins/claude-code/src/triage/writeback.test.ts
@@ -72,6 +72,14 @@ describe('parseTriageStream', () => {
     expect(status).toBe('skipped:no-consent');
   });
 
+  it('fails LOUD on an unrecognized sentinel status instead of silently skipping', () => {
+    // A version-skewed / corrupted producer emits a status this consumer does not
+    // know. It must NOT be treated as a clean zero-hit skip (which would tell the
+    // user their history was cleanly triaged when the outcome was never understood).
+    const stream = JSON.stringify({ done: true, count: 0, status: 'skipped:new-reason' }) + '\n';
+    expect(() => parseTriageStream(stream)).toThrow(/unrecognized status/i);
+  });
+
   it('throws on a truncated stream (no sentinel) rather than treating it as empty', () => {
     const stream = JSON.stringify(hit()) + '\n';
     expect(() => parseTriageStream(stream)).toThrow(/truncat|sentinel/i);

--- a/plugins/claude-code/src/triage/writeback.ts
+++ b/plugins/claude-code/src/triage/writeback.ts
@@ -44,12 +44,18 @@ export const SCRUBBED_NOTES = '[notes withheld: model text referenced a raw dete
 // -------------------------------------------------------------------------
 
 // The --triage stream terminator (mirrors backfill.ts's triageSentinel). Its
-// presence is the ONLY proof the stream was not truncated mid-scan.
-type TriageStatus = 'complete' | 'skipped:no-consent' | 'skipped:attached';
+// presence is the ONLY proof the stream was not truncated mid-scan. The status
+// set MUST stay in lockstep with backfill.ts's producer TriageStatus — a value
+// one side emits and the other doesn't is a silent skew (see isKnownStatus).
+type TriageStatus = 'complete' | 'skipped:no-consent';
+const TRIAGE_STATUSES = ['complete', 'skipped:no-consent'] as const;
+
+// `status` is only shape-checked (string) here; parseTriageStream validates it
+// against TRIAGE_STATUSES via isKnownStatus and fails loud on anything else.
 interface Sentinel {
   done: true;
   count: number;
-  status: TriageStatus;
+  status: string;
 }
 
 function isSentinel(v: unknown): v is Sentinel {
@@ -60,6 +66,10 @@ function isSentinel(v: unknown): v is Sentinel {
     typeof (v as { count?: unknown }).count === 'number' &&
     typeof (v as { status?: unknown }).status === 'string'
   );
+}
+
+function isKnownStatus(status: string): status is TriageStatus {
+  return (TRIAGE_STATUSES as readonly string[]).includes(status);
 }
 
 // Parse a completed `backfill --triage` stream into validated TriageHits. The
@@ -84,6 +94,17 @@ export function parseTriageStream(text: string): { hits: TriageHit[]; status: Tr
   }
   if (!isSentinel(tail)) {
     throw new Error('triage stream has no completion sentinel — refusing a truncated stream');
+  }
+  // A sentinel-shaped line whose status we don't recognise (a version-skewed or
+  // corrupted producer) must fail LOUD — never be quietly converted into a clean
+  // zero-hit "skip", which would tell the user their history was cleanly triaged
+  // when the scan's outcome was in fact never understood. The status value is not
+  // interpolated into the message: it is the producer's own field, kept out of
+  // the error to hold the raw-free line.
+  if (!isKnownStatus(tail.status)) {
+    throw new Error(
+      'triage stream sentinel carries an unrecognized status — refusing to treat it as a clean scan',
+    );
   }
   const hitLines = lines.slice(0, -1);
   if (tail.status !== 'complete') {


### PR DESCRIPTION
Addresses the three change requests from @joshuas99's review of #10 (merged), on the evidence-first setup-triage subsystem.

## What changed

**1. Store-drift gate on confirm** (`triage/adapter.ts`)
The plan file snapshots each category's store action in `current`, but `runConfirm` never checked it — a store edit between preview and confirm (CLI, web-ui, another wizard run) could silently apply an approved non-downgrade as a downgrade. Confirm now re-reads each planned category's live action and, on **any** drift, fails loud (exit 1, no write) so the wizard routes to the floor fallback and the user re-previews against the store they can actually see. The read is same-process, immediately before the transactional write; the sub-millisecond gap is an accepted residual window for a local single-user store (documented in-code).

Also removed the `token` field from the plan file — it was an integrity tag nothing verified (the plan-file path already binds preview→confirm). `PLAN_FILE_VERSION` bumped 2→3 so a stale v2 file is rejected.

**2. Preview egress boundary by construction** (`triage/adapter.ts`)
The top-level catch prints `err.message`; it was raw-free only by auditing today's throw sites. `runPreview` now wraps the judge-onward work and scrubs any error through `assertRawFree(err.message, rawValues)` — withholding the message wholesale on a `RawEgressError` — so a *future* throw that interpolates raw is contained. (Inherits `assertRawFree`'s MIN_RAW_LEN floor — the same containment bound as every other raw-egress checkpoint, noted in-code.)

**3. Unknown sentinel status fails loud** (`triage/writeback.ts`)
`parseTriageStream` treated any status `!== 'complete'` as an intentional skip, so a version-skewed/corrupted sentinel silently floored ("nothing to calibrate") instead of failing. It now validates the status against the known set and throws on anything unrecognized. Aligned the consumer `TriageStatus` to the producer by dropping the never-emitted `skipped:attached`.

## Tests
Drift gate (value-changed reject / added-row reject / apply-on-match with posture assertion / drift-read-throws → fail closed), the preview boundary (a raw-bearing throw is withheld; a raw-free one passes through), and the unknown-status throw.

## Verification
Reviewed by a dual blind adversarial pass before push (0 critical / 0 real warnings). Full gate green locally: format, lint (14/14), typecheck (14/14), test (24/24 — 274 in the plugin).

Feature/fix PR — no version bump (release bumps land separately), matching #10.
