### PR TITLE
ci: enforce the OSS dependency boundary (no enterprise imports)

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -37,4 +37,33 @@ export const base = tseslint.config(
   prettier,
 );
 
+// OSS/enterprise dependency wall (see CLAUDE.md "Package dependency rules"):
+// packages that ship in the public oss/ tree must never import enterprise-only
+// modules — @akasecurity/client (the tenant-aware HTTP client), drizzle-orm and
+// @akasecurity/schema-enterprise (the Postgres/tenancy layer). Apply this to
+// every OSS package except the plugin, which is the documented exception
+// allowed to use @akasecurity/client to sync to a backend when attached.
+const ENTERPRISE_IMPORT_MESSAGE =
+  'OSS packages must never import enterprise-only modules (this keeps tenancy/auth/Postgres code out of the public oss/ tree). See CLAUDE.md "Package dependency rules".';
+
+/** @type {import('typescript-eslint').ConfigArray} */
+export const noEnterpriseImports = tseslint.config({
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          { name: '@akasecurity/client', message: ENTERPRISE_IMPORT_MESSAGE },
+          { name: 'drizzle-orm', message: ENTERPRISE_IMPORT_MESSAGE },
+          { name: '@akasecurity/schema-enterprise', message: ENTERPRISE_IMPORT_MESSAGE },
+        ],
+        patterns: [
+          { group: ['drizzle-orm/*'], message: ENTERPRISE_IMPORT_MESSAGE },
+          { group: ['@akasecurity/schema-enterprise/*'], message: ENTERPRISE_IMPORT_MESSAGE },
+        ],
+      },
+    ],
+  },
+});
+
 export default base;

--- a/packages/local-ops/eslint.config.mjs
+++ b/packages/local-ops/eslint.config.mjs
@@ -1,8 +1,9 @@
 // @ts-check
-import { base } from '@akasecurity/eslint-config';
+import { base, noEnterpriseImports } from '@akasecurity/eslint-config';
 
 export default [
   ...base,
+  ...noEnterpriseImports,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/persistence/eslint.config.mjs
+++ b/packages/persistence/eslint.config.mjs
@@ -1,8 +1,9 @@
 // @ts-check
-import { base } from '@akasecurity/eslint-config';
+import { base, noEnterpriseImports } from '@akasecurity/eslint-config';
 
 export default [
   ...base,
+  ...noEnterpriseImports,
   {
     languageOptions: {
       parserOptions: {

--- a/web-ui/eslint.config.mjs
+++ b/web-ui/eslint.config.mjs
@@ -1,9 +1,11 @@
 // @ts-check
+import { noEnterpriseImports } from '@akasecurity/eslint-config';
 import { react } from '@akasecurity/eslint-config/react';
 import tseslint from 'typescript-eslint';
 
 export default [
   ...react,
+  ...noEnterpriseImports,
   {
     languageOptions: {
       parserOptions: {


### PR DESCRIPTION
## Why

This repo's architecture draws a hard line: packages in this open-source tree must never import enterprise-only modules (`@akasecurity/client`, `drizzle-orm`, `@akasecurity/schema-enterprise`), because that would pull tenancy/auth/Postgres concerns — and the private layer's dependencies — into the open-source surface.

Until now that boundary was documented in `CLAUDE.md` but enforced only by convention and code review, so a PR that accidentally introduced one of those imports into an OSS package would pass CI and merge silently. This adds the missing automated gate.

## What changed

- Added a `noEnterpriseImports` ESLint config export in `packages/eslint-config/src/index.js`, defining a `no-restricted-imports` rule that bans `@akasecurity/client`, `drizzle-orm`, and `@akasecurity/schema-enterprise` (plus their subpaths) with an explanatory error message pointing back to CLAUDE.md's dependency rules.
- Applied `noEnterpriseImports` in `packages/persistence/eslint.config.mjs`, `packages/local-ops/eslint.config.mjs`, and `web-ui/eslint.config.mjs`.
- Left the plugin packages (`plugins/claude-code`, and the shared `cli`) untouched — they are the documented exception allowed to use `@akasecurity/client` to sync to a backend when attached.
- No CI workflow changes needed: `.github/workflows/ci.yml`'s existing `pnpm lint` step already runs `turbo run lint`, which executes ESLint (including this new rule) for every package with a `lint` script — `persistence`/`local-ops`/`web-ui` included. The gate is live on the next PR with no extra wiring.

This is a preventive control, not a response to a known violation: the boundary holds in the current tree, and this change keeps a future regression from merging green.

## Verification

- `pnpm install --prefer-offline` — succeeded.
- `pnpm --filter @akasecurity/persistence lint`, `--filter @akasecurity/local-ops lint`, `--filter @akasecurity/web-ui lint` — all pass clean (confirms the new rule doesn't fire on current legitimate code).
- `pnpm lint` (full repo, all 14 workspace packages via Turborepo) — all pass, 0 regressions.
- `typecheck` passes for the three packages plus `@akasecurity/eslint-config` (the new export type-checks).
- Not run: full-repo `pnpm test` / `pnpm build`, and no negative test (deliberately introducing a forbidden import to confirm it fails) was added — this is a lint-config-only change with no new runtime behavior. A reviewer wanting that assurance can sanity-check locally in seconds.

## Notes / follow-ups

- `packages/dashboard-ui` is also named in `CLAUDE.md` as a package that must never import `@akasecurity/client`. It is left out here to keep this change small and mechanical; extending `noEnterpriseImports` to it is a reasonable follow-up.
