### PR TITLE
docs(plugin): point users at /aka:setup after install

### DIFF
--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -13,17 +13,23 @@ This package is distributed through the **Claude Code plugin marketplace**, not 
 
 ```text
 /plugin marketplace add akasecurity/marketplace
-/plugin install aka@akasecurity
+/plugin install ai-tc@akasecurity
 ```
 
-Or let the `aka` CLI do it for you:
+Or let the `aka` CLI install the plugin for you:
 
 ```bash
 npm install -g @akasecurity/cli
 aka plugins install claude-code
 ```
 
-Then run `aka init` to scaffold the local store, and `aka dashboard` to view findings.
+Either way, finish onboarding by running `/aka:setup` from inside Claude Code:
+
+```text
+/aka:setup
+```
+
+If you installed via the CLI, `aka init` scaffolds the local store and `aka dashboard` views findings.
 
 ## What it registers
 


### PR DESCRIPTION
The plugin README walked users through installing the plugin but never told them to run the onboarding wizard, so both install routes ended without a calibrated detection posture.

## Changes

- Add `/aka:setup` as a common step under **both** install routes (marketplace and `aka` CLI), rather than hanging it off one of them.
- Scope the `aka init` / `aka dashboard` line to the CLI route — it doesn't apply to a marketplace install.
- Correct the marketplace install command to `ai-tc@akasecurity` (was `aka@akasecurity`).
- Reword "Or let the `aka` CLI do it for you" → "…install the plugin for you", since with a setup step nearby "it" was ambiguous.

## Verification

Docs-only change; no runtime surface. Commit hooks (format-staged, commitlint) and the pre-push lint across all 14 workspace tasks passed.