### PR TITLE
ci(cli): archive SEA binaries and publish to GitHub Releases

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -28,9 +28,11 @@ jobs:
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
           - { os: windows-2022, target: win32-x64 }
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+      - uses: actions/setup-node@v6
         with:
           node-version: 26
           cache: pnpm

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         include:
           - { os: macos-14, target: darwin-arm64 }
-          - { os: macos-13, target: darwin-x64 }
           - { os: ubuntu-24.04, target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
           - { os: windows-2022, target: win32-x64 }

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,97 @@
+name: Release binaries
+
+# Builds the self-contained `aka` Single Executable Application for each OS/arch,
+# archives it with its sidecars, and attaches the archives + SHA256SUMS to a GitHub
+# Release. The result needs no Node.js installed. SEA has no cross-compilation, so each
+# target builds on its own runner; a final job gathers the archives and cuts the Release.
+#
+# Release flow: bump cli/package.json, then push a tag `bin-v<version>` (e.g. bin-v0.8.1).
+# Or run via workflow_dispatch for a dry run (build + archive, no Release).
+
+on:
+  push:
+    tags:
+      - 'bin-v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14, target: darwin-arm64 }
+          - { os: macos-13, target: darwin-x64 }
+          - { os: ubuntu-24.04, target: linux-x64 }
+          - { os: ubuntu-24.04-arm, target: linux-arm64 }
+          - { os: windows-2022, target: win32-x64 }
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # build:sea (ESM bundle) → bundle:web-ui (standalone sidecar) → package:sea
+      # (binary + self-verify via --version) → archive:sea (tarball/zip + sha256).
+      - run: pnpm --filter @akasecurity/cli build:sea
+      - run: pnpm --filter @akasecurity/cli bundle:web-ui
+      - run: pnpm --filter @akasecurity/cli package:sea
+      - run: pnpm --filter @akasecurity/cli archive:sea
+      - uses: actions/upload-artifact@v4
+        with:
+          name: aka-${{ matrix.target }}
+          path: |
+            cli/sea-dist/aka-*.tar.gz
+            cli/sea-dist/aka-*.zip
+            cli/sea-dist/aka-*.sha256
+          if-no-files-found: error
+
+  release:
+    name: Gather · Release
+    needs: build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # create the GitHub Release
+    steps:
+      - uses: actions/checkout@v7
+
+      # Fail fast on a version mismatch before touching the Release.
+      - name: Verify tag matches package version
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME#bin-v}"
+          pkg=$(node -p "require('./cli/package.json').version")
+          echo "tag=$tag  package.json=$pkg"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Version mismatch — tag bin-v$tag must equal cli/package.json ($pkg)"
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Aggregate SHA256SUMS
+        run: |
+          cd dist
+          cat aka-*.sha256 > SHA256SUMS
+          rm -f aka-*.sha256
+          cat SHA256SUMS
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: |
+            dist/aka-*.tar.gz
+            dist/aka-*.zip
+            dist/SHA256SUMS
+          generate_release_notes: true
+          prerelease: ${{ startsWith(github.ref_name, 'bin-v0.') }}

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -23,7 +23,6 @@ jobs:
       matrix:
         include:
           - { os: macos-14, target: darwin-arm64 }
-          - { os: macos-13, target: darwin-x64 }
           - { os: ubuntu-24.04, target: linux-x64 }
           - { os: ubuntu-24.04-arm, target: linux-arm64 }
           - { os: windows-2022, target: win32-x64 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -31,6 +31,7 @@
     "build:sea": "tsup --config tsup.sea.config.ts",
     "smoke:sea": "node scripts/smoke-sea.mjs",
     "package:sea": "node scripts/package-sea.mjs",
+    "archive:sea": "node scripts/archive-sea.mjs",
     "bundle:web-ui": "node scripts/bundle-web-ui.mjs",
     "prepack": "tsup && node scripts/bundle-web-ui.mjs",
     "lint": "eslint src test",

--- a/cli/scripts/archive-sea.mjs
+++ b/cli/scripts/archive-sea.mjs
@@ -1,0 +1,46 @@
+// Archive the packaged SEA binary + its sidecars into a distributable tarball (unix) or
+// zip (Windows), and emit the archive's SHA-256. Run after `package:sea`. Output:
+//   sea-dist/aka-<version>-<platform>-<arch>.(tar.gz|zip)  (+ a matching .sha256)
+// The archive contains the `aka-<platform>-<arch>/` directory (binary + boot.cjs +
+// cli.mjs + package.json + web-ui), so extracting yields a ready-to-run tree.
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const cliDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { platform, arch } = process;
+const isWin = platform === 'win32';
+const triple = `${platform}-${arch}`;
+const seaDist = join(cliDir, 'sea-dist');
+const stagedName = `aka-${triple}`;
+const stagedDir = join(seaDist, stagedName);
+if (!existsSync(stagedDir)) {
+  throw new Error(`missing ${stagedDir} — run \`pnpm package:sea\` first`);
+}
+
+const { version } = JSON.parse(readFileSync(join(cliDir, 'package.json'), 'utf8'));
+const archiveName = `aka-${version}-${triple}.${isWin ? 'zip' : 'tar.gz'}`;
+const archivePath = join(seaDist, archiveName);
+rmSync(archivePath, { force: true });
+
+if (isWin) {
+  execFileSync(
+    'powershell',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `Compress-Archive -Force -Path '${stagedDir}' -DestinationPath '${archivePath}'`,
+    ],
+    { stdio: 'inherit' },
+  );
+} else {
+  execFileSync('tar', ['-czf', archivePath, '-C', seaDist, stagedName], { stdio: 'inherit' });
+}
+
+const sha = createHash('sha256').update(readFileSync(archivePath)).digest('hex');
+const line = `${sha}  ${archiveName}\n`;
+writeFileSync(`${archivePath}.sha256`, line);
+process.stdout.write(`archived: ${archivePath}\n${line}`);

--- a/cli/scripts/bundle-web-ui.mjs
+++ b/cli/scripts/bundle-web-ui.mjs
@@ -26,9 +26,12 @@ const log = (m) => process.stdout.write(`bundle-web-ui: ${m}\n`);
 // 1. Build the web-ui standalone (Turbo-cached, so this is cheap when unchanged).
 //    Always rebuild so the bundle is fresh regardless of how prepack was invoked.
 log('building @akasecurity/web-ui (output: standalone)…');
+// `shell` on Windows: pnpm is pnpm.cmd there, and Node refuses to execFile a .cmd
+// without a shell — so route the launcher through cmd.exe. No-op elsewhere.
 execFileSync('pnpm', ['turbo', 'run', 'build', '--filter=@akasecurity/web-ui'], {
   cwd: repoRoot,
   stdio: 'inherit',
+  shell: process.platform === 'win32',
 });
 if (!existsSync(standalone)) {
   throw new Error(


### PR DESCRIPTION
Part of the SEA single-executable PR stack (pr1→pr6, review in order; each PR targets its predecessor, so merge pr1 first — GitHub retargets the rest automatically). Authored by @joshuas99; rebased onto current main with conflict resolutions noted below where applicable. Verified on the stack tip: full workspace suite 24/24 tasks green; SEA JS bundle builds (2.7 MB). The native per-platform binary build + release workflows run in CI only.

**This PR:** 3 commits — the release-binaries workflow, a Windows bundle fix + action pinning, and dropping the darwin-x64 target (macos-13 Intel runners retired).