### PR TITLE
feat(egress) [3/13]: detections — egress provider registry

### DIFF
--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -269,6 +269,21 @@
       "expect": null
     },
     {
+      "label": ":: (IPv6 unspecified) is excluded, like 0.0.0.0 on the v4 side",
+      "host": "::",
+      "expect": null
+    },
+    {
+      "label": "[::] (bracketed IPv6 unspecified) is excluded",
+      "host": "[::]",
+      "expect": null
+    },
+    {
+      "label": "ff02::1 (IPv6 multicast) is excluded, like 224.0.0.0/4 on the v4 side",
+      "host": "ff02::1",
+      "expect": null
+    },
+    {
       "label": "fe80::1 (IPv6 link-local) is excluded",
       "host": "fe80::1",
       "expect": null

--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -3,78 +3,153 @@
     {
       "label": "api.stripe.com resolves to Stripe (subdomain of a bare hostSuffix)",
       "host": "api.stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Stripe",
+        "category": "Payments"
+      }
     },
     {
       "label": "stripe.com resolves to Stripe (exact hostSuffix)",
       "host": "stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Stripe",
+        "category": "Payments"
+      }
     },
     {
       "label": "www.stripe.com resolves to Stripe (another subdomain)",
       "host": "www.stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Stripe",
+        "category": "Payments"
+      }
     },
     {
       "label": "api.datadoghq.eu resolves to Datadog (second hostSuffix entry)",
       "host": "api.datadoghq.eu",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Datadog", "category": "Observability" }
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Datadog",
+        "category": "Observability"
+      }
     },
     {
       "label": "evilstripe.com is NOT Stripe — mid-label suffix must not match",
       "host": "evilstripe.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "evilstripe.com", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "evilstripe.com",
+        "category": "External domain"
+      }
     },
     {
       "label": "evildatadoghq.com is NOT Datadog — same suffix hazard, different provider",
       "host": "evildatadoghq.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "evildatadoghq.com", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "evildatadoghq.com",
+        "category": "External domain"
+      }
     },
     {
       "label": "db.internal resolves internal via the .internal TLD",
       "host": "db.internal",
-      "expect": { "kind": "internal", "trust": "internal", "name": "db.internal", "category": "Internal services" }
+      "expect": {
+        "kind": "internal",
+        "trust": "internal",
+        "name": "db.internal",
+        "category": "Internal services"
+      }
     },
     {
       "label": "intranet (single-label host) resolves internal",
       "host": "intranet",
-      "expect": { "kind": "internal", "trust": "internal", "name": "intranet", "category": "Internal services" }
+      "expect": {
+        "kind": "internal",
+        "trust": "internal",
+        "name": "intranet",
+        "category": "Internal services"
+      }
     },
     {
       "label": "host.home.arpa resolves internal via the dotted home.arpa TLD",
       "host": "host.home.arpa",
-      "expect": { "kind": "internal", "trust": "internal", "name": "host.home.arpa", "category": "Internal services" }
+      "expect": {
+        "kind": "internal",
+        "trust": "internal",
+        "name": "host.home.arpa",
+        "category": "Internal services"
+      }
     },
     {
       "label": "app.corp resolves internal via the .corp TLD",
       "host": "app.corp",
-      "expect": { "kind": "internal", "trust": "internal", "name": "app.corp", "category": "Internal services" }
+      "expect": {
+        "kind": "internal",
+        "trust": "internal",
+        "name": "app.corp",
+        "category": "Internal services"
+      }
     },
     {
       "label": "goodcode.us resolves internal only when the caller supplies it as an internalDomain",
       "host": "goodcode.us",
       "opts": { "internalDomains": ["goodcode.us"] },
-      "expect": { "kind": "internal", "trust": "internal", "name": "goodcode.us", "category": "Internal services" }
+      "expect": {
+        "kind": "internal",
+        "trust": "internal",
+        "name": "goodcode.us",
+        "category": "Internal services"
+      }
     },
     {
       "label": "goodcode.us with no internalDomains hint resolves external",
       "host": "goodcode.us",
-      "expect": { "kind": "external", "trust": "unverified", "name": "goodcode.us", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "goodcode.us",
+        "category": "External domain"
+      }
     },
     {
       "label": "acme-partner.com has no registry match and no internal signal — external, not internal",
       "host": "acme-partner.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "acme-partner.com", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "acme-partner.com",
+        "category": "External domain"
+      }
     },
     {
       "label": "an unrecognized public domain with a malformed-IP-looking label still resolves external",
       "host": "999.1.1.1",
-      "expect": { "kind": "external", "trust": "unverified", "name": "999.1.1.1", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "999.1.1.1",
+        "category": "External domain"
+      }
     },
     {
       "label": "198.51.100.23 is a public IPv4 literal — kind ip",
       "host": "198.51.100.23",
-      "expect": { "kind": "ip", "trust": "ip", "name": "198.51.100.23", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "198.51.100.23",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "172.32.0.1 is just outside the private 172.16-31 range — kind ip, not excluded",
@@ -199,12 +274,22 @@
     {
       "label": "2001:db8::1 (bare public IPv6 literal) is kind ip",
       "host": "2001:db8::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "2001:db8::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "2001:db8::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "[2001:db8::1] (bracketed public IPv6 literal) is kind ip — URL authority form",
       "host": "[2001:db8::1]",
-      "expect": { "kind": "ip", "trust": "ip", "name": "[2001:db8::1]", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "[2001:db8::1]",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "febf::1 (top edge of fe80::/10 link-local) is excluded",
@@ -229,7 +314,12 @@
     {
       "label": "2001:DB8::1 (uppercase, RFC-canonical documentation spelling) is kind ip",
       "host": "2001:DB8::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "2001:db8::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "2001:db8::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "fe80::1%eth0 (zone-indexed link-local, bare form) is excluded",
@@ -259,12 +349,22 @@
     {
       "label": "::ffff:8.8.8.8 (IPv4-mapped public address) is kind ip",
       "host": "::ffff:8.8.8.8",
-      "expect": { "kind": "ip", "trust": "ip", "name": "::ffff:8.8.8.8", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "::ffff:8.8.8.8",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "db:8080 (colon-bearing, fails every IP-literal check) resolves external, never the trusted single-label internal fallback",
       "host": "db:8080",
-      "expect": { "kind": "external", "trust": "unverified", "name": "db:8080", "category": "External domain" }
+      "expect": {
+        "kind": "external",
+        "trust": "unverified",
+        "name": "db:8080",
+        "category": "External domain"
+      }
     }
   ],
   "sdks": [

--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -3,83 +3,83 @@
     {
       "label": "api.stripe.com resolves to Stripe (subdomain of a bare hostSuffix)",
       "host": "api.stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
     },
     {
       "label": "stripe.com resolves to Stripe (exact hostSuffix)",
       "host": "stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
     },
     {
       "label": "www.stripe.com resolves to Stripe (another subdomain)",
       "host": "www.stripe.com",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe", "category": "Payments" }
     },
     {
       "label": "api.datadoghq.eu resolves to Datadog (second hostSuffix entry)",
       "host": "api.datadoghq.eu",
-      "expect": { "kind": "provider", "trust": "recognized", "name": "Datadog" }
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Datadog", "category": "Observability" }
     },
     {
       "label": "evilstripe.com is NOT Stripe — mid-label suffix must not match",
       "host": "evilstripe.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "evilstripe.com" }
+      "expect": { "kind": "external", "trust": "unverified", "name": "evilstripe.com", "category": "External domain" }
     },
     {
       "label": "evildatadoghq.com is NOT Datadog — same suffix hazard, different provider",
       "host": "evildatadoghq.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "evildatadoghq.com" }
+      "expect": { "kind": "external", "trust": "unverified", "name": "evildatadoghq.com", "category": "External domain" }
     },
     {
       "label": "db.internal resolves internal via the .internal TLD",
       "host": "db.internal",
-      "expect": { "kind": "internal", "trust": "internal", "name": "db.internal" }
+      "expect": { "kind": "internal", "trust": "internal", "name": "db.internal", "category": "Internal services" }
     },
     {
       "label": "intranet (single-label host) resolves internal",
       "host": "intranet",
-      "expect": { "kind": "internal", "trust": "internal", "name": "intranet" }
+      "expect": { "kind": "internal", "trust": "internal", "name": "intranet", "category": "Internal services" }
     },
     {
       "label": "host.home.arpa resolves internal via the dotted home.arpa TLD",
       "host": "host.home.arpa",
-      "expect": { "kind": "internal", "trust": "internal", "name": "host.home.arpa" }
+      "expect": { "kind": "internal", "trust": "internal", "name": "host.home.arpa", "category": "Internal services" }
     },
     {
       "label": "app.corp resolves internal via the .corp TLD",
       "host": "app.corp",
-      "expect": { "kind": "internal", "trust": "internal", "name": "app.corp" }
+      "expect": { "kind": "internal", "trust": "internal", "name": "app.corp", "category": "Internal services" }
     },
     {
       "label": "goodcode.us resolves internal only when the caller supplies it as an internalDomain",
       "host": "goodcode.us",
       "opts": { "internalDomains": ["goodcode.us"] },
-      "expect": { "kind": "internal", "trust": "internal", "name": "goodcode.us" }
+      "expect": { "kind": "internal", "trust": "internal", "name": "goodcode.us", "category": "Internal services" }
     },
     {
       "label": "goodcode.us with no internalDomains hint resolves external",
       "host": "goodcode.us",
-      "expect": { "kind": "external", "trust": "unverified", "name": "goodcode.us" }
+      "expect": { "kind": "external", "trust": "unverified", "name": "goodcode.us", "category": "External domain" }
     },
     {
       "label": "acme-partner.com has no registry match and no internal signal — external, not internal",
       "host": "acme-partner.com",
-      "expect": { "kind": "external", "trust": "unverified", "name": "acme-partner.com" }
+      "expect": { "kind": "external", "trust": "unverified", "name": "acme-partner.com", "category": "External domain" }
     },
     {
       "label": "an unrecognized public domain with a malformed-IP-looking label still resolves external",
       "host": "999.1.1.1",
-      "expect": { "kind": "external", "trust": "unverified", "name": "999.1.1.1" }
+      "expect": { "kind": "external", "trust": "unverified", "name": "999.1.1.1", "category": "External domain" }
     },
     {
       "label": "198.51.100.23 is a public IPv4 literal — kind ip",
       "host": "198.51.100.23",
-      "expect": { "kind": "ip", "trust": "ip", "name": "198.51.100.23" }
+      "expect": { "kind": "ip", "trust": "ip", "name": "198.51.100.23", "category": "Unresolved host" }
     },
     {
       "label": "172.32.0.1 is just outside the private 172.16-31 range — kind ip, not excluded",
       "host": "172.32.0.1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "172.32.0.1" }
+      "expect": { "kind": "ip", "trust": "ip", "name": "172.32.0.1", "category": "Unresolved host" }
     },
     {
       "label": "localhost is excluded",
@@ -175,6 +175,36 @@
       "label": "maven.apache.org is excluded",
       "host": "maven.apache.org",
       "expect": null
+    },
+    {
+      "label": "[::1] (bracketed IPv6 loopback) is excluded",
+      "host": "[::1]",
+      "expect": null
+    },
+    {
+      "label": "::1 (bare IPv6 loopback) is excluded",
+      "host": "::1",
+      "expect": null
+    },
+    {
+      "label": "fe80::1 (IPv6 link-local) is excluded",
+      "host": "fe80::1",
+      "expect": null
+    },
+    {
+      "label": "fc00::1 (IPv6 unique-local) is excluded",
+      "host": "fc00::1",
+      "expect": null
+    },
+    {
+      "label": "2001:db8::1 (bare public IPv6 literal) is kind ip",
+      "host": "2001:db8::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "2001:db8::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "[2001:db8::1] (bracketed public IPv6 literal) is kind ip — URL authority form",
+      "host": "[2001:db8::1]",
+      "expect": { "kind": "ip", "trust": "ip", "name": "[2001:db8::1]", "category": "Unresolved host" }
     }
   ],
   "sdks": [

--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -205,6 +205,66 @@
       "label": "[2001:db8::1] (bracketed public IPv6 literal) is kind ip — URL authority form",
       "host": "[2001:db8::1]",
       "expect": { "kind": "ip", "trust": "ip", "name": "[2001:db8::1]", "category": "Unresolved host" }
+    },
+    {
+      "label": "febf::1 (top edge of fe80::/10 link-local) is excluded",
+      "host": "febf::1",
+      "expect": null
+    },
+    {
+      "label": "fdff::1 (top edge of fc00::/7 unique-local) is excluded",
+      "host": "fdff::1",
+      "expect": null
+    },
+    {
+      "label": "fec0::1 (just above fe80::/10) is kind ip, not excluded",
+      "host": "fec0::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "fec0::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "fe7f::1 (just below fe80::/10) is kind ip, not excluded",
+      "host": "fe7f::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "fe7f::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "2001:DB8::1 (uppercase, RFC-canonical documentation spelling) is kind ip",
+      "host": "2001:DB8::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "2001:db8::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "fe80::1%eth0 (zone-indexed link-local, bare form) is excluded",
+      "host": "fe80::1%eth0",
+      "expect": null
+    },
+    {
+      "label": "[fe80::1%eth0] (zone-indexed link-local, URL authority form) is excluded",
+      "host": "[fe80::1%eth0]",
+      "expect": null
+    },
+    {
+      "label": "fc::1 (abbreviated group 00fc::, not fc00::/7) is kind ip, not excluded",
+      "host": "fc::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "fc::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "fe8::1 (abbreviated group 0fe8::, not fe80::/10) is kind ip, not excluded",
+      "host": "fe8::1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "fe8::1", "category": "Unresolved host" }
+    },
+    {
+      "label": "::ffff:127.0.0.1 (IPv4-mapped loopback) is excluded",
+      "host": "::ffff:127.0.0.1",
+      "expect": null
+    },
+    {
+      "label": "::ffff:8.8.8.8 (IPv4-mapped public address) is kind ip",
+      "host": "::ffff:8.8.8.8",
+      "expect": { "kind": "ip", "trust": "ip", "name": "::ffff:8.8.8.8", "category": "Unresolved host" }
+    },
+    {
+      "label": "db:8080 (colon-bearing, fails every IP-literal check) resolves external, never the trusted single-label internal fallback",
+      "host": "db:8080",
+      "expect": { "kind": "external", "trust": "unverified", "name": "db:8080", "category": "External domain" }
     }
   ],
   "sdks": [

--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -1,0 +1,272 @@
+{
+  "hosts": [
+    {
+      "label": "api.stripe.com resolves to Stripe (subdomain of a bare hostSuffix)",
+      "host": "api.stripe.com",
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+    },
+    {
+      "label": "stripe.com resolves to Stripe (exact hostSuffix)",
+      "host": "stripe.com",
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+    },
+    {
+      "label": "www.stripe.com resolves to Stripe (another subdomain)",
+      "host": "www.stripe.com",
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Stripe" }
+    },
+    {
+      "label": "api.datadoghq.eu resolves to Datadog (second hostSuffix entry)",
+      "host": "api.datadoghq.eu",
+      "expect": { "kind": "provider", "trust": "recognized", "name": "Datadog" }
+    },
+    {
+      "label": "evilstripe.com is NOT Stripe — mid-label suffix must not match",
+      "host": "evilstripe.com",
+      "expect": { "kind": "external", "trust": "unverified", "name": "evilstripe.com" }
+    },
+    {
+      "label": "evildatadoghq.com is NOT Datadog — same suffix hazard, different provider",
+      "host": "evildatadoghq.com",
+      "expect": { "kind": "external", "trust": "unverified", "name": "evildatadoghq.com" }
+    },
+    {
+      "label": "db.internal resolves internal via the .internal TLD",
+      "host": "db.internal",
+      "expect": { "kind": "internal", "trust": "internal", "name": "db.internal" }
+    },
+    {
+      "label": "intranet (single-label host) resolves internal",
+      "host": "intranet",
+      "expect": { "kind": "internal", "trust": "internal", "name": "intranet" }
+    },
+    {
+      "label": "host.home.arpa resolves internal via the dotted home.arpa TLD",
+      "host": "host.home.arpa",
+      "expect": { "kind": "internal", "trust": "internal", "name": "host.home.arpa" }
+    },
+    {
+      "label": "app.corp resolves internal via the .corp TLD",
+      "host": "app.corp",
+      "expect": { "kind": "internal", "trust": "internal", "name": "app.corp" }
+    },
+    {
+      "label": "goodcode.us resolves internal only when the caller supplies it as an internalDomain",
+      "host": "goodcode.us",
+      "opts": { "internalDomains": ["goodcode.us"] },
+      "expect": { "kind": "internal", "trust": "internal", "name": "goodcode.us" }
+    },
+    {
+      "label": "goodcode.us with no internalDomains hint resolves external",
+      "host": "goodcode.us",
+      "expect": { "kind": "external", "trust": "unverified", "name": "goodcode.us" }
+    },
+    {
+      "label": "acme-partner.com has no registry match and no internal signal — external, not internal",
+      "host": "acme-partner.com",
+      "expect": { "kind": "external", "trust": "unverified", "name": "acme-partner.com" }
+    },
+    {
+      "label": "an unrecognized public domain with a malformed-IP-looking label still resolves external",
+      "host": "999.1.1.1",
+      "expect": { "kind": "external", "trust": "unverified", "name": "999.1.1.1" }
+    },
+    {
+      "label": "198.51.100.23 is a public IPv4 literal — kind ip",
+      "host": "198.51.100.23",
+      "expect": { "kind": "ip", "trust": "ip", "name": "198.51.100.23" }
+    },
+    {
+      "label": "172.32.0.1 is just outside the private 172.16-31 range — kind ip, not excluded",
+      "host": "172.32.0.1",
+      "expect": { "kind": "ip", "trust": "ip", "name": "172.32.0.1" }
+    },
+    {
+      "label": "localhost is excluded",
+      "host": "localhost",
+      "expect": null
+    },
+    {
+      "label": "127.0.0.1 (loopback) is excluded",
+      "host": "127.0.0.1",
+      "expect": null
+    },
+    {
+      "label": "10.1.2.3 (private) is excluded",
+      "host": "10.1.2.3",
+      "expect": null
+    },
+    {
+      "label": "192.168.0.5 (private) is excluded",
+      "host": "192.168.0.5",
+      "expect": null
+    },
+    {
+      "label": "0.0.0.0 (this-network) is excluded",
+      "host": "0.0.0.0",
+      "expect": null
+    },
+    {
+      "label": "169.254.1.1 (link-local) is excluded",
+      "host": "169.254.1.1",
+      "expect": null
+    },
+    {
+      "label": "172.16.5.5 (private, low end of the 16-31 range) is excluded",
+      "host": "172.16.5.5",
+      "expect": null
+    },
+    {
+      "label": "172.31.255.255 (private, high end of the 16-31 range) is excluded",
+      "host": "172.31.255.255",
+      "expect": null
+    },
+    {
+      "label": "224.0.0.1 (multicast/reserved) is excluded",
+      "host": "224.0.0.1",
+      "expect": null
+    },
+    {
+      "label": "example.com is excluded",
+      "host": "example.com",
+      "expect": null
+    },
+    {
+      "label": "sub.example.org (subdomain of an excluded reserved domain) is excluded",
+      "host": "sub.example.org",
+      "expect": null
+    },
+    {
+      "label": "api.example.net (subdomain of an excluded reserved domain) is excluded",
+      "host": "api.example.net",
+      "expect": null
+    },
+    {
+      "label": "foo.test is excluded",
+      "host": "foo.test",
+      "expect": null
+    },
+    {
+      "label": "www.w3.org is excluded",
+      "host": "www.w3.org",
+      "expect": null
+    },
+    {
+      "label": "w3.org (bare) is excluded",
+      "host": "w3.org",
+      "expect": null
+    },
+    {
+      "label": "schemas.openxmlformats.org is excluded",
+      "host": "schemas.openxmlformats.org",
+      "expect": null
+    },
+    {
+      "label": "schemas.microsoft.com is excluded",
+      "host": "schemas.microsoft.com",
+      "expect": null
+    },
+    {
+      "label": "schemas.android.com is excluded",
+      "host": "schemas.android.com",
+      "expect": null
+    },
+    {
+      "label": "maven.apache.org is excluded",
+      "host": "maven.apache.org",
+      "expect": null
+    }
+  ],
+  "sdks": [
+    {
+      "label": "npm:stripe resolves to stripe",
+      "ecosystem": "npm",
+      "pkg": "stripe",
+      "expectId": "stripe"
+    },
+    {
+      "label": "pypi:SENTRY_SDK resolves to sentry (PEP-503: case AND separator normalization)",
+      "ecosystem": "pypi",
+      "pkg": "SENTRY_SDK",
+      "expectId": "sentry"
+    },
+    {
+      "label": "pypi:google.cloud.storage resolves to gcp (PEP-503 dot-separator normalization)",
+      "ecosystem": "pypi",
+      "pkg": "google.cloud.storage",
+      "expectId": "gcp"
+    },
+    {
+      "label": "go:github.com/stripe/stripe-go/v76 resolves to stripe (path-prefix match)",
+      "ecosystem": "go",
+      "pkg": "github.com/stripe/stripe-go/v76",
+      "expectId": "stripe"
+    },
+    {
+      "label": "go:github.com/stripe/stripe-go (exact, no version suffix) resolves to stripe",
+      "ecosystem": "go",
+      "pkg": "github.com/stripe/stripe-go",
+      "expectId": "stripe"
+    },
+    {
+      "label": "go:github.com/stripe/stripe-go-extra does NOT match — prefix must respect the '/' boundary",
+      "ecosystem": "go",
+      "pkg": "github.com/stripe/stripe-go-extra",
+      "expectId": null
+    },
+    {
+      "label": "maven:com.stripe.subthing resolves to stripe (group-id prefix match)",
+      "ecosystem": "maven",
+      "pkg": "com.stripe.subthing",
+      "expectId": "stripe"
+    },
+    {
+      "label": "maven:com.stripeextra does NOT match — prefix must respect the '.' boundary",
+      "ecosystem": "maven",
+      "pkg": "com.stripeextra",
+      "expectId": null
+    },
+    {
+      "label": "nuget:stripe.NET resolves to stripe (case-insensitive exact)",
+      "ecosystem": "nuget",
+      "pkg": "stripe.NET",
+      "expectId": "stripe"
+    },
+    {
+      "label": "rubygems:stripe (lowercase, exact) resolves to stripe",
+      "ecosystem": "rubygems",
+      "pkg": "stripe",
+      "expectId": "stripe"
+    },
+    {
+      "label": "rubygems:Stripe (capitalized) does NOT match — rubygems is case-sensitive exact",
+      "ecosystem": "rubygems",
+      "pkg": "Stripe",
+      "expectId": null
+    },
+    {
+      "label": "composer:sentry/sentry resolves to sentry",
+      "ecosystem": "composer",
+      "pkg": "sentry/sentry",
+      "expectId": "sentry"
+    },
+    {
+      "label": "cargo:sentry resolves to sentry",
+      "ecosystem": "cargo",
+      "pkg": "sentry",
+      "expectId": "sentry"
+    },
+    {
+      "label": "npm:left-pad has no provider (miss)",
+      "ecosystem": "npm",
+      "pkg": "left-pad",
+      "expectId": null
+    },
+    {
+      "label": "pypi:requests has no provider (miss)",
+      "ecosystem": "pypi",
+      "pkg": "requests",
+      "expectId": null
+    }
+  ]
+}

--- a/packages/detections/src/egress/fixtures/registry-resolution.json
+++ b/packages/detections/src/egress/fixtures/registry-resolution.json
@@ -41,7 +41,7 @@
       }
     },
     {
-      "label": "evilstripe.com is NOT Stripe — mid-label suffix must not match",
+      "label": "evilstripe.com is NOT Stripe \u2014 mid-label suffix must not match",
       "host": "evilstripe.com",
       "expect": {
         "kind": "external",
@@ -51,7 +51,7 @@
       }
     },
     {
-      "label": "evildatadoghq.com is NOT Datadog — same suffix hazard, different provider",
+      "label": "evildatadoghq.com is NOT Datadog \u2014 same suffix hazard, different provider",
       "host": "evildatadoghq.com",
       "expect": {
         "kind": "external",
@@ -103,7 +103,9 @@
     {
       "label": "goodcode.us resolves internal only when the caller supplies it as an internalDomain",
       "host": "goodcode.us",
-      "opts": { "internalDomains": ["goodcode.us"] },
+      "opts": {
+        "internalDomains": ["goodcode.us"]
+      },
       "expect": {
         "kind": "internal",
         "trust": "internal",
@@ -122,7 +124,7 @@
       }
     },
     {
-      "label": "acme-partner.com has no registry match and no internal signal — external, not internal",
+      "label": "acme-partner.com has no registry match and no internal signal \u2014 external, not internal",
       "host": "acme-partner.com",
       "expect": {
         "kind": "external",
@@ -142,7 +144,7 @@
       }
     },
     {
-      "label": "198.51.100.23 is a public IPv4 literal — kind ip",
+      "label": "198.51.100.23 is a public IPv4 literal \u2014 kind ip",
       "host": "198.51.100.23",
       "expect": {
         "kind": "ip",
@@ -152,9 +154,14 @@
       }
     },
     {
-      "label": "172.32.0.1 is just outside the private 172.16-31 range — kind ip, not excluded",
+      "label": "172.32.0.1 is just outside the private 172.16-31 range \u2014 kind ip, not excluded",
       "host": "172.32.0.1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "172.32.0.1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "172.32.0.1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "localhost is excluded",
@@ -282,7 +289,7 @@
       }
     },
     {
-      "label": "[2001:db8::1] (bracketed public IPv6 literal) is kind ip — URL authority form",
+      "label": "[2001:db8::1] (bracketed public IPv6 literal) is kind ip \u2014 URL authority form",
       "host": "[2001:db8::1]",
       "expect": {
         "kind": "ip",
@@ -304,12 +311,22 @@
     {
       "label": "fec0::1 (just above fe80::/10) is kind ip, not excluded",
       "host": "fec0::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "fec0::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "fec0::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "fe7f::1 (just below fe80::/10) is kind ip, not excluded",
       "host": "fe7f::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "fe7f::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "fe7f::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "2001:DB8::1 (uppercase, RFC-canonical documentation spelling) is kind ip",
@@ -334,12 +351,22 @@
     {
       "label": "fc::1 (abbreviated group 00fc::, not fc00::/7) is kind ip, not excluded",
       "host": "fc::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "fc::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "fc::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "fe8::1 (abbreviated group 0fe8::, not fe80::/10) is kind ip, not excluded",
       "host": "fe8::1",
-      "expect": { "kind": "ip", "trust": "ip", "name": "fe8::1", "category": "Unresolved host" }
+      "expect": {
+        "kind": "ip",
+        "trust": "ip",
+        "name": "fe8::1",
+        "category": "Unresolved host"
+      }
     },
     {
       "label": "::ffff:127.0.0.1 (IPv4-mapped loopback) is excluded",
@@ -364,6 +391,26 @@
         "trust": "unverified",
         "name": "db:8080",
         "category": "External domain"
+      }
+    },
+    {
+      "label": "s3.amazonaws.com resolves to the coarse AWS bucket",
+      "host": "s3.amazonaws.com",
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Amazon Web Services",
+        "category": "Cloud platform"
+      }
+    },
+    {
+      "label": "a non-S3 AWS service host resolves to the same coarse AWS bucket, not to S3",
+      "host": "dynamodb.us-east-1.amazonaws.com",
+      "expect": {
+        "kind": "provider",
+        "trust": "recognized",
+        "name": "Amazon Web Services",
+        "category": "Cloud platform"
       }
     }
   ],
@@ -399,7 +446,7 @@
       "expectId": "stripe"
     },
     {
-      "label": "go:github.com/stripe/stripe-go-extra does NOT match — prefix must respect the '/' boundary",
+      "label": "go:github.com/stripe/stripe-go-extra does NOT match \u2014 prefix must respect the '/' boundary",
       "ecosystem": "go",
       "pkg": "github.com/stripe/stripe-go-extra",
       "expectId": null
@@ -411,7 +458,7 @@
       "expectId": "stripe"
     },
     {
-      "label": "maven:com.stripeextra does NOT match — prefix must respect the '.' boundary",
+      "label": "maven:com.stripeextra does NOT match \u2014 prefix must respect the '.' boundary",
       "ecosystem": "maven",
       "pkg": "com.stripeextra",
       "expectId": null
@@ -429,7 +476,7 @@
       "expectId": "stripe"
     },
     {
-      "label": "rubygems:Stripe (capitalized) does NOT match — rubygems is case-sensitive exact",
+      "label": "rubygems:Stripe (capitalized) does NOT match \u2014 rubygems is case-sensitive exact",
       "ecosystem": "rubygems",
       "pkg": "Stripe",
       "expectId": null

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -26,7 +26,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'Payments',
     hostSuffixes: ['stripe.com'],
     apiBase: 'https://api.stripe.com',
-    defaultDataClasses: ['customer', 'pii'],
+    defaultDataClasses: ['pii', 'customer'],
     sdks: {
       npm: ['stripe'],
       pypi: ['stripe'],
@@ -43,7 +43,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'Observability',
     hostSuffixes: ['datadoghq.com', 'datadoghq.eu'],
     apiBase: 'https://api.datadoghq.com',
-    defaultDataClasses: ['logs', 'metrics', 'telemetry'],
+    defaultDataClasses: ['telemetry', 'logs', 'metrics'],
     sdks: {
       npm: ['dd-trace', '@datadog/browser-logs'],
       pypi: ['datadog', 'ddtrace'],
@@ -93,7 +93,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'LLM provider',
     hostSuffixes: ['openai.com'],
     apiBase: 'https://api.openai.com',
-    defaultDataClasses: ['source', 'pii'],
+    defaultDataClasses: ['pii', 'source'],
     sdks: {
       npm: ['openai'],
       pypi: ['openai'],
@@ -111,7 +111,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'LLM provider',
     hostSuffixes: ['anthropic.com'],
     apiBase: 'https://api.anthropic.com',
-    defaultDataClasses: ['source', 'pii'],
+    defaultDataClasses: ['pii', 'source'],
     sdks: {
       npm: ['@anthropic-ai/sdk'],
       pypi: ['anthropic'],
@@ -120,9 +120,9 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     },
   },
   {
-    id: 'aws-s3',
-    name: 'Amazon S3',
-    category: 'Cloud storage',
+    id: 'aws',
+    name: 'Amazon Web Services',
+    category: 'Cloud platform',
     hostSuffixes: ['amazonaws.com'],
     apiBase: 'https://s3.amazonaws.com',
     defaultDataClasses: ['secrets', 'customer'],
@@ -281,7 +281,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     id: 'posthog',
     name: 'PostHog',
     category: 'Analytics',
-    hostSuffixes: ['posthog.com', 'i.posthog.com'],
+    hostSuffixes: ['posthog.com'],
     apiBase: 'https://us.i.posthog.com',
     defaultDataClasses: ['customer', 'telemetry'],
     sdks: {
@@ -313,7 +313,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'Observability',
     hostSuffixes: ['grafana.net'],
     apiBase: 'https://grafana.net',
-    defaultDataClasses: ['metrics', 'logs'],
+    defaultDataClasses: ['logs', 'metrics'],
     sdks: {
       npm: ['@grafana/faro-web-sdk'],
     },
@@ -430,7 +430,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'Backend platform',
     hostSuffixes: ['supabase.co', 'supabase.com'],
     apiBase: 'https://api.supabase.com',
-    defaultDataClasses: ['customer', 'pii'],
+    defaultDataClasses: ['pii', 'customer'],
     sdks: {
       npm: ['@supabase/supabase-js'],
       pypi: ['supabase'],
@@ -530,7 +530,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'LLM provider',
     hostSuffixes: ['cohere.com', 'cohere.ai'],
     apiBase: 'https://api.cohere.com',
-    defaultDataClasses: ['source', 'pii'],
+    defaultDataClasses: ['pii', 'source'],
     sdks: {
       npm: ['cohere-ai'],
       pypi: ['cohere'],
@@ -543,7 +543,7 @@ export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
     category: 'LLM provider',
     hostSuffixes: ['mistral.ai'],
     apiBase: 'https://api.mistral.ai',
-    defaultDataClasses: ['source', 'pii'],
+    defaultDataClasses: ['pii', 'source'],
     sdks: {
       npm: ['@mistralai/mistralai'],
       pypi: ['mistralai'],
@@ -580,7 +580,6 @@ const EXCLUDED_HOST_SUFFIXES = [
   'example.org',
   'example.net',
   'w3.org',
-  'www.w3.org',
   'schemas.openxmlformats.org',
   'schemas.microsoft.com',
   'schemas.android.com',

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -735,10 +735,22 @@ export function resolveHost(
     INTERNAL_TLDS.some((tld) => hostMatchesSuffix(h, tld)) ||
     internalDomains.some((domain) => hostMatchesSuffix(h, domain.toLowerCase()));
   if (isInternal) {
-    return { kind: 'internal', trust: 'internal', name: h, category: 'Internal services', entry: null };
+    return {
+      kind: 'internal',
+      trust: 'internal',
+      name: h,
+      category: 'Internal services',
+      entry: null,
+    };
   }
 
-  return { kind: 'external', trust: 'unverified', name: h, category: 'External domain', entry: null };
+  return {
+    kind: 'external',
+    trust: 'unverified',
+    name: h,
+    category: 'External domain',
+    entry: null,
+  };
 }
 
 /**

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -617,12 +617,54 @@ export function isPrivateOrReservedIPv4(host: string): boolean {
   return false;
 }
 
+// Strips the brackets a URL authority wraps an IPv6 literal in ('[::1]' ->
+// '::1'); any other string passes through unchanged.
+function stripIPv6Brackets(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+}
+
+const IPV6_HEX_GROUP = /^[0-9a-f]{1,4}$/;
+
 /**
- * Classify one host: registry match → provider/recognized; a public IPv4
- * literal → ip/ip; an internal signal (TLD, single label, or a caller-supplied
- * internalDomain) → internal/internal; anything else public → external/
- * unverified. Excluded hosts (loopback/private/reserved, schema-identifier
- * hosts) resolve to `null`.
+ * True when `host` (optionally bracketed, e.g. '[::1]') is a syntactically
+ * valid IPv6 literal: colon-separated hex groups, with at most one '::' run
+ * standing in for one or more omitted all-zero groups, resolving to exactly
+ * 8 groups.
+ */
+export function isValidIPv6(host: string): boolean {
+  const h = stripIPv6Brackets(host);
+  if (!h.includes(':')) return false;
+
+  const collapsedHalves = h.split('::');
+  if (collapsedHalves.length > 2) return false;
+
+  const sides = collapsedHalves.length === 2 ? collapsedHalves : [h];
+  const groups = sides.flatMap((side) => (side === '' ? [] : side.split(':')));
+  if (!groups.every((g) => IPV6_HEX_GROUP.test(g))) return false;
+
+  return collapsedHalves.length === 2 ? groups.length <= 7 : groups.length === 8;
+}
+
+/**
+ * True when a valid IPv6 literal (optionally bracketed) falls in the
+ * loopback (::1), link-local (fe80::/10), or unique-local (fc00::/7) range.
+ * Callers must confirm `isValidIPv6` first.
+ */
+export function isPrivateOrReservedIPv6(host: string): boolean {
+  const h = stripIPv6Brackets(host).toLowerCase();
+  if (h === '::1') return true;
+  const firstGroup = h.split(':')[0] ?? '';
+  if (firstGroup.startsWith('fc') || firstGroup.startsWith('fd')) return true;
+  if (firstGroup.startsWith('fe') && '89ab'.includes(firstGroup[2] ?? '')) return true;
+  return false;
+}
+
+/**
+ * Classify one host: registry match → provider/recognized; a public IPv4 or
+ * IPv6 literal → ip/ip; an internal signal (TLD, single label, or a
+ * caller-supplied internalDomain) → internal/internal; anything else public
+ * → external/unverified. Excluded hosts (loopback/private/reserved,
+ * schema-identifier hosts) resolve to `null`.
  */
 export function resolveHost(
   host: string,
@@ -632,6 +674,11 @@ export function resolveHost(
 
   if (isValidIPv4(h)) {
     if (isPrivateOrReservedIPv4(h)) return null;
+    return { kind: 'ip', trust: 'ip', name: h, category: 'Unresolved host', entry: null };
+  }
+
+  if (isValidIPv6(h)) {
+    if (isPrivateOrReservedIPv6(h)) return null;
     return { kind: 'ip', trust: 'ip', name: h, category: 'Unresolved host', entry: null };
   }
 

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -1,0 +1,698 @@
+// Provider recognition for the egress writer: a bundled table of known SaaS/API
+// hosts and dependency-manifest SDK identifiers, plus host classification
+// (provider / internal / external / ip) and the version material the scanner's
+// ledger key is derived from.
+//
+// Pure like everything in @akasecurity/detections: no I/O, no Node-API imports.
+import type {
+  DestinationKind,
+  EgressEcosystem,
+  ProviderRegistryEntry,
+  ShareTrustLevel,
+} from '@akasecurity/schema';
+
+// Bumped whenever the resolution/matching rules below change (not the registry
+// data itself — that's covered by PROVIDER_REGISTRY being embedded verbatim).
+const EXTRACTOR_VERSION = '1';
+
+// One row per known provider. `hostSuffixes` are suffix-matched (see
+// hostMatchesSuffix): 'stripe.com' matches 'api.stripe.com' but never
+// 'evilstripe.com'. `sdks` lists only ecosystems the provider ships a real SDK
+// for.
+export const PROVIDER_REGISTRY: readonly ProviderRegistryEntry[] = [
+  {
+    id: 'stripe',
+    name: 'Stripe',
+    category: 'Payments',
+    hostSuffixes: ['stripe.com'],
+    apiBase: 'https://api.stripe.com',
+    defaultDataClasses: ['customer', 'pii'],
+    sdks: {
+      npm: ['stripe'],
+      pypi: ['stripe'],
+      go: ['github.com/stripe/stripe-go'],
+      maven: ['com.stripe'],
+      rubygems: ['stripe'],
+      composer: ['stripe/stripe-php'],
+      nuget: ['Stripe.net'],
+    },
+  },
+  {
+    id: 'datadog',
+    name: 'Datadog',
+    category: 'Observability',
+    hostSuffixes: ['datadoghq.com', 'datadoghq.eu'],
+    apiBase: 'https://api.datadoghq.com',
+    defaultDataClasses: ['logs', 'metrics', 'telemetry'],
+    sdks: {
+      npm: ['dd-trace', '@datadog/browser-logs'],
+      pypi: ['datadog', 'ddtrace'],
+      go: ['github.com/DataDog/dd-trace-go'],
+      maven: ['com.datadoghq'],
+      rubygems: ['ddtrace', 'dogapi'],
+      nuget: ['Datadog.Trace'],
+    },
+  },
+  {
+    id: 'newrelic',
+    name: 'New Relic',
+    category: 'Observability',
+    hostSuffixes: ['newrelic.com', 'nr-data.net'],
+    apiBase: 'https://api.newrelic.com',
+    defaultDataClasses: ['telemetry', 'logs', 'metrics'],
+    sdks: {
+      npm: ['newrelic'],
+      pypi: ['newrelic'],
+      go: ['github.com/newrelic/go-agent'],
+      maven: ['com.newrelic.agent.java'],
+      rubygems: ['newrelic_rpm'],
+      nuget: ['NewRelic.Agent'],
+    },
+  },
+  {
+    id: 'sentry',
+    name: 'Sentry',
+    category: 'Error tracking',
+    hostSuffixes: ['sentry.io'],
+    apiBase: 'https://sentry.io',
+    defaultDataClasses: ['source', 'telemetry'],
+    sdks: {
+      npm: ['@sentry/node', '@sentry/react', '@sentry/nextjs'],
+      pypi: ['sentry-sdk'],
+      go: ['github.com/getsentry/sentry-go'],
+      maven: ['io.sentry'],
+      rubygems: ['sentry-ruby'],
+      cargo: ['sentry'],
+      composer: ['sentry/sentry'],
+      nuget: ['Sentry'],
+    },
+  },
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    category: 'LLM provider',
+    hostSuffixes: ['openai.com'],
+    apiBase: 'https://api.openai.com',
+    defaultDataClasses: ['source', 'pii'],
+    sdks: {
+      npm: ['openai'],
+      pypi: ['openai'],
+      go: ['github.com/sashabaranov/go-openai'],
+      maven: ['com.openai'],
+      rubygems: ['ruby-openai'],
+      cargo: ['async-openai'],
+      composer: ['openai-php/client'],
+      nuget: ['OpenAI'],
+    },
+  },
+  {
+    id: 'anthropic',
+    name: 'Anthropic',
+    category: 'LLM provider',
+    hostSuffixes: ['anthropic.com'],
+    apiBase: 'https://api.anthropic.com',
+    defaultDataClasses: ['source', 'pii'],
+    sdks: {
+      npm: ['@anthropic-ai/sdk'],
+      pypi: ['anthropic'],
+      go: ['github.com/anthropics/anthropic-sdk-go'],
+      nuget: ['Anthropic.SDK'],
+    },
+  },
+  {
+    id: 'aws-s3',
+    name: 'Amazon S3',
+    category: 'Cloud storage',
+    hostSuffixes: ['amazonaws.com'],
+    apiBase: 'https://s3.amazonaws.com',
+    defaultDataClasses: ['secrets', 'customer'],
+    sdks: {
+      npm: ['@aws-sdk/client-s3', 'aws-sdk'],
+      pypi: ['boto3'],
+      go: ['github.com/aws/aws-sdk-go', 'github.com/aws/aws-sdk-go-v2'],
+      maven: ['com.amazonaws', 'software.amazon.awssdk'],
+      rubygems: ['aws-sdk-s3'],
+      cargo: ['aws-sdk-s3'],
+      nuget: ['AWSSDK.S3'],
+    },
+  },
+  {
+    id: 'gcp',
+    name: 'Google Cloud',
+    category: 'Cloud platform',
+    hostSuffixes: ['googleapis.com'],
+    apiBase: 'https://storage.googleapis.com',
+    defaultDataClasses: ['customer', 'logs'],
+    sdks: {
+      npm: ['@google-cloud/storage'],
+      pypi: ['google-cloud-storage'],
+      go: ['cloud.google.com/go'],
+      maven: ['com.google.cloud'],
+      rubygems: ['google-cloud-storage'],
+      nuget: ['Google.Cloud.Storage.V1'],
+    },
+  },
+  {
+    id: 'azure',
+    name: 'Microsoft Azure',
+    category: 'Cloud platform',
+    hostSuffixes: ['azure.com', 'windows.net'],
+    apiBase: 'https://management.azure.com',
+    defaultDataClasses: ['customer', 'logs'],
+    sdks: {
+      npm: ['@azure/storage-blob'],
+      pypi: ['azure-storage-blob'],
+      go: ['github.com/Azure/azure-sdk-for-go'],
+      maven: ['com.azure'],
+      rubygems: ['azure-storage-blob'],
+      nuget: ['Azure.Storage.Blobs'],
+    },
+  },
+  {
+    id: 'slack',
+    name: 'Slack',
+    category: 'Notifications',
+    hostSuffixes: ['slack.com'],
+    apiBase: 'https://slack.com/api',
+    defaultDataClasses: ['logs'],
+    sdks: {
+      npm: ['@slack/web-api'],
+      pypi: ['slack-sdk'],
+      go: ['github.com/slack-go/slack'],
+      maven: ['com.slack.api'],
+      rubygems: ['slack-ruby-client'],
+      composer: ['slack-php/slack-api'],
+      nuget: ['SlackNet'],
+    },
+  },
+  {
+    id: 'segment',
+    name: 'Segment',
+    category: 'Analytics',
+    hostSuffixes: ['segment.io', 'segment.com'],
+    apiBase: 'https://api.segment.io',
+    defaultDataClasses: ['customer'],
+    sdks: {
+      npm: ['@segment/analytics-node', 'analytics-node'],
+      pypi: ['segment-analytics-python'],
+      go: ['github.com/segmentio/analytics-go'],
+      maven: ['com.segment.analytics.java'],
+      rubygems: ['analytics-ruby'],
+      nuget: ['Analytics'],
+    },
+  },
+  {
+    id: 'twilio',
+    name: 'Twilio',
+    category: 'Communications',
+    hostSuffixes: ['twilio.com'],
+    apiBase: 'https://api.twilio.com',
+    defaultDataClasses: ['pii', 'customer'],
+    sdks: {
+      npm: ['twilio'],
+      pypi: ['twilio'],
+      go: ['github.com/twilio/twilio-go'],
+      maven: ['com.twilio.sdk'],
+      rubygems: ['twilio-ruby'],
+      composer: ['twilio/sdk'],
+      nuget: ['Twilio'],
+    },
+  },
+  {
+    id: 'sendgrid',
+    name: 'SendGrid',
+    category: 'Email',
+    hostSuffixes: ['sendgrid.com'],
+    apiBase: 'https://api.sendgrid.com',
+    defaultDataClasses: ['pii'],
+    sdks: {
+      npm: ['@sendgrid/mail'],
+      pypi: ['sendgrid'],
+      go: ['github.com/sendgrid/sendgrid-go'],
+      maven: ['com.sendgrid'],
+      rubygems: ['sendgrid-ruby'],
+      composer: ['sendgrid/sendgrid'],
+      nuget: ['SendGrid'],
+    },
+  },
+  {
+    id: 'mailgun',
+    name: 'Mailgun',
+    category: 'Email',
+    hostSuffixes: ['mailgun.net'],
+    apiBase: 'https://api.mailgun.net',
+    defaultDataClasses: ['pii'],
+    sdks: {
+      npm: ['mailgun.js'],
+      pypi: ['mailgun'],
+      rubygems: ['mailgun-ruby'],
+      composer: ['mailgun/mailgun-php'],
+      nuget: ['Mailgun'],
+    },
+  },
+  {
+    id: 'mixpanel',
+    name: 'Mixpanel',
+    category: 'Analytics',
+    hostSuffixes: ['mixpanel.com'],
+    apiBase: 'https://api.mixpanel.com',
+    defaultDataClasses: ['customer', 'telemetry'],
+    sdks: {
+      npm: ['mixpanel'],
+      pypi: ['mixpanel'],
+      rubygems: ['mixpanel-ruby'],
+      nuget: ['Mixpanel'],
+    },
+  },
+  {
+    id: 'amplitude',
+    name: 'Amplitude',
+    category: 'Analytics',
+    hostSuffixes: ['amplitude.com'],
+    apiBase: 'https://api2.amplitude.com',
+    defaultDataClasses: ['customer', 'telemetry'],
+    sdks: {
+      npm: ['@amplitude/analytics-node'],
+      pypi: ['amplitude-analytics'],
+      nuget: ['Amplitude'],
+    },
+  },
+  {
+    id: 'posthog',
+    name: 'PostHog',
+    category: 'Analytics',
+    hostSuffixes: ['posthog.com', 'i.posthog.com'],
+    apiBase: 'https://us.i.posthog.com',
+    defaultDataClasses: ['customer', 'telemetry'],
+    sdks: {
+      npm: ['posthog-node', 'posthog-js'],
+      pypi: ['posthog'],
+      go: ['github.com/posthog/posthog-go'],
+      rubygems: ['posthog-ruby'],
+      composer: ['posthog/posthog-php'],
+      nuget: ['PostHog'],
+    },
+  },
+  {
+    id: 'honeycomb',
+    name: 'Honeycomb',
+    category: 'Observability',
+    hostSuffixes: ['honeycomb.io'],
+    apiBase: 'https://api.honeycomb.io',
+    defaultDataClasses: ['telemetry', 'metrics'],
+    sdks: {
+      npm: ['libhoney'],
+      pypi: ['libhoney'],
+      go: ['github.com/honeycombio/libhoney-go'],
+      rubygems: ['libhoney'],
+    },
+  },
+  {
+    id: 'grafana',
+    name: 'Grafana Cloud',
+    category: 'Observability',
+    hostSuffixes: ['grafana.net'],
+    apiBase: 'https://grafana.net',
+    defaultDataClasses: ['metrics', 'logs'],
+    sdks: {
+      npm: ['@grafana/faro-web-sdk'],
+    },
+  },
+  {
+    id: 'splunk',
+    name: 'Splunk',
+    category: 'Observability',
+    hostSuffixes: ['splunkcloud.com', 'splunk.com'],
+    apiBase: 'https://http-inputs.splunkcloud.com',
+    defaultDataClasses: ['logs'],
+    sdks: {
+      npm: ['splunk-logging'],
+      pypi: ['splunk-sdk'],
+      maven: ['com.splunk'],
+      nuget: ['Splunk.Logging.Common'],
+    },
+  },
+  {
+    id: 'pagerduty',
+    name: 'PagerDuty',
+    category: 'Incident response',
+    hostSuffixes: ['pagerduty.com'],
+    apiBase: 'https://api.pagerduty.com',
+    defaultDataClasses: ['logs'],
+    sdks: {
+      npm: ['@pagerduty/pdjs'],
+      pypi: ['pdpyras'],
+      go: ['github.com/PagerDuty/go-pagerduty'],
+      rubygems: ['pagerduty'],
+    },
+  },
+  {
+    id: 'github',
+    name: 'GitHub',
+    category: 'Developer platform',
+    hostSuffixes: ['github.com', 'githubusercontent.com'],
+    apiBase: 'https://api.github.com',
+    defaultDataClasses: ['source'],
+    sdks: {
+      npm: ['@octokit/rest', 'octokit'],
+      pypi: ['pygithub'],
+      go: ['github.com/google/go-github'],
+      maven: ['org.kohsuke.github-api'],
+      rubygems: ['octokit'],
+      cargo: ['octocrab'],
+      composer: ['knplabs/github-api'],
+      nuget: ['Octokit'],
+    },
+  },
+  {
+    id: 'gitlab',
+    name: 'GitLab',
+    category: 'Developer platform',
+    hostSuffixes: ['gitlab.com'],
+    apiBase: 'https://gitlab.com/api',
+    defaultDataClasses: ['source'],
+    sdks: {
+      npm: ['@gitbeaker/rest'],
+      pypi: ['python-gitlab'],
+      go: ['gitlab.com/gitlab-org/api/client-go'],
+      rubygems: ['gitlab'],
+      nuget: ['GitLabApiClient'],
+    },
+  },
+  {
+    id: 'auth0',
+    name: 'Auth0',
+    category: 'Identity',
+    hostSuffixes: ['auth0.com'],
+    apiBase: 'https://login.auth0.com',
+    defaultDataClasses: ['pii'],
+    sdks: {
+      npm: ['auth0'],
+      pypi: ['auth0-python'],
+      go: ['github.com/auth0/go-auth0'],
+      maven: ['com.auth0'],
+      rubygems: ['auth0'],
+      composer: ['auth0/auth0-php'],
+      nuget: ['Auth0.ManagementApi'],
+    },
+  },
+  {
+    id: 'okta',
+    name: 'Okta',
+    category: 'Identity',
+    hostSuffixes: ['okta.com', 'oktapreview.com'],
+    apiBase: 'https://login.okta.com',
+    defaultDataClasses: ['pii'],
+    sdks: {
+      npm: ['@okta/okta-sdk-nodejs'],
+      pypi: ['okta'],
+      go: ['github.com/okta/okta-sdk-golang'],
+      maven: ['com.okta.sdk'],
+      nuget: ['Okta.Sdk'],
+    },
+  },
+  {
+    id: 'clerk',
+    name: 'Clerk',
+    category: 'Identity',
+    hostSuffixes: ['clerk.com', 'clerk.dev'],
+    apiBase: 'https://api.clerk.com',
+    defaultDataClasses: ['pii'],
+    sdks: {
+      npm: ['@clerk/backend', '@clerk/nextjs'],
+      pypi: ['clerk-backend-api'],
+      go: ['github.com/clerk/clerk-sdk-go'],
+    },
+  },
+  {
+    id: 'supabase',
+    name: 'Supabase',
+    category: 'Backend platform',
+    hostSuffixes: ['supabase.co', 'supabase.com'],
+    apiBase: 'https://api.supabase.com',
+    defaultDataClasses: ['customer', 'pii'],
+    sdks: {
+      npm: ['@supabase/supabase-js'],
+      pypi: ['supabase'],
+      cargo: ['postgrest'],
+    },
+  },
+  {
+    id: 'firebase',
+    name: 'Firebase',
+    category: 'Backend platform',
+    hostSuffixes: ['firebaseio.com', 'firebase.google.com'],
+    apiBase: 'https://firebaseio.com',
+    defaultDataClasses: ['customer'],
+    sdks: {
+      npm: ['firebase', 'firebase-admin'],
+      pypi: ['firebase-admin'],
+      go: ['firebase.google.com/go'],
+      maven: ['com.google.firebase'],
+    },
+  },
+  {
+    id: 'mongodb-atlas',
+    name: 'MongoDB Atlas',
+    category: 'Database SaaS',
+    hostSuffixes: ['mongodb.net', 'mongodb.com'],
+    apiBase: 'https://cloud.mongodb.com',
+    defaultDataClasses: ['customer'],
+    sdks: {
+      npm: ['mongodb'],
+      pypi: ['pymongo'],
+      go: ['go.mongodb.org/mongo-driver'],
+      maven: ['org.mongodb'],
+      rubygems: ['mongo'],
+      cargo: ['mongodb'],
+      nuget: ['MongoDB.Driver'],
+    },
+  },
+  {
+    id: 'planetscale',
+    name: 'PlanetScale',
+    category: 'Database SaaS',
+    hostSuffixes: ['psdb.cloud', 'planetscale.com'],
+    apiBase: 'https://api.planetscale.com',
+    defaultDataClasses: ['customer'],
+    sdks: {
+      npm: ['@planetscale/database'],
+      go: ['github.com/planetscale/planetscale-go'],
+    },
+  },
+  {
+    id: 'algolia',
+    name: 'Algolia',
+    category: 'Search SaaS',
+    hostSuffixes: ['algolia.net', 'algolianet.com'],
+    apiBase: 'https://algolia.net',
+    defaultDataClasses: ['customer'],
+    sdks: {
+      npm: ['algoliasearch'],
+      pypi: ['algoliasearch'],
+      go: ['github.com/algolia/algoliasearch-client-go'],
+      maven: ['com.algolia'],
+      rubygems: ['algolia'],
+      composer: ['algolia/algoliasearch-client-php'],
+      nuget: ['Algolia.Search'],
+    },
+  },
+  {
+    id: 'cloudflare',
+    name: 'Cloudflare',
+    category: 'CDN / edge',
+    hostSuffixes: ['cloudflare.com', 'workers.dev'],
+    apiBase: 'https://api.cloudflare.com',
+    defaultDataClasses: ['logs'],
+    sdks: {
+      npm: ['cloudflare'],
+      pypi: ['cloudflare'],
+      go: ['github.com/cloudflare/cloudflare-go'],
+      nuget: ['CloudFlare.Client'],
+    },
+  },
+  {
+    id: 'huggingface',
+    name: 'Hugging Face',
+    category: 'LLM provider',
+    hostSuffixes: ['huggingface.co'],
+    apiBase: 'https://api-inference.huggingface.co',
+    defaultDataClasses: ['source'],
+    sdks: {
+      npm: ['@huggingface/inference'],
+      pypi: ['huggingface-hub', 'transformers'],
+      rubygems: ['hugging-face'],
+    },
+  },
+  {
+    id: 'cohere',
+    name: 'Cohere',
+    category: 'LLM provider',
+    hostSuffixes: ['cohere.com', 'cohere.ai'],
+    apiBase: 'https://api.cohere.com',
+    defaultDataClasses: ['source', 'pii'],
+    sdks: {
+      npm: ['cohere-ai'],
+      pypi: ['cohere'],
+      go: ['github.com/cohere-ai/cohere-go'],
+    },
+  },
+  {
+    id: 'mistral',
+    name: 'Mistral AI',
+    category: 'LLM provider',
+    hostSuffixes: ['mistral.ai'],
+    apiBase: 'https://api.mistral.ai',
+    defaultDataClasses: ['source', 'pii'],
+    sdks: {
+      npm: ['@mistralai/mistralai'],
+      pypi: ['mistralai'],
+      go: ['github.com/gage-technologies/mistral-go'],
+    },
+  },
+];
+
+// The scanner's ledger key material: this changes whenever the registry data
+// or the resolution rules change, forcing a one-time re-extraction.
+export const EGRESS_VERSION_MATERIAL = `${EXTRACTOR_VERSION}\n${JSON.stringify(PROVIDER_REGISTRY)}`;
+
+export interface HostResolution {
+  kind: DestinationKind;
+  trust: ShareTrustLevel;
+  name: string;
+  category: string;
+  entry: ProviderRegistryEntry | null;
+}
+
+// TLDs — plus the single-label rule below — that mark a host as internal
+// without any caller-supplied hint.
+const INTERNAL_TLDS = ['internal', 'local', 'corp', 'lan', 'intranet', 'home.arpa'];
+
+// Non-provider hosts excluded from resolution entirely: loopback/reserved
+// name suffixes (RFC 2606/6761-style) and the schema/XML-namespace hosts that
+// show up as URL-shaped literals in source but name no real destination.
+const EXCLUDED_HOST_SUFFIXES = [
+  'localhost',
+  'test',
+  'example',
+  'invalid',
+  'example.com',
+  'example.org',
+  'example.net',
+  'w3.org',
+  'www.w3.org',
+  'schemas.openxmlformats.org',
+  'schemas.microsoft.com',
+  'schemas.android.com',
+  'maven.apache.org',
+];
+
+// Exact match or dotted-suffix match — 'stripe.com' matches 'api.stripe.com'
+// but never 'evilstripe.com' (no dot boundary).
+function hostMatchesSuffix(host: string, suffix: string): boolean {
+  return host === suffix || host.endsWith(`.${suffix}`);
+}
+
+/** True when `host` is a syntactically valid dotted-quad IPv4 literal. */
+export function isValidIPv4(host: string): boolean {
+  const parts = host.split('.');
+  if (parts.length !== 4) return false;
+  return parts.every((part) => /^\d{1,3}$/.test(part) && Number(part) <= 255);
+}
+
+/**
+ * True when a valid IPv4 literal falls in a private, loopback, link-local, or
+ * reserved/multicast range (0.*, 10.*, 127.*, 169.254.*, 172.16-31.*,
+ * 192.168.*, >=224.*). Callers must confirm `isValidIPv4` first.
+ */
+export function isPrivateOrReservedIPv4(host: string): boolean {
+  const octets = host.split('.').map(Number);
+  const a = octets[0];
+  const b = octets[1];
+  if (a === undefined || b === undefined) return false;
+  if (a === 0 || a === 10 || a === 127 || a >= 224) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  return false;
+}
+
+/**
+ * Classify one host: registry match → provider/recognized; a public IPv4
+ * literal → ip/ip; an internal signal (TLD, single label, or a caller-supplied
+ * internalDomain) → internal/internal; anything else public → external/
+ * unverified. Excluded hosts (loopback/private/reserved, schema-identifier
+ * hosts) resolve to `null`.
+ */
+export function resolveHost(
+  host: string,
+  opts?: { internalDomains?: string[] },
+): HostResolution | null {
+  const h = host.toLowerCase();
+
+  if (isValidIPv4(h)) {
+    if (isPrivateOrReservedIPv4(h)) return null;
+    return { kind: 'ip', trust: 'ip', name: h, category: 'Unresolved host', entry: null };
+  }
+
+  if (EXCLUDED_HOST_SUFFIXES.some((suffix) => hostMatchesSuffix(h, suffix))) return null;
+
+  const entry = PROVIDER_REGISTRY.find((p) =>
+    p.hostSuffixes.some((suffix) => hostMatchesSuffix(h, suffix)),
+  );
+  if (entry) {
+    return {
+      kind: 'provider',
+      trust: 'recognized',
+      name: entry.name,
+      category: entry.category,
+      entry,
+    };
+  }
+
+  const internalDomains = opts?.internalDomains ?? [];
+  const isInternal =
+    !h.includes('.') ||
+    INTERNAL_TLDS.some((tld) => hostMatchesSuffix(h, tld)) ||
+    internalDomains.some((domain) => hostMatchesSuffix(h, domain.toLowerCase()));
+  if (isInternal) {
+    return { kind: 'internal', trust: 'internal', name: h, category: 'Internal services', entry: null };
+  }
+
+  return { kind: 'external', trust: 'unverified', name: h, category: 'External domain', entry: null };
+}
+
+/**
+ * Match one manifest dependency identifier against the registry for a single
+ * ecosystem. Matching rule per ecosystem: exact for npm/rubygems/cargo/
+ * composer; case-insensitive exact for nuget; PEP-503 normalized for pypi;
+ * path-prefix ('/' boundary) for go; group-id prefix ('.' boundary) for maven.
+ */
+export function resolveSdk(ecosystem: EgressEcosystem, pkg: string): ProviderRegistryEntry | null {
+  for (const entry of PROVIDER_REGISTRY) {
+    const idents = entry.sdks[ecosystem];
+    if (idents === undefined) continue;
+    if (idents.some((ident) => sdkMatches(ecosystem, pkg, ident))) return entry;
+  }
+  return null;
+}
+
+function sdkMatches(ecosystem: EgressEcosystem, pkg: string, ident: string): boolean {
+  switch (ecosystem) {
+    case 'nuget':
+      return pkg.toLowerCase() === ident.toLowerCase();
+    case 'pypi':
+      return normalizePypi(pkg) === normalizePypi(ident);
+    case 'go':
+      return pkg === ident || pkg.startsWith(`${ident}/`);
+    case 'maven':
+      return pkg === ident || pkg.startsWith(`${ident}.`);
+    default:
+      return pkg === ident;
+  }
+}
+
+// PEP-503 normalization: lowercase, collapse runs of -._ to a single '-'.
+function normalizePypi(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, '-');
+}

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -653,18 +653,20 @@ export function isValidIPv6(host: string): boolean {
 
 /**
  * True when a valid IPv6 literal (optionally bracketed, optionally
- * zone-indexed) falls in the loopback (::1), link-local (fe80::/10), or
- * unique-local (fc00::/7) range. The leading group is zero-padded to 4
- * digits before the range test, so an abbreviated group such as 'fc'
+ * zone-indexed) falls in the unspecified (::), loopback (::1), unique-local
+ * (fc00::/7), link-local (fe80::/10), or multicast (ff00::/8) range — the
+ * IPv6 counterparts of the IPv4 ranges above. The leading group is zero-padded
+ * to 4 digits before the range test, so an abbreviated group such as 'fc'
  * (address 00fc::, not fc00::) is not mistaken for membership. Callers must
  * confirm `isValidIPv6` first.
  */
 export function isPrivateOrReservedIPv6(host: string): boolean {
   const h = normalizeIPv6Literal(host);
-  if (h === '::1') return true;
+  if (h === '::' || h === '::1') return true;
   const firstGroup = (h.split(':')[0] ?? '').padStart(4, '0');
   if (firstGroup.startsWith('fc') || firstGroup.startsWith('fd')) return true;
   if (firstGroup.startsWith('fe') && '89ab'.includes(firstGroup[2] ?? '')) return true;
+  if (firstGroup.startsWith('ff')) return true;
   return false;
 }
 

--- a/packages/detections/src/egress/registry.ts
+++ b/packages/detections/src/egress/registry.ts
@@ -618,21 +618,28 @@ export function isPrivateOrReservedIPv4(host: string): boolean {
 }
 
 // Strips the brackets a URL authority wraps an IPv6 literal in ('[::1]' ->
-// '::1'); any other string passes through unchanged.
-function stripIPv6Brackets(host: string): string {
-  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+// '::1'), strips a zone index ('fe80::1%eth0' -> 'fe80::1' — RFC 4007 scopes
+// the zone to a local interface name, so it carries no address-range
+// information), and lowercases hex digits. Any other string is only
+// lowercased.
+function normalizeIPv6Literal(host: string): string {
+  const unbracketed = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  const zoneIndex = unbracketed.indexOf('%');
+  const unzoned = zoneIndex === -1 ? unbracketed : unbracketed.slice(0, zoneIndex);
+  return unzoned.toLowerCase();
 }
 
 const IPV6_HEX_GROUP = /^[0-9a-f]{1,4}$/;
 
 /**
- * True when `host` (optionally bracketed, e.g. '[::1]') is a syntactically
- * valid IPv6 literal: colon-separated hex groups, with at most one '::' run
- * standing in for one or more omitted all-zero groups, resolving to exactly
- * 8 groups.
+ * True when `host` — optionally bracketed (e.g. '[::1]'), optionally
+ * zone-indexed (e.g. 'fe80::1%eth0'), and case-insensitive — is a
+ * syntactically valid IPv6 literal: colon-separated hex groups, with at most
+ * one '::' run standing in for one or more omitted all-zero groups,
+ * resolving to exactly 8 groups.
  */
 export function isValidIPv6(host: string): boolean {
-  const h = stripIPv6Brackets(host);
+  const h = normalizeIPv6Literal(host);
   if (!h.includes(':')) return false;
 
   const collapsedHalves = h.split('::');
@@ -646,25 +653,44 @@ export function isValidIPv6(host: string): boolean {
 }
 
 /**
- * True when a valid IPv6 literal (optionally bracketed) falls in the
- * loopback (::1), link-local (fe80::/10), or unique-local (fc00::/7) range.
- * Callers must confirm `isValidIPv6` first.
+ * True when a valid IPv6 literal (optionally bracketed, optionally
+ * zone-indexed) falls in the loopback (::1), link-local (fe80::/10), or
+ * unique-local (fc00::/7) range. The leading group is zero-padded to 4
+ * digits before the range test, so an abbreviated group such as 'fc'
+ * (address 00fc::, not fc00::) is not mistaken for membership. Callers must
+ * confirm `isValidIPv6` first.
  */
 export function isPrivateOrReservedIPv6(host: string): boolean {
-  const h = stripIPv6Brackets(host).toLowerCase();
+  const h = normalizeIPv6Literal(host);
   if (h === '::1') return true;
-  const firstGroup = h.split(':')[0] ?? '';
+  const firstGroup = (h.split(':')[0] ?? '').padStart(4, '0');
   if (firstGroup.startsWith('fc') || firstGroup.startsWith('fd')) return true;
   if (firstGroup.startsWith('fe') && '89ab'.includes(firstGroup[2] ?? '')) return true;
   return false;
 }
 
+const IPV4_MAPPED_IPV6 = /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/;
+
+// Extracts the embedded dotted-quad from an IPv4-mapped IPv6 literal
+// ('::ffff:127.0.0.1' -> '127.0.0.1', optionally bracketed/zone-indexed);
+// null for any other string. The caller still validates the extracted
+// address with `isValidIPv4` — a syntax match here does not imply the
+// embedded octets are in range.
+function ipv4MappedAddress(host: string): string | null {
+  const match = IPV4_MAPPED_IPV6.exec(normalizeIPv6Literal(host));
+  return match?.[1] ?? null;
+}
+
 /**
  * Classify one host: registry match → provider/recognized; a public IPv4 or
- * IPv6 literal → ip/ip; an internal signal (TLD, single label, or a
- * caller-supplied internalDomain) → internal/internal; anything else public
- * → external/unverified. Excluded hosts (loopback/private/reserved,
- * schema-identifier hosts) resolve to `null`.
+ * IPv6 literal (including an IPv4-mapped IPv6 literal, e.g. '::ffff:8.8.8.8')
+ * → ip/ip; an internal signal (a single-label host with no colon, an
+ * internal TLD, or a caller-supplied internalDomain) → internal/internal;
+ * anything else public → external/unverified. Excluded hosts
+ * (loopback/private/reserved, schema-identifier hosts) resolve to `null`. A
+ * host containing ':' never qualifies for the single-label internal rule, so
+ * an IPv6-shaped literal that fails every literal check above still resolves
+ * external/unverified — never the trusted-internal fallback.
  */
 export function resolveHost(
   host: string,
@@ -679,6 +705,12 @@ export function resolveHost(
 
   if (isValidIPv6(h)) {
     if (isPrivateOrReservedIPv6(h)) return null;
+    return { kind: 'ip', trust: 'ip', name: h, category: 'Unresolved host', entry: null };
+  }
+
+  const mappedIPv4 = ipv4MappedAddress(h);
+  if (mappedIPv4 !== null && isValidIPv4(mappedIPv4)) {
+    if (isPrivateOrReservedIPv4(mappedIPv4)) return null;
     return { kind: 'ip', trust: 'ip', name: h, category: 'Unresolved host', entry: null };
   }
 
@@ -699,7 +731,7 @@ export function resolveHost(
 
   const internalDomains = opts?.internalDomains ?? [];
   const isInternal =
-    !h.includes('.') ||
+    (!h.includes('.') && !h.includes(':')) ||
     INTERNAL_TLDS.some((tld) => hostMatchesSuffix(h, tld)) ||
     internalDomains.some((domain) => hostMatchesSuffix(h, domain.toLowerCase()));
   if (isInternal) {

--- a/packages/detections/test/egress/registry.test.ts
+++ b/packages/detections/test/egress/registry.test.ts
@@ -12,10 +12,7 @@ import {
   resolveSdk,
 } from '../../src/egress/registry.ts';
 
-const fixturesDir = join(
-  fileURLToPath(new URL('.', import.meta.url)),
-  '../../src/egress/fixtures',
-);
+const fixturesDir = join(fileURLToPath(new URL('.', import.meta.url)), '../../src/egress/fixtures');
 
 interface HostCase {
   label: string;

--- a/packages/detections/test/egress/registry.test.ts
+++ b/packages/detections/test/egress/registry.test.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { DestinationKind, EgressEcosystem, ShareTrustLevel } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import {
+  EGRESS_VERSION_MATERIAL,
+  PROVIDER_REGISTRY,
+  resolveHost,
+  resolveSdk,
+} from '../../src/egress/registry.ts';
+
+const fixturesDir = join(
+  fileURLToPath(new URL('.', import.meta.url)),
+  '../../src/egress/fixtures',
+);
+
+interface HostCase {
+  label: string;
+  host: string;
+  opts?: { internalDomains?: string[] };
+  expect: { kind: DestinationKind; trust: ShareTrustLevel; name: string } | null;
+}
+
+interface SdkCase {
+  label: string;
+  ecosystem: EgressEcosystem;
+  pkg: string;
+  expectId: string | null;
+}
+
+interface RegistryFixture {
+  hosts: HostCase[];
+  sdks: SdkCase[];
+}
+
+function loadFixture(): RegistryFixture {
+  return JSON.parse(
+    readFileSync(join(fixturesDir, 'registry-resolution.json'), 'utf8'),
+  ) as RegistryFixture;
+}
+
+const fixture = loadFixture();
+
+describe('resolveHost — fixture corpus', () => {
+  it('has at least 2 resolved and 2 excluded (null) host cases', () => {
+    expect(fixture.hosts.filter((c) => c.expect !== null).length).toBeGreaterThanOrEqual(2);
+    expect(fixture.hosts.filter((c) => c.expect === null).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(fixture.hosts.map((c) => [c.label, c] as const))('%s', (_label, c) => {
+    const result = resolveHost(c.host, c.opts);
+    if (c.expect === null) {
+      expect(result).toBeNull();
+    } else {
+      expect(result).not.toBeNull();
+      expect(result?.kind).toBe(c.expect.kind);
+      expect(result?.trust).toBe(c.expect.trust);
+      expect(result?.name).toBe(c.expect.name);
+    }
+  });
+
+  it('providers carry the matched registry entry; non-providers carry null', () => {
+    const stripe = resolveHost('api.stripe.com');
+    expect(stripe?.entry?.id).toBe('stripe');
+    const external = resolveHost('acme-partner.com');
+    expect(external?.entry).toBeNull();
+  });
+});
+
+describe('resolveSdk — fixture corpus', () => {
+  it('has at least 2 hit and 2 miss sdk cases', () => {
+    expect(fixture.sdks.filter((c) => c.expectId !== null).length).toBeGreaterThanOrEqual(2);
+    expect(fixture.sdks.filter((c) => c.expectId === null).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(fixture.sdks.map((c) => [c.label, c] as const))('%s', (_label, c) => {
+    const result = resolveSdk(c.ecosystem, c.pkg);
+    if (c.expectId === null) {
+      expect(result).toBeNull();
+    } else {
+      expect(result?.id).toBe(c.expectId);
+    }
+  });
+});
+
+describe('PROVIDER_REGISTRY', () => {
+  it('has no duplicate ids', () => {
+    const ids = PROVIDER_REGISTRY.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('has 35 seeded providers, each with at least one hostSuffix and one dataClass', () => {
+    expect(PROVIDER_REGISTRY.length).toBe(35);
+    for (const p of PROVIDER_REGISTRY) {
+      expect(p.hostSuffixes.length).toBeGreaterThanOrEqual(1);
+      expect(p.defaultDataClasses.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+});
+
+describe('EGRESS_VERSION_MATERIAL', () => {
+  it('is EXTRACTOR_VERSION "1" plus the serialized registry, and so changes with the registry', () => {
+    expect(EGRESS_VERSION_MATERIAL).toBe(`1\n${JSON.stringify(PROVIDER_REGISTRY)}`);
+  });
+
+  it('differs from the material a different registry array would produce', () => {
+    const mutated = [...PROVIDER_REGISTRY, { ...PROVIDER_REGISTRY[0], id: 'zzz-not-real' }];
+    const mutatedMaterial = `1\n${JSON.stringify(mutated)}`;
+    expect(mutatedMaterial).not.toBe(EGRESS_VERSION_MATERIAL);
+  });
+});

--- a/packages/detections/test/egress/registry.test.ts
+++ b/packages/detections/test/egress/registry.test.ts
@@ -21,7 +21,7 @@ interface HostCase {
   label: string;
   host: string;
   opts?: { internalDomains?: string[] };
-  expect: { kind: DestinationKind; trust: ShareTrustLevel; name: string } | null;
+  expect: { kind: DestinationKind; trust: ShareTrustLevel; name: string; category: string } | null;
 }
 
 interface SdkCase {
@@ -59,6 +59,7 @@ describe('resolveHost — fixture corpus', () => {
       expect(result?.kind).toBe(c.expect.kind);
       expect(result?.trust).toBe(c.expect.trust);
       expect(result?.name).toBe(c.expect.name);
+      expect(result?.category).toBe(c.expect.category);
     }
   });
 
@@ -104,11 +105,5 @@ describe('PROVIDER_REGISTRY', () => {
 describe('EGRESS_VERSION_MATERIAL', () => {
   it('is EXTRACTOR_VERSION "1" plus the serialized registry, and so changes with the registry', () => {
     expect(EGRESS_VERSION_MATERIAL).toBe(`1\n${JSON.stringify(PROVIDER_REGISTRY)}`);
-  });
-
-  it('differs from the material a different registry array would produce', () => {
-    const mutated = [...PROVIDER_REGISTRY, { ...PROVIDER_REGISTRY[0], id: 'zzz-not-real' }];
-    const mutatedMaterial = `1\n${JSON.stringify(mutated)}`;
-    expect(mutatedMaterial).not.toBe(EGRESS_VERSION_MATERIAL);
   });
 });

--- a/packages/detections/test/egress/registry.test.ts
+++ b/packages/detections/test/egress/registry.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { DestinationKind, EgressEcosystem, ShareTrustLevel } from '@akasecurity/schema';
+import { DATA_CLASS_ORDER } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -95,6 +96,28 @@ describe('PROVIDER_REGISTRY', () => {
     for (const p of PROVIDER_REGISTRY) {
       expect(p.hostSuffixes.length).toBeGreaterThanOrEqual(1);
       expect(p.defaultDataClasses.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('lists every defaultDataClasses array most-sensitive first', () => {
+    // resolveEgress stores defaultDataClasses[0] as the endpoint's dataClass, so
+    // an out-of-rank array under-classifies the destination.
+    for (const p of PROVIDER_REGISTRY) {
+      const byRank = [...p.defaultDataClasses].sort(
+        (a, b) => DATA_CLASS_ORDER.indexOf(a) - DATA_CLASS_ORDER.indexOf(b),
+      );
+      expect(p.defaultDataClasses, `${p.id} is not sorted by sensitivity`).toEqual(byRank);
+    }
+  });
+
+  it('carries no hostSuffix already covered by another suffix on the same entry', () => {
+    for (const p of PROVIDER_REGISTRY) {
+      for (const suffix of p.hostSuffixes) {
+        const covered = p.hostSuffixes.some(
+          (other) => other !== suffix && suffix.endsWith(`.${other}`),
+        );
+        expect(covered, `${p.id} lists ${suffix}, already matched by a broader suffix`).toBe(false);
+      }
     }
   });
 });


### PR DESCRIPTION
**Stacked PR 3 of 13** — base: `egress-stack/02-migration`. Depends on #74.

A pure, node-free registry of 35 providers (host suffixes + per-ecosystem SDK names), resolveHost/resolveSdk, exclusion + IPv4/IPv6 classification helpers, and EGRESS_VERSION_MATERIAL (the scanner's ledger-key material). Unknown public hosts resolve to the external kind.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).