### PR TITLE
docs(installer): point install one-liners at bin-latest; document bin-v* SEA channel

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -146,9 +146,11 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: 'true'
 
-      # The install one-liners fetch the bootstrap scripts from the `cli-latest`
-      # tag, so a successful stable publish must move it to this release commit.
-      # Pre-releases leave it on the last stable release.
+      # The binary installer one-liners fetch install.sh/install.ps1 from the
+      # `bin-latest` tag (moved by release-binaries.yml), NOT `cli-latest`.
+      # `cli-latest` is kept as a stable alias for the npm CLI channel: a
+      # successful stable publish moves it to this commit; pre-releases leave it
+      # on the last stable release.
       - name: Point cli-latest at this release
         if: github.event_name == 'push'
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,25 @@ When a change touches the web-ui or any bundled package and the user wants to pu
 Versions are bumped by hand in a `chore(release):` commit (no changesets). The current pre-release
 line is `0.0.2-alpha.N` — a pre-release bump increments `N`.
 
+### Binary (SEA) channel — `bin-v*`
+
+The `aka` CLI also ships as a self-contained **Standalone Executable Application (SEA)** — a native
+binary that embeds the Node runtime, so end users need neither Node nor npm. This is a **separate
+release channel** from the `cli-v*` npm publish:
+
+- **Trigger:** push a tag `bin-v<version>`. It must equal `cli/package.json`'s version —
+  `release-binaries.yml` gates on it and fails the release on a mismatch. `workflow_dispatch` runs a
+  build-only dry run (no Release).
+- **Build:** `release-binaries.yml` builds the SEA on native runners per platform (no cross-compile)
+  — `darwin-arm64`, `linux-x64`, `linux-arm64`, `win32-x64` — via `build:sea` → `bundle:web-ui` →
+  `package:sea` → `archive:sea`.
+- **Assets:** `aka-<version>-<triple>.tar.gz` (`.zip` on Windows) plus an aggregated `SHA256SUMS`.
+  The `tools/installer/` one-liners verify the download against it, fail-closed.
+- **`bin-latest`:** on success the workflow force-moves `bin-latest` to the release commit; the
+  installer one-liners (`install.sh`/`install.ps1`) are fetched from `bin-latest`, not `main`.
+- `cli-v*` (npm) and `bin-v*` (binary) are **independent** — a binary release needs no npm publish
+  and vice versa, though they normally share one version line.
+
 ## Running locally
 
 No server, no Docker, no database engine — just Node and the local SQLite store.

--- a/cli/README.md
+++ b/cli/README.md
@@ -15,14 +15,14 @@ Everything runs on your machine. There's no account, no backend, and nothing lea
 npm install -g @akasecurity/cli
 ```
 
-Or use the bootstrap installer (checks for Node, then installs):
+Or use the bootstrap installer (downloads the self-contained binary — no Node.js required):
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.sh | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.ps1 | iex
+irm https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.ps1 | iex
 ```
 
 Requires **Node.js 24+** (the CLI uses the built-in `node:sqlite`).

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -685,23 +685,24 @@ interface + terminal dashboard and on-demand scans."
 - **Not now** — "skip — you can add it anytime with the one-liner below"
 
 **Yes, add it** is the install authorization — run the bootstrap installer
-directly, with no second picker (it ensures Node is available and installs the
-global CLI from the public npm registry). Run the line for their OS:
+directly, with no second picker (it downloads the self-contained `aka` binary for
+their platform — no Node.js or npm required — and links it onto PATH). Run the
+line for their OS:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.sh | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.ps1 | iex
+irm https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.ps1 | iex
 ```
 
-The one-liner pins to the stable release **tag** (`cli-latest`), never `main` —
-each release points that tag at its published `cli-v*` version, and the bootstrap
-scripts it fetches hold the installer's pinned ref + checksum, so fetching them
-from a mutable branch would defeat the integrity gate. To pin an exact version
-instead, set `AKA_INSTALL_REF=cli-v<version>` before running the line. Until the
-first release is published the one-liner 404s (fail-closed).
+The one-liner pins to the latest published binary release **tag** (`bin-latest`),
+never `main` — each binary release (`bin-v*`) moves that tag to its commit, and
+the installer verifies the downloaded binary against the release's `SHA256SUMS`
+(fail-closed), so a corrupted or tampered download is refused. To pin an exact
+version instead, set `AKA_INSTALL_REF=bin-v<version>` before running the line. If
+no `bin-v*` release exists yet the one-liner fails closed rather than guessing.
 
 After it completes, point them at `aka init` then `aka dashboard`. If they chose
 **Not now**, show the one-liner once so they can add it later, and move on —


### PR DESCRIPTION
## What & why

The bootstrap installer under `tools/installer/` is the **standalone-binary (SEA)** installer: it's fetched from the `bin-latest` tag and resolves `bin-v*` releases (`aka-<ver>-<triple>.tar.gz` + `SHA256SUMS`, fail-closed). But several user-facing install one-liners still pointed at `cli-latest` (the *npm* channel) and described an npm/Node bootstrap that no longer matches the installer. This aligns the docs with reality — no code and no release cut.

The `bin-v0.9.0` binary release now exists and `bin-latest` points at it, so these one-liners resolve correctly.

## Changes (docs/comments only)

- **`plugins/claude-code/commands/setup.md`** — repoint the `/aka:setup` wizard one-liners `cli-latest` → `bin-latest`; correct the surrounding description (self-contained binary, no Node/npm; `SHA256SUMS` fail-closed verification; `AKA_INSTALL_REF=bin-v<version>` to pin).
- **`cli/README.md`** — same one-liner repoint + description fix.
- **`.github/workflows/release-cli.yml`** — fix the stale comment claiming the installers fetch from `cli-latest`; clarify `cli-latest` is retained only as the npm-channel alias (`bin-latest` is what the installer uses, moved by `release-binaries.yml`).
- **`CLAUDE.md`** — document the `bin-v*` SEA release channel alongside `cli-v*`/`plugin-v*`.

## Not in scope

No release is cut by this PR. The corrected wizard one-liner reaches users at the **next plugin release** (`plugin-v*`); the CI-comment and `CLAUDE.md` changes take effect on merge with no release.

## Validation

- `prettier --check` clean on all four files.
- Workflow YAML parses (change is comment-only).
- No install one-liner references `cli-latest` anymore (`git grep`).
- The `bin-latest` install path was exercised end-to-end against the published `bin-v0.9.0` release: download → `SHA256SUMS` verify → link → `aka --version` → `0.9.0`.