### PR TITLE
feat: canonical product identity across all surfaces + copy guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # AI Traffic Control
 
+**AKA Security — We secure agent harnesses at the source.**
+
 AI Traffic Control (`ai-tc`) is an open-source control plane for coding agents. It watches an agent session's traffic (prompts, tool calls, responses, file reads), scans each event against your rule packs, and decides what happens next: monitor, warn, redact, block, or a manual exception. Secrets and regulated data like PCI, PHI, and PII are caught and kept on your machine, not sent to a model or a third party.
 
 ![Open source](https://img.shields.io/badge/Open_source-232F3E?style=flat-square)

--- a/cli/README.md
+++ b/cli/README.md
@@ -3,6 +3,8 @@
 [![npm](https://img.shields.io/npm/v/@akasecurity/cli?style=flat-square&labelColor=232F3E&color=00E0B8)](https://www.npmjs.com/package/@akasecurity/cli)
 [![Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-232F3E?style=flat-square)](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)
 
+**AKA Security — We secure agent harnesses at the source.**
+
 The `aka` command-line tool for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`) — an open-source, local-first control plane for coding agents. It inspects and governs the traffic of an agent session (prompts, tool calls, responses, file reads), scans each event against your rule packs, and records everything to a local SQLite store at `~/.aka/data/aka.db`.
 
 Everything runs on your machine. There's no account, no backend, and nothing leaves your computer to be scanned.

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -22,6 +22,12 @@ import { defaultWorkspaceSettings } from '@akasecurity/schema';
 import { HOME_OPTION, homeBase } from '../lib/args.ts';
 import { runPlugins } from './plugins.ts';
 
+// Canonical product name and tagline for the init plugin-offer copy — the same
+// identity the plugin presents, kept in lockstep by the identity-consistency guard.
+export const PRODUCT_NAME = 'AKA Security';
+export const PRODUCT_TAGLINE = 'We secure agent harnesses at the source.';
+export const PLUGIN_OFFER_IDENTITY = `${PRODUCT_NAME} — ${PRODUCT_TAGLINE}`;
+
 // `aka init` — scaffold the local AKA home: owner-only ~/.aka, a default
 // settings.json, and the SQLite store (openLocalDatabase creates the data dir,
 // applies migrations, and seeds the default per-category policies). Idempotent:
@@ -98,7 +104,8 @@ async function offerPluginInstall(autoYes: boolean): Promise<void> {
   if (!autoYes) {
     if (!process.stdin.isTTY) {
       out.write(
-        `\nNo Claude Code plugin detected. Install it via the marketplace:\n` +
+        `\n${PLUGIN_OFFER_IDENTITY}\n` +
+          `No Claude Code plugin detected. Install it via the marketplace:\n` +
           `  /plugin marketplace add ${agent.marketplaceSource ?? ''}\n` +
           `  /plugin install ${ref}\n` +
           `Or re-run \`aka init --yes\` to install it automatically.\n`,
@@ -106,7 +113,10 @@ async function offerPluginInstall(autoYes: boolean): Promise<void> {
       return;
     }
     if (
-      !(await confirm(`\nInstall the AKA Claude Code plugin now (via the marketplace)? [y/N] `))
+      !(await confirm(
+        `\n${PLUGIN_OFFER_IDENTITY}\n` +
+          `Install the ${PRODUCT_NAME} plugin for Claude Code now (via the marketplace)? [y/N] `,
+      ))
     ) {
       out.write('Skipped. Install anytime with `aka plugins install claude-code`.\n');
       return;

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -17,15 +17,13 @@ import {
   ensureDataDirSync,
   settingsDir,
 } from '@akasecurity/plugin-sdk';
-import { defaultWorkspaceSettings } from '@akasecurity/schema';
+import { defaultWorkspaceSettings, PRODUCT_NAME, PRODUCT_TAGLINE } from '@akasecurity/schema';
 
 import { HOME_OPTION, homeBase } from '../lib/args.ts';
 import { runPlugins } from './plugins.ts';
 
-// Canonical product name and tagline for the init plugin-offer copy — the same
-// identity the plugin presents, kept in lockstep by the identity-consistency guard.
-export const PRODUCT_NAME = 'AKA Security';
-export const PRODUCT_TAGLINE = 'We secure agent harnesses at the source.';
+// The init plugin-offer copy, built from the canonical product identity single-sourced
+// in @akasecurity/schema so the CLI and plugin present the same name and tagline.
 export const PLUGIN_OFFER_IDENTITY = `${PRODUCT_NAME} — ${PRODUCT_TAGLINE}`;
 
 // `aka init` — scaffold the local AKA home: owner-only ~/.aka, a default

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -1,0 +1,64 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type * as LocalOps from '@akasecurity/local-ops';
+import { dbPath, settingsDir } from '@akasecurity/plugin-sdk';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { runInit } from '../../src/commands/init.ts';
+
+// Force the offer's non-interactive branch to emit: report no installed plugin so
+// offerPluginInstall reaches the print path, independent of the host's ~/.claude.
+vi.mock('@akasecurity/local-ops', async (importActual) => {
+  const actual = await importActual<typeof LocalOps>();
+  return { ...actual, installedPluginVersions: vi.fn(() => new Map<string, string>()) };
+});
+
+let dir: string;
+let stdinTTY: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'aka-init-'));
+  // The interactive offer is TTY-gated; force the non-TTY branch so runInit
+  // prints the offer copy without blocking on a confirm prompt.
+  stdinTTY = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY');
+  Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  if (stdinTTY) Object.defineProperty(process.stdin, 'isTTY', stdinTTY);
+  else delete (process.stdin as { isTTY?: boolean }).isTTY;
+  vi.restoreAllMocks();
+});
+
+describe('plugin-install offer identity', () => {
+  it('emits offer copy carrying the canonical product name and tagline', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    await runInit(['--home', dir]);
+
+    const out = stdout.mock.calls.map((c) => String(c[0])).join('');
+    expect(out).toContain('AKA Security');
+    expect(out).toContain('We secure agent harnesses at the source.');
+  });
+});
+
+describe('runInit contract', () => {
+  it('still scaffolds ~/.aka and asks no posture questions', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    await runInit(['--home', dir]);
+
+    // Scaffolding: the settings file and the SQLite store both land under the home.
+    expect(existsSync(join(settingsDir(dir), 'settings.json'))).toBe(true);
+    expect(existsSync(dbPath(dir))).toBe(true);
+
+    const out = stdout.mock.calls.map((c) => String(c[0])).join('');
+    expect(out).toContain(`Initialized AKA at ${dir}`);
+    // init never interrogates the user about detection posture or historical access.
+    expect(out).not.toMatch(/posture/i);
+    expect(out).not.toMatch(/historical access/i);
+  });
+});

--- a/packages/schema/src/identity.ts
+++ b/packages/schema/src/identity.ts
@@ -1,0 +1,10 @@
+// Canonical product identity — the single source of the display name, tagline,
+// one-liner, and the setup-command description. Every surface that shows the
+// product's identity (the plugin, the CLI, the dashboard) imports these
+// constants so the copy is defined once and cannot drift between screens.
+export const PRODUCT_NAME = 'AKA Security';
+export const PRODUCT_TAGLINE = 'We secure agent harnesses at the source.';
+export const PRODUCT_ONE_LINER =
+  'I watch out for Claude as it codes — catching secrets and customer data before they slip out.';
+export const PRODUCT_SETUP_DESCRIPTION =
+  "Set up AKA Security — calibrate notifications and detection posture from Claude's real activity.";

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,5 +1,6 @@
 export * from './drizzle/sqlite-ddl.ts';
 export * from './exception-scope.ts';
+export * from './identity.ts';
 export * from './time.ts';
 // Pure read-time token cost/rollup/format logic (no Node-API deps) — shared by
 // the plugin, the web-ui Activity surfaces, and the CLI/TUI.

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -3,6 +3,8 @@
 [![npm](https://img.shields.io/npm/v/@akasecurity/ai-tc-claude-code?style=flat-square&labelColor=232F3E&color=00E0B8)](https://www.npmjs.com/package/@akasecurity/ai-tc-claude-code)
 [![Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-232F3E?style=flat-square)](https://github.com/akasecurity/ai-tc/blob/main/LICENSE)
 
+**AKA Security — We secure agent harnesses at the source.**
+
 The Claude Code plugin for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`). It hooks into a Claude Code session and inspects its traffic — prompts, tool calls, tool results, file reads — scanning each event against your rule packs and applying inline **warn / redact / block** policies. Every event is recorded to a local SQLite store at `~/.aka/data/aka.db`.
 
 Detection runs entirely on your machine. There's no account and no backend — nothing leaves your computer to be scanned.

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-description: Set up the AKA Control Plane plugin — evidence-first detection posture and historical access
+description: Set up AKA Security — calibrate notifications and detection posture from Claude's real activity.
 ---
 
 # AKA setup wizard

--- a/plugins/claude-code/src/hooks/onboarding-nudge.ts
+++ b/plugins/claude-code/src/hooks/onboarding-nudge.ts
@@ -1,0 +1,10 @@
+// First-run nudge copy for the UserPromptSubmit hook, kept in its own module
+// (no main() side effect) so it is the single source of truth for the
+// once-per-session "installed but not calibrated" pointer.
+
+/**
+ * The one-line pointer shown once per session on a machine that has not yet
+ * completed `/aka:setup`: AKA is installed but not calibrated to this machine.
+ */
+export const ONBOARDING_NUDGE =
+  'AKA Security is installed but not calibrated — run /aka:setup to tune notifications to this machine (about a minute).';

--- a/plugins/claude-code/src/hooks/user-prompt-submit.ts
+++ b/plugins/claude-code/src/hooks/user-prompt-submit.ts
@@ -28,6 +28,7 @@ import {
 } from '@akasecurity/plugin-sdk';
 
 import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
+import { ONBOARDING_NUDGE } from './onboarding-nudge.ts';
 import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
 import {
   claimStoreUnavailableWarning,
@@ -98,10 +99,7 @@ async function main(): Promise<void> {
   // stronger action to a detection. Gate it to once per session so a busy
   // pre-onboarding session isn't spammed every prompt.
   if (!config.onboarded && claimOnboardingNudge(config.dataDir, sessionId)) {
-    await emit({
-      systemMessage:
-        'AKA is active and monitoring your prompts (log-only by default — nothing is blocked or redacted yet). Run /aka:setup to choose your installation type and set enforcement (warn/redact/block) per detection.',
-    });
+    await emit({ systemMessage: ONBOARDING_NUDGE });
   }
 }
 

--- a/plugins/claude-code/src/identity.ts
+++ b/plugins/claude-code/src/identity.ts
@@ -1,7 +1,10 @@
 // Canonical product identity — the single source of the display name, tagline,
-// and one-liner. Every surface that shows the product's identity imports these
-// constants so the copy is defined once and cannot drift between screens.
+// one-liner, and the /aka:setup command description. Every surface that shows the
+// product's identity imports these constants so the copy is defined once and
+// cannot drift between screens.
 export const NAME = 'AKA Security';
 export const TAGLINE = 'We secure agent harnesses at the source.';
 export const ONE_LINER =
   'I watch out for Claude as it codes — catching secrets and customer data before they slip out.';
+export const SETUP_DESCRIPTION =
+  "Set up AKA Security — calibrate notifications and detection posture from Claude's real activity.";

--- a/plugins/claude-code/src/identity.ts
+++ b/plugins/claude-code/src/identity.ts
@@ -1,10 +1,9 @@
-// Canonical product identity — the single source of the display name, tagline,
-// one-liner, and the /aka:setup command description. Every surface that shows the
-// product's identity imports these constants so the copy is defined once and
-// cannot drift between screens.
-export const NAME = 'AKA Security';
-export const TAGLINE = 'We secure agent harnesses at the source.';
-export const ONE_LINER =
-  'I watch out for Claude as it codes — catching secrets and customer data before they slip out.';
-export const SETUP_DESCRIPTION =
-  "Set up AKA Security — calibrate notifications and detection posture from Claude's real activity.";
+// Canonical product identity, single-sourced from @akasecurity/schema. Re-exported
+// here under the plugin's local names so every surface that shows the product's
+// identity imports the same constants and the copy cannot drift between screens.
+export {
+  PRODUCT_NAME as NAME,
+  PRODUCT_ONE_LINER as ONE_LINER,
+  PRODUCT_SETUP_DESCRIPTION as SETUP_DESCRIPTION,
+  PRODUCT_TAGLINE as TAGLINE,
+} from '@akasecurity/schema';

--- a/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
@@ -1,0 +1,109 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { ONBOARDING_NUDGE } from '../../src/hooks/onboarding-nudge.ts';
+
+const CANONICAL_NUDGE =
+  'AKA Security is installed but not calibrated — run /aka:setup to tune notifications to this machine (about a minute).';
+const STALE_D9 = 'choose your installation type';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/hooks -> plugins/claude-code
+const PLUGIN_ROOT = join(HERE, '..', '..');
+const HOOK_SOURCE = join(PLUGIN_ROOT, 'src', 'hooks', 'user-prompt-submit.ts');
+// The built entry the suite's global setup compiles (test/journey/global-setup.ts).
+// Driving it proves the emit SITE, not just the exported constant.
+const HOOK_SCRIPT = join(PLUGIN_ROOT, 'scripts', 'user-prompt-submit.js');
+
+interface HookRun {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Drive the real built hook against a throwaway ~/.aka home, feeding a Claude
+// Code UserPromptSubmit payload on stdin. process.execPath is an absolute node
+// path, so the child needs no host PATH and inherits no ambient environment.
+function runHook(home: string, payload: unknown): HookRun {
+  try {
+    const stdout = execFileSync(process.execPath, [HOOK_SCRIPT], {
+      env: { HOME: home, USERPROFILE: home },
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  }
+}
+
+describe('ONBOARDING_NUDGE', () => {
+  it('is the canonical calibration-wizard copy', () => {
+    expect(ONBOARDING_NUDGE).toBe(CANONICAL_NUDGE);
+  });
+
+  it('drops the stale D9 installation-type framing', () => {
+    expect(ONBOARDING_NUDGE).not.toContain(STALE_D9);
+  });
+});
+
+describe('user-prompt-submit hook source (SCENARIO-0003)', () => {
+  it('no longer references the stale D9 installation-type string', () => {
+    // SCENARIO-0003 observable: no stale D9 string exists in the hook source.
+    expect(readFileSync(HOOK_SOURCE, 'utf8')).not.toContain(STALE_D9);
+  });
+});
+
+describe('user-prompt-submit hook — driven end-to-end', () => {
+  it('emits the calibration nudge (not the stale copy) on a clean prompt from an un-calibrated machine', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-nudge-'));
+    try {
+      const run = runHook(home, {
+        prompt: 'what does this function do?',
+        session_id: 'sess-nudge',
+        cwd: '/tmp',
+        hook_event_name: 'UserPromptSubmit',
+      });
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe('');
+      const payload = JSON.parse(run.stdout) as { systemMessage?: string };
+      // Proves the emit SITE carries the constant: a regression to any other copy
+      // at the emit call fails here, which the constant-equality check cannot catch.
+      expect(payload.systemMessage).toBe(ONBOARDING_NUDGE);
+      expect(run.stdout).not.toContain(STALE_D9);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to allow and never throws when a store fault is injected (AC-2 fail-open)', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-failopen-'));
+    try {
+      // Injected fault: an unreadable store (not the SQLite header) so enforcement
+      // cannot complete before the nudge. The hook must still resolve to allow.
+      const dataDir = join(home, '.aka', 'data');
+      mkdirSync(dataDir, { recursive: true });
+      writeFileSync(join(dataDir, 'aka.db'), 'not a database\n'.repeat(64));
+
+      const run = runHook(home, {
+        prompt: 'what does this function do?',
+        session_id: 'sess-failopen',
+        cwd: '/tmp',
+        hook_event_name: 'UserPromptSubmit',
+      });
+      // Allow = exit 0, no exception escaped (empty stderr), and never a block.
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe('');
+      expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
@@ -10,7 +10,7 @@ import { ONBOARDING_NUDGE } from '../../src/hooks/onboarding-nudge.ts';
 
 const CANONICAL_NUDGE =
   'AKA Security is installed but not calibrated — run /aka:setup to tune notifications to this machine (about a minute).';
-const STALE_D9 = 'choose your installation type';
+const STALE_INSTALL_NUDGE = 'choose your installation type';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test/hooks -> plugins/claude-code
@@ -49,15 +49,15 @@ describe('ONBOARDING_NUDGE', () => {
     expect(ONBOARDING_NUDGE).toBe(CANONICAL_NUDGE);
   });
 
-  it('drops the stale D9 installation-type framing', () => {
-    expect(ONBOARDING_NUDGE).not.toContain(STALE_D9);
+  it('drops the stale installation-type framing', () => {
+    expect(ONBOARDING_NUDGE).not.toContain(STALE_INSTALL_NUDGE);
   });
 });
 
-describe('user-prompt-submit hook source (SCENARIO-0003)', () => {
-  it('no longer references the stale D9 installation-type string', () => {
-    // SCENARIO-0003 observable: no stale D9 string exists in the hook source.
-    expect(readFileSync(HOOK_SOURCE, 'utf8')).not.toContain(STALE_D9);
+describe('user-prompt-submit hook source', () => {
+  it('no longer references the stale installation-type string', () => {
+    // The stale installation-type string no longer exists in the hook source.
+    expect(readFileSync(HOOK_SOURCE, 'utf8')).not.toContain(STALE_INSTALL_NUDGE);
   });
 });
 
@@ -77,13 +77,13 @@ describe('user-prompt-submit hook — driven end-to-end', () => {
       // Proves the emit SITE carries the constant: a regression to any other copy
       // at the emit call fails here, which the constant-equality check cannot catch.
       expect(payload.systemMessage).toBe(ONBOARDING_NUDGE);
-      expect(run.stdout).not.toContain(STALE_D9);
+      expect(run.stdout).not.toContain(STALE_INSTALL_NUDGE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
   });
 
-  it('falls back to allow and never throws when a store fault is injected (AC-2 fail-open)', () => {
+  it('falls back to allow and never throws when a store fault is injected (fail-open)', () => {
     const home = mkdtempSync(join(tmpdir(), 'aka-ups-failopen-'));
     try {
       // Injected fault: an unreadable store (not the SQLite header) so enforcement

--- a/plugins/claude-code/test/identity-consistency.test.ts
+++ b/plugins/claude-code/test/identity-consistency.test.ts
@@ -40,7 +40,7 @@ function readManifest(relative: string): Manifest {
   return JSON.parse(read(relative)) as Manifest;
 }
 
-describe('SCENARIO-0002 — identity/description consistency guard', () => {
+describe('identity/description consistency guard', () => {
   it('setup.md frontmatter description equals the canonical constant', () => {
     expect(frontmatterDescription(setupMd)).toBe(SETUP_DESCRIPTION);
   });

--- a/plugins/claude-code/test/identity-consistency.test.ts
+++ b/plugins/claude-code/test/identity-consistency.test.ts
@@ -2,9 +2,13 @@ import { readFileSync } from 'node:fs';
 
 import { describe, expect, it } from 'vitest';
 
-import { SETUP_DESCRIPTION } from '../src/identity.ts';
+import { NAME, SETUP_DESCRIPTION, TAGLINE } from '../src/identity.ts';
 
-const setupMd = readFileSync(new URL('../commands/setup.md', import.meta.url), 'utf8');
+function read(relative: string): string {
+  return readFileSync(new URL(relative, import.meta.url), 'utf8');
+}
+
+const setupMd = read('../commands/setup.md');
 
 // Reads the `description:` value from the leading YAML frontmatter block —
 // the string Claude Code registers as the /aka:setup slash-command description.
@@ -17,6 +21,24 @@ function frontmatterDescription(source: string): string {
 
 const STALE_SETUP_DESCRIPTION =
   'Set up the AKA Control Plane plugin — evidence-first detection posture and historical access';
+const STALE_TAGLINE = 'Agent Harness Security for Claude Code.';
+
+// The three READMEs whose prose must carry the canonical name and tagline.
+const READMES = [
+  ['repo-root README.md', '../../../README.md'],
+  ['cli/README.md', '../../../cli/README.md'],
+  ['plugins/claude-code/README.md', '../README.md'],
+] as const;
+
+interface Manifest {
+  owner?: { name?: string };
+  author?: { name?: string };
+  version?: string;
+}
+
+function readManifest(relative: string): Manifest {
+  return JSON.parse(read(relative)) as Manifest;
+}
 
 describe('SCENARIO-0002 — identity/description consistency guard', () => {
   it('setup.md frontmatter description equals the canonical constant', () => {
@@ -25,5 +47,31 @@ describe('SCENARIO-0002 — identity/description consistency guard', () => {
 
   it('setup.md carries no stale command description', () => {
     expect(setupMd).not.toContain(STALE_SETUP_DESCRIPTION);
+  });
+
+  it.each(READMES)('%s prose carries the canonical name and tagline', (_label, relative) => {
+    const readme = read(relative);
+    expect(readme).toContain(NAME);
+    expect(readme).toContain(TAGLINE);
+  });
+
+  it.each(READMES)('%s carries no stale tagline variant', (_label, relative) => {
+    expect(read(relative)).not.toContain(STALE_TAGLINE);
+  });
+
+  it('marketplace.json owner name equals the canonical NAME', () => {
+    const manifest = readManifest('../../../.claude-plugin/marketplace.json');
+    expect(manifest.owner?.name).toBe(NAME);
+  });
+
+  it('plugin.json author name equals the canonical NAME', () => {
+    const manifest = readManifest('../.claude-plugin/plugin.json');
+    expect(manifest.author?.name).toBe(NAME);
+  });
+
+  it('plugin.json version equals package.json version (lockstep)', () => {
+    const plugin = readManifest('../.claude-plugin/plugin.json');
+    const pkg = readManifest('../package.json');
+    expect(plugin.version).toBe(pkg.version);
   });
 });

--- a/plugins/claude-code/test/identity-consistency.test.ts
+++ b/plugins/claude-code/test/identity-consistency.test.ts
@@ -59,12 +59,6 @@ describe('SCENARIO-0002 — identity/description consistency guard', () => {
     expect(read(relative)).not.toContain(STALE_TAGLINE);
   });
 
-  it('cli init plugin-offer copy carries the canonical name and tagline', () => {
-    const initSource = read('../../../cli/src/commands/init.ts');
-    expect(initSource).toContain(NAME);
-    expect(initSource).toContain(TAGLINE);
-  });
-
   it('marketplace.json owner name equals the canonical NAME', () => {
     const manifest = readManifest('../../../.claude-plugin/marketplace.json');
     expect(manifest.owner?.name).toBe(NAME);

--- a/plugins/claude-code/test/identity-consistency.test.ts
+++ b/plugins/claude-code/test/identity-consistency.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { SETUP_DESCRIPTION } from '../src/identity.ts';
+
+const setupMd = readFileSync(new URL('../commands/setup.md', import.meta.url), 'utf8');
+
+// Reads the `description:` value from the leading YAML frontmatter block —
+// the string Claude Code registers as the /aka:setup slash-command description.
+function frontmatterDescription(source: string): string {
+  const frontmatter = /^---\n([\s\S]*?)\n---/.exec(source)?.[1];
+  const value = frontmatter ? /^description:[ \t]*(.*)$/m.exec(frontmatter)?.[1] : undefined;
+  if (value === undefined) throw new Error('setup.md has no frontmatter description');
+  return value.trim();
+}
+
+const STALE_SETUP_DESCRIPTION =
+  'Set up the AKA Control Plane plugin — evidence-first detection posture and historical access';
+
+describe('SCENARIO-0002 — identity/description consistency guard', () => {
+  it('setup.md frontmatter description equals the canonical constant', () => {
+    expect(frontmatterDescription(setupMd)).toBe(SETUP_DESCRIPTION);
+  });
+
+  it('setup.md carries no stale command description', () => {
+    expect(setupMd).not.toContain(STALE_SETUP_DESCRIPTION);
+  });
+});

--- a/plugins/claude-code/test/identity-consistency.test.ts
+++ b/plugins/claude-code/test/identity-consistency.test.ts
@@ -59,6 +59,12 @@ describe('SCENARIO-0002 — identity/description consistency guard', () => {
     expect(read(relative)).not.toContain(STALE_TAGLINE);
   });
 
+  it('cli init plugin-offer copy carries the canonical name and tagline', () => {
+    const initSource = read('../../../cli/src/commands/init.ts');
+    expect(initSource).toContain(NAME);
+    expect(initSource).toContain(TAGLINE);
+  });
+
   it('marketplace.json owner name equals the canonical NAME', () => {
     const manifest = readManifest('../../../.claude-plugin/marketplace.json');
     expect(manifest.owner?.name).toBe(NAME);

--- a/plugins/claude-code/test/journey/yes-scan.journey.test.ts
+++ b/plugins/claude-code/test/journey/yes-scan.journey.test.ts
@@ -19,6 +19,7 @@ import { openLocalDatabase } from '@akasecurity/persistence';
 import { CalibrationFrame, DetectionCategory, SetupHandoffOffer } from '@akasecurity/schema';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import { renderCategoriesTuned, STORE_UNAVAILABLE_NOTE } from '../../src/render.ts';
 import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
 import {
   planPathFromPreview,
@@ -140,10 +141,25 @@ describe('Yes-scan happy path, end-to-end', () => {
 
   it('apply: the ACTUAL writer confirms the floor-overlaid 8-pack', () => {
     // The applying confirmation from apply-suppressions.js --confirmed — the
-    // spine writer, not onboard.js --posture.
-    expect(confirm).toContain('✓ 8 categories tuned');
+    // spine writer, not onboard.js --posture. The tuned count is derived from the
+    // posture the run actually wrote (read back from the store) and rendered with
+    // the shipped helper, so the assertion carries no hardcoded count.
+    const categoriesTuned = Object.values(readPosture(journey.storeDir)).filter(Boolean).length;
+    expect(confirm).toContain(renderCategoriesTuned(categoriesTuned));
     expect(confirm).toContain('✓ 1 routine dismissed');
     expect(confirm).toMatch(/Ready:/);
+  });
+
+  it('happy path: no store-unavailable fail-open note leaks into the fail-open frames', () => {
+    // The two frames that degrade to the fail-open note on an unreadable store —
+    // the calibration preview's downgrade read and the first-run card's stats read —
+    // read cleanly the whole way here, so the note must be absent: a regression that
+    // spuriously renders it on a healthy store fails here instead of passing the
+    // positive-only assertions. The confirm write is deliberately excluded — it fails
+    // SECURE to stderr on a store fault and has no fail-open note path, so asserting
+    // its absence there is vacuous.
+    expect(preview).not.toContain(STORE_UNAVAILABLE_NOTE);
+    expect(firstRun).not.toContain(STORE_UNAVAILABLE_NOTE);
   });
 
   it('final store: settings.json records the consent and all 8 packs hold a valid posture', () => {

--- a/plugins/claude-code/test/setup-copy.test.ts
+++ b/plugins/claude-code/test/setup-copy.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const setupMd = readFileSync(new URL('../commands/setup.md', import.meta.url), 'utf8');
+
+// The prompt-authored scan-offer copy lives in commands/setup.md, so a
+// regression is otherwise only visible in the manual walkthrough. These guards
+// pin the verbatim strings the wizard shows at the scan offer.
+describe('setup.md scan-offer copy', () => {
+  it('carries the scope disclosure verbatim', () => {
+    expect(setupMd).toContain(
+      "A retroactive scan of recent activity — transcripts, temp files, agent memory — tunes the notifications we'll review next.",
+    );
+  });
+
+  it('carries the Yes-option subtitle verbatim', () => {
+    expect(setupMd).toContain('calibrate my notifications to your real activity');
+  });
+
+  it('carries the Not-now-option subtitle verbatim', () => {
+    expect(setupMd).toContain('start light and learn as we go');
+  });
+});


### PR DESCRIPTION
Third slice of the setup-wizard redesign, stacked on the wizard-spine PR (merge order: schema → wizard-spine → this).

Aligns every user-facing identity surface to one canonical constant and locks it against drift: the /aka:setup command description, the three READMEs, manifest owner/author fields (with version lockstep), the passive nudge line, and the CLI init plugin-offer copy — each with a consistency-guard test that fails on divergence. Also hardens the journey evidence: the apply-confirmation count is derived from the store read-back (no literal in the assertion path), and the store-unavailable note is asserted absent on healthy-store surfaces.

Review map by commit: setup description guard → README/manifest sync → nudge copy → init offer copy → scan-offer copy guard → journey assertion hardening. Evidence: plugin 359/359, cli 39/39, schema 476/476, journeys 13/13, lint/prettier clean.