### PR TITLE
Raise vitest timeouts for cli, scanner, and claude-code plugin

### DIFF
--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// exception.test.ts and dashboard.test.ts exercise real node:sqlite file I/O,
+// which runs slowly on the Windows CI runner under parallel load, so raise the
+// per-test AND per-hook timeouts above vitest's 5s/10s defaults (mirrors
+// packages/persistence/vitest.config.ts).
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
+  },
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vitest/config';
 
 // exception.test.ts and dashboard.test.ts exercise real node:sqlite file I/O,
-// which runs slowly on the Windows CI runner under parallel load, so raise the
+// The CLI suite exercises real node:sqlite file I/O, which runs slowly under
+// Turbo's parallel task load, so raise the per-test AND per-hook timeouts
 // per-test AND per-hook timeouts above vitest's 5s/10s defaults (mirrors
 // packages/persistence/vitest.config.ts).
 export default defineConfig({

--- a/packages/scanner/vitest.config.ts
+++ b/packages/scanner/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+// Real FS + gateway work runs slowly on the Windows CI runner under parallel
+// load, so raise the per-test AND per-hook timeouts above vitest's 5s/10s
+// defaults (mirrors packages/persistence/vitest.config.ts).
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
+  },
+});

--- a/plugins/claude-code/vitest.config.ts
+++ b/plugins/claude-code/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'vitest/config';
 // runs — the journey harness (test/journey) drives those built scripts.
 //
 // The journey tests spawn those built scripts as real child processes, which
-// runs slowly on the Windows CI runner under parallel load, so raise the
+// runs slowly under Turbo's parallel task load, so raise the
 // per-test AND per-hook timeouts above vitest's 5s/10s defaults (mirrors
 // packages/persistence/vitest.config.ts).
 export default defineConfig({

--- a/plugins/claude-code/vitest.config.ts
+++ b/plugins/claude-code/vitest.config.ts
@@ -2,9 +2,16 @@ import { defineConfig } from 'vitest/config';
 
 // globalSetup builds scripts/*.js once, in the main process, before any worker
 // runs — the journey harness (test/journey) drives those built scripts.
+//
+// The journey tests spawn those built scripts as real child processes, which
+// runs slowly on the Windows CI runner under parallel load, so raise the
+// per-test AND per-hook timeouts above vitest's 5s/10s defaults (mirrors
+// packages/persistence/vitest.config.ts).
 export default defineConfig({
   test: {
     environment: 'node',
     globalSetup: ['./test/journey/global-setup.ts'],
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
   },
 });


### PR DESCRIPTION
## Summary
- Adds `cli/vitest.config.ts` and `packages/scanner/vitest.config.ts` (`environment: 'node'`, `testTimeout: 20_000`, `hookTimeout: 20_000`) — both previously had **no config at all**, inheriting vitest's 5s/10s defaults while doing real `node:sqlite` I/O (`cli`) and real FS/gateway work (`scanner`).
- Adds the same timeouts to the existing `plugins/claude-code/vitest.config.ts` (preserving its `globalSetup`) — its journey tests spawn built hook scripts as real child processes.
- `packages/detections/vitest.config.ts` already sets these timeouts (fixed separately), so no change was needed there.

Mirrors the existing pattern in `packages/persistence` and `packages/local-ops`, whose configs raise timeouts for the same reason (slow on the Windows CI runner under parallel load — `detections`' ReDoS gate already timed out there once at the 5s default).

Closes akasecurity/engineering#23 (backlog: [qa/GITHUB_ISSUES.md#issue-22](https://github.com/akasecurity/engineering/blob/feature/qa/qa/GITHUB_ISSUES.md#issue-22)).

## Test plan
- [x] `pnpm turbo run test --filter=@akasecurity/cli` — 9 files, 41 tests passed
- [x] `pnpm turbo run test --filter=@akasecurity/scanner` — 5 files, 59 tests passed
- [x] `pnpm turbo run test --filter=@akasecurity/ai-tc-claude-code` — 74 files, 778 tests passed
- [x] `pnpm turbo run test --filter=@akasecurity/detections` — 869 tests passed (unchanged, confirms no regression)
- [x] `pnpm turbo run lint` for all four packages
- [x] `prettier --check` on the three touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)