### PR TITLE
fix(plugin-sdk): record each finding at its own action

### DIFF
--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -198,6 +198,19 @@ export function createPluginRuntime(
     return fallback ?? 'log';
   }
 
+  // The action that applies to ONE finding: an excepted finding's action is
+  // 'allow' — its grant was already consumed — and every other finding resolves
+  // through its own rule/category policy. This is per-finding, unlike `decide`'s
+  // worst-first collapse across the whole capture: a capture that mixes a
+  // blocked secret with a warned code-context match applies 'block' to the
+  // former and 'warn' to the latter.
+  function actionForFinding(
+    finding: MatchResult,
+    excepted?: ReadonlySet<MatchResult>,
+  ): ActionTaken {
+    return excepted?.has(finding) ? 'allow' : resolveAction(finding.ruleId, finding.category);
+  }
+
   function decide(
     findings: MatchResult[],
     text: string,
@@ -205,9 +218,7 @@ export function createPluginRuntime(
   ): CaptureResult {
     if (findings.length === 0) return { action: 'log', text, findings: [] };
 
-    // An excepted finding's action is 'allow' — its grant was already consumed.
-    const actionFor = (finding: MatchResult): ActionTaken =>
-      excepted?.has(finding) ? 'allow' : resolveAction(finding.ruleId, finding.category);
+    const actionFor = (finding: MatchResult): ActionTaken => actionForFinding(finding, excepted);
 
     let worst: ActionTaken = 'log';
     for (const finding of findings) {
@@ -458,8 +469,9 @@ export function createPluginRuntime(
       const findingKeyFingerprintKey = isAtRest ? keyForLedger() : null;
       const findingKeyFpCache = new Map<MatchResult, string>();
       // Mask the real secret here — the raw value never reaches the gateway/DB.
-      // An excepted finding is still recorded, with the action that actually
-      // applied to it ('allow'), so the findings table stays the one
+      // Every finding is recorded with the action that actually applied to IT —
+      // its own policy resolution, or 'allow' when a grant excepted it — not the
+      // capture's collapsed decision, so the findings table stays the one
       // enforcement audit trail.
       const findings: DetectedFindingWithKey[] = decision.findings.map((match) => {
         const maskedMatch = maskMatch(match.rawMatch);
@@ -485,7 +497,7 @@ export function createPluginRuntime(
           severity: match.severity,
           span: match.span,
           maskedMatch,
-          actionTaken: excepted.has(match) ? 'allow' : decision.action,
+          actionTaken: actionForFinding(match, excepted),
           confidence: match.confidence,
           ...(findingKey ? { findingKey } : {}),
         };

--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -204,11 +204,26 @@ export function createPluginRuntime(
   // worst-first collapse across the whole capture: a capture that mixes a
   // blocked secret with a warned code-context match applies 'block' to the
   // former and 'warn' to the latter.
+  //
+  // The legacy global ceiling is applied HERE so this stays the single
+  // definition of the action that actually applied: when it is enabled, 'warn'
+  // handling mode floors block/redact to warn. `decide`'s aggregate collapse and
+  // the findings audit trail both resolve through this function, so neither can
+  // record a stronger action than the capture actually took.
   function actionForFinding(
     finding: MatchResult,
     excepted?: ReadonlySet<MatchResult>,
   ): ActionTaken {
-    return excepted?.has(finding) ? 'allow' : resolveAction(finding.ruleId, finding.category);
+    if (excepted?.has(finding)) return 'allow';
+    const action = resolveAction(finding.ruleId, finding.category);
+    if (
+      ENFORCEMENT_CEILING_ENABLED &&
+      policyMode === 'warn' &&
+      (action === 'block' || action === 'redact')
+    ) {
+      return 'warn';
+    }
+    return action;
   }
 
   function decide(
@@ -220,22 +235,13 @@ export function createPluginRuntime(
 
     const actionFor = (finding: MatchResult): ActionTaken => actionForFinding(finding, excepted);
 
+    // `worst` already reflects the legacy global ceiling: actionForFinding caps
+    // block/redact to warn when it is enabled, so the collapse inherits the cap
+    // and never needs to re-apply it here.
     let worst: ActionTaken = 'log';
     for (const finding of findings) {
       const action = actionFor(finding);
       if (ACTION_PRIORITY.indexOf(action) < ACTION_PRIORITY.indexOf(worst)) worst = action;
-    }
-
-    // Legacy global ceiling (disabled by default — ENFORCEMENT_CEILING_ENABLED
-    // above): when enabled, the onboarding "handling" choice caps block/redact
-    // down to warn. Per-category policies are the sole enforcement authority
-    // while it's off.
-    if (
-      ENFORCEMENT_CEILING_ENABLED &&
-      policyMode === 'warn' &&
-      (worst === 'block' || worst === 'redact')
-    ) {
-      return { action: 'warn', text, findings };
     }
 
     if (worst === 'block') return { action: 'block', text: null, findings };
@@ -355,8 +361,11 @@ export function createPluginRuntime(
       if (!key) return references;
       const seen = new Set<string>();
       for (const finding of decision.findings) {
-        const action = resolveAction(finding.ruleId, finding.category);
-        if ((action !== 'block' && action !== 'redact') || excepted.has(finding)) continue;
+        // The same per-finding resolution the findings write uses, so the ledger
+        // and the findings table agree by construction on what was enforced
+        // (excepted findings resolve to 'allow' and are skipped here).
+        const action = actionForFinding(finding, excepted);
+        if (action !== 'block' && action !== 'redact') continue;
         const fp = fingerprintOf(key, finding, fpCache);
         const pair = `${finding.ruleId}:${fp}`;
         if (seen.has(pair)) continue;

--- a/packages/plugin-sdk/test/runtime.test.ts
+++ b/packages/plugin-sdk/test/runtime.test.ts
@@ -335,6 +335,41 @@ describe('capture', () => {
     expect(record?.event.content).toContain('[REDACTED:SECRET]');
   });
 
+  it('records each finding at its own action, not the capture-wide decision', async () => {
+    const b = bundle();
+    b.policies = [
+      {
+        id: randomUUID(),
+        scope: 'global',
+        target: { category: 'secret' },
+        action: 'block',
+        enabled: true,
+      },
+      {
+        id: randomUUID(),
+        scope: 'global',
+        target: { category: 'pii' },
+        action: 'warn',
+        enabled: true,
+      },
+    ];
+    const gw = fakeGateway(b);
+    const rt = createPluginRuntime(gw, settings());
+    const result = await rt.capture({
+      kind: 'prompt',
+      sourceTool: 'claude-code',
+      text: 'deploy with SECRET_MARKER and PII_MARKER now',
+    });
+    await rt.close();
+
+    // The capture as a whole collapses worst-first to 'block'...
+    expect(result.action).toBe('block');
+    // ...but the PII match only warns, so it is recorded as 'warn'.
+    const byRule = new Map(gw.records[0]?.findings.map((f) => [f.ruleId, f.actionTaken] as const));
+    expect(byRule.get('test/secret-marker')).toBe('block');
+    expect(byRule.get('test/pii-marker')).toBe('warn');
+  });
+
   it('stamps the supplied occurredAt on the event (historical backfill)', async () => {
     const gw = fakeGateway(bundle());
     const rt = createPluginRuntime(gw, settings());


### PR DESCRIPTION
## Summary

`actionTaken` was written from `decision.action` — the capture's **worst-first collapsed** decision — onto *every* finding in that capture. A capture mixing a blocked secret with a warned match recorded **both** as `block`, inflating block counts and erasing warns in the findings table (the "one enforcement audit trail").

`decide()` already computed the correct per-finding action internally via its local `actionFor`. This lifts that into a factory-scoped `actionForFinding()` used by both the decision path and the findings write, so the two cannot drift.

## Changes

- `runtime.ts`: extract `actionForFinding(finding, excepted)` — excepted → `'allow'`, otherwise the finding's own rule/category resolution
- `runtime.ts`: `decide()`'s `actionFor` now delegates to it (no behaviour change to the collapse)
- `runtime.ts`: the findings write uses `actionForFinding(match, excepted)` instead of `decision.action`
- `test/runtime.test.ts`: regression test pinning per-finding actions in a mixed capture

## Verification

- New test confirmed to **fail without the fix** (`expected 'block' to be 'warn'` — the PII match mislabeled as a block), and pass with it.
- Driven end-to-end through the real `StandaloneDataGateway` + SQLite store with `secrets→block` / `pii→warn` assigned via the same `setPolicy` the dashboard calls, then queried the way the Security page does:
  - per-finding: `[["pii/marker","warn"],["secrets/marker","block"]]`
  - enforcement card: `total: 2` → **1 blocked + 1 warned** (previously would have reported 2 blocked, 0 warned)
- `@akasecurity/plugin-sdk`: 212 tests pass, typecheck + lint clean. Full workspace suite green.

## Notes

- Behaviour change applies to **future captures only** — existing `log` rows are unchanged.
- Latent until now: on a store where every pack is unassigned (Monitor ⇒ `log`), nothing resolves to block/redact/warn, so the mislabeling never surfaced. It would corrupt the audit trail as soon as enforcement is switched on.
- `decide()`'s `ENFORCEMENT_CEILING_ENABLED` block is deliberately untouched (it's hard-disabled). If it's ever re-enabled, the ceiling caps the *aggregate* to `warn` while per-finding actions would record the uncapped `block`/`redact` — that path would need the same cap in `actionForFinding`.