### PR TITLE
fix(detections): align keyword spans with the original text

### DIFF
--- a/packages/detections/src/engine.ts
+++ b/packages/detections/src/engine.ts
@@ -1,5 +1,6 @@
 import type { Rule } from '@akasecurity/schema';
 
+import { escapeRegExp } from './escape-regexp.ts';
 import { KeywordMatcher } from './matchers/keyword.ts';
 import { RegexMatcher } from './matchers/regex.ts';
 import type { MatchResult, RulePack } from './types.ts';
@@ -62,9 +63,6 @@ interface Candidate {
 }
 
 // Escape regex metacharacters so a label is matched literally.
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 // Pass 2 helper: is `candidate` corroborated by another signal within its
 // rule's proximity window? Looks for (a) another match in one of `categories`

--- a/packages/detections/src/escape-regexp.ts
+++ b/packages/detections/src/escape-regexp.ts
@@ -1,0 +1,11 @@
+// Escapes every regex metacharacter so a literal string can be embedded in a
+// pattern. The escaped set is exactly the ECMAScript SyntaxCharacters, so the
+// result is a valid pattern under the `u` flag as well as without it.
+//
+// Load-bearing in two places — the keyword matcher and the engine's
+// `requiresNearby` label matching — and kept here as one copy so the two escape
+// sets cannot drift: a character added to one but not the other would silently
+// change what a keyword or a label matches.
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/detections/src/matchers/keyword.ts
+++ b/packages/detections/src/matchers/keyword.ts
@@ -2,21 +2,35 @@ import type { Rule, Span } from '@akasecurity/schema';
 
 import type { Matcher } from '../types.ts';
 
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 export class KeywordMatcher implements Matcher {
   match(text: string, rule: Rule): Span[] {
     if (rule.matcher.type !== 'keyword') return [];
     const { keywords, caseSensitive } = rule.matcher;
-    const haystack = caseSensitive ? text : text.toLowerCase();
     const spans: Span[] = [];
 
     for (const kw of keywords) {
-      const needle = caseSensitive ? kw : kw.toLowerCase();
-      let idx = 0;
-      while (idx < haystack.length) {
-        const pos = haystack.indexOf(needle, idx);
-        if (pos === -1) break;
-        spans.push({ start: pos, end: pos + kw.length });
-        idx = pos + 1;
+      // An empty keyword matches at every position without ever advancing
+      // `lastIndex`, so the walk below would not terminate. The schema rejects
+      // it; skipping keeps the matcher safe on its own if a rule bypasses that.
+      if (kw.length === 0) continue;
+
+      // Match against the original `text` directly — a case-folded copy can
+      // differ in length from `text` (e.g. "İ".toLowerCase() is two code
+      // units), which would misalign every offset found in it.
+      //
+      // `u` makes case-insensitive matching fold by code point ("ß" matches
+      // "ẞ"), which a code-unit comparison misses. It also makes an escaped
+      // keyword a well-formed pattern rather than a lenient one.
+      const re = new RegExp(escapeForRegExp(kw), caseSensitive ? 'gu' : 'giu');
+      let m: RegExpExecArray | null;
+      // An escaped non-empty keyword only ever matches a non-empty run, so the
+      // `g` flag always advances past it and the walk terminates.
+      while ((m = re.exec(text)) !== null) {
+        spans.push({ start: m.index, end: m.index + m[0].length });
       }
     }
     return spans;

--- a/packages/detections/src/matchers/keyword.ts
+++ b/packages/detections/src/matchers/keyword.ts
@@ -1,10 +1,7 @@
 import type { Rule, Span } from '@akasecurity/schema';
 
+import { escapeRegExp } from '../escape-regexp.ts';
 import type { Matcher } from '../types.ts';
-
-function escapeForRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 export class KeywordMatcher implements Matcher {
   match(text: string, rule: Rule): Span[] {
@@ -22,10 +19,14 @@ export class KeywordMatcher implements Matcher {
       // differ in length from `text` (e.g. "İ".toLowerCase() is two code
       // units), which would misalign every offset found in it.
       //
-      // `u` makes case-insensitive matching fold by code point ("ß" matches
-      // "ẞ"), which a code-unit comparison misses. It also makes an escaped
-      // keyword a well-formed pattern rather than a lenient one.
-      const re = new RegExp(escapeForRegExp(kw), caseSensitive ? 'gu' : 'giu');
+      // `u` is safe and preferred here for two reasons: `escapeRegExp` only ever
+      // escapes SyntaxCharacters, so the pattern is always valid under `u`
+      // (which rejects stray identity escapes a lenient regex would accept); and
+      // `u` keeps case-folding parity with the old case-folded-copy matcher for
+      // characters like "ß"/"ẞ" (which a plain `i` regex stops folding). No
+      // bundled keyword is non-ASCII, so the folding only matters for custom
+      // rules — but the parity is free.
+      const re = new RegExp(escapeRegExp(kw), caseSensitive ? 'gu' : 'giu');
       let m: RegExpExecArray | null;
       // An escaped non-empty keyword only ever matches a non-empty run, so the
       // `g` flag always advances past it and the walk terminates.

--- a/packages/detections/test/matchers/keyword.test.ts
+++ b/packages/detections/test/matchers/keyword.test.ts
@@ -1,0 +1,134 @@
+import type { Rule } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { KeywordMatcher } from '../../src/matchers/keyword.ts';
+
+// Constructed as plain objects (not Rule.parse()) — the matcher must stay safe
+// on its own even if a keyword somehow bypasses schema validation (the
+// empty-keyword reject lives in packages/schema's KeywordMatcher).
+function keywordRule(keywords: string[], caseSensitive?: boolean): Rule {
+  return {
+    specVersion: 1,
+    id: 'test-pack/test-rule',
+    name: 'test',
+    category: 'custom',
+    severity: 'low',
+    matcher: { type: 'keyword', keywords, caseSensitive: caseSensitive ?? false },
+  };
+}
+
+// Spans are only meaningful against the text they were found in.
+function slices(text: string, rule: Rule): string[] {
+  return new KeywordMatcher().match(text, rule).map((s) => text.slice(s.start, s.end));
+}
+
+describe('KeywordMatcher', () => {
+  it('returns spans that index the original text, not a case-folded copy', () => {
+    const matcher = new KeywordMatcher();
+    // "İ".toLowerCase() is two code units, so a lowercased haystack is one char
+    // longer than the input. Searching that copy while sizing the span with the
+    // original keyword's length shifted every later span by one, which made
+    // redact() mask the wrong characters and leak the match's first char.
+    const text = 'İ my password is hunter2';
+    expect(matcher.match(text, keywordRule(['password']))).toEqual([{ start: 5, end: 13 }]);
+    expect(slices(text, keywordRule(['password']))).toEqual(['password']);
+  });
+
+  it('keeps spans aligned for every keyword after a length-changing char', () => {
+    const text = 'İ password ﬁ secret';
+    expect(slices(text, keywordRule(['password', 'secret']))).toEqual(['password', 'secret']);
+  });
+
+  it('measures the span from the matched text, not the keyword', () => {
+    // The matched run and the keyword can differ under case-folding; the span
+    // must describe what is actually in `text`.
+    expect(slices('the STRASSE sign', keywordRule(['strasse']))).toEqual(['STRASSE']);
+  });
+
+  it('matches case-insensitively by default', () => {
+    const matcher = new KeywordMatcher();
+    expect(matcher.match('MY PASSWORD', keywordRule(['password']))).toEqual([
+      { start: 3, end: 11 },
+    ]);
+  });
+
+  it('honours caseSensitive', () => {
+    const matcher = new KeywordMatcher();
+    expect(matcher.match('MY PASSWORD', keywordRule(['password'], true))).toEqual([]);
+    expect(matcher.match('my password', keywordRule(['password'], true))).toEqual([
+      { start: 3, end: 11 },
+    ]);
+  });
+
+  it('treats regex metacharacters in a keyword as literal text', () => {
+    // Bundled rules ship keywords containing regex syntax — core-code-context/
+    // db-table-name has "SELECT * FROM ", core-financial/salary has "i make $".
+    // Unescaped, "*" would quantify the preceding space and "$" would anchor.
+    expect(slices('SELECT * FROM users', keywordRule(['SELECT * FROM ']))).toEqual([
+      'SELECT * FROM ',
+    ]);
+    expect(slices('SELECT COUNT(*) FROM t', keywordRule(['SELECT COUNT(*) FROM ']))).toEqual([
+      'SELECT COUNT(*) FROM ',
+    ]);
+    expect(slices('i make $200k', keywordRule(['i make $']))).toEqual(['i make $']);
+  });
+
+  it('does not let a metacharacter keyword match as a pattern', () => {
+    const matcher = new KeywordMatcher();
+    // "SELECT * FROM " as a live pattern would match "SELECTFROM " (zero spaces).
+    expect(matcher.match('SELECTFROM users', keywordRule(['SELECT * FROM ']))).toEqual([]);
+    // "i make $" anchored would match at end-of-input after "i make ".
+    expect(matcher.match('i make ', keywordRule(['i make $']))).toEqual([]);
+  });
+
+  it('returns one span per non-overlapping occurrence', () => {
+    const matcher = new KeywordMatcher();
+    expect(matcher.match('foo bar foo', keywordRule(['foo']))).toEqual([
+      { start: 0, end: 3 },
+      { start: 8, end: 11 },
+    ]);
+  });
+
+  it('advances past a self-overlapping keyword instead of re-matching it', () => {
+    const matcher = new KeywordMatcher();
+    // A self-overlapping keyword ("aa" in "aaa") yields the leading occurrence
+    // only. redact() masks that span either way, and no bundled keyword
+    // overlaps itself, so this pins the traversal, not a detection requirement.
+    expect(matcher.match('aaa', keywordRule(['aa']))).toEqual([{ start: 0, end: 2 }]);
+  });
+
+  it('folds case by code point, not code unit', () => {
+    // "ß" and "ẞ" are one code unit each but fold to each other only under the
+    // regex `u` flag; a code-unit comparison reports no match.
+    expect(slices('the ẞ here', keywordRule(['ß']))).toEqual(['ẞ']);
+    expect(slices('the ß here', keywordRule(['ẞ']))).toEqual(['ß']);
+  });
+
+  it('skips an empty keyword that bypasses schema validation', () => {
+    const matcher = new KeywordMatcher();
+    const start = Date.now();
+    // An empty keyword matches at every position without advancing lastIndex.
+    // Under the `u` flag a manual bump lands mid-surrogate and snaps back to
+    // the code-point boundary, re-matching the same index forever — so the
+    // keyword is skipped outright rather than walked.
+    expect(matcher.match('hello 🔑 world', keywordRule(['']))).toEqual([]);
+    expect(Date.now() - start).toBeLessThan(1000);
+  });
+
+  it('still matches the other keywords when one is empty', () => {
+    expect(slices('my password', keywordRule(['', 'password']))).toEqual(['password']);
+  });
+
+  it('returns no spans for a non-keyword matcher', () => {
+    const matcher = new KeywordMatcher();
+    const rule: Rule = {
+      specVersion: 1,
+      id: 'test-pack/test-rule',
+      name: 'test',
+      category: 'custom',
+      severity: 'low',
+      matcher: { type: 'regex', pattern: 'foo', flags: 'g' },
+    };
+    expect(matcher.match('foo', rule)).toEqual([]);
+  });
+});

--- a/packages/detections/test/matchers/keyword.test.ts
+++ b/packages/detections/test/matchers/keyword.test.ts
@@ -91,15 +91,32 @@ describe('KeywordMatcher', () => {
 
   it('advances past a self-overlapping keyword instead of re-matching it', () => {
     const matcher = new KeywordMatcher();
-    // A self-overlapping keyword ("aa" in "aaa") yields the leading occurrence
-    // only. redact() masks that span either way, and no bundled keyword
-    // overlaps itself, so this pins the traversal, not a detection requirement.
+    // The `g`-advance keeps only the leading occurrence of a self-overlapping
+    // keyword ("aa" in "aaa"). Four bundled keywords do self-overlap with a
+    // 1-char border — "todo-secret", "shipping address", and the two name-field
+    // keywords in core-pii/name — so on a contrived doubled input the change is
+    // observable: "shipping addresshipping address" now yields one span, where
+    // the old traversal yielded two. Accepted because the un-redacted remainder
+    // is the keyword's own tail, never a third-party secret, and `g`-advance is
+    // the correct regex semantics. Verified below.
     expect(matcher.match('aaa', keywordRule(['aa']))).toEqual([{ start: 0, end: 2 }]);
   });
 
-  it('folds case by code point, not code unit', () => {
-    // "ß" and "ẞ" are one code unit each but fold to each other only under the
-    // regex `u` flag; a code-unit comparison reports no match.
+  it('drops the overlapping second match of a self-bordering bundled keyword', () => {
+    const matcher = new KeywordMatcher();
+    // Pins the real behaviour the comment above describes: the surviving text is
+    // the keyword's own suffix ("hipping address"), not leaked third-party data.
+    const spans = matcher.match(
+      'shipping addresshipping address',
+      keywordRule(['shipping address']),
+    );
+    expect(spans).toEqual([{ start: 0, end: 16 }]);
+  });
+
+  it('folds "ß"/"ẞ" under the u flag, which a plain i regex would drop', () => {
+    // "ß" and "ẞ" fold to each other under the regex `u` flag but not under a
+    // plain `i` regex. The old case-folded-copy matcher folded them too (via
+    // toLowerCase), so `u` is what keeps parity here rather than adding folding.
     expect(slices('the ẞ here', keywordRule(['ß']))).toEqual(['ẞ']);
     expect(slices('the ß here', keywordRule(['ẞ']))).toEqual(['ß']);
   });

--- a/packages/detections/test/security/unicode.test.ts
+++ b/packages/detections/test/security/unicode.test.ts
@@ -1,0 +1,138 @@
+import { Rule } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { redact, scan } from '../../src/index.ts';
+
+// Parsed through the real schema — these assert the shipped path end to end
+// (scan -> span -> rawMatch -> redact), not just a matcher in isolation.
+function keywordRule(keywords: string[], id = 'test-pack/kw'): Rule {
+  return Rule.parse({
+    specVersion: 1,
+    id,
+    name: 'test',
+    category: 'secret',
+    severity: 'high',
+    matcher: { type: 'keyword', keywords },
+  });
+}
+
+function regexRule(pattern: string, id = 'test-pack/re'): Rule {
+  return Rule.parse({
+    specVersion: 1,
+    id,
+    name: 'test',
+    category: 'secret',
+    severity: 'high',
+    matcher: { type: 'regex', pattern, flags: 'gi' },
+  });
+}
+
+function slices(text: string, rules: Rule[]): string[] {
+  return scan(text, rules).map((f) => text.slice(f.span.start, f.span.end));
+}
+
+// Characters whose case-folded form differs in length from the source, plus
+// astral and bidi text. Any of these ahead of a match used to shift its span.
+const SHIFTING_CHARS: readonly (readonly [string, string])[] = [
+  ['U+0130 dotted capital I', 'İ'],
+  ['U+FB01 fi ligature', 'ﬁ'],
+  ['U+1E9E capital sharp s', 'ẞ'],
+  ['U+0587 armenian ech-yiwn', 'և'],
+  ['astral emoji', '🔑'],
+  ['combining acute', 'é'],
+  ['RTL override', '‮'],
+];
+
+describe('unicode span integrity', () => {
+  it('does not shift a keyword span after a length-changing lowercase char', () => {
+    // Regression: the matcher searched text.toLowerCase() but sized the span
+    // with the original keyword's length. "İ".toLowerCase() is two code units,
+    // so every span after it was off by one — redact() then masked from one
+    // char late, leaving the match's first character in the output.
+    const text = 'İ my password is hunter2';
+    const findings = scan(text, [keywordRule(['password'])]);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.span).toEqual({ start: 5, end: 13 });
+    expect(findings[0]?.rawMatch).toBe('password');
+    expect(redact(text, findings)).toBe('İ my [REDACTED:SECRET] is hunter2');
+  });
+
+  it.each(SHIFTING_CHARS)('keeps the span aligned with %s before the match', (_label, char) => {
+    const text = `${char} my password is hunter2`;
+    expect(slices(text, [keywordRule(['password'])])).toEqual(['password']);
+    expect(scan(text, [keywordRule(['password'])])[0]?.rawMatch).toBe('password');
+  });
+
+  it.each(SHIFTING_CHARS)('keeps the span aligned with %s inside the text', (_label, char) => {
+    const text = `a ${char} b password c`;
+    expect(slices(text, [keywordRule(['password'])])).toEqual(['password']);
+  });
+
+  it('keeps regex spans aligned after a length-changing char', () => {
+    const text = 'İ token=abc123def';
+    expect(slices(text, [regexRule('token=[a-z0-9]+')])).toEqual(['token=abc123def']);
+  });
+});
+
+describe('redaction containment', () => {
+  // Asserted against the keyword we planted, never against finding.rawMatch:
+  // engine.ts derives rawMatch by slicing the span it is given, so a finding is
+  // self-consistent even when its span is wrong. Comparing the two only proves
+  // slice() works. Ground truth is the only thing that catches a shifted span.
+  it('never leaves a planted secret in the redacted output', () => {
+    const secrets = ['password', 'secret'];
+    const rules = [keywordRule(['password']), keywordRule(['secret'], 'test-pack/kw2')];
+    let checked = 0;
+
+    for (const [, char] of SHIFTING_CHARS) {
+      for (const template of [
+        `${char} my password is x`,
+        `my password ${char} is secret`,
+        `${char}${char} password secret ${char}`,
+        `password ${char} secret`,
+        `${char} secret`,
+      ]) {
+        const findings = scan(template, rules);
+        const output = redact(template, findings);
+
+        for (const secret of secrets) {
+          if (!template.includes(secret)) continue;
+          // Every planted secret is present, so every one must be found...
+          expect(findings.some((f) => f.rawMatch === secret)).toBe(true);
+          // ...and none may survive redaction, whole or in part.
+          expect(output).not.toContain(secret);
+          expect(output).not.toContain(secret.slice(1));
+          checked++;
+        }
+      }
+    }
+
+    expect(checked).toBeGreaterThan(30);
+  });
+
+  it('does not leak the first character when a match follows a shifting char', () => {
+    // The exact failure shape of the original bug: a one-char shift left the
+    // match's leading character outside the redacted region.
+    for (const [, char] of SHIFTING_CHARS) {
+      const text = `${char} my password is hunter2`;
+      const output = redact(text, scan(text, [keywordRule(['password'])]));
+      expect(output).not.toContain('assword');
+      expect(output).not.toContain('p[REDACTED');
+    }
+  });
+});
+
+describe('non-ascii inputs do not corrupt spans', () => {
+  it('matches a keyword surrounded by astral characters', () => {
+    expect(slices('🔑🔑 password 🔑🔑', [keywordRule(['password'])])).toEqual(['password']);
+  });
+
+  it('tolerates a lone surrogate without throwing or mislocating', () => {
+    expect(slices('\ud800 password', [keywordRule(['password'])])).toEqual(['password']);
+  });
+
+  it('scans an empty string without matches', () => {
+    expect(scan('', [keywordRule(['password'])])).toEqual([]);
+  });
+});

--- a/packages/schema/src/zod/rule.ts
+++ b/packages/schema/src/zod/rule.ts
@@ -8,7 +8,11 @@ export type MatcherType = z.infer<typeof MatcherType>;
 
 export const KeywordMatcher = z.object({
   type: z.literal('keyword'),
-  keywords: z.array(z.string()).min(1),
+  // An empty keyword matches at every position, yielding one zero-length span
+  // per character — the KeywordMatcher has no per-rule match ceiling, so a
+  // large input would allocate a span per byte. Rejected here rather than
+  // capped there: a keyword that matches everything is never intentional.
+  keywords: z.array(z.string().min(1)).min(1),
   caseSensitive: z.boolean().default(false),
 });
 

--- a/packages/schema/test/zod/rule.test.ts
+++ b/packages/schema/test/zod/rule.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { Rule } from '../../src/zod/rule.ts';
+
+function keywordRule(matcher: Record<string, unknown>) {
+  return {
+    specVersion: 1,
+    id: 'test-pack/test-rule',
+    name: 'test',
+    category: 'secret',
+    severity: 'high',
+    matcher: { type: 'keyword', ...matcher },
+  };
+}
+
+describe('Rule keyword matcher contract', () => {
+  it('accepts a keyword rule and defaults caseSensitive to false', () => {
+    const parsed = Rule.parse(keywordRule({ keywords: ['password'] }));
+    expect(parsed.matcher).toEqual({
+      type: 'keyword',
+      keywords: ['password'],
+      caseSensitive: false,
+    });
+  });
+
+  it('rejects an empty keyword', () => {
+    // An empty keyword matches at every position; the KeywordMatcher has no
+    // per-rule match ceiling, so a large input would allocate a span per byte.
+    expect(Rule.safeParse(keywordRule({ keywords: [''] })).success).toBe(false);
+    expect(Rule.safeParse(keywordRule({ keywords: ['password', ''] })).success).toBe(false);
+  });
+
+  it('rejects an empty keyword list', () => {
+    expect(Rule.safeParse(keywordRule({ keywords: [] })).success).toBe(false);
+  });
+
+  it('accepts keywords containing regex metacharacters', () => {
+    // Bundled rules ship these verbatim — core-code-context/db-table-name has
+    // "SELECT * FROM ", core-financial/salary has "i make $". The matcher
+    // escapes them; the schema must not reject them.
+    const parsed = Rule.parse(
+      keywordRule({ keywords: ['SELECT * FROM ', 'SELECT COUNT(*) FROM ', 'i make $'] }),
+    );
+    expect(parsed.matcher.type).toBe('keyword');
+  });
+});


### PR DESCRIPTION
## The bug

The keyword matcher searched a **case-folded copy** of the input but sized each span with the **original keyword's** length:

```ts
const haystack = caseSensitive ? text : text.toLowerCase();
spans.push({ start: pos, end: pos + kw.length });
//            ^ index into the LOWERCASED haystack
//                         ^ length of the ORIGINAL keyword
```

`toLowerCase()` is not length-preserving — `İ` (U+0130) folds to two code units — so any such character before a match shifts every later span by one. **`redact()` then masks from one character late and leaves the secret's leading character in the output:**

```
input:     "İ my password is hunter2"
redacted:  "İ my p[REDACTED:SECRET]is hunter2"
                  ^^ the 'p' survives; a correct char is eaten instead
```

The bad span also flows into `rawMatch`, and from there into `maskedMatch` (what the user sees), the **exception fingerprint** (an HMAC of the wrong bytes can never match), and the blocked-detections reference.

Affects the **11 bundled keyword rules** — the default is `caseSensitive: false`. There was no Unicode test anywhere in the detections suite.

## The fix

Match an escaped literal against the **original** text, so offsets and lengths share one coordinate space.

- **`u` flag** — folds by code point, so `ß` now matches `ẞ`; the code-unit comparison missed it.
- **Empty keywords are skipped, not walked.** They match at every position without advancing, and under `u` a manual `lastIndex` bump lands mid-surrogate and snaps back to the code-point boundary, re-matching index 0 **forever**. An escaped non-empty keyword can only match a non-empty run, so the walk always terminates.
- **Escaping is load-bearing** and now pinned: bundled rules ship keywords containing regex syntax (`SELECT * FROM `, `SELECT COUNT(*) FROM `, `i make $`). Unescaped these become wrong patterns *silently*, rather than throwing.
- **Schema rejects empty keywords** — `.min(1)` sat on the array, not the string, so `keywords: [""]` was valid and produced a zero-length span per character with no per-rule ceiling.

## Verification

- **8 of the new tests fail on the pre-fix code**, including the leak assertion — verified by reverting the fix and re-running.
- All **101 bundled rule fixtures** still pass; full suite green.
- `packages/schema/test/zod/rule.test.ts` is new — the `Rule` schema had no dedicated test.

## A trap worth knowing

The tests assert against a **planted value**, never against `finding.rawMatch`. `engine.ts:172` computes `rawMatch = text.slice(span.start, span.end)` — so a finding is self-consistent *even when its span is wrong*, and a `rawMatch`-based containment check **passes on the buggy code**. The first draft of that test did exactly this and was silently worthless.

## Behaviour changes

- Self-overlapping keywords (`aa` in `aaa`) now yield one span, not two — `g` advances past each match where `idx = pos + 1` did not. No bundled keyword self-overlaps; pinned as traversal, not a detection requirement.
- `İ` still won't match its own lowercase `i̇` — that is *full* case folding; regex `u` does *simple* folding. No bundled keyword is affected, and closing it would mean reintroducing the case-folded copy that caused this bug.