### PR TITLE
feat(plugin): redesigned setup wizard — calibration spine, consent, first-run handoff

### DIFF
--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -8,15 +8,12 @@ You are onboarding the AKA Control Plane plugin for this machine. AKA works
 fully locally with **zero backend and zero Docker**: detection runs in-process
 and findings persist to a local SQLite store at `~/.aka/data/aka.db`.
 
-This wizard is **evidence-first**: instead of asking you to guess a global
-redact/warn setting up front, it looks at your _actual_ history for real
-leaked findings, triages them (silently filtering the routine false-positive
-noise regex rules produce), and recommends a detection **posture per
-category** (`secret`, `pii`, `financial`, `phi`, `code_context`, `code_flaw`,
-`config`, `custom`) — shown to you with its reasoning — before anything is
-written. If there isn't enough history to judge, or you decline the
-historical review, it falls back to a conservative severity-derived floor
-instead of guessing.
+This wizard tells a **calibration story**: introduce AKA → show what it does →
+offer one retroactive scan → report the real numbers it found and the posture it
+recommends → apply on confirmation → show the installed summary → hand off to the
+dashboard. Everything the user sees is derived from their _actual_ history — never
+a fabricated or demo number. When there isn't enough history to judge, the wizard
+falls back to a conservative severity-derived floor instead of guessing.
 
 The false-positive/severity judgment itself runs in a **separate, transient
 subprocess that writes no transcript** — the raw (unmasked) finding values are
@@ -24,21 +21,22 @@ never read into this conversation or your scannable history. You act only on the
 raw-free plan that subprocess prints back.
 
 Follow the steps below **in order**. Nothing is written to the policy store
-until step 5 (or the floor branch in step 2).
+until step 5 (or a floor fallback in step 3 if the calibration can't complete).
 
-## 0. Show the intro card
+## 0. Show the kickoff and 'what I do' cards
 
-Run the intro script and show the user its output **exactly as printed** — it is a
-space-aligned monospace card (name, repository, version, what AKA adds). The script
-already prints it inside a Markdown code fence; reproduce that verbatim and do
-**not** add another code fence, strip the fence, or reformat it (unfenced, Markdown
-collapses the indentation and mangles the `●` line).
+Run the intro script and show the user its output **exactly as printed**. It
+prints two space-aligned monospace cards — the kickoff card (name, repository,
+version, what AKA adds) and the "what I do" card — each inside its own Markdown
+code fence. Reproduce both fences verbatim and do **not** add another code fence,
+strip a fence, or reformat them (unfenced, Markdown collapses the indentation and
+mangles the `●` lines).
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/intro.js" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json"
 ```
 
-## 1. Ask historical-review consent
+## 1. Offer the retroactive scan
 
 Ask this **before** anything about detection posture — the posture
 recommendation in step 4 is _derived from_ the answer to this question, so it
@@ -47,55 +45,46 @@ interactive picker. The plugin can't draw its own selectable UI (it can't
 capture keystrokes), so do **not** print a fake option list or ask the user to
 "reply with a number"; let the picker collect the answer.
 
-**Historical & memory access** — "Secrets often leak before AKA is installed. May I also review your temp files, agent memory & prior conversation transcripts?"
+**Want me to look at what Claude's been up to?** — "A retroactive scan of recent activity — transcripts, temp files, agent memory — tunes the notifications we'll review next."
 
-List **Grant full review** as the first (top) option:
+Offer exactly two options:
 
-- **Grant full review** → `full` — scan scratch/temp files, agent memory & prior
-  transcripts for leaked secrets (deepest coverage · one-time consent, revocable
-  under Policies). This is what lets AKA recommend a posture backed by your
-  real findings instead of a generic default.
-- **Current session only** → `session-only` — decline historical access. AKA
-  starts in a conservative observe-first posture instead (step 2) and can
-  still review: the **working tree** (all source, config & dotfiles in the
-  repo), **this session** (prompts, tool calls & files Claude reads or writes
-  now), **git history** (commits reachable from HEAD, incl.
-  removed-but-tracked secrets), and **pointed scans** (any path you explicitly
-  hand AKA during a run).
+- **Yes, scan** — "calibrate my notifications to your real activity"
+- **Not now** — "start light and learn as we go"
 
-Map the picked label to the flag value shown above (`full`/`session-only`).
+Choosing **Yes, scan** records the same historical-review consent the wizard has
+always recorded — the identical scope, the one-time grant, and the
+revocable-under-Policies semantics — so the simpler question broadens nothing
+about what AKA may access. Those granular scope and revocation details stay
+inspectable on request and in the dashboard.
 
-## 2. Save the historical answer, then branch
+## 2. Save the answer, then branch
 
-Run the onboarding writer with the answer from step 1. This must happen
-**before** the backfill (step 3), because the backfill script reads
-`historicalAccess` from the saved settings to decide whether it's allowed to
-run. Omitting `--policy` is deliberate — the old global redact/warn toggle no
-longer drives enforcement (posture is per-category now); its field is kept
-for backward compatibility but this wizard doesn't ask about it.
+Branch on the answer from step 1. On the **Yes, scan** path the onboarding
+writer runs, and it must run **before** the backfill (step 3), because the
+backfill script reads `historicalAccess` from the saved settings to decide
+whether it's allowed to run. Omitting `--policy` is deliberate — the old global
+redact/warn toggle no longer drives enforcement (posture is per-category now);
+its field is kept for backward compatibility but this wizard doesn't ask about
+it.
 
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --historical <full|session-only>
-```
+**Branch on the choice:**
 
-**Branch on the historical answer:**
-
-- **If the user chose "Current session only" (`session-only`)** — there is no
-  history to calibrate a posture from. Write the severity-derived floor
-  immediately and skip straight to step 6 (first-run summary); steps 3–5 do
-  not run:
+- **If the user chose "Yes, scan"** — record the historical-review consent and
+  continue to step 3 (which runs the scan and leads to the calibrated result in
+  step 4). "Yes, scan" maps to the existing full historical-review path — no
+  access is granted beyond what that path already granted:
 
   ```bash
-  node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --floor
+  node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --historical full
   ```
 
-  Briefly tell the user why: without evidence, AKA starts every high-impact
-  category (`secret`/`pii`/`financial`/`phi`/`code_flaw`/`custom`) at `warn`
-  so nothing is under-watched, and low-value/observe-only categories
-  (`code_context`/`config`) at `monitor` — conservative, no guessing. This can
-  be revisited any time via `/aka:setup` or Policies.
-
-- **If the user chose "Grant full review" (`full`)** — continue to step 3.
+- **If the user chose "Not now"** — the start-light path that learns as it goes
+  is not built yet. Until it is, do **not** read any history and do **not** write
+  a posture. End setup gracefully: tell the user nothing was scanned and nothing
+  was changed, and that they can re-run `/aka:setup` anytime to calibrate or set
+  a posture. Do **not** run `onboard.js`, the backfill, or any other script —
+  steps 3–8 do not run.
 
 ## 3. Run the evidence triage — isolated judgment, nothing written yet
 
@@ -111,14 +100,23 @@ and streams one masked-plus-raw triage hit per line; masked findings are
 recorded to the local store as a side effect. The adapter runs the
 false-positive/severity **judgment in a separate transient subprocess** (no
 transcript), then prints back a **raw-free plan** you can safely show the user:
-the per-category posture it would apply, the masked false positives it would
-suppress, any categories it skipped, and its notes.
+the calibrated-result card (the real-count headline and the recommended posture),
+the per-category reasoning, the masked false positives it would suppress, any
+categories it skipped, and its notes.
 
 The preview also **persists that exact raw-free plan to a temp file and prints
 its path** — a line beginning `Plan saved to: <path>`. Capture that path: step 5
 applies **this saved plan verbatim**, so the confirm step performs no second scan
 and no second judgment. (The plan file carries only masked/fingerprint/enum data;
 it is deleted after a successful apply.)
+
+Alongside the human copy, the preview also emits a **machine-readable calibration
+frame** — a single JSON block delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>`
+carrying the raw-free calibration counts and categories. Do **not** show this block
+to the user (it is additive to the human copy above). Capture its `counts.important`
+value — the **surfaced count** — and pass it to the first-run summary in step 6 as
+`--surfaced <count>`. If the calibration could not complete (either fallback branch
+below), no frame block is emitted and there is no surfaced count to carry over.
 
 Everything you show the user in step 4 comes from **this command's output**. You
 never read the raw finding values yourself — do not echo, quote, or reconstruct
@@ -146,45 +144,27 @@ user the scan found nothing to calibrate from, and skip to step 6.
 
 Otherwise continue to step 4.
 
-## 4. Show the calibration and get explicit confirmation — before any write
+## 4. Show the calibrated result and get explicit confirmation — before any write
 
-The preview output is raw-free and has three parts. Show the user **all** of
-them.
+The preview output is raw-free. Lead with the **calibrated-result card** it
+printed and show it in full:
 
-**Known limitation — the showcase is a first-run artifact.** The backfill records
-each masked finding to the local store as a side effect, so a second `/aka:setup`
-over the _same_ history dedups those already-recorded findings to zero triage hits
-and the showcase comes back empty (the adapter reports "no triage hits to
-review"). That is expected, not a failure: a re-run recalibrates **only if there
-is genuinely new history** since the last run. The **first run's** showcase is the
-one that matters — it is not reconstructed from the store on a re-run (the raw
-values it needs are deliberately never persisted). If a re-run shows nothing to
-calibrate, take the floor branch as usual and tell the user the scan found no new
-history.
-
-1. **The per-category posture plan.** The action
-   (`monitor`/`warn`/`redact`/`block`) the writeback would set for every
-   category present in the evidence. Show it in full.
+1. **The calibrated headline.** The `Calibrated. N notifications, M important…`
+   line — every count templated over the real scan (surfaced findings are the
+   `M important` that matter; the rest are routine noise a plain scanner would
+   have screamed about). Show it verbatim; never substitute a demo number.
+2. **The recommended posture.** The condensed one-row-per-pack recommended view
+   the card printed — the level AKA would set for each category. Show it in full.
    - **Surface every downgrade — this is not optional.** The preview flags any
      category whose action would be **LOWERED** from a stronger existing setting
      (e.g. an existing `block`/`redact` dropping to `warn`/`monitor`) and prints
      a `WARNING` line summarizing them. Call these out prominently: a user who
-     hardened a category must **explicitly approve weakening it**. Never let an
-     enforcement downgrade through on the "apply as recommended" path without the
-     user having seen it.
-   - A category the adapter had to **skip** for its suppressions can still carry
-     a posture change; it appears in this plan too, so the user sees any posture
-     change even on a skipped category.
-2. **The intelligence showcase.** The masked-only per-category reasoning and
-   notes the judgment produced. Frame it as "look what it caught — and correctly
-   dismissed": the false-positive discard is as much the pitch as the catch (a
-   plain regex scanner would scream "161 CRITICAL secrets!"; AKA says "…all
-   placeholders — `warn` is enough"). Keep the framing neutral — no "sloppy" or
-   "bad practice".
+     hardened a category must **explicitly approve weakening it** before applying.
+     Never let an enforcement downgrade through without the user having seen it.
 3. **The false positives to be suppressed (the human gate).** The masked value,
-   rule, and masked context for each detection the writeback would suppress.
-   This is the checkpoint that stops a genuine secret being silenced: the user
-   reads the masked evidence and approves it.
+   rule, and masked context for each detection the writeback would suppress —
+   the routine noise being dismissed. This is the checkpoint that stops a genuine
+   secret being silenced: the user reads the masked evidence and approves it.
 
 Then use **AskUserQuestion** (the real picker, never a printed numbered list) to
 confirm:
@@ -194,27 +174,25 @@ false positives shown above?"
 
 - **Yes, apply** _(recommended)_ — write the posture and suppressions exactly as
   previewed.
-- **Let me adjust a category** — override one or more categories before saving
-  (for example, keep a category the plan would lower).
 
-If they choose to adjust, ask a follow-up **AskUserQuestion** per category,
-offering the four actions with honest semantics so they choose with full
-information: `monitor` logs only; `warn` flags the request and lets them decide;
-`redact` strips the value from **tool I/O** but is a **no-op on the
-prompt/conversation channel** (a secret pasted into chat still reaches the
-model); `block` refuses the action outright. Collect the overrides as a
-`{category: action}` map. Do **not** proceed to step 5 until the user has
-explicitly confirmed.
+Offer **only** the "Yes, apply" option for now. (TODO: add an "Adjust a category"
+option — an override loop over the recommended posture — once that flow is built;
+until then a user who wants a different posture re-runs `/aka:setup` or edits it
+in the dashboard.) Do **not** proceed to step 5 until the user has explicitly
+confirmed.
 
 ## 5. Write the posture and suppressions
 
 On confirmation, run the adapter again with `--confirmed --plan <path>`, passing
 the **plan-file path the preview printed in step 3** (`Plan saved to: <path>`). It
-reads that saved plan back and applies it **exactly as previewed** — it overwrites
-the per-category posture and writes one 30-day suppression per confirmed false
-positive **without re-running the backfill or the judge**. There is deliberately
-**no `backfill.js` pipe here**: re-scanning and re-judging would produce a fresh,
-non-deterministic plan and silently defeat the human gate the user just approved.
+reads that saved plan back and applies it **exactly as previewed** — establishing
+the **full 8-pack posture** the recommended view showed (the reviewed
+evidence packs overwrite; the conservative severity floor fill-gaps the remaining
+packs, so a pack the user had already hardened out of band is never downgraded) and
+writing one 30-day suppression per confirmed false positive **without re-running the
+backfill or the judge**. There is deliberately **no `backfill.js` pipe here**:
+re-scanning and re-judging would produce a fresh, non-deterministic plan and
+silently defeat the human gate the user just approved.
 
 The posture overwrite and the suppression writes are applied as a **single
 all-or-nothing transaction**: a mid-batch failure rolls back the posture change
@@ -226,39 +204,57 @@ conservative floor cannot collide with a partially-written posture.
 node "${CLAUDE_PLUGIN_ROOT}/scripts/apply-suppressions.js" --confirmed --plan <path>
 ```
 
+The script prints the applying confirmation — `✓ K categories tuned ·
+✓ N routine dismissed · Ready: …` — with both counts threaded from the real write.
+Show that line to the user.
+
 If `--plan` is missing or the file is unreadable/invalid, the adapter **fails loud
 (non-zero) and writes nothing** — it never falls back to a re-judge. Treat that
 like the `--confirmed` failure below: tell the user the write did not complete,
 fall back to the floor, and continue to step 6.
 
-If the user chose to **adjust** categories in step 4, apply their overrides on
-top afterwards. `onboard.js --posture` overwrites only the categories in the map
-it's given, leaving the rest as written by the adapter:
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --posture '{"secret":"block"}'
-```
-
-(The JSON is illustrative — pass only the categories the user changed, values
-one of `monitor`/`warn`/`redact`/`block`.) This is the only point in the wizard
-where a posture is persisted.
-
 If the `--confirmed` run exits non-zero, tell the user the write did not
 complete, fall back to the floor (`onboard.js --floor`), and continue to step 6
 so setup still finishes.
 
-## 6. Show the first-run summary
+## 6. Show the installed summary and hand off to the dashboard
 
-Run the first-run script and show its output **exactly as printed** (the
-install-complete summary with live findings/recommendation counts, the health
-score, and — now — the per-category posture just written or floored). The
-script already prints it inside a Markdown code fence; reproduce that
-verbatim and do **not** add another code fence, strip the fence, or reformat it (it
-is space-aligned monospace that Markdown would otherwise collapse).
+Run the first-run script and show its **install-complete summary** exactly as
+printed (live findings/recommendation counts, the health score, and the
+per-category posture just written or floored). The script prints that summary
+inside a Markdown code fence; reproduce the fenced card verbatim and do **not**
+add another code fence, strip the fence, or reformat it (it is space-aligned
+monospace that Markdown would otherwise collapse).
+
+Pass the **surfaced count** captured from step 3's calibration frame
+(`counts.important`) as `--surfaced <count>` — this is the 'N worth a look' figure
+the script emits in its own machine-readable handoff payload. If the
+calibration fell back to the floor (no frame was emitted in step 3), **omit
+`--surfaced` entirely** — the script then withholds that payload rather than
+fabricating a count.
+
+When `--surfaced` is passed, the script appends that handoff payload as a single
+JSON block delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>` after the fenced
+card. Like step 3's calibration frame, do **not** show this block to the user — it
+is additive and machine-only; only the fenced install summary above is
+user-facing.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/firstrun.js"
+node "${CLAUDE_PLUGIN_ROOT}/scripts/firstrun.js" --surfaced <count>
 ```
+
+**Then hand off to the dashboard.** When the payload carries a positive
+`worthALook` count, issue an explicit **AskUserQuestion** (the real picker, never a
+printed list) using that count for `N`:
+
+**N worth a look — see them in the browser?**
+
+- **Open dashboard** — open the local web dashboard on the surfaced findings.
+- **Not now** — stay here; they can open it anytime.
+
+Use the payload's `worthALook` value for `N` verbatim — do not invent or round it.
+If the payload was withheld (the floor fallback, or nothing surfaced), skip this
+handoff question rather than inventing a count.
 
 ## 7. Offer the AKA CLI + local dashboard (opt-in)
 

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -175,11 +175,10 @@ false positives shown above?"
 - **Yes, apply** _(recommended)_ — write the posture and suppressions exactly as
   previewed.
 
-Offer **only** the "Yes, apply" option for now. (TODO: add an "Adjust a category"
-option — an override loop over the recommended posture — once that flow is built;
-until then a user who wants a different posture re-runs `/aka:setup` or edits it
-in the dashboard.) Do **not** proceed to step 5 until the user has explicitly
-confirmed.
+Offer **only** the "Yes, apply" option for now. An "Adjust a category" option —
+an override loop over the recommended posture — arrives in a follow-up; until
+then a user who wants a different posture re-runs `/aka:setup` or edits it in the
+dashboard. Do **not** proceed to step 5 until the user has explicitly confirmed.
 
 ## 5. Write the posture and suppressions
 

--- a/plugins/claude-code/src/apply-suppressions.ts
+++ b/plugins/claude-code/src/apply-suppressions.ts
@@ -55,8 +55,9 @@ function loadRubric(): string {
 }
 
 async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
   const code = await runApply({
-    argv: process.argv.slice(2),
+    argv,
     // fd 0 = stdin; the wizard pipes `backfill.js --triage` into this on preview.
     // Called only on the preview path — the confirm path never reads a stream.
     readStream: (streamPath) =>

--- a/plugins/claude-code/src/backfill.ts
+++ b/plugins/claude-code/src/backfill.ts
@@ -65,10 +65,10 @@ export interface BackfillDeps {
   // drops any transcript message written at/after the backfill started (so a re-run
   // never re-ingests the wizard's own in-progress session), and `excludeSessionId`
   // skips AKA's OWN session transcript by id when the host exposes it. `dir`
-  // overrides the transcript root (the wizard's ~/.aka override threads a throwaway
-  // ~/.claude here). Injected (not read from the environment here) so runBackfill
-  // stays pure + testable; the CLI wiring at the bottom of this file computes the
-  // real values.
+  // overrides the transcript root; it is supplied only by the journey harness/tests
+  // to scan a throwaway ~/.claude in isolation — no production call site passes it.
+  // Injected (not read from the environment here) so runBackfill stays pure +
+  // testable; the CLI wiring at the bottom of this file computes the real values.
   guard?: Pick<HistoryWalkOptions, 'excludeSessionId' | 'beforeMs' | 'dir'>;
 }
 

--- a/plugins/claude-code/src/backfill.ts
+++ b/plugins/claude-code/src/backfill.ts
@@ -1,6 +1,6 @@
 /**
  * Historical backfill entry — invoked by the `/aka:setup` wizard right after
- * onboarding when the user chose "Grant full review" (historicalAccess: full).
+ * onboarding when the user chose "Yes, scan" (historicalAccess: full).
  * It sweeps prior Claude Code transcripts (~/.claude/projects) for secrets that
  * leaked BEFORE AKA was installed and records them into the same local store the
  * read surfaces query.
@@ -26,7 +26,7 @@ import {
 import { TriageHit } from '@akasecurity/schema';
 
 import { scanHistory, type ScanSummary } from './history/scan.ts';
-import type { HistoryWalkOptions } from './history/transcripts.ts';
+import { type HistoryWalkOptions } from './history/transcripts.ts';
 import { reconcileHistory } from './history/usage.ts';
 import { fenced, indent } from './present.ts';
 
@@ -61,13 +61,15 @@ export interface BackfillDeps {
     onHit?: (hit: TriageHit) => void,
   ) => Promise<ScanSummary>;
   reconcileHistory: (config: PluginConfig) => Promise<unknown>;
-  // Self-contamination guard threaded into the scan: `beforeMs` drops any
-  // transcript message written at/after the backfill started (so a re-run never
-  // re-ingests the wizard's own in-progress session), and `excludeSessionId`
-  // skips AKA's OWN session transcript by id when the host exposes it. Injected
-  // (not read from the environment here) so runBackfill stays pure + testable;
-  // the CLI wiring at the bottom of this file computes the real values.
-  guard?: Pick<HistoryWalkOptions, 'excludeSessionId' | 'beforeMs'>;
+  // Walk options threaded into the scan. The self-contamination guard: `beforeMs`
+  // drops any transcript message written at/after the backfill started (so a re-run
+  // never re-ingests the wizard's own in-progress session), and `excludeSessionId`
+  // skips AKA's OWN session transcript by id when the host exposes it. `dir`
+  // overrides the transcript root (the wizard's ~/.aka override threads a throwaway
+  // ~/.claude here). Injected (not read from the environment here) so runBackfill
+  // stays pure + testable; the CLI wiring at the bottom of this file computes the
+  // real values.
+  guard?: Pick<HistoryWalkOptions, 'excludeSessionId' | 'beforeMs' | 'dir'>;
 }
 
 export async function runBackfill(deps: BackfillDeps): Promise<void> {
@@ -201,9 +203,9 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
         process.exitCode = 1;
       },
     },
-    loadConfig,
+    loadConfig: () => loadConfig(),
     scanHistory,
-    reconcileHistory,
+    reconcileHistory: (cfg) => reconcileHistory(cfg),
     guard: {
       beforeMs: startedAt,
       ...(sessionId ? { excludeSessionId: sessionId } : {}),

--- a/plugins/claude-code/src/calibration.ts
+++ b/plugins/claude-code/src/calibration.ts
@@ -35,9 +35,7 @@ export function frameCalibration(preview: CalibrationPreview): CalibrationResult
   const surfacedCategories = preview.categories
     .filter((c) => c.genuineCount > 0)
     .map((c) => c.category);
-  const routineCategories = preview.categories
-    .filter((c) => c.fpCount > 0)
-    .map((c) => c.category);
+  const routineCategories = preview.categories.filter((c) => c.fpCount > 0).map((c) => c.category);
 
   const findingKinds = preview.categories
     .filter((c) => c.genuineCount + c.fpCount > 0)

--- a/plugins/claude-code/src/calibration.ts
+++ b/plugins/claude-code/src/calibration.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure calibration count-framing for the /aka:setup wizard's calibrated-result
+ * screen. Turns the backfill + apply-suppressions preview breakdown into the
+ * CalibrationFrame emitted for downstream consumers and the human-facing copy:
+ * 'Calibrated. N notifications, M important. (N−M) routine, M that matter (KIND)'.
+ * Surfaced (genuine, non-suppressed) findings are 'important'; suppressed findings
+ * are 'routine'; the total is their sum. No IO; no fixed counts — every number
+ * follows the preview input.
+ */
+import type {
+  CalibrationFrame,
+  CalibrationPreview,
+  CalibrationResult,
+  DetectionCategory,
+} from '@akasecurity/schema';
+
+// Plain-English kind of a surfaced category, for the 'M that matter (…)'
+// parenthetical. Presentation-only — not a persisted contract.
+const SURFACED_KIND_LABEL: Record<DetectionCategory, string> = {
+  secret: 'live keys',
+  pii: 'personal data',
+  financial: 'financial records',
+  phi: 'health records',
+  code_context: 'source context',
+  code_flaw: 'code flaws',
+  custom: 'custom matches',
+  config: 'configuration secrets',
+};
+
+export function frameCalibration(preview: CalibrationPreview): CalibrationResult {
+  const important = preview.categories.reduce((n, c) => n + c.genuineCount, 0);
+  const routine = preview.categories.reduce((n, c) => n + c.fpCount, 0);
+  const total = important + routine;
+
+  const surfacedCategories = preview.categories
+    .filter((c) => c.genuineCount > 0)
+    .map((c) => c.category);
+  const routineCategories = preview.categories
+    .filter((c) => c.fpCount > 0)
+    .map((c) => c.category);
+
+  const findingKinds = preview.categories
+    .filter((c) => c.genuineCount + c.fpCount > 0)
+    .map((c) => ({ category: c.category, count: c.genuineCount + c.fpCount, egress: c.egress }));
+
+  const frame: CalibrationFrame = {
+    counts: { total, important, routine },
+    routineCategories,
+    surfacedCategories,
+    findingKinds,
+    posture: preview.posture,
+  };
+
+  const kind = surfacedCategories.map((c) => SURFACED_KIND_LABEL[c]).join(', ');
+  const copy =
+    `Calibrated. ${String(total)} notifications, ${String(important)} important. ` +
+    `${String(routine)} routine, ${String(important)} that matter (${kind})`;
+
+  return { frame, copy };
+}

--- a/plugins/claude-code/src/calibration.ts
+++ b/plugins/claude-code/src/calibration.ts
@@ -50,9 +50,12 @@ export function frameCalibration(preview: CalibrationPreview): CalibrationResult
   };
 
   const kind = surfacedCategories.map((c) => SURFACED_KIND_LABEL[c]).join(', ');
+  // Omit the kind parenthetical entirely when nothing surfaced, so an
+  // all-suppressed run reads 'M that matter' rather than 'M that matter ()'.
+  const parenthetical = kind ? ` (${kind})` : '';
   const copy =
     `Calibrated. ${String(total)} notifications, ${String(important)} important. ` +
-    `${String(routine)} routine, ${String(important)} that matter (${kind})`;
+    `${String(routine)} routine, ${String(important)} that matter${parenthetical}`;
 
   return { frame, copy };
 }

--- a/plugins/claude-code/src/firstrun-core.ts
+++ b/plugins/claude-code/src/firstrun-core.ts
@@ -1,0 +1,113 @@
+/**
+ * The first-run screen's testable core — the dependency-injected orchestration
+ * behind the thin firstrun.ts entry (the install-complete screen of the
+ * `/aka:setup` wizard).
+ *
+ * Renders the install-complete card AND emits the handoff-offer payload
+ * as a structured JSON block alongside it. All IO (gateway reads, posture read,
+ * stdout) is injected so this is unit-testable with a seeded gateway; firstrun.ts
+ * wires the real implementations.
+ *
+ * The handoff payload's 'M worth a look' count is the surfaced/important count
+ * from the calibration preview (`counts.important`), threaded in via
+ * `--surfaced`. It is NOT the whole-store finding total: a suppressed finding
+ * stays in the store (its FP suppression is a temporary exception, not a
+ * deletion), so the total over-counts the surfaced items. When no count is
+ * supplied (no scan ran), the payload is omitted rather than fabricated.
+ */
+import type { DataGateway } from '@akasecurity/plugin-sdk';
+
+import { fenced } from './present.ts';
+import {
+  buildHandoffOffer,
+  buildRecommendations,
+  healthScore,
+  renderFirstRun,
+  STORE_UNAVAILABLE_NOTE,
+  topFindings,
+} from './render.ts';
+import { frameJsonBlock } from './setup-frame-json.ts';
+
+// The surfaced/important count for the handoff payload, parsed from
+// `--surfaced <n>`. Returns a non-negative integer, or undefined when the flag
+// is absent or malformed — the caller then omits the handoff payload instead of
+// fabricating a count. This is the same value the calibration preview emitted as
+// `counts.important`; the wizard orchestration reads it there and passes it here.
+export function parseSurfacedCount(argv: readonly string[]): number | undefined {
+  const i = argv.indexOf('--surfaced');
+  if (i === -1) return undefined;
+  const raw = argv[i + 1];
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
+export interface FirstRunDeps {
+  argv: readonly string[];
+  gateway: DataGateway;
+  // Per-category posture block for the card. Injected (rather than opening the
+  // store here) so the emission seam is unit-testable; readPostureBlock owns its
+  // own catch and degrades to '' so a policies-read fault only hides the Posture
+  // section rather than collapsing into the outer fail-open note.
+  readPosture: () => Promise<string>;
+  stdout: (s: string) => void;
+}
+
+// Emit the first-run card and, alongside it, the handoff-offer payload.
+// Reads only; never closes the gateway (the caller owns its lifecycle). Throws on
+// a store-read failure so the entry's fail-open catch can substitute its note.
+export async function runFirstRun(deps: FirstRunDeps): Promise<void> {
+  const [summary, findings] = await Promise.all([
+    deps.gateway.healthSummary(),
+    deps.gateway.recentFindings({ limit: 500 }),
+  ]);
+  // "Recommendations" mirrors /recommend exactly — the same builder + cap — so
+  // the card's count never disagrees with what that screen lists.
+  const recommendations = buildRecommendations(findings).length;
+
+  // Per-category posture — the wizard's policy write, read straight from the
+  // local store so the card shows what's actually enforced, not the single
+  // settings.policy string.
+  const postureBlock = await deps.readPosture();
+
+  // The surfaced/important count from the calibration preview (a real preview value) drives
+  // both the visible 'N worth a look' handoff line and the structured offer
+  // payload below; when no scan supplied one, both are omitted, never fabricated.
+  const surfaced = parseSurfacedCount(deps.argv);
+
+  deps.stdout(
+    `${fenced(
+      renderFirstRun({
+        posture: postureBlock,
+        health: healthScore(summary),
+        // The card's "Findings N" stat is the whole-store total — correct here.
+        findings: summary.findings,
+        recommendations,
+        // Only threaded when a scan supplied a count — never as an explicit
+        // undefined (exactOptionalPropertyTypes), so the card omits the handoff
+        // line rather than fabricating a zero.
+        ...(surfaced !== undefined ? { worthALook: surfaced } : {}),
+        topFindings: topFindings(findings),
+      }),
+    )}\n`,
+  );
+
+  // The handoff-offer payload, emitted ALONGSIDE the card above so a
+  // harness (and the later Claude layer) can read the structured offer without
+  // observing the AskUserQuestion the prompt layer issues.
+  if (surfaced !== undefined) {
+    deps.stdout(frameJsonBlock(buildHandoffOffer(surfaced)));
+  }
+}
+
+// Fail-open wrapper around runFirstRun: on a store-read failure it degrades to the
+// honest store-unavailable note instead of throwing, so no error escapes to break
+// the Claude session. The thin firstrun.ts entry delegates its catch here so the
+// degradation is unit-tested rather than living in untestable glue.
+export async function runFirstRunFailOpen(deps: FirstRunDeps): Promise<void> {
+  try {
+    await runFirstRun(deps);
+  } catch {
+    deps.stdout(`${STORE_UNAVAILABLE_NOTE}\n`);
+  }
+}

--- a/plugins/claude-code/src/firstrun.ts
+++ b/plugins/claude-code/src/firstrun.ts
@@ -33,7 +33,7 @@ try {
     await runFirstRunFailOpen({
       argv: process.argv.slice(2),
       gateway,
-      readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+      readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
       stdout: (s) => process.stdout.write(s),
     });
   } finally {

--- a/plugins/claude-code/src/firstrun.ts
+++ b/plugins/claude-code/src/firstrun.ts
@@ -1,7 +1,10 @@
 /**
  * First-run screen — the install-complete frame of the `/aka:setup` wizard.
+ * UNTESTABLE GLUE only: it wires real IO (config, data gateway, posture store,
+ * stdout) into the dependency-injected core in ./firstrun-core.ts, which holds
+ * the logic (and its tests).
  *
- *   node scripts/firstrun.js
+ *   node scripts/firstrun.js [--surfaced <n>]
  *
  * Posture (per-category policy), findings (real count) and recommendations (same
  * count /recommend renders) are read live; the Health score is derived (see
@@ -9,56 +12,37 @@
  * same data gateway the read commands use, so the numbers match what /health
  * and /findings show. Rendering lives in ./render.
  *
+ * `--surfaced <n>` is the surfaced/important count from the calibration preview,
+ * threaded through by the wizard orchestration into the handoff-offer payload —
+ * see ./firstrun-core.ts.
+ *
  * Fail-open: an unreadable store prints a friendly note.
  */
 import { openLocalDatabase } from '@akasecurity/persistence';
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
 import { loadConfig } from '@akasecurity/plugin-sdk';
 
+import { runFirstRunFailOpen } from './firstrun-core.ts';
 import { readPostureBlock } from './posture.ts';
-import { fenced } from './present.ts';
-import { buildRecommendations, healthScore, renderFirstRun, topFindings } from './render.ts';
-
-// The read surfaces this build registers.
-const COMMANDS = ['/health', '/recommend', '/findings', '/audit'];
+import { STORE_UNAVAILABLE_NOTE } from './render.ts';
 
 try {
   const cfg = loadConfig();
   const gateway = resolveDataGateway(cfg);
   try {
-    const [summary, findings] = await Promise.all([
-      gateway.healthSummary(),
-      gateway.recentFindings({ limit: 500 }),
-    ]);
-    // "Recommendations" mirrors /recommend exactly — the same builder + cap — so
-    // the card's count never disagrees with what that screen lists.
-    const recommendations = buildRecommendations(findings).length;
-
-    // Per-category posture — the wizard's policy write, read straight from the
-    // local store so the card shows what's actually enforced, not the single
-    // settings.policy string. readPostureBlock owns its own catch: a
-    // policies-read fault degrades to '' so the card omits only the Posture
-    // section (see renderFirstRun), rather than collapsing into the outer
-    // fail-open note below.
-    const postureBlock = await readPostureBlock(openLocalDatabase(cfg.dataDir));
-
-    process.stdout.write(
-      `${fenced(
-        renderFirstRun({
-          commands: COMMANDS,
-          posture: postureBlock,
-          health: healthScore(summary),
-          findings: summary.findings,
-          recommendations,
-          topFindings: topFindings(findings),
-        }),
-      )}\n`,
-    );
+    await runFirstRunFailOpen({
+      argv: process.argv.slice(2),
+      gateway,
+      readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+      stdout: (s) => process.stdout.write(s),
+    });
   } finally {
     await gateway.close();
   }
 } catch {
-  process.stdout.write('AKA could not read your data yet. It populates as you use Claude Code.\n');
+  // Config/gateway-resolution/close faults land here; the store-read failure inside
+  // runFirstRunFailOpen already degraded to the same note above.
+  process.stdout.write(`${STORE_UNAVAILABLE_NOTE}\n`);
 }
 
 process.exit(0);

--- a/plugins/claude-code/src/history/transcripts.ts
+++ b/plugins/claude-code/src/history/transcripts.ts
@@ -23,9 +23,9 @@ export interface ScannedMessage {
 }
 
 // Where Claude Code writes its per-project, per-session transcripts. `home`
-// overrides the OS home root (the wizard's ~/.aka override threads its parent dir
-// here so the journey harness scans a throwaway ~/.claude); omitted on every real
-// run, falling back to the OS home.
+// overrides the OS home root; it is supplied only by the journey harness/tests to
+// scan a throwaway ~/.claude in isolation — no production call site passes it, so
+// every real run falls back to the OS home.
 export function transcriptsDir(home?: string): string {
   return join(home ?? homedir(), '.claude', 'projects');
 }

--- a/plugins/claude-code/src/history/transcripts.ts
+++ b/plugins/claude-code/src/history/transcripts.ts
@@ -22,9 +22,12 @@ export interface ScannedMessage {
   occurredAt: string;
 }
 
-// Where Claude Code writes its per-project, per-session transcripts.
-export function transcriptsDir(): string {
-  return join(homedir(), '.claude', 'projects');
+// Where Claude Code writes its per-project, per-session transcripts. `home`
+// overrides the OS home root (the wizard's ~/.aka override threads its parent dir
+// here so the journey harness scans a throwaway ~/.claude); omitted on every real
+// run, falling back to the OS home.
+export function transcriptsDir(home?: string): string {
+  return join(home ?? homedir(), '.claude', 'projects');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/plugins/claude-code/src/identity.ts
+++ b/plugins/claude-code/src/identity.ts
@@ -1,0 +1,7 @@
+// Canonical product identity — the single source of the display name, tagline,
+// and one-liner. Every surface that shows the product's identity imports these
+// constants so the copy is defined once and cannot drift between screens.
+export const NAME = 'AKA Security';
+export const TAGLINE = 'We secure agent harnesses at the source.';
+export const ONE_LINER =
+  'I watch out for Claude as it codes — catching secrets and customer data before they slip out.';

--- a/plugins/claude-code/src/intro-card.ts
+++ b/plugins/claude-code/src/intro-card.ts
@@ -1,0 +1,34 @@
+// Pure manifest → setup-intro-card wiring for the `/aka:setup` wizard's first
+// screen. The display copy (name, tagline, one-liner) comes from the identity
+// constant; the factual fields (version, repository) come from the plugin
+// manifest so the card never drifts from the installed build. No I/O here — the
+// intro.ts adapter reads the manifest file and this turns it into the card, so
+// the wiring unit-tests without touching the filesystem.
+import { NAME, ONE_LINER, TAGLINE } from './identity.ts';
+import { renderSetupIntro } from './render.ts';
+
+export interface Manifest {
+  version?: string;
+  homepage?: string;
+}
+
+// "https://github.com/org/repo/tree/main/..." → "github.com/org/repo", the
+// compact form the card shows. Falls back to the raw value if it isn't a URL.
+function repoLabel(homepage: string | undefined): string {
+  if (!homepage) return '';
+  const stripped = homepage.replace(/^https?:\/\//, '');
+  const parts = stripped.split('/');
+  return parts.length >= 3 ? parts.slice(0, 3).join('/') : stripped;
+}
+
+// Fail-open: an empty manifest (unreadable/old plugin.json) still yields a card
+// with the identity copy and blank facts — onboarding never shows a stack trace.
+export function buildIntroCard(manifest: Manifest): string {
+  return renderSetupIntro({
+    name: NAME,
+    tagline: TAGLINE,
+    oneLiner: ONE_LINER,
+    repository: repoLabel(manifest.homepage),
+    version: manifest.version ?? '',
+  });
+}

--- a/plugins/claude-code/src/intro.ts
+++ b/plugins/claude-code/src/intro.ts
@@ -1,49 +1,25 @@
 /**
- * Setup-intro card — the first screen of the `/aka:setup` wizard (the onboarding
- * mock). Invoked by the wizard as:
+ * Setup-intro cards — the first two screens of the `/aka:setup` wizard: the
+ * kickoff card ("here I am") and the "what I do" card ("here's how I work"),
+ * shown back-to-back before the first question. Invoked by the wizard as:
  *
  *   node scripts/intro.js <path-to-.claude-plugin/plugin.json>
  *
  * The wizard passes the manifest path (it has ${CLAUDE_PLUGIN_ROOT} in the shell).
- * Factual fields —
- * version, repository, publisher — are read from that manifest so the card never
- * drifts from the actually-installed plugin; the descriptive copy (display name,
- * tagline, "what it adds") is product wording supplied here. Rendering lives in
- * ./render so it unit-tests without touching the filesystem.
+ * The kickoff card's factual fields — version, homepage — are read from that
+ * manifest so it never drifts from the actually-installed plugin; the display
+ * copy (name, tagline, one-liner) comes from the identity constant. The manifest
+ * → card wiring lives in ./intro-card so it unit-tests without touching the
+ * filesystem. The "what I do" card is static copy from ./render.
  *
- * Fail-open: an unreadable/old manifest still prints the card with the product
+ * Fail-open: an unreadable/old manifest still prints the cards with the identity
  * copy and blank/placeholder facts — onboarding should never show a stack trace.
  */
 import { readFileSync } from 'node:fs';
 
+import { buildIntroCard, type Manifest } from './intro-card.ts';
 import { fenced } from './present.ts';
-import { renderSetupIntro } from './render.ts';
-
-// Product copy. Not in the manifest because it's marketing wording, not a fact
-// about the installed build — the values below ARE read from the manifest.
-const NAME = 'AKA Security';
-const TAGLINE = 'Agent Harness Security for Claude Code.';
-const ADDS = 'Secures your local environment to prevent secret leakage and vulnerabilities.';
-
-interface Manifest {
-  version?: string;
-  homepage?: string;
-  author?: { name?: string } | string;
-}
-
-// "https://github.com/org/repo/tree/main/..." → "github.com/org/repo", the
-// compact form the mock shows. Falls back to the raw value if it isn't a URL.
-function repoLabel(homepage: string | undefined): string {
-  if (!homepage) return '';
-  const stripped = homepage.replace(/^https?:\/\//, '');
-  const parts = stripped.split('/');
-  return parts.length >= 3 ? parts.slice(0, 3).join('/') : stripped;
-}
-
-function authorName(author: Manifest['author']): string {
-  if (typeof author === 'string') return author;
-  return author?.name ?? '';
-}
+import { renderWhatIDo } from './render.ts';
 
 const manifestPath = process.argv[2];
 
@@ -51,21 +27,12 @@ let manifest: Manifest = {};
 try {
   manifest = JSON.parse(readFileSync(manifestPath ?? '', 'utf8')) as Manifest;
 } catch {
-  // Keep manifest empty; the card renders with product copy + blank facts.
+  // Keep manifest empty; the card renders with identity copy + blank facts.
 }
 
-process.stdout.write(
-  `${fenced(
-    renderSetupIntro({
-      name: NAME,
-      tagline: TAGLINE,
-      repository: repoLabel(manifest.homepage),
-      version: manifest.version ?? '',
-      publisher: authorName(manifest.author),
-      adds: ADDS,
-    }),
-  )}\n`,
-);
+// Each card is printed as its own Markdown code fence so the wizard can echo the
+// pair verbatim (space-aligned monospace collapses without the fence).
+process.stdout.write(`${fenced(buildIntroCard(manifest))}\n\n${fenced(renderWhatIDo())}\n`);
 
 // Match the other adapter scripts (query.js, onboard.js) which hard-exit on
 // completion so no stray handle can keep the process alive.

--- a/plugins/claude-code/src/onboard.ts
+++ b/plugins/claude-code/src/onboard.ts
@@ -32,6 +32,7 @@ import type { WorkspaceSettings } from '@akasecurity/schema';
 import { HistoricalAccess, SimpleDetectionPolicy } from '@akasecurity/schema';
 
 import { parsePosture } from './onboard-posture.ts';
+import { renderCategoriesTuned } from './render.ts';
 
 // Pull `--flag value` and `--flag=value` pairs out of argv. Unknown flags and
 // positionals are ignored — the wizard only ever passes the ones it knows.
@@ -140,10 +141,12 @@ if (rawPosture !== undefined || useFloor) {
     const db = openLocalDatabase(loadConfig().dataDir);
     try {
       applyCategoryPosture(posture, db.policies, mode);
+      // The applying confirmation — the "tuned" segment reports the
+      // categories the applied posture covers (the 8-pack matrix, or the
+      // severity-floor fallback), never a literal.
       const categoryCount = Object.keys(posture).length;
       process.stdout.write(
-        `AKA per-category posture saved (${String(categoryCount)} categories` +
-          `${useFloor ? ', severity floor' : ''}).\n`,
+        renderCategoriesTuned(categoryCount) + (useFloor ? ' (severity floor)' : '') + '\n',
       );
     } finally {
       db.close();

--- a/plugins/claude-code/src/posture.ts
+++ b/plugins/claude-code/src/posture.ts
@@ -9,8 +9,8 @@ import { renderPosture } from './render.ts';
 // Best-effort by design: this OWNS the catch so a policies-read fault degrades
 // to '' — renderFirstRun then hides only the Posture section instead of letting
 // the throw propagate to firstrun's outer fail-open handler and collapse the
-// entire card into the "AKA could not read your data yet…" note. Always closes
-// the handle it was given, on both paths.
+// entire card into the store-unavailable note. Always closes the handle it was
+// given, on both paths.
 export async function readPostureBlock(
   db: Pick<LocalDatabase, 'policies' | 'close'>,
 ): Promise<string> {

--- a/plugins/claude-code/src/posture.ts
+++ b/plugins/claude-code/src/posture.ts
@@ -6,15 +6,18 @@ import { renderPosture } from './render.ts';
 // store (the wizard's policy write) so the card shows what's actually enforced
 // rather than the single settings.policy string.
 //
-// Best-effort by design: this OWNS the catch so a policies-read fault degrades
-// to '' — renderFirstRun then hides only the Posture section instead of letting
-// the throw propagate to firstrun's outer fail-open handler and collapse the
-// entire card into the store-unavailable note. Always closes the handle it was
-// given, on both paths.
+// Best-effort by design: this OWNS the catch so a policies fault degrades to ''
+// — renderFirstRun then hides only the Posture section instead of letting the
+// throw propagate to firstrun's outer fail-open handler and collapse the entire
+// card into the store-unavailable note. The store is opened INSIDE the guarded
+// scope via the injected opener, so an open failure degrades identically to a
+// read failure. Always closes the handle when one was opened, on both paths.
 export async function readPostureBlock(
-  db: Pick<LocalDatabase, 'policies' | 'close'>,
+  open: () => Pick<LocalDatabase, 'policies' | 'close'>,
 ): Promise<string> {
+  let db: Pick<LocalDatabase, 'policies' | 'close'> | undefined;
   try {
+    db = open();
     const policies = await db.policies.readPolicies();
     return renderPosture(
       policies
@@ -25,9 +28,10 @@ export async function readPostureBlock(
         .filter((r) => r.category !== ''),
     );
   } catch {
-    // Best-effort: an unreadable policies store just omits the Posture section.
+    // Best-effort: an unreadable or unopenable policies store just omits the
+    // Posture section.
     return '';
   } finally {
-    db.close();
+    db?.close();
   }
 }

--- a/plugins/claude-code/src/render.ts
+++ b/plugins/claude-code/src/render.ts
@@ -13,9 +13,15 @@ import type {
   SessionTokenReport,
 } from '@akasecurity/plugin-sdk';
 import { aggregateTokenUsage, formatCostTotal, formatUsd } from '@akasecurity/plugin-sdk';
-import type { DetectionException, DetectionListItem } from '@akasecurity/schema';
+import type {
+  BuiltinPolicyId,
+  DetectionException,
+  DetectionListItem,
+  SetupHandoffOffer,
+} from '@akasecurity/schema';
 import { DetectionCategory, toApiAction } from '@akasecurity/schema';
 
+import { NAME } from './identity.ts';
 import {
   bar,
   defList,
@@ -28,6 +34,15 @@ import {
   table,
   wrapText,
 } from './present.ts';
+
+// The fail-open note shown when the local store can't be READ (missing / corrupt
+// / locked db) mid-wizard: the calibration and first-run frames print this instead
+// of throwing, so a store fault never breaks the Claude session.
+// TODO: the found-nothing / empty-store case (a store that reads fine but holds
+// nothing) is a separate path with its own copy, landing later — keep it distinct
+// from this store-unavailable read-failure note; do not conflate the two.
+export const STORE_UNAVAILABLE_NOTE =
+  "I couldn't read the local store right now. AKA stays fail-open — your Claude session is unaffected, and it populates as you use Claude Code.";
 
 const SEVERITY_WEIGHT: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
 
@@ -105,33 +120,94 @@ export function renderPosture(rows: { category: string; action: string }[]): str
     .join('\n');
 }
 
+// The condensed recommended-posture view for the calibrated-result frame: one
+// compact row per pack showing the level AKA recommends, in canonical category
+// order. This is the recommend-and-confirm glance — distinct from the start-light
+// branch's full 8×4 level table, which lays every level out per pack. Pure (no
+// I/O); the caller hands in the recommended posture (severityFloorPosture()),
+// whose palette levels (monitor/warn/redact/block) render verbatim.
+export function renderRecommendedPosture(
+  posture: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+): string {
+  const rows = (Object.keys(posture) as DetectionCategory[]).map((category) => ({
+    category,
+    level: posture[category] ?? '',
+  }));
+  const width = Math.max(0, ...rows.map((r) => r.category.length));
+  return rows
+    .sort((a, b) => categoryRank(a.category) - categoryRank(b.category))
+    .map((r) => `  ${r.category.padEnd(width)}  ${r.level}`)
+    .join('\n');
+}
+
+// The read commands the applying-confirmation "Ready" line points at once
+// calibration is applied. Written in the plugin's `/aka:<command>` namespace — the only form
+// that resolves when typed — so the call-to-action never names a command the
+// user can't actually invoke.
+// TODO: derive this from the plugin command registry once one is available.
+const READY_COMMANDS = ['/aka:health', '/aka:findings', '/aka:recommend'] as const;
+
+// The "tuned" segment — the count of posture categories the writer
+// wrote, threaded from the real write (never a literal). Single-sourced here so
+// onboard.ts's posture-write confirmation and the composed applying-confirmation
+// line read identically.
+export function renderCategoriesTuned(categoriesTuned: number): string {
+  const noun = categoriesTuned === 1 ? 'category' : 'categories';
+  return `✓ ${String(categoriesTuned)} ${noun} tuned`;
+}
+
+// The /aka:setup wizard's applying confirmation, shown once the
+// calibration takes effect: '✓ K categories tuned · ✓ N routine dismissed ·
+// Ready: …'. Both counts are threaded from the real apply result (the posture
+// writer's category count and the apply-suppressions result's written count),
+// never a literal. When nothing routine was dismissed (N === 0) the middle
+// segment is honest empty-state copy rather than a fabricated '✓ 0 routine
+// dismissed'. Pure (no I/O) so it unit-tests without a DB.
+export function renderApplied(categoriesTuned: number, dismissed: number): string {
+  const routine =
+    dismissed > 0 ? `✓ ${String(dismissed)} routine dismissed` : 'no routine to dismiss';
+  const ready = `Ready: ${READY_COMMANDS.join(' · ')}`;
+  return `${renderCategoriesTuned(categoriesTuned)} · ${routine} · ${ready}`;
+}
+
 const RULE_WIDTH = 64;
 
 // The setup-intro "card" the /aka:setup wizard shows first.
-// Factual fields (version, repository, publisher) are read from the plugin
-// manifest by the intro script; the descriptive copy (name, tagline, adds) is
-// product wording the script supplies. Pure here so it renders without any I/O.
+// Factual fields (version, repository) are read from the plugin manifest by the
+// intro script; the display copy (name, tagline, one-liner) comes from the
+// identity constant. Pure here so it renders without any I/O.
 export interface PluginMeta {
   name: string;
   tagline: string;
+  oneLiner: string;
   repository: string;
   version: string;
-  publisher: string;
-  adds: string;
 }
 
 export function renderSetupIntro(meta: PluginMeta): string {
   const heading = `● Found ${meta.name} — ${meta.tagline}`;
 
-  const details = defList([
-    ['Repository', meta.repository],
-    ['Version', `${meta.version} · ${meta.publisher}`],
-    ['Adds', meta.adds],
-  ]);
+  // The ' · verified' badge is appended here once the provenance check lands.
+  const provenance = `v${meta.version} · ${meta.repository}`;
 
-  const ask = "Before installing I'll ask two quick questions to tailor the setup.";
+  return [heading, '', indent(meta.oneLiner), '', indent(provenance)].join('\n');
+}
 
-  return [heading, '', indent(details), '', indent(ask)].join('\n');
+// The "What I do" card the /aka:setup wizard shows after the intro. Static
+// explanatory copy — no data to template, so it takes no arguments. Pure here so
+// it renders without any I/O and unit-tests as a plain string. The closing line
+// hands off to the scan offer that calibrates the notifications.
+export function renderWhatIDo(): string {
+  return [
+    '● I watch out for Claude as it works.',
+    '',
+    indent(
+      'As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.',
+    ),
+    indent("Most of it I handle quietly; I only notify you when it's worth your call."),
+    '',
+    indent("let's calibrate your notifications based on what Claude's been up to"),
+  ].join('\n');
 }
 
 // Derived posture score (0–100). HEURISTIC — we don't store a posture score, so
@@ -146,11 +222,10 @@ export function healthScore(summary: HealthSummary): number {
   return Math.round(100 * (0.6 * summary.coverage + 0.4 * handledRatio));
 }
 
-// The "First run" completion screen. Commands,
-// posture, findings and recommendations are real; `health` is the derived score
-// above. The host's input box and window chrome are not the plugin's to draw.
+// The "First run" completion screen. Posture, findings and
+// recommendations are real; `health` is the derived score above. The host's
+// input box and window chrome are not the plugin's to draw.
 export interface FirstRunSummary {
-  commands: string[];
   // Per-category posture block (renderPosture's output) — the wizard's
   // per-category policy read, one row per category. Optional/omittable: the
   // read lives inside firstrun's fail-open try/catch, so a store that can't
@@ -159,10 +234,22 @@ export interface FirstRunSummary {
   health: number;
   findings: number;
   recommendations: number;
+  // The surfaced/important count carried over from the calibration
+  // preview — drives the 'N worth a look' dashboard handoff. Rendered only when
+  // it is a positive count; the nothing-surfaced empty-state degradation is a
+  // separate screen handled elsewhere, so 0/undefined just omits the line here.
+  worthALook?: number;
   // Highest-severity findings from the first scan, ranked + capped by topFindings.
   // Omitted (or empty) on a clean scan — the section is hidden then.
   topFindings?: FindingView[];
 }
+
+// The commands the installed-summary "Try" line points at — the dashboard and the
+// working-tree scan, both shipped in this plugin's `/aka:<command>` namespace
+// (the only form that resolves when typed). Hardcoded to the current command
+// set so the call-to-action never names a command the user cannot invoke.
+// TODO: derive this from the plugin command registry once one is available.
+const TRY_COMMANDS = ['/aka:dashboard', '/aka:scan'] as const;
 
 // Rank findings for the install card's "Top findings" list: most severe first,
 // then most recent within a severity, capped to `limit`. Pure so the first-run
@@ -176,14 +263,28 @@ export function topFindings(findings: FindingView[], limit = 10): FindingView[] 
     .slice(0, limit);
 }
 
+// The handoff-offer payload: the 'M worth a look' count the installed
+// summary hands to its dashboard question, plus the two fixed offer options.
+// `worthALook` is the surfaced/important count the caller carries over from the
+// calibration preview (a real store-derived value) — this builder
+// never invents it. The prompt layer (setup.md) issues the AskUserQuestion; this
+// is the structured payload a harness reads to assert the offer.
+export function buildHandoffOffer(worthALook: number): SetupHandoffOffer {
+  return {
+    worthALook,
+    options: [
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ],
+  };
+}
+
 export function renderFirstRun(s: FirstRunSummary): string {
-  const heading = '✓ AKA Security installed';
+  const heading = `✓ ${NAME} installed — calibrated to this machine`;
 
-  const details = defList([['Commands', s.commands.join(' · ')]]);
+  const stats = `Health ${String(s.health)}/100 · Findings ${String(s.findings)} · Recommendations ${String(s.recommendations)}`;
 
-  const stats = `Health ${String(s.health)}/100   Findings ${String(s.findings)}   Recommendations ${String(s.recommendations)}`;
-
-  const lines = [heading, '', indent(details)];
+  const lines = [heading, '', indent(stats), '', indent(`Try: ${TRY_COMMANDS.join(' · ')}`)];
 
   // Per-category posture — hidden when unreadable (fail-open upstream leaves
   // it undefined/empty) so the card degrades gracefully instead of showing an
@@ -192,14 +293,7 @@ export function renderFirstRun(s: FirstRunSummary): string {
     lines.push('', indent('Posture'), '', indent(s.posture));
   }
 
-  lines.push(
-    '',
-    indent('─'.repeat(RULE_WIDTH)),
-    '',
-    indent('First scan complete'),
-    '',
-    indent(stats),
-  );
+  lines.push('', indent('─'.repeat(RULE_WIDTH)), '', indent('First scan complete'));
 
   // Top findings — a compact, severity-ranked glance at what the first scan
   // caught. Hidden on a clean scan so the card stays a tidy success state.
@@ -225,7 +319,18 @@ export function renderFirstRun(s: FirstRunSummary): string {
     );
   }
 
-  lines.push('', indent('Opening your health dashboard… run /health anytime'));
+  // Dashboard handoff — the 'N worth a look' offer over the real surfaced count,
+  // pairing the AskUserQuestion the prompt layer issues (Open dashboard / Not
+  // now). Shown only when something surfaced; the nothing-surfaced degradation
+  // is a separate frame, so a 0/absent count just omits the line here.
+  if (s.worthALook !== undefined && s.worthALook > 0) {
+    lines.push(
+      '',
+      indent(`${String(s.worthALook)} worth a look — see them in the browser?`),
+      indent('Open dashboard · Not now'),
+    );
+  }
+
   return lines.join('\n');
 }
 

--- a/plugins/claude-code/src/setup-frame-json.ts
+++ b/plugins/claude-code/src/setup-frame-json.ts
@@ -1,0 +1,36 @@
+/**
+ * Machine-readable frame payloads the /aka:setup wizard scripts emit ALONGSIDE
+ * their human-readable copy. A frame's structured JSON is wrapped in these
+ * markers so a harness (or the later Claude layer) can extract exactly one
+ * payload from a script's stdout without parsing the surrounding rendered card.
+ * The block is additive: the human copy is never replaced.
+ *
+ * The payload carries only masked/enum/count data by construction — the callers
+ * build it from raw-free plan/store values, never from raw detected content.
+ */
+
+export const FRAME_JSON_BEGIN = '<<<AKA_FRAME_JSON';
+export const FRAME_JSON_END = 'AKA_FRAME_JSON>>>';
+
+// Wrap a frame payload in the delimited block a script appends to its stdout.
+export function frameJsonBlock(payload: unknown): string {
+  return `${FRAME_JSON_BEGIN}\n${JSON.stringify(payload)}\n${FRAME_JSON_END}\n`;
+}
+
+// Extract and parse the single frame payload from a script's stdout, or
+// undefined when no block is present or its contents are not valid JSON. Shared
+// so the emitter and its readers (tests, harness) agree on the delimiters. A
+// malformed block resolves to undefined rather than throwing, so a reader can
+// treat "no readable frame" uniformly.
+export function readFrameJsonBlock(stdout: string): unknown {
+  const begin = stdout.indexOf(FRAME_JSON_BEGIN);
+  if (begin === -1) return undefined;
+  const from = begin + FRAME_JSON_BEGIN.length;
+  const end = stdout.indexOf(FRAME_JSON_END, from);
+  if (end === -1) return undefined;
+  try {
+    return JSON.parse(stdout.slice(from, end).trim());
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -15,14 +15,18 @@
  * All IO (stream read, judge spawn, DB, clock, stdout/stderr) is injected so this
  * is unit-testable with fakes; the script wires the real implementations.
  */
-import { assertRawFree, type ExceptionWriter } from '@akasecurity/plugin-sdk';
+import { assertRawFree, type ExceptionWriter, severityFloorPosture } from '@akasecurity/plugin-sdk';
 import type {
   ActionTaken,
+  CalibrationPreview,
   DetectionCategory,
   TriageHit,
   TriageRecommendation,
 } from '@akasecurity/schema';
 
+import { frameCalibration } from '../calibration.ts';
+import { renderApplied, renderRecommendedPosture, STORE_UNAVAILABLE_NOTE } from '../render.ts';
+import { frameJsonBlock } from '../setup-frame-json.ts';
 import { renderPosturePlan, renderShowcase, renderSuppressionGate } from './gate-display.ts';
 import { deletePlanFile, readPlanFile, writePlanFile } from './plan-file.ts';
 import {
@@ -30,6 +34,7 @@ import {
   parseTriageStream,
   performTriageWriteback,
   planTriageWriteback,
+  recommendedPosture,
 } from './writeback.ts';
 
 export interface AdapterDb {
@@ -112,18 +117,33 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
 
     // Read the store's current per-category action for the downgrade view.
     // Read-only; retained in the plan file so confirm needn't re-read the DB.
+    // Fail-open: this is the calibration step's only store read, and an unreadable
+    // store (missing / corrupt / locked db) must degrade the downgrade comparison
+    // to the honest store-unavailable note rather than throw and break the wizard.
+    // The calibrated counts below come from the reviewed plan, not the store, so
+    // they still render truthfully — no fabricated count stands in for the fault.
     const current: Partial<Record<DetectionCategory, ActionTaken>> = {};
-    const db = deps.openDb();
+    let storeUnavailable = false;
     try {
-      for (const category of Object.keys(plan.posture) as DetectionCategory[]) {
-        const action = db.policies.getCategoryAction(category);
-        if (action !== undefined) current[category] = action;
+      const db = deps.openDb();
+      try {
+        for (const category of Object.keys(plan.posture) as DetectionCategory[]) {
+          const action = db.policies.getCategoryAction(category);
+          if (action !== undefined) current[category] = action;
+        }
+      } finally {
+        db.close();
       }
-    } finally {
-      db.close();
+    } catch {
+      storeUnavailable = true;
     }
 
-    deps.stdout(renderPosturePlan(plan.posture, current) + '\n\n');
+    if (storeUnavailable) {
+      deps.stdout(`${STORE_UNAVAILABLE_NOTE}\n\n`);
+    }
+    // With no readable store the downgrade comparison has no baseline, so pass an
+    // empty current — every category renders as new rather than a partial/false view.
+    deps.stdout(renderPosturePlan(plan.posture, storeUnavailable ? {} : current) + '\n\n');
     deps.stdout(renderShowcase(plan.showcase) + '\n\n');
     deps.stdout(renderSuppressionGate(plan.entries, plan.join) + '\n');
     if (plan.skipped.length > 0) {
@@ -135,9 +155,42 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     }
     deps.stdout(`\nNotes: ${plan.notes}\n`);
 
+    // Emit the structured calibration frame ALONGSIDE the human gate
+    // above — additive, not a replacement. Counts and category lists come from
+    // the raw-free plan's per-category genuine/suppressed split (surviving
+    // categories only; a poisoned category was already dropped). The posture is
+    // the full recommended view — the severity floor overlaid with the
+    // evidence-derived actions the judge assigned — so every pack is present.
+    // The retroactive scan reads at-rest history (transcripts, temp files, agent
+    // memory), so every triaged kind is an at-rest exposure, not an
+    // outbound-leak: egress is false across the board here. The frame carries
+    // only masked/enum/count data, so it stays within this raw-egress boundary.
+    const preview: CalibrationPreview = {
+      categories: plan.showcase.map((c) => ({
+        category: c.category,
+        genuineCount: c.genuineCount,
+        fpCount: c.fpCount,
+        egress: false,
+      })),
+      posture: recommendedPosture(plan.posture),
+    };
+    const calibration = frameCalibration(preview);
+
+    // The calibrated-result card: the real-count headline over the
+    // preview's genuine/suppressed split, then the condensed one-row-per-pack
+    // recommended posture. Both are raw-free (counts, category enums, and palette
+    // levels only) and template over this run's numbers, never a fixed value.
+    deps.stdout(`${calibration.copy}\n\n${renderRecommendedPosture(preview.posture)}\n\n`);
+
+    // The machine-readable calibration frame carrying the same counts/posture the
+    // card above renders, for downstream consumers (the installed-summary handoff).
+    deps.stdout(frameJsonBlock(calibration.frame));
+
     // Persist the EXACT resolved raw-free plan the user is about to approve. The
-    // backstop (assertRawFree over the serialized doc) runs inside write().
-    const planPath = planIO.write(plan, current, rawValues);
+    // backstop (assertRawFree over the serialized doc) runs inside write(). With an
+    // unreadable store the baseline is empty (matching the displayed view), so a
+    // later confirm re-reads and drift-gates rather than trusting a partial read.
+    const planPath = planIO.write(plan, storeUnavailable ? {} : current, rawValues);
     deps.stdout(`\nPlan saved to: ${planPath}\n`);
     deps.stdout(
       `Re-run with: apply-suppressions.js --confirmed --plan ${planPath}\n` +
@@ -242,6 +295,13 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
       // `transaction` makes the posture + suppression writes ALL-OR-NOTHING, so a
       // mid-batch fault rolls the posture overwrite back too — the store is never
       // left half-applied (and the floor fallback below is safe: nothing persisted).
+      // Establish the full 8-pack the preview showed so settings holds
+      // all 8 packs and the confirmation reads '8 categories tuned': the reviewed,
+      // drift-gated evidence packs (plan.posture) OVERWRITE, and the severity floor
+      // fills the remaining packs with FILL-GAPS. The floor packs are not covered by
+      // the drift gate above (only the reviewed evidence is), so they must never
+      // overwrite — an out-of-band-hardened pack (e.g. code_context=block) is left
+      // as-is rather than silently reset to the weak floor.
       {
         posture: plan.posture,
         entries: plan.entries,
@@ -256,7 +316,7 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
         // Only set when the store provides one (exactOptionalPropertyTypes).
         ...(db.transaction ? { transaction: db.transaction } : {}),
       },
-      { createdBy: deps.createdBy(), now: deps.now() },
+      { createdBy: deps.createdBy(), now: deps.now(), floor: severityFloorPosture() },
     );
     // The write COMMITTED. From here nothing may flip the result to failure:
     // cleanup (plan-file delete) and reporting (stdout) are best-effort, and a
@@ -268,11 +328,9 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
       // A leftover temp plan file is harmless; the apply already succeeded.
     }
     try {
-      deps.stdout(
-        `AKA suppressions applied: ${String(res.written)} written` +
-          (res.skippedDuplicate > 0 ? `, ${String(res.skippedDuplicate)} already active` : '') +
-          `; posture calibrated for ${String(res.categoriesWritten)} categories.\n`,
-      );
+      // The applying confirmation — the tuned-category and routine-dismissed
+      // counts threaded from the real writeback result, never a literal.
+      deps.stdout(`${renderApplied(res.categoriesWritten, res.written)}\n`);
     } catch {
       // Reporting failed but the write did not — still a success.
     }

--- a/plugins/claude-code/src/triage/writeback.ts
+++ b/plugins/claude-code/src/triage/writeback.ts
@@ -22,6 +22,7 @@ import {
   assertRawFree,
   type ExceptionWriter,
   RawEgressError,
+  severityFloorPosture,
   type SuppressionEntry,
 } from '@akasecurity/plugin-sdk';
 import type {
@@ -252,6 +253,20 @@ export function planTriageWriteback(
   return { entries, posture, showcase, join, notes, skipped };
 }
 
+// The full recommended posture the preview shows: the cold-start severity floor
+// for all 8 packs, overlaid with the evidence-derived actions the judge assigned.
+// Single-sourced so the previewed posture matches the 8-pack the confirm write
+// establishes — the 'N categories tuned' count is the size of this map
+// (8), not the survivor subset the evidence produced. The confirm write does NOT
+// blanket-overwrite this map: the reviewed evidence packs overwrite, the floor
+// packs only fill gaps (see performTriageWriteback), so a pack the user already
+// hardened is never silently downgraded to the weak floor.
+export function recommendedPosture(
+  evidence: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+): Record<DetectionCategory, BuiltinPolicyId> {
+  return { ...severityFloorPosture(), ...evidence };
+}
+
 // -------------------------------------------------------------------------
 // performTriageWriteback (destructive; takes an already-resolved plan)
 // -------------------------------------------------------------------------
@@ -284,14 +299,36 @@ export interface TriageWritebackWriters {
 export async function performTriageWriteback(
   plan: TriageWritebackPlan,
   writers: TriageWritebackWriters,
-  opts: { createdBy: string; now: number },
+  opts: {
+    createdBy: string;
+    now: number;
+    // The cold-start severity floor to establish for the packs the evidence did
+    // not cover, so the confirmed store holds all 8 packs. Optional: omit it
+    // and only the plan's own posture is written (the pure-plan tests do this).
+    floor?: Partial<Record<DetectionCategory, BuiltinPolicyId>>;
+  },
 ): Promise<{ written: number; skippedDuplicate: number; categoriesWritten: number }> {
   const applyBoth = async (): Promise<{ written: number; skippedDuplicate: number }> => {
+    // The reviewed, drift-gated evidence posture: overwrite the surviving
+    // categories the user saw in the gate.
     applyCategoryPosture(plan.posture, writers.policies, 'overwrite');
-    return applySetupTriageSuppressions(plan.entries, writers.exceptions, opts);
+    // The cold-start floor for the remaining packs, when supplied: fill-gaps
+    // ONLY. A pack the user already hardened out-of-band (not in the evidence, so
+    // never reviewed or drift-checked) is left untouched — the floor establishes
+    // a posture only where none exists, never a downgrade (mirrors onboard.ts's
+    // --floor semantics).
+    if (opts.floor) applyCategoryPosture(opts.floor, writers.policies, 'fill-gaps');
+    return applySetupTriageSuppressions(plan.entries, writers.exceptions, {
+      createdBy: opts.createdBy,
+      now: opts.now,
+    });
   };
   const { written, skippedDuplicate } = writers.transaction
     ? await writers.transaction(applyBoth)
     : await applyBoth();
-  return { written, skippedDuplicate, categoriesWritten: Object.keys(plan.posture).length };
+  // Every category that now holds a posture: the reviewed evidence packs plus the
+  // floor packs (8 when the floor is supplied), so the tuned count is honest.
+  const tuned = new Set<DetectionCategory>(Object.keys(plan.posture) as DetectionCategory[]);
+  if (opts.floor) for (const c of Object.keys(opts.floor) as DetectionCategory[]) tuned.add(c);
+  return { written, skippedDuplicate, categoriesWritten: tuned.size };
 }

--- a/plugins/claude-code/test/calibration.test.ts
+++ b/plugins/claude-code/test/calibration.test.ts
@@ -72,7 +72,9 @@ describe('frameCalibration', () => {
 
   it("templates the 'Calibrated.' copy exactly over the preview values", () => {
     const { copy } = frameCalibration(preview);
-    expect(copy).toBe('Calibrated. 161 notifications, 3 important. 158 routine, 3 that matter (live keys)');
+    expect(copy).toBe(
+      'Calibrated. 161 notifications, 3 important. 158 routine, 3 that matter (live keys)',
+    );
   });
 
   it('templates over a different preview — the numbers follow the input', () => {
@@ -85,7 +87,9 @@ describe('frameCalibration', () => {
     };
     const { frame, copy } = frameCalibration(other);
     expect(frame.counts).toEqual({ total: 10, important: 2, routine: 8 });
-    expect(copy).toBe('Calibrated. 10 notifications, 2 important. 8 routine, 2 that matter (live keys)');
+    expect(copy).toBe(
+      'Calibrated. 10 notifications, 2 important. 8 routine, 2 that matter (live keys)',
+    );
     expect(copy).not.toContain('161');
   });
 
@@ -98,7 +102,9 @@ describe('frameCalibration', () => {
       posture: preview.posture,
     };
     const { copy } = frameCalibration(piiSurfaced);
-    expect(copy).toBe('Calibrated. 24 notifications, 4 important. 20 routine, 4 that matter (personal data)');
+    expect(copy).toBe(
+      'Calibrated. 24 notifications, 4 important. 20 routine, 4 that matter (personal data)',
+    );
     expect(copy).not.toContain('live keys');
   });
 });

--- a/plugins/claude-code/test/calibration.test.ts
+++ b/plugins/claude-code/test/calibration.test.ts
@@ -1,0 +1,104 @@
+import { CalibrationFrame, type CalibrationPreview } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { frameCalibration } from '../src/calibration.ts';
+
+// A backfill + apply-suppressions preview with 161 findings of which 3 are surfaced
+// (genuine live secret keys) and 158 are suppressed FPs. Every count is carried in
+// from the preview breakdown — nothing is hardcoded in the module under test.
+const preview: CalibrationPreview = {
+  categories: [
+    { category: 'secret', genuineCount: 3, fpCount: 0, egress: false },
+    { category: 'pii', genuineCount: 0, fpCount: 100, egress: false },
+    { category: 'code_context', genuineCount: 0, fpCount: 50, egress: false },
+    { category: 'config', genuineCount: 0, fpCount: 8, egress: false },
+  ],
+  posture: {
+    secret: 'warn',
+    pii: 'warn',
+    financial: 'warn',
+    phi: 'warn',
+    code_flaw: 'warn',
+    custom: 'warn',
+    code_context: 'monitor',
+    config: 'monitor',
+  },
+};
+
+describe('frameCalibration', () => {
+  it('reports 161 notifications, 3 important, 158 routine from the preview', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.counts).toEqual({ total: 161, important: 3, routine: 158 });
+  });
+
+  it('emits a valid CalibrationFrame shape', () => {
+    const { frame } = frameCalibration(preview);
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it("'important' equals the surfaced count and 'routine' equals the suppressed count", () => {
+    const surfaced = preview.categories.reduce((n, c) => n + c.genuineCount, 0);
+    const suppressed = preview.categories.reduce((n, c) => n + c.fpCount, 0);
+    const { frame } = frameCalibration(preview);
+    expect(frame.counts.important).toBe(surfaced);
+    expect(frame.counts.routine).toBe(suppressed);
+    // Emitter-enforced sum: total is exactly important + routine, no third source.
+    expect(frame.counts.total).toBe(frame.counts.important + frame.counts.routine);
+  });
+
+  it('partitions the surfaced and routine category lists', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.surfacedCategories).toEqual(['secret']);
+    expect(frame.routineCategories).toEqual(['pii', 'code_context', 'config']);
+  });
+
+  it('keeps a mixed category in both lists — its suppressed findings still count as routine', () => {
+    const mixed: CalibrationPreview = {
+      categories: [{ category: 'secret', genuineCount: 2, fpCount: 5, egress: false }],
+      posture: preview.posture,
+    };
+    const { frame } = frameCalibration(mixed);
+    expect(frame.surfacedCategories).toEqual(['secret']);
+    expect(frame.routineCategories).toEqual(['secret']);
+    expect(frame.counts).toEqual({ total: 7, important: 2, routine: 5 });
+  });
+
+  it('carries the egress-kind axis through into findingKinds', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.findingKinds).toContainEqual({ category: 'secret', count: 3, egress: false });
+    // Every finding kind carries the axis; none is dropped.
+    expect(frame.findingKinds.every((k) => typeof k.egress === 'boolean')).toBe(true);
+  });
+
+  it("templates the 'Calibrated.' copy exactly over the preview values", () => {
+    const { copy } = frameCalibration(preview);
+    expect(copy).toBe('Calibrated. 161 notifications, 3 important. 158 routine, 3 that matter (live keys)');
+  });
+
+  it('templates over a different preview — the numbers follow the input', () => {
+    const other: CalibrationPreview = {
+      categories: [
+        { category: 'secret', genuineCount: 2, fpCount: 0, egress: false },
+        { category: 'pii', genuineCount: 0, fpCount: 8, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { frame, copy } = frameCalibration(other);
+    expect(frame.counts).toEqual({ total: 10, important: 2, routine: 8 });
+    expect(copy).toBe('Calibrated. 10 notifications, 2 important. 8 routine, 2 that matter (live keys)');
+    expect(copy).not.toContain('161');
+  });
+
+  it("derives the 'that matter (…)' kind from the surfaced categories, not a fixed label", () => {
+    const piiSurfaced: CalibrationPreview = {
+      categories: [
+        { category: 'pii', genuineCount: 4, fpCount: 0, egress: false },
+        { category: 'secret', genuineCount: 0, fpCount: 20, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { copy } = frameCalibration(piiSurfaced);
+    expect(copy).toBe('Calibrated. 24 notifications, 4 important. 20 routine, 4 that matter (personal data)');
+    expect(copy).not.toContain('live keys');
+  });
+});

--- a/plugins/claude-code/test/calibration.test.ts
+++ b/plugins/claude-code/test/calibration.test.ts
@@ -93,6 +93,23 @@ describe('frameCalibration', () => {
     expect(copy).not.toContain('161');
   });
 
+  it('omits the kind parenthetical entirely when nothing surfaced (all suppressed)', () => {
+    const allSuppressed: CalibrationPreview = {
+      categories: [
+        { category: 'pii', genuineCount: 0, fpCount: 8, egress: false },
+        { category: 'config', genuineCount: 0, fpCount: 2, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { frame, copy } = frameCalibration(allSuppressed);
+    expect(frame.surfacedCategories).toEqual([]);
+    expect(frame.counts).toEqual({ total: 10, important: 0, routine: 10 });
+    expect(copy).toBe('Calibrated. 10 notifications, 0 important. 10 routine, 0 that matter');
+    // No dangling empty parenthetical.
+    expect(copy).not.toContain('()');
+    expect(copy).not.toContain('matter (');
+  });
+
   it("derives the 'that matter (…)' kind from the surfaced categories, not a fixed label", () => {
     const piiSurfaced: CalibrationPreview = {
       categories: [

--- a/plugins/claude-code/test/firstrun-core.test.ts
+++ b/plugins/claude-code/test/firstrun-core.test.ts
@@ -71,7 +71,7 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
       await runFirstRun({
         argv,
         gateway,
-        readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
         stdout: (s) => out.push(s),
       });
     } finally {
@@ -109,6 +109,42 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     expect(readFrameJsonBlock(blob)).toBeUndefined();
   });
 
+  it('omits only the Posture section (rest of the card renders) when opening the posture store throws', async () => {
+    const cfg = config(dir);
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'claude-code', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv: ['--surfaced', '2'],
+        gateway,
+        // The posture opener throws (unopenable store). It degrades identically
+        // to a read fault: only the Posture section is hidden.
+        readPosture: () =>
+          readPostureBlock(() => {
+            throw new Error('cannot open database');
+          }),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+
+    // The rest of the install card still renders over the live gateway…
+    expect(blob).toContain('installed');
+    expect(blob).toContain('First scan complete');
+    expect(blob).toContain('Findings');
+    // …and the handoff payload is still emitted.
+    expect(SetupHandoffOffer.safeParse(readFrameJsonBlock(blob)).success).toBe(true);
+    // …but the Posture section is omitted, not collapsed into the fail-open note.
+    expect(blob).not.toContain('Posture');
+    expect(blob).not.toContain("I couldn't read the local store");
+  });
+
   it('carries no raw detected value into the emitted frame block', async () => {
     const blob = await seedAndRun(['--surfaced', '2']);
     expect(blob).toContain('<<<AKA_FRAME_JSON');
@@ -140,7 +176,7 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
       await runFirstRun({
         argv: [],
         gateway,
-        readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
         stdout: (s) => out.push(s),
       });
     } finally {

--- a/plugins/claude-code/test/firstrun-core.test.ts
+++ b/plugins/claude-code/test/firstrun-core.test.ts
@@ -1,0 +1,203 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { handleCapture, resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
+import { SetupHandoffOffer } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { parseSurfacedCount, runFirstRun, runFirstRunFailOpen } from '../src/firstrun-core.ts';
+import { readPostureBlock } from '../src/posture.ts';
+import { readFrameJsonBlock } from '../src/setup-frame-json.ts';
+
+// Composed at runtime so the repo's own secret scanning doesn't flag this file.
+const AWS_EXAMPLE_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+// Composed for the same reason — a literal address would be redacted on write.
+const PII_EMAIL = ['jane.doe', 'example.com'].join('@');
+
+function config(dataDir: string): PluginConfig {
+  return {
+    settings: {
+      specVersion: 1,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'session-only',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'anthropic' },
+  };
+}
+
+describe('parseSurfacedCount', () => {
+  it('reads a non-negative integer from --surfaced', () => {
+    expect(parseSurfacedCount(['--surfaced', '3'])).toBe(3);
+    expect(parseSurfacedCount(['--surfaced', '0'])).toBe(0);
+  });
+
+  it('returns undefined when the flag is absent or malformed — never a fabricated count', () => {
+    expect(parseSurfacedCount([])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', 'lots'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', '-1'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', '2.5'])).toBeUndefined();
+  });
+});
+
+describe('runFirstRun — emits the handoff-offer payload alongside the card', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-firstrun-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function seedAndRun(argv: readonly string[]): Promise<string> {
+    const cfg = config(dir);
+    // Seed through the real write path so the card's stats trace to real data.
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'claude-code', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv,
+        gateway,
+        readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    return out.join('');
+  }
+
+  it('emits a valid SetupHandoffOffer whose worthALook is the passed --surfaced count', async () => {
+    const blob = await seedAndRun(['--surfaced', '2']);
+
+    // Additive: the human-readable install card is still present (not replaced).
+    expect(blob).toContain('installed');
+    expect(blob).toContain('First scan complete');
+
+    const payload = readFrameJsonBlock(blob);
+    const parsed = SetupHandoffOffer.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // 'M worth a look' is the surfaced/important count threaded in from the
+    // calibration preview — NOT the whole-store finding total (1 finding was seeded).
+    expect(parsed.data.worthALook).toBe(2);
+    expect(parsed.data.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('omits the handoff payload (never fabricates one) when no surfaced count is supplied', async () => {
+    const blob = await seedAndRun([]);
+
+    // The card still renders — only the machine-readable payload is withheld.
+    expect(blob).toContain('installed');
+    expect(readFrameJsonBlock(blob)).toBeUndefined();
+  });
+
+  it('carries no raw detected value into the emitted frame block', async () => {
+    const blob = await seedAndRun(['--surfaced', '2']);
+    expect(blob).toContain('<<<AKA_FRAME_JSON');
+    expect(JSON.stringify(readFrameJsonBlock(blob))).not.toContain(AWS_EXAMPLE_KEY);
+    // The card masks matches, so the raw key never appears anywhere on stdout.
+    expect(blob).not.toContain(AWS_EXAMPLE_KEY);
+  });
+
+  it('card stats trace to the seeded store, never a fixed literal', async () => {
+    const cfg = config(dir);
+    // Two distinct sensitive findings through the real write path: a critical
+    // secret and a medium PII match — two categories, two findings.
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'claude-code', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'claude-code', text: `contact ${PII_EMAIL}` },
+      cfg,
+    );
+
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    let summaryFindings: number;
+    try {
+      // Read back what the store actually holds so the assertion is a genuine
+      // trace (card number === store number), not a hardcoded expectation.
+      summaryFindings = (await gateway.healthSummary()).findings;
+      await runFirstRun({
+        argv: [],
+        gateway,
+        readPosture: () => readPostureBlock(openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+
+    // The 'Findings N' stat is the real whole-store total, not the render-unit
+    // fixture's literal.
+    expect(summaryFindings).toBe(2);
+    expect(blob).toContain(`Findings ${String(summaryFindings)}`);
+    expect(blob).not.toContain('Findings 142');
+    // 'Recommendations' mirrors /recommend over the real findings: one per
+    // category (secret + pii) → 2.
+    expect(blob).toContain('Recommendations 2');
+    // 'Health' is the derived score over the real summary, rendered out of 100 —
+    // never a fixed 82/100 sample.
+    expect(blob).toMatch(/Health \d+\/100/);
+    expect(blob).not.toContain('82/100');
+    // The Try line names only commands the shipped plugin registers — never the
+    // not-yet-shipped rename targets.
+    expect(blob).toContain('Try:');
+    expect(blob).not.toContain('/aka:secretscan');
+    expect(blob).not.toContain('/aka:codescan');
+  });
+});
+
+describe('runFirstRunFailOpen — degrades to the store-unavailable note on a store-read failure', () => {
+  it('writes the honest note instead of throwing when the gateway read fails', async () => {
+    const out: string[] = [];
+    // A gateway whose store reads fail (missing / corrupt / locked db). runFirstRun
+    // throws on a read failure; the fail-open wrapper must catch it and substitute
+    // the honest note so no error escapes to break the Claude session.
+    const failingGateway = {
+      healthSummary: () =>
+        Promise.reject(new Error('SQLITE_CORRUPT: database disk image is malformed')),
+      recentFindings: () => Promise.reject(new Error('SQLITE_CORRUPT')),
+      close: () => Promise.resolve(),
+    } as unknown as DataGateway;
+
+    let threw: unknown;
+    try {
+      await runFirstRunFailOpen({
+        argv: ['--surfaced', '2'],
+        gateway: failingGateway,
+        readPosture: () => Promise.resolve(''),
+        stdout: (s) => out.push(s),
+      });
+    } catch (e) {
+      threw = e;
+    }
+    const blob = out.join('');
+
+    // Fail-open: no throw escaped, and the honest store-unavailable note stands in.
+    expect(threw).toBeUndefined();
+    expect(blob).toContain("I couldn't read the local store");
+    // No fabricated card: the install card's stats never rendered over a dead store.
+    expect(blob).not.toContain('installed');
+  });
+});

--- a/plugins/claude-code/test/journey/fail-open.journey.test.ts
+++ b/plugins/claude-code/test/journey/fail-open.journey.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Store-read failure mid-wizard completes fail-open, proven end-to-end against
+ * the REAL script chain.
+ *
+ * This is the app-level e2e leg the unit seams (test/triage/adapter.test.ts,
+ * test/firstrun-core.test.ts) could not reach: it drives the shipped wizard
+ * scripts in frame order, then makes the local store unreadable AFTER the
+ * backfill has populated it and BEFORE the two store-reading steps run. The
+ * calibration preview (its current-posture downgrade read) and the first-run
+ * card (its stats + posture read) must each substitute the honest
+ * store-unavailable note, never throw out of the script (exit 0), and still
+ * reach completion — the calibration headline still carries the real
+ * plan-derived count, never a fabricated or zeroed one. The single corruption
+ * is left in place across both steps, so the fault genuinely persists rather
+ * than being papered over between reads.
+ *
+ * The found-nothing / empty-store copy is a distinct path and is not exercised
+ * here.
+ */
+import { CalibrationFrame, DetectionCategory } from '@akasecurity/schema';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { STORE_UNAVAILABLE_NOTE } from '../../src/render.ts';
+import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
+import { ROUTINE_KEY, SetupJourney, SURFACED_KEY } from './harness.ts';
+
+describe('store-read failure mid-wizard completes fail-open, end-to-end', () => {
+  let journey: SetupJourney;
+  let preview: { stdout: string; stderr: string; status: number };
+  let firstRun: { stdout: string; stderr: string; status: number };
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+    journey.seedTranscript();
+
+    journey.intro();
+    journey.onboardHistorical('full');
+
+    // A real backfill populates the store from the seeded history.
+    const triage = journey.backfillTriage().stdout;
+
+    // The store now goes unreadable mid-wizard (missing/corrupt/locked db). The
+    // single corruption stays in place for BOTH store-reading steps below.
+    journey.corruptStore();
+
+    // The calibration preview's only store read (the downgrade view)
+    // hits the unreadable store.
+    preview = journey.applyPreview(triage);
+
+    // The first-run card's stats + posture reads hit the same
+    // unreadable store.
+    firstRun = journey.firstRun(1);
+  }, 120_000);
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('the calibration preview substitutes the fail-open note, exits clean, and renders its full frame past the fault', () => {
+    // No error escaped the calibration script — it exited 0 with the note, not a throw.
+    expect(preview.status).toBe(0);
+    expect(preview.stdout).toContain(STORE_UNAVAILABLE_NOTE);
+
+    // The real calibrated headline still renders from the plan (two seeded keys:
+    // one surfaced, one routine FP) — a store-read failure never zeroes or
+    // fabricates the count.
+    expect(preview.stdout).toContain('Calibrated. 2 notifications, 1 important.');
+
+    // The step did not stop at the note — it continued past the failed store read
+    // and rendered the COMPLETE frame downstream of it: the recommended posture
+    // (every category) and the machine-readable calibration frame JSON, whose
+    // counts are the real plan-derived ones (not zeroed or fabricated).
+    for (const category of DetectionCategory.options) {
+      expect(preview.stdout).toContain(category);
+    }
+    const frame = CalibrationFrame.parse(readFrameJsonBlock(preview.stdout));
+    expect(frame.counts).toEqual({ total: 2, important: 1, routine: 1 });
+
+    // The step reached completion: the plan was still persisted for the confirm.
+    expect(preview.stdout).toContain('Plan saved to:');
+  });
+
+  it('the wizard reaches its terminal first-run frame fail-open, degrading cleanly without fabricating an install summary', () => {
+    // The terminal step ran as a distinct execution AFTER the preview fault (so the
+    // first fault never aborted the run) and degraded cleanly: exit 0, the honest
+    // note, and nothing on stderr.
+    expect(firstRun.status).toBe(0);
+    expect(firstRun.stderr).toBe('');
+    expect(firstRun.stdout).toContain(STORE_UNAVAILABLE_NOTE);
+
+    // It never papered over the unreadable store with a fabricated install card:
+    // the installed-card heading and its calibrated stats are absent, so the note
+    // stands in for the whole frame rather than a zeroed-out summary.
+    expect(firstRun.stdout).not.toContain('installed — calibrated to this machine');
+  });
+
+  it('the fail-open notes never leak a raw detected value', () => {
+    for (const out of [preview.stdout, firstRun.stdout]) {
+      expect(out).not.toContain(SURFACED_KEY);
+      expect(out).not.toContain(ROUTINE_KEY);
+    }
+  });
+});

--- a/plugins/claude-code/test/journey/global-setup.ts
+++ b/plugins/claude-code/test/journey/global-setup.ts
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Builds the plugin's scripts/*.js once before the suite runs. The journey
+// harness spawns those built scripts; Vitest runs globalSetup in the main process
+// to completion before any test worker starts, so the build finishes before any
+// worker can spawn a script — no worker ever reads a script mid-rewrite. Runs
+// once per `vitest run`, not per worker or per test file.
+const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+export function setup(): void {
+  execFileSync('pnpm', ['run', 'build'], { cwd: PLUGIN_ROOT, stdio: 'pipe' });
+}

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -146,7 +146,10 @@ export class SetupJourney {
   corruptStore(): void {
     rmSync(this.storeDir, { recursive: true, force: true });
     mkdirSync(this.storeDir, { recursive: true });
-    writeFileSync(join(this.storeDir, 'aka.db'), 'AKA corrupt-store fixture — not a database\n'.repeat(64));
+    writeFileSync(
+      join(this.storeDir, 'aka.db'),
+      'AKA corrupt-store fixture — not a database\n'.repeat(64),
+    );
   }
 
   private run(script: string, args: string[], input?: string): StepResult {

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared /aka:setup journey harness — the scripted-reproducible executor behind
+ * the setup journey e2e proofs. It drives the REAL wizard script
+ * chain (the built scripts/*.js the prompt actually shells out to) in frame order
+ * against a throwaway ~/.aka home, so a journey is proven end-to-end without ever
+ * touching a developer's real store.
+ *
+ * The home override is the platform's own: each script resolves ~/.aka and
+ * ~/.claude via os.homedir(), which honors $HOME on POSIX, so the harness points
+ * the whole chain at a temp home by spawning each script with HOME set — no
+ * script-level flag or process.env read is added to shipped code (the scripts
+ * must not hard-resolve the home, and they don't).
+ *
+ * The one external dependency the chain has — the `claude -p` triage judge the
+ * apply-suppressions preview spawns — is stubbed hermetically by putting a
+ * controlled `claude` executable first on the child PATH (see writeFakeJudge).
+ * Everything else is the real thing: the real backfill scan, the real store
+ * writes, the real rendered frames.
+ *
+ * Later iterations extend THIS harness with their frames (the Not-now branch, the
+ * empty states).
+ */
+import { execFileSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/journey -> plugins/claude-code
+export const PLUGIN_ROOT = join(HERE, '..', '..');
+const SCRIPTS_DIR = join(PLUGIN_ROOT, 'scripts');
+const MANIFEST_PATH = join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The host env, read once so the child spawns inherit PATH/node. The journey
+// harness genuinely needs the host environment (to find node + the stub judge on
+// PATH and to override HOME) — the one sanctioned reason to touch it.
+// eslint-disable-next-line n/no-process-env -- test harness needs host PATH to spawn the real scripts
+const HOST_ENV = process.env;
+
+export interface StepResult {
+  stdout: string;
+  stderr: string;
+  // The script's exit code (0 on a clean exit). A fail-open step must still exit 0
+  // with its note on stdout — a non-zero status here means an error escaped.
+  status: number;
+}
+
+// One AWS access-key id per canonical test secret. Composed at runtime so the
+// repo's own secret scan doesn't flag this file (mirrors history/scan.test.ts).
+export const SURFACED_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+export const ROUTINE_KEY = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+
+export class SetupJourney {
+  readonly home: string;
+  // The resolved ~/.aka/data store dir the scripts actually write to (base/data),
+  // for opening the store to assert final state. NOT the base — opening the base
+  // would create a fresh floor-seeded DB and read nothing the scripts wrote.
+  readonly storeDir: string;
+  // The settings.json the onboarding writer records the consent + prefs into.
+  readonly settingsPath: string;
+  private readonly binDir: string;
+
+  constructor() {
+    this.home = mkdtempSync(join(tmpdir(), 'aka-journey-home-'));
+    this.storeDir = join(this.home, '.aka', 'data');
+    this.settingsPath = join(this.home, '.aka', 'settings', 'settings.json');
+    this.binDir = mkdtempSync(join(tmpdir(), 'aka-journey-bin-'));
+    this.writeFakeJudge();
+  }
+
+  cleanup(): void {
+    rmSync(this.home, { recursive: true, force: true });
+    rmSync(this.binDir, { recursive: true, force: true });
+  }
+
+  // Seed a prior Claude Code transcript under the temp home carrying two leaked
+  // AWS keys, timestamped inside the retention window but before the scan starts,
+  // so the backfill has real history to calibrate from.
+  seedTranscript(): void {
+    const projectDir = join(this.home, '.claude', 'projects', '-Users-me-project');
+    mkdirSync(projectDir, { recursive: true });
+    const surfacedTs = new Date(Date.now() - 3 * DAY_MS).toISOString();
+    const routineTs = new Date(Date.now() - 2 * DAY_MS).toISOString();
+    const lines = [
+      JSON.stringify({
+        type: 'user',
+        timestamp: surfacedTs,
+        message: { role: 'user', content: `here is a prod key ${SURFACED_KEY}` },
+      }),
+      JSON.stringify({
+        type: 'user',
+        timestamp: routineTs,
+        message: { role: 'user', content: `and an example placeholder ${ROUTINE_KEY}` },
+      }),
+    ];
+    writeFileSync(join(projectDir, 'session.jsonl'), lines.join('\n'));
+  }
+
+  // The kickoff intro card.
+  intro(): StepResult {
+    return this.run('intro.js', [MANIFEST_PATH]);
+  }
+
+  // Consent side effect — record the historical-review answer. `full` is
+  // the Yes-scan leg (consent to look at prior activity).
+  onboardHistorical(access: 'full' | 'session-only'): StepResult {
+    return this.run('onboard.js', ['--historical', access]);
+  }
+
+  // Out-of-band posture write, e.g. a pack the user hardened before running the
+  // wizard — used to prove the confirm write never downgrades it.
+  onboardPosture(posture: Record<string, string>): StepResult {
+    return this.run('onboard.js', ['--posture', JSON.stringify(posture)]);
+  }
+
+  // The backfill triage stream (JSONL + sentinel).
+  backfillTriage(): StepResult {
+    return this.run('backfill.js', ['--triage']);
+  }
+
+  // The calibration preview: judge (stubbed), plan, gate, frame JSON,
+  // and the persisted plan-file path. Takes the backfill stream on stdin.
+  applyPreview(triageStream: string): StepResult {
+    return this.run('apply-suppressions.js', [], triageStream);
+  }
+
+  // Apply the confirmed plan verbatim (establishes the floor-overlaid
+  // 8-pack + suppressions in one transaction).
+  applyConfirm(planPath: string): StepResult {
+    return this.run('apply-suppressions.js', ['--confirmed', '--plan', planPath]);
+  }
+
+  // The installed summary + handoff-offer payload.
+  firstRun(surfaced: number): StepResult {
+    return this.run('firstrun.js', ['--surfaced', String(surfaced)]);
+  }
+
+  // Replace the store the scripts read with an unreadable one, so the next
+  // store-reading wizard step (calibration downgrade view / first-run stats)
+  // hits the missing/corrupt/locked-store fault the fail-open path must absorb.
+  // The bytes are not the "SQLite format 3\0" header, so the first PRAGMA on open
+  // fails SQLITE_NOTADB — the exact read failure the fail-open path guards against.
+  corruptStore(): void {
+    rmSync(this.storeDir, { recursive: true, force: true });
+    mkdirSync(this.storeDir, { recursive: true });
+    writeFileSync(join(this.storeDir, 'aka.db'), 'AKA corrupt-store fixture — not a database\n'.repeat(64));
+  }
+
+  private run(script: string, args: string[], input?: string): StepResult {
+    const env: NodeJS.ProcessEnv = {
+      ...HOST_ENV,
+      HOME: this.home,
+      // Windows resolves the home dir from USERPROFILE; keep both in lockstep.
+      USERPROFILE: this.home,
+      // Stub judge first on PATH so apply-suppressions' `claude -p` spawn hits it,
+      // never a live model.
+      PATH: `${this.binDir}:${HOST_ENV.PATH ?? ''}`,
+    };
+    try {
+      const stdout = execFileSync(process.execPath, [join(SCRIPTS_DIR, script), ...args], {
+        env,
+        encoding: 'utf8',
+        ...(input !== undefined ? { input } : {}),
+        maxBuffer: 64 * 1024 * 1024,
+      });
+      return { stdout, stderr: '', status: 0 };
+    } catch (err) {
+      // A non-zero exit still carries the captured streams; surface them so the
+      // test asserts against real script output rather than a bare throw.
+      const e = err as { stdout?: string; stderr?: string; status?: number };
+      return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+    }
+  }
+
+  // A controlled `claude` on PATH: the apply-suppressions preview spawns
+  // `claude -p … <prompt>` for its triage judgment. This stub parses the hits out
+  // of the prompt's trailing fenced block and returns a deterministic, raw-free
+  // TriageRecommendation envelope — the first hit per category surfaced (genuine),
+  // the rest marked routine false positives — so no live model is ever hit.
+  private writeFakeJudge(): void {
+    const src = `#!/usr/bin/env node
+'use strict';
+const argv = process.argv.slice(2);
+const prompt = argv.length ? argv[argv.length - 1] : '';
+const fences = [...String(prompt).matchAll(/\`\`\`[a-z]*\\n([\\s\\S]*?)\`\`\`/g)];
+const block = fences.length ? fences[fences.length - 1][1] : '';
+const byCategory = new Map();
+for (const line of block.split('\\n')) {
+  const trimmed = line.trim();
+  if (!trimmed) continue;
+  let hit;
+  try { hit = JSON.parse(trimmed); } catch { continue; }
+  if (!hit || typeof hit.category !== 'string' || typeof hit.id !== 'string') continue;
+  const ids = byCategory.get(hit.category) ?? [];
+  ids.push(hit.id);
+  byCategory.set(hit.category, ids);
+}
+const perCategory = [];
+for (const [category, ids] of byCategory) {
+  ids.sort();
+  const fps = ids.slice(1);
+  perCategory.push({
+    category,
+    action: 'warn',
+    reasoning: 'canonical example key — routine placeholder, no live credential',
+    genuineCount: ids.length - fps.length,
+    fpCount: fps.length,
+    fpIds: fps,
+  });
+}
+const verdict = { perCategory, notes: 'looks routine' };
+const result = '\`\`\`json\\n' + JSON.stringify(verdict) + '\\n\`\`\`';
+process.stdout.write(JSON.stringify({ result, is_error: false }));
+`;
+    const path = join(this.binDir, 'claude');
+    writeFileSync(path, src);
+    chmodSync(path, 0o755);
+  }
+}
+
+// Pull the persisted plan-file path the preview printed (`Plan saved to: <path>`).
+export function planPathFromPreview(previewStdout: string): string {
+  const line = previewStdout.split('\n').find((l) => l.startsWith('Plan saved to:'));
+  if (line === undefined) throw new Error('preview did not print a plan-file path');
+  return line.replace('Plan saved to:', '').trim();
+}

--- a/plugins/claude-code/test/journey/yes-scan.journey.test.ts
+++ b/plugins/claude-code/test/journey/yes-scan.journey.test.ts
@@ -1,0 +1,219 @@
+/**
+ * /aka:setup calibration wizard, Yes-scan happy path, proven end-to-end against
+ * the REAL script chain.
+ *
+ * This owns no behavior — the underlying units do — it just runs the shipped
+ * scripts in wizard-step order and asserts each step's rendered output, the frame
+ * JSON, and the final store/settings state. Of note, the Yes-path applies the
+ * confirmed calibration through the ACTUAL writer, apply-suppressions.js
+ * --confirmed (not onboard.js --posture): that is the spine that establishes the
+ * floor-overlaid 8-pack (reviewed-evidence overwrite + severity-floor fill-gaps)
+ * and emits the '8 categories tuned · N routine dismissed'
+ * confirmation. The AskUserQuestion issuances (the consent question and the
+ * dashboard handoff) are prompt-authored setup.md territory this script-chain
+ * harness cannot observe; it asserts the offer PAYLOAD instead.
+ */
+import { readFileSync } from 'node:fs';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { CalibrationFrame, DetectionCategory, SetupHandoffOffer } from '@akasecurity/schema';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
+import {
+  planPathFromPreview,
+  PLUGIN_ROOT,
+  ROUTINE_KEY,
+  SetupJourney,
+  SURFACED_KEY,
+} from './harness.ts';
+
+// The real installed plugin version, so the provenance assertion tracks the
+// shipped manifest instead of a hardcoded literal.
+const MANIFEST = JSON.parse(
+  readFileSync(`${PLUGIN_ROOT}/.claude-plugin/plugin.json`, 'utf8'),
+) as { version: string };
+
+// Reading the per-category posture the confirm write established, straight from
+// the store the scripts wrote to (the honest final-state seam).
+function readPosture(storeDir: string): Record<string, string | undefined> {
+  const db = openLocalDatabase(storeDir);
+  try {
+    const out: Record<string, string | undefined> = {};
+    for (const category of DetectionCategory.options) {
+      out[category] = db.policies.getCategoryAction(category);
+    }
+    return out;
+  } finally {
+    db.close();
+  }
+}
+
+describe('Yes-scan happy path, end-to-end', () => {
+  let journey: SetupJourney;
+  // Frame outputs captured once across the whole spine run.
+  let intro: string;
+  let preview: string;
+  let confirm: string;
+  let firstRun: string;
+  let calibrationFrame: CalibrationFrame;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+    journey.seedTranscript();
+
+    // Kickoff intro.
+    intro = journey.intro().stdout;
+
+    // Consent (side effect) — record the Yes-scan consent.
+    journey.onboardHistorical('full');
+
+    // Backfill triage stream → calibration preview (judge stubbed).
+    const triage = journey.backfillTriage().stdout;
+    preview = journey.applyPreview(triage).stdout;
+
+    const frame = CalibrationFrame.parse(readFrameJsonBlock(preview));
+    calibrationFrame = frame;
+
+    // Apply the confirmed plan through the real writer.
+    confirm = journey.applyConfirm(planPathFromPreview(preview)).stdout;
+
+    // Installed summary, carrying the surfaced count from the calibration preview.
+    firstRun = journey.firstRun(frame.counts.important).stdout;
+  }, 120_000);
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('intro: renders the canonical identity and the version·repo provenance line', () => {
+    expect(intro).toContain('AKA Security');
+    expect(intro).toContain('We secure agent harnesses at the source.');
+    expect(intro).toContain(`v${MANIFEST.version} · github.com/akasecurity/ai-tc`);
+    // No provenance badge yet — that lands with the signature check.
+    expect(intro).not.toContain('verified');
+  });
+
+  it('intro: the intro script also emits the "what I do" calibration card', () => {
+    // The kickoff and "what I do" cards are printed by the same
+    // intro run, back-to-back, before the scan offer. This asserts the wiring
+    // (the copy itself is unit-owned in render.test.ts).
+    expect(intro).toContain('I watch out for Claude as it works.');
+    expect(intro).toContain(
+      "let's calibrate your notifications based on what Claude's been up to",
+    );
+  });
+
+  it('preview: leads with the real-count headline and the condensed recommended posture', () => {
+    // The calibrated-result card the wizard shows the user — the counts are the
+    // real scan's (two seeded keys: one surfaced, one routine FP), and the kind
+    // parenthetical names the surfaced category's kind.
+    expect(preview).toContain('Calibrated. 2 notifications, 1 important.');
+    expect(preview).toContain('1 routine, 1 that matter (live keys)');
+    // The condensed recommended view lists every pack with its recommended
+    // level (the evidence pack took 'warn'); a full 8×4 level grid is the
+    // start-light branch's, not the spine's.
+    for (const category of DetectionCategory.options) {
+      expect(preview).toContain(category);
+    }
+    expect(preview).toMatch(/secret\s+warn/);
+  });
+
+  it('preview: the backfill records real findings and the calibration preview never leaks raw keys', () => {
+    // The preview's frame JSON validates as a CalibrationFrame and its counts come
+    // from the real scan (two seeded keys: one surfaced, one routine FP).
+    expect(calibrationFrame.counts).toEqual({ total: 2, important: 1, routine: 1 });
+    expect(calibrationFrame.surfacedCategories).toEqual(['secret']);
+    // The retroactive scan reads at-rest history, so the kind is not an egress leak.
+    expect(calibrationFrame.findingKinds).toContainEqual({
+      category: 'secret',
+      count: 2,
+      egress: false,
+    });
+    // The previewed posture is the full recommended 8-pack, so the
+    // confirm write has all 8 to establish.
+    expect(Object.keys(calibrationFrame.posture).sort()).toEqual([...DetectionCategory.options].sort());
+    // Nothing raw crosses the isolated-judge boundary into the preview stdout.
+    expect(preview).not.toContain(SURFACED_KEY);
+    expect(preview).not.toContain(ROUTINE_KEY);
+  });
+
+  it('apply: the ACTUAL writer confirms the floor-overlaid 8-pack', () => {
+    // The applying confirmation from apply-suppressions.js --confirmed — the
+    // spine writer, not onboard.js --posture.
+    expect(confirm).toContain('✓ 8 categories tuned');
+    expect(confirm).toContain('✓ 1 routine dismissed');
+    expect(confirm).toMatch(/Ready:/);
+  });
+
+  it('final store: settings.json records the consent and all 8 packs hold a valid posture', () => {
+    const settings = JSON.parse(
+      readFileSync(journey.settingsPath, 'utf8'),
+    ) as { historicalAccess?: string };
+    expect(settings.historicalAccess).toBe('full');
+
+    const posture = readPosture(journey.storeDir);
+    // Every pack got a posture (the evidence pack + the severity-floor fill).
+    for (const category of DetectionCategory.options) {
+      expect(posture[category], `posture for ${category}`).toBeTruthy();
+    }
+    // The reviewed evidence pack took its judged action; the DB stores the palette
+    // level verbatim ('warn').
+    expect(posture.secret).toBe('warn');
+  });
+
+  it('final store: the routine false positive dismissed on apply is a real suppression row', async () => {
+    const db = openLocalDatabase(journey.storeDir);
+    try {
+      const active = await db.exceptions.list();
+      expect(active).toHaveLength(1);
+      expect(active[0]?.createdVia).toBe('setup-triage');
+      expect(active[0]?.category).toBe('secret');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('installed summary: the installed card and the handoff-offer payload carry the real surfaced count', () => {
+    expect(firstRun).toContain('✓ AKA Security installed');
+    const offer = SetupHandoffOffer.parse(readFrameJsonBlock(firstRun));
+    expect(offer.worthALook).toBe(1);
+    expect(offer.options.map((o) => o.id)).toEqual(['open-dashboard', 'not-now']);
+  });
+});
+
+describe('no-downgrade invariant end-to-end', () => {
+  let journey: SetupJourney;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+    journey.seedTranscript();
+
+    journey.intro();
+    journey.onboardHistorical('full');
+    // The user had hardened an UNREVIEWED floor pack (code_context) out of band
+    // before the scan. The evidence only covers `secret`, so the confirm write's
+    // severity-floor fill must leave code_context alone — never reset it to the
+    // weak floor.
+    journey.onboardPosture({ code_context: 'block' });
+
+    const triage = journey.backfillTriage().stdout;
+    const preview = journey.applyPreview(triage).stdout;
+    journey.applyConfirm(planPathFromPreview(preview));
+  }, 120_000);
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('a pre-existing hardened floor pack survives a Yes-scan confirm', () => {
+    const posture = readPosture(journey.storeDir);
+    // Preserved, not downgraded to the floor.
+    expect(posture.code_context).toBe('block');
+    // The reviewed evidence pack still took its judged action, and all 8 packs hold.
+    expect(posture.secret).toBe('warn');
+    for (const category of DetectionCategory.options) {
+      expect(posture[category], `posture for ${category}`).toBeTruthy();
+    }
+  });
+});

--- a/plugins/claude-code/test/journey/yes-scan.journey.test.ts
+++ b/plugins/claude-code/test/journey/yes-scan.journey.test.ts
@@ -30,9 +30,9 @@ import {
 
 // The real installed plugin version, so the provenance assertion tracks the
 // shipped manifest instead of a hardcoded literal.
-const MANIFEST = JSON.parse(
-  readFileSync(`${PLUGIN_ROOT}/.claude-plugin/plugin.json`, 'utf8'),
-) as { version: string };
+const MANIFEST = JSON.parse(readFileSync(`${PLUGIN_ROOT}/.claude-plugin/plugin.json`, 'utf8')) as {
+  version: string;
+};
 
 // Reading the per-category posture the confirm write established, straight from
 // the store the scripts wrote to (the honest final-state seam).
@@ -99,9 +99,7 @@ describe('Yes-scan happy path, end-to-end', () => {
     // intro run, back-to-back, before the scan offer. This asserts the wiring
     // (the copy itself is unit-owned in render.test.ts).
     expect(intro).toContain('I watch out for Claude as it works.');
-    expect(intro).toContain(
-      "let's calibrate your notifications based on what Claude's been up to",
-    );
+    expect(intro).toContain("let's calibrate your notifications based on what Claude's been up to");
   });
 
   it('preview: leads with the real-count headline and the condensed recommended posture', () => {
@@ -132,7 +130,9 @@ describe('Yes-scan happy path, end-to-end', () => {
     });
     // The previewed posture is the full recommended 8-pack, so the
     // confirm write has all 8 to establish.
-    expect(Object.keys(calibrationFrame.posture).sort()).toEqual([...DetectionCategory.options].sort());
+    expect(Object.keys(calibrationFrame.posture).sort()).toEqual(
+      [...DetectionCategory.options].sort(),
+    );
     // Nothing raw crosses the isolated-judge boundary into the preview stdout.
     expect(preview).not.toContain(SURFACED_KEY);
     expect(preview).not.toContain(ROUTINE_KEY);
@@ -147,9 +147,9 @@ describe('Yes-scan happy path, end-to-end', () => {
   });
 
   it('final store: settings.json records the consent and all 8 packs hold a valid posture', () => {
-    const settings = JSON.parse(
-      readFileSync(journey.settingsPath, 'utf8'),
-    ) as { historicalAccess?: string };
+    const settings = JSON.parse(readFileSync(journey.settingsPath, 'utf8')) as {
+      historicalAccess?: string;
+    };
     expect(settings.historicalAccess).toBe('full');
 
     const posture = readPosture(journey.storeDir);

--- a/plugins/claude-code/test/onboard.test.ts
+++ b/plugins/claude-code/test/onboard.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { openLocalDatabase, readWorkspaceSettings } from '@akasecurity/persistence';
+import {
+  applyCategoryPosture,
+  applyOnboarding,
+  severityFloorPosture,
+} from '@akasecurity/plugin-sdk';
+import { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { parsePosture } from '../src/onboard-posture.ts';
+
+// The recommended-posture default map, frozen here so the test fails loudly if
+// severityFloorPosture() ever drifts from it (the "unchanged from before the
+// redesign" guarantee).
+const RECOMMENDED_DEFAULTS = {
+  secret: 'warn',
+  pii: 'warn',
+  financial: 'warn',
+  phi: 'warn',
+  code_flaw: 'warn',
+  custom: 'warn',
+  code_context: 'monitor',
+  config: 'monitor',
+} as const;
+
+describe('recommended (unadjusted) posture — the default map', () => {
+  it('severityFloorPosture() equals the recommended defaults exactly', () => {
+    // Reuse the schema helper the onboard path already writes on `--floor`; do not
+    // introduce a parallel constant.
+    expect(severityFloorPosture()).toEqual(RECOMMENDED_DEFAULTS);
+  });
+
+  it('seeds exactly 8 packs, each at a valid palette level', () => {
+    const posture = severityFloorPosture();
+    expect(Object.keys(posture).sort()).toEqual([...DetectionCategory.options].sort());
+    expect(Object.keys(posture)).toHaveLength(8);
+    for (const level of Object.values(posture)) {
+      expect(BuiltinPolicyId.safeParse(level).success).toBe(true);
+    }
+  });
+
+  it('round-trips through the onboard --posture seam (parsePosture)', () => {
+    // onboard.ts feeds `--posture <json>` through parsePosture; the recommended
+    // map must survive that path unchanged so the wizard can drive it.
+    const posture = severityFloorPosture();
+    expect(parsePosture(JSON.stringify(posture))).toEqual(RECOMMENDED_DEFAULTS);
+  });
+});
+
+describe('onboard writes a valid store/settings state with the recommended posture', () => {
+  let base: string;
+  let db: LocalDatabase;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'aka-onboard-test-'));
+    // The same real local store onboard.ts opens via openLocalDatabase(dataDir).
+    db = openLocalDatabase(join(base, 'data'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('applyOnboarding writes a valid settings.json (session-only historical access)', () => {
+    const written = applyOnboarding({ historicalAccess: 'session-only' }, base);
+    expect(written.historicalAccess).toBe('session-only');
+    expect(written.onboardedAt).not.toBeNull();
+    // Re-read from disk through the versioned schema — proves the file parses.
+    const read = readWorkspaceSettings(base);
+    expect(read.historicalAccess).toBe('session-only');
+    expect(read.onboardedAt).not.toBeNull();
+  });
+
+  it('applyCategoryPosture persists the recommended map as 8 category rows (monitor→log)', async () => {
+    applyCategoryPosture(severityFloorPosture(), db.policies, 'overwrite');
+    const rows = await db.policies.readPolicies();
+    const byCategory = new Map(
+      rows
+        .map((p) => [(p.target as { category?: string }).category, p.action] as const)
+        .filter(([c]) => c !== undefined),
+    );
+    expect(byCategory.size).toBe(8);
+    // warn packs store as 'warn'; monitor packs store as 'log' (the palette→
+    // ActionTaken mapping), which surfaces back to the user as 'monitor'.
+    expect(byCategory.get('secret')).toBe('warn');
+    expect(byCategory.get('pii')).toBe('warn');
+    expect(byCategory.get('financial')).toBe('warn');
+    expect(byCategory.get('phi')).toBe('warn');
+    expect(byCategory.get('code_flaw')).toBe('warn');
+    expect(byCategory.get('custom')).toBe('warn');
+    expect(byCategory.get('code_context')).toBe('log');
+    expect(byCategory.get('config')).toBe('log');
+  });
+
+  it('the severity-floor fill-gaps write never downgrades an already-calibrated pack', () => {
+    // The `--floor` fallback path onboard.ts takes on a too-thin backfill uses the
+    // SAME map (severityFloorPosture) in fill-gaps mode: a confirmed calibration is
+    // preserved. This behavior is unchanged by the redesign.
+    db.policies.upsertCategoryAction('secret', 'block');
+    applyCategoryPosture(severityFloorPosture(), db.policies, 'fill-gaps');
+    expect(db.policies.getCategoryAction('secret')).toBe('block');
+    // code_context keeps the default the store seeds on open ('log'); fill-gaps
+    // never downgrades the already-calibrated 'secret' row.
+    expect(db.policies.getCategoryAction('code_context')).toBe('log');
+  });
+});

--- a/plugins/claude-code/test/posture.test.ts
+++ b/plugins/claude-code/test/posture.test.ts
@@ -24,7 +24,7 @@ describe('readPostureBlock', () => {
         { target: { category: 'code_context' }, action: 'log' },
       ]),
     );
-    const block = await readPostureBlock(db);
+    const block = await readPostureBlock(() => db);
     expect(block).toContain('secret');
     expect(block).toContain('redact');
     // 'log' (ActionTaken) surfaces to the user as 'monitor'.
@@ -42,9 +42,18 @@ describe('readPostureBlock', () => {
     // The fault must NOT propagate — that would collapse the whole install card
     // into firstrun's fail-open note. It degrades to '' so only the Posture
     // section is hidden, and the handle is still closed.
-    const block = await readPostureBlock(db);
+    const block = await readPostureBlock(() => db);
     expect(block).toBe('');
     expect(closed).toBe(true);
+  });
+
+  it('degrades to an empty block when opening the store throws', async () => {
+    // A store-open fault must degrade identically to a read fault: the Posture
+    // section is hidden, nothing propagates to collapse the whole install card.
+    const block = await readPostureBlock(() => {
+      throw new Error('cannot open database');
+    });
+    expect(block).toBe('');
   });
 
   it('closes the database handle on the happy path too', async () => {
@@ -55,7 +64,7 @@ describe('readPostureBlock', () => {
         closed = true;
       },
     );
-    await readPostureBlock(db);
+    await readPostureBlock(() => db);
     expect(closed).toBe(true);
   });
 });

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -290,9 +290,7 @@ describe('pure renderers', () => {
       "Most of it I handle quietly; I only notify you when it's worth your call.",
     );
     // Leads into the calibration handoff that hands off to the scan offer.
-    expect(out).toContain(
-      "let's calibrate your notifications based on what Claude's been up to",
-    );
+    expect(out).toContain("let's calibrate your notifications based on what Claude's been up to");
     // No internal narration (design-doc / decision citations) leaks into the copy.
     expect(out).not.toMatch(/Decision|design doc|ADR/i);
     // The whole card, so a copy regression is caught as a snapshot diff.

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -1,30 +1,46 @@
 import { randomUUID } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { handleCapture, resolveDataGateway } from '@akasecurity/plugin-runtime';
 import type { FindingView, HealthSummary, PluginConfig } from '@akasecurity/plugin-sdk';
+import { severityFloorPosture } from '@akasecurity/plugin-sdk';
 import type { DetectionException } from '@akasecurity/schema';
+import { SetupHandoffOffer } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { NAME, ONE_LINER, TAGLINE } from '../src/identity.ts';
+import { buildIntroCard, type Manifest } from '../src/intro-card.ts';
 import { paint } from '../src/present.ts';
 import {
+  buildHandoffOffer,
   buildHealthReport,
   buildRecommendations,
   healthScore,
+  renderApplied,
   renderAudit,
+  renderCategoriesTuned,
   renderExceptions,
   renderFindings,
   renderFirstRun,
   renderHealth,
   renderPosture,
   renderRecommend,
-  renderSetupIntro,
+  renderRecommendedPosture,
   renderStatusLine,
+  renderWhatIDo,
   runQuery,
   topFindings,
 } from '../src/render.ts';
+
+// The real shipped plugin manifest — the same plugin.json the intro adapter
+// reads at runtime. Read here so the provenance assertions track the actual
+// installed version, not a literal that silently rots on a version bump.
+const PLUGIN_MANIFEST = JSON.parse(
+  readFileSync(fileURLToPath(new URL('../.claude-plugin/plugin.json', import.meta.url)), 'utf8'),
+) as Manifest;
 
 // In standalone mode the effective ruleset is the store's INSTALLED snapshot
 // (seeded from bundledDetections() by resolveDataGateway), not ad-hoc packs
@@ -238,21 +254,64 @@ describe('pure renderers', () => {
     expect(strip(renderFindings([partial], status))).toContain('—');
   });
 
-  it('setup intro: card with manifest facts', () => {
-    const out = strip(
-      renderSetupIntro({
-        name: 'AKA Security',
-        tagline: 'Agent Harness Security for Claude Code.',
-        repository: 'github.com/akasecurity/ai-tc',
-        version: '0.0.1',
-        publisher: 'AKA',
-        adds: 'Secures your local environment to prevent secret leakage and vulnerabilities.',
-      }),
+  it('identity: exports the canonical name, tagline, and one-liner', () => {
+    expect(NAME).toBe('AKA Security');
+    expect(TAGLINE).toBe('We secure agent harnesses at the source.');
+    expect(ONE_LINER).toBe(
+      'I watch out for Claude as it codes — catching secrets and customer data before they slip out.',
     );
-    expect(out).toContain('Found AKA Security');
-    expect(out).toContain('github.com/akasecurity/ai-tc');
-    expect(out).toContain('0.0.1 · AKA');
-    expect(out).toContain('two quick questions');
+  });
+
+  it('setup intro: the adapter builds the card from the real manifest, sourced from identity.ts', () => {
+    // Exercises the shipped intro adapter (manifest → card) end to end: the
+    // identity strings can only appear if intro-card.ts sources them from the
+    // shared identity constant, and the provenance version comes from the real
+    // plugin manifest — so a stale local copy or a version drift fails here.
+    const out = strip(buildIntroCard(PLUGIN_MANIFEST));
+    expect(out).toContain(NAME);
+    expect(out).toContain(TAGLINE);
+    expect(out).toContain(ONE_LINER);
+    // Provenance line: the real installed version + canonical repo, no 'verified' badge yet.
+    expect(out).toContain(`v${PLUGIN_MANIFEST.version ?? ''} · github.com/akasecurity/ai-tc`);
+    expect(out).not.toContain('verified');
+    // The old tagline and the stale two-question line are gone.
+    expect(out).not.toContain('Agent Harness Security for Claude Code.');
+    expect(out).not.toContain('two quick questions');
+  });
+
+  it('what I do: the calibration card carries the walkthrough voice, verbatim', () => {
+    const out = strip(renderWhatIDo());
+    // Every line from the calibration walkthrough, verbatim.
+    expect(out).toContain('I watch out for Claude as it works.');
+    expect(out).toContain(
+      'As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.',
+    );
+    expect(out).toContain(
+      "Most of it I handle quietly; I only notify you when it's worth your call.",
+    );
+    // Leads into the calibration handoff that hands off to the scan offer.
+    expect(out).toContain(
+      "let's calibrate your notifications based on what Claude's been up to",
+    );
+    // No internal narration (design-doc / decision citations) leaks into the copy.
+    expect(out).not.toMatch(/Decision|design doc|ADR/i);
+    // The whole card, so a copy regression is caught as a snapshot diff.
+    expect(out).toMatchInlineSnapshot(`
+      "● I watch out for Claude as it works.
+
+        As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.
+        Most of it I handle quietly; I only notify you when it's worth your call.
+
+        let's calibrate your notifications based on what Claude's been up to"
+    `);
+  });
+
+  it('setup intro: the adapter fails open with a blank version when the manifest is unreadable', () => {
+    // Empty manifest — the fallback intro.ts uses when plugin.json can't be read.
+    const out = strip(buildIntroCard({}));
+    // Still a card: the identity one-liner renders even with no manifest facts.
+    expect(out).toContain(ONE_LINER);
+    expect(out).not.toContain('verified');
   });
 
   it('healthScore: blends coverage and handled ratio into 0–100', () => {
@@ -276,63 +335,124 @@ describe('pure renderers', () => {
     ).toBe(70);
   });
 
-  it('first run: install-complete summary with real-ish stats', () => {
-    const out = strip(
-      renderFirstRun({
-        commands: ['/health', '/recommend', '/findings', '/audit'],
-        posture: renderPosture([
-          { category: 'secret', action: 'redact' },
-          { category: 'code_context', action: 'log' },
-        ]),
-        health: 72,
-        findings: 142,
-        recommendations: 6,
-      }),
+  describe('renderFirstRun — installed card', () => {
+    // The command files the shipped plugin registers — the Try line must never
+    // outrun this set, since a named command with no matching file would 404 when
+    // the user types it. Read from disk (never a hardcoded copy) so a renamed or
+    // removed command is caught here.
+    const REGISTERED = new Set(
+      readdirSync(fileURLToPath(new URL('../commands', import.meta.url)))
+        .filter((f) => f.endsWith('.md'))
+        .map((f) => f.replace(/\.md$/, '')),
     );
-    expect(out).toContain('AKA Security installed');
-    expect(out).toContain('/health · /recommend · /findings · /audit');
-    expect(out).toContain('Posture');
-    expect(out).toContain('secret');
-    expect(out).toContain('redact');
-    // 'log' (ActionTaken) surfaces to the user as 'monitor'.
-    expect(out).toContain('monitor');
-    expect(out).toContain('Health 72/100');
-    expect(out).toContain('Findings 142');
-    expect(out).toContain('Recommendations 6');
-    expect(out).toContain('run /health anytime');
-  });
 
-  it('first run: clean scan hides the Top findings section', () => {
-    const out = strip(
-      renderFirstRun({
-        commands: ['/health'],
-        health: 100,
-        findings: 0,
-        recommendations: 0,
-        topFindings: [],
-      }),
-    );
-    expect(out).not.toContain('Top findings');
-  });
+    const populated = (over: Partial<Parameters<typeof renderFirstRun>[0]> = {}): string =>
+      strip(
+        renderFirstRun({
+          posture: renderPosture([
+            { category: 'secret', action: 'redact' },
+            { category: 'code_context', action: 'log' },
+          ]),
+          health: 72,
+          findings: 142,
+          recommendations: 6,
+          worthALook: 2,
+          topFindings: [
+            finding({ ruleId: 'secrets/aws-access-key', category: 'secret', severity: 'critical' }),
+          ],
+          ...over,
+        }),
+      );
 
-  it('first run: lists the top findings table when the scan caught something', () => {
-    const out = strip(
-      renderFirstRun({
-        commands: ['/health'],
-        health: 80,
-        findings: 2,
-        recommendations: 2,
+    it("heading reads 'AKA Security installed — calibrated to this machine'", () => {
+      expect(populated()).toContain('AKA Security installed — calibrated to this machine');
+    });
+
+    it('stats line templates the real health · findings · recommendations, never a fixed literal', () => {
+      const out = populated();
+      expect(out).toContain('Health 72/100');
+      expect(out).toContain('Findings 142');
+      expect(out).toContain('Recommendations 6');
+      // A different set of real values flows straight through — proof it is
+      // templated over the store, not a baked-in literal.
+      const other = populated({ health: 91, findings: 3, recommendations: 1 });
+      expect(other).toContain('Health 91/100');
+      expect(other).toContain('Findings 3');
+      expect(other).toContain('Recommendations 1');
+      // The fixed sample numbers never appear.
+      expect(out).not.toContain('82/100');
+      expect(out).not.toContain('40 findings');
+    });
+
+    it('shows the posture line the user chose', () => {
+      const out = populated();
+      expect(out).toContain('Posture');
+      expect(out).toContain('secret');
+      expect(out).toContain('redact');
+      // 'log' (ActionTaken) surfaces to the user as 'monitor'.
+      expect(out).toContain('monitor');
+    });
+
+    it("renders the '2 worth a look' handoff with the real surfaced count and the Open dashboard / Not now framing", () => {
+      const out = populated({ worthALook: 2 });
+      expect(out).toContain('2 worth a look — see them in the browser?');
+      expect(out).toContain('Open dashboard');
+      expect(out).toContain('Not now');
+      // The count is the surfaced value, echoed — a different count flows through.
+      expect(populated({ worthALook: 5 })).toContain('5 worth a look');
+    });
+
+    it('the Try line names only commands the shipped plugin registers, in invokable /aka: form', () => {
+      const out = populated();
+      const tryLine = out.split('\n').find((l) => l.includes('Try:'));
+      expect(tryLine).toBeDefined();
+      const named = tryLine?.match(/\/aka:[a-z]+/g) ?? [];
+      // The line actually names commands (guards against an empty match passing).
+      expect(named.length).toBeGreaterThan(0);
+      for (const cmd of named) {
+        const base = /^\/aka:([a-z]+)$/.exec(cmd)?.[1] ?? '';
+        expect(REGISTERED.has(base)).toBe(true);
+      }
+      // The not-yet-shipped rename targets do not exist yet — the Try line must not print them.
+      expect(out).not.toContain('/aka:secretscan');
+      expect(out).not.toContain('/aka:codescan');
+    });
+
+    it('clean scan hides the Top findings section', () => {
+      const out = populated({ topFindings: [], worthALook: 0 });
+      expect(out).not.toContain('Top findings');
+    });
+
+    it('lists the top findings table when the scan caught something', () => {
+      const out = populated({
         topFindings: [
           finding({ ruleId: 'secrets/aws-access-key', category: 'secret', severity: 'critical' }),
           finding({ ruleId: 'pii/email', category: 'pii', severity: 'low' }),
         ],
-      }),
-    );
-    expect(out).toContain('Top findings (2)');
-    expect(out).toContain('secrets/aws-access-key');
-    expect(out).toContain('pii/email');
-    // The masked match shows; the raw secret never does (finding() masks it).
-    expect(out).toContain('AKIA…MPLE');
+      });
+      expect(out).toContain('Top findings (2)');
+      expect(out).toContain('secrets/aws-access-key');
+      expect(out).toContain('pii/email');
+      // The masked match shows; the raw secret never does (finding() masks it).
+      expect(out).toContain('AKIA…MPLE');
+    });
+  });
+
+  it('buildHandoffOffer: handoff payload — the worth-a-look count + two options', () => {
+    const offer = buildHandoffOffer(3);
+    expect(SetupHandoffOffer.safeParse(offer).success).toBe(true);
+    // The count is whatever the caller derived from the store — echoed, not invented.
+    expect(offer.worthALook).toBe(3);
+    expect(offer.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('buildHandoffOffer: honest zero — a clean store carries a real 0, not a fabricated number', () => {
+    const offer = buildHandoffOffer(0);
+    expect(SetupHandoffOffer.safeParse(offer).success).toBe(true);
+    expect(offer.worthALook).toBe(0);
   });
 
   it('topFindings: ranks by severity then recency, capped to the limit', () => {
@@ -410,6 +530,118 @@ describe('renderPosture', () => {
     ]);
     const order = out.split('\n').map((line) => line.trim().split(/\s+/)[0]);
     expect(order).toEqual(['pii', 'financial', 'secret', 'code_context']);
+  });
+});
+
+describe('renderRecommendedPosture — condensed recommended view', () => {
+  it('shows each pack with its recommended level, compact and in canonical order', () => {
+    const out = renderRecommendedPosture(severityFloorPosture());
+    // One compact row per pack — the recommended level, not the full 8×4 grid of
+    // every level (that is the start-light branch's table).
+    const packs = out
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => line.trim().split(/\s+/)[0]);
+    expect(packs).toEqual([
+      'pii',
+      'financial',
+      'secret',
+      'phi',
+      'code_context',
+      'code_flaw',
+      'custom',
+      'config',
+    ]);
+    // The recommendation: sensitive packs surface (warn); observe-only packs
+    // monitor. Palette vocabulary only — no DB 'log' leaks through.
+    expect(out).not.toMatch(/\blog\b/);
+    expect(out).not.toMatch(/\bblock\b/);
+    // The whole block, so a layout/copy regression is caught as a snapshot diff.
+    expect(out).toMatchInlineSnapshot(`
+      "  pii           warn
+        financial     warn
+        secret        warn
+        phi           warn
+        code_context  monitor
+        code_flaw     warn
+        custom        warn
+        config        monitor"
+    `);
+  });
+
+  it('renders whatever recommended map it is handed (no hardcoded levels)', () => {
+    const out = renderRecommendedPosture({
+      secret: 'block',
+      pii: 'redact',
+      financial: 'warn',
+      phi: 'warn',
+      code_context: 'monitor',
+      code_flaw: 'warn',
+      custom: 'warn',
+      config: 'monitor',
+    });
+    expect(out).toContain('secret');
+    expect(out).toContain('block');
+    expect(out).toContain('redact');
+  });
+});
+
+describe('renderApplied — applying confirmation', () => {
+  // The read-command files the shipped plugin registers — the real registry the
+  // Ready line must not outrun. A command it names with no matching file would
+  // 404 when the user runs it, so the line is asserted against this set, never a
+  // hardcoded copy.
+  const REGISTERED = new Set(
+    readdirSync(fileURLToPath(new URL('../commands', import.meta.url)))
+      .filter((f) => f.endsWith('.md'))
+      .map((f) => f.replace(/\.md$/, '')),
+  );
+
+  it('templates the real dismissed count and confirms the tuned pack count', () => {
+    const out = renderApplied(8, 12);
+    expect(out).toContain('✓ 8 categories tuned');
+    expect(out).toContain('✓ 12 routine dismissed');
+    // N is templated from the real count — a different value flows straight
+    // through, never a baked-in literal.
+    expect(renderApplied(8, 3)).toContain('✓ 3 routine dismissed');
+    // The tuned count is threaded too, not hardcoded to 8.
+    expect(renderApplied(5, 3)).toContain('✓ 5 categories tuned');
+  });
+
+  it('renders an honest zero-state when nothing routine was dismissed', () => {
+    const out = renderApplied(8, 0);
+    expect(out).toContain('✓ 8 categories tuned');
+    // No fabricated '✓ 0 routine dismissed' — honest copy instead.
+    expect(out).not.toContain('0 routine dismissed');
+    expect(out).toMatch(/no routine/i);
+  });
+
+  it('the Ready line names only commands the plugin actually registers, in invokable /aka: form', () => {
+    const ready = (renderApplied(8, 5).split('Ready:')[1] ?? '').trim();
+    const named = ready.match(/\/[a-z:]+/g) ?? [];
+    // The line actually names commands (guards against an empty match passing).
+    expect(named.length).toBeGreaterThan(0);
+    for (const cmd of named) {
+      // The plugin registers commands under its `aka` namespace, so the only
+      // form that resolves when typed is `/aka:<command>` — a bare `/<command>`
+      // would not invoke. Require the namespace, then check the base name is a
+      // real registered command file (never a hardcoded copy).
+      const match = /^\/aka:([a-z]+)$/.exec(cmd);
+      expect(match).not.toBeNull();
+      expect(REGISTERED.has(match?.[1] ?? '')).toBe(true);
+    }
+  });
+
+  it("reads '✓ 8 categories tuned' from the real 8-pack the posture writer wrote", () => {
+    // onboard.ts feeds its confirmation the size of the posture it actually
+    // wrote: renderCategoriesTuned(Object.keys(posture).length). Drive that with
+    // the real recommended map so the '8' is the true pack count, not a
+    // literal — this is the segment that composes into the applying-confirmation line.
+    const packCount = Object.keys(severityFloorPosture()).length;
+    expect(packCount).toBe(8);
+    expect(renderCategoriesTuned(packCount)).toBe('✓ 8 categories tuned');
+    // Same phrase renderApplied composes — single-sourced, so the two can't drift.
+    expect(renderApplied(packCount, 5)).toContain(renderCategoriesTuned(packCount));
   });
 });
 

--- a/plugins/claude-code/test/setup-frame-json.test.ts
+++ b/plugins/claude-code/test/setup-frame-json.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { frameJsonBlock, readFrameJsonBlock } from '../src/setup-frame-json.ts';
+
+describe('frameJsonBlock / readFrameJsonBlock', () => {
+  it('round-trips a payload through the delimited block', () => {
+    const payload = { worthALook: 2, options: [] };
+    const block = readFrameJsonBlock(frameJsonBlock(payload));
+    expect(block).toEqual(payload);
+  });
+
+  it('extracts the block even when surrounded by human-readable copy', () => {
+    const stdout = `some card\n${frameJsonBlock({ a: 1 })}trailing note\n`;
+    expect(readFrameJsonBlock(stdout)).toEqual({ a: 1 });
+  });
+
+  it('returns undefined when no block is present', () => {
+    expect(readFrameJsonBlock('just a plain card, no frame here')).toBeUndefined();
+  });
+
+  it('returns undefined (never throws) when the block contents are malformed JSON', () => {
+    const broken = '<<<AKA_FRAME_JSON\n{ not: valid json ]\nAKA_FRAME_JSON>>>\n';
+    expect(readFrameJsonBlock(broken)).toBeUndefined();
+  });
+});

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -8,7 +8,10 @@ import type {
   TriageHit,
   TriageRecommendation,
 } from '@akasecurity/schema';
-import { CalibrationFrame, DetectionCategory as DetectionCategorySchema } from '@akasecurity/schema';
+import {
+  CalibrationFrame,
+  DetectionCategory as DetectionCategorySchema,
+} from '@akasecurity/schema';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
@@ -271,7 +274,9 @@ describe('runApply — confirm persists the full recommended 8-pack posture', ()
     expect(code).toBe(0);
     // The whole 8-pack lands — not just the evidence-derived category. This is
     // the "recommended posture" the user confirmed, persisted verbatim.
-    expect(Object.keys(confirmDb.posture).sort()).toEqual([...DetectionCategorySchema.options].sort());
+    expect(Object.keys(confirmDb.posture).sort()).toEqual(
+      [...DetectionCategorySchema.options].sort(),
+    );
     // Evidence overrides the floor for its category; the floor fills every other pack.
     expect(confirmDb.posture.secret).toBe('redact');
     expect(confirmDb.posture.code_context).toBe('log'); // monitor floor -> log action

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -8,8 +8,10 @@ import type {
   TriageHit,
   TriageRecommendation,
 } from '@akasecurity/schema';
+import { CalibrationFrame, DetectionCategory as DetectionCategorySchema } from '@akasecurity/schema';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
 import { runApply } from '../../src/triage/adapter.ts';
 import { readPlanFile, writePlanFile } from '../../src/triage/plan-file.ts';
 
@@ -208,8 +210,10 @@ describe('runApply — confirm applies the persisted plan without re-judging', (
     expect(code).toBe(0);
     expect(runJudge).not.toHaveBeenCalled();
     expect(readStream).not.toHaveBeenCalled();
-    // applied exactly the previewed plan: posture secret->warn, one suppression
-    expect(confirmDb.posture).toEqual({ secret: 'warn' });
+    // applied exactly the previewed plan: the full recommended 8-pack (evidence
+    // secret->warn, floor for the rest) plus one suppression
+    expect(Object.keys(confirmDb.posture)).toHaveLength(8);
+    expect(confirmDb.posture.secret).toBe('warn');
     expect(confirmDb.created).toHaveLength(1);
     expect(confirmDb.created[0]).toMatchObject({
       ruleId: 'core-secret/aws',
@@ -220,7 +224,60 @@ describe('runApply — confirm applies the persisted plan without re-judging', (
     });
     // plan file deleted after a successful apply
     expect(existsSync(path)).toBe(false);
-    expect(out.join('')).toMatch(/suppressions applied/i);
+    // The confirm path emits the applying confirmation, threading the
+    // real writeback counts: all 8 packs tuned, one routine suppression dismissed.
+    const applied = out.join('');
+    expect(applied).toContain('✓ 8 categories tuned');
+    expect(applied).toContain('✓ 1 routine dismissed');
+    expect(applied).toMatch(/Ready:/);
+  });
+});
+
+describe('runApply — confirm persists the full recommended 8-pack posture', () => {
+  it('writes all 8 packs (severity floor overlaid with evidence) and reports "8 categories tuned"', async () => {
+    // Evidence action that DIFFERS from the severity floor (secret floors to warn;
+    // the judge here says redact) so the overlay precedence is observable end-to-end.
+    const v: TriageRecommendation = {
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'redact',
+          reasoning: 'canonical fake AWS example key',
+          genuineCount: 0,
+          fpCount: 1,
+          fpIds: ['0'],
+        },
+      ],
+      notes: 'looks routine',
+    };
+    const path = await previewPlan(streamText(), v);
+    const confirmDb = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: confirmDb.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+
+    expect(code).toBe(0);
+    // The whole 8-pack lands — not just the evidence-derived category. This is
+    // the "recommended posture" the user confirmed, persisted verbatim.
+    expect(Object.keys(confirmDb.posture).sort()).toEqual([...DetectionCategorySchema.options].sort());
+    // Evidence overrides the floor for its category; the floor fills every other pack.
+    expect(confirmDb.posture.secret).toBe('redact');
+    expect(confirmDb.posture.code_context).toBe('log'); // monitor floor -> log action
+    expect(confirmDb.posture.config).toBe('log');
+    // The applying-confirmation copy holds end-to-end: all 8 categories tuned, not the survivor subset.
+    expect(out.join('')).toContain('✓ 8 categories tuned');
   });
 });
 
@@ -317,7 +374,8 @@ describe('runApply — confirm is atomic and reports what actually persisted', (
       },
     });
     expect(code).toBe(0); // the write persisted; a delete throw must not flip it
-    expect(db.posture).toEqual({ secret: 'warn' });
+    expect(Object.keys(db.posture)).toHaveLength(8); // the full recommended 8-pack landed
+    expect(db.posture.secret).toBe('warn');
     expect(db.created).toHaveLength(1);
     expect(db.closed).toBe(1); // closed exactly once, no double-close
   });
@@ -338,7 +396,8 @@ describe('runApply — confirm is atomic and reports what actually persisted', (
       stderr: vi.fn(),
     });
     expect(code).toBe(0);
-    expect(db.posture).toEqual({ secret: 'warn' });
+    expect(Object.keys(db.posture)).toHaveLength(8); // the full recommended 8-pack landed
+    expect(db.posture.secret).toBe('warn');
     expect(db.closed).toBe(1);
   });
 
@@ -458,10 +517,50 @@ describe('runApply — confirm rejects a plan stale against the current store (d
       stderr: vi.fn(),
     });
     expect(code).toBe(0);
-    expect(out.join('')).toMatch(/applied/i);
-    // no drift → the write proceeded: one suppression row AND the posture overwrite
+    // The applying confirmation on the real confirm path: all 8 packs tuned, one
+    // routine suppression dismissed.
+    expect(out.join('')).toContain('✓ 8 categories tuned');
+    expect(out.join('')).toContain('✓ 1 routine dismissed');
+    // no drift → the write proceeded: one suppression row AND the full 8-pack
+    // posture overwrite (the evidence category kept its judged action)
     expect(confirmDb.created).toHaveLength(1);
-    expect(confirmDb.posture).toEqual({ secret: 'warn' });
+    expect(Object.keys(confirmDb.posture)).toHaveLength(8);
+    expect(confirmDb.posture.secret).toBe('warn');
+  });
+
+  it('never downgrades a pre-existing stronger posture on an UNREVIEWED floor pack', async () => {
+    // The judge only produces `secret` evidence, so `code_context` is a floor pack
+    // the wizard never reviewed and the drift gate never checks. The user had
+    // already hardened it to `block` out-of-band. Establishing the full 8-pack must
+    // NOT reset that stronger setting to the weak severity floor — the floor packs
+    // fill gaps only. (The preview shows a recommended posture for all 8, but the
+    // confirm write overwrites only the reviewed evidence and fills gaps for the rest.)
+    const path = await previewWith({ code_context: 'block' });
+    const confirmDb = fakeDb();
+    confirmDb.posture.code_context = 'block'; // still hardened at confirm — no drift
+    const out: string[] = [];
+    const code = await runApply({
+      argv: ['--confirmed', '--plan', path],
+      readStream: () => {
+        throw new Error('stream must not be read');
+      },
+      runJudge: () => {
+        throw new Error('judge must not run');
+      },
+      openDb: confirmDb.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+    // The hardened floor pack is PRESERVED, not silently reset to the floor.
+    expect(confirmDb.posture.code_context).toBe('block');
+    // The reviewed evidence pack took its judged action; the rest sit at the floor.
+    expect(confirmDb.posture.secret).toBe('warn');
+    // All 8 packs hold a posture and the tuned count stays honest.
+    expect(Object.keys(confirmDb.posture)).toHaveLength(8);
+    expect(out.join('')).toContain('✓ 8 categories tuned');
   });
 
   it('treats a category ADDED to the store since preview as drift (undefined → value)', async () => {
@@ -576,5 +675,130 @@ describe('runApply — confirm fails loud on a bad --plan', () => {
     expect(err.join('')).toMatch(/plan file/i);
     expect(db.posture).toEqual({});
     expect(db.created).toEqual([]);
+  });
+});
+
+describe('runApply — preview emits the calibration frame JSON alongside the human gate', () => {
+  // A verdict with a surfaced (genuine) count so `important` is provably non-zero
+  // and tracks it, not just the suppressed FPs.
+  const genuineVerdict = (): TriageRecommendation => ({
+    perCategory: [
+      {
+        category: 'secret',
+        action: 'warn',
+        reasoning: 'canonical fake AWS example key',
+        genuineCount: 2,
+        fpCount: 1,
+        fpIds: ['0'],
+      },
+    ],
+    notes: 'looks routine',
+  });
+
+  it('emits a valid CalibrationFrame whose counts come from the plan (genuine vs suppressed)', async () => {
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => streamText(),
+      runJudge: () => genuineVerdict(),
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+    const blob = out.join('');
+
+    // Additive: the human gate render is still present (not replaced).
+    expect(blob).toContain('false-positive');
+
+    // The calibrated-result card the wizard leads with: the real-count
+    // headline over this run's genuine/suppressed split, then the condensed
+    // one-row-per-pack recommended posture.
+    expect(blob).toContain('Calibrated. 3 notifications, 2 important.');
+    expect(blob).toMatch(/secret\s+warn/);
+
+    const frame = readFrameJsonBlock(blob);
+    const parsed = CalibrationFrame.safeParse(frame);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // important = surfaced (genuine) count, routine = suppressed (fp) count.
+    expect(parsed.data.counts).toEqual({ total: 3, important: 2, routine: 1 });
+    expect(parsed.data.surfacedCategories).toEqual(['secret']);
+    expect(parsed.data.routineCategories).toEqual(['secret']);
+    // The retroactive scan reads at-rest history, so every kind is at-rest.
+    expect(parsed.data.findingKinds).toContainEqual({
+      category: 'secret',
+      count: 3,
+      egress: false,
+    });
+    // The posture map is the full recommended view (all 8 packs), with the
+    // evidence-derived action overriding secret.
+    expect(Object.keys(parsed.data.posture).sort()).toEqual(
+      [...DetectionCategorySchema.options].sort(),
+    );
+    expect(parsed.data.posture.secret).toBe('warn');
+  });
+
+  it('carries no raw detected value into the frame JSON (masked/enum/count only)', async () => {
+    const db = fakeDb();
+    const out: string[] = [];
+    await runApply({
+      argv: [],
+      readStream: () => streamText(),
+      runJudge: () => genuineVerdict(),
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    const blob = out.join('');
+    // The frame block itself never echoes the raw hit value.
+    expect(blob).toContain('<<<AKA_FRAME_JSON');
+    expect(JSON.stringify(readFrameJsonBlock(blob))).not.toContain(RAW);
+  });
+});
+
+describe('runApply — preview degrades fail-open when the local store is unreadable', () => {
+  it('substitutes the store-unavailable note instead of throwing, and never fabricates a count', async () => {
+    const out: string[] = [];
+    let code: number | undefined;
+    let threw: unknown;
+    try {
+      code = await runApply({
+        argv: [],
+        readStream: () => streamText(),
+        runJudge: () => verdict(),
+        // A store that cannot be opened mid-preview (missing / corrupt / locked db):
+        // the calibration step's only store read is the current-posture downgrade
+        // view, and it must degrade rather than break the wizard.
+        openDb: () => {
+          throw new Error('SQLITE_CANTOPEN: unable to open database file');
+        },
+        now: () => 0,
+        createdBy: () => 'tester',
+        stdout: (s) => out.push(s),
+        stderr: vi.fn(),
+      });
+    } catch (e) {
+      threw = e;
+    }
+    const blob = out.join('');
+
+    // Fail-open: no thrown error escaped the calibration preview, and it completed.
+    expect(threw).toBeUndefined();
+    expect(code).toBe(0);
+
+    // The honest store-unavailable note stands in for the store-derived downgrade
+    // comparison — the store-read-failure path, not the found-nothing/empty copy.
+    expect(blob).toContain("I couldn't read the local store");
+
+    // The real calibration count (from the scan/plan, not the store) still renders —
+    // a store-read failure never fabricates or zeroes the calibrated headline.
+    expect(blob).toContain('Calibrated. 1 notifications');
   });
 });

--- a/plugins/claude-code/test/triage/writeback.test.ts
+++ b/plugins/claude-code/test/triage/writeback.test.ts
@@ -1,10 +1,12 @@
 import type { ActionTaken, DetectionCategory, TriageHit } from '@akasecurity/schema';
+import { severityFloorPosture } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import {
   parseTriageStream,
   performTriageWriteback,
   planTriageWriteback,
+  recommendedPosture,
   SCRUBBED_NOTES,
 } from '../../src/triage/writeback.ts';
 
@@ -263,6 +265,28 @@ describe('performTriageWriteback', () => {
     expect(fake.created[0]).toMatchObject({ createdVia: 'setup-triage', createdBy: 'me' });
   });
 
+  it('overwrites the reviewed evidence but only FILL-GAPS the floor (no downgrade)', async () => {
+    // A store where an unreviewed floor pack is already hardened stronger than the
+    // floor, and the evidence pack (secret) already holds a value.
+    const fake = fakeWriters();
+    fake.posture.code_context = 'block'; // hardened out-of-band, not in the evidence
+    fake.posture.secret = 'block'; // reviewed pack with a prior value
+    const plan = planTriageWriteback([hit()], rec([{ action: 'redact' }])); // secret -> redact
+    const res = await performTriageWriteback(plan, fake.writers, {
+      createdBy: 'me',
+      now: 0,
+      floor: severityFloorPosture(),
+    });
+    // The reviewed evidence pack is OVERWRITTEN with its judged action.
+    expect(fake.posture.secret).toBe('redact');
+    // The hardened floor pack is PRESERVED (fill-gaps skips an existing row).
+    expect(fake.posture.code_context).toBe('block');
+    // Every other pack got the floor.
+    expect(Object.keys(fake.posture)).toHaveLength(8);
+    // The count reflects the full established 8-pack, not the survivor subset.
+    expect(res.categoriesWritten).toBe(8);
+  });
+
   it('does not write any suppression when the plan resolved none', async () => {
     // fpIds point at an id absent from the join, so nothing resolves regardless
     // of the relaxed count check.
@@ -321,5 +345,24 @@ describe('performTriageWriteback', () => {
     // nothing persisted: posture NOT overwritten, no exception row survived
     expect(posture).toEqual({});
     expect(created).toEqual([]);
+  });
+});
+
+describe('recommendedPosture', () => {
+  it('overlays the severity floor for all 8 packs with the evidence-derived actions', () => {
+    // Evidence covers only two packs, one of them differing from its floor value.
+    const full = recommendedPosture({ secret: 'redact', pii: 'warn' });
+    // All 8 packs are present — never the survivor subset.
+    expect(Object.keys(full).sort()).toEqual(Object.keys(severityFloorPosture()).sort());
+    expect(Object.keys(full)).toHaveLength(8);
+    // Evidence wins where present; the floor fills every other pack unchanged.
+    expect(full.secret).toBe('redact'); // floor is 'warn' — evidence overrides
+    expect(full.pii).toBe('warn');
+    expect(full.code_context).toBe('monitor'); // untouched floor default
+    expect(full.config).toBe('monitor');
+  });
+
+  it('returns the bare severity floor when there is no evidence', () => {
+    expect(recommendedPosture({})).toEqual(severityFloorPosture());
   });
 });

--- a/plugins/claude-code/vitest.config.ts
+++ b/plugins/claude-code/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+// globalSetup builds scripts/*.js once, in the main process, before any worker
+// runs — the journey harness (test/journey) drives those built scripts.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globalSetup: ['./test/journey/global-setup.ts'],
+  },
+});


### PR DESCRIPTION
Second slice, stacked on the CalibrationFrame schema PR (merge that first; GitHub retargets this one). Re-sequences the setup wizard into the scan-calibration spine: product-identity intro cards, real-count calibration framing with recommended posture defaults, a single scan-consent choice, posture persistence on the scan path, the first-run installed card + dashboard handoff, fail-open degradation on store-read failure, and an end-to-end journey test harness driving the real script chain against a temp home.

Review map by commit: identity/intro cards → frame renders → calibration framing + frame JSON → consent + setup re-sequence → posture persistence → first-run handoff + journey harness. Evidence: full workspace 24/24 tasks green; journey suites 12/12; plugin 342/342; typecheck/lint clean.