### PR TITLE
fix(dashboard-ui): make detail-opening table rows keyboard and screen-reader accessible

### DIFF
--- a/packages/dashboard-ui/src/data-shares/DataSharesTableView.tsx
+++ b/packages/dashboard-ui/src/data-shares/DataSharesTableView.tsx
@@ -78,6 +78,7 @@ function GroupRow({
   return (
     <TableRow
       onClick={onOpen}
+      aria-label={`View details for destination ${d.name}`}
       className={cn('cursor-pointer', selected ? 'bg-primary-tint' : 'hover:bg-surface-2')}
     >
       <TableCell className="w-9">
@@ -160,6 +161,7 @@ function EndpointRow({
   return (
     <TableRow
       onClick={onClick}
+      aria-label={`View details for endpoint ${ep.method} ${ep.url}`}
       className={cn(
         'cursor-pointer',
         selected ? 'bg-primary-tint' : 'bg-surface-2 hover:bg-surface-3',

--- a/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
@@ -53,6 +53,7 @@ export function ExceptionsTableView({
             <TableRow
               key={ex.id}
               className="cursor-pointer"
+              aria-label={`View details for exception ${ex.id.slice(0, 8)}`}
               onClick={() => {
                 onSelect(ex.id);
               }}

--- a/packages/dashboard-ui/src/findings/FindingsTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsTableView.tsx
@@ -144,6 +144,7 @@ export function FindingsTableView({
                     onClick={() => {
                       onSelectGroup(group);
                     }}
+                    aria-label={`View details for ${group.subtype} finding`}
                     className={cn(
                       'cursor-pointer hover:bg-surface-2',
                       isGroupSelected && 'bg-surface-2',
@@ -175,6 +176,7 @@ export function FindingsTableView({
                         onClick={() => {
                           onSelectInstance(group, instance);
                         }}
+                        aria-label={`View details for ${group.subtype} finding in ${instance.repo}`}
                         className={cn(
                           'cursor-pointer hover:bg-surface-2',
                           selection?.instance?.id === instance.id

--- a/packages/ui-kit/src/table.tsx
+++ b/packages/ui-kit/src/table.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithRef } from 'react';
+import type { ComponentPropsWithRef, KeyboardEvent, MouseEvent } from 'react';
 
 import { cn } from './lib/cn.ts';
 
@@ -34,11 +34,51 @@ export function TableBody({ className, ...props }: ComponentPropsWithRef<'tbody'
   );
 }
 
-export function TableRow({ className, ...props }: ComponentPropsWithRef<'tr'>) {
+export function TableRow({
+  className,
+  onClick,
+  onKeyDown,
+  tabIndex,
+  role,
+  ...props
+}: ComponentPropsWithRef<'tr'>) {
+  // A row that carries an onClick is a navigation affordance (e.g. "open this
+  // item's detail"), not a plain data row — give it the keyboard/AT support a
+  // clickable row needs: focusable, announced as actionable, and Enter/Space
+  // activatable. Rows without onClick are untouched.
+  const isInteractive = typeof onClick === 'function';
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTableRowElement>) {
+    onKeyDown?.(event);
+    // Only treat Enter/Space as "activate the row" when the row itself is the
+    // event target — a focusable control inside the row (e.g. an Expand
+    // button) has already handled its own keydown/click by the time it would
+    // bubble here, so this must not double-fire the row's action.
+    if (
+      !isInteractive ||
+      event.defaultPrevented ||
+      event.target !== event.currentTarget ||
+      (event.key !== 'Enter' && event.key !== ' ')
+    ) {
+      return;
+    }
+    event.preventDefault();
+    onClick(event as unknown as MouseEvent<HTMLTableRowElement>);
+  }
+
   return (
     <tr
       data-slot="table-row"
-      className={cn('border-b border-text/6 transition-colors', className)}
+      role={isInteractive ? (role ?? 'button') : role}
+      tabIndex={isInteractive ? (tabIndex ?? 0) : tabIndex}
+      onClick={onClick}
+      onKeyDown={isInteractive ? handleKeyDown : onKeyDown}
+      className={cn(
+        'border-b border-text/6 transition-colors',
+        isInteractive &&
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
+        className,
+      )}
       {...props}
     />
   );


### PR DESCRIPTION
## Why

Several dashboard tables (exceptions, findings, data shares) open an item's detail view only via a mouse click on the table row. The row was a plain `<tr>` with no keyboard focus, no keyboard activation, and no accessible role or name — so keyboard-only and screen-reader users had no way to reach a core navigation flow: opening a finding's, exception's, or data-share's detail view.

This is a straightforward accessibility gap in a primary interaction path.

## What changed

- `packages/ui-kit/src/table.tsx` — `TableRow` now treats an `onClick` prop as a row-level navigation affordance: when present, the row gets `role="button"`, `tabIndex={0}`, a visible focus ring, and an `onKeyDown` handler that activates on Enter/Space. The handler only fires when the row itself is the event target (not a nested control, like the existing Expand button), so it doesn't double-fire alongside a child control's own keyboard handling. Rows without `onClick` are completely unaffected.
- `packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx`, `.../findings/FindingsTableView.tsx`, `.../data-shares/DataSharesTableView.tsx` — added a descriptive `aria-label` to each interactive row (e.g. "View details for exception …") so assistive tech announces what activating the row does.
- No visual design changes and no change to existing mouse-click behavior — this only adds the missing keyboard/AT path.

## Verification

Ran inside a fresh clone (`pnpm install --prefer-offline` succeeded):
- `pnpm --filter @akasecurity/ui-kit typecheck` / `lint` — passed (after fixing one `no-unnecessary-condition` finding from the initial draft)
- `pnpm --filter @akasecurity/dashboard-ui typecheck` / `lint` — passed
- `pnpm --filter @akasecurity/dashboard-ui test` — 10 files / 69 tests passed (existing suite; unaffected)
- `pnpm --filter @akasecurity/web-ui typecheck` — passed (downstream consumer of both touched packages)
- `npx prettier --check` on the four changed files — passed
- **Not run:** manual keyboard interaction in a real browser. The target-vs-currentTarget reasoning follows from the DOM event model but hasn't been eyeballed live. `packages/dashboard-ui`'s `vitest.config.ts` has no jsdom/`@testing-library` setup yet (its own comment says so), so no automated component/interaction test was added — that would mean introducing new test infra, which felt out of scope here.

## Notes / follow-ups

- `TableRow` uses `role="button"` directly on the `<tr>` rather than restructuring each row to wrap its content in a nested `<button>`. This keeps the change minimal and visual-design-neutral, but a row carrying both `role="button"` and a real nested `<button>` (the existing Expand control) is not a textbook ARIA pattern. The keydown guard prevents double-activation and screen readers we're aware of handle it, but a reviewer who wants the by-the-book version (a genuine focusable element as the row's primary action target) should treat that as a separate, larger follow-up.
- No manual screen-reader (VoiceOver/NVDA) pass was performed; recommend a follow-up manual a11y check before release.
