### PR TITLE
chore(release): merge release/0.9.0 back to main

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -132,19 +132,33 @@ jobs:
       # publish credential — no NPM_TOKEN needed. NPM_CONFIG_PROVENANCE has npm
       # attach a Sigstore attestation binding the published package to this
       # repository and workflow.
+      # Pre-release versions (any `-` suffix) publish under the `rc` dist-tag;
+      # stable versions publish under `latest`.
       - name: Publish to npm
         if: github.event_name == 'push' || inputs.publish
-        run: pnpm --filter @akasecurity/cli publish --no-git-checks
+        run: |
+          version=$(node -p "require('./cli/package.json').version")
+          case "$version" in
+            *-*) dist_tag="rc" ;;
+            *)   dist_tag="latest" ;;
+          esac
+          pnpm --filter @akasecurity/cli publish --no-git-checks --tag "$dist_tag"
         env:
           NPM_CONFIG_PROVENANCE: 'true'
 
       # The install one-liners fetch the bootstrap scripts from the `cli-latest`
-      # tag, so a successful publish must move it to this release commit.
+      # tag, so a successful stable publish must move it to this release commit.
+      # Pre-releases leave it on the last stable release.
       - name: Point cli-latest at this release
         if: github.event_name == 'push'
         run: |
-          git tag -f cli-latest
-          git push -f origin cli-latest
+          case "${GITHUB_REF_NAME#cli-v}" in
+            *-*) echo "Pre-release — cli-latest stays on the last stable release" ;;
+            *)
+              git tag -f cli-latest
+              git push -f origin cli-latest
+              ;;
+          esac
 
       - name: Create GitHub Release
         if: github.event_name == 'push'

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -112,9 +112,17 @@ jobs:
       # exchange this job's OIDC token for a short-lived publish credential — no
       # NPM_TOKEN needed. NPM_CONFIG_PROVENANCE has npm attach a Sigstore
       # attestation binding the published package to this repository and workflow.
+      # Pre-release versions (any `-` suffix) publish under the `rc` dist-tag;
+      # stable versions publish under `latest`.
       - name: Publish to npm
         if: github.event_name == 'push' || inputs.publish
-        run: pnpm --filter @akasecurity/ai-tc-claude-code publish --no-git-checks
+        run: |
+          version=$(node -p "require('./plugins/claude-code/package.json').version")
+          case "$version" in
+            *-*) dist_tag="rc" ;;
+            *)   dist_tag="latest" ;;
+          esac
+          pnpm --filter @akasecurity/ai-tc-claude-code publish --no-git-checks --tag "$dist_tag"
         env:
           NPM_CONFIG_PROVENANCE: 'true'
 
@@ -162,6 +170,12 @@ jobs:
       # built-in GITHUB_TOKEN can publish to this repo's Packages; setup-node wrote
       # the matching auth token into .npmrc.
       - name: Publish to GitHub Packages
-        run: pnpm --filter @akasecurity/ai-tc-claude-code publish --registry https://npm.pkg.github.com --no-git-checks
+        run: |
+          version=$(node -p "require('./plugins/claude-code/package.json').version")
+          case "$version" in
+            *-*) dist_tag="rc" ;;
+            *)   dist_tag="latest" ;;
+          esac
+          pnpm --filter @akasecurity/ai-tc-claude-code publish --registry https://npm.pkg.github.com --no-git-checks --tag "$dist_tag"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.0-rc1",
+  "version": "0.9.0",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.8.2",
+  "version": "0.9.0-rc1",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.8.2",
+  "version": "0.9.0-rc1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.0-rc1",
+  "version": "0.9.0",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.0-rc1",
+  "version": "0.9.0",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.8.2",
+  "version": "0.9.0-rc1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Brings the 0.9.0 release line back into main:

- `chore(release): 0.9.0-rc1` and `chore(release): 0.9.0` — version bumps for cli, plugins/claude-code, and the plugin manifest (now at 0.9.0)
- `ci(release): publish pre-release versions under the rc dist-tag` — release workflows publish any `-`-suffixed version to npm under the `rc` dist-tag and leave the `cli-latest` bootstrap tag on the last stable release; stable versions are unchanged (`latest` + tag move)

Both 0.9.0 artifacts are already published from these commits (npm `latest` = 0.9.0 for `@akasecurity/cli` and `@akasecurity/ai-tc-claude-code`; GitHub Releases `cli-v0.9.0` / `plugin-v0.9.0`).