### PR TITLE
fix(detections): harden regex matcher against catastrophic backtracking

### DIFF
--- a/packages/detections/src/matchers/limits.ts
+++ b/packages/detections/src/matchers/limits.ts
@@ -5,3 +5,17 @@
 // well-formed but pathologically broad match (a 1-character keyword, or a regex
 // like "." over a very large input) that would otherwise emit one span per byte.
 export const MAX_MATCHES_PER_RULE = 10_000;
+
+// Hard ceiling on how much text a single regex rule is ever run against. A
+// backtracking engine's worst-case cost for a pathological pattern (nested
+// quantifiers like "(a+)+", overlapping alternation, etc.) grows with input
+// size — for some patterns exponentially — so bounding the text a caller-
+// supplied pattern is evaluated over bounds the worst case it can trigger,
+// independent of whether the pattern itself is ever inspected for complexity.
+// This package is synchronous and has no timeout/worker available to it, so
+// this input-size cap (plus the pattern-length cap in the schema package) is
+// the only defense it can offer on its own; a caller that runs untrusted,
+// externally-authored patterns (e.g. a rule-testing API) still needs its own
+// time-bounded isolation around the call. Generous enough that no real source
+// file, log line, or prompt is ever truncated in practice.
+export const MAX_REGEX_INPUT_LENGTH = 200_000;

--- a/packages/detections/src/matchers/regex.ts
+++ b/packages/detections/src/matchers/regex.ts
@@ -1,7 +1,7 @@
 import type { Rule, Span } from '@akasecurity/schema';
 
 import type { Matcher } from '../types.ts';
-import { MAX_MATCHES_PER_RULE } from './limits.ts';
+import { MAX_MATCHES_PER_RULE, MAX_REGEX_INPUT_LENGTH } from './limits.ts';
 
 export class RegexMatcher implements Matcher {
   match(text: string, rule: Rule): Span[] {
@@ -12,10 +12,25 @@ export class RegexMatcher implements Matcher {
     // span whenever the captured value also occurs earlier in the match, and a
     // mislocated span makes redact() mask the wrong characters.
     const re = new RegExp(pattern, flags.includes('d') ? flags : `${flags}d`);
+    // Bound how much of `text` a single caller-supplied pattern is ever run
+    // against — see MAX_REGEX_INPUT_LENGTH for why this matters for a
+    // catastrophically-backtracking pattern. `scanText` is always a prefix of
+    // `text`, so spans found within it are valid offsets into the original.
+    const scanText =
+      text.length > MAX_REGEX_INPUT_LENGTH ? text.slice(0, MAX_REGEX_INPUT_LENGTH) : text;
     const spans: Span[] = [];
     let m: RegExpExecArray | null;
+    // Defense-in-depth iteration budget: a well-formed loop only ever advances
+    // `lastIndex`, so it cannot run more than one iteration per character of
+    // `scanText`. This should never trip — it exists purely as a backstop
+    // against an unforeseen zero-advance edge case, independent of the
+    // MAX_MATCHES_PER_RULE cap below (which stops recording spans, not
+    // iterating).
+    const maxIterations = scanText.length + 1;
+    let iterations = 0;
 
-    while ((m = re.exec(text)) !== null) {
+    while ((m = re.exec(scanText)) !== null) {
+      if (++iterations > maxIterations) break;
       const group = captureGroup != null ? m[captureGroup] : m[0];
       // A zero-length match (e.g. "\d*" matching "") never advances `lastIndex`
       // on its own, so a `g`-flag loop that just re-runs `exec` at the same

--- a/packages/detections/test/matchers/regex.test.ts
+++ b/packages/detections/test/matchers/regex.test.ts
@@ -66,4 +66,21 @@ describe('RegexMatcher', () => {
     expect(Date.now() - start).toBeLessThan(1000);
     expect(spans).toEqual([]);
   });
+
+  it('does not truncate input at or under MAX_REGEX_INPUT_LENGTH (no regression)', () => {
+    const matcher = new RegexMatcher();
+    const text = `${'x'.repeat(199_997)}foo`;
+    const spans = matcher.match(text, regexRule('foo', 'g'));
+    expect(spans).toEqual([{ start: 199_997, end: 200_000 }]);
+  });
+
+  it('ignores a match past MAX_REGEX_INPUT_LENGTH instead of scanning unbounded input', () => {
+    const matcher = new RegexMatcher();
+    // A caller-supplied pattern is only ever run against a bounded prefix of
+    // `text` — this bounds the worst-case cost a pathological pattern can incur
+    // on an arbitrarily large caller-controlled input.
+    const text = `${'x'.repeat(200_001)}foo`;
+    const spans = matcher.match(text, regexRule('foo', 'g'));
+    expect(spans).toEqual([]);
+  });
 });

--- a/packages/schema/src/zod/rule.ts
+++ b/packages/schema/src/zod/rule.ts
@@ -43,10 +43,18 @@ function matchesEmptyString(pattern: string, flags: string): boolean {
   }
 }
 
+// The longest pattern in the bundled rule packs is ~650 characters (a
+// multi-alternative cloud-connection-string rule); 2000 leaves generous
+// headroom for legitimate rules while still rejecting absurdly long patterns
+// at the contract boundary before they ever reach the engine or a publish
+// pipeline — both larger compile cost and more surface for pathological
+// backtracking scale with pattern size.
+const MAX_PATTERN_LENGTH = 2000;
+
 export const RegexMatcher = z
   .object({
     type: z.literal('regex'),
-    pattern: z.string(),
+    pattern: z.string().min(1).max(MAX_PATTERN_LENGTH),
     flags: z.string().default('gi'),
     captureGroup: z.number().int().nonnegative().optional(),
   })

--- a/packages/schema/test/zod/rule.test.ts
+++ b/packages/schema/test/zod/rule.test.ts
@@ -44,3 +44,36 @@ describe('Rule keyword matcher contract', () => {
     expect(parsed.matcher.type).toBe('keyword');
   });
 });
+
+function regexRule(pattern: string) {
+  return {
+    specVersion: 1,
+    id: 'test-pack/test-rule',
+    name: 'test',
+    category: 'secret',
+    severity: 'high',
+    matcher: { type: 'regex', pattern, flags: 'g' },
+  };
+}
+
+describe('Rule regex matcher contract', () => {
+  it('rejects an empty pattern', () => {
+    expect(Rule.safeParse(regexRule('')).success).toBe(false);
+  });
+
+  it('accepts a pattern at the length ceiling', () => {
+    // The longest bundled pattern is ~650 chars (a multi-alternative
+    // cloud-connection-string rule); 2000 is the schema's cap.
+    const parsed = Rule.safeParse(regexRule('a'.repeat(2000)));
+    expect(parsed.success).toBe(true);
+  });
+
+  it('rejects a pattern past the length ceiling', () => {
+    // An unbounded `pattern` string lets a caller submit an absurdly long
+    // regex to any endpoint that validates through this schema (e.g. a
+    // rule-testing API); capping it here rejects that at the contract
+    // boundary regardless of what validates patterns downstream.
+    const parsed = Rule.safeParse(regexRule('a'.repeat(2001)));
+    expect(parsed.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The detection engine's `RegexMatcher` compiles and runs a rule's `pattern` with no bound on the pattern's length or on how much input text a single evaluation processes. Any consumer that validates or scans with an externally-authored regex — a pulled rule pack, a user-authored custom rule, a rule-authoring UI — has no limit on the worst-case CPU a single pathological pattern can consume. That is a classic catastrophic-backtracking (ReDoS) exposure in a package whose whole job is evaluating untrusted patterns.

This bounds untrusted pattern evaluation in the shared matcher and its schema contract, reducing the worst case for every consumer of this package.

## What changed

- `packages/schema/src/zod/rule.ts`: `RegexMatcher.pattern` now has a `min(1).max(2000)` bound instead of an unbounded `z.string()`. 2000 chars leaves generous headroom over the longest pattern bundled in `rules/` (~650 chars) while rejecting absurdly long patterns at the contract boundary before they reach the engine or a publish pipeline.
- `packages/detections/src/matchers/limits.ts`: added `MAX_REGEX_INPUT_LENGTH` (200,000 chars) — a hard ceiling on how much text a single regex rule is ever evaluated against, since a backtracking engine's worst-case cost for a pathological pattern grows with input size.
- `packages/detections/src/matchers/regex.ts`: `RegexMatcher.match()` now evaluates the pattern against a bounded prefix of the input text (`MAX_REGEX_INPUT_LENGTH`) and enforces a defense-in-depth iteration budget on the match loop. Matching behavior, offsets, and existing rule outcomes are unchanged for any input at or under the cap.
- Added test coverage for both new bounds (`packages/schema/test/zod/rule.test.ts`, `packages/detections/test/matchers/regex.test.ts`).

## Scope of this change

This package is intentionally synchronous and dependency-free (no I/O, no Node-API deps), so it cannot interrupt a single pathological `exec()` call mid-flight. Bounding inputs shrinks the worst case; it does not eliminate it.

Any consumer that evaluates untrusted, externally-authored patterns should additionally run evaluation under time-bounded isolation (a worker or subprocess with a hard wall-clock budget). That is standard practice for untrusted regex evaluation and is the call site's responsibility, not something a synchronous matcher can provide.

## Verification

- `pnpm install --prefer-offline` succeeded in a fresh clone.
- `pnpm --filter @akasecurity/detections test` — 871 passed (869 pre-existing + 2 new), including the existing adversarial-pattern battery in `packages/detections/test/security/redos.test.ts` — no regressions.
- `pnpm --filter @akasecurity/schema test` — 532 passed (529 pre-existing + 3 new) — no regressions.
- `typecheck` and `lint` clean for both `@akasecurity/detections` and `@akasecurity/schema`.
- `prettier --check` on all changed files — clean.
- Not run: the full monorepo test/build matrix — only the two packages touched by this change.

## Notes / follow-ups

- The pattern-length cap (2000) and input-length cap (200,000) are conservative defaults chosen to leave headroom over every bundled rule pattern and realistic scan input while still bounding worst-case behavior; a reviewer may want to tune these against real-world pattern/pack sizes.
- This PR does not add a static complexity linter for pathological pattern shapes (e.g. nested quantifiers). The existing `matchesEmptyString` schema refine and the `redos.test.ts` battery cover a meaningful subset for bundled rules; a general static analyzer for arbitrary patterns is a larger effort deliberately left out of this fix.
