### PR TITLE
feat(plugin): relay setup-wizard cards verbatim via AKA_SHOW regions

### DIFF
--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -23,13 +23,36 @@ raw-free plan that subprocess prints back.
 Follow the steps below **in order**. Nothing is written to the policy store
 until step 5 (or a floor fallback in step 3 if the calibration can't complete).
 
+## Execution contract (read before step 0)
+
+Every script prints output in three region kinds. Your job for each is fixed:
+
+- **`<<<AKA_SHOW … AKA_SHOW>>>`** — relay every AKA_SHOW region verbatim as your
+  next message: paste the content _between_ the markers exactly — a card region
+  carries its own code fence, a plain confirmation line does not, but either way
+  you paste exactly what's between the markers — never the marker lines, never a
+  paraphrase or summary.
+- **`<<<AKA_FRAME_JSON … AKA_FRAME_JSON>>>`** — machine-only. Parse it if a step
+  tells you to read a value from it; never display it.
+- **Anything else on stdout** — status for you (paths like `Plan saved to:`,
+  errors, exit signals). Act on it; never relay it.
+
+Invariants:
+
+- **Never write a confirmation or acknowledgement the wizard did not emit** — the
+  script's AKA_SHOW line is the confirmation.
+- **Each step's AKA_SHOW regions must be relayed before you advance.**
+- **One picker per decision; never re-ask a decision already collected.**
+
 ## 0. Show the intro card
 
-Run the intro script and show the user its output **exactly as printed**. It
+Run the intro script and relay its AKA_SHOW region per the execution contract:
+paste the content between the markers verbatim, never the marker lines. It
 prints a single space-aligned monospace card — identity and provenance, then
-what AKA does — inside a Markdown code fence. Reproduce the fence verbatim and
-do **not** add another code fence, strip the fence, or reformat it (unfenced,
-Markdown collapses the indentation and mangles the `●` lines).
+what AKA does — inside a Markdown code fence that is part of that pasted
+content. Keep the fence as printed and do **not** add another code fence, strip
+the fence, or reformat it (unfenced, Markdown collapses the indentation and
+mangles the `●` lines).
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/scripts/intro.js" "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json"
@@ -68,8 +91,8 @@ same "recommended base + changed-packs overlay" shape step 4b's adjust fork
 uses: the tightened categories raise, every other category keeps its existing
 recommended level, each carrying its rationale line. Where you compose the view
 yourself (the adjust fork, the calibrated result) this tightened recommendation
-IS that view; where the view is printed verbatim by a script (the step-2
-start-light card, reproduced exactly as printed), show the tightened
+IS that view; where the view is a script's AKA_SHOW card (the step-2
+start-light card, relayed per the execution contract), show the tightened
 recommendation and its rationale lines adjacent to that card rather than
 rewriting the card's own printed levels.
 
@@ -146,11 +169,12 @@ it.
   scan to triage, no calibrated result to confirm, and no suppression plan to
   write. Do the following in order:
 
-  1. **Show the start-light card.** Run the start-light script and reproduce its
-     fenced card **exactly as printed** — the
+  1. **Show the start-light card.** Run the start-light script and relay its
+     AKA_SHOW card per the execution contract — the
      `● Starting light — your detection categories` heading, the full 8-pack ×
      4-level default posture table, the per-pack rationale, and the re-tune
-     hint. It reads no history and writes nothing; it only prints the card
+     hint, pasted between the markers exactly as printed, fence included. It
+     reads no history and writes nothing; it only prints the card
      (the severity-floor default map — secret, pii, financial, phi, code_flaw, custom at
      `warn`; code_context, config at `monitor`).
 
@@ -380,10 +404,10 @@ recommended.
 2. **Show the adjust-confirm table.** Compose the merged 8-pack map — the
    recommended base with the user's picks overlaid — and render the adjust-confirm
    card by passing the calibrated recommended posture as `--recommended` and that
-   merged map as `--posture`. Reproduce its
-   fenced `category │ recommended │ yours` table **exactly as printed** (it is
-   space-aligned monospace; do **not** add another code fence, strip the fence, or
-   reformat it):
+   merged map as `--posture`. Relay its AKA_SHOW region per the execution
+   contract — the fenced `category │ recommended │ yours` table, pasted between
+   the markers exactly as printed (it is space-aligned monospace; do **not** add
+   another code fence, strip the fence, or reformat it):
 
    ```bash
    node "${CLAUDE_PLUGIN_ROOT}/scripts/start-light.js" --adjust-confirm --recommended '<recommended-json>' --posture '<merged-json>' --current '<current-json>'
@@ -505,12 +529,13 @@ so setup still finishes.
 
 ## 6. Show the installed summary and hand off to the dashboard
 
-Run the first-run script and show its **install-complete summary** exactly as
-printed (live findings/recommendation counts, the health score, and the
-per-category posture just written or floored). The script prints that summary
-inside a Markdown code fence; reproduce the fenced card verbatim and do **not**
-add another code fence, strip the fence, or reformat it (it is space-aligned
-monospace that Markdown would otherwise collapse).
+Run the first-run script and relay its **install-complete summary** AKA_SHOW
+region per the execution contract (live findings/recommendation counts, the
+health score, and the per-category posture just written or floored). The
+script wraps that summary in a Markdown code fence; paste it between the
+markers exactly as printed and do **not** add another code fence, strip the
+fence, or reformat it (it is space-aligned monospace that Markdown would
+otherwise collapse).
 
 Pass the **surfaced count** captured from step 3's calibration frame
 (`counts.important`) as `--surfaced <count>` — this is the 'N worth a look' figure
@@ -579,7 +604,8 @@ parts, all of which you **show to the user verbatim, in order**:
 3. inside that same fence, a most-exposed-first recommendation line and a
    secret-scan chaining line.
 
-Reproduce the count line and the whole fenced block exactly as printed — do not
+This entire human-text block is the entry's AKA_SHOW region — relay it per the
+execution contract, pasting it between the markers exactly as printed — do not
 drop the recommendation or chaining lines, and do not paraphrase.
 
 Alongside that fenced block, explain the findings in plain language grounded
@@ -658,12 +684,9 @@ interface + terminal dashboard and on-demand scans."
   dashboard, a local user interface, and on-demand scans"
 - **Not now** — "skip — you can add it anytime with the one-liner below"
 
-If they choose **Yes**, run the bootstrap installer (it ensures Node is available
-and installs the global CLI from the public npm registry). **Ask permission
-before running it, warmly** — e.g. "Would you like me to install the CLI? I'll
-install it via the npm package manager." — don't recite the shell mechanics or
-frame it as a scary "fetches and runs a script from GitHub" warning. Then run
-the line for their OS:
+**Yes, add it** is the install authorization — run the bootstrap installer
+directly, with no second picker (it ensures Node is available and installs the
+global CLI from the public npm registry). Run the line for their OS:
 
 ```bash
 # macOS / Linux
@@ -695,3 +718,6 @@ failed CLI install changes nothing about that.
 and pointed at `/health`. Whichever way the CLI offer went — installed,
 declined, or a failed install you already reported — end with one warm close:
 "That's it — I'm watching out for Claude going forward."
+
+Before you finish, confirm every AKA_SHOW region on the path you took was
+relayed to the user. If you summarized one instead of pasting it, paste it now.

--- a/plugins/claude-code/src/firstrun-core.ts
+++ b/plugins/claude-code/src/firstrun-core.ts
@@ -23,7 +23,7 @@
 import type { DataGateway } from '@akasecurity/plugin-sdk';
 
 import { readRegisteredCommands } from './command-registry.ts';
-import { fenced } from './present.ts';
+import { fenced, show } from './present.ts';
 import {
   buildHandoffOffer,
   buildRecommendations,
@@ -103,27 +103,29 @@ export async function runFirstRun(deps: FirstRunDeps): Promise<void> {
   const registry = readRegisteredCommands();
 
   deps.stdout(
-    `${fenced(
-      renderFirstRun(
-        {
-          // A surfaced count means a scan ran and carried a real preview value
-          // through setup — the same signal that gates the handoff payload
-          // below. Its absence means the floor fallback ran instead.
-          calibration: surfaced !== undefined ? 'scan' : 'floor',
-          posture: postureBlock,
-          health: healthScore(summary),
-          // The card's "Findings N" stat is the whole-store total — correct here.
-          findings: summary.findings,
-          recommendations,
-          // Only threaded when a scan supplied a count — never as an explicit
-          // undefined (exactOptionalPropertyTypes), so the card omits the handoff
-          // line rather than fabricating a zero.
-          ...(surfaced !== undefined ? { worthALook: surfaced } : {}),
-          topFindings: topFindings(findings),
-        },
-        registry,
+    show(
+      fenced(
+        renderFirstRun(
+          {
+            // A surfaced count means a scan ran and carried a real preview value
+            // through setup — the same signal that gates the handoff payload
+            // below. Its absence means the floor fallback ran instead.
+            calibration: surfaced !== undefined ? 'scan' : 'floor',
+            posture: postureBlock,
+            health: healthScore(summary),
+            // The card's "Findings N" stat is the whole-store total — correct here.
+            findings: summary.findings,
+            recommendations,
+            // Only threaded when a scan supplied a count — never as an explicit
+            // undefined (exactOptionalPropertyTypes), so the card omits the handoff
+            // line rather than fabricating a zero.
+            ...(surfaced !== undefined ? { worthALook: surfaced } : {}),
+            topFindings: topFindings(findings),
+          },
+          registry,
+        ),
       ),
-    )}\n`,
+    ),
   );
 
   // The handoff-offer payload, emitted ALONGSIDE the card above so a
@@ -142,6 +144,6 @@ export async function runFirstRunFailOpen(deps: FirstRunDeps): Promise<void> {
   try {
     await runFirstRun(deps);
   } catch {
-    deps.stdout(`${STORE_UNAVAILABLE_NOTE}\n`);
+    deps.stdout(show(STORE_UNAVAILABLE_NOTE));
   }
 }

--- a/plugins/claude-code/src/firstrun.ts
+++ b/plugins/claude-code/src/firstrun.ts
@@ -25,6 +25,7 @@ import { loadConfig } from '@akasecurity/plugin-sdk';
 
 import { runFirstRunFailOpen } from './firstrun-core.ts';
 import { readPostureBlock } from './posture.ts';
+import { show } from './present.ts';
 import { STORE_UNAVAILABLE_NOTE } from './render.ts';
 
 try {
@@ -43,7 +44,7 @@ try {
 } catch {
   // Config/gateway-resolution/close faults land here; the store-read failure inside
   // runFirstRunFailOpen already degraded to the same note above.
-  process.stdout.write(`${STORE_UNAVAILABLE_NOTE}\n`);
+  process.stdout.write(show(STORE_UNAVAILABLE_NOTE));
 }
 
 process.exit(0);

--- a/plugins/claude-code/src/intro.ts
+++ b/plugins/claude-code/src/intro.ts
@@ -17,7 +17,7 @@
 import { readFileSync } from 'node:fs';
 
 import { buildIntroCard, type Manifest } from './intro-card.ts';
-import { fenced } from './present.ts';
+import { fenced, show } from './present.ts';
 
 const manifestPath = process.argv[2];
 
@@ -32,7 +32,7 @@ try {
 // (space-aligned monospace collapses without the fence). Renders the version
 // and repository line without a verified badge — it performs no provenance
 // check or npm subprocess.
-process.stdout.write(`${fenced(buildIntroCard(manifest))}\n`);
+process.stdout.write(show(fenced(buildIntroCard(manifest))));
 
 // Match the other adapter scripts (query.js, onboard.js) which hard-exit on
 // completion so no stray handle can keep the process alive.

--- a/plugins/claude-code/src/onboard.ts
+++ b/plugins/claude-code/src/onboard.ts
@@ -32,6 +32,7 @@ import type { WorkspaceSettings } from '@akasecurity/schema';
 import { HistoricalAccess, SimpleDetectionPolicy } from '@akasecurity/schema';
 
 import { parsePosture } from './onboard-posture.ts';
+import { show } from './present.ts';
 import { renderCategoriesTuned } from './render.ts';
 
 // Pull `--flag value` and `--flag=value` pairs out of argv. Unknown flags and
@@ -94,7 +95,7 @@ if (Object.keys(answers).length === 0 && rawPosture === undefined && !useFloor) 
 if (Object.keys(answers).length > 0) {
   try {
     const settings = applyOnboarding(answers);
-    process.stdout.write("Got it — I'll look over Claude's recent work to tune things.\n");
+    process.stdout.write(show("Got it — I'll look over Claude's recent work to tune things."));
     // Caps any existing block/redact category rows to warn once when this
     // store's chosen handling is 'warn'. Failure here does not fail the
     // settings write above.
@@ -105,8 +106,10 @@ if (Object.keys(answers).length > 0) {
         const { capped } = capWarnEraEnforcementOnce(db, settings.policy, dataDir);
         if (capped > 0) {
           process.stdout.write(
-            `I eased ${String(capped)} detection level${capped === 1 ? '' : 's'} back to ` +
-              `"warn" to match the new defaults — you can raise any of them again in this setup.\n`,
+            show(
+              `I eased ${String(capped)} detection level${capped === 1 ? '' : 's'} back to ` +
+                `"warn" to match the new defaults — you can raise any of them again in this setup.`,
+            ),
           );
         }
       } finally {
@@ -141,7 +144,7 @@ if (rawPosture !== undefined || useFloor) {
       // severity-floor fallback), never a literal.
       const categoryCount = Object.keys(posture).length;
       process.stdout.write(
-        renderCategoriesTuned(categoryCount) + (useFloor ? ' — safe defaults' : '') + '\n',
+        show(renderCategoriesTuned(categoryCount) + (useFloor ? ' — safe defaults' : '')),
       );
     } finally {
       db.close();

--- a/plugins/claude-code/src/present.ts
+++ b/plugins/claude-code/src/present.ts
@@ -1,3 +1,5 @@
+import { showBlock } from './setup-show.ts';
+
 // Tiny zero-dependency terminal layout kit for the read surfaces. The
 // hook/command scripts ship self-contained (no node_modules on the user's
 // machine), so we can't pull in picocolors/cli-table — plain text and a few
@@ -202,4 +204,11 @@ export function fenced(body: string): string {
   const longestRun = Math.max(0, ...[...body.matchAll(/`+/g)].map((m) => m[0].length));
   const fence = '`'.repeat(Math.max(3, longestRun + 1));
   return [fence, body, fence].join('\n');
+}
+
+// Wrap user-facing output in a SHOW relay region. The wizard's global contract
+// pastes everything between the markers verbatim; the markers are delimiters,
+// never shown. A card is show(fenced(card)); a plain confirmation is show(line).
+export function show(body: string): string {
+  return showBlock(body);
 }

--- a/plugins/claude-code/src/remediation/entry.ts
+++ b/plugins/claude-code/src/remediation/entry.ts
@@ -54,7 +54,7 @@ import {
 } from '@akasecurity/schema';
 
 import { readRegisteredCommands } from '../command-registry.ts';
-import { fenced } from '../present.ts';
+import { fenced, show } from '../present.ts';
 import { frameJsonBlock, readFrameJsonBlock } from '../setup-frame-json.ts';
 import { presentBatchedRemediation, routeRemediationOption } from './chain.ts';
 import { resolveRemediationDeliverable } from './deliverable.ts';
@@ -106,12 +106,12 @@ function moreWorthALook(frameText: string, findings: readonly MaskedSecretFindin
 function present(frameText: string): void {
   const findings = loadSecretLeakFindings(() => frameText);
   if (findings === undefined) {
-    process.stdout.write(FRAME_READ_NOTE);
+    process.stdout.write(show(FRAME_READ_NOTE));
     return;
   }
   const decision = presentBatchedRemediation(findings, { entrySource: 'first-run' });
   if (decision.kind !== 'decision') {
-    process.stdout.write("No exposed keys to deal with — you're clear.\n");
+    process.stdout.write(show("No exposed keys to deal with — you're clear."));
     return;
   }
   const layout = renderRemediationDecision(
@@ -119,7 +119,7 @@ function present(frameText: string): void {
     moreWorthALook(frameText, findings),
     readRegisteredCommands(),
   );
-  process.stdout.write(`${decision.prompt}\n\n${fenced(layout)}\n`);
+  process.stdout.write(show(`${decision.prompt}\n\n${fenced(layout)}`));
   process.stdout.write(frameJsonBlock(decision));
 }
 
@@ -197,7 +197,7 @@ async function route(
 
   const findings = loadSecretLeakFindings(() => frameText);
   if (findings === undefined) {
-    process.stdout.write(FRAME_READ_NOTE);
+    process.stdout.write(show(FRAME_READ_NOTE));
     return;
   }
 
@@ -225,18 +225,20 @@ async function route(
       // so it does not print the standalone confirmation here — reported once.
       if (!outcome.withRotationChecklist) {
         process.stdout.write(
-          `${renderRedactionOutcome({
-            redactedKeys: outcome.redactedKeys,
-            findings,
-            unredactedFindings: redaction.unredacted,
-          })}\n`,
+          show(
+            renderRedactionOutcome({
+              redactedKeys: outcome.redactedKeys,
+              findings,
+              unredactedFindings: redaction.unredacted,
+            }),
+          ),
         );
       }
       // A 'redacted' outcome comes only from a redact route, where
       // requireRedactPosture already produced a validated level; persist it after
       // the strike and before any resolved summary.
       if (postureLevel !== undefined) {
-        process.stdout.write(postureConfirmation(writeSecretPosture(postureLevel)));
+        process.stdout.write(show(postureConfirmation(writeSecretPosture(postureLevel))));
       }
       if (outcome.withRotationChecklist) {
         const deliverable = resolveRemediationDeliverable({
@@ -245,14 +247,14 @@ async function route(
           unredactedFindings: redaction.unredacted,
           cwd: process.cwd(),
         });
-        process.stdout.write(`${deliverable.summary}\n`);
+        process.stdout.write(show(deliverable.summary));
       }
       break;
     case 'posture-set':
-      process.stdout.write(postureConfirmation(outcome.posture));
+      process.stdout.write(show(postureConfirmation(outcome.posture)));
       break;
     case 'left':
-      process.stdout.write('Left them as they are — nothing redacted, nothing changed.\n');
+      process.stdout.write(show('Left them as they are — nothing redacted, nothing changed.'));
       break;
   }
 }
@@ -274,7 +276,9 @@ if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
     }
   } catch (err) {
     process.stdout.write(
-      `Could not run the remediation chain (${err instanceof Error ? err.message : 'unknown error'}).\n`,
+      show(
+        `Could not run the remediation chain (${err instanceof Error ? err.message : 'unknown error'}).`,
+      ),
     );
   }
 

--- a/plugins/claude-code/src/setup-show.ts
+++ b/plugins/claude-code/src/setup-show.ts
@@ -1,0 +1,91 @@
+/**
+ * User-facing SHOW regions the /aka:setup wizard scripts emit. A script wraps
+ * everything the user should see — fenced cards and plain confirmation lines —
+ * in these markers; the wizard's global relay contract pastes the content
+ * between the markers verbatim. The markers are delimiters, never shown. This is
+ * the human-facing twin of setup-frame-json.ts's machine-frame markers: same
+ * delimiter style, opposite disposition (show vs hide).
+ */
+import { FRAME_JSON_BEGIN, FRAME_JSON_END } from './setup-frame-json.ts';
+
+export const SHOW_BEGIN = '<<<AKA_SHOW';
+export const SHOW_END = 'AKA_SHOW>>>';
+
+// Wrap a body in a SHOW region a script writes to stdout. The trailing newline
+// keeps the region on its own lines even when callers concatenate emissions.
+export function showBlock(body: string): string {
+  return `${SHOW_BEGIN}\n${body}\n${SHOW_END}\n`;
+}
+
+// Extract every SHOW region's content, in order. A region missing its end marker
+// is skipped rather than throwing, so a reader treats malformed output as "no
+// further show content" uniformly.
+export function readShowBlocks(stdout: string): string[] {
+  const blocks: string[] = [];
+  let from = 0;
+  for (;;) {
+    const begin = stdout.indexOf(SHOW_BEGIN, from);
+    if (begin === -1) break;
+    const contentStart = begin + SHOW_BEGIN.length;
+    const end = stdout.indexOf(SHOW_END, contentStart);
+    if (end === -1) break;
+    blocks.push(stdout.slice(contentStart, end).replace(/^\n/, '').replace(/\n$/, ''));
+    from = end + SHOW_END.length;
+  }
+  return blocks;
+}
+
+export interface Surface {
+  shows: string[];
+  frames: unknown[];
+  status: string;
+}
+
+// Partition a script's stdout into the three wizard output regions in a single
+// left-to-right walk, so every byte lands in exactly one of them: `shows` is
+// what the model relays verbatim; `frames` is machine-only parsed JSON (malformed
+// blocks are dropped); `status` is the untagged remainder (paths, errors) with
+// every show and frame region removed. A region missing its end marker stops the
+// walk but still appends everything from that marker onward — including any
+// trailing untagged text — to `status`, rather than dropping it.
+export function parseSurface(stdout: string): Surface {
+  const shows: string[] = [];
+  const frames: unknown[] = [];
+  let status = '';
+  let cursor = 0;
+  while (cursor < stdout.length) {
+    const nextShow = stdout.indexOf(SHOW_BEGIN, cursor);
+    const nextFrame = stdout.indexOf(FRAME_JSON_BEGIN, cursor);
+    const candidates = [nextShow, nextFrame].filter((i) => i !== -1);
+    if (candidates.length === 0) {
+      status += stdout.slice(cursor);
+      break;
+    }
+    const next = Math.min(...candidates);
+    status += stdout.slice(cursor, next);
+    if (next === nextShow) {
+      const contentStart = next + SHOW_BEGIN.length;
+      const end = stdout.indexOf(SHOW_END, contentStart);
+      if (end === -1) {
+        status += stdout.slice(next);
+        break;
+      }
+      shows.push(stdout.slice(contentStart, end).replace(/^\n/, '').replace(/\n$/, ''));
+      cursor = end + SHOW_END.length;
+    } else {
+      const from = next + FRAME_JSON_BEGIN.length;
+      const end = stdout.indexOf(FRAME_JSON_END, from);
+      if (end === -1) {
+        status += stdout.slice(next);
+        break;
+      }
+      try {
+        frames.push(JSON.parse(stdout.slice(from, end).trim()));
+      } catch {
+        // Malformed frame: drop it, mirroring readFrameJsonBlock's fail-soft.
+      }
+      cursor = end + FRAME_JSON_END.length;
+    }
+  }
+  return { shows, frames, status };
+}

--- a/plugins/claude-code/src/start-light.ts
+++ b/plugins/claude-code/src/start-light.ts
@@ -25,7 +25,7 @@
 import { severityFloorPosture } from '@akasecurity/plugin-sdk';
 
 import { parseCurrent, parsePosture } from './onboard-posture.ts';
-import { fenced } from './present.ts';
+import { fenced, show } from './present.ts';
 import { renderAdjustConfirm, renderStartLight } from './render.ts';
 
 const argv = process.argv.slice(2);
@@ -70,7 +70,7 @@ try {
 
   // One Markdown code fence so the wizard can echo the card verbatim (space-aligned
   // monospace collapses without the fence).
-  process.stdout.write(`${fenced(card)}\n`);
+  process.stdout.write(show(fenced(card)));
 } catch (err) {
   const message = err instanceof Error ? err.message : String(err);
   process.stdout.write(`AKA setup failed: ${message}\n`);

--- a/plugins/claude-code/src/triage/adapter.ts
+++ b/plugins/claude-code/src/triage/adapter.ts
@@ -26,6 +26,7 @@ import type {
 
 import { frameCalibration, frameEmptyState } from '../calibration.ts';
 import { readRegisteredCommands } from '../command-registry.ts';
+import { fenced, show } from '../present.ts';
 import { renderApplied, renderRecommendedPosture, STORE_UNAVAILABLE_NOTE } from '../render.ts';
 import { frameJsonBlock } from '../setup-frame-json.ts';
 import { dedupeForJudge } from './dedupe.ts';
@@ -127,7 +128,7 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       // A scan ran and surfaced nothing: render the honest scan-ran-clean empty
       // state over the recommended posture, plus its zero-count CalibrationFrame.
       const empty = frameEmptyState('scan-clean', severityFloorPosture());
-      deps.stdout(`${empty.copy}\n\n`);
+      deps.stdout(show(fenced(empty.copy)));
       deps.stdout(frameJsonBlock(empty.frame));
       return 0;
     }
@@ -135,7 +136,7 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       // A scan ran over an empty history set: render the honest no-history empty
       // state over the start-light posture, plus its zero-count CalibrationFrame.
       const empty = frameEmptyState('no-history', severityFloorPosture());
-      deps.stdout(`${empty.copy}\n\n`);
+      deps.stdout(show(fenced(empty.copy)));
       deps.stdout(frameJsonBlock(empty.frame));
       return 0;
     }
@@ -143,7 +144,7 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // refused to read history because access was never granted. Nothing was
     // examined, so this must not borrow the looked-and-found-nothing copy above:
     // that would report a clean bill of health for a scan that never ran.
-    deps.stdout("I didn't review anything — historical access wasn't granted.\n");
+    deps.stdout(show("I didn't review anything — historical access wasn't granted."));
     return 0;
   }
 
@@ -170,7 +171,9 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       // on screen. It also makes the fallback observable — otherwise the only
       // difference between one batch and ten is how long the wizard hangs.
       deps.stdout(
-        `Reviewing ${String(reps.length)} distinct values in ${String(chunks.length)} batches — this is the large-history path, so give it a moment.\n\n`,
+        show(
+          `Reviewing ${String(reps.length)} distinct values in ${String(chunks.length)} batches — this is the large-history path, so give it a moment.`,
+        ),
       );
     }
     let rec: TriageRecommendation;
@@ -217,22 +220,23 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
       storeUnavailable = true;
     }
 
+    // Collect every human-copy piece of the gate — the human gate is ONE
+    // consolidated SHOW region below, not a sequence of separate emits.
+    const gate: string[] = [];
     if (storeUnavailable) {
-      deps.stdout(`${STORE_UNAVAILABLE_NOTE}\n\n`);
+      gate.push(STORE_UNAVAILABLE_NOTE);
     }
     // With no readable store the downgrade comparison has no baseline, so pass an
     // empty current — every category renders as new rather than a partial/false view.
-    deps.stdout(renderPosturePlan(plan.posture, storeUnavailable ? {} : current) + '\n\n');
-    deps.stdout(renderShowcase(plan.showcase) + '\n\n');
-    deps.stdout(renderSuppressionGate(plan.entries, plan.join) + '\n');
+    gate.push(renderPosturePlan(plan.posture, storeUnavailable ? {} : current));
+    gate.push(renderShowcase(plan.showcase));
+    gate.push(renderSuppressionGate(plan.entries, plan.join));
     if (plan.skipped.length > 0) {
-      deps.stdout(
-        `\nSkipped (fail-secure): ${plan.skipped
-          .map((s) => `${s.category} — ${s.reason}`)
-          .join('; ')}\n`,
+      gate.push(
+        `Skipped (fail-secure): ${plan.skipped.map((s) => `${s.category} — ${s.reason}`).join('; ')}`,
       );
     }
-    deps.stdout(`\nNotes: ${plan.notes}\n`);
+    gate.push(`Notes: ${plan.notes}`);
 
     // Emit the structured calibration frame ALONGSIDE the human gate
     // above — additive, not a replacement. Counts and category lists come from
@@ -280,7 +284,14 @@ function runPreview(deps: AdapterDeps, planIO: PlanFileIO): number {
     // preview's genuine/suppressed split, then the condensed one-row-per-pack
     // recommended posture. Both are raw-free (counts, category enums, and palette
     // levels only) and template over this run's numbers, never a fixed value.
-    deps.stdout(`${calibration.copy}\n\n${renderRecommendedPosture(preview.posture)}\n\n`);
+    gate.push(calibration.copy);
+    gate.push(renderRecommendedPosture(preview.posture));
+
+    // The whole human gate — the posture plan, showcase, suppression gate, notes,
+    // and the calibrated-result card — is ONE relay region: the model pastes it
+    // verbatim, so it must read as a single coherent screen, not several stray
+    // fragments the model has to stitch back together.
+    deps.stdout(show(fenced(gate.join('\n\n'))));
 
     // The machine-readable calibration frame carrying the same counts/posture the
     // card above renders, for downstream consumers (the installed-summary handoff).
@@ -432,7 +443,7 @@ async function runConfirm(deps: AdapterDeps, planIO: PlanFileIO): Promise<number
       // counts threaded from the real writeback result, never a literal; the
       // Ready line's curated set validated against the installed command registry.
       deps.stdout(
-        `${renderApplied(res.categoriesWritten, res.written, readRegisteredCommands())}\n`,
+        show(renderApplied(res.categoriesWritten, res.written, readRegisteredCommands())),
       );
     } catch {
       // Reporting failed but the write did not — still a success.

--- a/plugins/claude-code/test/firstrun-core.test.ts
+++ b/plugins/claude-code/test/firstrun-core.test.ts
@@ -17,6 +17,7 @@ import {
 } from '../src/firstrun-core.ts';
 import { readPostureBlock } from '../src/posture.ts';
 import { readFrameJsonBlock } from '../src/setup-frame-json.ts';
+import { parseSurface } from '../src/setup-show.ts';
 
 // Composed at runtime so the repo's own secret scanning doesn't flag this file.
 const AWS_EXAMPLE_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
@@ -261,6 +262,17 @@ describe('runFirstRun — emits the handoff-offer payload alongside the card', (
     expect(blob).not.toContain(AWS_EXAMPLE_KEY);
   });
 
+  it('install summary is a SHOW region; the handoff payload stays a frame', async () => {
+    const blob = await seedAndRun(['--surfaced', '2', '--live-keys', '1']);
+    const surface = parseSurface(blob);
+    // The install card (its "Health N/100" line) is relayed verbatim as a SHOW region.
+    expect(surface.shows.some((s) => s.includes('Health'))).toBe(true);
+    // The handoff payload stays a machine-only FRAME, never shown.
+    expect(surface.frames).toHaveLength(1);
+    // The card text never leaks into the untagged status remainder.
+    expect(surface.status).not.toContain('Health');
+  });
+
   it('card stats trace to the seeded store, never a fixed literal', async () => {
     const cfg = config(dir);
     // Two distinct sensitive findings through the real write path: a critical
@@ -350,5 +362,12 @@ describe('runFirstRunFailOpen — degrades to the store-unavailable note on a st
     expect(blob).toContain("I couldn't check my records just now");
     // No fabricated card: the install card's stats never rendered over a dead store.
     expect(blob).not.toContain('installed');
+
+    // The note is relayed as a SHOW region, not left in the untagged status remainder.
+    const surface = parseSurface(blob);
+    expect(surface.shows.some((s) => s.includes("I couldn't check my records just now"))).toBe(
+      true,
+    );
+    expect(surface.status).not.toContain("I couldn't check my records just now");
   });
 });

--- a/plugins/claude-code/test/intro-show.test.ts
+++ b/plugins/claude-code/test/intro-show.test.ts
@@ -1,0 +1,32 @@
+/**
+ * scripts/intro.js — the setup-wizard intro card emitter. Runs the BUILT script
+ * the wizard actually shells out to (passing the real plugin manifest path, as
+ * the wizard does) and asserts its stdout is a single SHOW region carrying the
+ * fenced card — the honest end-to-end check that intro.ts's emit is wrapped
+ * through present.ts's show(), not just that show()+fenced() compose correctly
+ * in isolation.
+ */
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseSurface } from '../src/setup-show.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test -> plugins/claude-code
+const PLUGIN_ROOT = join(HERE, '..');
+const SCRIPT = join(PLUGIN_ROOT, 'scripts', 'intro.js');
+const MANIFEST = join(PLUGIN_ROOT, '.claude-plugin', 'plugin.json');
+
+describe('scripts/intro.js', () => {
+  const stdout = execFileSync(process.execPath, [SCRIPT, MANIFEST], { encoding: 'utf8' });
+  const surface = parseSurface(stdout);
+
+  it('emits the intro card inside exactly one SHOW region, with no untagged status output', () => {
+    expect(surface.shows).toHaveLength(1);
+    expect(surface.shows[0]).toContain('● AKA Security');
+    expect(surface.status.trim()).toBe('');
+  });
+});

--- a/plugins/claude-code/test/onboard.test.ts
+++ b/plugins/claude-code/test/onboard.test.ts
@@ -1,6 +1,8 @@
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import type { LocalDatabase } from '@akasecurity/persistence';
 import { openLocalDatabase, readWorkspaceSettings } from '@akasecurity/persistence';
@@ -13,6 +15,36 @@ import { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { parsePosture } from '../src/onboard-posture.ts';
+import { parseSurface } from '../src/setup-show.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test -> plugins/claude-code
+const SCRIPT = join(HERE, '..', 'scripts', 'onboard.js');
+
+interface Run {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Runs the BUILT script the wizard actually shells out to, against a fresh,
+// throwaway ~/.aka home per call so this suite's assertions stay independent
+// of the real machine's store (mirrors start-light.test.ts's runStartLight).
+function onboardRun(args: string[] = []): Run {
+  const home = mkdtempSync(join(tmpdir(), 'aka-onboard-run-test-'));
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      env: { HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
 
 // The recommended-posture default map, frozen here so the test fails loudly if
 // severityFloorPosture() ever drifts from it (the "unchanged from before the
@@ -108,5 +140,21 @@ describe('onboard writes a valid store/settings state with the recommended postu
     // code_context keeps the default the store seeds on open ('log'); fill-gaps
     // never downgrades the already-calibrated 'secret' row.
     expect(db.policies.getCategoryAction('code_context')).toBe('log');
+  });
+});
+
+describe('onboard emits user-facing output inside SHOW regions', () => {
+  it('--historical full wraps the warm confirmation as a SHOW region', () => {
+    const run = onboardRun(['--historical', 'full']);
+    const surface = parseSurface(run.stdout);
+    expect(surface.shows.join('\n')).toContain("Got it — I'll look over Claude's recent work");
+    expect(surface.status).not.toContain("Got it — I'll look over");
+  });
+
+  it('--floor wraps the applied-posture confirmation as a SHOW region', () => {
+    const run = onboardRun(['--floor']);
+    const surface = parseSurface(run.stdout);
+    expect(surface.shows.join('\n')).toContain('safe defaults');
+    expect(surface.status).not.toContain('safe defaults');
   });
 });

--- a/plugins/claude-code/test/relay-contract-guard.test.ts
+++ b/plugins/claude-code/test/relay-contract-guard.test.ts
@@ -36,6 +36,7 @@ const FILES = [
   'src/firstrun.ts',
   'src/firstrun-core.ts',
   'src/triage/adapter.ts',
+  'src/apply-suppressions.ts',
   'src/remediation/entry.ts',
 ] as const;
 
@@ -207,6 +208,14 @@ const ALLOWLIST: AllowlistEntry[] = [
       'The FirstRunDeps.stdout DI wiring: a pure passthrough callback. Its argument `s` is already ' +
       'wrapped in show(...)/frameJsonBlock(...) by firstrun-core.ts before it ever reaches this ' +
       'callback, so no raw content originates at this call site.',
+  },
+  {
+    file: 'src/apply-suppressions.ts',
+    substring: 'process.stdout.write(s)',
+    reason:
+      'The apply-suppressions stdout DI wiring: a pure passthrough callback into runApply() — ' +
+      'symmetric with firstrun.ts. All content originates in triage/adapter.ts (covered), already ' +
+      'wrapped in show(...)/frameJsonBlock(...) or an allowlisted STATUS path before it reaches here.',
   },
   {
     file: 'src/triage/adapter.ts',

--- a/plugins/claude-code/test/relay-contract-guard.test.ts
+++ b/plugins/claude-code/test/relay-contract-guard.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Static drift guard for the `/aka:setup` wizard's relay contract: every
+ * USER-FACING stdout emit from a wizard script must pass through `show()` /
+ * `showBlock()` (present.ts / setup-show.ts) so the harness's SHOW-region
+ * relay pastes it verbatim, or be a `frameJsonBlock()` machine frame
+ * (setup-frame-json.ts). Anything else on stdout is model-facing STATUS
+ * (paths, fail() errors) that the model reads but never relays to the user.
+ *
+ * A raw `process.stdout.write(...)` / `deps.stdout(...)` call that emits
+ * neither a SHOW region nor a FRAME is a silent contract violation: the text
+ * reaches stdout but the relay chokepoint never wraps it, so it is never
+ * shown to the user. This test statically scans a MAINTAINED list of the
+ * wizard's user-facing script sources for every such call site and asserts
+ * each one is accounted for by one of:
+ *
+ *   (a) the call passes through `show(` / `showBlock(`
+ *   (b) the call is a `frameJsonBlock(`
+ *   (c) the call is on the explicit ALLOWLIST below, keyed by file + a
+ *       distinctive substring, each with a one-line reason
+ *
+ * The allowlist is the enumerated set of INTENTIONAL non-relayed emits, not a
+ * catch-all — keep it minimal. A failure here names the file + line so a
+ * developer either wraps the emit in `show(...)` or, if it is genuinely
+ * status, adds it to the allowlist with a reason.
+ */
+import { existsSync, readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// The wizard's user-facing emit surfaces. Add a new wizard script here when it
+// starts writing to stdout — an unlisted file is invisible to this guard.
+const FILES = [
+  'src/intro.ts',
+  'src/onboard.ts',
+  'src/start-light.ts',
+  'src/firstrun.ts',
+  'src/firstrun-core.ts',
+  'src/triage/adapter.ts',
+  'src/remediation/entry.ts',
+] as const;
+
+const CALL_HEADS = ['process.stdout.write', 'deps.stdout'] as const;
+
+interface EmitSite {
+  file: string;
+  line: number;
+  // The full call expression text, e.g. `process.stdout.write(show(...))`.
+  callText: string;
+}
+
+// Blank out every `//` line comment and `/* */` block comment in `source`,
+// replacing their characters with spaces (newlines preserved) while leaving
+// code and string/template literals byte-for-byte intact — so the result is
+// the exact same length, with every index still lining up with `source`.
+// Comment prose ("doesn't", "the wizard's `--posture` flag", `'redact-only'`)
+// is full of apostrophes and stray parens that are NOT string literals or
+// call parens; without this pass they get misread as one, throwing off the
+// paren-depth count below. String/template literals are copied verbatim
+// (not masked) so a real call's `(`/`)` balance is unaffected by this pass.
+function maskComments(source: string): string {
+  let out = '';
+  let i = 0;
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (ch === '/' && next === '/') {
+      while (i < source.length && source[i] !== '\n') {
+        out += ' ';
+        i++;
+      }
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      out += '  ';
+      i += 2;
+      while (i < source.length && !(source[i] === '*' && source[i + 1] === '/')) {
+        out += source[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      out += '  ';
+      i += 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      const end = skipStringLiteral(source, i, ch);
+      out += source.slice(i, end + 1);
+      i = end + 1;
+      continue;
+    }
+    out += source.charAt(i);
+    i++;
+  }
+  return out;
+}
+
+// Find the index just past the matching close paren for the call opened at
+// `openParenIndex` (which must point AT the '('), skipping over string/
+// template literal contents (which may themselves contain unbalanced parens,
+// e.g. `` `Plan saved to: ${x}` `` or `'AKA setup failed: ' + msg`) so they
+// never perturb the depth count. Callers must run this over a
+// comment-masked source (see maskComments) — a raw source's comment prose
+// can itself contain unbalanced quotes/parens that would misread as code.
+function matchingCloseParen(source: string, openParenIndex: number): number {
+  let depth = 0;
+  for (let i = openParenIndex; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '"' || ch === "'" || ch === '`') {
+      i = skipStringLiteral(source, i, ch);
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  throw new Error(`unbalanced parens scanning call at index ${String(openParenIndex)}`);
+}
+
+// Return the index of the unescaped closing quote matching `quote`, starting
+// the scan right after the opening quote at `start`.
+function skipStringLiteral(source: string, start: number, quote: string): number {
+  let i = start + 1;
+  for (; i < source.length; i++) {
+    if (source[i] === '\\') {
+      i++;
+      continue;
+    }
+    if (source[i] === quote) return i;
+  }
+  return i;
+}
+
+// Every `process.stdout.write(...)` / `deps.stdout(...)` call site in
+// `source`, in file order, with its 1-indexed source line and the full call
+// expression text (spanning multiple lines is fine — callers only need the
+// text to search, not a formatted statement). Call-head and paren-balance
+// scanning runs over a comment-masked copy so comment prose can't be
+// misread as code; the reported `callText` is sliced from the ORIGINAL
+// source (same indices — masking preserves length and offsets) so
+// violation messages show the real code, comments included.
+function findEmitSites(file: string, source: string): EmitSite[] {
+  const masked = maskComments(source);
+  const sites: EmitSite[] = [];
+  for (const head of CALL_HEADS) {
+    let searchFrom = 0;
+    for (;;) {
+      const headIndex = masked.indexOf(head, searchFrom);
+      if (headIndex === -1) break;
+      const openParenIndex = masked.indexOf('(', headIndex + head.length);
+      // Guard against a false hit like a `deps.stdout` property reference with
+      // no immediately-following call (not expected in these files, but this
+      // keeps the scan from throwing if one ever appears).
+      if (
+        openParenIndex === -1 ||
+        masked.slice(headIndex + head.length, openParenIndex).trim() !== ''
+      ) {
+        searchFrom = headIndex + head.length;
+        continue;
+      }
+      const closeParenIndex = matchingCloseParen(masked, openParenIndex);
+      const line = source.slice(0, headIndex).split('\n').length;
+      sites.push({
+        file,
+        line,
+        callText: source.slice(headIndex, closeParenIndex + 1),
+      });
+      searchFrom = closeParenIndex + 1;
+    }
+  }
+  return sites;
+}
+
+function passesThroughShow(callText: string): boolean {
+  return /\bshow\(|\bshowBlock\(/.test(callText);
+}
+
+function isFrame(callText: string): boolean {
+  return /\bframeJsonBlock\(/.test(callText);
+}
+
+interface AllowlistEntry {
+  file: (typeof FILES)[number];
+  substring: string;
+  reason: string;
+}
+
+// The enumerated set of INTENTIONAL non-relayed stdout emits — model-facing
+// STATUS, never user-facing copy. Keep this list explicit and minimal; a new
+// entry needs a one-line reason a reviewer can check against the code.
+const ALLOWLIST: AllowlistEntry[] = [
+  {
+    file: 'src/onboard.ts',
+    substring: 'AKA setup failed:',
+    reason:
+      "fail()'s error line — a wizard-wiring/validation failure the model reads, never a relayed card.",
+  },
+  {
+    file: 'src/start-light.ts',
+    substring: 'AKA setup failed:',
+    reason: "fail()'s error line — same as onboard.ts: model-facing STATUS, not user-facing copy.",
+  },
+  {
+    file: 'src/firstrun.ts',
+    substring: 'process.stdout.write(s)',
+    reason:
+      'The FirstRunDeps.stdout DI wiring: a pure passthrough callback. Its argument `s` is already ' +
+      'wrapped in show(...)/frameJsonBlock(...) by firstrun-core.ts before it ever reaches this ' +
+      'callback, so no raw content originates at this call site.',
+  },
+  {
+    file: 'src/triage/adapter.ts',
+    substring: 'Plan saved to:',
+    reason:
+      'The raw-free plan-file path printed for the wizard to hand to the confirm step — a ' +
+      'model-facing STATUS path, not copy the user needs relayed.',
+  },
+  {
+    file: 'src/triage/adapter.ts',
+    substring: 'Re-run with:',
+    reason:
+      'The confirm re-run command line (apply-suppressions.js --confirmed --plan <path>) — ' +
+      'model-facing STATUS instructing the model how to continue the chain, not user-facing copy.',
+  },
+];
+
+function readSource(file: string): string {
+  return readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+}
+
+describe('wizard relay contract guard', () => {
+  it.each(FILES)('scans an existing file: %s', (file) => {
+    expect(existsSync(new URL(`../${file}`, import.meta.url))).toBe(true);
+  });
+
+  it('routes every stdout emit through show()/showBlock(), frameJsonBlock(), or the STATUS allowlist', () => {
+    const violations: string[] = [];
+    const usedAllowlistEntries = new Set<AllowlistEntry>();
+
+    for (const file of FILES) {
+      const source = readSource(file);
+      for (const site of findEmitSites(file, source)) {
+        if (passesThroughShow(site.callText) || isFrame(site.callText)) continue;
+
+        const allow = ALLOWLIST.find(
+          (entry) => entry.file === site.file && site.callText.includes(entry.substring),
+        );
+        if (allow) {
+          usedAllowlistEntries.add(allow);
+          continue;
+        }
+
+        violations.push(
+          `${site.file}:${String(site.line)} — stdout emit is not wrapped in show()/showBlock(), ` +
+            `is not a frameJsonBlock(), and matches no ALLOWLIST entry:\n` +
+            `    ${site.callText.replace(/\s+/g, ' ').slice(0, 160)}\n` +
+            `  Wrap it in show(...) (show(fenced(...)) for a card) if this is user-facing copy, ` +
+            `or add it to ALLOWLIST in test/relay-contract-guard.test.ts with a one-line reason if ` +
+            `it is genuinely model-facing STATUS.`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the STATUS allowlist minimal — every entry matches a real, current emit', () => {
+    const stale: string[] = [];
+
+    for (const entry of ALLOWLIST) {
+      const source = readSource(entry.file);
+      const sites = findEmitSites(entry.file, source);
+      const stillMatches = sites.some(
+        (site) =>
+          !passesThroughShow(site.callText) &&
+          !isFrame(site.callText) &&
+          site.callText.includes(entry.substring),
+      );
+      if (!stillMatches) {
+        stale.push(`${entry.file} — "${entry.substring}" (reason: ${entry.reason})`);
+      }
+    }
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/plugins/claude-code/test/remediation/production-entry.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/production-entry.scenario.test.ts
@@ -2,11 +2,12 @@ import { execFileSync } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import type { CalibrationPreview } from '@akasecurity/schema';
+import type { CalibrationPreview, MaskedSecretFinding } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { frameCalibration } from '../../src/calibration.ts';
 import { frameJsonBlock } from '../../src/setup-frame-json.ts';
+import { parseSurface } from '../../src/setup-show.ts';
 
 // The empty-findings honest-degrade leg, proven at the declared INTEGRATION
 // seam: the shipped, entry-point-agnostic direct-invocation entry — the same
@@ -47,6 +48,50 @@ function present(frameText: string): string {
   });
 }
 
+// Route mode: the same built entry, spawned with `--option`/`--posture`.
+function route(frameText: string, ...args: string[]): string {
+  return execFileSync(process.execPath, [REMEDIATE_SCRIPT, ...args], {
+    input: frameText,
+    encoding: 'utf8',
+  });
+}
+
+// A backfill + apply-suppressions preview that DID surface a secret leak — the
+// counterpart to the empty-findings `preview` above — so the count line, the
+// fenced finding table, and the frame block can be proven as SHOW/FRAME regions
+// against a real (non-empty) remediation decision. The masked finding mirrors
+// findings.test.ts's raw-free MaskedSecretFinding shape — no raw value anywhere.
+const secretsPreview: CalibrationPreview = {
+  categories: [{ category: 'secret', genuineCount: 2, fpCount: 0, egress: false }],
+  posture: {
+    secret: 'warn',
+    pii: 'warn',
+    financial: 'warn',
+    phi: 'warn',
+    code_flaw: 'warn',
+    custom: 'warn',
+    code_context: 'monitor',
+    config: 'monitor',
+  },
+};
+
+const stripeFinding: MaskedSecretFinding = {
+  provider: 'stripe',
+  maskedToken: 'sk_live_****',
+  where: { filePath: '~/.claude/transcripts/2026-07-01.jsonl' },
+  state: 'still-valid',
+};
+const awsFinding: MaskedSecretFinding = {
+  provider: 'aws',
+  maskedToken: 'AKIA****************',
+  where: { filePath: '/tmp/agent-dump.txt', span: { start: 12, end: 32 } },
+  state: 'still-valid',
+};
+
+function secretsFrameText(): string {
+  return frameJsonBlock(frameCalibration(secretsPreview, [stripeFinding, awsFinding]).frame);
+}
+
 describe('production remediation entry: honest degrade on a successfully-read, zero-finding set', () => {
   it('a frame that read cleanly but carried no secret findings degrades honestly — no fabricated count, no remediation decision', () => {
     // `frameCalibration` is called with no maskedFindings argument, so it
@@ -56,29 +101,63 @@ describe('production remediation entry: honest degrade on a successfully-read, z
     const emptyFrameText = frameJsonBlock(frameCalibration(preview).frame);
 
     const out = present(emptyFrameText);
+    const surface = parseSurface(out);
 
     // The honest no-op the entry prints when `presentBatchedRemediation` returns
     // `{ kind: 'no-decision' }` over an empty findings set — never a fabricated
-    // count and never the remediation-decision copy.
-    expect(out).toBe("No exposed keys to deal with — you're clear.\n");
-    expect(out).not.toContain('exposed secret');
-    expect(out).not.toContain('Redact + rotation checklist');
+    // count and never the remediation-decision copy. It rides inside a SHOW
+    // region — the same relay chokepoint every other user-facing note in this
+    // entry now uses.
+    expect(surface.shows).toEqual(["No exposed keys to deal with — you're clear."]);
+    expect(surface.status).not.toContain('exposed secret');
+    expect(surface.status).not.toContain('Redact + rotation checklist');
     // No frame JSON block is emitted for a no-decision outcome — nothing for a
     // wizard/harness to mistake for a real remediation-decision payload.
-    expect(out).not.toContain('AKA_FRAME_JSON');
+    expect(surface.frames).toHaveLength(0);
   });
 
   it('is distinct from the read-failure path: a successful empty read never reads like an unreadable frame', () => {
     const emptyFrameText = frameJsonBlock(frameCalibration(preview).frame);
     const unreadableFrameText = 'this is not a calibration frame block';
 
-    const emptyOut = present(emptyFrameText);
-    const unreadableOut = present(unreadableFrameText);
+    const emptyOut = parseSurface(present(emptyFrameText));
+    const unreadableOut = parseSurface(present(unreadableFrameText));
 
-    expect(emptyOut).toBe("No exposed keys to deal with — you're clear.\n");
-    expect(unreadableOut).toBe(
+    expect(emptyOut.shows).toEqual(["No exposed keys to deal with — you're clear."]);
+    // FRAME_READ_NOTE carries its own trailing newline (shared with the
+    // route-mode read-failure path), so the SHOW region's content keeps it too.
+    expect(unreadableOut.shows).toEqual([
       "I couldn't pull up what I found just now — the details weren't available.\n",
-    );
-    expect(emptyOut).not.toEqual(unreadableOut);
+    ]);
+    expect(emptyOut.shows).not.toEqual(unreadableOut.shows);
+  });
+});
+
+describe('production remediation entry: SHOW-relay coverage (present + route)', () => {
+  it('present mode emits the count line + fenced finding table as a SHOW region, keeps the decision frame a FRAME, and never leaks the finding into status', () => {
+    const out = present(secretsFrameText());
+    const surface = parseSurface(out);
+
+    expect(surface.shows).toHaveLength(1);
+    const [card] = surface.shows;
+    expect(card).toContain('exposed secret keys');
+    // The fenced finding table rides inside the same SHOW region as the count line.
+    expect(card).toContain('sk_live_****');
+    expect(card).toContain('```');
+
+    // The machine-readable decision frame is untouched — still a FRAME, never a SHOW.
+    expect(surface.frames).toHaveLength(1);
+
+    // The finding text never leaks into the untagged status remainder.
+    expect(surface.status).not.toContain('exposed secret keys');
+    expect(surface.status).not.toContain('sk_live_****');
+  });
+
+  it('route "leave" emits its note as a SHOW region', () => {
+    const out = route(secretsFrameText(), '--option', 'leave');
+    const surface = parseSurface(out);
+
+    expect(surface.shows).toEqual(['Left them as they are — nothing redacted, nothing changed.']);
+    expect(surface.status).not.toContain('Left them as they are');
   });
 });

--- a/plugins/claude-code/test/setup-copy.test.ts
+++ b/plugins/claude-code/test/setup-copy.test.ts
@@ -205,3 +205,25 @@ describe('setup.md frame-0.6 "Review leaked keys" branch', () => {
     expect(section).toContain("scripts/remediate.js\" --option <id> <<'AKA_FRAME'");
   });
 });
+
+// Task 9: the prompt states the relay contract once, up front, rather than
+// leaving a skimming model to infer AKA_SHOW handling per step. These guards
+// pin the contract's verbatim invariant strings and the step-7 double-ask trim.
+describe('setup.md execution contract', () => {
+  it('states the one-sentence relay rule for AKA_SHOW regions', () => {
+    expect(setupMd).toContain('relay every AKA_SHOW region verbatim');
+  });
+  it('forbids ad-libbed confirmations', () => {
+    expect(setupMd).toContain('write a confirmation or acknowledgement the wizard did not emit');
+  });
+  it('requires each step’s SHOW regions before advancing', () => {
+    expect(setupMd).toContain('must be relayed before you advance');
+  });
+  it('states one picker per decision', () => {
+    expect(setupMd).toContain('picker per decision');
+  });
+  it('step 7 has a single install gate (no second permission picker)', () => {
+    // The old double-ask phrasing must be gone.
+    expect(setupMd).not.toContain('Ask permission before running it, warmly');
+  });
+});

--- a/plugins/claude-code/test/setup-show.test.ts
+++ b/plugins/claude-code/test/setup-show.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { fenced, show } from '../src/present.ts';
+import { frameJsonBlock } from '../src/setup-frame-json.ts';
+import { parseSurface, readShowBlocks, showBlock } from '../src/setup-show.ts';
+
+describe('showBlock / readShowBlocks', () => {
+  it('round-trips a body through the delimited block', () => {
+    expect(readShowBlocks(showBlock('hello card'))).toEqual(['hello card']);
+  });
+
+  it('preserves a fenced multi-line body verbatim', () => {
+    const card = '```\n● AKA\n  line two\n```';
+    expect(readShowBlocks(showBlock(card))).toEqual([card]);
+  });
+
+  it('extracts every block when several are present amid other copy', () => {
+    const stdout = `${showBlock('one')}Plan saved to: /tmp/x\n${showBlock('two')}`;
+    expect(readShowBlocks(stdout)).toEqual(['one', 'two']);
+  });
+
+  it('returns [] when no block is present', () => {
+    expect(readShowBlocks('just a status line, no markers')).toEqual([]);
+  });
+
+  it('ignores a block whose end marker is missing (never throws)', () => {
+    expect(readShowBlocks('<<<AKA_SHOW\nunterminated')).toEqual([]);
+  });
+});
+
+describe('parseSurface — three-region partition', () => {
+  it('splits show regions, frames, and status with no overlap', () => {
+    const stdout =
+      show(fenced('● card headline')) +
+      frameJsonBlock({ counts: { important: 2 } }) +
+      '\nPlan saved to: /tmp/plan.json\n';
+    const surface = parseSurface(stdout);
+
+    expect(surface.shows).toEqual(['```\n● card headline\n```']);
+    expect(surface.frames).toEqual([{ counts: { important: 2 } }]);
+    // Status is the untagged remainder only — never the card text or a marker.
+    expect(surface.status).toContain('Plan saved to: /tmp/plan.json');
+    expect(surface.status).not.toContain('card headline');
+    expect(surface.status).not.toContain('AKA_SHOW');
+    expect(surface.status).not.toContain('AKA_FRAME_JSON');
+  });
+
+  it('show() delegates to showBlock (same delimiters)', () => {
+    expect(show('x')).toBe('<<<AKA_SHOW\nx\nAKA_SHOW>>>\n');
+  });
+
+  it('does not leak marker-shaped text inside a frame payload into shows', () => {
+    const stdout = frameJsonBlock({ note: '<<<AKA_SHOW\nx\nAKA_SHOW>>>' });
+    const surface = parseSurface(stdout);
+
+    expect(surface.frames).toEqual([{ note: '<<<AKA_SHOW\nx\nAKA_SHOW>>>' }]);
+    expect(surface.shows).toEqual([]);
+  });
+
+  it('keeps untagged status text that follows an unterminated show marker', () => {
+    const stdout = '<<<AKA_SHOW\nunterminated\nPlan saved to: /tmp/plan.json\n';
+    const surface = parseSurface(stdout);
+
+    expect(surface.status).toContain('Plan saved to: /tmp/plan.json');
+    expect(surface.shows).toEqual([]);
+  });
+});

--- a/plugins/claude-code/test/start-light.test.ts
+++ b/plugins/claude-code/test/start-light.test.ts
@@ -20,13 +20,14 @@ import { severityFloorPosture } from '@akasecurity/plugin-sdk';
 import type { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
-import { fenced } from '../src/present.ts';
+import { fenced, show } from '../src/present.ts';
 import {
   RE_TUNE_HINT,
   renderAdjustConfirm,
   renderPostureGrid,
   renderStartLight,
 } from '../src/render.ts';
+import { parseSurface } from '../src/setup-show.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test -> plugins/claude-code
@@ -66,13 +67,22 @@ describe('scripts/start-light.js', () => {
     expect(result.status).toBe(0);
     expect(result.stderr).toBe('');
     // The whole card wrapped in the shared code fence, rendered from the severity floor.
-    expect(result.stdout.trim()).toBe(fenced(renderStartLight(severityFloorPosture())));
+    expect(result.stdout.trim()).toBe(
+      show(fenced(renderStartLight(severityFloorPosture()))).trim(),
+    );
   });
 
   it('the fenced card carries the heading, the 8×4 default posture grid, and the re-tune hint', () => {
     expect(result.stdout).toContain('Starting light — your detection categories');
     expect(result.stdout).toContain(renderPostureGrid(severityFloorPosture()));
     expect(result.stdout).toContain(RE_TUNE_HINT);
+  });
+
+  it('emits the start-light card inside a single SHOW region', () => {
+    const surface = parseSurface(result.stdout);
+    expect(surface.shows).toHaveLength(1);
+    expect(surface.shows[0]).toContain('Starting light');
+    expect(surface.status.trim()).toBe('');
   });
 });
 
@@ -93,7 +103,9 @@ describe('scripts/start-light.js --adjust-confirm', () => {
     expect(result.stderr).toBe('');
     // The whole card wrapped in the shared fence, rendered from the recommended
     // posture against the adjusted --posture map it was handed.
-    expect(result.stdout.trim()).toBe(fenced(renderAdjustConfirm(recommended, chosen)));
+    expect(result.stdout.trim()).toBe(
+      show(fenced(renderAdjustConfirm(recommended, chosen))).trim(),
+    );
   });
 
   it("carries the 'category │ recommended │ yours' columns, the changed pack, and the re-tune hint", () => {
@@ -163,7 +175,9 @@ describe('scripts/start-light.js --adjust-confirm', () => {
       JSON.stringify(merged),
     ]);
     expect(withRec.status).toBe(0);
-    expect(withRec.stdout.trim()).toBe(fenced(renderAdjustConfirm(calibrated, merged)));
+    expect(withRec.stdout.trim()).toBe(
+      show(fenced(renderAdjustConfirm(calibrated, merged))).trim(),
+    );
     // The untouched escalated pack repeats its calibrated level in both columns —
     // it does not render as a spurious change against the floor.
     expect(withRec.stdout).toMatch(/secret\s+block\s+block/);

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -15,6 +15,7 @@ import {
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
+import { parseSurface } from '../../src/setup-show.ts';
 import { runApply } from '../../src/triage/adapter.ts';
 import { readPlanFile, writePlanFile } from '../../src/triage/plan-file.ts';
 
@@ -132,6 +133,47 @@ describe('runApply — preview persists a plan and writes nothing', () => {
   });
 });
 
+describe('runApply — preview consolidates the human gate into one SHOW region', () => {
+  it('emits exactly one SHOW gate, one FRAME, and keeps Plan-saved-to as untagged status', async () => {
+    const db = fakeDb();
+    const out: string[] = [];
+    const code = await runApply({
+      argv: [],
+      readStream: () => streamText(),
+      runJudge: () => verdict(),
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: (s) => out.push(s),
+      stderr: vi.fn(),
+    });
+    expect(code).toBe(0);
+    const surface = parseSurface(out.join(''));
+
+    // The whole human gate — posture plan, showcase, suppression gate, notes,
+    // AND the calibrated-result card — is ONE consolidated relay region.
+    expect(surface.shows).toHaveLength(1);
+    const [gate] = surface.shows;
+    if (gate === undefined) throw new Error('no SHOW region emitted');
+    expect(gate).toContain('canonical fake AWS example key'); // suppression-gate reasoning
+    expect(gate).toContain('routine'); // the showcase's genuine/routine split
+    expect(gate).toContain("I went through Claude's recent work"); // calibrated headline
+    expect(gate).toMatch(/secret\s+warn/); // renderRecommendedPosture row, inside the card
+
+    // The machine-readable calibration frame stays its own single FRAME region.
+    expect(surface.frames).toHaveLength(1);
+
+    // The plan-file path and re-run instructions stay untagged status — the model
+    // needs them, but they are not part of the relayed human copy.
+    expect(surface.status).toContain('Plan saved to:');
+    expect(surface.status).toContain('Re-run with:');
+
+    // None of the human gate's copy leaks into the untagged status remainder.
+    expect(surface.status).not.toContain('canonical fake AWS example key');
+    expect(surface.status).not.toContain("I went through Claude's recent work");
+  });
+});
+
 describe('runApply — preview renders the honest empty state on a clean scan', () => {
   it('prints the scan-ran-clean copy and a zero-count frame when the scan completes with no hits', async () => {
     const db = fakeDb();
@@ -157,6 +199,12 @@ describe('runApply — preview renders the honest empty state on a clean scan', 
     // Preview stays read-only: no posture upsert, no exception created.
     expect(db.posture).toEqual({});
     expect(db.created).toEqual([]);
+    // The empty-state copy is relayed as a SHOW region, and the frame stays the
+    // single FRAME region — the scan-ran-clean path follows the same three-region
+    // rule as the populated preview gate.
+    const surface = parseSurface(blob);
+    expect(surface.shows.some((s) => s.includes('nothing needs your attention'))).toBe(true);
+    expect(surface.frames).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## What & why

The `/aka:setup` wizard is prompt-driven: an agent runs the wizard scripts and is asked to show their output to the user — the intro card, the calibration result, the install summary, confirmation lines, the secret-leak finding table. The scripts already render these as self-contained monospace cards (`fenced()`), so the only remaining job is a faithful, verbatim relay.

That relay was enforced only by convention, and it drifts. Working through a long wizard, an agent can summarize a card in prose instead of showing it, ad-lib a confirmation the script never emitted, or double-ask a question — leaving the user without the card the wizard actually prepared.

## The change: a three-region output protocol

Every wizard script now tags its stdout into three explicit regions:

| Region | Marker | Handling |
| --- | --- | --- |
| Show | `<<<AKA_SHOW … AKA_SHOW>>>` | relay the content between the markers verbatim |
| Frame | `<<<AKA_FRAME_JSON … AKA_FRAME_JSON>>>` | machine-only; never displayed |
| Status | *(untagged stdout)* | model-facing (paths, errors); acted on, never relayed |

- A small `show()` helper (beside `fenced()` in `present.ts`) wraps every user-facing emit; `setup-show.ts` owns the markers plus a `parseSurface()` partition the tests use to assert region placement.
- `setup.md` gains a one-time **execution contract** stating the relay rule and a few invariants (never write a confirmation the wizard didn't emit; relay each step's regions before advancing; one picker per decision), so the per-step prose no longer has to re-explain it.
- A **guard test** (`relay-contract-guard.test.ts`) statically verifies that every user-facing `stdout` emit in the wizard scripts routes through `show()` / `showBlock()` / `frameJsonBlock()` or an explicit status allowlist — so a future emit that forgets the wrapper fails CI rather than silently going un-relayed.

## Scope

Plugin-only — no `schema` / `persistence` / `detections` changes, and no change to detection or calibration behavior. `AKA_FRAME_JSON` emission and parsing are untouched, so existing frame-reading keeps working; the `AKA_SHOW` regions are purely additive. New files: `src/setup-show.ts` and the guard + region tests.

## Testing

Full plugin suite passes (build, typecheck, and lint clean). The guard both passes and *bites*: unwrapping any user-facing emit makes it fail.
