### PR TITLE
feat(dashboard-ui,schema): shared magnitude, terse-time & widget-state helpers

### DIFF
--- a/cli/src/lib/tokens.ts
+++ b/cli/src/lib/tokens.ts
@@ -1,7 +1,7 @@
 // Token/cost formatting for the CLI's read surfaces — the `aka stats` block and
 // the TUI health screen. All three are the SHARED @akasecurity/schema
 // formatters (re-exported under the CLI's local names) so the CLI, the plugin's
-// `/aka:tokens`, and the web-ui print the same token magnitude (k/M/B) AND the
+// `/aka:tokens`, and the web-ui print the same token magnitude (K/M/B/T) AND the
 // same cost figure/qualifier convention.
 export {
   formatTokenCount as compactTokens,

--- a/cli/test/commands/stats.test.ts
+++ b/cli/test/commands/stats.test.ts
@@ -77,7 +77,7 @@ describe('renderTokenUsage', () => {
 
     expect(lines[0]).toBe('Token usage (30d): 3 sessions · 1.3M tokens · $3.40');
     expect(text).toContain('anthropic/claude-opus-4-8');
-    expect(text).toContain('980.0k');
+    expect(text).toContain('980K');
     expect(text).toContain('$3.20');
     expect(text).not.toContain('≥'); // fully priced → no lower-bound marker
   });

--- a/packages/dashboard-ui/src/activity/format.ts
+++ b/packages/dashboard-ui/src/activity/format.ts
@@ -94,7 +94,7 @@ export function cacheHitPct(tokens: TokenRollup): number {
 }
 
 /** Compact token count for the detail band — the shared @akasecurity/schema
- * humanizer (`128400` → `128.4k`, rolling k→M→B) so every surface reads
+ * humanizer (`128400` → `128.4K`, rolling K→M→B→T) so every surface reads
  * identically. */
 export function tokenLabel(n: number): string {
   return formatTokenCount(n);

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -4,7 +4,7 @@
 // svgr/asset imports). Data-fetching stays in the apps — these take data via props.
 export { COLORS } from './lib/colors.ts';
 export type { IconComponent } from './lib/icons.ts';
-export { relativeTime } from './lib/relativeTime.ts';
+export { relativeTime, relativeTimeShort } from './lib/relativeTime.ts';
 export {
   BLOCKED_WINDOW_MS,
   BLOCKED_WINDOW_PHRASE,
@@ -32,6 +32,7 @@ export { PageHead } from './shared/PageHead.tsx';
 export { Provider, type ProviderId, type ProviderMeta, PROVIDERS } from './shared/Provider.tsx';
 export { type StatDelta, StatTile } from './shared/StatTile.tsx';
 export { TimeRangeSelect } from './shared/TimeRangeSelect.tsx';
+export { WidgetEmpty, WidgetError } from './shared/widget-state.tsx';
 
 // Shared detail-pane primitives (section headings, label/value rows) reused by
 // every detail view and by app-injected footers.

--- a/packages/dashboard-ui/src/lib/relativeTime.ts
+++ b/packages/dashboard-ui/src/lib/relativeTime.ts
@@ -25,3 +25,33 @@ export function relativeTime(iso: string | undefined): string {
   }
   return 'just now';
 }
+
+// Terse unit suffixes for relativeTimeShort, keyed by the same units as `UNITS`
+// above so the two helpers can never drift on tier boundaries.
+const SHORT_SUFFIX: Partial<Record<Intl.RelativeTimeFormatUnit, string>> = {
+  year: 'y',
+  month: 'mo',
+  week: 'w',
+  day: 'd',
+  hour: 'h',
+  minute: 'm',
+};
+
+/**
+ * Terse relative age for compact feeds where the long form ("2 minutes ago")
+ * won't fit a narrow column: "2m" · "14m" · "1h" · "3d" · "2w" · "3mo" · "1y".
+ * Weeks cap at "4w" — the `month` tier (30d) precedes `week`, so 30+ days read
+ * as "1mo"+. Under a minute reads "now" (same 45s cutoff as {@link relativeTime}'s
+ * "just now"). Floors to the whole unit — "1h" means at least an hour elapsed.
+ */
+export function relativeTimeShort(iso: string | undefined): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const abs = Math.abs((then - Date.now()) / 1000);
+  if (abs < 45) return 'now';
+  for (const [unit, secs] of UNITS) {
+    if (abs >= secs) return `${String(Math.floor(abs / secs))}${SHORT_SUFFIX[unit] ?? ''}`;
+  }
+  return 'now';
+}

--- a/packages/dashboard-ui/src/shared/StatTile.tsx
+++ b/packages/dashboard-ui/src/shared/StatTile.tsx
@@ -47,6 +47,8 @@ export function StatTile({
   delta,
   spark,
   sparkColor,
+  sparkLabels,
+  sparkFormatValue,
   loading = false,
 }: {
   icon: IconComponent;
@@ -57,6 +59,10 @@ export function StatTile({
   delta?: StatDelta;
   spark?: number[];
   sparkColor?: string;
+  /** Per-point hover labels for the sparkline tooltip (see Sparkline). */
+  sparkLabels?: string[];
+  /** Sparkline tooltip value formatter. */
+  sparkFormatValue?: (v: number) => string;
   loading?: boolean;
 }) {
   return (
@@ -82,7 +88,13 @@ export function StatTile({
       )}
       {spark && !loading && (
         <div className="mt-0.5">
-          <Sparkline data={spark} color={sparkColor ?? COLORS.primary} height={34} />
+          <Sparkline
+            data={spark}
+            color={sparkColor ?? COLORS.primary}
+            height={34}
+            {...(sparkLabels ? { labels: sparkLabels } : {})}
+            {...(sparkFormatValue ? { formatValue: sparkFormatValue } : {})}
+          />
         </div>
       )}
     </Card>

--- a/packages/dashboard-ui/src/shared/charts.tsx
+++ b/packages/dashboard-ui/src/shared/charts.tsx
@@ -67,6 +67,13 @@ export function Donut({
  * the parent via `preserveAspectRatio="none"` — no ResizeObserver needed — so it
  * drops into a stat tile or a narrow table cell. `vectorEffect` keeps the stroke
  * an even width despite the non-uniform scale.
+ *
+ * Decorative by default. Pass `labels` (one per point, index-aligned to `data`)
+ * to make it hoverable: the nearest point gets a marker dot and a tooltip with
+ * its label + value. The dot and tooltip are absolutely-positioned HTML (a circle
+ * inside the stretched SVG would render as an ellipse); x positions are
+ * percentages of the same viewBox fractions the path uses, so they track the
+ * non-uniform scale.
  */
 export function Sparkline({
   data,
@@ -74,14 +81,21 @@ export function Sparkline({
   height = 34,
   fill = true,
   strokeWidth = 2,
+  labels,
+  formatValue,
 }: {
   data: number[];
   color: string;
   height?: number;
   fill?: boolean;
   strokeWidth?: number;
+  /** Per-point hover labels (same length as `data`); omit for a decorative line. */
+  labels?: string[];
+  /** Tooltip value formatter (defaults to String). */
+  formatValue?: (v: number) => string;
 }) {
   const gradientId = `spark-${useId().replace(/:/g, '')}`;
+  const [hover, setHover] = useState<number | null>(null);
   const viewW = 100;
   const pad = 2;
   const max = Math.max(...data);
@@ -104,8 +118,9 @@ export function Sparkline({
       .y1((d) => d[1])
       .curve(curveMonotoneX)(points) ?? undefined;
 
-  return (
-    // Decorative: the trend is a supporting glyph beside a labeled value.
+  const svg = (
+    // Decorative: the trend is a supporting glyph beside a labeled value; the
+    // hover tooltip (when enabled) is a pointer affordance on top of that.
     <svg
       aria-hidden
       width="100%"
@@ -133,6 +148,66 @@ export function Sparkline({
         vectorEffect="non-scaling-stroke"
       />
     </svg>
+  );
+
+  // Defensive: hover only when every point has a label — a mis-aligned labels
+  // array degrades to the decorative line rather than mislabeling points.
+  const interactive = labels?.length === data.length && data.length > 0;
+  if (!interactive) return svg;
+
+  const hoverValue = hover === null ? undefined : data[hover];
+  const hoverLabel = hover === null ? undefined : labels[hover];
+
+  return (
+    <div
+      aria-hidden
+      className="relative"
+      onMouseMove={(e) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        if (rect.width === 0) return;
+        const viewX = ((e.clientX - rect.left) / rect.width) * viewW;
+        const i =
+          data.length <= 1
+            ? 0
+            : Math.round(((viewX - pad) / (viewW - pad * 2)) * (data.length - 1));
+        setHover(Math.min(data.length - 1, Math.max(0, i)));
+      }}
+      onMouseLeave={() => {
+        setHover(null);
+      }}
+    >
+      {svg}
+      {hover !== null && hoverValue !== undefined && hoverLabel !== undefined && (
+        <>
+          <span
+            className="pointer-events-none absolute size-2 -translate-x-1/2 -translate-y-1/2 rounded-full border border-white/80"
+            style={{
+              left: `${String((xAt(hover) / viewW) * 100)}%`,
+              top: yAt(hoverValue),
+              background: color,
+            }}
+          />
+          <div
+            className="pointer-events-none absolute z-10 -translate-x-1/2 whitespace-nowrap"
+            style={{
+              left: `clamp(36px, ${String((xAt(hover) / viewW) * 100)}%, calc(100% - 36px))`,
+              bottom: height + 6,
+              borderRadius: 8,
+              border: `1px solid ${COLORS.border}`,
+              background: COLORS.surface,
+              padding: '4px 8px',
+              fontSize: 12,
+              boxShadow: '0 4px 12px rgb(0 0 0 / 0.08)',
+            }}
+          >
+            <div style={{ color: COLORS.text3, fontSize: 11 }}>{hoverLabel}</div>
+            <div className="font-semibold" style={{ color: COLORS.text2 }}>
+              {(formatValue ?? String)(hoverValue)}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/packages/dashboard-ui/test/lib/relativeTime.test.ts
+++ b/packages/dashboard-ui/test/lib/relativeTime.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { relativeTimeShort } from '../../src/lib/relativeTime.ts';
+
+// Anchor "now" so the age math is deterministic regardless of when the suite runs.
+const NOW = new Date('2026-06-21T12:00:00Z');
+const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+const SEC = 1000;
+const MIN = 60 * SEC;
+const HOUR = 60 * MIN;
+const DAY = 24 * HOUR;
+const WEEK = 7 * DAY;
+
+describe('relativeTimeShort', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads "now" under the 45s cutoff', () => {
+    expect(relativeTimeShort(ago(0))).toBe('now');
+    expect(relativeTimeShort(ago(44 * SEC))).toBe('now');
+  });
+
+  it('floors to the largest whole unit with a terse suffix', () => {
+    expect(relativeTimeShort(ago(2 * MIN))).toBe('2m');
+    expect(relativeTimeShort(ago(38 * MIN))).toBe('38m');
+    expect(relativeTimeShort(ago(90 * MIN))).toBe('1h'); // floors, not rounds
+    expect(relativeTimeShort(ago(2 * HOUR))).toBe('2h');
+    expect(relativeTimeShort(ago(3 * DAY))).toBe('3d');
+    expect(relativeTimeShort(ago(2 * WEEK))).toBe('2w');
+    expect(relativeTimeShort(ago(29 * DAY))).toBe('4w'); // weeks cap here — month tier starts at 30d
+    expect(relativeTimeShort(ago(40 * DAY))).toBe('1mo'); // covers the `month` suffix the loop can emit
+    expect(relativeTimeShort(ago(400 * DAY))).toBe('1y');
+  });
+
+  it('returns "" for missing or unparseable input', () => {
+    expect(relativeTimeShort(undefined)).toBe('');
+    expect(relativeTimeShort('not-a-date')).toBe('');
+  });
+});

--- a/packages/schema/src/token/format.ts
+++ b/packages/schema/src/token/format.ts
@@ -5,17 +5,28 @@
 // Node deps. Cost is a read-time ESTIMATE derived from the price map, never
 // stored — the `≥` lower-bound marker carries that when pricing is unknown.
 
+// One compact-number formatter shared by every magnitude surface — token
+// totals, KPI tiles, connected-tool prompt counts — so the same value prints
+// identically everywhere. Rolls up to K · M · B · T with up to one decimal and
+// a dropped trailing ".0" ("1M", not "1.0M"); exact integers under 1000 print
+// in full. Negative-safe.
+const COMPACT = new Intl.NumberFormat('en-US', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+});
+
+/** Compact magnitude with K/M/B/T roll-up: `999` · `1.1K` · `45.2K` · `318M` · `4.5B` · `1.5T`. */
+export function compactNumber(n: number): string {
+  return COMPACT.format(n);
+}
+
 /**
- * Compact token magnitude with SI-style roll-up: `12.3k`, `4.5M`, `1.2B` — 1000k
- * rolls to 1M, 1000M to 1B (rather than the old always-`k` form that printed an
- * unreadable "4464193.1k"). Under 1000 prints the exact integer. Negative-safe.
+ * Compact token magnitude — {@link compactNumber} applied to a raw token count
+ * (`12.3K`, `4.5M`, `4.5B`), so token totals print the same K/M/B/T figures as
+ * every other magnitude on the dashboard.
  */
 export function formatTokenCount(n: number): string {
-  const abs = Math.abs(n);
-  if (abs < 1_000) return String(n);
-  if (abs < 1_000_000) return `${(n / 1_000).toFixed(1)}k`;
-  if (abs < 1_000_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  return `${(n / 1_000_000_000).toFixed(1)}B`;
+  return compactNumber(n);
 }
 
 /**

--- a/packages/schema/test/token/format.test.ts
+++ b/packages/schema/test/token/format.test.ts
@@ -1,26 +1,42 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatCostTotal, formatTokenCount, formatUsd } from '../../src/token/format.ts';
+import {
+  compactNumber,
+  formatCostTotal,
+  formatTokenCount,
+  formatUsd,
+} from '../../src/token/format.ts';
 
-describe('formatTokenCount', () => {
+describe('compactNumber', () => {
   it('prints exact integers under 1000', () => {
-    expect(formatTokenCount(0)).toBe('0');
-    expect(formatTokenCount(500)).toBe('500');
-    expect(formatTokenCount(999)).toBe('999');
+    expect(compactNumber(0)).toBe('0');
+    expect(compactNumber(500)).toBe('500');
+    expect(compactNumber(999)).toBe('999');
   });
 
-  it('rolls up k → M → B at each 1000x boundary', () => {
-    expect(formatTokenCount(1_000)).toBe('1.0k');
-    expect(formatTokenCount(12_340)).toBe('12.3k');
-    expect(formatTokenCount(1_000_000)).toBe('1.0M'); // 1000k rolls to 1M
-    expect(formatTokenCount(4_500_000)).toBe('4.5M');
-    expect(formatTokenCount(1_000_000_000)).toBe('1.0B'); // 1000M rolls to 1B
-    // The real-store total that used to render as "4464193.1k".
-    expect(formatTokenCount(4_464_193_100)).toBe('4.5B');
+  it('rolls up K → M → B → T at each 1000x boundary, dropping a trailing .0', () => {
+    expect(compactNumber(1_000)).toBe('1K');
+    expect(compactNumber(1_127)).toBe('1.1K');
+    expect(compactNumber(12_340)).toBe('12.3K');
+    expect(compactNumber(318_000)).toBe('318K');
+    expect(compactNumber(1_000_000)).toBe('1M'); // 1000K rolls to 1M
+    expect(compactNumber(4_500_000)).toBe('4.5M');
+    expect(compactNumber(1_000_000_000)).toBe('1B'); // 1000M rolls to 1B
+    expect(compactNumber(4_464_193_100)).toBe('4.5B');
+    expect(compactNumber(1_500_000_000_000)).toBe('1.5T');
   });
 
   it('is negative-safe', () => {
-    expect(formatTokenCount(-2_500_000)).toBe('-2.5M');
+    expect(compactNumber(-2_500_000)).toBe('-2.5M');
+  });
+});
+
+describe('formatTokenCount', () => {
+  it('is the shared compactNumber applied to a token count', () => {
+    expect(formatTokenCount(999)).toBe('999');
+    expect(formatTokenCount(12_340)).toBe('12.3K');
+    expect(formatTokenCount(4_500_000)).toBe('4.5M');
+    expect(formatTokenCount(4_464_193_100)).toBe('4.5B');
   });
 });
 


### PR DESCRIPTION
## What

Adds the shared presentational primitives the enterprise Operations and Data Flow pages consume when wired to their APIs. OSS-side half of a cross-repo change (the enterprise wiring lives in `ai-tc-enterprise`).

## Changes

- **`@akasecurity/schema`** — new `compactNumber` (one `Intl` compact formatter: K/M/B/T roll-up, up to one decimal, dropped trailing `.0`, negative-safe). `formatTokenCount` now delegates to it, so token totals print the same figures as every other magnitude (`980K`, not `980.0k`). Tests updated; the `aka stats` snapshot follows the new casing.
- **`@akasecurity/dashboard-ui`** —
  - `Sparkline` gains an opt-in per-point hover tooltip (via `labels`/`formatValue`); decorative by default, degrades safely when labels are mis-aligned.
  - `StatTile` forwards `sparkLabels`/`sparkFormatValue` to the sparkline.
  - `relativeTimeShort` — terse feed ages (`2m` · `1h` · `3d` · `2w` · `1mo` · `1y`) for narrow columns, with a unit-tier table shared with `relativeTime`.
  - `WidgetError` / `WidgetEmpty` are now exported from the barrel.
- Aligned the token-format doc comments with the new uppercase output.

## Verification

- `@akasecurity/schema`: typecheck + `format.test.ts` (6) green
- `@akasecurity/dashboard-ui`: typecheck + full suite (65) green, lint clean
- `@akasecurity/cli`: `stats.test.ts` (updated snapshot) green