### PR TITLE
test(detections): make ReDoS probe-battery meta-tests machine-independent

### DIFF
--- a/packages/detections/test/security/redos.test.ts
+++ b/packages/detections/test/security/redos.test.ts
@@ -164,6 +164,41 @@ function worstProbeMs(rule: Rule): { ms: number; probe: string } {
   return { ms, probe };
 }
 
+// A same-length ordinary input for `rule` that cannot enter the pattern's
+// repeated group, so scan() runs linearly over it. Its cost is this machine's
+// baseline for an input of this size — the denominator a catastrophic probe is
+// measured against, so the ratio reflects backtracking blowup rather than raw
+// machine speed. 'z' matches none of the meta-test patterns' required prefixes
+// or character classes, so every probe fails before the group and never
+// backtracks. `min` over several samples rejects scheduler noise on a
+// sub-millisecond measurement.
+function benignBaselineMs(rule: Rule, length: number): number {
+  const text = 'z'.repeat(length);
+  scan(text, [rule]);
+  let ms = Infinity;
+  for (let i = 0; i < 7; i++) {
+    const start = performance.now();
+    scan(text, [rule]);
+    ms = Math.min(ms, performance.now() - start);
+  }
+  return ms;
+}
+
+// A catastrophic probe must cost dramatically more than an ordinary input of the
+// same length on the SAME machine. This ratio is scale-free: hardware speed and
+// CPU contention slow both measurements together and cancel out, where an
+// absolute-millisecond threshold does not. The measured factor runs into the
+// thousands; this bound keeps orders of magnitude of headroom while still failing
+// loudly if a probe stops being adversarial.
+const CATASTROPHIC_RATIO = 50;
+
+// The worst probe's slowdown over a same-length benign baseline for `rule`.
+function backtrackRatio(rule: Rule): { ratio: number; ms: number; benignMs: number } {
+  const { ms, probe } = worstProbeMs(rule);
+  const benignMs = benignBaselineMs(rule, probe.length);
+  return { ratio: ms / benignMs, ms, benignMs };
+}
+
 describe('bundled rules survive adversarial input', () => {
   it('discovers every bundled rule', () => {
     // Guards against the suite silently shrinking to zero if discovery breaks.
@@ -239,13 +274,20 @@ describe('the probe battery itself', () => {
   // adversarial (a refactor drops the terminator, shrinks the lengths, …) —
   // 101 green tests that check nothing.
   //
-  // A pattern belongs here only if it blows the budget on an early SHORT probe.
-  // The assertion is a lower bound on time, so the case runs for as long as the
-  // pattern is slow, and how slow is hardware-dependent: `(.*a){20}$` costs
-  // ~1.2s on one machine and over 5s on the Windows runner, where it exceeded
-  // the test timeout. It proved nothing the two below do not, so it is not
-  // worth a multi-second case. Add a pattern here only after checking what its
-  // first matching probe costs.
+  // Each case proves the battery drives a catastrophic pattern to backtrack far
+  // past ordinary input by asserting a RATIO — worst probe time over a
+  // same-length benign baseline on the same machine — not an absolute
+  // millisecond threshold. Wall-clock ms shifts with hardware and CPU load, and
+  // which pattern sits closest to a fixed line shifts with it; the ratio does
+  // not, because both measurements move together.
+  //
+  // A pattern belongs here only if `worstProbeMs` crosses BUDGET_MS on an early
+  // SHORT probe. That first over-budget probe runs to completion, so its cost
+  // must stay well under the vitest timeout: `(.*a){20}$` costs ~1.2s on one
+  // machine and over 5s on the Windows runner, where it exceeded the timeout. It
+  // proved nothing the cases below do not, so it is not worth a multi-second
+  // probe. Add a pattern here only after checking what its first matching probe
+  // costs.
   it.each([
     ['nested quantifier', '^(a+)+$'],
     ['adjacent quantifiers in a quantified group', '(x+x+)+y'],
@@ -256,7 +298,13 @@ describe('the probe battery itself', () => {
     // thing standing between one of these and `rules/`.
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
-    expect(worstProbeMs(parsed.data).ms).toBeGreaterThan(BUDGET_MS);
+    const { ratio, ms, benignMs } = backtrackRatio(parsed.data);
+    expect(
+      ratio,
+      `worst probe ran ${ms.toFixed(1)}ms vs a ${benignMs.toFixed(3)}ms same-length ` +
+        `baseline (ratio ${ratio.toFixed(0)}×); the probe battery should drive this ` +
+        `pattern to backtrack orders of magnitude past ordinary input.`,
+    ).toBeGreaterThan(CATASTROPHIC_RATIO);
   });
 
   // The fixed lowercase-and-digit alphabet cannot see these: a literal prefix
@@ -273,7 +321,13 @@ describe('the probe battery itself', () => {
     const parsed = parseRegexRule(pattern);
     expect(parsed.success).toBe(true);
     if (!parsed.success) return;
-    expect(worstProbeMs(parsed.data).ms).toBeGreaterThan(BUDGET_MS);
+    const { ratio, ms, benignMs } = backtrackRatio(parsed.data);
+    expect(
+      ratio,
+      `worst probe ran ${ms.toFixed(1)}ms vs a ${benignMs.toFixed(3)}ms same-length ` +
+        `baseline (ratio ${ratio.toFixed(0)}×); the probe battery should drive this ` +
+        `pattern to backtrack orders of magnitude past ordinary input.`,
+    ).toBeGreaterThan(CATASTROPHIC_RATIO);
   });
 
   it('the fixed alphabet alone would miss the alphabet-specific patterns', () => {

--- a/packages/detections/test/security/redos.test.ts
+++ b/packages/detections/test/security/redos.test.ts
@@ -192,10 +192,15 @@ function benignBaselineMs(rule: Rule, length: number): number {
 // loudly if a probe stops being adversarial.
 const CATASTROPHIC_RATIO = 50;
 
+// Below any genuine scan cost, so it only replaces an unmeasurably fast baseline
+// that rounded to zero and never distorts a real measurement — it exists purely
+// to keep the ratio's denominator above zero.
+const MIN_BASELINE_MS = 1e-6;
+
 // The worst probe's slowdown over a same-length benign baseline for `rule`.
 function backtrackRatio(rule: Rule): { ratio: number; ms: number; benignMs: number } {
   const { ms, probe } = worstProbeMs(rule);
-  const benignMs = benignBaselineMs(rule, probe.length);
+  const benignMs = Math.max(benignBaselineMs(rule, probe.length), MIN_BASELINE_MS);
   return { ratio: ms / benignMs, ms, benignMs };
 }
 


### PR DESCRIPTION
## Summary

- The probe-battery meta-tests in `packages/detections/test/security/redos.test.ts` (the `describe('the probe battery itself')` block) asserted `worstProbeMs(rule).ms > BUDGET_MS` (100ms) to prove the battery *detects* a catastrophic-backtracking pattern. That absolute wall-clock threshold is non-portable: a short catastrophic probe sits close to the 100ms line, and **which** pattern lands nearest it varies with hardware and CPU load — so under heavy parallel contention 1–3 of these cases flake.
- This replaces the absolute-ms assertion with a scale-free **ratio**: worst probe time over a same-length benign baseline measured on the same machine. Hardware speed and contention scale both terms together and cancel, leaving the intrinsic exponential-vs-linear blowup (measured in the thousands). Bound set at `50×` with orders of magnitude of headroom.
- The product-facing guardrail tests (`%s stays within the scan budget`, which assert real bundled rules stay *under* budget) and the `the fixed alphabet alone would miss…` meta-test are **untouched**.

Reproduced the flake by measuring under 20+ CPU burners on 16 cores (load average up to ~170): the named patterns' catastrophic time swings across the 100ms line while others stay far from it — confirming the threshold, not the code, is the problem. After the fix, the full `detections` suite (868 tests) passed 3/3 consecutive runs under that same brutal contention.

## Changes

| File | Change |
|------|--------|
| `packages/detections/test/security/redos.test.ts` | Add `benignBaselineMs` + `backtrackRatio` helpers and a `CATASTROPHIC_RATIO` bound; switch the two catastrophic-detection meta-tests from an absolute-ms threshold to a scale-free ratio assertion. Guardrail tests unchanged. |

## Checklist

- [x] `pnpm format:check` passes (detections)
- [x] `pnpm lint` passes (detections)
- [x] `pnpm typecheck` passes (detections)
- [x] `pnpm test` passes (detections, incl. 5×/3× consecutive runs under heavy CPU contention)
- [x] PR title follows Conventional Commits (`test:`)

Test-only change — no `rules/` changes, so no fixtures required.