### PR TITLE
Scope the triage dedupe to values, ground the judge verdict, keep chunk reasonings

### DIFF
--- a/plugins/claude-code/eval/prompt-contract.ts
+++ b/plugins/claude-code/eval/prompt-contract.ts
@@ -34,6 +34,7 @@ import type {
   BuiltinPolicyId,
   CalibrationFrame,
   DetectionCategory,
+  MaskedSecretFinding,
   SecretFindingState,
 } from '@akasecurity/schema';
 import {
@@ -174,29 +175,40 @@ export function checkNarrationContract(
   }
 
   for (const fact of claims.citedFindingFacts) {
-    const finding = (frame.maskedFindings ?? []).find((f) => f.maskedToken === fact.maskedToken);
-    if (!finding) {
+    // One leaked value can be found in several artifacts, and the frame carries
+    // one finding per OCCURRENCE (each with its own location — that is what puts
+    // a file in redaction scope). So a masked token can name SEVERAL findings,
+    // and an asserted attribute is grounded when it matches any of them: pinning
+    // the check to the first would reject a true statement about the second file
+    // the same key was found in.
+    const cited = (frame.maskedFindings ?? []).filter((f) => f.maskedToken === fact.maskedToken);
+    if (cited.length === 0) {
       return {
         ok: false,
         reason: `cited finding "${fact.maskedToken}" has no corresponding frame fact — invented claim`,
       };
     }
-    if (fact.assertedProvider !== undefined && fact.assertedProvider !== finding.provider) {
+    const grounded = <T>(
+      asserted: T | undefined,
+      recorded: (f: MaskedSecretFinding) => T,
+    ): boolean => asserted === undefined || cited.some((f) => recorded(f) === asserted);
+
+    if (!grounded(fact.assertedProvider, (f) => f.provider)) {
       return {
         ok: false,
-        reason: `cited finding "${fact.maskedToken}" asserts provider "${fact.assertedProvider}", but the frame records provider "${finding.provider}" — invented finding attribute`,
+        reason: `cited finding "${fact.maskedToken}" asserts provider "${String(fact.assertedProvider)}", but the frame records provider(s) ${cited.map((f) => `"${f.provider}"`).join(', ')} — invented finding attribute`,
       };
     }
-    if (fact.assertedLocation !== undefined && fact.assertedLocation !== finding.where.filePath) {
+    if (!grounded(fact.assertedLocation, (f) => f.where.filePath)) {
       return {
         ok: false,
-        reason: `cited finding "${fact.maskedToken}" asserts location "${fact.assertedLocation}", but the frame records location "${finding.where.filePath}" — invented finding attribute`,
+        reason: `cited finding "${fact.maskedToken}" asserts location "${String(fact.assertedLocation)}", but the frame records location(s) ${cited.map((f) => `"${f.where.filePath}"`).join(', ')} — invented finding attribute`,
       };
     }
-    if (fact.assertedState !== undefined && fact.assertedState !== finding.state) {
+    if (!grounded(fact.assertedState, (f) => f.state)) {
       return {
         ok: false,
-        reason: `cited finding "${fact.maskedToken}" asserts state "${fact.assertedState}", but the frame records state "${finding.state}" — invented finding attribute`,
+        reason: `cited finding "${fact.maskedToken}" asserts state "${String(fact.assertedState)}", but the frame records state(s) ${cited.map((f) => `"${f.state}"`).join(', ')} — invented finding attribute`,
       };
     }
   }

--- a/plugins/claude-code/eval/prompt.md
+++ b/plugins/claude-code/eval/prompt.md
@@ -66,7 +66,8 @@ one** fenced JSON block containing a `TriageRecommendation`:
       "action": "block",
       "reasoning": "one or two sentences, no negative framing of the FPs",
       "genuineCount": 2,
-      "fpCount": 2
+      "fpCount": 2,
+      "fpIds": ["3", "17"]
     }
   ],
   "notes": ""
@@ -78,6 +79,13 @@ one** fenced JSON block containing a `TriageRecommendation`:
 - `action` must be exactly one of `monitor`, `warn`, `redact`, `block`.
 - `genuineCount` and `fpCount` are your counts of genuine vs. false-positive
   hits you identified within that category (both required, both ≥ 0).
+- `fpIds` (required) lists the `id` of every hit in that category you judged a
+  false positive. **Copy each `id` verbatim from the hit you are describing** —
+  they are stable identifiers assigned by the scanner, not positions in the
+  input. Do not renumber them, do not start from 1, and never emit an `id` that
+  is not present in the hits you were given: ids you were not shown belong to
+  other hits, and naming one would silence a detection you never examined.
+  `fpCount` must equal `fpIds.length`.
 - `notes` is optional free text (empty string if nothing to add) for anything
   that doesn't fit a single category — e.g. cross-category observations.
 - The fenced ```json block must be the last thing in your reply and must

--- a/plugins/claude-code/src/remediation/entry.ts
+++ b/plugins/claude-code/src/remediation/entry.ts
@@ -82,10 +82,17 @@ const FRAME_READ_NOTE =
 // unreadable/malformed frame yields 0 (no fabricated figure) rather than
 // throwing — the caller already degraded honestly if the frame itself could
 // not be read.
-function moreWorthALook(frameText: string, secretCount: number): number {
+//
+// SCOPE: `counts.important` counts distinct VALUES (the judge reasons over one
+// representative per value), while `findings` carries one entry per artifact a
+// value was found in. Subtracting the raw finding count would mix the two and
+// understate the remainder whenever one key sits in several transcripts, so the
+// batch's coverage is converted to its distinct-value count first.
+function moreWorthALook(frameText: string, findings: readonly MaskedSecretFinding[]): number {
   try {
     const frame = CalibrationFrame.parse(readFrameJsonBlock(frameText));
-    return Math.max(0, frame.counts.important - secretCount);
+    const distinctValues = new Set(findings.map((f) => f.maskedToken)).size;
+    return Math.max(0, frame.counts.important - distinctValues);
   } catch {
     return 0;
   }
@@ -109,7 +116,7 @@ function present(frameText: string): void {
   }
   const layout = renderRemediationDecision(
     findings,
-    moreWorthALook(frameText, decision.secretCount),
+    moreWorthALook(frameText, findings),
     readRegisteredCommands(),
   );
   process.stdout.write(`${decision.prompt}\n\n${fenced(layout)}\n`);

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -31,7 +31,7 @@ import { frameJsonBlock } from '../setup-frame-json.ts';
 import { dedupeForJudge } from './dedupe.ts';
 import { deriveFalsePositivePatterns } from './false-positive-patterns.ts';
 import { renderPosturePlan, renderShowcase, renderSuppressionGate } from './gate-display.ts';
-import { chunkForJudge, chunkIds, mergeRecommendations } from './merge.ts';
+import { chunkForJudge, chunkIds, groundVerdict, mergeRecommendations } from './merge.ts';
 import { deletePlanFile, readPlanFile, writePlanFile } from './plan-file.ts';
 import { deriveSurfacedSecretFindings } from './surfaced-secrets.ts';
 import {
@@ -153,7 +153,11 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       // chunkForJudge always returns at least one chunk for a non-empty input
       // (reps is non-empty: runPreview already returned on hits.length === 0).
       if (soleChunk === undefined) throw new Error('chunkForJudge returned no chunks');
-      rec = deps.runJudge(soleChunk);
+      // Grounded even though there is only one batch: the judge saw the
+      // representative set, not the full hit list, so an fpId naming a
+      // collapsed duplicate is still an id it never read — and a value-scoped
+      // consumer would expand that one id across the whole value class.
+      rec = groundVerdict(deps.runJudge(soleChunk), chunkIds(soleChunk));
     } else {
       // Each chunk's verdict is paired with the ids that chunk actually
       // contained: the merge drops any fpId naming a hit its judge never saw,

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -80,7 +80,9 @@ export interface AdapterDeps {
   planIO?: PlanFileIO;
   // Byte budget per judging batch. Defaults to chunkForJudge's own; injectable
   // so a test can drive the multi-batch path without a quarter-megabyte of
-  // fixture, which is otherwise the only way to reach it.
+  // fixture, which is otherwise the only way to reach it. `--max-judge-bytes`
+  // (below) exposes the same override on the command line, so the batch path
+  // can be exercised on a real machine without a giant history.
   maxJudgeBytes?: number;
 }
 
@@ -89,6 +91,21 @@ function getFlag(argv: readonly string[], name: string): string | undefined {
   if (i === -1) return undefined;
   const next = argv[i + 1];
   return next !== undefined && !next.startsWith('--') ? next : '';
+}
+
+// The per-batch byte budget, from `--max-judge-bytes N` or the injected dep.
+// Reaching the batch path otherwise takes a quarter-megabyte of real history,
+// so this is how the fallback gets exercised deliberately — set it low (a few
+// thousand) against a small history and every hit becomes its own batch.
+// Ignores a missing/zero/non-numeric value and falls back to the default,
+// rather than letting a typo silently disable batching.
+function resolveMaxJudgeBytes(deps: AdapterDeps): number | undefined {
+  const flag = getFlag(deps.argv, 'max-judge-bytes');
+  if (flag !== undefined && flag !== '') {
+    const parsed = Number(flag);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return deps.maxJudgeBytes;
 }
 
 // Returns a process exit code (0 ok, 1 failure). Never calls process.exit itself.
@@ -146,7 +163,16 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // representative's verdict covers every occurrence, so the judge (and every
     // downstream derivation below) reasons over distinct values, not raw counts.
     const reps = dedupeForJudge(hits);
-    const chunks = chunkForJudge(reps, deps.maxJudgeBytes);
+    const chunks = chunkForJudge(reps, resolveMaxJudgeBytes(deps));
+    if (chunks.length > 1) {
+      // Say so BEFORE the judging runs: each batch is its own `claude -p`
+      // subprocess, so a large history sits here for a while with nothing else
+      // on screen. It also makes the fallback observable — otherwise the only
+      // difference between one batch and ten is how long the wizard hangs.
+      deps.stdout(
+        `Reviewing ${String(reps.length)} distinct values in ${String(chunks.length)} batches — this is the large-history path, so give it a moment.\n\n`,
+      );
+    }
     let rec: TriageRecommendation;
     if (chunks.length === 1) {
       const [soleChunk] = chunks;

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -31,7 +31,7 @@ import { frameJsonBlock } from '../setup-frame-json.ts';
 import { dedupeForJudge } from './dedupe.ts';
 import { deriveFalsePositivePatterns } from './false-positive-patterns.ts';
 import { renderPosturePlan, renderShowcase, renderSuppressionGate } from './gate-display.ts';
-import { chunkForJudge, mergeRecommendations } from './merge.ts';
+import { chunkForJudge, chunkIds, mergeRecommendations } from './merge.ts';
 import { deletePlanFile, readPlanFile, writePlanFile } from './plan-file.ts';
 import { deriveSurfacedSecretFindings } from './surfaced-secrets.ts';
 import {
@@ -78,6 +78,10 @@ export interface AdapterDeps {
   stdout: (s: string) => void;
   stderr: (s: string) => void;
   planIO?: PlanFileIO;
+  // Byte budget per judging batch. Defaults to chunkForJudge's own; injectable
+  // so a test can drive the multi-batch path without a quarter-megabyte of
+  // fixture, which is otherwise the only way to reach it.
+  maxJudgeBytes?: number;
 }
 
 function getFlag(argv: readonly string[], name: string): string | undefined {
@@ -118,7 +122,11 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       deps.stdout(frameJsonBlock(empty.frame));
       return 0;
     }
-    deps.stdout("I didn't find anything to review — nothing to tune.\n");
+    // The only status that reaches here is `skipped:no-consent` — the backfill
+    // refused to read history because access was never granted. Nothing was
+    // examined, so this must not borrow the looked-and-found-nothing copy above:
+    // that would report a clean bill of health for a scan that never ran.
+    deps.stdout("I didn't review anything — historical access wasn't granted.\n");
     return 0;
   }
 
@@ -138,7 +146,7 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // representative's verdict covers every occurrence, so the judge (and every
     // downstream derivation below) reasons over distinct values, not raw counts.
     const reps = dedupeForJudge(hits);
-    const chunks = chunkForJudge(reps);
+    const chunks = chunkForJudge(reps, deps.maxJudgeBytes);
     let rec: TriageRecommendation;
     if (chunks.length === 1) {
       const [soleChunk] = chunks;
@@ -147,7 +155,10 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       if (soleChunk === undefined) throw new Error('chunkForJudge returned no chunks');
       rec = deps.runJudge(soleChunk);
     } else {
-      rec = mergeRecommendations(chunks.map((c) => deps.runJudge(c)));
+      // Each chunk's verdict is paired with the ids that chunk actually
+      // contained: the merge drops any fpId naming a hit its judge never saw,
+      // which a single judgment guaranteed structurally and chunking does not.
+      rec = mergeRecommendations(chunks.map((c) => ({ rec: deps.runJudge(c), ids: chunkIds(c) })));
     }
     // Fed the SAME representative set the judge saw, so the join/fpIds the plan
     // resolves suppressions from line up with the ids the verdict references.
@@ -216,11 +227,22 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // secret hits the model did NOT dismiss as false positives, projected to the
     // raw-free MaskedSecretFinding shape and carried additively in the frame.
     // Empty for a clean/all-suppressed run, so the optional field is omitted.
-    const maskedFindings = deriveSurfacedSecretFindings(reps, rec, plan);
+    // Fed the FULL hit list, NOT `reps`: this is the pipeline's one
+    // location-scoped consumer — each finding carries a single filePath, and
+    // that path is both the only thing that puts a file in the redaction pass's
+    // scope and the unit the complete-vs-partial redaction gate counts. One key
+    // pasted into three transcripts must surface as three findings or redaction
+    // strikes one file and still reports the run resolved. The judge's
+    // value-scoped dismissal is expanded back over each class inside.
+    const maskedFindings = deriveSurfacedSecretFindings(hits, rec, plan);
     // The masked false-positive pattern groups the fixture/exception offer names
     // its pattern and count from: the marked hits, re-derived to their masked
     // token and grouped, carried additively in the frame. Empty when nothing was
     // marked a false positive, so the optional field is omitted (fail-open).
+    // `reps` on purpose (unlike maskedFindings above): the offer writes
+    // fingerprint-keyed exceptions, so its unit is the distinct VALUE — one
+    // exception covers every occurrence, and counting occurrences here would
+    // inflate the offer's count over the number of exceptions it can grant.
     const falsePositivePatterns = deriveFalsePositivePatterns(reps, rec, plan);
     const calibration = frameCalibration(preview, maskedFindings, falsePositivePatterns);
 

--- a/plugins/claude-code/src/triage/dedupe.ts
+++ b/plugins/claude-code/src/triage/dedupe.ts
@@ -1,14 +1,42 @@
+/**
+ * Value-identity collapse for the setup-triage judge. Repeated occurrences of
+ * the same detected value under the same rule are ONE judgment, not many: the
+ * judge reasons over distinct values, and value-scoped suppression carries that
+ * one verdict back to every occurrence.
+ *
+ * SCOPE — read before choosing which list to hand a consumer. The key is
+ * deliberately file-independent (`valueFingerprint` is an HMAC of the raw value
+ * alone; see backfill.ts), so the collapsed set is:
+ *   - the RIGHT input for a VALUE-scoped consumer — the judge, and the
+ *     suppression writeback whose exceptions key on
+ *     (ruleId, valueFingerprint, keyVersion);
+ *   - the WRONG input for a LOCATION-scoped one — a `MaskedSecretFinding`
+ *     carries a single `where.filePath` and the redaction pass only ever opens
+ *     files a finding names, so a collapsed set would strike one file, leave
+ *     the key live in the others, and still satisfy the complete-redaction
+ *     honesty gate (which counts those same findings).
+ * A location-scoped consumer therefore takes the FULL hit list and expands the
+ * judge's per-representative verdict back over the class with `dedupeKey`.
+ */
 import type { TriageHit } from '@akasecurity/schema';
+
+// The value identity a hit collapses on. `undefined` for a hit the sink could
+// not fingerprint — it has no value identity to share, so it is never collapsed
+// into another hit and never inherits another hit's verdict.
+export function dedupeKey(hit: TriageHit): string | undefined {
+  if (hit.valueFingerprint === undefined) return undefined;
+  return `${hit.ruleId}█${hit.valueFingerprint}`;
+}
 
 export function dedupeForJudge(hits: readonly TriageHit[]): TriageHit[] {
   const seen = new Set<string>();
   const out: TriageHit[] = [];
   for (const h of hits) {
-    if (h.valueFingerprint === undefined) {
+    const key = dedupeKey(h);
+    if (key === undefined) {
       out.push(h);
       continue;
     }
-    const key = `${h.ruleId}█${h.valueFingerprint}`;
     if (seen.has(key)) continue;
     seen.add(key);
     out.push(h);

--- a/plugins/claude-code/src/triage/merge.ts
+++ b/plugins/claude-code/src/triage/merge.ts
@@ -1,11 +1,46 @@
+/**
+ * Batch-and-merge fallback for the setup-triage judge. When the distinct-value
+ * set is too large for one judgment, `chunkForJudge` splits it by serialized
+ * byte budget and `mergeRecommendations` folds the per-chunk verdicts back into
+ * the single `TriageRecommendation` the rest of the pipeline consumes.
+ *
+ * Chunking costs two invariants that a single judgment gave for free, and both
+ * are restored here rather than downstream:
+ *
+ *  1. GROUNDED IDS. A verdict's `fpIds` are resolved against the join built
+ *     from the FULL representative set (writeback.ts), so an id a chunk's judge
+ *     invented — or renumbered locally, which lands squarely in a sibling
+ *     chunk's id space, since backfill.ts numbers hits with one monotonic
+ *     stream ordinal — would suppress, and silently un-surface, a hit that
+ *     judge never read. Each chunk's ids are therefore filtered to the hits
+ *     that chunk actually contained, and anything dropped is reported.
+ *
+ *  2. CATEGORY DISTRUST. writeback.ts rejects a whole category whose
+ *     `reasoning` echoes a raw detected value, explicitly so that "a poisoned
+ *     first occurrence [is not] 'rescued' by a later duplicate — once a
+ *     category leaked raw we distrust it for the whole run". Keeping only one
+ *     chunk's reasoning would discard the poisoned sibling before that check
+ *     ever runs. Every chunk's reasoning is therefore carried into the merged
+ *     text, so `assertRawFree` sees all of it and one poisoned chunk still
+ *     distrusts the category.
+ */
 import type {
   BuiltinPolicyId,
+  DetectionCategory,
   TriageCategoryRec,
   TriageHit,
   TriageRecommendation,
 } from '@akasecurity/schema';
 
 const RANK: Record<BuiltinPolicyId, number> = { monitor: 0, warn: 1, redact: 2, block: 3 };
+
+// One chunk's judgment, paired with the ids of the hits that chunk's judge
+// actually saw. The pairing is the point: an `fpId` is only grounded in
+// evidence when it names a hit that was in the batch the verdict describes.
+export interface ChunkVerdict {
+  readonly rec: TriageRecommendation;
+  readonly ids: ReadonlySet<string>;
+}
 
 export function chunkForJudge(hits: readonly TriageHit[], maxBytes = 262_144): TriageHit[][] {
   const chunks: TriageHit[][] = [];
@@ -25,34 +60,67 @@ export function chunkForJudge(hits: readonly TriageHit[], maxBytes = 262_144): T
   return chunks;
 }
 
-export function mergeRecommendations(recs: readonly TriageRecommendation[]): TriageRecommendation {
-  if (recs.length === 1) {
-    const [sole] = recs;
-    if (sole === undefined) throw new Error('mergeRecommendations: empty recommendation');
-    return sole;
-  }
-  const byCat = new Map<string, TriageCategoryRec>();
-  for (const rec of recs) {
+// The ids a chunk's judge saw, for pairing with its verdict. A hit the sink
+// could not id contributes nothing — a verdict can't reference what has no id.
+export function chunkIds(hits: readonly TriageHit[]): Set<string> {
+  return new Set(hits.map((h) => h.id).filter((id): id is string => id !== undefined));
+}
+
+// Accumulator: a category's merged row plus every chunk's reasoning, kept with
+// the rank of the action it argued for so the strictest one can lead.
+interface CategoryAccumulator extends TriageCategoryRec {
+  reasonings: { rank: number; text: string }[];
+}
+
+// The strictest chunk's reasoning first (it argues for the action that won), then
+// the rest in chunk order — Array.sort is stable, so equal ranks keep their
+// order. Identical texts collapse. Every chunk's text survives, which is what
+// keeps writeback's raw-echo distrust honest across a merge.
+function joinReasonings(reasonings: readonly { rank: number; text: string }[]): string {
+  const ordered = [...reasonings].sort((a, b) => b.rank - a.rank);
+  return [...new Set(ordered.map((r) => r.text.trim()).filter((t) => t !== ''))].join(' ');
+}
+
+export function mergeRecommendations(verdicts: readonly ChunkVerdict[]): TriageRecommendation {
+  const byCat = new Map<DetectionCategory, CategoryAccumulator>();
+  const strayNotes: string[] = [];
+
+  for (const { rec, ids } of verdicts) {
     for (const c of rec.perCategory) {
+      // Drop ids this chunk's judge could not have been describing, and say so:
+      // silence here would look identical to a clean verdict at the human gate.
+      const grounded = c.fpIds.filter((id) => ids.has(id));
+      const strayCount = c.fpIds.length - grounded.length;
+      if (strayCount > 0) {
+        strayNotes.push(
+          `${c.category}: dropped ${String(strayCount)} false-positive id(s) naming hits outside the batch they were judged in`,
+        );
+      }
+      const entry = { rank: RANK[c.action], text: c.reasoning };
       const prev = byCat.get(c.category);
       if (!prev) {
-        byCat.set(c.category, { ...c, fpIds: [...c.fpIds] });
+        byCat.set(c.category, { ...c, fpIds: [...grounded], reasonings: [entry] });
         continue;
       }
       prev.genuineCount += c.genuineCount;
+      // The model's CLAIMED count, summed as-is — deliberately NOT recomputed
+      // from `fpIds`. resolve.ts compares the two and surfaces any divergence to
+      // the human gate ('model reported N FPs, M resolved'), which is exactly the
+      // signal a dropped stray id should raise; recomputing would erase it.
       prev.fpCount += c.fpCount;
-      prev.fpIds = [...new Set([...prev.fpIds, ...c.fpIds])];
-      if (RANK[c.action] > RANK[prev.action]) {
-        prev.action = c.action;
-        prev.reasoning = c.reasoning;
-      }
+      prev.fpIds = [...new Set([...prev.fpIds, ...grounded])];
+      prev.reasonings.push(entry);
+      // Strictest action wins, so a merge can only ever tighten.
+      if (RANK[c.action] > RANK[prev.action]) prev.action = c.action;
     }
   }
+
+  const perCategory = [...byCat.values()].map(({ reasonings, ...cat }): TriageCategoryRec => ({
+    ...cat,
+    reasoning: joinReasonings(reasonings),
+  }));
   return {
-    perCategory: [...byCat.values()],
-    notes: recs
-      .map((r) => r.notes)
-      .filter(Boolean)
-      .join('\n'),
+    perCategory,
+    notes: [...verdicts.map((v) => v.rec.notes), ...strayNotes].filter(Boolean).join('\n'),
   };
 }

--- a/plugins/claude-code/src/triage/merge.ts
+++ b/plugins/claude-code/src/triage/merge.ts
@@ -81,34 +81,54 @@ function joinReasonings(reasonings: readonly { rank: number; text: string }[]): 
   return [...new Set(ordered.map((r) => r.text.trim()).filter((t) => t !== ''))].join(' ');
 }
 
+// Drop every fpId that names a hit the judge behind this verdict did not see,
+// and disclose each drop in `notes` — silence would look identical to a clean
+// verdict at the human gate.
+//
+// This runs on EVERY judging path, not only the chunked one. Dedupe alone is
+// enough to need it: the judge is shown the representative set while downstream
+// consumers hold the full hit list, so an id naming a collapsed duplicate is an
+// id the judge never read. Left ungrounded it is not merely inert — a
+// value-scoped consumer expands one such id across the whole value class and
+// silently buries a key the judge called genuine.
+export function groundVerdict(
+  rec: TriageRecommendation,
+  ids: ReadonlySet<string>,
+): TriageRecommendation {
+  const perCategory: TriageCategoryRec[] = [];
+  const strayNotes: string[] = [];
+  for (const c of rec.perCategory) {
+    const grounded = c.fpIds.filter((id) => ids.has(id));
+    const strayCount = c.fpIds.length - grounded.length;
+    if (strayCount > 0) {
+      strayNotes.push(
+        `${c.category}: dropped ${String(strayCount)} false-positive id(s) naming hits outside the batch they were judged in`,
+      );
+    }
+    // fpCount keeps the model's CLAIMED count, deliberately NOT recomputed from
+    // the grounded ids. resolve.ts compares the two and surfaces any divergence
+    // to the human gate ('model reported N FPs, M resolved') — exactly the
+    // signal a dropped stray id should raise; recomputing would erase it.
+    perCategory.push({ ...c, fpIds: grounded });
+  }
+  return { perCategory, notes: [rec.notes, ...strayNotes].filter(Boolean).join('\n') };
+}
+
 export function mergeRecommendations(verdicts: readonly ChunkVerdict[]): TriageRecommendation {
   const byCat = new Map<DetectionCategory, CategoryAccumulator>();
-  const strayNotes: string[] = [];
+  const grounded = verdicts.map((v) => groundVerdict(v.rec, v.ids));
 
-  for (const { rec, ids } of verdicts) {
+  for (const rec of grounded) {
     for (const c of rec.perCategory) {
-      // Drop ids this chunk's judge could not have been describing, and say so:
-      // silence here would look identical to a clean verdict at the human gate.
-      const grounded = c.fpIds.filter((id) => ids.has(id));
-      const strayCount = c.fpIds.length - grounded.length;
-      if (strayCount > 0) {
-        strayNotes.push(
-          `${c.category}: dropped ${String(strayCount)} false-positive id(s) naming hits outside the batch they were judged in`,
-        );
-      }
       const entry = { rank: RANK[c.action], text: c.reasoning };
       const prev = byCat.get(c.category);
       if (!prev) {
-        byCat.set(c.category, { ...c, fpIds: [...grounded], reasonings: [entry] });
+        byCat.set(c.category, { ...c, fpIds: [...c.fpIds], reasonings: [entry] });
         continue;
       }
       prev.genuineCount += c.genuineCount;
-      // The model's CLAIMED count, summed as-is — deliberately NOT recomputed
-      // from `fpIds`. resolve.ts compares the two and surfaces any divergence to
-      // the human gate ('model reported N FPs, M resolved'), which is exactly the
-      // signal a dropped stray id should raise; recomputing would erase it.
       prev.fpCount += c.fpCount;
-      prev.fpIds = [...new Set([...prev.fpIds, ...grounded])];
+      prev.fpIds = [...new Set([...prev.fpIds, ...c.fpIds])];
       prev.reasonings.push(entry);
       // Strictest action wins, so a merge can only ever tighten.
       if (RANK[c.action] > RANK[prev.action]) prev.action = c.action;
@@ -121,6 +141,9 @@ export function mergeRecommendations(verdicts: readonly ChunkVerdict[]): TriageR
   }));
   return {
     perCategory,
-    notes: [...verdicts.map((v) => v.rec.notes), ...strayNotes].filter(Boolean).join('\n'),
+    notes: grounded
+      .map((r) => r.notes)
+      .filter(Boolean)
+      .join('\n'),
   };
 }

--- a/plugins/claude-code/src/triage/surfaced-secrets.ts
+++ b/plugins/claude-code/src/triage/surfaced-secrets.ts
@@ -18,6 +18,7 @@ import type {
   TriageRecommendation,
 } from '@akasecurity/schema';
 
+import { dedupeKey } from './dedupe.ts';
 import type { TriageWritebackPlan } from './writeback.ts';
 
 // A leaked key's live/revoked status is genuinely unknowable on this machine: the
@@ -51,6 +52,16 @@ export function deriveProvider(ruleId: string): string {
 // fingerprint alone). A secret category the plan distrusted (its reasoning echoed
 // a raw value, so it carries no posture) surfaces nothing, staying consistent
 // with the frame's surfacedCategories.
+//
+// LOCATION-SCOPED: this takes the FULL hit list, never the judge's collapsed
+// representative set. One finding is emitted per OCCURRENCE because each
+// carries a single `where.filePath` and is the only thing that puts a file in
+// the redaction pass's scope (see remediation/surfaced-redact.ts, which builds
+// its per-file map exclusively from these paths) and the only thing the
+// complete-vs-partial redaction gate counts. Collapsing here would strike the
+// first file a key was found in, leave it live in the rest, and still print
+// the clean "resolved" framing. The judge's verdict, which IS value-scoped, is
+// expanded back over each value class below so the two scopes stay consistent.
 export function deriveSurfacedSecretFindings(
   hits: readonly TriageHit[],
   rec: TriageRecommendation,
@@ -61,10 +72,27 @@ export function deriveSurfacedSecretFindings(
   const dismissedIds = new Set(
     rec.perCategory.filter((c) => c.category === 'secret').flatMap((c) => c.fpIds),
   );
+  // The judge saw ONE representative per (ruleId, valueFingerprint) class, so a
+  // dismissal binds every occurrence of that value — expand the id verdict to
+  // the whole class, or a dismissed representative's duplicates would surface
+  // as live leaks the model has already ruled out. A hit with no fingerprint
+  // has no class, so it neither joins nor inherits one (dedupeKey ->
+  // undefined), preserving the id-keyed behaviour above for it.
+  const dismissedKeys = new Set(
+    hits
+      .filter((h) => h.id !== undefined && dismissedIds.has(h.id))
+      .map((h) => dedupeKey(h))
+      .filter((k): k is string => k !== undefined),
+  );
+  const isDismissed = (h: TriageHit): boolean => {
+    if (h.id !== undefined && dismissedIds.has(h.id)) return true;
+    const key = dedupeKey(h);
+    return key !== undefined && dismissedKeys.has(key);
+  };
   const rawValues = hits.map((h) => h.rawMatch);
 
   return hits
-    .filter((h) => h.category === 'secret' && !(h.id !== undefined && dismissedIds.has(h.id)))
+    .filter((h) => h.category === 'secret' && !isDismissed(h))
     .map((h) => ({
       provider: deriveProvider(h.ruleId),
       maskedToken: safeMaskedMatch(h.rawMatch),

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -1417,3 +1417,78 @@ describe('runApply — an fpId the judge was never shown, on the single-batch pa
     expect(db.created).toEqual([]);
   });
 });
+
+describe('runApply — --max-judge-bytes makes the batch path exercisable', () => {
+  const bigHits = (n: number): TriageHit[] => {
+    const pad = 'x'.repeat(512);
+    return Array.from({ length: n }, (_, i) =>
+      hit({
+        id: String(i),
+        valueFingerprint: String(i).padStart(2, '0').repeat(32),
+        rawMatch: `${RAW}${String(i)}`,
+        context: `export KEY=${RAW}${String(i)} ${pad}`,
+        filePath: `/h/.claude/projects/p/s${String(i)}.jsonl`,
+      }),
+    );
+  };
+  const streamOf = (hits: readonly TriageHit[]): string =>
+    hits.map((h) => JSON.stringify(h)).join('\n') +
+    '\n' +
+    JSON.stringify({ done: true, count: hits.length, status: 'complete' }) +
+    '\n';
+
+  const cleanVerdict = (seen: readonly TriageHit[]): TriageRecommendation => ({
+    perCategory: [
+      {
+        category: 'secret',
+        action: 'warn',
+        reasoning: 'batch verdict',
+        genuineCount: seen.length,
+        fpCount: 0,
+        fpIds: [],
+      },
+    ],
+    notes: '',
+  });
+
+  const drive = async (argv: string[]) => {
+    const hits = bigHits(6);
+    const runJudge = vi.fn(cleanVerdict);
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv,
+      readStream: () => streamOf(hits),
+      runJudge,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    return { code, out: out.join(''), batches: runJudge.mock.calls.length };
+  };
+
+  it('splits into batches and announces it before the judging runs', async () => {
+    const { code, out, batches } = await drive(['--max-judge-bytes', '1200']);
+    expect(code).toBe(0);
+    expect(batches).toBeGreaterThan(1);
+    expect(out).toContain(`in ${String(batches)} batches`);
+    // Announced ahead of the results, so it reads as progress rather than a summary.
+    expect(out.indexOf('batches')).toBeLessThan(out.indexOf('detection level'));
+  });
+
+  it('stays on the single-batch path with no flag, and says nothing about batches', async () => {
+    const { code, out, batches } = await drive([]);
+    expect(code).toBe(0);
+    expect(batches).toBe(1);
+    expect(out).not.toContain('batches');
+  });
+
+  it('ignores a junk value rather than silently disabling batching', async () => {
+    for (const bad of ['0', '-5', 'lots', '']) {
+      const { batches } = await drive(['--max-judge-bytes', bad]);
+      expect(batches).toBe(1);
+    }
+  });
+});

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -191,7 +191,7 @@ describe('runApply — preview renders the no-history empty state on an empty-hi
 });
 
 describe('runApply — preview renders the skipped-scan copy when triage was skipped', () => {
-  it('prints the warm empty-review copy and drops the internal status token', async () => {
+  it('says nothing was reviewed — not that nothing was found — and drops the status token', async () => {
     const db = fakeDb();
     const out: string[] = [];
     const code = await runApply({
@@ -207,7 +207,12 @@ describe('runApply — preview renders the skipped-scan copy when triage was ski
     });
     expect(code).toBe(0);
     const blob = out.join('');
-    expect(blob).toContain("I didn't find anything to review — nothing to tune.");
+    // Nothing was examined here — historical access was never granted. The copy
+    // must not borrow the looked-and-found-nothing wording the scan-ran-clean
+    // branch uses, which would report a clean bill of health for a scan that
+    // never ran.
+    expect(blob).toContain("I didn't review anything — historical access wasn't granted.");
+    expect(blob).not.toContain("didn't find anything");
     // The internal status token never reaches user-facing copy.
     expect(blob).not.toContain('skipped:no-consent');
     expect(blob).not.toContain('No triage hits to review');
@@ -1197,5 +1202,147 @@ describe('runApply — dedups repeated hits before the judge and before the writ
     if (!parsed.success) throw new Error('emitted frame did not validate');
     expect(parsed.data.maskedFindings).toHaveLength(1);
     expect(parsed.data.maskedFindings?.[0]?.maskedToken).toBe(safeMaskedMatch(OTHER));
+  });
+});
+
+describe('runApply — location-scoped findings survive the value-scoped dedup', () => {
+  // The judge is value-scoped (one representative per distinct value); the
+  // surfaced findings are location-scoped (one per artifact holding the key,
+  // because each names the file the redaction pass will open and each is a unit
+  // the complete-vs-partial redaction gate counts). Collapsing the second onto
+  // the first strikes one transcript and still reports the run resolved.
+  it('emits one finding per artifact for a single value found in three transcripts', async () => {
+    const FP1 = 'ef'.repeat(32);
+    const dup = (id: string, tag: string): TriageHit =>
+      hit({
+        id,
+        valueFingerprint: FP1,
+        rawMatch: RAW,
+        context: `export KEY=${RAW} ${tag}`,
+        filePath: `/h/.claude/projects/p/${tag}.jsonl`,
+      });
+    const hits = [dup('0', 's1'), dup('1', 's2'), dup('2', 's3')];
+    const stream =
+      hits.map((h) => JSON.stringify(h)).join('\n') +
+      '\n' +
+      JSON.stringify({ done: true, count: 3, status: 'complete' }) +
+      '\n';
+
+    // Genuine — nothing dismissed, so every occurrence must surface.
+    const runJudge = vi.fn((seen: readonly TriageHit[]): TriageRecommendation => ({
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'redact',
+          reasoning: 'a live-looking key left in old transcripts',
+          genuineCount: seen.length,
+          fpCount: 0,
+          fpIds: [],
+        },
+      ],
+      notes: '',
+    }));
+
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => stream,
+      runJudge,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+
+    // The judge still reasons over ONE representative — the dedup is intact.
+    const [call] = runJudge.mock.calls;
+    if (call === undefined) throw new Error('runJudge was not called');
+    expect(call[0]).toHaveLength(1);
+
+    // ...but all three artifacts reach the frame, so redaction opens all three
+    // and a one-file strike is reported as partial rather than resolved.
+    const parsed = CalibrationFrame.safeParse(readFrameJsonBlock(out.join('')));
+    if (!parsed.success) throw new Error('emitted frame did not validate');
+    expect(parsed.data.maskedFindings?.map((f) => f.where.filePath)).toEqual([
+      '/h/.claude/projects/p/s1.jsonl',
+      '/h/.claude/projects/p/s2.jsonl',
+      '/h/.claude/projects/p/s3.jsonl',
+    ]);
+    // One value, so one masked token — the rows differ only by location.
+    expect(new Set(parsed.data.maskedFindings?.map((f) => f.maskedToken)).size).toBe(1);
+  });
+});
+
+describe('runApply — the batch-and-merge path the large-history fallback takes', () => {
+  // Nothing else in the suite drives chunks.length > 1 through runPreview, so
+  // without this the whole batch/merge fallback ships unexercised end to end.
+  it('judges in batches and refuses an fpId naming a hit its batch never saw', async () => {
+    // 12 distinct values, each ~1KB of context, split by a small byte budget.
+    const pad = 'x'.repeat(1024);
+    const hits = Array.from({ length: 12 }, (_, i) =>
+      hit({
+        id: String(i),
+        valueFingerprint: String(i).padStart(2, '0').repeat(32),
+        rawMatch: `${RAW}${String(i)}`,
+        context: `export KEY=${RAW}${String(i)} ${pad}`,
+        filePath: `/h/.claude/projects/p/s${String(i)}.jsonl`,
+      }),
+    );
+    const stream =
+      hits.map((h) => JSON.stringify(h)).join('\n') +
+      '\n' +
+      JSON.stringify({ done: true, count: 12, status: 'complete' }) +
+      '\n';
+
+    // Every batch dismisses id '0' — grounded for the batch that actually holds
+    // it, an ungrounded cross-batch reference for every other batch.
+    const runJudge = vi.fn((seen: readonly TriageHit[]): TriageRecommendation => ({
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'warn',
+          reasoning: 'batch verdict',
+          genuineCount: seen.length - 1,
+          fpCount: 1,
+          fpIds: ['0'],
+        },
+      ],
+      notes: '',
+    }));
+
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => stream,
+      runJudge,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+      maxJudgeBytes: 3_000,
+    });
+    expect(code).toBe(0);
+    // It really did batch.
+    expect(runJudge.mock.calls.length).toBeGreaterThan(1);
+
+    const blob = out.join('');
+    // The out-of-batch references were dropped and disclosed, not silently kept.
+    expect(blob).toContain('naming hits outside the batch they were judged in');
+
+    // Exactly one suppression is offered — id '0', from the batch that held it.
+    // Without the chunk-membership filter every batch's stray '0' would resolve
+    // against the full join and the other 11 genuine keys would be dismissed
+    // from the remediation table by a judge that never read them.
+    const parsed = CalibrationFrame.safeParse(readFrameJsonBlock(out.join('')));
+    if (!parsed.success) throw new Error('emitted frame did not validate');
+    expect(parsed.data.maskedFindings).toHaveLength(11);
+    expect(parsed.data.maskedFindings?.map((f) => f.where.filePath)).not.toContain(
+      '/h/.claude/projects/p/s0.jsonl',
+    );
   });
 });

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -1346,3 +1346,74 @@ describe('runApply — the batch-and-merge path the large-history fallback takes
     );
   });
 });
+
+describe('runApply — an fpId the judge was never shown, on the single-batch path', () => {
+  // Dedupe alone makes the judged set a strict subset of the hits the frame
+  // derivations hold, so grounding is needed even when there is only one batch.
+  // Ungrounded, one stray id expands across the whole value class and buries a
+  // key the judge called genuine — with no batching involved.
+  it('drops the stray id instead of letting it bury the whole value class', async () => {
+    const FP1 = 'ba'.repeat(32);
+    const dup = (id: string, tag: string): TriageHit =>
+      hit({
+        id,
+        valueFingerprint: FP1,
+        rawMatch: RAW,
+        context: `export KEY=${RAW} ${tag}`,
+        filePath: `/h/.claude/projects/p/${tag}.jsonl`,
+      });
+    const hits = [dup('0', 's1'), dup('1', 's2'), dup('2', 's3')];
+    const stream =
+      hits.map((h) => JSON.stringify(h)).join('\n') +
+      '\n' +
+      JSON.stringify({ done: true, count: 3, status: 'complete' }) +
+      '\n';
+
+    // The judge sees only the representative (id '0') and calls the value
+    // GENUINE — but names id '2', an occurrence collapsed before judging.
+    const runJudge = vi.fn((seen: readonly TriageHit[]): TriageRecommendation => {
+      expect(seen.map((h) => h.id)).toEqual(['0']);
+      return {
+        perCategory: [
+          {
+            category: 'secret',
+            action: 'redact',
+            reasoning: 'a live-looking key left in old transcripts',
+            genuineCount: 1,
+            fpCount: 1,
+            fpIds: ['2'],
+          },
+        ],
+        notes: '',
+      };
+    });
+
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => stream,
+      runJudge,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+
+    const blob = out.join('');
+    expect(blob).toContain('naming hits outside the batch they were judged in');
+
+    // The genuine key still reaches the finding table for all three artifacts.
+    const parsed = CalibrationFrame.safeParse(readFrameJsonBlock(blob));
+    if (!parsed.success) throw new Error('emitted frame did not validate');
+    expect(parsed.data.maskedFindings?.map((f) => f.where.filePath)).toEqual([
+      '/h/.claude/projects/p/s1.jsonl',
+      '/h/.claude/projects/p/s2.jsonl',
+      '/h/.claude/projects/p/s3.jsonl',
+    ]);
+    // Nothing was suppressed on the strength of an id the judge never saw.
+    expect(db.created).toEqual([]);
+  });
+});

--- a/plugins/claude-code/test/triage/merge.test.ts
+++ b/plugins/claude-code/test/triage/merge.test.ts
@@ -1,69 +1,163 @@
+import type { TriageCategoryRec, TriageHit, TriageRecommendation } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
-import { chunkForJudge, mergeRecommendations } from '../../src/triage/merge.ts';
+import {
+  chunkForJudge,
+  chunkIds,
+  type ChunkVerdict,
+  mergeRecommendations,
+} from '../../src/triage/merge.ts';
+
+const hit = (o: Partial<TriageHit> = {}): TriageHit => ({
+  ruleId: 'r',
+  category: 'secret',
+  severity: 'high',
+  maskedMatch: 'm',
+  rawMatch: 'raw',
+  context: 'c',
+  confidence: 0.9,
+  ...o,
+});
+
+const cat = (o: Partial<TriageCategoryRec> = {}): TriageCategoryRec => ({
+  category: 'secret',
+  action: 'warn',
+  reasoning: 'r',
+  genuineCount: 0,
+  fpCount: 0,
+  fpIds: [],
+  ...o,
+});
+
+const chunk = (rec: TriageRecommendation, ids: string[]): ChunkVerdict => ({
+  rec,
+  ids: new Set(ids),
+});
+
+const secretOf = (m: TriageRecommendation): TriageCategoryRec => {
+  const c = m.perCategory.find((x) => x.category === 'secret');
+  if (c === undefined) throw new Error('expected a merged secret category');
+  return c;
+};
 
 describe('mergeRecommendations', () => {
   it('merges per category: sums, unions ids, strictest action wins', () => {
     const m = mergeRecommendations([
-      {
-        perCategory: [
-          {
-            category: 'secret',
-            action: 'warn',
-            reasoning: 'a',
-            genuineCount: 1,
-            fpCount: 1,
-            fpIds: ['1'],
-          },
-        ],
-        notes: 'n1',
-      },
-      {
-        perCategory: [
-          {
-            category: 'secret',
-            action: 'redact',
-            reasoning: 'b',
-            genuineCount: 2,
-            fpCount: 0,
-            fpIds: [],
-          },
-          {
-            category: 'pii',
-            action: 'warn',
-            reasoning: 'c',
-            genuineCount: 1,
-            fpCount: 0,
-            fpIds: [],
-          },
-        ],
-        notes: 'n2',
-      },
+      chunk(
+        {
+          perCategory: [
+            cat({ action: 'warn', reasoning: 'a', genuineCount: 1, fpCount: 1, fpIds: ['1'] }),
+          ],
+          notes: 'n1',
+        },
+        ['1'],
+      ),
+      chunk(
+        {
+          perCategory: [
+            cat({ action: 'redact', reasoning: 'b', genuineCount: 2, fpCount: 0, fpIds: [] }),
+            cat({ category: 'pii', action: 'warn', reasoning: 'c', genuineCount: 1 }),
+          ],
+          notes: 'n2',
+        },
+        ['2'],
+      ),
     ]);
-    const sec = m.perCategory.find((c) => c.category === 'secret');
-    if (sec === undefined) throw new Error('expected a merged secret category');
+    const sec = secretOf(m);
     expect([sec.genuineCount, sec.fpCount, sec.action, sec.fpIds]).toEqual([3, 1, 'redact', ['1']]);
     expect(m.notes).toBe('n1\nn2');
+  });
+
+  // The grounding invariant a single judgment gave for free: ids are global
+  // stream ordinals, so a chunk that renumbers locally names a sibling chunk's
+  // hits. Such an id must never reach the join, or it suppresses — and
+  // un-surfaces — a genuine finding its judge never read.
+  it('drops fpIds naming hits outside the chunk they were judged in, and says so', () => {
+    const m = mergeRecommendations([
+      chunk({ perCategory: [cat({ fpCount: 1, fpIds: ['0'] })], notes: '' }, ['0', '1']),
+      // This judge only saw ids '2'/'3' but returned '0' — chunk 1's genuine hit.
+      chunk({ perCategory: [cat({ fpCount: 2, fpIds: ['2', '0'] })], notes: '' }, ['2', '3']),
+    ]);
+    const sec = secretOf(m);
+    expect(sec.fpIds).toEqual(['0', '2']);
+    expect(m.notes).toContain('dropped 1 false-positive id(s)');
+    // The model's CLAIMED count is summed unchanged, so resolve.ts still raises
+    // the count-vs-resolved discrepancy at the human gate rather than the drop
+    // passing as a clean verdict.
+    expect(sec.fpCount).toBe(3);
+  });
+
+  it('keeps every chunk id when each verdict stays inside its own batch', () => {
+    const m = mergeRecommendations([
+      chunk({ perCategory: [cat({ fpCount: 1, fpIds: ['0'] })], notes: '' }, ['0', '1']),
+      chunk({ perCategory: [cat({ fpCount: 1, fpIds: ['2'] })], notes: '' }, ['2', '3']),
+    ]);
+    expect(secretOf(m).fpIds).toEqual(['0', '2']);
+  });
+
+  it('folds an empty verdict list to an empty recommendation', () => {
+    expect(mergeRecommendations([])).toEqual({ perCategory: [], notes: '' });
+  });
+
+  // writeback.ts rejects a category whose reasoning echoes a raw value, and says
+  // why: "once a category leaked raw we distrust it for the whole run". Keeping
+  // only the winning chunk's reasoning would throw the poisoned sibling away
+  // before assertRawFree ever saw it.
+  it('carries every chunk reasoning into the merged text so a poisoned chunk cannot be dropped', () => {
+    const m = mergeRecommendations([
+      chunk(
+        {
+          perCategory: [cat({ action: 'warn', reasoning: 'the key AKIAIOSFODNN7EXAMPLE is real' })],
+          notes: '',
+        },
+        ['0'],
+      ),
+      chunk({ perCategory: [cat({ action: 'redact', reasoning: 'clean prose' })], notes: '' }, [
+        '1',
+      ]),
+    ]);
+    const sec = secretOf(m);
+    expect(sec.action).toBe('redact');
+    // Strictest first (it argued for the winning action), poisoned text retained.
+    expect(sec.reasoning).toBe('clean prose the key AKIAIOSFODNN7EXAMPLE is real');
+  });
+
+  it('collapses identical reasonings instead of repeating them', () => {
+    const m = mergeRecommendations([
+      chunk({ perCategory: [cat({ reasoning: 'same' })], notes: '' }, ['0']),
+      chunk({ perCategory: [cat({ reasoning: 'same' })], notes: '' }, ['1']),
+    ]);
+    expect(secretOf(m).reasoning).toBe('same');
   });
 });
 
 describe('chunkForJudge', () => {
   it('chunkForJudge returns a single chunk under the cap', () => {
-    expect(
-      chunkForJudge(
-        [
-          {
-            ruleId: 'r',
-            category: 'secret',
-            severity: 'high',
-            maskedMatch: 'm',
-            rawMatch: 'raw',
-            context: 'c',
-            confidence: 0.9,
-          },
-        ],
-        262_144,
-      ),
-    ).toHaveLength(1);
+    expect(chunkForJudge([hit()], 262_144)).toHaveLength(1);
+  });
+
+  it('splits once the serialized budget is exceeded, losing no hit and keeping order', () => {
+    const hits = Array.from({ length: 20 }, (_, i) => hit({ id: String(i) }));
+    const [first] = hits;
+    if (first === undefined) throw new Error('unreachable: fixed-length array');
+    const oneHit = Buffer.byteLength(JSON.stringify(first)) + 1;
+    const chunks = chunkForJudge(hits, oneHit * 5);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.flat()).toHaveLength(20);
+    expect(chunks.flatMap((c) => c.map((h) => h.id))).toEqual(hits.map((h) => h.id));
+  });
+
+  it('gives a single over-budget hit its own chunk rather than dropping it', () => {
+    const chunks = chunkForJudge([hit({ id: '0' }), hit({ id: '1' })], 1);
+    expect(chunks.map((c) => c.map((h) => h.id))).toEqual([['0'], ['1']]);
+  });
+});
+
+describe('chunkIds', () => {
+  it('collects the ids a judge saw and ignores un-idd hits', () => {
+    expect([...chunkIds([hit({ id: '7' }), hit({ id: undefined }), hit({ id: '9' })])]).toEqual([
+      '7',
+      '9',
+    ]);
   });
 });

--- a/plugins/claude-code/test/triage/merge.test.ts
+++ b/plugins/claude-code/test/triage/merge.test.ts
@@ -5,6 +5,7 @@ import {
   chunkForJudge,
   chunkIds,
   type ChunkVerdict,
+  groundVerdict,
   mergeRecommendations,
 } from '../../src/triage/merge.ts';
 
@@ -159,5 +160,27 @@ describe('chunkIds', () => {
       '7',
       '9',
     ]);
+  });
+});
+
+describe('groundVerdict', () => {
+  // Runs on every judging path, not only the chunked one: dedupe alone makes the
+  // judged set a strict subset of the hits downstream consumers hold.
+  it('drops ids outside the judged set, discloses the drop, and keeps the claimed fpCount', () => {
+    const g = groundVerdict(
+      { perCategory: [cat({ fpCount: 2, fpIds: ['0', '9'] })], notes: 'n' },
+      new Set(['0']),
+    );
+    expect(g.perCategory[0]?.fpIds).toEqual(['0']);
+    // The claimed count is untouched so resolve.ts still raises the discrepancy.
+    expect(g.perCategory[0]?.fpCount).toBe(2);
+    expect(g.notes).toBe(
+      'n\nsecret: dropped 1 false-positive id(s) naming hits outside the batch they were judged in',
+    );
+  });
+
+  it('is a no-op when every id was judged', () => {
+    const rec = { perCategory: [cat({ fpCount: 1, fpIds: ['0'] })], notes: '' };
+    expect(groundVerdict(rec, new Set(['0', '1']))).toEqual(rec);
   });
 });

--- a/plugins/claude-code/test/triage/surfaced-secrets.test.ts
+++ b/plugins/claude-code/test/triage/surfaced-secrets.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
+import { groundVerdict } from '../../src/triage/merge.ts';
 import { deriveProvider, deriveSurfacedSecretFindings } from '../../src/triage/surfaced-secrets.ts';
 import { planTriageWriteback } from '../../src/triage/writeback.ts';
 
@@ -376,5 +377,50 @@ describe('deriveSurfacedSecretFindings — one value found in several artifacts'
     const plan = planTriageWriteback(hits, dismissedRec);
     const out = deriveSurfacedSecretFindings(hits, dismissedRec, plan);
     expect(out.map((f) => f.where.filePath)).toEqual(['/h/.claude/projects/p/s9.jsonl']);
+  });
+});
+
+// The dedupe means the judge is shown the representative set while this
+// derivation holds the full hit list, so the two sets differ and an fpId naming
+// a hit outside the judged set must never take effect. Ungrounded, a single
+// stray id expands across the whole value class and buries a key the judge
+// explicitly called genuine — the amplification the class expansion creates and
+// `groundVerdict` (merge.ts, applied on every judging path) prevents.
+describe('deriveSurfacedSecretFindings — an fpId the judge never saw', () => {
+  it('does not let a stray id bury the value class once the verdict is grounded', () => {
+    const occurrences = ['s1', 's2', 's3'].map((tag, i) =>
+      hit({ id: String(i), filePath: `/h/.claude/projects/p/${tag}.jsonl` }),
+    );
+    const [representative] = occurrences;
+    if (representative === undefined) throw new Error('unreachable: fixed-length array');
+
+    // The judge saw only the representative and called the value GENUINE, but
+    // emitted id '2' — an occurrence collapsed before judging, never shown to it.
+    const strayRec: TriageRecommendation = {
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'redact',
+          reasoning: 'a live-looking provider key',
+          genuineCount: 1,
+          fpCount: 1,
+          fpIds: ['2'],
+        },
+      ],
+      notes: '',
+    };
+    const judged = new Set(['0']);
+    const grounded = groundVerdict(strayRec, judged);
+    expect(grounded.perCategory[0]?.fpIds).toEqual([]);
+    expect(grounded.notes).toContain('dropped 1 false-positive id(s)');
+
+    const plan = planTriageWriteback([representative], grounded);
+    const out = deriveSurfacedSecretFindings(occurrences, grounded, plan);
+    // All three artifacts still surface — the genuine key is not buried.
+    expect(out.map((f) => f.where.filePath)).toEqual([
+      '/h/.claude/projects/p/s1.jsonl',
+      '/h/.claude/projects/p/s2.jsonl',
+      '/h/.claude/projects/p/s3.jsonl',
+    ]);
   });
 });

--- a/plugins/claude-code/test/triage/surfaced-secrets.test.ts
+++ b/plugins/claude-code/test/triage/surfaced-secrets.test.ts
@@ -282,3 +282,99 @@ describe('deriveSurfacedSecretFindings — genuine, non-suppressed secret leaks'
     expect(deriveSurfacedSecretFindings([surfaced], rec, plan)).toEqual([]);
   });
 });
+
+// The derivation is LOCATION-scoped: each finding carries one filePath, and that
+// path is the only thing that puts a file in the redaction pass's scope and the
+// only unit the complete-vs-partial redaction gate counts. The judge, by
+// contrast, is VALUE-scoped — it sees one representative per distinct value.
+// These tests pin both halves of that split.
+describe('deriveSurfacedSecretFindings — one value found in several artifacts', () => {
+  // Same value, same rule, three different transcripts: one collapsed finding
+  // would put ONE file in redaction scope, leave the key live in the other two,
+  // and still satisfy the complete-redaction gate (`redactedKeys === findings.length`).
+  const occurrences = ['s1', 's2', 's3'].map((tag, i) =>
+    hit({ id: String(i), filePath: `/h/.claude/projects/p/${tag}.jsonl` }),
+  );
+  // The one the judge would have seen, standing in for the whole value class.
+  const [representative] = occurrences;
+  if (representative === undefined) throw new Error('unreachable: fixed-length array');
+
+  const genuineRec: TriageRecommendation = {
+    perCategory: [
+      {
+        category: 'secret',
+        action: 'redact',
+        reasoning: 'a live-looking provider key in old transcripts',
+        genuineCount: 1,
+        fpCount: 0,
+        fpIds: [],
+      },
+    ],
+    notes: '',
+  };
+
+  it('surfaces every occurrence so each artifact holding the key enters redaction scope', () => {
+    const plan = planTriageWriteback(occurrences, genuineRec);
+    const out = deriveSurfacedSecretFindings(occurrences, genuineRec, plan);
+
+    expect(out).toHaveLength(3);
+    expect(out.map((f) => f.where.filePath)).toEqual([
+      '/h/.claude/projects/p/s1.jsonl',
+      '/h/.claude/projects/p/s2.jsonl',
+      '/h/.claude/projects/p/s3.jsonl',
+    ]);
+    // One value, so one masked token across all three — the rows differ only by
+    // location, which is exactly what the remediation table's WHERE column shows.
+    expect(new Set(out.map((f) => f.maskedToken)).size).toBe(1);
+    for (const f of out) expect(MaskedSecretFinding.safeParse(f).success).toBe(true);
+  });
+
+  it('expands the judge’s per-representative dismissal over every occurrence of that value', () => {
+    // The judge saw only the representative (id '0') and dismissed it. The other
+    // two occurrences were never named in fpIds — but they are the same value, so
+    // the verdict binds them too and none of the three may surface as a live leak.
+    const dismissedRec: TriageRecommendation = {
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'warn',
+          reasoning: 'canonical documentation example value',
+          genuineCount: 0,
+          fpCount: 1,
+          fpIds: ['0'],
+        },
+      ],
+      notes: '',
+    };
+    const plan = planTriageWriteback([representative], dismissedRec);
+    expect(deriveSurfacedSecretFindings(occurrences, dismissedRec, plan)).toEqual([]);
+  });
+
+  it('never lets a dismissal cross to a different rule sharing the fingerprint', () => {
+    // Suppressions key on ruleId+fingerprint+keyVersion, so the value class does
+    // too: a same-value hit under a DIFFERENT rule is a different class and must
+    // still surface after the first rule's hit is dismissed.
+    const otherRule = hit({
+      id: '9',
+      ruleId: 'secrets/generic-high-entropy',
+      filePath: '/h/.claude/projects/p/s9.jsonl',
+    });
+    const dismissedRec: TriageRecommendation = {
+      perCategory: [
+        {
+          category: 'secret',
+          action: 'warn',
+          reasoning: 'example value under the aws rule',
+          genuineCount: 0,
+          fpCount: 1,
+          fpIds: ['0'],
+        },
+      ],
+      notes: '',
+    };
+    const hits = [representative, otherRule];
+    const plan = planTriageWriteback(hits, dismissedRec);
+    const out = deriveSurfacedSecretFindings(hits, dismissedRec, plan);
+    expect(out.map((f) => f.where.filePath)).toEqual(['/h/.claude/projects/p/s9.jsonl']);
+  });
+});


### PR DESCRIPTION
Stacked on #53 (`fix/setup-triage-e2big-and-copy`) — please merge that first; GitHub will retarget this to `main`. Rebased onto `bff3911`, so it includes Will's review-response commit.

The E2BIG fix in #53 is correct. The dedupe that ships alongside it is applied one layer too deep, and the batch-and-merge fallback drops two invariants a single judgment gave for free. This addresses those, plus the untested-fallback gap.

## Where this lands against the #53 reviews

**@pmontiel-git — copy findings: all resolved upstream**, by Will's `bff3911`. Verified on the rebased branch: `renderStartLight` no longer claims a no-history state on the decline path (`render.ts:207`); `renderFirstRun` attributes the total to the store (`render.ts:453`); `renderAdjustConfirm` says "detection categories" (`render.ts:251`); the user-visible `settings.json` string is gone from `onboard.ts`; the `I-1`/`M-1` case IDs are gone from `gate-display.ts`. Nothing left for me to do there. (Will's `render.ts:453` fix also resolves the copy-provenance item I'd flagged as out of scope on the first pass.)

**@pmontiel-git — engine: this PR disagrees with two conclusions.** Flagging it plainly rather than quietly changing code that was signed off:

> *"Dedup covers every occurrence … No 'suppress one, leave the rest live' path."*

True for **suppression**, which is value-scoped at enforcement. Not true for **redaction**, which is location-scoped: `remediation/surfaced-redact.ts:137-147` builds its per-file map exclusively from `finding.where.filePath`, so a collapsed finding set leaves the other files unopened. Section 1 below has the reproduction.

> *"Batch/merge is safe … merge unions `fpIds` and takes the most-restrictive action."*

The union is the problem. `fpIds` are global stream ordinals resolved against the join built from the *full* set, so an id from one batch can name — and suppress — a hit that batch's judge never read. Section 2.

Both are subtle and only visible from the *consumer* side, which is exactly why they survived a careful read of the engine in isolation.

**@joshuas99 — "want to try out the merge / dedupe updates."** Reaching the batch path takes ~256KB of real history, which is why it shipped untested. Now drivable:

```bash
# force every hit into its own batch against an ordinary history
node scripts/backfill.js --triage | node scripts/apply-suppressions.js --max-judge-bytes 2000
```

A missing, zero, or non-numeric value falls back to the default rather than silently disabling batching. The wizard also now announces the split **before** judging starts — each batch is its own `claude -p` subprocess, so previously the only observable difference between one batch and ten was how long it hung. Plus the end-to-end coverage in "Testing" below. Josh, if you meant something else by "try out", say so and I'll add it.

---

## 1. Value-dedupe was applied to the one location-scoped consumer

`deriveSurfacedSecretFindings` received the collapsed representative set. But `valueFingerprint` is an HMAC of the raw value alone (`backfill.ts:133`) — file-independent — while a `MaskedSecretFinding` carries a single `where.filePath`, and that path is:

- the only thing that puts a file in redaction scope — `remediation/surfaced-redact.ts:137-147` builds `byFile` exclusively from `finding.where.filePath`, and `:162` is the only read loop;
- the unit the complete-vs-partial redaction gate counts — `remediation/render.ts:100-102` computes `isComplete` over `input.findings.length`.

So one key pasted into three transcripts collapsed to one finding. Redaction struck the first file, left the key live in the other two, and `isComplete` was satisfied:

```
before:  "✓ Redacted 1 key."
after:   "Redacted 1 of 3 keys; 2 keys still need attention in .../s2.jsonl, .../s3.jsonl"
```

`renderPartialRedactionLine` — the function whose entire purpose is naming the files that still hold a key — was unreachable. That is #47's guarantee.

**Fix:** pass the full hit list there, and expand the judge's value-scoped dismissal over the whole `(ruleId, valueFingerprint)` class so a dismissed representative's duplicates still stay dismissed. `deriveFalsePositivePatterns` keeps the representative set on purpose — it writes fingerprint-keyed exceptions, so its unit really is the distinct value; both call sites now say which scope they are and why.

## 2. Chunked judging lost the grounding of `fpIds`

Ids are global stream ordinals (`backfill.ts:132`, `id: String(count)`). Each batch's judge saw one slice, the merge unioned `fpIds` with no membership check, and `resolve.ts:25` resolved them against the join built from the *full* set. An id from batch 2 could suppress a hit batch 2 never read — and `deriveSurfacedSecretFindings` is not human-gated, so it silently dropped a real key from the remediation table.

**Fix:** `groundVerdict(rec, ids)` drops every fpId naming a hit outside the batch it was judged in and discloses each drop in `notes`. `fpCount` keeps the model's claimed value, so `resolve.ts:57`'s existing count-discrepancy note still fires at the human gate rather than the drop passing as clean.

Applied on **both** paths. Dedupe alone is enough to need it: the judge sees representatives while downstream consumers hold every occurrence, so an id naming a collapsed duplicate is an id the judge never read. Ungrounded it is not inert — combined with the class expansion in (1), one stray id buries a key the judge called *genuine*. Reproduced before fixing: three occurrences, `genuineCount: 1`, one stray fpId, and zero findings surfaced. (My own first pass had this bug; a self-review caught it.)

## 3. A raw-echoing `reasoning` could be laundered past the fail-secure

`writeback.ts:206-208` states the rule verbatim: *"a poisoned first occurrence being 'rescued' by a later duplicate — once a category leaked raw we distrust it for the whole run."* The merge kept only the strictest batch's `reasoning`, discarding a poisoned sibling before `assertRawFree` (`writeback.ts:221`) ever saw it. No raw egressed — but whether a category got distrusted depended on which batch the byte-packer happened to put a hit in.

**Fix:** every batch's reasoning is carried into the merged text (strictest first, duplicates collapsed), so one poisoned batch still distrusts the category. This also fixes the attribution problem where a single batch's sentence was printed above summed counts and stamped as the `justification` on every unioned fpId.

## Also

- **`eval/prompt.md` documents `id` and `fpIds`.** The schema requires `fpIds` (`triage.ts:55`, not optional) but the rubric never mentioned either field, so the ids were entirely model-improvised. It now says to copy ids verbatim and never emit one it was not shown.
- **Narration contract** (`eval/prompt-contract.ts`) grounds a cited fact against any finding sharing its masked token. One value can legitimately appear in several artifacts now, and pinning to the first would reject a true statement about the second file.
- **`skipped:no-consent`** said *"I didn't find anything to review"* — a clean bill of health for a scan that never ran. It now says *"I didn't review anything — historical access wasn't granted."*
- **`moreWorthALook`** (`remediation/entry.ts:88`) subtracted an occurrence-scoped finding count from the value-scoped `counts.important`. It now subtracts the batch's distinct-value count.

## Testing

746 passing (20 new), lint + typecheck + prettier clean.

The batch-and-merge fallback had no integration coverage — setting `chunkForJudge`'s budget to `MAX_SAFE_INTEGER` (so the split never engages) passed all 726 tests on #53. It is now driven end to end through `runApply`.

Each fix is mutation-tested — reverting any one fails a targeted test, and nothing else:

| mutation | test that fails |
|---|---|
| collapse locations again | `emits one finding per artifact for a single value found in three transcripts` |
| drop the class-dismissal expansion | `expands the judge's per-representative dismissal over every occurrence` |
| un-ground the single-batch path | `drops the stray id instead of letting it bury the whole value class` |
| stop grounding fpIds | `refuses an fpId naming a hit its batch never saw` (+3) |
| keep only the strictest reasoning | `carries every batch reasoning into the merged text` |
| restore the found-nothing copy | `says nothing was reviewed — not that nothing was found` |
