### PR TITLE
feat(dashboard): improve overflow handling for long text and popovers

### DIFF
--- a/packages/dashboard-ui/src/detections/DetectionDetailView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionDetailView.tsx
@@ -39,7 +39,9 @@ function RuleCard({ rule, onOpen }: { rule: DetectionRule; onOpen: () => void })
         </span>
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <span className="truncate text-sm font-semibold text-text">{rule.name}</span>
+            <span className="truncate text-sm font-semibold text-text" title={rule.name}>
+              {rule.name}
+            </span>
             <span className="text-xs text-text-3">
               {CATEGORY_LABEL[rule.category] || rule.category}
             </span>

--- a/packages/dashboard-ui/src/detections/DetectionsListView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionsListView.tsx
@@ -49,7 +49,9 @@ function DetectionRow({
                 (d.enabled ? 'bg-ok ring-3 ring-ok-fill' : 'bg-border-strong')
               }
             />
-            <span className="truncate text-sm font-semibold text-text">{d.name}</span>
+            <span className="truncate text-sm font-semibold text-text" title={d.name}>
+              {d.name}
+            </span>
           </div>
           <div className="font-mono text-xs text-text-3">v{d.version}</div>
         </div>

--- a/packages/dashboard-ui/src/detections/atoms.tsx
+++ b/packages/dashboard-ui/src/detections/atoms.tsx
@@ -85,7 +85,9 @@ export function PublisherTag({ publisher, kind }: { publisher: string; kind: Pub
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5 text-xs font-semibold text-text-2">
       <Icon aria-hidden focusable={false} className="size-3.5 shrink-0" style={{ color: fg }} />
-      <span className="truncate">{publisher}</span>
+      <span className="truncate" title={publisher}>
+        {publisher}
+      </span>
       {m.verified && (
         <span title={m.label} className="text-[10px] font-bold" style={{ color: fg }}>
           ✓

--- a/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
@@ -34,7 +34,7 @@ export function ExceptionsTableView({
     );
   }
   return (
-    <div className="overflow-x-auto rounded-xl border border-border bg-surface">
+    <div className="overflow-x-auto rounded-xl border border-border bg-surface p-4">
       <Table>
         <TableHeader>
           <TableRow>

--- a/packages/dashboard-ui/src/findings/FindingDetailView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingDetailView.tsx
@@ -178,7 +178,7 @@ function LocationRow({ instance, onClick }: { instance: FindingInstance; onClick
       className="flex items-center cursor-pointer gap-3 rounded-lg border border-border bg-surface px-3 py-2.5 text-left transition-colors hover:bg-surface-2"
     >
       <Provider id={instance.provider} />
-      <div className="flex min-w-0 flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="text-xs font-medium text-text">{instance.repo}</span>
         <span className="font-mono text-label text-text-3 wrap-break-word">{instance.file}</span>
       </div>

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -180,7 +180,7 @@ function MultiSelectFilter({
         )}
         <ChevronDownIcon className="size-3.5" />
       </PopoverTrigger>
-      <PopoverContent className="min-w-52">
+      <PopoverContent className="min-w-52 max-h-80">
         {options.map((opt) => {
           const checked = selected.includes(opt.value);
           return (

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -3,6 +3,7 @@
 import type { FindingFacets, FindingProvider } from '@akasecurity/schema';
 import { Button, cn, Popover, PopoverContent, PopoverTrigger } from '@akasecurity/ui-kit';
 
+import { numberFormat } from '../security/widget-shared.tsx';
 import { CheckIcon, ChevronDownIcon, SearchIcon, SlidersIcon } from '../shared/icons.tsx';
 import { PROVIDERS } from '../shared/Provider.tsx';
 import {
@@ -137,9 +138,9 @@ export function FindingsToolbarView({
       />
       <span className="h-6 bg-border w-px" />
       <span className="text-sm text-text-3">
-        <span className="font-semibold text-text">{findingCount}</span> finding
+        <span className="font-semibold text-text">{numberFormat.format(findingCount)}</span> finding
         {findingCount === 1 ? '' : 's'} ·{' '}
-        <span className="font-semibold text-text">{typeCount}</span> type
+        <span className="font-semibold text-text">{numberFormat.format(typeCount)}</span> type
         {typeCount === 1 ? '' : 's'}
       </span>
     </div>

--- a/packages/dashboard-ui/src/inventory/AssetDetail.tsx
+++ b/packages/dashboard-ui/src/inventory/AssetDetail.tsx
@@ -53,7 +53,9 @@ export function AssetDetail({
           <Ico name={tile.icon} className="size-4.5" />
         </span>
         <div className="min-w-0 flex-1">
-          <div className="truncate font-mono text-sm font-semibold text-text">{asset.name}</div>
+          <div className="truncate font-mono text-sm font-semibold text-text" title={asset.name}>
+            {asset.name}
+          </div>
           <div className="mt-px text-xs text-text-3">{typeLabel}</div>
         </div>
         {onClose && (

--- a/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
+++ b/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
@@ -115,9 +115,7 @@ export function HarnessOverview({
                     </span>
                     <div className="min-w-0 flex-1">
                       <div className="text-xs font-semibold text-text">{x.title}</div>
-                      <div className="mt-0.5 truncate font-mono text-xs text-text-3">
-                        {x.detail}
-                      </div>
+                      <div className="mt-0.5 font-mono text-xs text-text-3">{x.detail}</div>
                     </div>
                     <div className="flex shrink-0 flex-col items-end gap-1">
                       <Badge variant={m.tone}>{m.label}</Badge>

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -296,7 +296,9 @@ function HarnessTreeRow(props: InventoryNavProps & { h: HarnessSummary }) {
         >
           <Provider id={h.id} size={28} />
           <div className="min-w-0 flex-1">
-            <div className="truncate text-sm font-semibold text-text">{h.label}</div>
+            <div className="truncate text-sm font-semibold text-text" title={h.label}>
+              {h.label}
+            </div>
             <div className="mt-px text-xs text-text-3">
               {h.kind} · {h.assetCount} assets
             </div>
@@ -458,14 +460,18 @@ function ProjectNavRow({
           className="size-2 shrink-0 rounded-full"
           style={{ background: langColor(p.language) }}
         />
-        <span className="truncate text-sm font-semibold text-text">{p.name}</span>
+        <span className="truncate text-sm font-semibold text-text" title={p.name}>
+          {p.name}
+        </span>
         <span className="ml-auto shrink-0">
           <VisBadge v={p.visibility} />
         </span>
       </div>
       <div className="mb-2 flex items-center gap-1.5 font-mono text-xs text-text-3">
-        <Ico name="repo" className="size-3" />
-        {p.repo}
+        <Ico name="repo" className="size-3 shrink-0" />
+        <span className="truncate" title={p.repo}>
+          {p.repo}
+        </span>
       </div>
       <div className="flex items-center gap-2.5">
         <AccessBar counts={c} />
@@ -518,8 +524,12 @@ function AssetNavRow({
         <Ico name={tile.icon} className="size-3.5" />
       </span>
       <div className="min-w-0 flex-1">
-        <div className="truncate font-mono text-xs font-semibold text-text">{it.name}</div>
-        <div className="mt-0.5 truncate font-mono text-label text-text-3">{it.sub}</div>
+        <div className="truncate font-mono text-xs font-semibold text-text" title={it.name}>
+          {it.name}
+        </div>
+        <div className="mt-0.5 truncate font-mono text-label text-text-3" title={it.sub}>
+          {it.sub}
+        </div>
       </div>
       <div className="flex shrink-0 flex-col items-end gap-1">
         {trust && <TrustPill value={trust} />}

--- a/packages/dashboard-ui/src/policies/PoliciesView.tsx
+++ b/packages/dashboard-ui/src/policies/PoliciesView.tsx
@@ -93,7 +93,9 @@ function PolicyRow({
         <Icon aria-hidden focusable={false} />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block truncate text-sm font-semibold text-text">{policy.name}</span>
+        <span className="block truncate text-sm font-semibold text-text" title={policy.name}>
+          {policy.name}
+        </span>
         <span className="mt-px block text-xs text-text-3">
           {count} detection{count === 1 ? '' : 's'}
         </span>

--- a/packages/dashboard-ui/src/security/EnforcementCardView.tsx
+++ b/packages/dashboard-ui/src/security/EnforcementCardView.tsx
@@ -26,7 +26,7 @@ export function EnforcementCardView({
         <div className="flex justify-between gap-3">
           <div>
             <div className="text-sm font-semibold text-text">Enforcement actions</div>
-            <div className="mt-0.5 text-xs text-text-3">All users · {rangeLabel.toLowerCase()}</div>
+            <div className="mt-0.5 text-xs text-text-3">{rangeLabel.toLowerCase()}</div>
           </div>
           <div className="text-right">
             {isLoading ? (

--- a/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
@@ -72,7 +72,9 @@ function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) 
       </span>
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-semibold text-text">{item.ruleId}</span>
+          <span className="truncate text-sm font-semibold text-text" title={item.ruleId}>
+            {item.ruleId}
+          </span>
           <span className="ml-auto shrink-0 text-xs text-text-3">
             {relativeTime(item.resolvedAt)}
           </span>
@@ -80,7 +82,9 @@ function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) 
         <div className="mt-1.5 flex items-center gap-1.5 text-xs text-text-3">
           <span className="shrink-0">{SEVERITY_META[item.severity].label}</span>
           <span className="shrink-0 text-border-strong">·</span>
-          <span className="truncate font-mono">{item.path}</span>
+          <span className="truncate font-mono" title={item.path}>
+            {item.path}
+          </span>
         </div>
       </div>
     </div>

--- a/packages/dashboard-ui/src/security/SeverityCardView.tsx
+++ b/packages/dashboard-ui/src/security/SeverityCardView.tsx
@@ -73,7 +73,7 @@ export function SeverityCardView({
         <CardHeading>
           <CardTitle>{resolutionMode ? 'By severity' : 'Open by severity'}</CardTitle>
           <CardDescription>
-            {isLoading ? 'Loading…' : error ? '—' : `${String(total)} findings`}
+            {isLoading ? 'Loading…' : error ? '—' : `${numberFormat.format(total)} findings`}
           </CardDescription>
         </CardHeading>
       </CardHeader>

--- a/packages/dashboard-ui/src/security/TopSourcesCardView.tsx
+++ b/packages/dashboard-ui/src/security/TopSourcesCardView.tsx
@@ -22,7 +22,7 @@ export interface TopSourcesView {
 
 export function TopSourcesCardView({ items, isLoading, error }: TopSourcesView) {
   return (
-    <Card className="flex flex-col shadow-sm">
+    <Card className="flex flex-col shadow-sm min-w-0">
       <CardHeader>
         <CardIcon>
           <TargetIcon aria-hidden focusable={false} className="size-4" />
@@ -60,17 +60,18 @@ function SourceRow({ source }: { source: TopSource }) {
       >
         <Icon aria-hidden focusable={false} className="size-3.5" />
       </span>
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center justify-between">
-          {/* `name` is a repo slug (mono reads well) or a user's email (mono looks
-              off and truncates awkwardly) — only monospace the repo slug. */}
-          <span className={cn('truncate text-sm text-text', !isUser && 'font-mono')}>
-            {source.name}
-          </span>
-          <span className="text-sm font-bold text-text">
-            {numberFormat.format(source.findingsCount)}
-          </span>
-        </div>
+      <div className="min-w-0 flex-1 flex items-center justify-between gap-2">
+        {/* `name` is a repo slug (mono reads well) or a user's email (mono looks
+            off and truncates awkwardly) — only monospace the repo slug. */}
+        <span
+          className={cn('truncate text-sm text-text', !isUser && 'font-mono')}
+          title={source.name}
+        >
+          {source.name}
+        </span>
+        <span className="text-sm font-bold text-text shrink-0">
+          {numberFormat.format(source.findingsCount)}
+        </span>
       </div>
     </div>
   );

--- a/packages/ui-kit/src/popover.tsx
+++ b/packages/ui-kit/src/popover.tsx
@@ -23,6 +23,7 @@ export function PopoverContent({
   className,
   align = 'start',
   sideOffset = 6,
+  collisionPadding = 8,
   ...props
 }: PopoverContentProps) {
   return (
@@ -30,8 +31,9 @@ export function PopoverContent({
       <PopoverPrimitive.Content
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn(
-          'z-50 min-w-32 rounded-lg border border-border bg-surface p-1 shadow-lg outline-none',
+          'z-50 max-h-(--radix-popover-content-available-height) min-w-32 overflow-y-auto rounded-lg border border-border bg-surface p-1 shadow-lg outline-none',
           className,
         )}
         {...props}

--- a/web-ui/app/(app)/scan/DirectoryBrowser.tsx
+++ b/web-ui/app/(app)/scan/DirectoryBrowser.tsx
@@ -163,7 +163,9 @@ export function DirectoryBrowser({ onSelect }: { onSelect: (path: string) => voi
                     className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-2"
                   >
                     <Ico name="folder" className="size-4 shrink-0 text-primary" />
-                    <span className="truncate text-text">{entry.name}</span>
+                    <span className="truncate text-text" title={entry.name}>
+                      {entry.name}
+                    </span>
                   </button>
                 ))}
               {!loading && !error && entries.length === 0 && (


### PR DESCRIPTION
Ports [akasecurity/ai-tc-oss-mirror#45](https://github.com/akasecurity/ai-tc-oss-mirror/pull/45) into this repo. The upstream patch applied with no conflicts; the tree here is byte-identical to the mirror's, apart from one formatting normalization noted below.

Split into four commits by theme rather than landing as one blob.

## Changes

- **`fix(ui-kit): keep popovers inside the viewport`** — `PopoverContent` caps to Radix's available height with internal `overflow-y-auto`, and defaults `collisionPadding` to `8` (overridable per call site). Non-breaking: existing popovers get the behavior for free. Also caps the findings filter list at `max-h-80`.
- **`feat(dashboard): show full text on hover for truncated names and paths`** — `title` attributes on truncated names/paths across detections, findings, inventory, policies, security cards, and the scan directory browser.
- **`feat(dashboard): group thousands in finding counts`** — finding/type counts go through `numberFormat` in the findings toolbar and severity card.
- **`fix(dashboard): tidy card and table spacing`** — TopSources row flattened to one flex line, exceptions table padding, enforcement subtitle, harness detail wrapping, finding location spacing.

## Note on one deviation from upstream

This repo's pre-commit prettier hook rewrote the popover class from `max-h-[var(--radix-popover-content-available-height)]` to Tailwind v4's CSS-variable shorthand `max-h-(--radix-popover-content-available-height)`. Verified functionally identical — the production build emits `max-height:var(--radix-popover-content-available-height)` either way.

## Verification

- `typecheck` + `lint` across `ui-kit`, `dashboard-ui`, `web-ui` and deps: 18/18 green
- `web-ui` production build: clean, all routes compile
- Tests: 62 pass (`ui-kit` has no suite — presentational primitives)
- Prettier: clean
- Pre-push lint hook: 14/14
- Confirmed `--radix-popover-content-available-height` is populated by the installed `@radix-ui/react-popover@1.1.19`
- Audited all four `PopoverContent` call sites for regression from the new shared defaults; `tailwind-merge` correctly resolves the per-call-site `max-h` override

## Release note

Touches bundled packages (`ui-kit`, `dashboard-ui`) and `web-ui`, so this flows into the `cli` artifact on the next publish. No version bump included here — per `CLAUDE.md` that's a separate `chore(release):` commit and needs a release-type decision. The plugin bundles none of these, so it needs no bump.