### PR TITLE
ci(plugin): also publish the plugin to GitHub Packages

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -1,10 +1,12 @@
 name: Release plugin
 
-# Publishes the Claude Code plugin package to the public npm registry and
-# attaches the packed tarball to a GitHub Release. The plugin's hook scripts are
-# a build artifact (plugins/claude-code/scripts/, git-ignored) — they are
-# generated here and shipped inside the package, never committed. End users
-# install via the `ai-tc` marketplace, whose source resolves this package.
+# Publishes the Claude Code plugin package to the public npm registry AND to the
+# repo's GitHub Packages registry, and attaches the packed tarball to a GitHub
+# Release. The plugin's hook scripts are a build artifact
+# (plugins/claude-code/scripts/, git-ignored) — they are generated here and shipped
+# inside the package, never committed. End users install via the `ai-tc` marketplace,
+# whose source resolves this package from public npm (GitHub Packages requires auth
+# even for public reads, so it is a secondary artifact, not the marketplace source).
 #
 # Release flow: bump version in package.json + .claude-plugin/plugin.json, then
 # push a tag `plugin-v<version>` (e.g. plugin-v0.1.0).
@@ -118,3 +120,43 @@ jobs:
           files: ${{ runner.temp }}/*.tgz
           generate_release_notes: true
           prerelease: ${{ startsWith(github.ref_name, 'plugin-v0.') }}
+
+  # Publish the same package to the repo's GitHub Packages registry (requirement:
+  # packages land in the org's GitHub registry). Kept a separate job so its GitHub
+  # Packages .npmrc/auth never collides with the public-npm publish above. The
+  # @akasecurity scope must match the akasecurity org that owns this repo.
+  github-packages:
+    name: Publish to GitHub Packages
+    needs: verify
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: pnpm
+          registry-url: https://npm.pkg.github.com
+          scope: '@akasecurity'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin (Turbo)
+        run: pnpm turbo run build --filter=@akasecurity/ai-tc-claude-code
+
+      # publishConfig.registry pins public npm, so override the target here. The
+      # built-in GITHUB_TOKEN can publish to this repo's Packages; setup-node wrote
+      # the matching auth token into .npmrc.
+      - name: Publish to GitHub Packages
+        run: pnpm --filter @akasecurity/ai-tc-claude-code publish --registry https://npm.pkg.github.com --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of the SEA single-executable PR stack (pr1→pr6, review in order; each PR targets its predecessor, so merge pr1 first — GitHub retargets the rest automatically). Authored by @joshuas99; rebased onto current main with conflict resolutions noted below where applicable. Verified on the stack tip: full workspace suite 24/24 tasks green; SEA JS bundle builds (2.7 MB). The native per-platform binary build + release workflows run in CI only.

**This PR:** adds GitHub Packages publication for the plugin alongside npm.