### PR TITLE
Add an E2E harness that spawns the built hook scripts

### DIFF
--- a/plugins/claude-code/test/helpers/run-hook.test.ts
+++ b/plugins/claude-code/test/helpers/run-hook.test.ts
@@ -1,0 +1,123 @@
+/**
+ * One smoke test per hook, proving the harness itself works: it spawns the
+ * real built script, feeds it valid minimal input, and gets back a sane
+ * {status, stdout, stderr}. This is NOT the fail-open matrix (malformed
+ * input, corrupt store, …) — that's a separate, larger effort building on
+ * this harness. Each run gets its own throwaway ~/.aka so nothing here ever
+ * touches a developer's real store.
+ */
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runHook, tempHomeEnv, withTempHome } from './run-hook.ts';
+
+// A hook's stdout is either empty (allow) or one JSON object — never
+// malformed, regardless of which decision it made.
+function expectValidHookStdout(stdout: string): void {
+  if (stdout === '') return;
+  expect(() => {
+    JSON.parse(stdout);
+  }).not.toThrow();
+}
+
+describe('runHook', () => {
+  it('fails with a clear message when the target script has not been built', () => {
+    expect(() => runHook('not-a-real-hook', '{}')).toThrow(/does not exist/);
+  });
+
+  it('SessionStart: runs against valid input and exits 0', () => {
+    withTempHome((home) => {
+      const cwd = join(home, 'project');
+      mkdirSync(cwd, { recursive: true });
+      const stdin = JSON.stringify({
+        session_id: 'smoke-session',
+        cwd,
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      });
+
+      const result = runHook('session-start', stdin, { env: tempHomeEnv(home) });
+
+      expect(result.status).toBe(0);
+      expectValidHookStdout(result.stdout);
+    });
+  });
+
+  it('UserPromptSubmit: runs against valid input and exits 0', () => {
+    withTempHome((home) => {
+      const cwd = join(home, 'project');
+      mkdirSync(cwd, { recursive: true });
+      const stdin = JSON.stringify({
+        prompt: 'hello from the smoke test',
+        session_id: 'smoke-session',
+        cwd,
+        hook_event_name: 'UserPromptSubmit',
+      });
+
+      const result = runHook('user-prompt-submit', stdin, { env: tempHomeEnv(home) });
+
+      expect(result.status).toBe(0);
+      expectValidHookStdout(result.stdout);
+    });
+  });
+
+  it('PreToolUse: runs against valid input and exits 0', () => {
+    withTempHome((home) => {
+      const cwd = join(home, 'project');
+      mkdirSync(cwd, { recursive: true });
+      const stdin = JSON.stringify({
+        tool_name: 'Read',
+        tool_input: { file_path: join(cwd, 'notes.txt') },
+        session_id: 'smoke-session',
+        cwd,
+        hook_event_name: 'PreToolUse',
+      });
+
+      const result = runHook('pre-tool-use', stdin, { env: tempHomeEnv(home) });
+
+      expect(result.status).toBe(0);
+      expectValidHookStdout(result.stdout);
+    });
+  });
+
+  it('PostToolUse: runs against valid input and exits 0', () => {
+    withTempHome((home) => {
+      const cwd = join(home, 'project');
+      mkdirSync(cwd, { recursive: true });
+      const stdin = JSON.stringify({
+        tool_name: 'Read',
+        tool_input: { file_path: join(cwd, 'notes.txt') },
+        tool_response: { content: 'hello world' },
+        session_id: 'smoke-session',
+        cwd,
+        hook_event_name: 'PostToolUse',
+      });
+
+      const result = runHook('post-tool-use', stdin, { env: tempHomeEnv(home) });
+
+      expect(result.status).toBe(0);
+      expectValidHookStdout(result.stdout);
+    });
+  });
+
+  it('Stop: runs against valid input and exits 0', () => {
+    withTempHome((home) => {
+      const cwd = join(home, 'project');
+      mkdirSync(cwd, { recursive: true });
+      const stdin = JSON.stringify({
+        session_id: 'smoke-session',
+        transcript_path: join(cwd, 'transcript.jsonl'),
+        cwd,
+        hook_event_name: 'Stop',
+        stop_hook_active: false,
+      });
+
+      const result = runHook('stop', stdin, { env: tempHomeEnv(home) });
+
+      expect(result.status).toBe(0);
+      expectValidHookStdout(result.stdout);
+    });
+  });
+});

--- a/plugins/claude-code/test/helpers/run-hook.ts
+++ b/plugins/claude-code/test/helpers/run-hook.ts
@@ -1,0 +1,102 @@
+/**
+ * Spawns a hook's BUILT script (scripts/<name>.js) exactly as Claude Code
+ * invokes it — the only layer that tests what ships, not the source. Hook
+ * entries call main() on import and exit the process, so they can never be
+ * imported directly by a test; spawning the compiled artifact is the only
+ * way to exercise them.
+ *
+ * `stdin` is a raw string (or Buffer), not a JS value the helper serializes —
+ * the fail-open matrix this harness exists for (malformed JSON, truncated
+ * JSON, binary garbage) requires feeding a hook exactly that kind of invalid
+ * payload, which a helper that only accepted JSON-serializable input could
+ * never produce. Callers who want valid input build it themselves, e.g.
+ * `runHook('session-start', JSON.stringify({ session_id: 'x' }))`.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/helpers -> plugins/claude-code
+const PLUGIN_ROOT = join(HERE, '..', '..');
+const SCRIPTS_DIR = join(PLUGIN_ROOT, 'scripts');
+
+export interface HookResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunHookOptions {
+  /** argv passed after the script path (e.g. the plugin manifest path). */
+  args?: readonly string[];
+  /** Extra env vars layered on top of the inherited process env. */
+  env?: Readonly<Record<string, string>>;
+  timeoutMs?: number;
+}
+
+// The host env, read once so spawned scripts inherit PATH/node — the one
+// sanctioned reason to touch it here (mirrors test/journey/harness.ts).
+// eslint-disable-next-line n/no-process-env -- test harness needs host PATH to spawn the real scripts
+const HOST_ENV = process.env;
+
+// Spawns the built scripts/<name>.js exactly as Claude Code invokes it: raw
+// stdin in, exit code + stdout/stderr out. `scripts/` is gitignored and only
+// produced by `pnpm run build` — fail with a clear message rather than a
+// confusing ENOENT if a caller runs this without building first (in normal
+// use this package's vitest.config.ts globalSetup already builds before any
+// test file runs, so this is a defensive fallback, not the primary guard).
+export function runHook(name: string, stdin: string, options: RunHookOptions = {}): HookResult {
+  const scriptPath = join(SCRIPTS_DIR, `${name}.js`);
+  if (!existsSync(scriptPath)) {
+    throw new Error(
+      `runHook('${name}'): ${scriptPath} does not exist. scripts/ is gitignored and only ` +
+        'produced by `pnpm run build` (plugins/claude-code) — build the plugin before running this test.',
+    );
+  }
+
+  try {
+    const stdout = execFileSync(process.execPath, [scriptPath, ...(options.args ?? [])], {
+      input: stdin,
+      encoding: 'utf8',
+      timeout: options.timeoutMs ?? 15_000,
+      env: { ...HOST_ENV, ...options.env },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    // A non-zero exit (or a killed/timed-out process) still carries the
+    // captured streams; surface them so a test can assert against the real
+    // output instead of a bare throw.
+    const e = err as { stdout?: string; stderr?: string; status?: number | null };
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    };
+  }
+}
+
+// An isolated ~/.aka + ~/.claude for one runHook() call: os.homedir() — which
+// every hook resolves its data dir and transcript store through — honors
+// $HOME on POSIX, so overriding it points the whole chain at a throwaway temp
+// home instead of a developer's real store (same technique as
+// test/journey/harness.ts). Windows resolves the home dir from USERPROFILE
+// instead of HOME, so both are set in lockstep.
+export function withTempHome<T>(fn: (home: string) => T): T {
+  const home = mkdtempSync(join(tmpdir(), 'aka-hook-e2e-'));
+  try {
+    return fn(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// Convenience: temp-home env vars for RunHookOptions.env, so a caller can
+// write `runHook(name, stdin, { env: tempHomeEnv(home) })` instead of
+// repeating the HOME/USERPROFILE pair at every call site.
+export function tempHomeEnv(home: string): Record<string, string> {
+  return { HOME: home, USERPROFILE: home };
+}


### PR DESCRIPTION
## Summary
- Adds `plugins/claude-code/test/helpers/run-hook.ts`: `runHook(name, stdin, options) → {status, stdout, stderr}`, spawning the **built** `scripts/<name>.js` via `process.execPath` — the only way to exercise a hook entry, since they call `main()` on import and would hang vitest collection if imported directly.
- `stdin` is a raw string, not a JS value the helper serializes to JSON — the fail-open matrix this harness exists to support (malformed JSON, truncated JSON, binary garbage) needs to feed a hook exactly that kind of invalid payload.
- `withTempHome()` / `tempHomeEnv()` isolate each run to a throwaway `~/.aka` via `HOME`/`USERPROFILE` — the same technique `test/journey/harness.ts` already uses for the setup-wizard chain — so nothing here ever touches a developer's real store.
- `runHook()` throws a clear, actionable error if the target script hasn't been built (`scripts/` is gitignored), rather than a bare `ENOENT`.
- One smoke test per hook (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`) proves the harness works end to end against valid minimal input.

Closes akasecurity/engineering#6 (backlog: [qa/GITHUB_ISSUES.md#issue-5](https://github.com/akasecurity/engineering/blob/feature/qa/qa/GITHUB_ISSUES.md#issue-5)).

### On the CI acceptance criterion
The issue asks for CI to order build before the E2E job via `needs:`. No workflow change was needed: `turbo.json`'s `test` task already declares `"dependsOn": ["build", "^build", "^typecheck"]`, so `pnpm turbo run test` builds this package before running its tests regardless of step ordering in `ci.yml`. On top of that, this package's `vitest.config.ts` already has a `globalSetup` that builds `scripts/*.js` once before any test file runs in the same `vitest run` — so the ordering is already double-guaranteed, just not via a GitHub Actions job-level `needs:` (there's no separate E2E job to order against; it's the same job/task graph).

## Test plan
- [x] New `plugins/claude-code/test/helpers/run-hook.test.ts` — 6 tests: one per hook (all exit 0 against valid input) + the "script not built" error-message check.
- [x] `pnpm turbo run test --filter=@akasecurity/ai-tc-claude-code` — 75 files, 784 tests passed
- [x] `pnpm turbo run lint --filter=@akasecurity/ai-tc-claude-code`
- [x] `pnpm turbo run typecheck --filter=@akasecurity/ai-tc-claude-code`
- [x] `prettier --check` on both new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)