### PR TITLE
docs(persistence): scrub internal narration from store comments

### DIFF
--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -198,13 +198,13 @@ export function applyMigrations(db: DatabaseSync): void {
 // SQLite generated-column DDL for the six token-usage facets: the four counts are
 // integer, model/provider are text, all VIRTUAL via json_extract.
 //
-// CANONICAL SOURCE is the `0010_token_usage_audit_columns` migration in
+// CANONICAL SOURCE is the `0001_adorable_marten_broadcloak` migration in
 // `@akasecurity/schema` (packages/schema/src/drizzle/sqlite-ddl.ts), itself generated from
 // the local-store drizzle column defs in `packages/schema/src/drizzle/local/sqlite.ts`. This
 // list is an INTENTIONAL re-hardcoding, not a careless copy: `@akasecurity/persistence` is
 // forbidden from importing `@akasecurity/schema`'s drizzle layer (boundary rule — it may
 // only touch the Zod/DDL re-exports, never the drizzle internals), so we cannot
-// share the column objects directly. Any column added/removed/renamed in the 0010
+// share the column objects directly. Any column added/removed/renamed in that
 // migration MUST be mirrored here. `migrations.test.ts` guards the column-NAME set
 // against drift so a mismatch fails loudly instead of silently skipping a facet.
 export const TOKEN_USAGE_COLUMNS: readonly { name: string; ddl: string }[] = [

--- a/packages/persistence/src/repositories/resolution-sql.ts
+++ b/packages/persistence/src/repositories/resolution-sql.ts
@@ -1,11 +1,11 @@
 // Single source of truth for the LATEST-RESOLUTION-WINS SQL used everywhere a
 // finding's lifecycle status is derived from the append-only finding_resolution
 // table. The rule: a key is classified by its NEWEST row only (max created_at,
-// tie-broken by rowid — the SQLite twin of the Postgres `seq` tiebreak), never
-// by "does ANY row exist" — otherwise a fixed-at-source key that is later
-// redetected (the same secret re-added) would stay invisibly "caught" under its
-// stale resolved row forever. See SqliteResolutionsRepository's class doc for
-// the full invariant, and keep the two consumers in lockstep:
+// ties broken by the higher rowid so rows sharing a created_at still resolve in
+// insertion order), never by "does ANY row exist" — otherwise a fixed-at-source
+// key that is later redetected (the same secret re-added) would stay invisibly
+// "caught" under its stale resolved row forever. See SqliteResolutionsRepository's
+// class doc for the full invariant, and keep the two consumers in lockstep:
 //
 //   - SqliteSecurityRepository.severitySummary (caught / open-at-rest buckets)
 //   - SqliteFindingsRepository.listGroupedFindings (per-finding status column)

--- a/packages/persistence/test/migrations.test.ts
+++ b/packages/persistence/test/migrations.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../src/migrations.ts';
 
 // The six token-usage generated columns are defined in THREE places that must stay
-// in lockstep: the canonical `0010_token_usage_audit_columns` migration in
+// in lockstep: the canonical `0001_adorable_marten_broadcloak` migration in
 // `@akasecurity/schema` (packages/schema/src/drizzle/sqlite-ddl.ts, generated from the
 // drizzle defs in packages/schema/src/drizzle/local/sqlite.ts), and the
 // re-hardcoded ALTER copy in `migrations.ts` (TOKEN_USAGE_COLUMNS). The copy exists
@@ -21,7 +21,7 @@ import {
 //
 // This is the drift guard. We can't import the canonical column list cleanly
 // (sqlite-ddl exposes only the whole-file migration SQL, not a structured column
-// set), so the expected names are hardcoded here. If the 0010 migration adds,
+// set), so the expected names are hardcoded here. If that migration adds,
 // removes, or renames a token column, mirror it in BOTH places and update this list
 // — the test fails loudly the moment the persistence copy drifts in count or name.
 const EXPECTED_TOKEN_COLUMN_NAMES = [


### PR DESCRIPTION
## Summary

Fixes two comments in `@akasecurity/persistence` that violated the public-repo comment hygiene rule in `CLAUDE.md`. Comment-only — no behavior change.

**1. `resolution-sql.ts` — removed a cross-repo design reference.**
The latest-resolution-wins tiebreak was described as *"the SQLite twin of the Postgres `seq` tiebreak"*. That design isn't part of this repo and shouldn't be narrated in shipped source. The comment now states what the tiebreak actually does: ties on `created_at` are broken by the higher `rowid`, so rows sharing a timestamp still resolve in insertion order.

**2. `migrations.ts` — corrected a stale migration citation.**
The comment cited a canonical migration named `0010_token_usage_audit_columns`, which does not exist in the current migration line. Verified against `SQLITE_MIGRATIONS`:

- The six token-usage generated columns (`input_tokens`, `output_tokens`, `cache_creation_input_tokens`, `cache_read_input_tokens`, `model`, `provider`) ship in **`0001_adorable_marten_broadcloak`**.
- `0010` is **`events_session_expression_index`** — an unrelated partial expression index.

Fixed the tag and the follow-on *"the 0010 migration"* reference. The same stale citation appeared twice in the paired drift-guard comment in `test/migrations.test.ts`, so that's corrected too — otherwise the guard and the code it guards would cite different migrations.

Rationale lives here rather than in the comments themselves, per the `CLAUDE.md` hygiene rule.

## Checklist

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes

<sub>`format:check` warns on one local, untracked maintainer planning doc excluded via `.git/info/exclude` — pre-existing, not part of this branch, and not visible to CI. Everything tracked is clean.</sub>

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

### Detection-rule changes only (`rules/`)

N/A — no `rules/` changes.