### PR TITLE
test(plugin): pin the backfill retention window to a fixed reference

### DIFF
--- a/plugins/claude-code/test/history/usage.test.ts
+++ b/plugins/claude-code/test/history/usage.test.ts
@@ -29,6 +29,15 @@ function config(dataDir: string): PluginConfig {
 
 const SESSION = 'sess-abc';
 
+// Pin the backfill's retention window to a fixed reference just after the fixtures'
+// own timestamps (all at 2026-06-20T10:00:0x). `reconcileHistory` windows records to
+// `(now ?? Date.now()) - windowDays` — without a fixed `now` these fixed-date
+// fixtures fall out of the default 30-day window once the wall clock advances past
+// them, dropping every record. Threading `NOW` keeps the walk deterministic and
+// independent of the wall clock. (`reconcileSession`/`reconcileSessionTail` parse
+// unbounded, so their tests don't need it.)
+const NOW = Date.parse('2026-06-20T12:00:00.000Z');
+
 // A realistic transcript: a real prompt (promptId p1), the assistant call answering
 // it (parentUuid → the prompt), a tool-result user record (type:user, fresh uuid,
 // SAME promptId p1), then a second assistant call whose parentUuid points at the
@@ -194,7 +203,7 @@ describe('reconcileHistory — backfill', () => {
 
   it('writes one llm_call per usage-bearing assistant message and a session root', async () => {
     seed(transcripts, transcript());
-    const summary = await reconcileHistory(config(dataDir), { dir: transcripts });
+    const summary = await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     expect(summary.sessions).toBe(1);
     expect(summary.llmCalls).toBe(2); // msg_1 + msg_2; synthetic + zero-usage dropped
@@ -207,7 +216,7 @@ describe('reconcileHistory — backfill', () => {
 
   it('is idempotent — re-running yields the same row count (deterministic ids + INSERT OR IGNORE)', async () => {
     seed(transcripts, transcript());
-    const opts = { dir: transcripts };
+    const opts = { dir: transcripts, now: NOW };
 
     const first = await reconcileHistory(config(dataDir), opts);
     expect(first.llmCalls).toBe(2);
@@ -220,7 +229,7 @@ describe('reconcileHistory — backfill', () => {
 
   it('run_key is the parent prompt promptId, NOT the tool-result uuid', async () => {
     seed(transcripts, transcript());
-    await reconcileHistory(config(dataDir), { dir: transcripts });
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     const r = rows(dataDir);
     // Both calls in the turn share the prompt's promptId — even msg_2, whose direct
@@ -233,7 +242,7 @@ describe('reconcileHistory — backfill', () => {
 
   it('maps token + correlation fields onto the llm_call attributes', async () => {
     seed(transcripts, transcript());
-    await reconcileHistory(config(dataDir), { dir: transcripts });
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     const a = rows(dataDir).byMessageId.get('msg_1');
     expect(a).toMatchObject({
@@ -304,7 +313,7 @@ describe('reconcileHistory — tool calls', () => {
 
   it('writes one tool_call per tool_use, parented on the session root, with run_key + metadata', async () => {
     seed(transcripts, toolTranscript());
-    const summary = await reconcileHistory(config(dataDir), { dir: transcripts });
+    const summary = await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     expect(summary.toolCalls).toBe(1);
     const { parentId, rootId, attrs } = toolCallRow(dataDir);
@@ -330,7 +339,7 @@ describe('reconcileHistory — tool calls', () => {
 
   it('is idempotent — re-running yields the same tool_call count', async () => {
     seed(transcripts, toolTranscript());
-    const opts = { dir: transcripts };
+    const opts = { dir: transcripts, now: NOW };
 
     await reconcileHistory(config(dataDir), opts);
     expect(toolCallCount(dataDir)).toBe(1);
@@ -402,7 +411,7 @@ describe('reconcileHistory — tool calls', () => {
 
   it('writes an inspection_finding for a secret in a tool target, linked to the tool_call', async () => {
     seed(transcripts, secretTranscript());
-    await reconcileHistory(config(dataDir), { dir: transcripts });
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     const findings = inspectionRows(dataDir);
     expect(findings.length).toBeGreaterThan(0);
@@ -419,7 +428,7 @@ describe('reconcileHistory — tool calls', () => {
 
   it('inspection findings are idempotent (content-addressed) across re-runs', async () => {
     seed(transcripts, secretTranscript());
-    const opts = { dir: transcripts };
+    const opts = { dir: transcripts, now: NOW };
     await reconcileHistory(config(dataDir), opts);
     const first = inspectionRows(dataDir).length;
     await reconcileHistory(config(dataDir), opts);
@@ -463,7 +472,7 @@ describe('reconcileHistory — tool calls', () => {
 
   it('masks a secret straddling the target size cap — no unmasked prefix leaks', async () => {
     seed(transcripts, straddlingSecretTranscript());
-    await reconcileHistory(config(dataDir), { dir: transcripts });
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: NOW });
 
     const target = String(toolCallRow(dataDir).attrs.target);
     // The cap held: MAX_TARGET_LEN (500) chars + the single-char '…' truncation marker.


### PR DESCRIPTION
`main` is red as of today (2026-07-20), on date alone.

## What broke

`plugins/claude-code/test/history/usage.test.ts` stamps its transcript fixtures at `2026-06-20T10:00:0x`. `reconcileHistory` windows records to:

```ts
// plugins/claude-code/src/history/transcripts.ts:531-532
const windowDays = opts.windowDays ?? 30;
return (opts.now ?? Date.now()) - windowDays * DAY_MS;
```

Fixtures dated 2026-06-20 + a 30-day default window = expiry on **2026-07-20**. Past that point the walk drops every record and `summary.sessions`/`summary.llmCalls` come back `0`, failing eight assertions across `reconcileHistory — backfill` and `reconcileHistory — tool calls`.

## Verification

- Reproduced on `origin/main` under **both Node 24 and Node 26** — not environmental, not a runtime-version issue.
- Last green CI on `main`: **2026-07-18** (`d7b02c0`). Every green check predates expiry.
- Confirmed the same 8 failures on `main`, `wave0/identity-copy`, `wave1/posture-adjust-not-now`, `wave1/calibration-robustness`, `wave1/registry-command-lines`, `wave1/secret-leak-remediation`, `wave1/remediation-production-entry` and `wave1/provenance-and-remediation-tail`.
- With this change on top of `main`: plugin suite **274/274**, workspace `lint` + `typecheck` + `test` (24/24 tasks) all green on Node 24.

## Why it lands separately

The fix already exists at the top of the wave1 stack (#51), but the breakage is at the bottom. Since `ci.yml` only triggers on `pull_request: branches: [main]`, no stacked PR has run CI — each one fires only once it retargets to `main` on merge, and would fail there until #51 landed. Extracting the fix unblocks CI for the whole stack.

Test-only; no behavior change. `reconcileSession`/`reconcileSessionTail` parse unbounded and are unaffected.