### PR TITLE
fix(detections): cap KeywordMatcher matches per rule for parity with RegexMatcher

### DIFF
--- a/packages/detections/src/matchers/keyword.ts
+++ b/packages/detections/src/matchers/keyword.ts
@@ -2,6 +2,7 @@ import type { Rule, Span } from '@akasecurity/schema';
 
 import { escapeRegExp } from '../escape-regexp.ts';
 import type { Matcher } from '../types.ts';
+import { MAX_MATCHES_PER_RULE } from './limits.ts';
 
 export class KeywordMatcher implements Matcher {
   match(text: string, rule: Rule): Span[] {
@@ -14,6 +15,11 @@ export class KeywordMatcher implements Matcher {
       // `lastIndex`, so the walk below would not terminate. The schema rejects
       // it; skipping keeps the matcher safe on its own if a rule bypasses that.
       if (kw.length === 0) continue;
+
+      // The per-rule ceiling is shared across all of a rule's keywords: a
+      // 1-character keyword over a very large input would otherwise emit one
+      // span per occurrence. Stop before scanning any further keyword.
+      if (spans.length >= MAX_MATCHES_PER_RULE) break;
 
       // Match against the original `text` directly — a case-folded copy can
       // differ in length from `text` (e.g. "İ".toLowerCase() is two code
@@ -32,6 +38,7 @@ export class KeywordMatcher implements Matcher {
       // `g` flag always advances past it and the walk terminates.
       while ((m = re.exec(text)) !== null) {
         spans.push({ start: m.index, end: m.index + m[0].length });
+        if (spans.length >= MAX_MATCHES_PER_RULE) break;
       }
     }
     return spans;

--- a/packages/detections/src/matchers/limits.ts
+++ b/packages/detections/src/matchers/limits.ts
@@ -1,0 +1,7 @@
+// The absolute per-rule match ceiling shared by every matcher. It bounds how
+// many spans a single rule can produce — and therefore allocate — regardless of
+// input size. Two failure modes hit this cap: a matcher loop that never
+// advances (a zero-width regex match, or a future engine edge case), and a
+// well-formed but pathologically broad match (a 1-character keyword, or a regex
+// like "." over a very large input) that would otherwise emit one span per byte.
+export const MAX_MATCHES_PER_RULE = 10_000;

--- a/packages/detections/src/matchers/regex.ts
+++ b/packages/detections/src/matchers/regex.ts
@@ -1,13 +1,7 @@
 import type { Rule, Span } from '@akasecurity/schema';
 
 import type { Matcher } from '../types.ts';
-
-// An absolute per-scan match ceiling. A whole-match pattern that can match the
-// empty string (e.g. "\d*") re-matches at the same index forever unless
-// `lastIndex` is advanced — the `g`-flag loop below now does that — but this
-// ceiling stays as a second backstop against any other way a rule ends up
-// looping (a huge text, an unexpected zero-width edge case in a future engine).
-const MAX_MATCHES_PER_RULE = 10_000;
+import { MAX_MATCHES_PER_RULE } from './limits.ts';
 
 export class RegexMatcher implements Matcher {
   match(text: string, rule: Rule): Span[] {

--- a/packages/detections/test/matchers/keyword.test.ts
+++ b/packages/detections/test/matchers/keyword.test.ts
@@ -96,6 +96,16 @@ describe('KeywordMatcher', () => {
     expect(spans.length).toBe(10_000);
   });
 
+  it('shares the cap across keywords, not per keyword', () => {
+    const matcher = new KeywordMatcher();
+    // "a" alone fills the ceiling exactly; the second keyword must not push past
+    // it. Pins the outer-loop guard specifically — without it the next keyword's
+    // first match slips through the inner break and the total overshoots to 10,001.
+    const text = 'a'.repeat(10_000) + 'b'.repeat(5_000);
+    const spans = matcher.match(text, keywordRule(['a', 'b']));
+    expect(spans.length).toBe(10_000);
+  });
+
   it('advances past a self-overlapping keyword instead of re-matching it', () => {
     const matcher = new KeywordMatcher();
     // The `g`-advance keeps only the leading occurrence of a self-overlapping

--- a/packages/detections/test/matchers/keyword.test.ts
+++ b/packages/detections/test/matchers/keyword.test.ts
@@ -89,6 +89,13 @@ describe('KeywordMatcher', () => {
     ]);
   });
 
+  it('caps total matches at MAX_MATCHES_PER_RULE instead of growing unbounded', () => {
+    const matcher = new KeywordMatcher();
+    const text = 'a'.repeat(20_000);
+    const spans = matcher.match(text, keywordRule(['a']));
+    expect(spans.length).toBe(10_000);
+  });
+
   it('advances past a self-overlapping keyword instead of re-matching it', () => {
     const matcher = new KeywordMatcher();
     // The `g`-advance keeps only the leading occurrence of a self-overlapping

--- a/packages/schema/src/zod/rule.ts
+++ b/packages/schema/src/zod/rule.ts
@@ -9,9 +9,8 @@ export type MatcherType = z.infer<typeof MatcherType>;
 export const KeywordMatcher = z.object({
   type: z.literal('keyword'),
   // An empty keyword matches at every position, yielding one zero-length span
-  // per character — the KeywordMatcher has no per-rule match ceiling, so a
-  // large input would allocate a span per byte. Rejected here rather than
-  // capped there: a keyword that matches everything is never intentional.
+  // per character. Rejected here because a keyword that matches everything is
+  // never intentional.
   keywords: z.array(z.string().min(1)).min(1),
   caseSensitive: z.boolean().default(false),
 });


### PR DESCRIPTION
Deferred follow-up from the review of #23 (reviewer @Vaishnav-OM) — kept separate so as not to widen that approved PR.

## What

`RegexMatcher` already bounds its output at `MAX_MATCHES_PER_RULE = 10_000`; `KeywordMatcher` had no equivalent ceiling. Empty keywords are already rejected by the schema (`z.string().min(1)`) and skipped defensively in the matcher, so this is **not** the hang case — it bounds a well-formed but pathologically broad keyword (e.g. `"a"`) over a very large input, which would otherwise allocate one span per occurrence.

## Changes

- **Extract the constant** into a shared `packages/detections/src/matchers/limits.ts` so both matchers reference one value instead of duplicating the literal. `regex.ts` now imports it (behavior unchanged).
- **Cap `KeywordMatcher.match`** at the same 10,000 ceiling, enforced both inside the per-keyword walk and as an outer-loop guard, so the limit bounds *total* spans across all of a rule's keywords (matching the regex matcher's per-rule semantics).
- **Simplify the `KeywordMatcher` schema comment** in `packages/schema/src/zod/rule.ts` — the "no per-rule match ceiling / allocate a span per byte" premise is now obsolete; the empty-keyword rejection stands on its own merits.
- **Add a test** mirroring `regex.test.ts`: a 1-char keyword over a 20k-char input yields exactly 10,000 spans.

## Verification

- `pnpm --filter @akasecurity/detections test` → **752 passed** (incl. all **101 rule fixtures** + the new cap test)
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` → all clean
- `pnpm --filter @akasecurity/schema test` → 456 passed (touched `rule.ts`)