### PR TITLE
feat(schema): add additive CalibrationFrame contract for the setup wizard

### DIFF
--- a/packages/schema/src/zod/index.ts
+++ b/packages/schema/src/zod/index.ts
@@ -18,6 +18,7 @@ export * from './registry.ts';
 export * from './rule.ts';
 export * from './rule-test.ts';
 export * from './security.ts';
+export * from './setup-frame.ts';
 export * from './shares.ts';
 export * from './shares-access.ts';
 export * from './triage.ts';

--- a/packages/schema/src/zod/setup-frame.ts
+++ b/packages/schema/src/zod/setup-frame.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+import { DetectionCategory } from './finding.ts';
+import { BuiltinPolicyId } from './policy.ts';
+import { TriageCategoryRec } from './triage.ts';
+
+// The calibration counts shown at the calibrated-result frame ('Calibrated. N
+// notifications, M important. (N−M) routine, M that matter'). `important` counts
+// the surfaced findings, `routine` the suppressed ones, `total` their sum; the
+// sum equality is enforced by the emitter, not this schema.
+export const CalibrationCounts = z.object({
+  total: z.number().int().nonnegative(),
+  important: z.number().int().nonnegative(),
+  routine: z.number().int().nonnegative(),
+});
+export type CalibrationCounts = z.infer<typeof CalibrationCounts>;
+
+// One kind of finding present in the scanned history, counted and tagged on the
+// egress-kind axis: `egress` marks an outbound-leak kind, distinct from an
+// at-rest exposure (e.g. a live key sitting in a transcript). The honest-positive
+// line is gated on the absence of any egress-kind finding across a frame's
+// `findingKinds`.
+export const CalibrationFindingKind = z.object({
+  category: DetectionCategory,
+  count: z.number().int().nonnegative(),
+  egress: z.boolean(),
+});
+export type CalibrationFindingKind = z.infer<typeof CalibrationFindingKind>;
+
+// The structured frame data the wizard scripts emit and the rendered copy
+// templates over: the calibration counts, the routine (suppressed) and surfaced
+// (important) category lists, the finding kinds with their egress axis, and the
+// recommended per-category posture map.
+//
+// This shape is extended additively — existing fields are never reshaped, later
+// consumers only add fields. Two known extension points: masked per-finding
+// summaries are added here as an optional field by the finding-table consumer,
+// and an egress predicate is computed over `findingKinds` (its `egress` axis) by
+// the honest-positive-line consumer.
+//
+// No `.meta({ id })` — no API route references this shape, matching the
+// TriageHit/TriageRecommendation convention (an unrouted id would still register
+// in Zod's global registry and leak an orphan component into the generated
+// OpenAPI client).
+export const CalibrationFrame = z.object({
+  counts: CalibrationCounts,
+  routineCategories: z.array(DetectionCategory),
+  surfacedCategories: z.array(DetectionCategory),
+  findingKinds: z.array(CalibrationFindingKind),
+  posture: z.record(DetectionCategory, BuiltinPolicyId),
+});
+export type CalibrationFrame = z.infer<typeof CalibrationFrame>;
+
+// One category slice of the backfill + apply-suppressions preview the calibration
+// frame is derived from: the triage genuine/FP split (`genuineCount` are the
+// surfaced/'important' findings, `fpCount` the suppressed/'routine' ones, reused
+// from TriageCategoryRec) plus the egress-kind axis carried through into the
+// frame's findingKinds.
+export const CalibrationPreviewCategory = TriageCategoryRec.pick({
+  category: true,
+  genuineCount: true,
+  fpCount: true,
+}).extend({
+  egress: z.boolean(),
+});
+export type CalibrationPreviewCategory = z.infer<typeof CalibrationPreviewCategory>;
+
+// The preview the calibration frame is derived from: the per-category triage
+// breakdown plus the recommended per-category posture map, emitted unchanged in
+// the frame.
+export const CalibrationPreview = z.object({
+  categories: z.array(CalibrationPreviewCategory),
+  posture: z.record(DetectionCategory, BuiltinPolicyId),
+});
+export type CalibrationPreview = z.infer<typeof CalibrationPreview>;
+
+// The calibration module's output: the structured frame plus the copy that
+// templates over it ('Calibrated. N notifications, M important. …').
+export const CalibrationResult = z.object({
+  frame: CalibrationFrame,
+  copy: z.string(),
+});
+export type CalibrationResult = z.infer<typeof CalibrationResult>;
+
+// One option of the installed-summary dashboard handoff: a stable id
+// the prompt layer routes on and the label it shows.
+export const SetupHandoffOption = z.object({
+  id: z.enum(['open-dashboard', 'not-now']),
+  label: z.string(),
+});
+export type SetupHandoffOption = z.infer<typeof SetupHandoffOption>;
+
+// The handoff-offer payload: the 'M worth a look' count the installed
+// summary templates into its dashboard handoff question, and the two offer
+// options. `worthALook` is the surfaced/important count from the calibration
+// preview — a real store-derived value, never fabricated. The
+// AskUserQuestion issuance itself lives in the prompt layer; this is the
+// structured payload a harness reads to assert the offer without observing the
+// interactive picker. No `.meta({ id })`, matching the CalibrationFrame
+// convention above (no API route references it).
+//
+// `options` is a fixed two-entry tuple — Open dashboard then Not now — so the
+// contract matches the producer exactly: a dropped, reordered, or extra option
+// fails validation, not just a non-array.
+export const SetupHandoffOffer = z.object({
+  worthALook: z.number().int().nonnegative(),
+  options: z.tuple([
+    SetupHandoffOption.extend({ id: z.literal('open-dashboard') }),
+    SetupHandoffOption.extend({ id: z.literal('not-now') }),
+  ]),
+});
+export type SetupHandoffOffer = z.infer<typeof SetupHandoffOffer>;

--- a/packages/schema/src/zod/setup-frame.ts
+++ b/packages/schema/src/zod/setup-frame.ts
@@ -6,13 +6,19 @@ import { TriageCategoryRec } from './triage.ts';
 
 // The calibration counts shown at the calibrated-result frame ('Calibrated. N
 // notifications, M important. (N−M) routine, M that matter'). `important` counts
-// the surfaced findings, `routine` the suppressed ones, `total` their sum; the
-// sum equality is enforced by the emitter, not this schema.
-export const CalibrationCounts = z.object({
-  total: z.number().int().nonnegative(),
-  important: z.number().int().nonnegative(),
-  routine: z.number().int().nonnegative(),
-});
+// the surfaced findings, `routine` the suppressed ones, `total` their sum. The
+// sum equality (`total === important + routine`) is enforced by the schema's
+// refinement, so a frame whose counts do not add up fails validation.
+export const CalibrationCounts = z
+  .object({
+    total: z.number().int().nonnegative(),
+    important: z.number().int().nonnegative(),
+    routine: z.number().int().nonnegative(),
+  })
+  .refine((c) => c.total === c.important + c.routine, {
+    message: 'total must equal important + routine',
+    path: ['total'],
+  });
 export type CalibrationCounts = z.infer<typeof CalibrationCounts>;
 
 // One kind of finding present in the scanned history, counted and tagged on the

--- a/packages/schema/test/zod/setup-frame.test.ts
+++ b/packages/schema/test/zod/setup-frame.test.ts
@@ -44,7 +44,9 @@ describe('CalibrationCounts', () => {
     expect(CalibrationCounts.safeParse({ total: 1.5, important: 0, routine: 0 }).success).toBe(
       false,
     );
-    expect(CalibrationCounts.safeParse({ total: 0, important: -1, routine: 0 }).success).toBe(false);
+    expect(CalibrationCounts.safeParse({ total: 0, important: -1, routine: 0 }).success).toBe(
+      false,
+    );
   });
 
   it('rejects a missing member', () => {

--- a/packages/schema/test/zod/setup-frame.test.ts
+++ b/packages/schema/test/zod/setup-frame.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CalibrationCounts,
+  CalibrationFindingKind,
+  CalibrationFrame,
+} from '../../src/zod/setup-frame.ts';
+
+// A populated example frame: 161 total notifications, 3 important (surfaced),
+// 158 routine (suppressed); the surfaced findings are at-rest live secret keys
+// (no egress-kind evidence).
+const populatedFrame = {
+  counts: { total: 161, important: 3, routine: 158 },
+  routineCategories: ['pii', 'code_context', 'config'],
+  surfacedCategories: ['secret'],
+  findingKinds: [
+    { category: 'secret', count: 3, egress: false },
+    { category: 'pii', count: 12, egress: false },
+  ],
+  posture: {
+    secret: 'warn',
+    pii: 'warn',
+    financial: 'warn',
+    phi: 'warn',
+    code_flaw: 'warn',
+    custom: 'warn',
+    code_context: 'monitor',
+    config: 'monitor',
+  },
+};
+
+describe('CalibrationCounts', () => {
+  it('parses a well-formed count triple', () => {
+    expect(CalibrationCounts.safeParse({ total: 161, important: 3, routine: 158 }).success).toBe(
+      true,
+    );
+  });
+
+  it('accepts a fully-zero count triple (never rendered as theater, but valid)', () => {
+    expect(CalibrationCounts.safeParse({ total: 0, important: 0, routine: 0 }).success).toBe(true);
+  });
+
+  it('rejects a non-integer or negative count', () => {
+    expect(CalibrationCounts.safeParse({ total: 1.5, important: 0, routine: 0 }).success).toBe(
+      false,
+    );
+    expect(CalibrationCounts.safeParse({ total: 0, important: -1, routine: 0 }).success).toBe(false);
+  });
+
+  it('rejects a missing member', () => {
+    expect(CalibrationCounts.safeParse({ total: 1, important: 1 }).success).toBe(false);
+  });
+});
+
+describe('CalibrationFindingKind', () => {
+  it('parses a kind carrying the egress axis', () => {
+    expect(
+      CalibrationFindingKind.safeParse({ category: 'secret', count: 3, egress: false }).success,
+    ).toBe(true);
+    expect(
+      CalibrationFindingKind.safeParse({ category: 'secret', count: 1, egress: true }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a missing egress axis', () => {
+    expect(CalibrationFindingKind.safeParse({ category: 'secret', count: 3 }).success).toBe(false);
+  });
+
+  it('rejects a non-boolean egress axis', () => {
+    expect(
+      CalibrationFindingKind.safeParse({ category: 'secret', count: 3, egress: 'no' }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an unknown or mis-cased category', () => {
+    expect(
+      CalibrationFindingKind.safeParse({ category: 'secrets', count: 3, egress: false }).success,
+    ).toBe(false);
+  });
+});
+
+describe('CalibrationFrame', () => {
+  it('parses a populated frame (161 total / 3 important / 158 routine, surfaced secret)', () => {
+    expect(CalibrationFrame.safeParse(populatedFrame).success).toBe(true);
+  });
+
+  it('rejects a frame whose surfaced category list is not a DetectionCategory', () => {
+    expect(
+      CalibrationFrame.safeParse({ ...populatedFrame, surfacedCategories: ['secrets'] }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a frame whose posture map assigns a non-built-in policy id', () => {
+    expect(
+      CalibrationFrame.safeParse({
+        ...populatedFrame,
+        posture: { ...populatedFrame.posture, secret: 'allow' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a frame whose posture map omits a category', () => {
+    const { config, ...partial } = populatedFrame.posture;
+    void config;
+    expect(CalibrationFrame.safeParse({ ...populatedFrame, posture: partial }).success).toBe(false);
+  });
+
+  it('rejects a frame with a malformed finding kind', () => {
+    expect(
+      CalibrationFrame.safeParse({
+        ...populatedFrame,
+        findingKinds: [{ category: 'secret', count: -1, egress: false }],
+      }).success,
+    ).toBe(false);
+  });
+
+  it('rejects a frame missing a required top-level field', () => {
+    const { counts, ...rest } = populatedFrame;
+    void counts;
+    expect(CalibrationFrame.safeParse(rest).success).toBe(false);
+  });
+});

--- a/packages/schema/test/zod/setup-frame.test.ts
+++ b/packages/schema/test/zod/setup-frame.test.ts
@@ -4,6 +4,7 @@ import {
   CalibrationCounts,
   CalibrationFindingKind,
   CalibrationFrame,
+  SetupHandoffOffer,
 } from '../../src/zod/setup-frame.ts';
 
 // A populated example frame: 161 total notifications, 3 important (surfaced),
@@ -51,6 +52,18 @@ describe('CalibrationCounts', () => {
 
   it('rejects a missing member', () => {
     expect(CalibrationCounts.safeParse({ total: 1, important: 1 }).success).toBe(false);
+  });
+
+  it('accepts counts whose total equals important + routine', () => {
+    expect(CalibrationCounts.safeParse({ total: 161, important: 3, routine: 158 }).success).toBe(
+      true,
+    );
+  });
+
+  it('rejects counts whose total does not equal important + routine', () => {
+    expect(CalibrationCounts.safeParse({ total: 160, important: 3, routine: 158 }).success).toBe(
+      false,
+    );
   });
 });
 
@@ -120,5 +133,37 @@ describe('CalibrationFrame', () => {
     const { counts, ...rest } = populatedFrame;
     void counts;
     expect(CalibrationFrame.safeParse(rest).success).toBe(false);
+  });
+});
+
+describe('SetupHandoffOffer', () => {
+  const openDashboard = { id: 'open-dashboard', label: 'Open dashboard' };
+  const notNow = { id: 'not-now', label: 'Not now' };
+
+  it('parses the fixed two-entry offer (open-dashboard then not-now)', () => {
+    expect(
+      SetupHandoffOffer.safeParse({ worthALook: 3, options: [openDashboard, notNow] }).success,
+    ).toBe(true);
+  });
+
+  it('rejects a dropped option (only one entry)', () => {
+    expect(SetupHandoffOffer.safeParse({ worthALook: 3, options: [openDashboard] }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects reordered options (not-now before open-dashboard)', () => {
+    expect(
+      SetupHandoffOffer.safeParse({ worthALook: 3, options: [notNow, openDashboard] }).success,
+    ).toBe(false);
+  });
+
+  it('rejects an extra option beyond the fixed tuple', () => {
+    expect(
+      SetupHandoffOffer.safeParse({
+        worthALook: 3,
+        options: [openDashboard, notNow, { id: 'not-now', label: 'Later' }],
+      }).success,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
First slice of the redesigned setup/onboarding wizard. Adds the additive CalibrationFrame Zod contract: calibration counts (surfaced/routine), category breakdown, finding kinds, posture map, and the first-run handoff-offer payload. Additive only — no existing shape changes. Evidence: schema suite 466/466, typecheck + lint clean.

Stack: this PR → wave0/wizard-spine (review this one first).