### PR TITLE
feat: default the time range to 7d everywhere

### DIFF
--- a/cli/src/commands/stats.ts
+++ b/cli/src/commands/stats.ts
@@ -22,7 +22,7 @@ const RANGE_DAYS: Record<SecurityRange, number> = { '7d': 7, '30d': 30, '3m': 90
 function parseRange(value: string | undefined): SecurityRange {
   return (SECURITY_RANGES as readonly string[]).includes(value ?? '')
     ? (value as SecurityRange)
-    : '30d';
+    : '7d';
 }
 
 // `aka stats` — print local-store aggregates: findings by severity + enforcement

--- a/packages/dashboard-ui/src/lib/timeRanges.ts
+++ b/packages/dashboard-ui/src/lib/timeRanges.ts
@@ -16,7 +16,7 @@ export const TIME_RANGES: TimeRangeOption[] = [
   { value: '6m', label: 'Last 6 months' },
 ];
 
-export const DEFAULT_TIME_RANGE: TimeRange = '30d';
+export const DEFAULT_TIME_RANGE: TimeRange = '7d';
 
 const DAY_MS = 86_400_000;
 

--- a/packages/schema/src/zod/security.ts
+++ b/packages/schema/src/zod/security.ts
@@ -54,7 +54,7 @@ export type SecurityRange = z.infer<typeof SecurityRange>;
 // An unsupported value fails Zod validation → 400 (shared VALIDATION_ERROR
 // envelope, consistent with every other query param in this API).
 export const SecurityRangeQuery = z.object({
-  range: z.enum(SECURITY_RANGES).default('30d'),
+  range: z.enum(SECURITY_RANGES).default('7d'),
 });
 export type SecurityRangeQuery = z.infer<typeof SecurityRangeQuery>;
 
@@ -205,7 +205,7 @@ export const TopSourcesResponse = z
 export type TopSourcesResponse = z.infer<typeof TopSourcesResponse>;
 
 export const TopSourcesQuery = z.object({
-  range: z.enum(SECURITY_RANGES).default('30d'),
+  range: z.enum(SECURITY_RANGES).default('7d'),
   limit: z.coerce.number().int().min(1).max(50).default(5),
   // Omit for both kinds.
   kind: z.enum(SOURCE_KINDS).optional(),

--- a/web-ui/app/(app)/activity/filters.ts
+++ b/web-ui/app/(app)/activity/filters.ts
@@ -83,7 +83,7 @@ export function buildActivityParams(opts: {
   if (q) sp.set('q', q);
   for (const h of opts.harness) sp.append('harness', h);
   // Omit only the actual default (what parseRange returns for a missing param),
-  // else a non-default range like 7d gets dropped and the next server render
+  // else a non-default range like 30d gets dropped and the next server render
   // resets it to DEFAULT_TIME_RANGE.
   if (opts.range !== DEFAULT_TIME_RANGE) sp.set('range', opts.range);
   if (opts.id) sp.set('id', opts.id);


### PR DESCRIPTION
Makes 7 days the default time range across the dashboard, the schema query contracts, and the CLI. Previously the default was 30 days.

## Changes

- **`packages/dashboard-ui/src/lib/timeRanges.ts`** — `DEFAULT_TIME_RANGE` is now `7d`. This is the single source the web dashboard reads: the security page, the activity list, and the range picker all resolve through `parseRange`, which falls back to this constant.
- **`packages/schema/src/zod/security.ts`** — `SecurityRangeQuery` and `TopSourcesQuery` both default to `7d`.
- **`cli/src/commands/stats.ts`** — `aka stats` falls back to `7d` when `--range` is missing or invalid.
- **`web-ui/app/(app)/activity/filters.ts`** — comment-only: the example in the "omit the default from the URL" note said `7d`, which is no longer a *non*-default value. Swapped it for `30d`.

No other hardcoded default existed — every other call site already routed through the constants above.

## Deliberately unchanged

Three nearby values look like time ranges but are a different concept:

- `DEFAULT_BLOCKED_WINDOW` (`30m`) — the exceptions page's "Recently blocked" ledger, which runs on a minute/hour scale (`30m`/`1h`/`4h`/`24h`). `7d` isn't a valid value there.
- `findingsLast30d` — a fixed 30-day rollup metric on detections, not a user-selectable range.
- The plugin's history backfill `windowDays = 30` — how far back the one-time transcript scan reaches.

## Verification

- `pnpm test` — all 26 tasks pass.
- `pnpm typecheck` — clean.
- `pnpm lint` — clean (ran via the pre-push hook).