### PR TITLE
Fix setup-triage E2BIG and rewrite the setup-wizard copy

### DIFF
--- a/packages/schema/src/zod/setup-frame.ts
+++ b/packages/schema/src/zod/setup-frame.ts
@@ -5,11 +5,11 @@ import { BuiltinPolicyId } from './policy.ts';
 import { MaskedSecretFinding } from './remediation.ts';
 import { TriageCategoryRec } from './triage.ts';
 
-// The calibration counts shown at the calibrated-result frame ('Calibrated. N
-// notifications, M important. (N−M) routine, M that matter'). `important` counts
-// the surfaced findings, `routine` the suppressed ones, `total` their sum. The
-// sum equality (`total === important + routine`) is enforced by the schema's
-// refinement, so a frame whose counts do not add up fails validation.
+// The calibration counts shown at the calibrated-result frame ('I went through
+// Claude's recent work — N detections, M results worth a look.'). `important`
+// counts the surfaced findings, `routine` the suppressed ones, `total` their
+// sum. The sum equality (`total === important + routine`) is enforced by the
+// schema's refinement, so a frame whose counts do not add up fails validation.
 export const CalibrationCounts = z
   .object({
     total: z.number().int().nonnegative(),
@@ -127,12 +127,22 @@ export const CalibrationPreview = z.object({
 export type CalibrationPreview = z.infer<typeof CalibrationPreview>;
 
 // The calibration module's output: the structured frame plus the copy that
-// templates over it ('Calibrated. N notifications, M important. …').
+// templates over it ('I went through Claude's recent work — N detections, M
+// results worth a look.').
 export const CalibrationResult = z.object({
   frame: CalibrationFrame,
   copy: z.string(),
 });
 export type CalibrationResult = z.infer<typeof CalibrationResult>;
+
+// Whether the installed-summary card followed a completed calibration scan or
+// fell back to the severity floor with no scan run. `'scan'` is the same
+// signal that gates the dashboard handoff below (a surfaced/important count
+// was carried through setup); `'floor'` is the cold-start fallback with
+// nothing scanned. Drives the install heading and the post-stats divider so
+// the card never claims a scan that did not happen.
+export const FirstRunCalibration = z.enum(['scan', 'floor']);
+export type FirstRunCalibration = z.infer<typeof FirstRunCalibration>;
 
 // One option of the installed-summary frame 0.6 handoff: a stable id the prompt
 // layer routes on and the label it shows. `enter-remediation` is the live-key

--- a/packages/schema/test/zod/setup-frame.test.ts
+++ b/packages/schema/test/zod/setup-frame.test.ts
@@ -5,10 +5,11 @@ import {
   CalibrationFindingKind,
   CalibrationFrame,
   FalsePositivePatternGroup,
+  FirstRunCalibration,
   SetupHandoffOffer,
 } from '../../src/zod/setup-frame.ts';
 
-// A populated example frame: 161 total notifications, 3 important (surfaced),
+// A populated example frame: 161 total detections, 3 important (surfaced),
 // 158 routine (suppressed); the surfaced findings are at-rest live secret keys
 // (no egress-kind evidence).
 const populatedFrame = {
@@ -312,5 +313,17 @@ describe('SetupHandoffOffer', () => {
         options: [openDashboard, notNow, { id: 'not-now', label: 'Later' }],
       }).success,
     ).toBe(false);
+  });
+});
+
+describe('FirstRunCalibration', () => {
+  it('accepts scan and floor', () => {
+    expect(FirstRunCalibration.safeParse('scan').success).toBe(true);
+    expect(FirstRunCalibration.safeParse('floor').success).toBe(true);
+  });
+
+  it('rejects any other value', () => {
+    expect(FirstRunCalibration.safeParse('calibrated').success).toBe(false);
+    expect(FirstRunCalibration.safeParse('').success).toBe(false);
   });
 });

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -660,7 +660,10 @@ interface + terminal dashboard and on-demand scans."
 
 If they choose **Yes**, run the bootstrap installer (it ensures Node is available
 and installs the global CLI from the public npm registry). **Ask permission
-before running it**, then run the line for their OS:
+before running it, warmly** — e.g. "Would you like me to install the CLI? I'll
+install it via the npm package manager." — don't recite the shell mechanics or
+frame it as a scary "fetches and runs a script from GitHub" warning. Then run
+the line for their OS:
 
 ```bash
 # macOS / Linux

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -23,14 +23,13 @@ raw-free plan that subprocess prints back.
 Follow the steps below **in order**. Nothing is written to the policy store
 until step 5 (or a floor fallback in step 3 if the calibration can't complete).
 
-## 0. Show the kickoff and 'what I do' cards
+## 0. Show the intro card
 
 Run the intro script and show the user its output **exactly as printed**. It
-prints two space-aligned monospace cards — the kickoff card (name, repository,
-version, what AKA adds) and the "what I do" card — each inside its own Markdown
-code fence. Reproduce both fences verbatim and do **not** add another code fence,
-strip a fence, or reformat them (unfenced, Markdown collapses the indentation and
-mangles the `●` lines).
+prints a single space-aligned monospace card — identity and provenance, then
+what AKA does — inside a Markdown code fence. Reproduce the fence verbatim and
+do **not** add another code fence, strip the fence, or reformat it (unfenced,
+Markdown collapses the indentation and mangles the `●` lines).
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/intro.js" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json"
@@ -102,14 +101,14 @@ interactive picker. The plugin can't draw its own selectable UI (it can't
 capture keystrokes), so do **not** print a fake option list or ask the user to
 "reply with a number"; let the picker collect the answer.
 
-**Want me to look at what Claude's been up to?** — "A retroactive scan of recent activity — transcripts, temp files, agent memory — tunes the notifications we'll review next."
+**Want me to look over what Claude's been up to?** — "I'll review Claude's recent work — transcripts, temp files, agent memory — to tune what I bring to you next."
 
 Offer exactly two options:
 
-- **Yes, scan** — "calibrate my notifications to your real activity"
-- **Not now** — "start light and learn as we go"
+- **Yes, take a look** — "tune what I bring you, based on Claude's real work here"
+- **Not now** — "start light and I'll learn as we go"
 
-Choosing **Yes, scan** records the same historical-review consent the wizard has
+Choosing **Yes, take a look** records the same historical-review consent the wizard has
 always recorded — the identical scope, the one-time grant, and the
 revocable-under-Policies semantics — so the simpler question broadens nothing
 about what AKA may access. Those granular scope and revocation details stay
@@ -117,7 +116,7 @@ inspectable on request and in the dashboard.
 
 ## 2. Save the answer, then branch
 
-Branch on the answer from step 1. On the **Yes, scan** path the onboarding
+Branch on the answer from step 1. On the **Yes, take a look** path the onboarding
 writer runs, and it must run **before** the backfill (step 3), because the
 backfill script reads `historicalAccess` from the saved settings to decide
 whether it's allowed to run. Omitting `--policy` is deliberate — the old global
@@ -127,9 +126,9 @@ it.
 
 **Branch on the choice:**
 
-- **If the user chose "Yes, scan"** — record the historical-review consent and
+- **If the user chose "Yes, take a look"** — record the historical-review consent and
   continue to step 3 (which runs the scan and leads to the calibrated result in
-  step 4). "Yes, scan" maps to the existing full historical-review path — no
+  step 4). "Yes, take a look" maps to the existing full historical-review path — no
   access is granted beyond what that path already granted:
 
   ```bash
@@ -148,9 +147,10 @@ it.
   write. Do the following in order:
 
   1. **Show the start-light card.** Run the start-light script and reproduce its
-     fenced card **exactly as printed** — the `Start light — set your packs`
-     heading, the full 8-pack × 4-level default posture table, the per-pack rationale, and the
-     re-tune hint. It reads no history and writes nothing; it only prints the card
+     fenced card **exactly as printed** — the
+     `● Starting light — your detection categories` heading, the full 8-pack ×
+     4-level default posture table, the per-pack rationale, and the re-tune
+     hint. It reads no history and writes nothing; it only prints the card
      (the severity-floor default map — secret, pii, financial, phi, code_flaw, custom at
      `warn`; code_context, config at `monitor`).
 
@@ -164,12 +164,12 @@ it.
      fake option list or ask the user to "reply with a number"; let the picker
      collect the answer.
 
-     **Set your packs** — "Keep the recommended defaults, or adjust individual packs?"
+     **Set your detection categories** — "Keep the defaults I'd recommend, or adjust any of them?"
 
-     - **Keep defaults** _(recommended)_ — "the conservative default posture shown above"
-     - **Adjust packs** — "change one or more pack levels; keep the rest as recommended"
+     - **Keep defaults** _(recommended)_ — "the careful defaults shown above"
+     - **Adjust** — "change one or more levels, keep the rest as I recommend"
 
-     If they choose **Adjust packs**, use AskUserQuestion again to collect the new
+     If they choose **Adjust**, use AskUserQuestion again to collect the new
      level (monitor/warn/redact/block) for each pack they want to change, then
      merge those overrides over the severity-floor defaults to form the full 8-pack map.
 
@@ -185,17 +185,17 @@ it.
      node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --posture '<json>'
      ```
 
-     Either write prints only `✓ K categories tuned` (the `--floor` write appends
-     ` (severity floor)`) — which is the honest confirmation here, because nothing
-     was scanned or suppressed. Show that line to the user; do **not** invent a
-     dismissed count or any calibration counts.
+     Either write prints only `✓ Set all K detection categories` (the `--floor`
+     write appends ` — safe defaults`) — which is the honest confirmation here,
+     because nothing was scanned or suppressed. Show that line to the user; do
+     **not** invent a dismissed count or any calibration counts.
 
   4. **Rejoin the spine at the installed summary (step 6).** Continue to step 6
      to show the installed summary and hand off to the dashboard, using honest
      no-scan copy. No scan ran, so there is **no surfaced count** — call
      `firstrun.js` with **no `--surfaced` flag** (the same floor-fallback rule
-     step 6 already follows when no calibration frame was emitted). Steps 7–8
-     then run as written.
+     step 6 already follows when no calibration frame was emitted). Step 7
+     then runs as written.
 
 ## 3. Run the evidence triage — isolated judgment, nothing written yet
 
@@ -263,12 +263,13 @@ conservative severity floor (high-impact categories at `warn`, observe-only at
 `/aka:setup`.
 
 **Nothing to calibrate.** A scan that **completes but surfaces nothing** prints
-the honest **scan-ran-clean** card — `Calibrated. I looked at Claude's recent
-activity — nothing needs your attention…` over the recommended posture — with a
-zero-count calibration frame (its `counts.important` is `0`) and **no `Plan saved
-to:` path**. An empty or intentionally-skipped scan instead prints `No triage hits
-to review …`. In either case there's no evidence to calibrate from and no plan to
-confirm: show the card the adapter printed, take the floor branch
+the honest **scan-ran-clean** card — `I looked over Claude's recent work —
+nothing needs your attention right now. You're starting clean; here's what I'd
+recommend:` over the recommended posture — with a zero-count calibration frame
+(its `counts.important` is `0`) and **no `Plan saved to:` path**. An empty or
+intentionally-skipped scan instead prints `I didn't find anything to review —
+nothing to tune.`. In either case there's no evidence to calibrate from and no
+plan to confirm: show the card the adapter printed, take the floor branch
 (`onboard.js --floor`), tell the user the scan found nothing to calibrate from, and
 skip to step 6 (with **no `--surfaced`**, the floor-fallback rule there — nothing
 was surfaced to carry over). Do **not** continue to step 4.
@@ -280,10 +281,11 @@ Otherwise (the preview printed a `Plan saved to:` path) continue to step 4.
 The preview output is raw-free. Lead with the **calibrated-result card** it
 printed and show it in full:
 
-1. **The calibrated headline.** The `Calibrated. N notifications, M important…`
-   line — every count templated over the real scan (surfaced findings are the
-   `M important` that matter; the rest are routine noise a plain scanner would
-   have screamed about). Show it verbatim; never substitute a demo number.
+1. **The calibrated headline.** The `I went through Claude's recent work — N
+detections, M results worth a look.` line — every count templated over the
+   real scan (surfaced findings are the `M results` worth a look; the rest are
+   routine noise a plain scanner would have screamed about). Show it verbatim;
+   never substitute a demo number.
 2. **The recommended posture.** The condensed one-row-per-pack recommended view
    the card printed — the level AKA would set for each category. Show it in full.
    - **Surface the downgrades the preview flags — this is not optional.** For the
@@ -315,13 +317,13 @@ printed and show it in full:
    exception with a duration picker (the exception scope axis — `once` /
    `temporary` / `permanent`):
 
-   **Add an exception for `<pattern>` (×N)?** — "`<pattern>` looks like a test
-   fixture — add a pre-filled exception so it stops surfacing?"
+   **Make an exception for `<pattern>` (×N)?** — "This `<pattern>` looks like a
+   test fixture — want me to set an exception so it stops popping up?"
 
-   - **Once** — single use, expires automatically in 30 minutes if unused
-   - **Temporary** — expires after a set window, then re-evaluates normally
+   - **Once** — just this once — expires in 30 minutes
+   - **Temporary** — for a set window, then I'll check it again
    - **Permanent** — stays until you revoke it
-   - **Not now** — skip; nothing is written
+   - **Not now** — skip — I won't write anything
 
    **Temporary needs a concrete window.** `once` and `permanent` fully determine
    the scope on their own, but `temporary` does not — resolving it into the
@@ -350,13 +352,13 @@ printed and show it in full:
 Then use **AskUserQuestion** (the real picker, never a printed numbered list) to
 confirm:
 
-**Apply this calibration?** — "Apply this detection posture and suppress the
-false positives shown above?"
+**Want me to apply this?** — "I'll set these levels and suppress the false
+positives above."
 
 - **Yes, apply** _(recommended)_ — write the posture and suppressions exactly as
   previewed.
-- **Adjust a category** — "change one or more pack levels first; keep the rest as
-  recommended"
+- **Adjust a category** — "change one or more first; keep the rest as I
+  recommend"
 
 Do **not** proceed until the user picks one. On **Yes, apply**, continue to
 step 5 and apply the previewed plan verbatim — that is the confirm spine,
@@ -453,10 +455,11 @@ be LOWERED from a stronger existing setting` footer whenever a pick weakens
    overlay.
 
    On success, present the applying-frame confirmation the **spine** printed —
-   `✓ 8 categories tuned · ✓ N routine dismissed · Ready: …` — the store now holds
-   the adjusted posture. The overlay's own smaller `✓ N categories tuned` line
-   (the count of just the changed packs) is bookkeeping — **do not show it**; the
-   applying frame reports the full 8-pack posture. Then continue to step 6.
+   `✓ Set all 8 detection categories · set aside N routine results · Ready: …` —
+   the store now holds the adjusted posture. The overlay's own smaller
+   `✓ Set all N detection categories` line (the count of just the changed packs)
+   is bookkeeping — **do not show it**; the applying frame reports the full
+   8-pack posture. Then continue to step 6.
 
    **On "Back to recommended"** — take the **Yes, apply** path instead: continue
    to step 5 and apply the previewed plan verbatim with no override.
@@ -487,9 +490,9 @@ conservative floor cannot collide with a partially-written posture.
 node "${CLAUDE_PLUGIN_ROOT}/scripts/apply-suppressions.js" --confirmed --plan <path>
 ```
 
-The script prints the applying confirmation — `✓ K categories tuned ·
-✓ N routine dismissed · Ready: …` — with both counts threaded from the real write.
-Show that line to the user.
+The script prints the applying confirmation — `✓ Set all K detection categories
+· set aside N routine results · Ready: …` — with both counts threaded from the
+real write. Show that line to the user.
 
 If `--plan` is missing or the file is unreadable/invalid, the adapter **fails loud
 (non-zero) and writes nothing** — it never falls back to a re-judge. Treat that
@@ -539,14 +542,15 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/firstrun.js" --surfaced <count> --live-keys 
 `worthALook` count, issue an explicit **AskUserQuestion** (the real picker, never a
 printed list) using that count for `N`:
 
-**N worth a look — see them in the browser?**
+**N worth a look — want to see them in the browser?**
 
-- **Review leaked keys** — _(offer this option first only when the payload's
-  `options` include `enter-remediation`, i.e. `liveKeys > 0`)_ enter the
+- **Review leaked keys** — "let's deal with the exposed keys I found" —
+  _(offer this option first only when the payload's `options` include
+  `enter-remediation`, i.e. `liveKeys > 0`)_; entering it starts the
   secret-leak remediation chain on the surfaced live keys. This composes with —
   never replaces — the dashboard handoff below, so both stay reachable.
-- **Open dashboard** — open the local web dashboard on the surfaced findings.
-- **Not now** — stay here; they can open it anytime.
+- **Open dashboard** — "open the local dashboard on what I found"
+- **Not now** — "stay here — you can open it anytime"
 
 Use the payload's `worthALook` value for `N` verbatim — do not invent or round it.
 Offer **Review leaked keys** exactly when the payload's `options` carry the
@@ -569,7 +573,8 @@ delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>` carrying the same decis
 structured (do **not** show that block to the user). The human text has three
 parts, all of which you **show to the user verbatim, in order**:
 
-1. the templated count line ("N exposed secret keys found in old transcripts"),
+1. the templated count line ("I found N exposed secret keys sitting in old
+   transcripts."),
 2. the fenced finding table (provider, masked token, where, state), and
 3. inside that same fence, a most-exposed-first recommendation line and a
    secret-scan chaining line.
@@ -599,7 +604,7 @@ the route, issue a second **AskUserQuestion** presenting the standing-posture
 prompt, offering exactly these four options, in order (each option's label maps
 to the `--posture` level in parentheses):
 
-**Set the 'secret' posture**
+**Set the 'secret' detection level**
 
 - **Redact** (`redact`)
 - **Warn** (`warn`)
@@ -646,12 +651,12 @@ a richer, still-fully-local surface over the same `~/.aka` store this plugin
 writes. The plugin works completely on its own; this is additive (and the path to
 future multi-agent support). Use **AskUserQuestion**:
 
-**Add the AKA CLI + dashboard?** — "Install the `aka` CLI for a local web +
-terminal dashboard and on-demand scans? Everything stays on your machine."
+**Want the AKA CLI + dashboard too?** — "The `aka` CLI adds a local user
+interface + terminal dashboard and on-demand scans."
 
-- **Yes, install it** _(recommended)_ — adds the `aka` binary: `aka stats`,
-  `aka tui` (terminal dashboard), `aka dashboard` (local web UI), `aka scan`.
-- **Not now** — skip; it can be added anytime with the one-liner below.
+- **Yes, add it** _(recommended)_ — "adds the `aka` command: stats, a terminal
+  dashboard, a local user interface, and on-demand scans"
+- **Not now** — "skip — you can add it anytime with the one-liner below"
 
 If they choose **Yes**, run the bootstrap installer (it ensures Node is available
 and installs the global CLI from the public npm registry). **Ask permission
@@ -683,8 +688,7 @@ what happened, show the one-liner so they can retry later, and continue the
 wizard normally. The plugin is already fully set up and works on its own; a
 failed CLI install changes nothing about that.
 
-## 8. Report the result
-
-- The first-run summary already confirms the saved posture and points at
-  `/health`. Add at most one short sentence: detection runs locally and nothing
-  leaves the machine.
+**Close the wizard.** The first-run summary already confirmed the saved posture
+and pointed at `/health`. Whichever way the CLI offer went — installed,
+declined, or a failed install you already reported — end with one warm close:
+"That's it — I'm watching out for Claude going forward."

--- a/plugins/claude-code/src/calibration.ts
+++ b/plugins/claude-code/src/calibration.ts
@@ -2,12 +2,12 @@
  * Pure calibration count-framing for the /aka:setup wizard's calibrated-result
  * screen. frameCalibration turns the backfill + apply-suppressions preview
  * breakdown into the CalibrationFrame emitted for downstream consumers and the
- * human-facing copy 'Calibrated. N notifications, M important. (N−M) routine,
- * M that matter (KIND)' — every count follows the preview input. frameEmptyState
- * produces the honest empty-state copy over a zero-count frame for a scan that
- * found nothing or a machine with no history. Surfaced (genuine, non-suppressed)
- * findings are 'important'; suppressed findings are 'routine'; the total is their
- * sum. No IO.
+ * human-facing copy "I went through Claude's recent work — N detections, M
+ * result(s) worth a look. (KIND)" — every count follows the preview input.
+ * frameEmptyState produces the honest empty-state copy over a zero-count frame
+ * for a scan that found nothing or a machine with no history. Surfaced
+ * (genuine, non-suppressed) findings are 'important'; suppressed findings are
+ * 'routine'; the total is their sum. No IO.
  */
 import type {
   CalibrationFrame,
@@ -20,8 +20,8 @@ import type {
 
 import { renderPostureGrid, renderRecommendedPosture } from './render.ts';
 
-// Plain-English kind of a surfaced category, for the 'M that matter (…)'
-// parenthetical. Presentation-only — not a persisted contract.
+// Plain-English kind of a surfaced category, for the 'M result(s) worth a
+// look. (…)' parenthetical. Presentation-only — not a persisted contract.
 const SURFACED_KIND_LABEL: Record<DetectionCategory, string> = {
   secret: 'live keys',
   pii: 'personal data',
@@ -72,11 +72,11 @@ export function frameCalibration(
 
   const kind = surfacedCategories.map((c) => SURFACED_KIND_LABEL[c]).join(', ');
   // Omit the kind parenthetical entirely when nothing surfaced, so an
-  // all-suppressed run reads 'M that matter' rather than 'M that matter ()'.
+  // all-suppressed run reads 'worth a look.' with no dangling ' ()'.
   const parenthetical = kind ? ` (${kind})` : '';
   const headline =
-    `Calibrated. ${String(total)} notifications, ${String(important)} important. ` +
-    `${String(routine)} routine, ${String(important)} that matter${parenthetical}`;
+    `I went through Claude's recent work — ${String(total)} detection${total === 1 ? '' : 's'}, ` +
+    `${String(important)} result${important === 1 ? '' : 's'} worth a look.${parenthetical}`;
 
   // The frame carries the finding kinds (incl. the egress axis) for downstream
   // consumers; the calibrated headline is the copy. A positive observation over
@@ -93,20 +93,21 @@ export function frameCalibration(
 // persisted contract.
 export type EmptyCause = 'scan-clean' | 'no-history';
 
-// The scan-ran-clean headline: a scan looked at recent activity and found
+// The scan-ran-clean headline: a scan looked at recent work and found
 // nothing worth surfacing, so the user starts from the recommended posture.
 const SCAN_CLEAN_HEADLINE =
-  "Calibrated. I looked at Claude's recent activity — nothing needs your attention. " +
-  "You're starting clean; here's the posture I'd recommend:";
+  "I looked over Claude's recent work — nothing needs your attention right now. " +
+  "You're starting clean; here's what I'd recommend:";
 
-// The no-history headline: there is nothing on this machine to calibrate from,
-// so each pack starts at its conservative default (the start-light 0.3b table).
+// The no-history headline: there is nothing on this machine to learn from,
+// so each detection category starts at its careful default (the start-light
+// 0.3b table).
 const NO_HISTORY_HEADLINE =
-  "Nothing to calibrate from yet — Claude hasn't left activity on this machine. " +
-  'Each pack starts at a conservative default:';
+  "Nothing to learn from yet — Claude hasn't left any work on this machine. " +
+  "I'll start each detection category at a careful default:";
 
 // The empty-state framing: two distinct honest copies, one per cause, each
-// stating why it is empty — never '0 notifications' theater. A scan-clean state
+// stating why it is empty — never '0 detections' theater. A scan-clean state
 // renders the recommended posture; a no-history state renders the start-light
 // table. Both carry a valid zero-count CalibrationFrame. This is the
 // found-nothing/empty-store copy only; an unreadable store is the separate

--- a/plugins/claude-code/src/firstrun-core.ts
+++ b/plugins/claude-code/src/firstrun-core.ts
@@ -106,6 +106,10 @@ export async function runFirstRun(deps: FirstRunDeps): Promise<void> {
     `${fenced(
       renderFirstRun(
         {
+          // A surfaced count means a scan ran and carried a real preview value
+          // through setup — the same signal that gates the handoff payload
+          // below. Its absence means the floor fallback ran instead.
+          calibration: surfaced !== undefined ? 'scan' : 'floor',
           posture: postureBlock,
           health: healthScore(summary),
           // The card's "Findings N" stat is the whole-store total — correct here.

--- a/plugins/claude-code/src/intro-card.ts
+++ b/plugins/claude-code/src/intro-card.ts
@@ -1,10 +1,10 @@
 // Pure manifest → setup-intro-card wiring for the `/aka:setup` wizard's first
-// screen. The display copy (name, tagline, one-liner) comes from the identity
-// constant; the factual fields (version, repository) come from the plugin
-// manifest so the card never drifts from the installed build. No I/O here — the
-// intro.ts adapter reads the manifest file and this turns it into the card, so
-// the wiring unit-tests without touching the filesystem.
-import { NAME, ONE_LINER, TAGLINE } from './identity.ts';
+// screen. The display name comes from the identity constant; the factual fields
+// (version, repository) come from the plugin manifest so the card never drifts
+// from the installed build. No I/O here — the intro.ts adapter reads the
+// manifest file and this turns it into the card, so the wiring unit-tests
+// without touching the filesystem.
+import { NAME } from './identity.ts';
 import type { NpmRunner } from './provenance.ts';
 import { verifyProvenance } from './provenance.ts';
 import { renderSetupIntro } from './render.ts';
@@ -34,8 +34,6 @@ function repoLabel(homepage: string | undefined): string {
 export function buildIntroCard(manifest: Manifest, verified?: boolean): string {
   return renderSetupIntro({
     name: NAME,
-    tagline: TAGLINE,
-    oneLiner: ONE_LINER,
     repository: repoLabel(manifest.homepage),
     version: manifest.version ?? '',
     verified: verified === true,

--- a/plugins/claude-code/src/intro.ts
+++ b/plugins/claude-code/src/intro.ts
@@ -1,25 +1,23 @@
 /**
- * Setup-intro cards — the first two screens of the `/aka:setup` wizard: the
- * kickoff card ("here I am") and the "what I do" card ("here's how I work"),
- * shown back-to-back before the first question. Invoked by the wizard as:
+ * Setup-intro card — the first screen of the `/aka:setup` wizard: identity +
+ * provenance on the header line, then the "what I do" body, shown before the
+ * first question. Invoked by the wizard as:
  *
  *   node scripts/intro.js <path-to-.claude-plugin/plugin.json>
  *
  * The wizard passes the manifest path (it has ${CLAUDE_PLUGIN_ROOT} in the shell).
- * The kickoff card's factual fields — version, homepage — are read from that
- * manifest so it never drifts from the actually-installed plugin; the display
- * copy (name, tagline, one-liner) comes from the identity constant. The manifest
- * → card wiring lives in ./intro-card so it unit-tests without touching the
- * filesystem. The "what I do" card is static copy from ./render.
+ * The card's factual fields — version, homepage — are read from that manifest so
+ * it never drifts from the actually-installed plugin; the display name comes
+ * from the identity constant. The manifest → card wiring lives in ./intro-card
+ * so it unit-tests without touching the filesystem.
  *
- * Fail-open: an unreadable/old manifest still prints the cards with the identity
+ * Fail-open: an unreadable/old manifest still prints the card with the identity
  * copy and blank/placeholder facts — onboarding should never show a stack trace.
  */
 import { readFileSync } from 'node:fs';
 
 import { buildIntroCard, type Manifest } from './intro-card.ts';
 import { fenced } from './present.ts';
-import { renderWhatIDo } from './render.ts';
 
 const manifestPath = process.argv[2];
 
@@ -30,11 +28,11 @@ try {
   // Keep manifest empty; the card renders with identity copy + blank facts.
 }
 
-// Each card is printed as its own Markdown code fence so the wizard can echo the
-// pair verbatim (space-aligned monospace collapses without the fence). The
-// kickoff card renders the version and repository line without a verified
-// badge — it performs no provenance check or npm subprocess.
-process.stdout.write(`${fenced(buildIntroCard(manifest))}\n\n${fenced(renderWhatIDo())}\n`);
+// Printed as a Markdown code fence so the wizard can echo it verbatim
+// (space-aligned monospace collapses without the fence). Renders the version
+// and repository line without a verified badge — it performs no provenance
+// check or npm subprocess.
+process.stdout.write(`${fenced(buildIntroCard(manifest))}\n`);
 
 // Match the other adapter scripts (query.js, onboard.js) which hard-exit on
 // completion so no stray handle can keep the process alive.

--- a/plugins/claude-code/src/onboard.ts
+++ b/plugins/claude-code/src/onboard.ts
@@ -94,11 +94,7 @@ if (Object.keys(answers).length === 0 && rawPosture === undefined && !useFloor) 
 if (Object.keys(answers).length > 0) {
   try {
     const settings = applyOnboarding(answers);
-    process.stdout.write(
-      `AKA configured: policy=${settings.policy}, ` +
-        `historicalAccess=${settings.historicalAccess}. ` +
-        `Settings saved to ~/.aka/settings/settings.json.\n`,
-    );
+    process.stdout.write("Got it — I'll look over Claude's recent work to tune things.\n");
     // Caps any existing block/redact category rows to warn once when this
     // store's chosen handling is 'warn'. Failure here does not fail the
     // settings write above.
@@ -109,9 +105,8 @@ if (Object.keys(answers).length > 0) {
         const { capped } = capWarnEraEnforcementOnce(db, settings.policy, dataDir);
         if (capped > 0) {
           process.stdout.write(
-            `AKA: kept ${String(capped)} existing block/redact categories at warn ` +
-              `(the global "warn only" handling was retired). Confirm per-category ` +
-              `enforcement in this setup.\n`,
+            `I eased ${String(capped)} detection level${capped === 1 ? '' : 's'} back to ` +
+              `"warn" to match the new defaults — you can raise any of them again in this setup.\n`,
           );
         }
       } finally {
@@ -146,7 +141,7 @@ if (rawPosture !== undefined || useFloor) {
       // severity-floor fallback), never a literal.
       const categoryCount = Object.keys(posture).length;
       process.stdout.write(
-        renderCategoriesTuned(categoryCount) + (useFloor ? ' (severity floor)' : '') + '\n',
+        renderCategoriesTuned(categoryCount) + (useFloor ? ' — safe defaults' : '') + '\n',
       );
     } finally {
       db.close();

--- a/plugins/claude-code/src/onboard.ts
+++ b/plugins/claude-code/src/onboard.ts
@@ -116,7 +116,7 @@ if (Object.keys(answers).length > 0) {
       // Best-effort: see comment above.
     }
   } catch (err) {
-    fail(err instanceof Error ? err.message : 'could not write settings.json');
+    fail(err instanceof Error ? err.message : 'could not save your settings');
   }
 }
 

--- a/plugins/claude-code/src/remediation/chain.ts
+++ b/plugins/claude-code/src/remediation/chain.ts
@@ -36,7 +36,7 @@ const REMEDIATION_OPTIONS: BatchedRemediationDecision['options'] = [
 // per-row in the finding table (render.ts).
 function countCopy(secretCount: number): string {
   const noun = secretCount === 1 ? 'key' : 'keys';
-  return `${secretCount.toString()} exposed secret ${noun} found in old transcripts`;
+  return `I found ${secretCount.toString()} exposed secret ${noun} sitting in old transcripts.`;
 }
 
 // Build the batched remediation decision over the surfaced secret leaks. The

--- a/plugins/claude-code/src/remediation/entry.ts
+++ b/plugins/claude-code/src/remediation/entry.ts
@@ -71,10 +71,10 @@ function fail(message: string): never {
 // The honest note both modes print when the calibration frame could not be read
 // or parsed. `loadSecretLeakFindings` returns `undefined` on a read/parse fault
 // (distinct from `[]`, a clean read with no secrets), so neither mode fabricates
-// an all-clear ("No secret-leak findings to review.") or a false success
-// ("✓ Redacted 0 keys.") off a frame it never actually read.
+// an all-clear ("No exposed keys to deal with — you're clear.") or a false
+// success ("✓ Redacted 0 keys.") off a frame it never actually read.
 const FRAME_READ_NOTE =
-  'Could not read the calibration frame — the surfaced findings were unavailable.\n';
+  "I couldn't pull up what I found just now — the details weren't available.\n";
 
 // The batched remediation decision's chaining line "N more worth a look" count: the calibration
 // preview's whole-run surfaced count minus the secret findings this batch
@@ -104,7 +104,7 @@ function present(frameText: string): void {
   }
   const decision = presentBatchedRemediation(findings, { entrySource: 'first-run' });
   if (decision.kind !== 'decision') {
-    process.stdout.write('No secret-leak findings to review.\n');
+    process.stdout.write("No exposed keys to deal with — you're clear.\n");
     return;
   }
   const layout = renderRemediationDecision(
@@ -120,8 +120,8 @@ function present(frameText: string): void {
 // write and the 'set-secret-redact' shortcut print.
 function postureConfirmation(result: StandingPostureResult): string {
   return result.persisted
-    ? `✓ Set 'secret' posture to ${result.level}\n`
-    : "Could not persist the 'secret' posture — the local store was unavailable.\n";
+    ? `✓ From now on, I'll treat secrets like these as ${result.level}.\n`
+    : "I couldn't save that detection level just now — my records weren't reachable.\n";
 }
 
 // Persist the chosen standing 'secret' posture to the policies store, opening
@@ -245,7 +245,7 @@ async function route(
       process.stdout.write(postureConfirmation(outcome.posture));
       break;
     case 'left':
-      process.stdout.write('Left the leaked keys as-is — no redaction, no posture change.\n');
+      process.stdout.write('Left them as they are — nothing redacted, nothing changed.\n');
       break;
   }
 }

--- a/plugins/claude-code/src/remediation/posture.ts
+++ b/plugins/claude-code/src/remediation/posture.ts
@@ -28,7 +28,7 @@ import { BUILTIN_POLICIES, type BuiltinPolicyId } from '@akasecurity/schema';
 import type { CategoryPolicyWriter } from '../triage/writeback.ts';
 
 // The prompt heading the standing-posture step presents above the palette.
-const STANDING_POSTURE_PROMPT = "Set the 'secret' posture";
+const STANDING_POSTURE_PROMPT = "Set the 'secret' detection level";
 
 // The palette the standing-posture step offers, in its own display order — Redact, Warn,
 // Block, Monitor — which is deliberately distinct from the catalog's canonical

--- a/plugins/claude-code/src/remediation/render.ts
+++ b/plugins/claude-code/src/remediation/render.ts
@@ -53,7 +53,7 @@ export function renderRemediationDecision(
     STATE_LABEL[f.state],
   ]);
   const findingTable = table(['Provider', 'Token', 'Where', 'State'], rows, { rowSep: true });
-  const chainingLine = `${String(moreCount)} more worth a look — run ${scanCommand}`;
+  const chainingLine = `${String(moreCount)} more worth a look — run ${scanCommand} when you're ready.`;
   return [findingTable, '', RECOMMENDATION_LINE, '', chainingLine].join('\n');
 }
 
@@ -99,7 +99,7 @@ export function renderRedactionOutcome(input: {
 }): string {
   const totalKeys = input.findings.length;
   const isComplete = input.redactedKeys === totalKeys && input.unredactedFindings.length === 0;
-  if (isComplete) return renderRedactionConfirmation(input.redactedKeys);
+  if (isComplete) return `${renderRedactionConfirmation(input.redactedKeys)}.`;
   return renderPartialRedactionLine(input.redactedKeys, totalKeys, input.unredactedFindings);
 }
 

--- a/plugins/claude-code/src/remediation/rotation-checklist.ts
+++ b/plugins/claude-code/src/remediation/rotation-checklist.ts
@@ -130,7 +130,7 @@ export function renderChecklistMarkdown(entries: readonly RotationChecklistEntry
 }
 
 export function renderRotationChecklistResolvedLine(location: string): string {
-  return `✓ Drafted rotation-checklist.md (${location})`;
+  return `✓ I drafted a rotation checklist for you (${location}).`;
 }
 
 export function writeRotationChecklist(

--- a/plugins/claude-code/src/render.ts
+++ b/plugins/claude-code/src/render.ts
@@ -207,7 +207,7 @@ export function renderStartLight(
     '● Starting light — your detection categories',
     '',
     indent(
-      "I don't have any of Claude's past work to learn from yet, so I'll start each detection category at a careful default.",
+      "For now, each detection category starts at a careful default. Run /aka:setup whenever you like and I'll tune these from Claude's recent work.",
     ),
     '',
     renderPostureGrid(posture),
@@ -248,7 +248,7 @@ export function renderAdjustConfirm(
     return planned !== undefined && isDowngrade(planned, current[category]);
   });
   return [
-    '● Adjust — set the packs you want, keep the rest',
+    '● Adjust — set the detection categories you want, keep the rest',
     '',
     indent(table(['category', 'recommended', 'yours'], rows)),
     '',
@@ -450,7 +450,7 @@ export function renderFirstRun(s: FirstRunSummary, registry: readonly string[]):
   // alone rather than claiming a review that did not happen.
   const warmSummary =
     s.calibration === 'scan'
-      ? `I've gone over ${String(s.findings)} detections from Claude's recent work — ${String(s.worthALook ?? 0)} worth your attention.`
+      ? `Your store holds ${String(s.findings)} detections — ${String(s.worthALook ?? 0)} worth your attention.`
       : undefined;
   const stats =
     s.findings === 0

--- a/plugins/claude-code/src/render.ts
+++ b/plugins/claude-code/src/render.ts
@@ -18,12 +18,12 @@ import type {
   BuiltinPolicyId,
   DetectionException,
   DetectionListItem,
+  FirstRunCalibration,
   SetupHandoffOffer,
 } from '@akasecurity/schema';
 import { BUILTIN_ORDER, DetectionCategory, toApiAction } from '@akasecurity/schema';
 
 import { selectRegisteredCommands } from './command-registry.ts';
-import { NAME } from './identity.ts';
 import {
   bar,
   defList,
@@ -45,7 +45,7 @@ import { downgradeWarning, isDowngrade } from './triage/gate-display.ts';
 // (a store that reads fine but holds nothing) is a distinct path with its own
 // honest copy — frameEmptyState in calibration.ts — not this note.
 export const STORE_UNAVAILABLE_NOTE =
-  "I couldn't read the local store right now. AKA stays fail-open — your Claude session is unaffected, and it populates as you use Claude Code.";
+  "I couldn't check my records just now — we can check again soon. Your Claude session keeps going, and I'll fill in as you work.";
 
 const SEVERITY_WEIGHT: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
 
@@ -161,7 +161,7 @@ export function renderPostureGrid(
     category,
     ...BUILTIN_ORDER.map((level) => (posture[category] === level ? GRID_MARK : '')),
   ]);
-  return indent(table(['Pack', ...BUILTIN_ORDER], rows));
+  return indent(table(['Category', ...BUILTIN_ORDER], rows));
 }
 
 // The re-tune hint that closes the start-light card and the applied frame,
@@ -176,7 +176,7 @@ export const RE_TUNE_HINT = 'Re-tune anytime with /aka:setup or the dashboard';
 // the user's call; the monitor packs (code_context, config) watch quietly to keep
 // the noise down. Presentation copy only — not a persisted contract.
 const PACK_RATIONALE: Record<DetectionCategory, string> = {
-  secret: 'live credentials are the costliest thing to leak, so I bring them to you on sight.',
+  secret: 'keys and credentials are the costliest thing to lose, so I bring those straight to you.',
   pii: 'personal data carries real obligations, so I surface it before it moves.',
   financial: 'card and account numbers are sensitive by default, so these come to you.',
   phi: 'health information is regulated wherever it lands, so I flag it for your call.',
@@ -184,8 +184,7 @@ const PACK_RATIONALE: Record<DetectionCategory, string> = {
     'proprietary code context is common and mostly benign, so I watch quietly and keep the record.',
   code_flaw: 'an insecure pattern is worth a look before it ships, so I raise it.',
   custom: 'your own policy matches start surfaced so nothing you care about slips by unseen.',
-  config:
-    'configuration values are noisy to flag, so I keep an eye on them without a notification.',
+  config: 'config values are noisy, so I keep an eye on them without notifying you.',
 };
 
 // The start-light card — frame 0.3b of the /aka:setup Not-now branch, shown when
@@ -205,9 +204,11 @@ export function renderStartLight(
     (pack) => `  ${pack} — ${posture[pack] ?? ''}: ${PACK_RATIONALE[pack]}`,
   );
   return [
-    '● Start light — set your packs',
+    '● Starting light — your detection categories',
     '',
-    indent('No history to calibrate from yet, so each pack starts at a conservative default.'),
+    indent(
+      "I don't have any of Claude's past work to learn from yet, so I'll start each detection category at a careful default.",
+    ),
     '',
     renderPostureGrid(posture),
     '',
@@ -268,79 +269,70 @@ export function renderAdjustConfirm(
 // invoke.
 export const READY_COMMANDS = ['/aka:health', '/aka:findings', '/aka:recommend'] as const;
 
-// The "tuned" segment — the count of posture categories the writer
-// wrote, threaded from the real write (never a literal). Single-sourced here so
+// The "set" segment — the count of detection categories the writer wrote,
+// threaded from the real write (never a literal). Single-sourced here so
 // onboard.ts's posture-write confirmation and the composed applying-confirmation
 // line read identically.
 export function renderCategoriesTuned(categoriesTuned: number): string {
-  const noun = categoriesTuned === 1 ? 'category' : 'categories';
-  return `✓ ${String(categoriesTuned)} ${noun} tuned`;
+  return `✓ Set all ${String(categoriesTuned)} detection categories`;
 }
 
 // The /aka:setup wizard's applying confirmation, shown once the
-// calibration takes effect: '✓ K categories tuned · ✓ N routine dismissed ·
-// Ready: …'. Both counts are threaded from the real apply result (the posture
-// writer's category count and the apply-suppressions result's written count),
-// never a literal. When nothing routine was dismissed (N === 0) the middle
-// segment is honest empty-state copy rather than a fabricated '✓ 0 routine
-// dismissed'. `registry` is the installed command registry (readRegisteredCommands()),
-// resolved at the caller's I/O boundary and threaded in so this stays a pure
-// formatter: the Ready line's curated set is validated against it, and an
-// unregistered curated command throws rather than rendering. Pure (no I/O) so it
-// unit-tests without a DB.
+// calibration takes effect: '✓ Set all K detection categories · set aside N
+// routine results · Ready: …'. Both counts are threaded from the real apply
+// result (the posture writer's category count and the apply-suppressions
+// result's written count), never a literal. When nothing routine was set aside
+// (N === 0) the middle segment is honest empty-state copy rather than a
+// fabricated 'set aside 0 routine results'. `registry` is the installed command
+// registry (readRegisteredCommands()), resolved at the caller's I/O boundary and
+// threaded in so this stays a pure formatter: the Ready line's curated set is
+// validated against it, and an unregistered curated command throws rather than
+// rendering. Pure (no I/O) so it unit-tests without a DB.
 export function renderApplied(
   categoriesTuned: number,
   dismissed: number,
   registry: readonly string[],
 ): string {
   const routine =
-    dismissed > 0 ? `✓ ${String(dismissed)} routine dismissed` : 'no routine to dismiss';
+    dismissed > 0
+      ? `set aside ${String(dismissed)} routine result${dismissed === 1 ? '' : 's'}`
+      : 'nothing routine to set aside';
   const ready = `Ready: ${selectRegisteredCommands(READY_COMMANDS, registry).join(' · ')}`;
   return `${renderCategoriesTuned(categoriesTuned)} · ${routine} · ${ready}`;
 }
 
 const RULE_WIDTH = 64;
 
-// The setup-intro "card" the /aka:setup wizard shows first.
-// Factual fields (version, repository) are read from the plugin manifest by the
-// intro script; the display copy (name, tagline, one-liner) comes from the
-// identity constant. Pure here so it renders without any I/O.
+// The single setup-intro card the /aka:setup wizard shows first: identity +
+// provenance on the header line, then the "what I do" body. Factual fields
+// (version, repository, verified) are read from the plugin manifest by the intro
+// script; the display name comes from the identity constant. Pure here so it
+// renders without any I/O.
 export interface PluginMeta {
   name: string;
-  tagline: string;
-  oneLiner: string;
   repository: string;
   version: string;
   verified?: boolean;
 }
 
 export function renderSetupIntro(meta: PluginMeta): string {
-  const heading = `● Found ${meta.name} — ${meta.tagline}`;
-
   // The ' · verified' badge appears only when the provenance check confirmed the
   // exact package@version's attestation binds to the expected repository + workflow.
   const provenance =
     meta.verified === true
       ? `v${meta.version} · ${meta.repository} · verified`
       : `v${meta.version} · ${meta.repository}`;
+  const heading = `● ${meta.name}  ·  ${provenance}`;
 
-  return [heading, '', indent(meta.oneLiner), '', indent(provenance)].join('\n');
-}
-
-// The "What I do" card the /aka:setup wizard shows after the intro. Static
-// explanatory copy — no data to template, so it takes no arguments. Pure here so
-// it renders without any I/O and unit-tests as a plain string. The closing line
-// hands off to the scan offer that calibrates the notifications.
-export function renderWhatIDo(): string {
   return [
-    '● I watch out for Claude as it works.',
+    heading,
+    '',
+    indent("I'm a security harness for Claude."),
     '',
     indent(
-      'As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.',
+      'While it codes, I keep the sensitive information — secrets, keys, regulated data — safely on your machine.',
     ),
     indent("Most of it I handle quietly; I only notify you when it's worth your call."),
-    '',
-    indent("let's calibrate your notifications based on what Claude's been up to"),
   ].join('\n');
 }
 
@@ -360,6 +352,11 @@ export function healthScore(summary: HealthSummary): number {
 // recommendations are real; `health` is the derived score above. The host's
 // input box and window chrome are not the plugin's to draw.
 export interface FirstRunSummary {
+  // Whether the card followed a completed calibration scan or fell back to the
+  // severity floor with no scan run — the same signal that gates the dashboard
+  // handoff (`worthALook`) below. Drives the heading and the post-stats
+  // divider so the card never claims a scan that did not happen.
+  calibration: FirstRunCalibration;
   // Per-category posture block (renderPosture's output) — the wizard's
   // per-category policy read, one row per category. Optional/omittable: the
   // read lives inside firstrun's fail-open try/catch, so a store that can't
@@ -432,17 +429,33 @@ export function buildHandoffOffer(worthALook: number, liveKeys: number): SetupHa
 // formatter: the Try line's curated set is validated against it here, and an
 // unregistered curated command throws rather than rendering.
 export function renderFirstRun(s: FirstRunSummary, registry: readonly string[]): string {
-  const heading = `✓ ${NAME} installed — calibrated to this machine`;
+  // Path-honest heading: the scan-path copy claims a scan only when one ran.
+  // The floor path is reached for three different causes — a deliberate
+  // "Not now" decline, a scan that ran clean, or a genuine no-history/failed
+  // scan — and this function can't tell them apart, so the floor copy stays
+  // cause-neutral rather than naming a failure that may not have happened.
+  const heading =
+    s.calibration === 'scan'
+      ? "✓ You're all set — tuned to this machine."
+      : "✓ You're all set — I've started you on safe defaults. Rerun /aka:setup anytime to calibrate from Claude's activity.";
 
   // Nothing-surfaced degradation: with no findings in the store the numeric
-  // Health/Findings/Recommendations triple would read as a scan tally over an
+  // Health/detections/recommendations triple would read as a scan tally over an
   // empty result. The stats line becomes an honest empty-state instead — an
   // explicit zero-state, never a fabricated count. (The dashboard handoff is
   // withheld on the same nothing-surfaced footing below.)
+  const statRow = `Health ${String(s.health)}/100 · ${String(s.findings)} detections · ${String(s.recommendations)} recommendations`;
+  // A warm one-line summary rides above the stat row, but only on the scan
+  // path: the floor path never scanned anything, so it renders the stat row
+  // alone rather than claiming a review that did not happen.
+  const warmSummary =
+    s.calibration === 'scan'
+      ? `I've gone over ${String(s.findings)} detections from Claude's recent work — ${String(s.worthALook ?? 0)} worth your attention.`
+      : undefined;
   const stats =
     s.findings === 0
       ? "Nothing needs your attention — you're starting clean."
-      : `Health ${String(s.health)}/100 · Findings ${String(s.findings)} · Recommendations ${String(s.recommendations)}`;
+      : [warmSummary, statRow].filter((line): line is string => line !== undefined).join('\n');
 
   const tryCommands = selectRegisteredCommands(TRY_COMMANDS, registry);
   const lines = [heading, '', indent(stats), '', indent(`Try: ${tryCommands.join(' · ')}`)];
@@ -454,7 +467,10 @@ export function renderFirstRun(s: FirstRunSummary, registry: readonly string[]):
     lines.push('', indent('Posture'), '', indent(s.posture));
   }
 
-  lines.push('', indent('─'.repeat(RULE_WIDTH)), '', indent('First scan complete'));
+  // The divider mirrors the heading's scan-vs-floor honesty: no scan ran on
+  // the floor path, so it never claims one completed.
+  const divider = s.calibration === 'scan' ? 'First scan complete' : 'Safe defaults in place';
+  lines.push('', indent('─'.repeat(RULE_WIDTH)), '', indent(divider));
 
   // Top findings — a compact, severity-ranked glance at what the first scan
   // caught. Hidden on a clean scan so the card stays a tidy success state.
@@ -487,7 +503,7 @@ export function renderFirstRun(s: FirstRunSummary, registry: readonly string[]):
   if (s.worthALook !== undefined && s.worthALook > 0) {
     lines.push(
       '',
-      indent(`${String(s.worthALook)} worth a look — see them in the browser?`),
+      indent(`${String(s.worthALook)} worth a look — want to see them in the browser?`),
       indent('Open dashboard · Not now'),
     );
   }

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -28,8 +28,10 @@ import { frameCalibration, frameEmptyState } from '../calibration.ts';
 import { readRegisteredCommands } from '../command-registry.ts';
 import { renderApplied, renderRecommendedPosture, STORE_UNAVAILABLE_NOTE } from '../render.ts';
 import { frameJsonBlock } from '../setup-frame-json.ts';
+import { dedupeForJudge } from './dedupe.ts';
 import { deriveFalsePositivePatterns } from './false-positive-patterns.ts';
 import { renderPosturePlan, renderShowcase, renderSuppressionGate } from './gate-display.ts';
+import { chunkForJudge, mergeRecommendations } from './merge.ts';
 import { deletePlanFile, readPlanFile, writePlanFile } from './plan-file.ts';
 import { deriveSurfacedSecretFindings } from './surfaced-secrets.ts';
 import {
@@ -116,7 +118,7 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       deps.stdout(frameJsonBlock(empty.frame));
       return 0;
     }
-    deps.stdout(`No triage hits to review (${status}). Nothing to suppress.\n`);
+    deps.stdout("I didn't find anything to review — nothing to tune.\n");
     return 0;
   }
 
@@ -131,8 +133,25 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
   // checkpoint (plan-file backstop, reasoning/notes checks), not a weaker one.
   const rawValues = hits.map((h) => h.rawMatch);
   try {
-    const rec = deps.runJudge(hits);
-    const plan = planTriageWriteback(hits, rec);
+    // Collapse repeated occurrences of the same detected value to one
+    // representative BEFORE the judge — value-scoped suppression means one
+    // representative's verdict covers every occurrence, so the judge (and every
+    // downstream derivation below) reasons over distinct values, not raw counts.
+    const reps = dedupeForJudge(hits);
+    const chunks = chunkForJudge(reps);
+    let rec: TriageRecommendation;
+    if (chunks.length === 1) {
+      const [soleChunk] = chunks;
+      // chunkForJudge always returns at least one chunk for a non-empty input
+      // (reps is non-empty: runPreview already returned on hits.length === 0).
+      if (soleChunk === undefined) throw new Error('chunkForJudge returned no chunks');
+      rec = deps.runJudge(soleChunk);
+    } else {
+      rec = mergeRecommendations(chunks.map((c) => deps.runJudge(c)));
+    }
+    // Fed the SAME representative set the judge saw, so the join/fpIds the plan
+    // resolves suppressions from line up with the ids the verdict references.
+    const plan = planTriageWriteback(reps, rec);
 
     // Read the store's current per-category action for the downgrade view.
     // Read-only; retained in the plan file so confirm needn't re-read the DB.
@@ -197,12 +216,12 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // secret hits the model did NOT dismiss as false positives, projected to the
     // raw-free MaskedSecretFinding shape and carried additively in the frame.
     // Empty for a clean/all-suppressed run, so the optional field is omitted.
-    const maskedFindings = deriveSurfacedSecretFindings(hits, rec, plan);
+    const maskedFindings = deriveSurfacedSecretFindings(reps, rec, plan);
     // The masked false-positive pattern groups the fixture/exception offer names
     // its pattern and count from: the marked hits, re-derived to their masked
     // token and grouped, carried additively in the frame. Empty when nothing was
     // marked a false positive, so the optional field is omitted (fail-open).
-    const falsePositivePatterns = deriveFalsePositivePatterns(hits, rec, plan);
+    const falsePositivePatterns = deriveFalsePositivePatterns(reps, rec, plan);
     const calibration = frameCalibration(preview, maskedFindings, falsePositivePatterns);
 
     // The calibrated-result card: the real-count headline over the
@@ -284,7 +303,7 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
   // preview captured in `plan.current`. If the store changed since (a CLI edit, a
   // web-ui save, another wizard run), applying the plan blindly could turn an
   // approved non-downgrade into a SILENT downgrade — the exact case the preview's
-  // renderPosturePlan WARNING exists to surface. Re-read each planned category and
+  // renderPosturePlan surfaces via its "Heads up" downgrade note. Re-read each planned category and
   // compare; on drift, fail loud with no write so the wizard routes to the floor
   // fallback and the user re-previews against the store they can actually see.
   // undefined (no row) compares equal on both sides, so an added/removed row
@@ -325,7 +344,7 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
       // mid-batch fault rolls the posture overwrite back too — the store is never
       // left half-applied (and the floor fallback below is safe: nothing persisted).
       // Establish the full 8-pack the preview showed so settings holds
-      // all 8 packs and the confirmation reads '8 categories tuned': the reviewed,
+      // all 8 packs and the confirmation reads 'Set all 8 detection categories': the reviewed,
       // drift-gated evidence packs (plan.posture) OVERWRITE, and the severity floor
       // fills the remaining packs with FILL-GAPS. The floor packs are not covered by
       // the drift gate above (only the reviewed evidence is), so they must never

--- a/plugins/claude-code/src/triage/dedupe.ts
+++ b/plugins/claude-code/src/triage/dedupe.ts
@@ -1,0 +1,17 @@
+import type { TriageHit } from '@akasecurity/schema';
+
+export function dedupeForJudge(hits: readonly TriageHit[]): TriageHit[] {
+  const seen = new Set<string>();
+  const out: TriageHit[] = [];
+  for (const h of hits) {
+    if (h.valueFingerprint === undefined) {
+      out.push(h);
+      continue;
+    }
+    const key = `${h.ruleId}█${h.valueFingerprint}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(h);
+  }
+  return out;
+}

--- a/plugins/claude-code/src/triage/gate-display.ts
+++ b/plugins/claude-code/src/triage/gate-display.ts
@@ -36,7 +36,7 @@ function findContext(entry: SuppressionEntry, join: readonly JoinEntry[]): strin
 // Enforcement strength, least -> most restrictive, over the stored ActionTaken
 // palette. `allow` (an active exception override) sits below `log`/monitor. A
 // DOWNGRADE is a planned action that ranks strictly below the category's stored
-// one — the case I-1 requires the human to see and confirm before it is written.
+// one — a downgrade the human must see and confirm before it is written.
 const ACTION_RANK: Record<ActionTaken, number> = {
   allow: 0,
   log: 1,
@@ -70,7 +70,7 @@ export function isDowngrade(planned: BuiltinPolicyId, current: ActionTaken | und
 // a stronger existing setting — an enforcement downgrade must never happen silently.
 // `current` is the store's existing action per category (undefined = no row yet).
 // This iterates the resolved plan's posture, so a category that had its suppression
-// skipped but still has a posture change (M-1) is surfaced here too.
+// skipped but still has a posture change is surfaced here too.
 export function renderPosturePlan(
   posture: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
   current: Partial<Record<DetectionCategory, ActionTaken>>,

--- a/plugins/claude-code/src/triage/gate-display.ts
+++ b/plugins/claude-code/src/triage/gate-display.ts
@@ -98,15 +98,15 @@ export function renderPosturePlan(
   if (lines.length === 0) {
     return 'No per-category detection posture will be written.';
   }
-  return `Per-category detection posture to be applied:\n${lines.join('\n')}${downgradeWarning(downgrades)}`;
+  return `Here's the detection level I'd set for each type:\n${lines.join('\n')}${downgradeWarning(downgrades)}`;
 }
 
-// The downgrade WARNING footer, single-sourced so every gate that can weaken
+// The downgrade footer, single-sourced so every gate that can weaken
 // enforcement (the confirm preview and the adjust fork's confirm card) states it
 // identically. Empty string when nothing would be lowered.
 export function downgradeWarning(downgrades: readonly DetectionCategory[]): string {
   if (downgrades.length === 0) return '';
-  return `\n\nWARNING: ${String(downgrades.length)} categor${downgrades.length === 1 ? 'y' : 'ies'} (${downgrades.join(', ')}) would be LOWERED from a stronger existing setting. Confirm you intend to weaken enforcement there before applying.`;
+  return `\n\nHeads up — this would lower ${String(downgrades.length)} detection level${downgrades.length === 1 ? '' : 's'} (${downgrades.join(', ')}) below what you've already set. Confirm you mean to lower ${downgrades.length === 1 ? 'it' : 'them'} before I apply.`;
 }
 
 // The intelligence showcase. One compact block per
@@ -129,7 +129,7 @@ export function renderShowcase(showcase: readonly ShowcaseCategory[]): string {
       `   ${s.reasoning}`,
     ].join('\n');
   });
-  return `What the judgment found, per category:\n\n${blocks.join('\n\n')}`;
+  return `Here's what I found, by type:\n\n${blocks.join('\n\n')}`;
 }
 
 export function renderSuppressionGate(
@@ -142,8 +142,8 @@ export function renderSuppressionGate(
 
   const header =
     entries.length === 1
-      ? 'The following detection will be suppressed as a false positive:'
-      : `The following ${String(entries.length)} detections will be suppressed as false positives:`;
+      ? 'This looks like a false positive — take a look before I suppress it:'
+      : `These ${String(entries.length)} look like false positives — take a look before I suppress them:`;
 
   const blocks = entries.map((entry, i) => {
     const context = findContext(entry, join);

--- a/plugins/claude-code/src/triage/judge.ts
+++ b/plugins/claude-code/src/triage/judge.ts
@@ -7,9 +7,15 @@
  * scannable transcript store (~/.claude/projects), the judgment runs as a
  * SEPARATE, transient `claude -p` subprocess that writes NO transcript:
  *
- *   claude -p --no-session-persistence --output-format json <prompt>
+ *   claude -p --no-session-persistence --output-format json   (prompt on stdin)
  *   env: CLAUDE_CODE_SKIP_PROMPT_HISTORY=1   (no transcript, any OS; keeps auth)
  *        CLAUDE_CONFIG_DIR=<fresh mkdtemp>   (darwin only, belt-and-suspenders)
+ *
+ * The prompt (rubric + raw hits) rides on the child's stdin, not argv: argv is
+ * capped by the OS's ARG_MAX (~1MB on most platforms), and a large hit set
+ * pushed the prompt past it, failing the spawn with E2BIG. stdin has no such
+ * ceiling, and keeps the raw hits off the process list and out of any
+ * argv-echoing error message as a bonus.
  *
  * HOME is deliberately NOT isolated as the primary guard — that would break
  * auth on Linux (credentials live under $HOME there). The env pair above is
@@ -85,22 +91,31 @@ export function judgeEnv(): NodeJS.ProcessEnv {
 }
 
 // Real subprocess spawn used in production wiring. Kept separate from runJudge
-// so unit tests inject a fake and NEVER hit a live model. Returns raw stdout
+// so unit tests inject a fake and NEVER hit a live model. The prompt (which
+// carries the raw hits) rides on stdin rather than argv — argv has an OS
+// ceiling (ARG_MAX, ~1MB on most platforms) that a large hit set can exceed,
+// failing the spawn with E2BIG; stdin has no such limit. Returns raw stdout
 // (the JSON envelope) for parseVerdict.
-export function spawnClaude(argv: readonly string[], env: NodeJS.ProcessEnv): string {
+export function spawnClaude(
+  argv: readonly string[],
+  env: NodeJS.ProcessEnv,
+  stdin: string,
+): string {
   return execFileSync('claude', [...argv], {
     env,
+    input: stdin,
     encoding: 'utf8',
     timeout: 180_000,
     maxBuffer: 32 * 1024 * 1024,
   });
 }
 
-// Raw-free description of a spawn failure. An execFileSync error's `.message`
-// echoes the FULL argv — which carries the raw hits in the prompt — plus the
-// captured stdout/stderr; none of it may cross back to the parent command. We
-// surface ONLY the non-content metadata (exit status / signal / node error
-// code), never `.message`, `.stdout`, or `.stderr`.
+// Raw-free description of a spawn failure. The prompt now rides on stdin, not
+// argv, so an execFileSync error's `.message` (which echoes argv) can no
+// longer carry the raw hits — but its captured stdout/stderr still might, and
+// none of it may cross back to the parent command. This stays belt-and-
+// suspenders: we surface ONLY the non-content metadata (exit status / signal /
+// node error code), never `.message`, `.stdout`, or `.stderr`.
 function spawnFailureMeta(err: unknown): string {
   const e = err as { status?: number | null; signal?: string | null; code?: string };
   const parts: string[] = [];
@@ -115,10 +130,11 @@ function spawnFailureMeta(err: unknown): string {
 // -------------------------------------------------------------------------
 
 export interface JudgeDeps {
-  // Injected spawn seam: receives the argv AFTER `claude` and the subprocess
-  // env, returns process stdout (the --output-format json envelope). Tests
-  // inject a fake returning a canned envelope so no real `claude -p` runs.
-  spawn: (argv: readonly string[], env: NodeJS.ProcessEnv) => string;
+  // Injected spawn seam: receives the argv AFTER `claude`, the subprocess env,
+  // and the prompt (fed on stdin, not argv — see spawnClaude), and returns
+  // process stdout (the --output-format json envelope). Tests inject a fake
+  // returning a canned envelope so no real `claude -p` runs.
+  spawn: (argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string) => string;
   // Override the rubric source (defaults to eval/prompt.md); injectable so
   // tests need not read the real file.
   loadRubric?: () => string;
@@ -126,28 +142,31 @@ export interface JudgeDeps {
 
 // Build the judge prompt (rubric + raw hits as JSONL) and run it through the
 // ephemeral subprocess, returning the parsed verdict. The RAW hits ride in the
-// prompt on purpose (the rubric needs them); judgeEnv()'s env is what keeps
-// them out of any transcript. Always cleans up the darwin config dir.
+// prompt on purpose (the rubric needs them); the prompt rides on stdin (not
+// argv) so a large hit set never trips the OS's ARG_MAX and so raw can't leak
+// via a spawn error's argv-echoing `.message`. judgeEnv()'s env is what keeps
+// the prompt out of any transcript. Always cleans up the darwin config dir.
 export function runJudge(hits: readonly TriageHit[], deps: JudgeDeps): TriageRecommendation {
   const rubric = deps.loadRubric?.() ?? readFileSync(DEFAULT_RUBRIC_PATH, 'utf8');
   const hitsJsonl = hits.map((h) => JSON.stringify(h)).join('\n');
   const fullPrompt = `${rubric}\n\n## Hits\n\n\`\`\`\n${hitsJsonl}\n\`\`\`\n`;
 
-  const argv = ['-p', '--no-session-persistence', '--output-format', 'json', fullPrompt] as const;
+  const argv = ['-p', '--no-session-persistence', '--output-format', 'json'] as const;
   const env = judgeEnv();
   try {
     // The spawn is isolated from the parse: a spawn failure (execFileSync) throws
-    // an error whose `.message` embeds the full argv — i.e. the raw hits in the
-    // prompt — plus captured stdout/stderr. Re-throw it as raw-free metadata so
-    // nothing raw can ride the error out to the parent command's stderr.
+    // an error whose captured stdout/stderr may still carry raw content even
+    // though the prompt itself no longer rides argv. Re-throw it as raw-free
+    // metadata so nothing raw can ride the error out to the parent command's
+    // stderr — belt-and-suspenders now that stdin is the only raw-bearing seam.
     let stdout: string;
     try {
-      stdout = deps.spawn(argv, env);
+      stdout = deps.spawn(argv, env, fullPrompt);
     } catch (err) {
-      // Deliberately NOT chaining `err` as `cause`: the execFileSync error carries
-      // the raw prompt in .message/.stdout/.stderr, and attaching it would re-expose
+      // Deliberately NOT chaining `err` as `cause`: the execFileSync error's captured
+      // stdout/stderr may still carry raw content, and attaching it would re-expose
       // exactly what this throw exists to strip. Only raw-free metadata is surfaced.
-      // eslint-disable-next-line preserve-caught-error -- caught error carries raw; see above
+      // eslint-disable-next-line preserve-caught-error -- caught error may carry raw; see above
       throw new Error(`claude -p judge subprocess failed (${spawnFailureMeta(err)})`);
     }
     return parseVerdict(stdout);

--- a/plugins/claude-code/src/triage/merge.ts
+++ b/plugins/claude-code/src/triage/merge.ts
@@ -1,0 +1,58 @@
+import type {
+  BuiltinPolicyId,
+  TriageCategoryRec,
+  TriageHit,
+  TriageRecommendation,
+} from '@akasecurity/schema';
+
+const RANK: Record<BuiltinPolicyId, number> = { monitor: 0, warn: 1, redact: 2, block: 3 };
+
+export function chunkForJudge(hits: readonly TriageHit[], maxBytes = 262_144): TriageHit[][] {
+  const chunks: TriageHit[][] = [];
+  let current: TriageHit[] = [];
+  let size = 0;
+  for (const h of hits) {
+    const b = Buffer.byteLength(JSON.stringify(h)) + 1;
+    if (size + b > maxBytes && current.length > 0) {
+      chunks.push(current);
+      current = [];
+      size = 0;
+    }
+    current.push(h);
+    size += b;
+  }
+  chunks.push(current);
+  return chunks;
+}
+
+export function mergeRecommendations(recs: readonly TriageRecommendation[]): TriageRecommendation {
+  if (recs.length === 1) {
+    const [sole] = recs;
+    if (sole === undefined) throw new Error('mergeRecommendations: empty recommendation');
+    return sole;
+  }
+  const byCat = new Map<string, TriageCategoryRec>();
+  for (const rec of recs) {
+    for (const c of rec.perCategory) {
+      const prev = byCat.get(c.category);
+      if (!prev) {
+        byCat.set(c.category, { ...c, fpIds: [...c.fpIds] });
+        continue;
+      }
+      prev.genuineCount += c.genuineCount;
+      prev.fpCount += c.fpCount;
+      prev.fpIds = [...new Set([...prev.fpIds, ...c.fpIds])];
+      if (RANK[c.action] > RANK[prev.action]) {
+        prev.action = c.action;
+        prev.reasoning = c.reasoning;
+      }
+    }
+  }
+  return {
+    perCategory: [...byCat.values()],
+    notes: recs
+      .map((r) => r.notes)
+      .filter(Boolean)
+      .join('\n'),
+  };
+}

--- a/plugins/claude-code/src/triage/writeback.ts
+++ b/plugins/claude-code/src/triage/writeback.ts
@@ -265,8 +265,8 @@ export function planTriageWriteback(
 // The full recommended posture the preview shows: the cold-start severity floor
 // for all 8 packs, overlaid with the evidence-derived actions the judge assigned.
 // Single-sourced so the previewed posture matches the 8-pack the confirm write
-// establishes — the 'N categories tuned' count is the size of this map
-// (8), not the survivor subset the evidence produced. The confirm write does NOT
+// establishes — the 'Set all N detection categories' count is the size of this
+// map (8), not the survivor subset the evidence produced. The confirm write does NOT
 // blanket-overwrite this map: the reviewed evidence packs overwrite, the floor
 // packs only fill gaps (see performTriageWriteback), so a pack the user already
 // hardened is never silently downgraded to the weak floor.

--- a/plugins/claude-code/test/calibration.test.ts
+++ b/plugins/claude-code/test/calibration.test.ts
@@ -34,7 +34,7 @@ const preview: CalibrationPreview = {
 };
 
 describe('frameCalibration', () => {
-  it('reports 161 notifications, 3 important, 158 routine from the preview', () => {
+  it('reports 161 detections, 3 important, 158 routine from the preview', () => {
     const { frame } = frameCalibration(preview);
     expect(frame.counts).toEqual({ total: 161, important: 3, routine: 158 });
   });
@@ -78,10 +78,21 @@ describe('frameCalibration', () => {
     expect(frame.findingKinds.every((k) => typeof k.egress === 'boolean')).toBe(true);
   });
 
-  it("templates the 'Calibrated.' copy exactly over the preview values", () => {
+  it('templates the headline copy exactly over the preview values', () => {
     const { copy } = frameCalibration(preview);
     expect(copy).toBe(
-      'Calibrated. 161 notifications, 3 important. 158 routine, 3 that matter (live keys)',
+      "I went through Claude's recent work — 161 detections, 3 results worth a look. (live keys)",
+    );
+  });
+
+  it('uses the singular "detection"/"result" (no trailing s) when the total and important count are each exactly one', () => {
+    const singleImportant: CalibrationPreview = {
+      categories: [{ category: 'secret', genuineCount: 1, fpCount: 0, egress: false }],
+      posture: preview.posture,
+    };
+    const { copy } = frameCalibration(singleImportant);
+    expect(copy).toBe(
+      "I went through Claude's recent work — 1 detection, 1 result worth a look. (live keys)",
     );
   });
 
@@ -96,7 +107,7 @@ describe('frameCalibration', () => {
     const { frame, copy } = frameCalibration(other);
     expect(frame.counts).toEqual({ total: 10, important: 2, routine: 8 });
     expect(copy).toBe(
-      'Calibrated. 10 notifications, 2 important. 8 routine, 2 that matter (live keys)',
+      "I went through Claude's recent work — 10 detections, 2 results worth a look. (live keys)",
     );
     expect(copy).not.toContain('161');
   });
@@ -112,13 +123,15 @@ describe('frameCalibration', () => {
     const { frame, copy } = frameCalibration(allSuppressed);
     expect(frame.surfacedCategories).toEqual([]);
     expect(frame.counts).toEqual({ total: 10, important: 0, routine: 10 });
-    expect(copy).toBe('Calibrated. 10 notifications, 0 important. 10 routine, 0 that matter');
+    expect(copy).toBe(
+      "I went through Claude's recent work — 10 detections, 0 results worth a look.",
+    );
     // No dangling empty parenthetical.
     expect(copy).not.toContain('()');
-    expect(copy).not.toContain('matter (');
+    expect(copy).not.toContain('look. (');
   });
 
-  it("derives the 'that matter (…)' kind from the surfaced categories, not a fixed label", () => {
+  it("derives the 'worth a look (…)' kind from the surfaced categories, not a fixed label", () => {
     const piiSurfaced: CalibrationPreview = {
       categories: [
         { category: 'pii', genuineCount: 4, fpCount: 0, egress: false },
@@ -128,7 +141,7 @@ describe('frameCalibration', () => {
     };
     const { copy } = frameCalibration(piiSurfaced);
     expect(copy).toBe(
-      'Calibrated. 24 notifications, 4 important. 20 routine, 4 that matter (personal data)',
+      "I went through Claude's recent work — 24 detections, 4 results worth a look. (personal data)",
     );
     expect(copy).not.toContain('live keys');
   });
@@ -253,9 +266,9 @@ describe('frameEmptyState', () => {
   // The exact per-cause headlines, spelled out here (not sourced from the module)
   // so the test pins the shipped copy rather than mirroring the implementation.
   const SCAN_CLEAN_HEADLINE =
-    "Calibrated. I looked at Claude's recent activity — nothing needs your attention. You're starting clean; here's the posture I'd recommend:";
+    "I looked over Claude's recent work — nothing needs your attention right now. You're starting clean; here's what I'd recommend:";
   const NO_HISTORY_HEADLINE =
-    "Nothing to calibrate from yet — Claude hasn't left activity on this machine. Each pack starts at a conservative default:";
+    "Nothing to learn from yet — Claude hasn't left any work on this machine. I'll start each detection category at a careful default:";
 
   it('scan-ran-clean renders the exact clean copy over the recommended posture', () => {
     const { copy } = frameEmptyState('scan-clean', posture);
@@ -272,15 +285,15 @@ describe('frameEmptyState', () => {
     const noHistory = frameEmptyState('no-history', posture).copy;
     expect(clean).not.toBe(noHistory);
     // scan-ran-clean states a scan looked and found nothing.
-    expect(clean).toContain("I looked at Claude's recent activity");
-    // no-history states there is nothing on this machine to calibrate from.
-    expect(noHistory).toContain("Claude hasn't left activity on this machine");
+    expect(clean).toContain("I looked over Claude's recent work");
+    // no-history states there is nothing on this machine to learn from.
+    expect(noHistory).toContain("Claude hasn't left any work on this machine");
   });
 
-  it('never renders a fabricated count — no "0 notifications" theater', () => {
+  it('never renders a fabricated count — no "0 detections" theater', () => {
     for (const cause of ['scan-clean', 'no-history'] as const) {
       const { copy } = frameEmptyState(cause, posture);
-      expect(copy).not.toMatch(/\d+\s+notifications/);
+      expect(copy).not.toMatch(/\d+\s+detections/);
     }
   });
 

--- a/plugins/claude-code/test/consent-contract.test.ts
+++ b/plugins/claude-code/test/consent-contract.test.ts
@@ -65,7 +65,9 @@ describe('Leg 1 — "Yes, scan" records the historical-review consent without br
 
   it('records the historicalAccess=full grant', () => {
     expect(persisted.historicalAccess).toBe('full');
-    expect(onboardStdout).toContain('historicalAccess=full');
+    // The confirmation is user-facing copy, not a dev-internal key=value dump —
+    // it never echoes the raw historicalAccess value.
+    expect(onboardStdout).toContain("Got it — I'll look over Claude's recent work to tune things.");
   });
 
   it('records a consent scope provably identical to the prior historical-review flow', () => {

--- a/plugins/claude-code/test/firstrun-core.test.ts
+++ b/plugins/claude-code/test/firstrun-core.test.ts
@@ -116,7 +116,8 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     const blob = await seedAndRun(['--surfaced', '3', '--live-keys', '2']);
 
     // Additive: the human-readable install card is still present (not replaced).
-    expect(blob).toContain('installed');
+    // A surfaced count means a scan ran — the scan-path heading + divider.
+    expect(blob).toContain("You're all set — tuned to this machine.");
     expect(blob).toContain('First scan complete');
 
     const payload = readFrameJsonBlock(blob);
@@ -181,7 +182,9 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     const blob = await seedAndRun([]);
 
     // The card still renders — only the machine-readable payload is withheld.
-    expect(blob).toContain('installed');
+    // No --surfaced means no scan ran — the floor-path heading + divider.
+    expect(blob).toContain("I've started you on safe defaults");
+    expect(blob).toContain('Safe defaults in place');
     expect(readFrameJsonBlock(blob)).toBeUndefined();
   });
 
@@ -203,8 +206,9 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     }
     const blob = out.join('');
 
-    // The install card still renders as a tidy success state…
-    expect(blob).toContain('installed');
+    // The install card still renders as a tidy success state, on the floor-path
+    // heading — no --surfaced was passed, so no scan ran…
+    expect(blob).toContain("I've started you on safe defaults");
     // …with an honest empty-state stats line, never a fabricated scan tally…
     expect(blob).toContain("you're starting clean");
     expect(blob).not.toContain('worth a look');
@@ -237,15 +241,16 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     }
     const blob = out.join('');
 
-    // The rest of the install card still renders over the live gateway…
-    expect(blob).toContain('installed');
+    // The rest of the install card still renders over the live gateway, on the
+    // scan-path heading — --surfaced was passed, so a scan ran…
+    expect(blob).toContain("You're all set — tuned to this machine.");
     expect(blob).toContain('First scan complete');
-    expect(blob).toContain('Findings');
+    expect(blob).toContain('detections');
     // …and the handoff payload is still emitted.
     expect(SetupHandoffOffer.safeParse(readFrameJsonBlock(blob)).success).toBe(true);
     // …but the Posture section is omitted, not collapsed into the fail-open note.
     expect(blob).not.toContain('Posture');
-    expect(blob).not.toContain("I couldn't read the local store");
+    expect(blob).not.toContain("I couldn't check my records just now");
   });
 
   it('carries no raw detected value into the emitted frame block', async () => {
@@ -287,14 +292,14 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     }
     const blob = out.join('');
 
-    // The 'Findings N' stat is the real whole-store total, not the render-unit
+    // The 'N detections' stat is the real whole-store total, not the render-unit
     // fixture's literal.
     expect(summaryFindings).toBe(2);
-    expect(blob).toContain(`Findings ${String(summaryFindings)}`);
-    expect(blob).not.toContain('Findings 142');
-    // 'Recommendations' mirrors /recommend over the real findings: one per
+    expect(blob).toContain(`${String(summaryFindings)} detections`);
+    expect(blob).not.toContain('142 detections');
+    // 'recommendations' mirrors /recommend over the real findings: one per
     // category (secret + pii) → 2.
-    expect(blob).toContain('Recommendations 2');
+    expect(blob).toContain('2 recommendations');
     // 'Health' is the derived score over the real summary, rendered out of 100 —
     // never a fixed 82/100 sample.
     expect(blob).toMatch(/Health \d+\/100/);
@@ -342,7 +347,7 @@ describe('runFirstRunFailOpen — degrades to the store-unavailable note on a st
 
     // Fail-open: no throw escaped, and the honest store-unavailable note stands in.
     expect(threw).toBeUndefined();
-    expect(blob).toContain("I couldn't read the local store");
+    expect(blob).toContain("I couldn't check my records just now");
     // No fabricated card: the install card's stats never rendered over a dead store.
     expect(blob).not.toContain('installed');
   });

--- a/plugins/claude-code/test/journey/fail-open.journey.test.ts
+++ b/plugins/claude-code/test/journey/fail-open.journey.test.ts
@@ -64,7 +64,9 @@ describe('store-read failure mid-wizard completes fail-open, end-to-end', () => 
     // The real calibrated headline still renders from the plan (two seeded keys:
     // one surfaced, one routine FP) — a store-read failure never zeroes or
     // fabricates the count.
-    expect(preview.stdout).toContain('Calibrated. 2 notifications, 1 important.');
+    expect(preview.stdout).toContain(
+      "I went through Claude's recent work — 2 detections, 1 result worth a look. (live keys)",
+    );
 
     // The step did not stop at the note — it continued past the failed store read
     // and rendered the COMPLETE frame downstream of it: the recommended posture
@@ -89,9 +91,9 @@ describe('store-read failure mid-wizard completes fail-open, end-to-end', () => 
     expect(firstRun.stdout).toContain(STORE_UNAVAILABLE_NOTE);
 
     // It never papered over the unreadable store with a fabricated install card:
-    // the installed-card heading and its calibrated stats are absent, so the note
+    // neither the scan-path nor the floor-path heading appears, so the note
     // stands in for the whole frame rather than a zeroed-out summary.
-    expect(firstRun.stdout).not.toContain('installed — calibrated to this machine');
+    expect(firstRun.stdout).not.toContain("You're all set");
   });
 
   it('the fail-open notes never leak a raw detected value', () => {

--- a/plugins/claude-code/test/journey/fixture-exception.journey.test.ts
+++ b/plugins/claude-code/test/journey/fixture-exception.journey.test.ts
@@ -20,7 +20,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { checkFpSignalContract } from '../../eval/prompt-contract.ts';
 import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
-import { REPEATED_FP_KEY, SetupJourney } from './harness.ts';
+import { REPEATED_FP_KEYS, SetupJourney } from './harness.ts';
 
 // The one emitted group, asserted present by the caller first — extracted
 // without a non-null assertion so an actually-missing group fails loud with a
@@ -60,16 +60,21 @@ describe('FP-pattern signal grounds end-to-end over a repeated-value false posit
 
   it('the preview frame carries the masked FP-pattern signal with the expected token, count, and per-value identity', () => {
     expect(preview.status).toBe(0);
-    // The same rule surfaced three hits of the SAME raw value: one genuine
-    // (the stub judge's first-sorted survivor), two marked false positive —
-    // so the emitted group's count is 2, not 1.
+    // The same rule surfaced three hits of three DISTINCT values (dedup does
+    // not collapse them — different fingerprints): one genuine (the stub
+    // judge's first-sorted survivor), two marked false positive — so the
+    // emitted group's count is 2, not 1.
     expect(frame.counts).toEqual({ total: 3, important: 1, routine: 2 });
 
     expect(frame.falsePositivePatterns).toBeDefined();
     expect(frame.falsePositivePatterns).toHaveLength(1);
     const group = soleGroup(frame);
 
-    expect(group.pattern).toBe(safeMaskedMatch(REPEATED_FP_KEY));
+    const [firstKey] = REPEATED_FP_KEYS;
+    if (firstKey === undefined) throw new Error('REPEATED_FP_KEYS must not be empty');
+    // Every key in REPEATED_FP_KEYS masks identically (mask-collision), so any
+    // one of them names the group's expected pattern.
+    expect(group.pattern).toBe(safeMaskedMatch(firstKey));
     expect(group.count).toBe(2);
     expect(group.values).toHaveLength(2);
     for (const value of group.values) {
@@ -79,9 +84,11 @@ describe('FP-pattern signal grounds end-to-end over a repeated-value false posit
       expect(typeof value.keyVersion).toBe('number');
     }
 
-    // The raw value never crosses into the preview's stdout — only its masked
-    // pattern token does.
-    expect(preview.stdout).not.toContain(REPEATED_FP_KEY);
+    // No raw value from the seeded set ever crosses into the preview's
+    // stdout — only the masked pattern token does.
+    for (const raw of REPEATED_FP_KEYS) {
+      expect(preview.stdout).not.toContain(raw);
+    }
   });
 
   it("the checker's FP-signal grounding passes for the real emitted pattern/count and fails for an invented pattern or a fabricated count", () => {

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -82,11 +82,20 @@ export const ROUTINE_KEY = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
 export const MULTI_KEY_STRIPE_KEY = ['sk', '_live_', 'aBcDeFgHiJkLmNoPqRsTuVwXyZmulti1'].join('');
 export const MULTI_KEY_GITHUB_KEY = ['ghp_', 'aBcDeFgHiJkLmNoPqRsTuVwXyZ12multi901'].join('');
 
-// A fourth real AWS key, reused identically across THREE seeded messages by
-// seedRepeatedFalsePositiveTranscript() below — the repeated-value false
-// positive under one rule that gives the masked FP-pattern signal a group whose
-// count > 1. Composed at runtime for the same reason as the other keys above.
-export const REPEATED_FP_KEY = ['AKIA', 'TEQPSWRIUQF4V7JF'].join('');
+// Three DISTINCT real AWS keys — under the same rule, seeded by
+// seedRepeatedFalsePositiveTranscript() below — that collide on their
+// safeMaskedMatch pattern: every key here starts 'A' (the AKIA prefix) and
+// ends 'F', and maskMatch's generic rule reveals only the first + last
+// character ('A' + six asterisks + 'F'), so the three mask identically despite
+// carrying different values (and different valueFingerprints — dedupeForJudge
+// does not collapse them). This gives the masked FP-pattern signal a group
+// whose count > 1 from genuinely distinct values, not from one repeated raw
+// value. Composed at runtime for the same reason as the other keys above.
+export const REPEATED_FP_KEYS: readonly string[] = [
+  ['AKIA', 'TEQPSWRIUQF4V7JF'].join(''),
+  ['AKIA', 'TEQPSWRIUQG4V7JF'].join(''),
+  ['AKIA', 'TEQPSWRIUQH4V7JF'].join(''),
+];
 
 export class SetupJourney {
   readonly home: string;
@@ -186,26 +195,27 @@ export class SetupJourney {
     return transcriptPath;
   }
 
-  // Seed a prior Claude Code transcript under the temp home carrying the SAME
-  // leaked AWS key (REPEATED_FP_KEY) repeated across THREE distinct messages —
-  // same rule, same raw value, same re-derived masked token — timestamped
-  // inside the retention window. Each message's surrounding text differs so
-  // the scan's content-hash dedup (scanHistory streams a hash of the whole
-  // message text) treats them as three distinct messages rather than folding
-  // them into one, so the backfill streams three separate hits under the SAME
-  // rule. The stub judge (writeFakeJudge) marks the first (sorted) hit under a
-  // shared rule genuine and every other hit false-positive, so the marked
-  // (model-dismissed) hits here are the other two — a masked FP-pattern group
-  // whose count is 2, not 1, proving the signal groups a REPEATED value rather
-  // than merely naming a single dismissed hit.
+  // Seed a prior Claude Code transcript under the temp home carrying the THREE
+  // DISTINCT leaked AWS keys in REPEATED_FP_KEYS — same rule, different raw
+  // values, same re-derived masked token (mask-collision, not a literal
+  // repeat) — across three distinct messages, timestamped inside the
+  // retention window. Each carries a different valueFingerprint, so
+  // dedupeForJudge does not collapse them: the backfill streams three
+  // separate hits under the SAME rule, and all three reach the judge as
+  // distinct representatives. The stub judge (writeFakeJudge) marks the first
+  // (sorted) hit under a shared rule genuine and every other hit false-positive,
+  // so the marked (model-dismissed) hits here are the other two — sharing one
+  // masked token, they fold into a single masked FP-pattern group whose count
+  // is 2, not 1, proving the signal groups by masked-token collision across
+  // genuinely distinct values rather than merely naming a single dismissed hit.
   seedRepeatedFalsePositiveTranscript(): string {
     const projectDir = join(this.home, '.claude', 'projects', '-Users-me-repeated-fp');
     mkdirSync(projectDir, { recursive: true });
-    const lines = [5, 4, 3].map((daysAgo, i) =>
+    const lines = REPEATED_FP_KEYS.map((key, i) =>
       JSON.stringify({
         type: 'user',
-        timestamp: new Date(Date.now() - daysAgo * DAY_MS).toISOString(),
-        message: { role: 'user', content: `example fixture key #${String(i)}: ${REPEATED_FP_KEY}` },
+        timestamp: new Date(Date.now() - (5 - i) * DAY_MS).toISOString(),
+        message: { role: 'user', content: `example fixture key #${String(i)}: ${key}` },
       }),
     );
     const transcriptPath = join(projectDir, 'session.jsonl');
@@ -371,19 +381,19 @@ export class SetupJourney {
   }
 
   // A controlled `claude` on PATH: the apply-suppressions preview spawns
-  // `claude -p … <prompt>` for its triage judgment. This stub parses the hits out
-  // of the prompt's trailing fenced block and returns a deterministic, raw-free
-  // TriageRecommendation envelope — the first hit per (category, rule) surfaced
-  // (genuine), the rest marked routine false positives — so a repeated hit under
-  // the SAME rule (e.g. the SURFACED_KEY/ROUTINE_KEY aws-access-key pair) still
-  // dismisses all but one, while distinct rules in the same category (e.g. aws +
-  // stripe + github secrets) each surface their own genuine hit. No live model
-  // is ever hit.
+  // `claude -p …` for its triage judgment, feeding the prompt on STDIN (never
+  // argv — see judge.ts's spawnClaude). This stub reads stdin, parses the hits
+  // out of the prompt's trailing fenced block, and returns a deterministic,
+  // raw-free TriageRecommendation envelope — the first hit per (category, rule)
+  // surfaced (genuine), the rest marked routine false positives — so a repeated
+  // hit under the SAME rule (e.g. the SURFACED_KEY/ROUTINE_KEY aws-access-key
+  // pair) still dismisses all but one, while distinct rules in the same
+  // category (e.g. aws + stripe + github secrets) each surface their own
+  // genuine hit. No live model is ever hit.
   private writeFakeJudge(): void {
     const src = `#!/usr/bin/env node
 'use strict';
-const argv = process.argv.slice(2);
-const prompt = argv.length ? argv[argv.length - 1] : '';
+const prompt = require('node:fs').readFileSync(0, 'utf8');
 const fences = [...String(prompt).matchAll(/\`\`\`[a-z]*\\n([\\s\\S]*?)\`\`\`/g)];
 const block = fences.length ? fences[fences.length - 1][1] : '';
 const byCategory = new Map();

--- a/plugins/claude-code/test/journey/narration-contract.journey.test.ts
+++ b/plugins/claude-code/test/journey/narration-contract.journey.test.ts
@@ -228,7 +228,7 @@ describe('fail-open leg: the narration signal is absent — both the calibration
 
   it('the remediation decision degrades honestly too — no decision, and no frame JSON is emitted for it (nothing to narrate)', () => {
     expect(present.status).toBe(0);
-    expect(present.stdout).toContain('No secret-leak findings to review.');
+    expect(present.stdout).toContain("No exposed keys to deal with — you're clear.");
     expect(readFrameJsonBlock(present.stdout)).toBeUndefined();
   });
 

--- a/plugins/claude-code/test/journey/no-history.journey.test.ts
+++ b/plugins/claude-code/test/journey/no-history.journey.test.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
 import { SetupJourney } from './harness.ts';
 
-const NO_HISTORY_COPY = 'Nothing to calibrate from yet';
+const NO_HISTORY_COPY = 'Nothing to learn from yet';
 const SCAN_CLEAN_COPY = 'nothing needs your attention';
 
 describe('empty-history backfill renders the no-history calibration copy end-to-end', () => {

--- a/plugins/claude-code/test/journey/not-now.journey.test.ts
+++ b/plugins/claude-code/test/journey/not-now.journey.test.ts
@@ -14,9 +14,9 @@
  * touched on the floor-only path, so no historical-review consent is recorded.
  *
  * The applying-frame confirmation is the Not-now analog of the Yes-path
- * apply-suppressions --confirmed line: it reports only the categories tuned (no
- * suppression pass ran, no scan produced counts), so it carries neither a
- * 'routine dismissed' count nor the calibration headline.
+ * apply-suppressions --confirmed line: it reports only the detection categories
+ * set (no suppression pass ran, no scan produced counts), so it carries neither
+ * a 'routine results set aside' count nor the calibration headline.
  *
  * Frame 0.6 (firstrun.js, the no-scan installed summary) closes the journey here:
  * driven with NO --surfaced count, its store-derived stats and 'N worth a look'
@@ -119,27 +119,27 @@ describe('Not-now start-light path, end-to-end', () => {
     // The Not-now branch's start-light card — the copy is unit-owned in
     // render.test.ts / start-light.test.ts; this asserts the frame renders it
     // end-to-end from the built script.
-    expect(startLight).toContain('Start light — set your packs');
+    expect(startLight).toContain('Starting light — your detection categories');
     // The full 8×4 default posture matrix, rendered from the severity-floor defaults.
     expect(startLight).toContain(renderPostureGrid(severityFloorPosture()));
     // Per-pack rationale — a shipped reason line for each pack, never omitted.
-    expect(startLight).toContain('live credentials are the costliest thing to leak');
+    expect(startLight).toContain('keys and credentials are the costliest thing to lose');
     // The frame closes with the re-tune hint.
     expect(startLight).toContain(RE_TUNE_HINT);
   });
 
-  it('applying (0.5): honest no-scan confirmation — categories tuned, no routine/calibration counts', () => {
+  it('applying (0.5): honest no-scan confirmation — detection categories set, no routine/calibration counts', () => {
     // The applying confirmation from onboard.js --floor — the Not-now analog of
     // the Yes-path apply-suppressions --confirmed line. The tuned count is derived
     // from the posture the run actually wrote (read back from the store), so the
     // assertion carries no hardcoded count.
     const categoriesTuned = Object.values(readPosture(journey.storeDir)).filter(Boolean).length;
     expect(applied).toContain(renderCategoriesTuned(categoriesTuned));
-    // No suppression pass ran, so there is no dismissed count to report.
-    expect(applied).not.toContain('routine dismissed');
+    // No suppression pass ran, so there is no routine-results count to report.
+    expect(applied).not.toContain('routine result');
     // No scan ran, so the calibration headline and its counts never appear.
-    expect(applied).not.toContain('Calibrated.');
-    expect(applied).not.toContain('notifications');
+    expect(applied).not.toContain("I went through Claude's recent work");
+    expect(applied).not.toContain('detections');
   });
 
   it('frame JSON: no calibration frame is emitted on the Not-now spine through 0.5', () => {
@@ -155,7 +155,8 @@ describe('Not-now start-light path, end-to-end', () => {
     // The installed-summary heading and, beneath it, the per-category Posture block
     // reflecting exactly the floor posture the 0.5 write established — read back
     // from the store (the honest final-state seam) and rendered into the card.
-    expect(firstRun).toContain('AKA Security installed');
+    // No scan ran, so the card carries the floor-path heading, not the scan one.
+    expect(firstRun).toContain("I've started you on safe defaults");
     const posture = readPosture(journey.storeDir);
     const rows = DetectionCategory.options.flatMap((category) => {
       const action = posture[category];
@@ -165,14 +166,15 @@ describe('Not-now start-light path, end-to-end', () => {
   });
 
   it('installed summary (0.6): store-derived stats and the handoff degrade to the honest no-scan empty-state', () => {
-    // No scan ran, so the numeric Health/Findings/Recommendations tally is replaced
-    // by the honest empty-state line — never a fabricated zero tally. Guard every
-    // count in that tally, so a regression to a fabricated `Findings 0` /
-    // `Recommendations 0` line fails here too, not only the health score.
+    // No scan ran, so the numeric Health/detections/recommendations tally is
+    // replaced by the honest empty-state line — never a fabricated zero tally.
+    // Guard every count in that tally, so a regression to a fabricated
+    // `0 detections` / `0 recommendations` line fails here too, not only the
+    // health score.
     expect(firstRun).toContain('Nothing needs your attention');
     expect(firstRun).not.toMatch(/Health \d+\/100/);
-    expect(firstRun).not.toMatch(/Findings \d+/);
-    expect(firstRun).not.toMatch(/Recommendations \d+/);
+    expect(firstRun).not.toMatch(/\d+ detections/);
+    expect(firstRun).not.toMatch(/\d+ recommendations/);
     // No surfaced count was threaded, so the 'N worth a look' dashboard handoff is
     // withheld entirely — no fabricated or placeholder count.
     expect(firstRun).not.toContain('worth a look');

--- a/plugins/claude-code/test/journey/remediation-production-entry.journey.test.ts
+++ b/plugins/claude-code/test/journey/remediation-production-entry.journey.test.ts
@@ -133,7 +133,7 @@ describe('frame 0.6 -> remediation decision -> option routing: production entry 
   it('the real-count leg: the remediation-decision presentation is the full four-option layout over the real finding, masked-only, no "case" vocabulary', () => {
     // The count is templated from the real surfaced finding (1), never hardcoded.
     expect(decision.secretCount).toBe(1);
-    expect(decision.prompt).toBe('1 exposed secret key found in old transcripts');
+    expect(decision.prompt).toBe('I found 1 exposed secret key sitting in old transcripts.');
     expect(decision.options.map((o) => o.id)).toEqual([
       'redact-rotation-checklist',
       'redact-only',
@@ -209,13 +209,13 @@ describe('frame 0.6 -> remediation decision -> option routing: production entry 
     const brokenFrame = 'this is not a calibration frame block';
 
     const presentOutBroken = journey.remediationPresent(brokenFrame).stdout;
-    expect(presentOutBroken).toContain('Could not read the calibration frame');
-    expect(presentOutBroken).not.toContain('No secret-leak findings to review');
+    expect(presentOutBroken).toContain("I couldn't pull up what I found just now");
+    expect(presentOutBroken).not.toContain("No exposed keys to deal with — you're clear");
 
     // A valid --posture, so the route clears posture validation (which precedes
     // the frame read) and the unreadable frame itself is what degrades honestly.
     const redactOutBroken = journey.remediationRoute(brokenFrame, 'redact-only', 'redact').stdout;
-    expect(redactOutBroken).toContain('Could not read the calibration frame');
+    expect(redactOutBroken).toContain("I couldn't pull up what I found just now");
     expect(redactOutBroken).not.toContain(renderRedactionConfirmation(0));
     expect(redactOutBroken.toLowerCase()).not.toContain('redacted');
   });
@@ -232,7 +232,7 @@ describe('frame 0.6 -> remediation decision -> option routing: production entry 
 describe("'Redact only' presents the standing-posture step, parameterized over all four choices, driven from the built remediate.js", () => {
   it('the standing-posture prompt offers exactly Redact / Warn / Block / Monitor, in that order', () => {
     const step = presentStandingSecretPosture();
-    expect(step.prompt).toContain("Set the 'secret' posture");
+    expect(step.prompt).toContain("Set the 'secret' detection level");
     expect(step.options.map((o) => o.level)).toEqual(['redact', 'warn', 'block', 'monitor']);
     expect(step.options.map((o) => o.label)).toEqual(['Redact', 'Warn', 'Block', 'Monitor']);
   });
@@ -270,7 +270,7 @@ describe("'Redact only' presents the standing-posture step, parameterized over a
         // redaction count stays at N=1 across every choice — the sweep is
         // over the four posture choices, not the finding count.
         expect(redactOut).toContain(renderRedactionConfirmation(1));
-        expect(redactOut).toContain(`✓ Set 'secret' posture to ${level}`);
+        expect(redactOut).toContain(`✓ From now on, I'll treat secrets like these as ${level}.`);
         const after = readFileSync(transcript, 'utf8');
         expect(after).not.toContain(SURFACED_KEY);
         expect(after).toContain('[REDACTED:SECRET]');

--- a/plugins/claude-code/test/journey/remediation.journey.test.ts
+++ b/plugins/claude-code/test/journey/remediation.journey.test.ts
@@ -147,7 +147,7 @@ describe('direct-invocation remediation chain, no wizard state', () => {
     // One decision moment over the whole set; the count templates over the real
     // three findings with no unverifiable 'still valid' claim.
     expect(decision.secretCount).toBe(3);
-    expect(decision.prompt).toContain('3 exposed secret keys found in old transcripts');
+    expect(decision.prompt).toContain('I found 3 exposed secret keys sitting in old transcripts.');
     expect(decision.prompt.toLowerCase()).not.toContain('still valid');
     // Exactly the four options, in stable order — no more, no fewer.
     expect(decision.options.map((o) => o.id)).toEqual([
@@ -205,7 +205,7 @@ describe('direct-invocation remediation chain, no wizard state', () => {
     // The store's seeded default is 'warn', so the standing Redact choice is an
     // observable change — not a coincidental match with the baseline.
     expect(postureBaseline).toBe('warn');
-    expect(routeResult.stdout).toContain("✓ Set 'secret' posture to redact");
+    expect(routeResult.stdout).toContain("✓ From now on, I'll treat secrets like these as redact.");
     // The 'secret' posture is durable in the policies store — read back on a fresh
     // connection, so future secret detections are governed by it.
     expect(postureAfter).toBe('redact');
@@ -213,7 +213,7 @@ describe('direct-invocation remediation chain, no wizard state', () => {
 
   it('step 4: rotation-checklist.md is written at the repo root, most-exposed-first, masked, with per-provider console paths', () => {
     expect(existsSync(join(repoRoot, 'rotation-checklist.md'))).toBe(true);
-    expect(routeResult.stdout).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(routeResult.stdout).toContain('✓ I drafted a rotation checklist for you (repo root).');
 
     // Three DISTINCT provider+masked-token entries — the fixture's three keys
     // never collapse into one row. Every seeded entry has the same occurrence
@@ -250,7 +250,7 @@ describe('direct-invocation remediation chain, no wizard state', () => {
     expect(routeResult.stdout).toContain(
       `✓ Redacted 3 keys across ${String(distinctTranscripts.size)} transcripts`,
     );
-    expect(routeResult.stdout).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(routeResult.stdout).toContain('✓ I drafted a rotation checklist for you (repo root).');
   });
 
   it('step 4: the inline checklist preview matches the written rotation-checklist.md entry-for-entry', () => {

--- a/plugins/claude-code/test/journey/yes-scan.journey.test.ts
+++ b/plugins/claude-code/test/journey/yes-scan.journey.test.ts
@@ -8,7 +8,7 @@
  * confirmed calibration through the ACTUAL writer, apply-suppressions.js
  * --confirmed (not onboard.js --posture): that is the spine that establishes the
  * floor-overlaid 8-pack (reviewed-evidence overwrite + severity-floor fill-gaps)
- * and emits the '8 categories tuned · N routine dismissed'
+ * and emits the '✓ Set all 8 detection categories · set aside N routine results'
  * confirmation. The AskUserQuestion issuances (the consent question and the
  * dashboard handoff) are prompt-authored setup.md territory this script-chain
  * harness cannot observe; it asserts the offer PAYLOAD instead.
@@ -92,26 +92,26 @@ describe('Yes-scan happy path, end-to-end', () => {
 
   it('intro: renders the canonical identity and the version·repo provenance line', () => {
     expect(intro).toContain('AKA Security');
-    expect(intro).toContain('We secure agent harnesses at the source.');
     expect(intro).toContain(`v${MANIFEST.version} · github.com/akasecurity/ai-tc`);
     // No provenance badge yet — that lands with the signature check.
     expect(intro).not.toContain('verified');
   });
 
-  it('intro: the intro script also emits the "what I do" calibration card', () => {
-    // The kickoff and "what I do" cards are printed by the same
-    // intro run, back-to-back, before the scan offer. This asserts the wiring
-    // (the copy itself is unit-owned in render.test.ts).
-    expect(intro).toContain('I watch out for Claude as it works.');
-    expect(intro).toContain("let's calibrate your notifications based on what Claude's been up to");
+  it('intro: the merged card also carries the "what I do" body, from the same intro run', () => {
+    // The identity header and the "what I do" body render in a single merged
+    // card from the same intro run, before the scan offer. This asserts the
+    // wiring (the copy itself is unit-owned in render.test.ts).
+    expect(intro).toContain("I'm a security harness for Claude.");
+    expect(intro).toContain('While it codes, I keep the sensitive information');
   });
 
   it('preview: leads with the real-count headline and the condensed recommended posture', () => {
     // The calibrated-result card the wizard shows the user — the counts are the
     // real scan's (two seeded keys: one surfaced, one routine FP), and the kind
     // parenthetical names the surfaced category's kind.
-    expect(preview).toContain('Calibrated. 2 notifications, 1 important.');
-    expect(preview).toContain('1 routine, 1 that matter (live keys)');
+    expect(preview).toContain(
+      "I went through Claude's recent work — 2 detections, 1 result worth a look. (live keys)",
+    );
     // The condensed recommended view lists every pack with its recommended
     // level (the evidence pack took 'warn'); a full 8×4 level grid is the
     // start-light branch's, not the spine's.
@@ -149,7 +149,7 @@ describe('Yes-scan happy path, end-to-end', () => {
     // the shipped helper, so the assertion carries no hardcoded count.
     const categoriesTuned = Object.values(readPosture(journey.storeDir)).filter(Boolean).length;
     expect(confirm).toContain(renderCategoriesTuned(categoriesTuned));
-    expect(confirm).toContain('✓ 1 routine dismissed');
+    expect(confirm).toContain('set aside 1 routine result');
     expect(confirm).toMatch(/Ready:/);
   });
 
@@ -194,7 +194,8 @@ describe('Yes-scan happy path, end-to-end', () => {
   });
 
   it('installed summary: the installed card and the handoff-offer payload carry the real surfaced count', () => {
-    expect(firstRun).toContain('✓ AKA Security installed');
+    // A scan ran, so the card carries the scan-path heading.
+    expect(firstRun).toContain("✓ You're all set — tuned to this machine.");
     const offer = SetupHandoffOffer.parse(readFrameJsonBlock(firstRun));
     expect(offer.worthALook).toBe(1);
     // The happy path surfaced one live-key secret, so frame 0.6 composes the

--- a/plugins/claude-code/test/remediation/batched-decision.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/batched-decision.scenario.test.ts
@@ -152,7 +152,7 @@ describe('batched four-option remediation decision (app-level: no case, secret-o
     if (decision.kind !== 'decision')
       throw new Error(`expected a decision, got '${decision.kind}'`);
     expect(decision.secretCount).toBe(3);
-    expect(decision.prompt).toContain('3 exposed secret keys found in old transcripts');
+    expect(decision.prompt).toContain('I found 3 exposed secret keys sitting in old transcripts.');
     expect(decision.prompt.toLowerCase()).not.toContain('still valid');
 
     // Exactly the four options, in stable order — no more, no fewer.
@@ -237,7 +237,7 @@ describe('batched four-option remediation decision (app-level: no case, secret-o
 
     // The standing-posture step then offers exactly Redact / Warn / Block / Monitor.
     const c3 = presentStandingSecretPosture();
-    expect(c3.prompt).toContain("Set the 'secret' posture");
+    expect(c3.prompt).toContain("Set the 'secret' detection level");
     expect(c3.options.map((o) => o.level)).toEqual(['redact', 'warn', 'block', 'monitor']);
     expect(c3.options.map((o) => o.label)).toEqual(['Redact', 'Warn', 'Block', 'Monitor']);
 

--- a/plugins/claude-code/test/remediation/chain.test.ts
+++ b/plugins/claude-code/test/remediation/chain.test.ts
@@ -75,7 +75,7 @@ describe('presentBatchedRemediation', () => {
     // No status word either: the finding's status is what the data holds (unknown),
     // rendered per-row — the count copy states only the count and where.
     expect(decision.prompt.toLowerCase()).not.toContain('live');
-    expect(decision.prompt).toContain('3 exposed secret keys found in old transcripts');
+    expect(decision.prompt).toContain('I found 3 exposed secret keys sitting in old transcripts.');
   });
 
   it("never emits the word 'case' in user-facing copy", () => {

--- a/plugins/claude-code/test/remediation/deliverable.test.ts
+++ b/plugins/claude-code/test/remediation/deliverable.test.ts
@@ -71,7 +71,7 @@ describe('resolveRemediationDeliverable', () => {
       'sk_live_…one',
     ]);
     expect(result.summary).toContain('✓ Redacted 3 keys across 2 transcripts');
-    expect(result.summary).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(result.summary).toContain('✓ I drafted a rotation checklist for you (repo root).');
 
     const previewLines = result.summary.split('\n').filter((line) => line.startsWith('- [ ] '));
     expect(previewLines).toEqual(renderChecklistMarkdown(result.entries).trimEnd().split('\n'));
@@ -100,7 +100,7 @@ describe('resolveRemediationDeliverable', () => {
       note: `Could not draft rotation-checklist.md at ${missingTarget}.`,
     });
     expect(result.summary).toContain(`Could not draft rotation-checklist.md at ${missingTarget}.`);
-    expect(result.summary).not.toContain('✓ Drafted rotation-checklist.md');
+    expect(result.summary).not.toContain('✓ I drafted a rotation checklist for you');
   });
 
   it('threads unredactedFindings through to an honest partial summary — never the "resolved" framing on a partial strike', () => {

--- a/plugins/claude-code/test/remediation/first-run-handoff.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/first-run-handoff.scenario.test.ts
@@ -199,7 +199,9 @@ describe('first-run handoff seam: calibration findings trigger (or skip) remedia
     // the remediation decision equals the surfaced live-key count (3) — NOT the broader display count (4).
     expect(entry.decision.secretCount).toBe(surfacedLiveKeys);
     expect(entry.decision.secretCount).toBe(offer.liveKeys);
-    expect(entry.decision.prompt).toContain('3 exposed secret keys found in old transcripts');
+    expect(entry.decision.prompt).toContain(
+      'I found 3 exposed secret keys sitting in old transcripts.',
+    );
   });
 
   it('no-findings branch — only non-secret findings surfaced: no remediation offered; dashboard handoff only', async () => {

--- a/plugins/claude-code/test/remediation/posture.test.ts
+++ b/plugins/claude-code/test/remediation/posture.test.ts
@@ -38,8 +38,8 @@ function throwingPolicies(): CategoryPolicyWriter {
 }
 
 describe('presentStandingSecretPosture — standing-posture palette', () => {
-  it("presents the 'Set the secret posture' prompt", () => {
-    expect(presentStandingSecretPosture().prompt).toContain("Set the 'secret' posture");
+  it("presents the 'Set the secret detection level' prompt", () => {
+    expect(presentStandingSecretPosture().prompt).toContain("Set the 'secret' detection level");
   });
 
   it('offers EXACTLY Redact / Warn / Block / Monitor in that order', () => {

--- a/plugins/claude-code/test/remediation/production-entry.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/production-entry.scenario.test.ts
@@ -60,7 +60,7 @@ describe('production remediation entry: honest degrade on a successfully-read, z
     // The honest no-op the entry prints when `presentBatchedRemediation` returns
     // `{ kind: 'no-decision' }` over an empty findings set — never a fabricated
     // count and never the remediation-decision copy.
-    expect(out).toBe('No secret-leak findings to review.\n');
+    expect(out).toBe("No exposed keys to deal with — you're clear.\n");
     expect(out).not.toContain('exposed secret');
     expect(out).not.toContain('Redact + rotation checklist');
     // No frame JSON block is emitted for a no-decision outcome — nothing for a
@@ -75,9 +75,9 @@ describe('production remediation entry: honest degrade on a successfully-read, z
     const emptyOut = present(emptyFrameText);
     const unreadableOut = present(unreadableFrameText);
 
-    expect(emptyOut).toBe('No secret-leak findings to review.\n');
+    expect(emptyOut).toBe("No exposed keys to deal with — you're clear.\n");
     expect(unreadableOut).toBe(
-      'Could not read the calibration frame — the surfaced findings were unavailable.\n',
+      "I couldn't pull up what I found just now — the details weren't available.\n",
     );
     expect(emptyOut).not.toEqual(unreadableOut);
   });

--- a/plugins/claude-code/test/remediation/redact-only-posture.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/redact-only-posture.scenario.test.ts
@@ -102,7 +102,7 @@ describe("'Redact only' through the built remediate.js persists the standing pos
     const out = journey.remediationRoute(preview, 'redact-only', 'redact').stdout;
 
     expect(out).toContain(renderRedactionConfirmation(1));
-    expect(out).toContain("✓ Set 'secret' posture to redact");
+    expect(out).toContain("✓ From now on, I'll treat secrets like these as redact.");
     const after = readFileSync(transcriptPath, 'utf8');
     expect(after).not.toContain(SURFACED_KEY);
     expect(after).toContain('[REDACTED:SECRET]');

--- a/plugins/claude-code/test/remediation/redact-rotation-checklist-posture.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/redact-rotation-checklist-posture.scenario.test.ts
@@ -150,7 +150,7 @@ describe("'Redact + rotation checklist' through the built remediate.js persists 
     // is reported EXACTLY ONCE — inside the resolved summary, in its
     // transcript-count form — never repeated as a standalone confirmation ahead
     // of the posture line.
-    const postureIdx = out.indexOf("✓ Set 'secret' posture to redact");
+    const postureIdx = out.indexOf("✓ From now on, I'll treat secrets like these as redact.");
     const summaryIdx = out.indexOf('Leaked secrets — resolved');
     expect(postureIdx).toBeGreaterThanOrEqual(0);
     expect(summaryIdx).toBeGreaterThan(postureIdx);
@@ -170,7 +170,7 @@ describe("'Redact + rotation checklist' through the built remediate.js persists 
     // The deliverable landed at the isolated repo root the script was spawned
     // with as its cwd, never the ai-tc working tree.
     expect(out).toContain('✓ Redacted 1 key across 1 transcript');
-    expect(out).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(out).toContain('✓ I drafted a rotation checklist for you (repo root).');
     const checklistPath = join(repoRoot, 'rotation-checklist.md');
     expect(existsSync(checklistPath)).toBe(true);
     expect(readFileSync(checklistPath, 'utf8')).not.toContain(SURFACED_KEY);
@@ -227,7 +227,7 @@ describe("'Redact + rotation checklist' through the built remediate.js: the per-
     // N (3 keys) and M (2 transcripts) are independently real: three raw values
     // struck across exactly two artifacts, never N relabelled as M.
     expect(out).toContain('✓ Redacted 3 keys across 2 transcripts');
-    expect(out).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(out).toContain('✓ I drafted a rotation checklist for you (repo root).');
 
     const afterA = readFileSync(transcriptA, 'utf8');
     const afterB = readFileSync(transcriptB, 'utf8');

--- a/plugins/claude-code/test/remediation/render.test.ts
+++ b/plugins/claude-code/test/remediation/render.test.ts
@@ -112,12 +112,12 @@ describe('renderRemediationDecision — decision layout', () => {
 
   it('closes with the chaining line naming the registered secret-scan command', () => {
     const out = renderRemediationDecision([stripeFinding()], 1, REGISTRY_SCAN);
-    expect(out).toContain('1 more worth a look — run /aka:scan');
+    expect(out).toContain("1 more worth a look — run /aka:scan when you're ready.");
   });
 
   it('reflects the registry — names /aka:secretscan when that is what is registered, not a hardcode', () => {
     const out = renderRemediationDecision([stripeFinding()], 2, REGISTRY_SECRETSCAN);
-    expect(out).toContain('2 more worth a look — run /aka:secretscan');
+    expect(out).toContain("2 more worth a look — run /aka:secretscan when you're ready.");
   });
 
   it('fails loud when no secret-scan command is registered', () => {
@@ -161,7 +161,7 @@ describe('renderResolvedSummary', () => {
 
     expect(summary).toContain('Leaked secrets — resolved');
     expect(summary).toContain('✓ Redacted 3 keys across 2 transcripts');
-    expect(summary).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(summary).toContain('✓ I drafted a rotation checklist for you (repo root).');
 
     // A fourth finding (all four struck: redactedKeys tracks findings.length so
     // the "resolved" framing stays honest) proves the transcript count is
@@ -228,7 +228,7 @@ describe('renderResolvedSummary', () => {
     );
     // The checklist deliverable still lands — rotation is still owed regardless
     // of whether the leaked text itself was struck.
-    expect(summary).toContain('✓ Drafted rotation-checklist.md (repo root)');
+    expect(summary).toContain('✓ I drafted a rotation checklist for you (repo root).');
   });
 
   it('pluralizes the partial message correctly across more than one remaining key', () => {
@@ -289,14 +289,14 @@ describe('renderRedactionOutcome — redact-only confirmation', () => {
   it('renders the clean confirmation when every finding was struck', () => {
     const findings = [stripeFinding(), awsFinding()];
     expect(renderRedactionOutcome({ redactedKeys: 2, findings, unredactedFindings: [] })).toBe(
-      '✓ Redacted 2 keys',
+      '✓ Redacted 2 keys.',
     );
   });
 
   it('pluralizes the clean confirmation over a single struck key', () => {
     const findings = [stripeFinding()];
     expect(renderRedactionOutcome({ redactedKeys: 1, findings, unredactedFindings: [] })).toBe(
-      '✓ Redacted 1 key',
+      '✓ Redacted 1 key.',
     );
   });
 

--- a/plugins/claude-code/test/remediation/rotation-checklist.test.ts
+++ b/plugins/claude-code/test/remediation/rotation-checklist.test.ts
@@ -125,7 +125,7 @@ describe('rotation checklist', () => {
       status: 'written',
       filePath: join(repositoryRoot, 'rotation-checklist.md'),
       locationLabel: 'repo root',
-      resolvedLine: '✓ Drafted rotation-checklist.md (repo root)',
+      resolvedLine: '✓ I drafted a rotation checklist for you (repo root).',
     });
     expect(readFileSync(join(repositoryRoot, 'rotation-checklist.md'), 'utf8')).toBe(
       renderChecklistMarkdown(entries),
@@ -143,7 +143,7 @@ describe('rotation checklist', () => {
       status: 'written',
       filePath: join(invocationDirectory, 'rotation-checklist.md'),
       locationLabel: `invocation working directory: ${invocationDirectory}`,
-      resolvedLine: `✓ Drafted rotation-checklist.md (invocation working directory: ${invocationDirectory})`,
+      resolvedLine: `✓ I drafted a rotation checklist for you (invocation working directory: ${invocationDirectory}).`,
     });
     expect(readFileSync(join(invocationDirectory, 'rotation-checklist.md'), 'utf8')).toBe(
       renderChecklistMarkdown(entries),

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -577,19 +577,15 @@ describe('pure renderers', () => {
 
     it('scan path: a warm summary line rides above the stat row, over the real counts', () => {
       const out = populated({ findings: 142, worthALook: 2, calibration: 'scan' });
-      expect(out).toContain(
-        "I've gone over 142 detections from Claude's recent work — 2 worth your attention.",
-      );
+      expect(out).toContain('Your store holds 142 detections — 2 worth your attention.');
       // A different set of real values flows straight through.
       const other = populated({ findings: 9, worthALook: 4, calibration: 'scan' });
-      expect(other).toContain(
-        "I've gone over 9 detections from Claude's recent work — 4 worth your attention.",
-      );
+      expect(other).toContain('Your store holds 9 detections — 4 worth your attention.');
     });
 
     it('floor path: no warm summary line — the floor path never scanned anything', () => {
       const out = populated({ calibration: 'floor' });
-      expect(out).not.toContain("I've gone over");
+      expect(out).not.toContain('Your store holds');
       // The stat row still renders over the real store counts.
       expect(out).toContain('Health 72/100');
       expect(out).toContain('142 detections');
@@ -661,7 +657,7 @@ describe('pure renderers', () => {
       expect(out).not.toContain('worth a look');
       expect(out).not.toContain('0 detections');
       expect(out).not.toContain('0 recommendations');
-      expect(out).not.toContain("I've gone over");
+      expect(out).not.toContain('Your store holds');
       // Instead, an explicit honest empty-state line.
       expect(out).toContain("you're starting clean");
       // The card still reads as a tidy success state: scan-path heading + posture.
@@ -959,7 +955,7 @@ describe('renderStartLight — 0.3b start-light card', () => {
     expect(renderStartLight(posture)).toMatchInlineSnapshot(`
       "● Starting light — your detection categories
 
-        I don't have any of Claude's past work to learn from yet, so I'll start each detection category at a careful default.
+        For now, each detection category starts at a careful default. Run /aka:setup whenever you like and I'll tune these from Claude's recent work.
 
         CATEGORY       MONITOR   WARN   REDACT   BLOCK
         ────────────   ───────   ────   ──────   ─────
@@ -1077,7 +1073,7 @@ describe('renderAdjustConfirm — 0.4b adjust-confirm table', () => {
 
   it('matches the whole-card snapshot so copy/layout regressions surface', () => {
     expect(renderAdjustConfirm(recommended, chosen)).toMatchInlineSnapshot(`
-      "● Adjust — set the packs you want, keep the rest
+      "● Adjust — set the detection categories you want, keep the rest
 
         CATEGORY       RECOMMENDED   YOURS  
         ────────────   ───────────   ───────

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -37,7 +37,6 @@ import {
   renderRecommendedPosture,
   renderStartLight,
   renderStatusLine,
-  renderWhatIDo,
   runQuery,
   topFindings,
 } from '../src/render.ts';
@@ -269,22 +268,47 @@ describe('pure renderers', () => {
     );
   });
 
-  it('setup intro: the adapter builds the card from the real manifest, sourced from identity.ts', () => {
+  it('setup intro: the merged card builds from the real manifest, sourced from identity.ts', () => {
     // Exercises the shipped intro adapter (manifest → card) end to end: the
-    // identity strings can only appear if intro-card.ts sources them from the
-    // shared identity constant, and the provenance version comes from the real
-    // plugin manifest — so a stale local copy or a version drift fails here.
+    // identity name can only appear if intro-card.ts sources it from the shared
+    // identity constant, and the provenance version comes from the real plugin
+    // manifest — so a stale local copy or a version drift fails here.
     const out = strip(buildIntroCard(PLUGIN_MANIFEST, /* verified */ false));
     expect(out).toContain(NAME);
-    expect(out).toContain(TAGLINE);
-    expect(out).toContain(ONE_LINER);
+    // The "what I do" body, merged into the same card — no duplicated one-liner.
+    expect(out).toContain("I'm a security harness for Claude.");
+    expect(out).toContain(
+      'While it codes, I keep the sensitive information — secrets, keys, regulated data — safely on your machine.',
+    );
+    expect(out).toContain(
+      "Most of it I handle quietly; I only notify you when it's worth your call.",
+    );
     // Provenance line: the real installed version + canonical repo, no 'verified' badge
     // when the caller passes verified: false.
     expect(out).toContain(`v${PLUGIN_MANIFEST.version ?? ''} · github.com/akasecurity/ai-tc`);
     expect(out).not.toContain('verified');
-    // The old tagline and the stale two-question line are gone.
+    // The tagline, the one-liner and the handoff line are gone — the scan-offer
+    // question carries the handoff instead — and the old copy never leaks back in.
+    expect(out).not.toContain(TAGLINE);
+    expect(out).not.toContain(ONE_LINER);
+    expect(out).not.toContain("let's calibrate your notifications");
     expect(out).not.toContain('Agent Harness Security for Claude Code.');
     expect(out).not.toContain('two quick questions');
+    // No internal narration (design-doc / decision citations) leaks into the copy.
+    expect(out).not.toMatch(/Decision|design doc|ADR/i);
+    // The whole card, built from the real manifest version/repo, so a layout
+    // regression is caught here rather than only by the individual toContains
+    // above (a literal snapshot can't be frozen since the version is real data).
+    expect(out).toBe(
+      [
+        `● ${NAME}  ·  v${PLUGIN_MANIFEST.version ?? ''} · github.com/akasecurity/ai-tc`,
+        '',
+        "  I'm a security harness for Claude.",
+        '',
+        '  While it codes, I keep the sensitive information — secrets, keys, regulated data — safely on your machine.',
+        "  Most of it I handle quietly; I only notify you when it's worth your call.",
+      ].join('\n'),
+    );
   });
 
   it('setup intro: the adapter appends the verified badge when the caller confirms provenance', () => {
@@ -294,36 +318,13 @@ describe('pure renderers', () => {
     );
   });
 
-  it('what I do: the calibration card carries the walkthrough voice, verbatim', () => {
-    const out = strip(renderWhatIDo());
-    // Every line from the calibration walkthrough, verbatim.
-    expect(out).toContain('I watch out for Claude as it works.');
-    expect(out).toContain(
-      'As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.',
-    );
-    expect(out).toContain(
-      "Most of it I handle quietly; I only notify you when it's worth your call.",
-    );
-    // Leads into the calibration handoff that hands off to the scan offer.
-    expect(out).toContain("let's calibrate your notifications based on what Claude's been up to");
-    // No internal narration (design-doc / decision citations) leaks into the copy.
-    expect(out).not.toMatch(/Decision|design doc|ADR/i);
-    // The whole card, so a copy regression is caught as a snapshot diff.
-    expect(out).toMatchInlineSnapshot(`
-      "● I watch out for Claude as it works.
-
-        As it codes, I intelligently contain sensitive data — secrets and regulated information — to your computer.
-        Most of it I handle quietly; I only notify you when it's worth your call.
-
-        let's calibrate your notifications based on what Claude's been up to"
-    `);
-  });
-
-  it('setup intro: the adapter fails open with a blank version when the manifest is unreadable', () => {
+  it('setup intro: the adapter fails open with blank facts when the manifest is unreadable', () => {
     // Empty manifest — the fallback intro.ts uses when plugin.json can't be read.
     const out = strip(buildIntroCard({}));
-    // Still a card: the identity one-liner renders even with no manifest facts.
-    expect(out).toContain(ONE_LINER);
+    // Still a card: the identity name and "what I do" body render even with no
+    // manifest facts.
+    expect(out).toContain(NAME);
+    expect(out).toContain("I'm a security harness for Claude.");
     expect(out).not.toContain('verified');
   });
 
@@ -508,6 +509,7 @@ describe('pure renderers', () => {
       strip(
         renderFirstRun(
           {
+            calibration: 'scan',
             posture: renderPosture([
               { category: 'secret', action: 'redact' },
               { category: 'code_context', action: 'log' },
@@ -529,24 +531,69 @@ describe('pure renderers', () => {
         ),
       );
 
-    it("heading reads 'AKA Security installed — calibrated to this machine'", () => {
-      expect(populated()).toContain('AKA Security installed — calibrated to this machine');
+    it('scan path: heading reads "You\'re all set — tuned to this machine."', () => {
+      const out = populated({ calibration: 'scan' });
+      expect(out).toContain("✓ You're all set — tuned to this machine.");
+      // The floor-path heading never leaks onto the scan path.
+      expect(out).not.toContain('safe defaults');
     });
 
-    it('stats line templates the real health · findings · recommendations, never a fixed literal', () => {
+    it('scan path: divider reads "First scan complete"', () => {
+      const out = populated({ calibration: 'scan' });
+      expect(out).toContain('First scan complete');
+      expect(out).not.toContain('Safe defaults in place');
+    });
+
+    it('floor path: heading reads the cause-neutral no-scan fallback copy', () => {
+      const out = populated({ calibration: 'floor' });
+      expect(out).toContain(
+        "✓ You're all set — I've started you on safe defaults. Rerun /aka:setup anytime to calibrate from Claude's activity.",
+      );
+      // The scan-path heading never leaks onto the floor path.
+      expect(out).not.toContain('tuned to this machine');
+    });
+
+    it('floor path: divider reads "Safe defaults in place" (no scan ran)', () => {
+      const out = populated({ calibration: 'floor' });
+      expect(out).toContain('Safe defaults in place');
+      expect(out).not.toContain('First scan complete');
+    });
+
+    it('stats line templates the real health · detections · recommendations, never a fixed literal', () => {
       const out = populated();
       expect(out).toContain('Health 72/100');
-      expect(out).toContain('Findings 142');
-      expect(out).toContain('Recommendations 6');
+      expect(out).toContain('142 detections');
+      expect(out).toContain('6 recommendations');
       // A different set of real values flows straight through — proof it is
       // templated over the store, not a baked-in literal.
       const other = populated({ health: 91, findings: 3, recommendations: 1 });
       expect(other).toContain('Health 91/100');
-      expect(other).toContain('Findings 3');
-      expect(other).toContain('Recommendations 1');
+      expect(other).toContain('3 detections');
+      expect(other).toContain('1 recommendations');
       // The fixed sample numbers never appear.
       expect(out).not.toContain('82/100');
       expect(out).not.toContain('40 findings');
+    });
+
+    it('scan path: a warm summary line rides above the stat row, over the real counts', () => {
+      const out = populated({ findings: 142, worthALook: 2, calibration: 'scan' });
+      expect(out).toContain(
+        "I've gone over 142 detections from Claude's recent work — 2 worth your attention.",
+      );
+      // A different set of real values flows straight through.
+      const other = populated({ findings: 9, worthALook: 4, calibration: 'scan' });
+      expect(other).toContain(
+        "I've gone over 9 detections from Claude's recent work — 4 worth your attention.",
+      );
+    });
+
+    it('floor path: no warm summary line — the floor path never scanned anything', () => {
+      const out = populated({ calibration: 'floor' });
+      expect(out).not.toContain("I've gone over");
+      // The stat row still renders over the real store counts.
+      expect(out).toContain('Health 72/100');
+      expect(out).toContain('142 detections');
+      expect(out).toContain('6 recommendations');
     });
 
     it('shows the posture line the user chose', () => {
@@ -560,7 +607,7 @@ describe('pure renderers', () => {
 
     it("renders the '2 worth a look' handoff with the real surfaced count and the Open dashboard / Not now framing", () => {
       const out = populated({ worthALook: 2 });
-      expect(out).toContain('2 worth a look — see them in the browser?');
+      expect(out).toContain('2 worth a look — want to see them in the browser?');
       expect(out).toContain('Open dashboard');
       expect(out).toContain('Not now');
       // The count is the surfaced value, echoed — a different count flows through.
@@ -592,11 +639,12 @@ describe('pure renderers', () => {
       // No scan surfaced anything: no worthALook, an empty store (0 findings /
       // recommendations), a clean scan (no top findings). The card degrades
       // honestly — the numeric stats triple becomes explicit empty-state copy
-      // rather than a bare 'Findings 0 · Recommendations 0' scan tally, and the
+      // rather than a bare '0 detections · 0 recommendations' scan tally, and the
       // dashboard handoff is withheld (never a fabricated '0 worth a look').
       const out = strip(
         renderFirstRun(
           {
+            calibration: 'scan',
             posture: renderPosture([{ category: 'secret', action: 'redact' }]),
             health: 40,
             findings: 0,
@@ -608,14 +656,16 @@ describe('pure renderers', () => {
         ),
       );
 
-      // No fabricated dashboard handoff and no bare numeric scan tally.
+      // No fabricated dashboard handoff, no bare numeric scan tally, and no
+      // fabricated warm-summary claim of a review over zero detections.
       expect(out).not.toContain('worth a look');
-      expect(out).not.toContain('Findings 0');
-      expect(out).not.toContain('Recommendations 0');
+      expect(out).not.toContain('0 detections');
+      expect(out).not.toContain('0 recommendations');
+      expect(out).not.toContain("I've gone over");
       // Instead, an explicit honest empty-state line.
       expect(out).toContain("you're starting clean");
-      // The card still reads as a tidy success state: installed heading + posture.
-      expect(out).toContain('installed — calibrated to this machine');
+      // The card still reads as a tidy success state: scan-path heading + posture.
+      expect(out).toContain("You're all set — tuned to this machine.");
       expect(out).toContain('Posture');
       expect(out).toContain('secret');
       expect(out).toContain('redact');
@@ -846,7 +896,7 @@ describe('renderPostureGrid — full 8×4 posture matrix', () => {
     // Feeding the default posture map, the mark sits in monitor for the observe-only
     // packs (code_context, config) and in warn for the rest.
     expect(out).toMatchInlineSnapshot(`
-      "  PACK           MONITOR   WARN   REDACT   BLOCK
+      "  CATEGORY       MONITOR   WARN   REDACT   BLOCK
         ────────────   ───────   ────   ──────   ─────
         pii                      ●                    
         financial                ●                    
@@ -876,7 +926,7 @@ describe('renderStartLight — 0.3b start-light card', () => {
   const posture = severityFloorPosture();
 
   it('leads with the start-light heading', () => {
-    expect(renderStartLight(posture)).toContain('Start light — set your packs');
+    expect(renderStartLight(posture)).toContain('Starting light — your detection categories');
   });
 
   it('embeds the full 8×4 default posture grid, composed from the shared primitive', () => {
@@ -907,11 +957,11 @@ describe('renderStartLight — 0.3b start-light card', () => {
 
   it('matches the whole-card snapshot so copy/layout regressions surface', () => {
     expect(renderStartLight(posture)).toMatchInlineSnapshot(`
-      "● Start light — set your packs
+      "● Starting light — your detection categories
 
-        No history to calibrate from yet, so each pack starts at a conservative default.
+        I don't have any of Claude's past work to learn from yet, so I'll start each detection category at a careful default.
 
-        PACK           MONITOR   WARN   REDACT   BLOCK
+        CATEGORY       MONITOR   WARN   REDACT   BLOCK
         ────────────   ───────   ────   ──────   ─────
         pii                      ●                    
         financial                ●                    
@@ -924,12 +974,12 @@ describe('renderStartLight — 0.3b start-light card', () => {
 
         pii — warn: personal data carries real obligations, so I surface it before it moves.
         financial — warn: card and account numbers are sensitive by default, so these come to you.
-        secret — warn: live credentials are the costliest thing to leak, so I bring them to you on sight.
+        secret — warn: keys and credentials are the costliest thing to lose, so I bring those straight to you.
         phi — warn: health information is regulated wherever it lands, so I flag it for your call.
         code_context — monitor: proprietary code context is common and mostly benign, so I watch quietly and keep the record.
         code_flaw — warn: an insecure pattern is worth a look before it ships, so I raise it.
         custom — warn: your own policy matches start surfaced so nothing you care about slips by unseen.
-        config — monitor: configuration values are noisy to flag, so I keep an eye on them without a notification.
+        config — monitor: config values are noisy, so I keep an eye on them without notifying you.
 
         Re-tune anytime with /aka:setup or the dashboard"
     `);
@@ -990,18 +1040,20 @@ describe('renderAdjustConfirm — 0.4b adjust-confirm table', () => {
   // enforcement downgrade the same way — a pack hardened out of band can otherwise
   // be lowered here with nothing shown to the user.
   describe('downgrade guard against the stored posture', () => {
-    it('appends the WARNING footer when a pick ranks below the stored action', () => {
+    it('appends the downgrade footer when a pick ranks below the stored action', () => {
       // The store holds 'secret' at block; the user picks redact.
       const out = renderAdjustConfirm(recommended, chosen, { secret: 'block' });
-      expect(out).toContain('WARNING: 1 category (secret) would be LOWERED');
+      expect(out).toContain('Heads up — this would lower 1 detection level (secret) below');
     });
 
-    it('names every lowered pack and pluralizes the count', () => {
+    it('names every lowered detection category and pluralizes the count', () => {
       const out = renderAdjustConfirm(recommended, chosen, {
         secret: 'block',
         config: 'redact',
       });
-      expect(out).toContain('WARNING: 2 categories (secret, config) would be LOWERED');
+      expect(out).toContain(
+        'Heads up — this would lower 2 detection levels (secret, config) below',
+      );
     });
 
     it('stays silent when every pick is the same or stronger than the stored action', () => {
@@ -1061,23 +1113,26 @@ describe('renderApplied — applying confirmation', () => {
   // against the commands the plugin actually registers.
   const REGISTRY = readRegisteredCommands();
 
-  it('templates the real dismissed count and confirms the tuned pack count', () => {
+  it('templates the real dismissed count and confirms the tuned category count', () => {
     const out = renderApplied(8, 12, REGISTRY);
-    expect(out).toContain('✓ 8 categories tuned');
-    expect(out).toContain('✓ 12 routine dismissed');
+    expect(out).toContain('✓ Set all 8 detection categories');
+    expect(out).toContain('set aside 12 routine results');
     // N is templated from the real count — a different value flows straight
     // through, never a baked-in literal.
-    expect(renderApplied(8, 3, REGISTRY)).toContain('✓ 3 routine dismissed');
+    expect(renderApplied(8, 3, REGISTRY)).toContain('set aside 3 routine results');
+    // Singular is grammatical when exactly one routine result was set aside.
+    expect(renderApplied(8, 1, REGISTRY)).toContain('set aside 1 routine result');
+    expect(renderApplied(8, 1, REGISTRY)).not.toContain('1 routine results');
     // The tuned count is threaded too, not hardcoded to 8.
-    expect(renderApplied(5, 3, REGISTRY)).toContain('✓ 5 categories tuned');
+    expect(renderApplied(5, 3, REGISTRY)).toContain('✓ Set all 5 detection categories');
   });
 
-  it('renders an honest zero-state when nothing routine was dismissed', () => {
+  it('renders an honest empty-state when nothing routine was set aside', () => {
     const out = renderApplied(8, 0, REGISTRY);
-    expect(out).toContain('✓ 8 categories tuned');
-    // No fabricated '✓ 0 routine dismissed' — honest copy instead.
-    expect(out).not.toContain('0 routine dismissed');
-    expect(out).toMatch(/no routine/i);
+    expect(out).toContain('✓ Set all 8 detection categories');
+    // No fabricated 'set aside 0 routine results' — honest copy instead.
+    expect(out).not.toContain('set aside 0');
+    expect(out).toContain('nothing routine to set aside');
   });
 
   it('the Ready line names only commands the plugin actually registers, in invokable /aka: form', () => {
@@ -1104,14 +1159,14 @@ describe('renderApplied — applying confirmation', () => {
     expect(() => renderApplied(8, 5, withoutHealth)).toThrow(/aka:health/);
   });
 
-  it("reads '✓ 8 categories tuned' from the real 8-pack the posture writer wrote", () => {
+  it("reads '✓ Set all 8 detection categories' from the real 8-pack the posture writer wrote", () => {
     // onboard.ts feeds its confirmation the size of the posture it actually
     // wrote: renderCategoriesTuned(Object.keys(posture).length). Drive that with
     // the real recommended map so the '8' is the true pack count, not a
     // literal — this is the segment that composes into the applying-confirmation line.
     const packCount = Object.keys(severityFloorPosture()).length;
     expect(packCount).toBe(8);
-    expect(renderCategoriesTuned(packCount)).toBe('✓ 8 categories tuned');
+    expect(renderCategoriesTuned(packCount)).toBe('✓ Set all 8 detection categories');
     // Same phrase renderApplied composes — single-sourced, so the two can't drift.
     expect(renderApplied(packCount, 5, REGISTRY)).toContain(renderCategoriesTuned(packCount));
   });

--- a/plugins/claude-code/test/setup-copy.test.ts
+++ b/plugins/claude-code/test/setup-copy.test.ts
@@ -20,16 +20,16 @@ const forkSection = setupMd.slice(forkStart, forkEnd === -1 ? undefined : forkEn
 describe('setup.md 0.3 scan-offer copy', () => {
   it('carries the scope disclosure verbatim', () => {
     expect(setupMd).toContain(
-      "A retroactive scan of recent activity — transcripts, temp files, agent memory — tunes the notifications we'll review next.",
+      "I'll review Claude's recent work — transcripts, temp files, agent memory — to tune what I bring to you next.",
     );
   });
 
   it('carries the Yes-option subtitle verbatim', () => {
-    expect(setupMd).toContain('calibrate my notifications to your real activity');
+    expect(setupMd).toContain("tune what I bring you, based on Claude's real work here");
   });
 
   it('carries the Not-now-option subtitle verbatim', () => {
-    expect(setupMd).toContain('start light and learn as we go');
+    expect(setupMd).toContain("start light and I'll learn as we go");
   });
 });
 
@@ -44,7 +44,7 @@ describe('setup.md 0.3b Not-now start-light branch', () => {
   });
 
   it('names the start-light card heading the wizard reproduces verbatim', () => {
-    expect(setupMd).toContain('Start light — set your packs');
+    expect(setupMd).toContain('● Starting light — your detection categories');
   });
 
   it('writes the chosen posture via --floor for defaults or --posture for adjustments', () => {
@@ -98,28 +98,29 @@ describe('setup.md 0.4b adjust reroute branch', () => {
 
 // The 0.4b adjust fork rejoins the spine at the applying frame (0.5) with its own
 // full-8-pack confirmation prose in commands/setup.md — distinct from the step-5
-// spine's generic '✓ K categories tuned'. Freeze that fork-specific rejoin copy so
-// a voice regression fails CI, not only the manual walkthrough. Scope is the branch
-// frames only; frame 0.6 and the Yes-scan spine copy (frames 0.1–0.6) are baselined
-// elsewhere and are not re-frozen here.
+// spine's generic '✓ Set all K detection categories'. Freeze that fork-specific
+// rejoin copy so a voice regression fails CI, not only the manual walkthrough.
+// Scope is the branch frames only; frame 0.6 and the Yes-take-a-look spine copy
+// (frames 0.1–0.6) are baselined elsewhere and are not re-frozen here.
 //
 // The rest of the branch-frame voice baseline is already covered and is not
-// duplicated here: the 0.3b start-light heading ('Start light — set your packs'),
-// the 0.4b 'Adjust a category' option, and the save-option copy are frozen verbatim
-// by the 0.3b/0.4b branch blocks above. Strings that live in a rendered card rather
-// than setup.md prose — the start-light heading, the 'Re-tune anytime with /aka:setup
-// or the dashboard' re-tune hint, and the confirm table's 'CATEGORY │ RECOMMENDED │
-// YOURS' header (rendered uppercase, space-aligned; the lowercase '│'-framed phrase
-// is only prose narration of it) — are guarded against real stdout by
+// duplicated here: the 0.3b start-light heading ('● Starting light — your
+// detection categories'), the 0.4b 'Adjust a category' option, and the
+// save-option copy are frozen verbatim by the 0.3b/0.4b branch blocks above.
+// Strings that live in a rendered card rather than setup.md prose — the
+// start-light heading, the 'Re-tune anytime with /aka:setup or the dashboard'
+// re-tune hint, and the confirm table's 'CATEGORY │ RECOMMENDED │ YOURS' header
+// (rendered uppercase, space-aligned; the lowercase '│'-framed phrase is only
+// prose narration of it) — are guarded against real stdout by
 // start-light.test.ts, so this guard stays on the setup.md-prose surface.
 describe('setup.md branch-frame voice baseline (0.4b → 0.5 rejoin)', () => {
   it('rejoins the applying frame (0.5) with the full-8-pack tuned/dismissed prose', () => {
     // Command-line templating carve-out: assert only the stable applying-frame
     // prose, never the 'Ready: …' command names the registry templates over the
     // actually-registered command set. Asserted within the fork section so it is
-    // the fork's own '✓ 8 categories tuned' applying frame, not the step-5 spine's
-    // generic '✓ K categories tuned'.
-    expect(forkSection).toContain('✓ 8 categories tuned · ✓ N routine dismissed');
+    // the fork's own '✓ Set all 8 detection categories' applying frame, not the
+    // step-5 spine's generic '✓ Set all K detection categories'.
+    expect(forkSection).toContain('✓ Set all 8 detection categories · set aside N routine results');
   });
 });
 
@@ -174,7 +175,7 @@ describe('setup.md frame-0.6 "Review leaked keys" branch', () => {
     expect(idx).toBeGreaterThanOrEqual(0);
     const section = setupMd.slice(idx, setupMd.indexOf('\n## 7', idx));
     expect(section).toContain('If they chose "Redact + rotation checklist" or "Redact only"');
-    expect(section).toContain("Set the 'secret' posture");
+    expect(section).toContain("Set the 'secret' detection level");
     const redact = section.indexOf('**Redact** (`redact`)');
     const warn = section.indexOf('**Warn** (`warn`)');
     const block = section.indexOf('**Block** (`block`)');

--- a/plugins/claude-code/test/start-light.test.ts
+++ b/plugins/claude-code/test/start-light.test.ts
@@ -70,7 +70,7 @@ describe('scripts/start-light.js', () => {
   });
 
   it('the fenced card carries the heading, the 8×4 default posture grid, and the re-tune hint', () => {
-    expect(result.stdout).toContain('Start light — set your packs');
+    expect(result.stdout).toContain('Starting light — your detection categories');
     expect(result.stdout).toContain(renderPostureGrid(severityFloorPosture()));
     expect(result.stdout).toContain(RE_TUNE_HINT);
   });
@@ -189,10 +189,8 @@ describe('scripts/start-light.js --adjust-confirm', () => {
         hardened,
       ]);
       expect(run.status).toBe(0);
-      expect(run.stdout).toContain('WARNING: 1 category (secret) would be LOWERED');
-      expect(run.stdout).toContain(
-        'Confirm you intend to weaken enforcement there before applying',
-      );
+      expect(run.stdout).toContain('Heads up — this would lower 1 detection level (secret) below');
+      expect(run.stdout).toContain('Confirm you mean to lower it before I apply');
     });
 
     it('stays silent when the chosen level is the same or higher than the stored action', () => {

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -178,12 +178,39 @@ describe('runApply — preview renders the no-history empty state on an empty-hi
     expect(code).toBe(0);
     const blob = out.join('');
     // The honest no-history empty state, distinct from the scan-clean copy.
-    expect(blob).toContain('Nothing to calibrate from yet');
+    expect(blob).toContain('Nothing to learn from yet');
     expect(blob).not.toContain('nothing needs your attention');
     expect(blob).not.toContain('No triage hits to review');
     // A zero-count CalibrationFrame is still emitted for downstream consumers.
     const frame = CalibrationFrame.parse(readFrameJsonBlock(blob));
     expect(frame.counts).toEqual({ total: 0, important: 0, routine: 0 });
+    // Preview stays read-only: no posture upsert, no exception created.
+    expect(db.posture).toEqual({});
+    expect(db.created).toEqual([]);
+  });
+});
+
+describe('runApply — preview renders the skipped-scan copy when triage was skipped', () => {
+  it('prints the warm empty-review copy and drops the internal status token', async () => {
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () =>
+        `${JSON.stringify({ done: true, count: 0, status: 'skipped:no-consent' })}\n`,
+      runJudge: () => verdict(),
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+    const blob = out.join('');
+    expect(blob).toContain("I didn't find anything to review — nothing to tune.");
+    // The internal status token never reaches user-facing copy.
+    expect(blob).not.toContain('skipped:no-consent');
+    expect(blob).not.toContain('No triage hits to review');
     // Preview stays read-only: no posture upsert, no exception created.
     expect(db.posture).toEqual({});
     expect(db.created).toEqual([]);
@@ -286,16 +313,17 @@ describe('runApply — confirm applies the persisted plan without re-judging', (
     // plan file deleted after a successful apply
     expect(existsSync(path)).toBe(false);
     // The confirm path emits the applying confirmation, threading the
-    // real writeback counts: all 8 packs tuned, one routine suppression dismissed.
+    // real writeback counts: all 8 detection categories set, one routine
+    // suppression set aside.
     const applied = out.join('');
-    expect(applied).toContain('✓ 8 categories tuned');
-    expect(applied).toContain('✓ 1 routine dismissed');
+    expect(applied).toContain('✓ Set all 8 detection categories');
+    expect(applied).toContain('set aside 1 routine result');
     expect(applied).toMatch(/Ready:/);
   });
 });
 
 describe('runApply — confirm persists the full recommended 8-pack posture', () => {
-  it('writes all 8 packs (severity floor overlaid with evidence) and reports "8 categories tuned"', async () => {
+  it('writes all 8 packs (severity floor overlaid with evidence) and reports "Set all 8 detection categories"', async () => {
     // Evidence action that DIFFERS from the severity floor (secret floors to warn;
     // the judge here says redact) so the overlay precedence is observable end-to-end.
     const v: TriageRecommendation = {
@@ -339,8 +367,8 @@ describe('runApply — confirm persists the full recommended 8-pack posture', ()
     expect(confirmDb.posture.secret).toBe('redact');
     expect(confirmDb.posture.code_context).toBe('log'); // monitor floor -> log action
     expect(confirmDb.posture.config).toBe('log');
-    // The applying-confirmation copy holds end-to-end: all 8 categories tuned, not the survivor subset.
-    expect(out.join('')).toContain('✓ 8 categories tuned');
+    // The applying-confirmation copy holds end-to-end: all 8 detection categories set, not the survivor subset.
+    expect(out.join('')).toContain('✓ Set all 8 detection categories');
   });
 });
 
@@ -580,10 +608,10 @@ describe('runApply — confirm rejects a plan stale against the current store (d
       stderr: vi.fn(),
     });
     expect(code).toBe(0);
-    // The applying confirmation on the real confirm path: all 8 packs tuned, one
-    // routine suppression dismissed.
-    expect(out.join('')).toContain('✓ 8 categories tuned');
-    expect(out.join('')).toContain('✓ 1 routine dismissed');
+    // The applying confirmation on the real confirm path: all 8 detection
+    // categories set, one routine result set aside.
+    expect(out.join('')).toContain('✓ Set all 8 detection categories');
+    expect(out.join('')).toContain('set aside 1 routine result');
     // no drift → the write proceeded: one suppression row AND the full 8-pack
     // posture overwrite (the evidence category kept its judged action)
     expect(confirmDb.created).toHaveLength(1);
@@ -623,7 +651,7 @@ describe('runApply — confirm rejects a plan stale against the current store (d
     expect(confirmDb.posture.secret).toBe('warn');
     // All 8 packs hold a posture and the tuned count stays honest.
     expect(Object.keys(confirmDb.posture)).toHaveLength(8);
-    expect(out.join('')).toContain('✓ 8 categories tuned');
+    expect(out.join('')).toContain('✓ Set all 8 detection categories');
   });
 
   it('treats a category ADDED to the store since preview as drift (undefined → value)', async () => {
@@ -780,7 +808,9 @@ describe('runApply — preview emits the calibration frame JSON alongside the hu
     // The calibrated-result card the wizard leads with: the real-count
     // headline over this run's genuine/suppressed split, then the condensed
     // one-row-per-pack recommended posture.
-    expect(blob).toContain('Calibrated. 3 notifications, 2 important.');
+    expect(blob).toContain(
+      "I went through Claude's recent work — 3 detections, 2 results worth a look.",
+    );
     expect(blob).toMatch(/secret\s+warn/);
 
     const frame = readFrameJsonBlock(blob);
@@ -1088,10 +1118,84 @@ describe('runApply — preview degrades fail-open when the local store is unread
 
     // The honest store-unavailable note stands in for the store-derived downgrade
     // comparison — the store-read-failure path, not the found-nothing/empty copy.
-    expect(blob).toContain("I couldn't read the local store");
+    expect(blob).toContain("I couldn't check my records just now");
 
     // The real calibration count (from the scan/plan, not the store) still renders —
     // a store-read failure never fabricates or zeroes the calibrated headline.
-    expect(blob).toContain('Calibrated. 1 notifications');
+    expect(blob).toContain("I went through Claude's recent work — 1 detection,");
+  });
+});
+
+describe('runApply — dedups repeated hits before the judge and before the writeback plan', () => {
+  it('feeds the judge and the plan/frame derivations the SAME deduped representative set', async () => {
+    const FP1 = 'ab'.repeat(32);
+    const FP2 = 'cd'.repeat(32);
+    const OTHER = ['sk', 'live', '51H8xEXAMPLErawstripesecretVALUE0000'].join('_');
+
+    // Three occurrences of the SAME value (fp1) plus one distinct value (fp2).
+    const dup = (id: string, tag: string): TriageHit =>
+      hit({ id, valueFingerprint: FP1, rawMatch: RAW, context: `export KEY=${RAW} ${tag}` });
+    const h0 = dup('0', 'first');
+    const h1 = dup('1', 'second');
+    const h2 = dup('2', 'third');
+    const h3 = hit({
+      id: '3',
+      ruleId: 'secrets/stripe-live-key',
+      valueFingerprint: FP2,
+      rawMatch: OTHER,
+      context: `token=${OTHER}`,
+    });
+    const stream =
+      [h0, h1, h2, h3].map((h) => JSON.stringify(h)).join('\n') +
+      '\n' +
+      JSON.stringify({ done: true, count: 4, status: 'complete' }) +
+      '\n';
+
+    // Echoes how many hits it saw, and dismisses only id '0' as a false positive —
+    // so if dedup did NOT happen, the duplicate occurrences h1/h2 (never listed in
+    // fpIds) would wrongly surface as extra "genuine" findings alongside h3.
+    const runJudge = vi.fn((hits: readonly TriageHit[]): TriageRecommendation => ({
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'warn',
+          reasoning: 'one dismissed as a duplicate example value',
+          genuineCount: hits.length - 1,
+          fpCount: 1,
+          fpIds: ['0'],
+        },
+      ],
+      notes: 'looks routine',
+    }));
+
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => stream,
+      runJudge,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+
+    // The judge saw the deduped representative set (2), not all 4 raw occurrences.
+    expect(runJudge).toHaveBeenCalledTimes(1);
+    const [call] = runJudge.mock.calls;
+    if (call === undefined) throw new Error('runJudge was not called');
+    const [seenByJudge] = call;
+    expect(seenByJudge).toHaveLength(2);
+    expect(seenByJudge.map((h) => h.id)).toEqual(['0', '3']);
+
+    // The writeback plan / calibration derivations were fed the SAME representative
+    // set: only h3 is genuine (h0 was dismissed) — the duplicate occurrences h1/h2
+    // must not reappear as extra surfaced findings.
+    const parsed = CalibrationFrame.safeParse(readFrameJsonBlock(out.join('')));
+    if (!parsed.success) throw new Error('emitted frame did not validate');
+    expect(parsed.data.maskedFindings).toHaveLength(1);
+    expect(parsed.data.maskedFindings?.[0]?.maskedToken).toBe(safeMaskedMatch(OTHER));
   });
 });

--- a/plugins/claude-code/test/triage/dedupe.test.ts
+++ b/plugins/claude-code/test/triage/dedupe.test.ts
@@ -1,0 +1,28 @@
+import type { TriageHit } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { dedupeForJudge } from '../../src/triage/dedupe.ts';
+
+const hit = (o: Partial<TriageHit>): TriageHit => ({
+  ruleId: 'r',
+  category: 'secret',
+  severity: 'high',
+  maskedMatch: 'm',
+  rawMatch: 'raw',
+  context: 'c',
+  confidence: 0.9,
+  ...o,
+});
+
+describe('dedupeForJudge', () => {
+  it('collapses repeats by (ruleId,valueFingerprint), keeps distinct + fingerprint-less', () => {
+    const out = dedupeForJudge([
+      hit({ id: '0', valueFingerprint: 'fp1' }),
+      hit({ id: '1', valueFingerprint: 'fp1' }),
+      hit({ id: '2', valueFingerprint: 'fp2' }),
+      hit({ id: '3', valueFingerprint: undefined }),
+      hit({ id: '4', valueFingerprint: undefined }),
+    ]);
+    expect(out.map((h) => h.id)).toEqual(['0', '2', '3', '4']);
+  });
+});

--- a/plugins/claude-code/test/triage/gate-display.test.ts
+++ b/plugins/claude-code/test/triage/gate-display.test.ts
@@ -168,7 +168,7 @@ describe('renderPosturePlan', () => {
     // stored block (rank 4) -> planned warn (rank 2): a downgrade the human must see.
     const out = renderPosturePlan({ secret: 'warn' }, { secret: 'block' });
     expect(out).toContain('LOWERED from block');
-    expect(out.toUpperCase()).toContain('WARNING');
+    expect(out).toContain('Heads up');
     expect(out).toContain('secret');
   });
 
@@ -182,7 +182,7 @@ describe('renderPosturePlan', () => {
     // stored log(=monitor) -> planned warn is an UPGRADE; stored warn -> warn unchanged.
     const out = renderPosturePlan({ secret: 'warn', pii: 'warn' }, { secret: 'log', pii: 'warn' });
     expect(out).not.toContain('LOWERED');
-    expect(out.toUpperCase()).not.toContain('WARNING');
+    expect(out).not.toContain('Heads up');
     expect(out).toContain('secret: warn (was monitor)');
     expect(out).toContain('pii: warn (unchanged)');
   });
@@ -192,7 +192,7 @@ describe('renderPosturePlan', () => {
       { secret: 'warn', financial: 'monitor' },
       { secret: 'block', financial: 'redact' },
     );
-    expect(out).toMatch(/2 categories/);
+    expect(out).toMatch(/2 detection levels/);
     expect(out).toContain('secret');
     expect(out).toContain('financial');
   });

--- a/plugins/claude-code/test/triage/judge.test.ts
+++ b/plugins/claude-code/test/triage/judge.test.ts
@@ -79,30 +79,66 @@ describe('runJudge', () => {
     confidence: 0.9,
   };
 
-  it('spawns claude -p with --no-session-persistence + --output-format json, raw prompt, and parses', () => {
+  it('spawns claude -p with --no-session-persistence + --output-format json, and the prompt on stdin', () => {
     let seenArgv: readonly string[] = [];
     let seenEnv: NodeJS.ProcessEnv = {};
+    let seenStdin = '';
     const rec = runJudge([hit], {
-      spawn: (argv, env) => {
+      spawn: (argv, env, stdin) => {
         seenArgv = argv;
         seenEnv = env;
+        seenStdin = stdin;
         return envelope(VERDICT_FENCE);
       },
       loadRubric: () => 'RUBRIC BODY',
     });
 
-    expect(seenArgv[0]).toBe('-p');
-    expect(seenArgv).toContain('--no-session-persistence');
-    expect(seenArgv).toContain('--output-format');
-    expect(seenArgv).toContain('json');
-    // The full raw hit (rawMatch + context) rides in the prompt — that is the
-    // point; SKIP_PROMPT_HISTORY + --no-session-persistence keep it out of any
-    // transcript.
-    expect(seenArgv.at(-1)).toContain('AKIAIOSFODNN7EXAMPLE');
-    expect(seenArgv.at(-1)).toContain('RUBRIC BODY');
+    expect(seenArgv).toEqual(['-p', '--no-session-persistence', '--output-format', 'json']);
+    // The full raw hit (rawMatch + context) rides on stdin — that is the point;
+    // SKIP_PROMPT_HISTORY + --no-session-persistence keep it out of any
+    // transcript, and stdin (unlike argv) keeps it off the process list and out
+    // of ARG_MAX.
+    expect(seenStdin).toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(seenStdin).toContain('RUBRIC BODY');
     expect(seenEnv.CLAUDE_CODE_SKIP_PROMPT_HISTORY).toBe('1');
 
     expect(rec.perCategory[0]?.action).toBe('block');
+  });
+
+  it('passes the prompt on stdin, never in argv', () => {
+    let seenArgv: readonly string[] = [],
+      seenStdin = '';
+    const rec = runJudge(
+      [
+        {
+          ruleId: 'r',
+          category: 'secret',
+          severity: 'high',
+          maskedMatch: 'A***E',
+          rawMatch: 'AKIAREALKEY',
+          context: 'x',
+          confidence: 0.9,
+          id: '0',
+          valueFingerprint: 'fp1',
+          keyVersion: 1,
+        },
+      ],
+      {
+        spawn: (argv, _env, stdin) => {
+          seenArgv = argv;
+          seenStdin = stdin;
+          return JSON.stringify({
+            is_error: false,
+            result: '```json\n{"perCategory":[],"notes":"ok"}\n```',
+          });
+        },
+        loadRubric: () => 'RUBRIC',
+      },
+    );
+    expect(seenArgv).toEqual(['-p', '--no-session-persistence', '--output-format', 'json']);
+    expect(seenArgv.join(' ')).not.toContain('AKIAREALKEY');
+    expect(seenStdin).toContain('AKIAREALKEY'); // raw rides stdin, isolated subprocess only
+    expect(rec.notes).toBe('ok');
   });
 
   it('re-throws a spawn failure as raw-free metadata (execFileSync puts the prompt in .message)', () => {

--- a/plugins/claude-code/test/triage/merge.test.ts
+++ b/plugins/claude-code/test/triage/merge.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { chunkForJudge, mergeRecommendations } from '../../src/triage/merge.ts';
+
+describe('mergeRecommendations', () => {
+  it('merges per category: sums, unions ids, strictest action wins', () => {
+    const m = mergeRecommendations([
+      {
+        perCategory: [
+          {
+            category: 'secret',
+            action: 'warn',
+            reasoning: 'a',
+            genuineCount: 1,
+            fpCount: 1,
+            fpIds: ['1'],
+          },
+        ],
+        notes: 'n1',
+      },
+      {
+        perCategory: [
+          {
+            category: 'secret',
+            action: 'redact',
+            reasoning: 'b',
+            genuineCount: 2,
+            fpCount: 0,
+            fpIds: [],
+          },
+          {
+            category: 'pii',
+            action: 'warn',
+            reasoning: 'c',
+            genuineCount: 1,
+            fpCount: 0,
+            fpIds: [],
+          },
+        ],
+        notes: 'n2',
+      },
+    ]);
+    const sec = m.perCategory.find((c) => c.category === 'secret');
+    if (sec === undefined) throw new Error('expected a merged secret category');
+    expect([sec.genuineCount, sec.fpCount, sec.action, sec.fpIds]).toEqual([3, 1, 'redact', ['1']]);
+    expect(m.notes).toBe('n1\nn2');
+  });
+});
+
+describe('chunkForJudge', () => {
+  it('chunkForJudge returns a single chunk under the cap', () => {
+    expect(
+      chunkForJudge(
+        [
+          {
+            ruleId: 'r',
+            category: 'secret',
+            severity: 'high',
+            maskedMatch: 'm',
+            rawMatch: 'raw',
+            context: 'c',
+            confidence: 0.9,
+          },
+        ],
+        262_144,
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/plugins/claude-code/tsup.config.ts
+++ b/plugins/claude-code/tsup.config.ts
@@ -81,5 +81,12 @@ export default defineConfig({
     // default path (eval/prompt.md) is not in the package `files`, so the adapter
     // reads scripts/triage-rubric.md at runtime — copied here from the single source.
     copyFileSync('eval/prompt.md', join('scripts', 'triage-rubric.md'));
+    // Mark the emitted scripts as ESM. The plugin ships to the Claude Code plugin
+    // cache as scripts/ without the plugin's own package.json, so Node has no
+    // "type" field nearby and walks the directory tree to infer the module type —
+    // printing a MODULE_TYPELESS_PACKAGE_JSON reparse warning on every invocation.
+    // A package.json beside the scripts is the nearest ancestor Node finds, so it
+    // reads them as ESM directly and the warning never fires.
+    writeFileSync(join('scripts', 'package.json'), JSON.stringify({ type: 'module' }) + '\n');
   },
 });

--- a/rules/core-code-context/db-table-name.json
+++ b/rules/core-code-context/db-table-name.json
@@ -10,7 +10,6 @@
       "SELECT * FROM ",
       "SELECT COUNT(*) FROM ",
       "INSERT INTO ",
-      "UPDATE ",
       "DELETE FROM ",
       "CREATE TABLE ",
       "ALTER TABLE ",

--- a/rules/core-code-context/fixtures/db-table-name.json
+++ b/rules/core-code-context/fixtures/db-table-name.json
@@ -23,5 +23,10 @@
     "label": "not SQL",
     "text": "FROM the bottom of my heart",
     "shouldMatch": false
+  },
+  {
+    "label": "prose verb 'update', not a SQL statement",
+    "text": "rebuild the dev bundle and update the plugin",
+    "shouldMatch": false
   }
 ]


### PR DESCRIPTION
## Summary

Two changes to the Claude Code plugin's `/aka:setup` flow.

### Engine — fix an E2BIG crash in setup-triage and cut redundant work

- The setup-triage judge passed its entire prompt as a command-line argument to the `claude -p` subprocess, which fails with `E2BIG` ("argument list too long") on machines with a large history. The prompt now travels on the subprocess **stdin**, removing the ceiling. This is also a safety improvement — the prompt no longer appears in the process argument list.
- Hits are **deduplicated by value identity** before judging, so the judge sees one representative per distinct value instead of every occurrence; value-scoped suppression still covers all occurrences. A **batch + merge** fallback bounds the work when the distinct-value set is itself large.

### Copy — a consistent, accurate setup-wizard voice

- One controlled vocabulary across the wizard (detections / results / detection category / detection level).
- First-run and calibration copy is accurate on every path — no "calibrated" claim when nothing was scanned; the fallback heading reads honestly whether the user declined the scan, the scan came back clean, or no history was available.
- The two intro cards are merged into one; developer internals (settings keys, file paths) are dropped from user-facing confirmations.

## Testing

- `pnpm --filter @akasecurity/ai-tc-claude-code test` — 726 passing
- `pnpm --filter @akasecurity/schema test` — 515 passing
- lint + typecheck clean


## Additional changes since review

- Review fixes: honest decline copy, store-vs-scan counts, "detection categories" vocabulary, and a hygiene scrub (settings.json / internal case-ids out of user-facing copy + comments).
- Warmer CLI-install prompt.
- ESM `scripts/package.json` marker — silences a Node module-type reparse warning on the bundled plugin scripts.
- Detection-rule fix: drop the over-broad `UPDATE ` keyword from `db-table-name` (+ fixture).
