### PR TITLE
refactor(cli): route self-spawn + dashboard boot through subcommands (SEA-ready)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -4,7 +4,7 @@ import { cliVersion, notifyFromCache, refreshCache } from '@akasecurity/local-op
 import { commandsHelp } from './command-manifest.ts';
 import { runCheckUpdates } from './commands/check-updates.ts';
 import { runCompletion } from './commands/completion.ts';
-import { runDashboard } from './commands/dashboard.ts';
+import { runDashboard, runDashboardServer } from './commands/dashboard.ts';
 import { runDetections } from './commands/detections.ts';
 import { runException } from './commands/exception.ts';
 import { runInit } from './commands/init.ts';
@@ -35,11 +35,21 @@ const COMMANDS: Record<string, (argv: string[]) => void | Promise<void>> = {
   '__update-refresh': (argv) => {
     refreshCache(homeFromArgv(argv));
   },
+  // Hidden: boots the bundled Next standalone server in-process (see dashboard.ts).
+  // `aka dashboard` spawns this so a SEA binary can serve the dashboard without
+  // exec-ing an external script. Returns the promise so main() awaits the boot.
+  '__dashboard-server': (argv) => runDashboardServer(argv),
 };
 
 // Commands that already surface (or manage) update state — the passive post-command
 // notice would be redundant or recursive after these.
-const SKIP_NOTICE = new Set(['update', 'check-updates', '__update-refresh', 'completion']);
+const SKIP_NOTICE = new Set([
+  'update',
+  'check-updates',
+  '__update-refresh',
+  '__dashboard-server',
+  'completion',
+]);
 
 const USAGE = `aka — AI Traffic Control (local-first, everything stays on your machine)
 

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -3,10 +3,10 @@ import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { createServer } from 'node:net';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { parseArgs } from 'node:util';
 
-import { cliRecordedBy } from '@akasecurity/local-ops';
+import { cliRecordedBy, isSea, reinvokeArgv } from '@akasecurity/local-ops';
 import { openLocalDatabase } from '@akasecurity/persistence';
 import { bundledDetections, dataDir } from '@akasecurity/plugin-sdk';
 
@@ -14,6 +14,13 @@ import { openUrl } from '../lib/open-url.ts';
 
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
+
+// The package root that ships the bundled web-ui. Under a plain-node launch it is
+// one level above dist/ (this module's dir). A SEA binary has no source dir, so it
+// is the directory holding the executable, where release packaging places web-ui/.
+function pkgBase(): string {
+  return isSea() ? dirname(process.execPath) : join(here, '..');
+}
 
 // Is the port free to bind? Lets us print a friendly message instead of forwarding
 // Next's raw EADDRINUSE (after which the readiness regex never fires and the
@@ -98,9 +105,10 @@ export async function runDashboard(argv: string[]): Promise<void> {
   // Bundled standalone server ships under <package>/web-ui/ (dist/ is one level
   // under the package root). Next's monorepo standalone keeps the app nested
   // (web-ui/server.js) alongside a bundled node_modules, so check both.
+  const base = pkgBase();
   const bundledServer = [
-    join(here, '..', 'web-ui', 'server.js'),
-    join(here, '..', 'web-ui', 'web-ui', 'server.js'),
+    join(base, 'web-ui', 'server.js'),
+    join(base, 'web-ui', 'web-ui', 'server.js'),
   ].find((p) => existsSync(p));
   if (bundledServer) {
     launchStandalone(bundledServer, port, shouldOpen, url);
@@ -142,10 +150,19 @@ export async function runDashboard(argv: string[]): Promise<void> {
 }
 
 // Run the prebuilt Next standalone server (a plain Node server that reads PORT
-// from the environment). Inheriting the parent env is required so the child sees
-// PATH etc.; PORT/HOSTNAME are overridden for this launch.
+// from the environment). A SEA binary cannot spawn `server.js` as a script — it
+// would re-run the embedded CLI main — so route through the hidden
+// `__dashboard-server` subcommand, which requires the server IN-PROCESS in the
+// child. On plain node the effect is identical: a child process serving the
+// dashboard, with browser-open + signal forwarding handled by onReadyOpen.
 function launchStandalone(serverJs: string, port: string, shouldOpen: boolean, url: string): void {
-  const child = spawn(process.execPath, [serverJs], {
+  const reinvoke = reinvokeArgv('__dashboard-server', ['--server-js', serverJs]);
+  if (!reinvoke) {
+    process.stderr.write('aka dashboard: cannot resolve the CLI entry to launch the server.\n');
+    process.exitCode = 1;
+    return;
+  }
+  const child = spawn(reinvoke.command, reinvoke.args, {
     cwd: dirname(serverJs),
     stdio: ['inherit', 'pipe', 'inherit'],
     // Inherit the parent env so the child server sees PATH etc.; PORT/HOSTNAME tell
@@ -154,6 +171,26 @@ function launchStandalone(serverJs: string, port: string, shouldOpen: boolean, u
     env: { ...process.env, PORT: port, HOSTNAME: '127.0.0.1' },
   });
   onReadyOpen(child, shouldOpen, url, `Starting the AKA dashboard at ${url}\n`);
+}
+
+// The hidden `__dashboard-server` command: boot the prebuilt Next standalone server
+// IN-PROCESS. Spawned by launchStandalone with cwd = the server's dir and PORT/HOSTNAME
+// already in the env (the server's only bind inputs). Loading it in-process — rather
+// than running it as a child script — is what lets a SEA binary (which cannot exec an
+// arbitrary script) serve the dashboard; on plain node the behavior is unchanged.
+// Next's standalone server.js is an ESM module with no `require.main` guard: importing
+// it evaluates its top level, which starts the server (kept alive by its listen socket).
+// A dynamic import by file URL resolves without relying on this module's on-disk
+// location — which a SEA does not have.
+export async function runDashboardServer(argv: string[]): Promise<void> {
+  const { values } = parseArgs({ args: argv, options: { 'server-js': { type: 'string' } } });
+  const serverJs = values['server-js'];
+  if (serverJs === undefined || serverJs === '') {
+    process.stderr.write('aka __dashboard-server: --server-js <path> is required\n');
+    process.exitCode = 1;
+    return;
+  }
+  await import(pathToFileURL(serverJs).href);
 }
 
 // Pipe a child server's stdout through, open the browser once it reports ready,

--- a/cli/test/commands/dashboard.test.ts
+++ b/cli/test/commands/dashboard.test.ts
@@ -1,11 +1,11 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
-import { refreshUpdateMirror } from '../../src/commands/dashboard.ts';
+import { refreshUpdateMirror, runDashboardServer } from '../../src/commands/dashboard.ts';
 
 let dir: string;
 
@@ -43,4 +43,37 @@ it('pre-launch mirror refresh records the bundled inventory on a healthy store',
   const packs = (raw.prepare('SELECT count(*) AS n FROM available_packs').get() as { n: number }).n;
   raw.close();
   expect(packs).toBeGreaterThan(0); // the bundled packs landed in the mirror
+});
+
+// The `__dashboard-server` subcommand boots the standalone server IN-PROCESS via a
+// dynamic import — the mechanism a SEA binary relies on (it cannot exec an external
+// script). Next's real server.js is ESM with no `require.main` guard, so importing it
+// evaluates its top level and starts the server; the stand-in mirrors that shape.
+// Plain-node CI exercising this is what retires that risk before any binary exists.
+it('__dashboard-server imports the given server-js in-process (ESM, no entry guard)', async () => {
+  const serverJs = join(dir, 'server.mjs');
+  // Mirrors Next's standalone entry: ESM, __dirname via import.meta.url, boots on load.
+  writeFileSync(
+    serverJs,
+    "import { writeFileSync } from 'node:fs';\n" +
+      "import { fileURLToPath } from 'node:url';\n" +
+      "import { dirname, join } from 'node:path';\n" +
+      'const __dirname = dirname(fileURLToPath(import.meta.url));\n' +
+      "writeFileSync(join(__dirname, 'booted.txt'), 'ok');\n",
+  );
+
+  await runDashboardServer(['--server-js', serverJs]);
+
+  expect(existsSync(join(dir, 'booted.txt'))).toBe(true);
+});
+
+it('__dashboard-server without --server-js fails with a message, does not throw', async () => {
+  const stderr = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+  const prevExit = process.exitCode;
+
+  await expect(runDashboardServer([])).resolves.toBeUndefined();
+
+  expect(stderr.mock.calls.map((c) => String(c[0])).join('')).toContain('--server-js');
+  expect(process.exitCode).toBe(1);
+  process.exitCode = prevExit; // don't leak a failing exit code into the runner
 });

--- a/packages/local-ops/src/index.ts
+++ b/packages/local-ops/src/index.ts
@@ -19,6 +19,8 @@ export type { ProjectInventoryResult } from './project-inventory.ts';
 export { recordProjectInventory } from './project-inventory.ts';
 export type { AgentPlugin } from './registry.ts';
 export { AGENT_PLUGINS, findAgent, pluginRef } from './registry.ts';
+export type { Reinvocation } from './self-exec.ts';
+export { isSea, reinvokeArgv } from './self-exec.ts';
 export { compareSemver, isNewer } from './semver.ts';
 export {
   cachePath,

--- a/packages/local-ops/src/self-exec.test.ts
+++ b/packages/local-ops/src/self-exec.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildReinvocation, isSea, reinvokeArgv } from './self-exec.ts';
+
+describe('buildReinvocation', () => {
+  it('plain node: re-runs the entry script, then the subcommand and args', () => {
+    expect(
+      buildReinvocation(false, '/usr/bin/node', '/pkg/dist/cli.js', '__update-refresh', [
+        '--home',
+        '/home/.aka',
+      ]),
+    ).toEqual({
+      command: '/usr/bin/node',
+      args: ['/pkg/dist/cli.js', '__update-refresh', '--home', '/home/.aka'],
+    });
+  });
+
+  it('SEA: drops the entry script — the embedded main ignores argv[1]', () => {
+    expect(
+      buildReinvocation(true, '/opt/aka', '/pkg/dist/cli.js', '__dashboard-server', [
+        '--server-js',
+        '/opt/web-ui/server.js',
+      ]),
+    ).toEqual({
+      command: '/opt/aka',
+      args: ['__dashboard-server', '--server-js', '/opt/web-ui/server.js'],
+    });
+  });
+
+  it('SEA passes the subcommand as the FIRST arg (never a script path)', () => {
+    const r = buildReinvocation(true, '/opt/aka', '/pkg/dist/cli.js', '__update-refresh', []);
+    expect(r?.args[0]).toBe('__update-refresh');
+  });
+
+  it('plain node with no entry script cannot self-spawn', () => {
+    expect(buildReinvocation(false, '/usr/bin/node', undefined, '__update-refresh', [])).toBeNull();
+  });
+});
+
+describe('isSea / reinvokeArgv under the test runtime', () => {
+  it('reports not-a-SEA when run as a normal node process', () => {
+    expect(isSea()).toBe(false);
+  });
+
+  it('reinvokeArgv includes the entry script under plain node', () => {
+    const r = reinvokeArgv('__update-refresh', ['--home', '/tmp/.aka']);
+    expect(r).not.toBeNull();
+    expect(r?.command).toBe(process.execPath);
+    // process.argv[1] (the test runner entry) is present, then our subcommand.
+    expect(r?.args.slice(-3)).toEqual(['__update-refresh', '--home', '/tmp/.aka']);
+    expect(r?.args.length).toBeGreaterThan(3);
+  });
+});

--- a/packages/local-ops/src/self-exec.ts
+++ b/packages/local-ops/src/self-exec.ts
@@ -1,0 +1,48 @@
+import { createRequire } from 'node:module';
+
+// Re-invoking the running `aka` executable. A Node Single Executable Application
+// (SEA) runs its EMBEDDED main and ignores argv[1] as a script path, so a
+// self-spawn must pass a hidden subcommand — never the entry script — as the first
+// argument. Under a plain `node dist/cli.js` launch the entry script is still
+// required, so this returns the argv shape appropriate to the current runtime; the
+// plain-node shape is byte-identical to the historical hand-built one.
+
+const require = createRequire(import.meta.url);
+
+// Whether this process is a Single Executable Application. `node:sea` exists on
+// Node 21.7+; the import is guarded so a runtime without it (or a bundler that
+// drops it) reports "not a SEA" rather than throwing at module load.
+export function isSea(): boolean {
+  try {
+    const sea = require('node:sea') as { isSea?: () => boolean };
+    return typeof sea.isSea === 'function' ? sea.isSea() : false;
+  } catch {
+    return false;
+  }
+}
+
+export interface Reinvocation {
+  command: string;
+  args: string[];
+}
+
+// Pure argv builder — kept separate from the global reads so it is exhaustively
+// testable across both runtimes without spawning or mocking `node:sea`.
+export function buildReinvocation(
+  sea: boolean,
+  execPath: string,
+  entry: string | undefined,
+  subcommand: string,
+  extraArgs: string[],
+): Reinvocation | null {
+  if (sea) return { command: execPath, args: [subcommand, ...extraArgs] };
+  // Plain node: re-run the entry script, then the subcommand. Missing argv[1]
+  // means we cannot self-spawn — callers treat null as "skip", exactly as before.
+  if (entry === undefined) return null;
+  return { command: execPath, args: [entry, subcommand, ...extraArgs] };
+}
+
+// Build the command + argv to re-invoke THIS executable at a hidden subcommand.
+export function reinvokeArgv(subcommand: string, extraArgs: string[] = []): Reinvocation | null {
+  return buildReinvocation(isSea(), process.execPath, process.argv[1], subcommand, extraArgs);
+}

--- a/packages/local-ops/src/update-cache.ts
+++ b/packages/local-ops/src/update-cache.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { dataDir } from '@akasecurity/persistence';
 import type { UpdateCache } from '@akasecurity/schema';
 
+import { reinvokeArgv } from './self-exec.ts';
 import { gatherReportLive, isRecord } from './updates.ts';
 
 // Passive-notice cache: a small JSON file next to the local store so a command can
@@ -75,10 +76,10 @@ export function refreshCache(home: string): void {
 // Fire a detached `aka __update-refresh --home <home>` that outlives this process,
 // so the NEXT command sees a fresh cache. Zero latency on the current command.
 function triggerBackgroundRefresh(home: string): void {
-  const entry = process.argv[1];
-  if (!entry) return;
+  const reinvoke = reinvokeArgv('__update-refresh', ['--home', home]);
+  if (!reinvoke) return;
   try {
-    spawn(process.execPath, [entry, '__update-refresh', '--home', home], {
+    spawn(reinvoke.command, reinvoke.args, {
       detached: true,
       stdio: 'ignore',
     }).unref();


### PR DESCRIPTION
Part of the SEA single-executable PR stack (pr1→pr6, review in order; each PR targets its predecessor, so merge pr1 first — GitHub retargets the rest automatically). Authored by @joshuas99; rebased onto current main with conflict resolutions noted below where applicable. Verified on the stack tip: full workspace suite 24/24 tasks green; SEA JS bundle builds (2.7 MB). The native per-platform binary build + release workflows run in CI only.

**This PR:** replaces script-path self-spawns with subcommand dispatch so the CLI works when packaged as a single binary. Conflict resolution vs main: the dashboard test had been relocated to cli/test/commands/ upstream — this PR's added symbols and two new __dashboard-server tests were merged onto the relocated file (4 dashboard tests green).