### PR TITLE
feat(egress) [4/13]: detections — URL/IP extraction with evidence-only method inference

### DIFF
--- a/packages/detections/src/egress/extract.ts
+++ b/packages/detections/src/egress/extract.ts
@@ -98,14 +98,75 @@ const IP_SMTP_CONTEXT = /\b(smtp|mail)\b/i;
 
 // Redaction. Values are masked, keys are kept readable. The quote class
 // covers backtick-quoted (template literal) values the same as single- and
-// double-quoted ones. A value that starts with `Bearer` followed by a space,
-// quote, or backtick is left for the bearer rule below, which masks the
-// token while keeping the scheme keyword visible; a `Bearer`-prefixed value
-// with no such delimiter (e.g. `Bearer-x`, `Bearer.x`) is masked here instead.
+// double-quoted ones.
+
+// Field names whose value is a credential, shared by both value rules below so
+// the two can never cover different key sets.
+const SECRET_KEY_NAMES =
+  'api[_-]?key|apikey|private[_-]?key|access[_-]?key|access[_-]?token|token|secret|credentials?|password|passwd|pwd|authorization|sig|signature|sas|assertion';
+
+// HTTP authorization schemes that place the credential after the scheme
+// keyword. Any scheme here keeps its keyword readable and loses its credential.
+const AUTH_SCHEMES = 'Bearer|Basic|Token|Digest|ApiKey|SSWS|AWS4-HMAC-SHA256';
+
 const USERINFO = /:\/\/[^@/\s]+@/g;
-const SECRET_VALUE =
-  /((?:api[_-]?key|apikey|token|secret|password|passwd|authorization|access[_-]?key|access[_-]?token|sig|signature|sas|assertion)['"`]?\s*[:=]\s*['"`]?)(?!Bearer[\s'"`])[^\s'"`&]+/gi;
+
+// `<field>: <value>`. A value that opens with a scheme keyword followed by a
+// space, quote, or backtick is left to AUTH_SCHEME_VALUE, which keeps the
+// keyword visible; a scheme-prefixed value with no such delimiter (`Bearer-x`,
+// `Bearer.x`) names no separate credential and is masked whole here.
+const SECRET_VALUE = new RegExp(
+  `((?:${SECRET_KEY_NAMES})['"\`]?\\s*[:=]\\s*['"\`]?)(?!(?:${AUTH_SCHEMES})[\\s'"\`])[^\\s'"\`&]+`,
+  'gi',
+);
+
+// `Authorization: <scheme> <credential>`. Anchored on the field name so an
+// ordinary sentence opening with a scheme word ("token bucket refill rate")
+// keeps its next word.
+const AUTH_SCHEME_VALUE = new RegExp(
+  `((?:${SECRET_KEY_NAMES})['"\`]?\\s*[:=]\\s*['"\`]?)(${AUTH_SCHEMES})\\s+[^\\s'"\`]+`,
+  'gi',
+);
+
+// A bearer token carrying no field name in front of it.
 const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
+
+// Webhook endpoints whose URL path segments ARE the credential: anyone holding
+// the full path can post to the channel. The routing prefix stays readable and
+// everything after it is masked, in the stored URL and in the snippet alike.
+const WEBHOOK_SECRET_PATHS: readonly { hosts: readonly string[]; prefix: string }[] = [
+  { hosts: ['hooks.slack.com'], prefix: '/services/' },
+  {
+    hosts: ['discord.com', 'discordapp.com', 'ptb.discord.com', 'canary.discord.com'],
+    prefix: '/api/webhooks/',
+  },
+  { hosts: ['hooks.zapier.com'], prefix: '/hooks/' },
+  { hosts: ['outlook.office.com', 'outlook.office365.com'], prefix: '/webhook/' },
+];
+
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// Built from WEBHOOK_SECRET_PATHS so the snippet rule and the URL rule can
+// never drift apart. The tail class mirrors URL_CANDIDATE's terminator set.
+const WEBHOOK_URL = new RegExp(
+  `(https?://(?:${WEBHOOK_SECRET_PATHS.flatMap((entry) =>
+    entry.hosts.map((host) => `${escapeRegExp(host)}${escapeRegExp(entry.prefix)}`),
+  ).join('|')}))[^\\s'"\`<>()[\\]{},;]+`,
+  'gi',
+);
+
+// Mask the credential-bearing tail of a known webhook path, or return the path
+// untouched when the host/prefix pair is not one of them.
+function maskWebhookPath(host: string, pathname: string): string {
+  for (const entry of WEBHOOK_SECRET_PATHS) {
+    if (entry.hosts.includes(host) && pathname.startsWith(entry.prefix)) {
+      return `${entry.prefix}${MASK}`;
+    }
+  }
+  return pathname;
+}
 
 const VENDORED_PATH = /(^|\/)(vendor|third_party|external)\//;
 
@@ -116,14 +177,17 @@ export function isVendoredPath(file: string): boolean {
 
 /**
  * Strip credentials and secret values out of one source line and cap it at
- * SNIPPET_MAX characters. `Authorization: Bearer <token>` keeps the scheme
- * keyword and masks the token.
+ * SNIPPET_MAX characters. `Authorization: <scheme> <credential>` keeps the
+ * scheme keyword and masks the credential; a webhook URL keeps its routing
+ * prefix and loses the path segments that authorize posting to it.
  */
 export function redactSnippet(line: string): string {
   return line
     .trim()
     .replace(USERINFO, '://')
+    .replace(WEBHOOK_URL, `$1${MASK}`)
     .replace(SECRET_VALUE, `$1${MASK}`)
+    .replace(AUTH_SCHEME_VALUE, `$1$2 ${MASK}`)
     .replace(BEARER_TOKEN, `Bearer ${MASK}`)
     .slice(0, SNIPPET_MAX);
 }
@@ -187,7 +251,8 @@ interface ParsedDestination {
 }
 
 // Normalize one raw URL candidate: collapse placeholder spans to `${var}`,
-// parse it, and rebuild it without userinfo, query, or fragment. Returns null
+// parse it, and rebuild it without userinfo, query, or fragment, masking the
+// credential-bearing tail of a known webhook path on the way. Returns null
 // for an unparseable candidate or a placeholder in the authority (a fully
 // dynamic host names no destination).
 function parseCandidate(candidate: string, scheme: string): ParsedDestination | null {
@@ -213,7 +278,8 @@ function parseCandidate(candidate: string, scheme: string): ParsedDestination | 
   if (host === '' || host.includes(VAR_SENTINEL)) return null;
 
   const authority = parsed.host.toLowerCase();
-  const url = `${transport}://${authority}${parsed.pathname}`.split(VAR_SENTINEL).join(VAR_TOKEN);
+  const path = maskWebhookPath(host, parsed.pathname);
+  const url = `${transport}://${authority}${path}`.split(VAR_SENTINEL).join(VAR_TOKEN);
 
   return {
     url,

--- a/packages/detections/src/egress/extract.ts
+++ b/packages/detections/src/egress/extract.ts
@@ -96,10 +96,15 @@ const IP_HOST_CONTEXT = /\b(host|hostname|server|address|endpoint|ip|url|uri)\b/
 const IP_SFTP_CONTEXT = /\bs(ftp|cp|sh)\b/i;
 const IP_SMTP_CONTEXT = /\b(smtp|mail)\b/i;
 
-// Redaction. Values are masked, keys are kept readable.
+// Redaction. Values are masked, keys are kept readable. The quote class
+// covers backtick-quoted (template literal) values the same as single- and
+// double-quoted ones. A value that starts with `Bearer` followed by a space,
+// quote, or backtick is left for the bearer rule below, which masks the
+// token while keeping the scheme keyword visible; a `Bearer`-prefixed value
+// with no such delimiter (e.g. `Bearer-x`, `Bearer.x`) is masked here instead.
 const USERINFO = /:\/\/[^@/\s]+@/g;
 const SECRET_VALUE =
-  /((?:api[_-]?key|apikey|token|secret|password|passwd|authorization|access[_-]?key|access[_-]?token|sig|signature|sas|assertion)['"]?\s*[:=]\s*['"]?)(?!Bearer\b)[^\s'"&]+/gi;
+  /((?:api[_-]?key|apikey|token|secret|password|passwd|authorization|access[_-]?key|access[_-]?token|sig|signature|sas|assertion)['"`]?\s*[:=]\s*['"`]?)(?!Bearer[\s'"`])[^\s'"`&]+/gi;
 const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
 
 const VENDORED_PATH = /(^|\/)(vendor|third_party|external)\//;
@@ -125,7 +130,7 @@ export function redactSnippet(line: string): string {
 
 /**
  * Pull every URL literal and bare public IPv4 reference out of one file's
- * text, in line order.
+ * text, sorted ascending by line, then by url (never by match order).
  */
 export function extractEgress(text: string): RawEndpointHit[] {
   const lineStarts = lineStartOffsets(text);
@@ -286,8 +291,11 @@ function identifierWords(line: string): string {
 }
 
 // Methods are evidence, never fabrication: a bare client call counts as GET
-// only when the whole call is visible and carries no method key. Anything the
-// windows cannot prove is a plain reference.
+// only when the whole call is visible, the URL is its only argument, and it
+// carries no method key. Anything the windows cannot prove is a plain
+// reference — including a call that passes a second argument such as an
+// options object, since that object's own contents (e.g. its HTTP method)
+// sit outside the window this pass can see.
 function inferMethod(text: string, start: number, end: number): HttpMethod {
   const before = text.slice(Math.max(0, start - BEFORE_WINDOW), start);
   const after = text.slice(end, end + AFTER_WINDOW);
@@ -303,7 +311,13 @@ function inferMethod(text: string, start: number, end: number): HttpMethod {
 
   if (CLIENT_OPENER.test(before)) {
     const close = callCloseIndex(after);
-    if (close !== -1 && !ANY_METHOD_KEY.test(after.slice(0, close))) return 'GET';
+    if (
+      close !== -1 &&
+      isSoleArgument(after, close) &&
+      !ANY_METHOD_KEY.test(after.slice(0, close))
+    ) {
+      return 'GET';
+    }
   }
 
   return 'REF';
@@ -327,6 +341,16 @@ function callCloseIndex(span: string): number {
     }
   }
   return -1;
+}
+
+// True when nothing sits between the URL match and the call's closing paren
+// except an optional single trailing comma. A comma anywhere else in that
+// span — including one that opens a nested call's own argument list — marks
+// a second argument to the outer call, so the URL is not its sole argument.
+function isSoleArgument(span: string, close: number): boolean {
+  const between = span.slice(0, close - 1).trimEnd();
+  const withoutTrailingComma = between.endsWith(',') ? between.slice(0, -1) : between;
+  return !withoutTrailingComma.includes(',');
 }
 
 // Per-line derivations are computed on first use and reused by every later

--- a/packages/detections/src/egress/extract.ts
+++ b/packages/detections/src/egress/extract.ts
@@ -90,6 +90,12 @@ const OPTIONS_METHOD = /method\s*[:=]\s*['"](GET|POST|PUT|DELETE)/i;
 const CLIENT_OPENER = /\b(fetch|urlopen|got|ky)\s*\(\s*['"`]*$/i;
 const ANY_METHOD_KEY = /\bmethod\s*[:=]/i;
 
+// End of the statement the URL sits in: a semicolon, or a line break starting a
+// new binding or block. A `method:` key past one of these describes a later,
+// unrelated expression, so it proves nothing about this URL.
+const STATEMENT_BREAK =
+  /;|\n\s*(?:(?:const|let|var|val|function|func|fn|def|class|return|export|import|if|for|while|switch|try|public|private)\b|\w+\s*=[^=])/;
+
 // Bare dotted-quad literals, with an optional port.
 const IPV4_CANDIDATE = /\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b/g;
 const IP_HOST_CONTEXT = /\b(host|hostname|server|address|endpoint|ip|url|uri)\b/i;
@@ -175,21 +181,46 @@ export function isVendoredPath(file: string): boolean {
   return VENDORED_PATH.test(file);
 }
 
-/**
- * Strip credentials and secret values out of one source line and cap it at
- * SNIPPET_MAX characters. `Authorization: <scheme> <credential>` keeps the
- * scheme keyword and masks the credential; a webhook URL keeps its routing
- * prefix and loses the path segments that authorize posting to it.
- */
-export function redactSnippet(line: string): string {
+function redactLine(line: string): string {
   return line
     .trim()
     .replace(USERINFO, '://')
     .replace(WEBHOOK_URL, `$1${MASK}`)
     .replace(SECRET_VALUE, `$1${MASK}`)
     .replace(AUTH_SCHEME_VALUE, `$1$2 ${MASK}`)
-    .replace(BEARER_TOKEN, `Bearer ${MASK}`)
-    .slice(0, SNIPPET_MAX);
+    .replace(BEARER_TOKEN, `Bearer ${MASK}`);
+}
+
+/**
+ * Strip credentials and secret values out of one source line and cap it at
+ * SNIPPET_MAX characters. `Authorization: <scheme> <credential>` keeps the
+ * scheme keyword and masks the credential; a webhook URL keeps its routing
+ * prefix and loses the path segments that authorize posting to it.
+ *
+ * `anchor` is the hit's offset within `line`; the cap window is centered on it
+ * so a hit far along a very long line — a minified bundle puts a whole file on
+ * one line — still lands inside the stored evidence. Redaction always runs over
+ * the whole line first, so masking never depends on where the window falls.
+ */
+export function redactSnippet(line: string, anchor = 0): string {
+  const redacted = redactLine(line);
+  if (redacted.length <= SNIPPET_MAX) return redacted;
+
+  const lead = line.length - line.trimStart().length;
+  const trimmed = line.trim();
+  // Masking only ever shortens, so an unchanged length means nothing matched
+  // and offsets carry over untouched. Otherwise re-redact the prefix to find
+  // where the anchor landed; that pass is only reached on a line long enough
+  // to need windowing that also carried a secret.
+  const mapped =
+    redacted.length === trimmed.length
+      ? anchor - lead
+      : redactLine(trimmed.slice(0, Math.max(0, anchor - lead))).length;
+  const start = Math.min(
+    Math.max(0, mapped - Math.floor(SNIPPET_MAX / 2)),
+    redacted.length - SNIPPET_MAX,
+  );
+  return redacted.slice(start, start + SNIPPET_MAX);
 }
 
 /**
@@ -203,8 +234,9 @@ export function extractEgress(text: string): RawEndpointHit[] {
   // Derived once per line rather than once per hit: a minified bundle puts
   // every hit in a file on a single very long line.
   const lineTextOf = memoizeByLine((index) => lineTextAt(text, lineStarts, index));
-  const snippetOf = memoizeByLine((index) => redactSnippet(lineTextOf(index)));
   const ipContextOf = memoizeByLine((index) => ipLineContext(lineTextOf(index)));
+  const snippetAt = (index: number, offset: number): string =>
+    redactSnippet(lineTextOf(index), offset - (lineStarts[index] ?? 0));
 
   for (const match of text.matchAll(URL_CANDIDATE)) {
     const start = match.index;
@@ -224,7 +256,7 @@ export function extractEgress(text: string): RawEndpointHit[] {
       ...parsed,
       method: inferMethod(text, start, start + matched.length),
       line: index + 1,
-      snippet: snippetOf(index),
+      snippet: snippetAt(index, start),
     });
   }
 
@@ -236,7 +268,7 @@ export function extractEgress(text: string): RawEndpointHit[] {
     const parsed = parseBareIp(match[0], ipContextOf(index));
     if (parsed === null) continue;
 
-    hits.push({ ...parsed, method: 'REF', line: index + 1, snippet: snippetOf(index) });
+    hits.push({ ...parsed, method: 'REF', line: index + 1, snippet: snippetAt(index, start) });
   }
 
   return hits.sort(compareHits);
@@ -358,10 +390,12 @@ function identifierWords(line: string): string {
 
 // Methods are evidence, never fabrication: a bare client call counts as GET
 // only when the whole call is visible, the URL is its only argument, and it
-// carries no method key. Anything the windows cannot prove is a plain
-// reference — including a call that passes a second argument such as an
-// options object, since that object's own contents (e.g. its HTTP method)
-// sit outside the window this pass can see.
+// carries no method key. A `method:` key after the URL counts only while it is
+// still inside the URL's own statement — otherwise a bare `const ENDPOINT =
+// '…'` followed by an unrelated `{ method: 'POST' }` would borrow that verb.
+// Anything the windows cannot prove is a plain reference — including a call
+// that passes a second argument such as an options object, since that object's
+// own contents (e.g. its HTTP method) sit outside the window this pass can see.
 function inferMethod(text: string, start: number, end: number): HttpMethod {
   const before = text.slice(Math.max(0, start - BEFORE_WINDOW), start);
   const after = text.slice(end, end + AFTER_WINDOW);
@@ -373,7 +407,9 @@ function inferMethod(text: string, start: number, end: number): HttpMethod {
   if (firstArgument?.[1] !== undefined) return verbOf(firstArgument[1]);
 
   const options = OPTIONS_METHOD.exec(after);
-  if (options?.[1] !== undefined) return verbOf(options[1]);
+  if (options?.[1] !== undefined && !STATEMENT_BREAK.test(after.slice(0, options.index))) {
+    return verbOf(options[1]);
+  }
 
   if (CLIENT_OPENER.test(before)) {
     const close = callCloseIndex(after);

--- a/packages/detections/src/egress/extract.ts
+++ b/packages/detections/src/egress/extract.ts
@@ -1,0 +1,377 @@
+// Static egress extraction for one source file's text: URL literals and bare
+// public IPv4 addresses, each carrying a transport, an evidence-based HTTP
+// method, and a redacted snippet.
+//
+// Pure like everything in @akasecurity/detections: no I/O, no Node-API
+// imports — line numbers come from counting newlines in the raw text. Callers
+// gate what reaches extractEgress: code files only (EGRESS_CODE_EXTENSIONS),
+// never lockfiles, never text containing NUL bytes.
+import type { HttpMethod, Transport } from '@akasecurity/schema';
+
+import { isPrivateOrReservedIPv4, isValidIPv4 } from './registry.ts';
+
+/** One URL or bare-IP destination reference found in a file's text. */
+export interface RawEndpointHit {
+  /** Normalized: no userinfo, query, or fragment; placeholders as `${var}`. */
+  url: string;
+  /** Lowercased, without the port. */
+  host: string;
+  port: number | null;
+  transport: Transport;
+  /** A verb only where the surrounding text proves one; otherwise 'REF'. */
+  method: HttpMethod;
+  /** True when the URL carried a placeholder span. */
+  template: boolean;
+  /** 1-based, counted in the raw text. */
+  line: number;
+  /** Redacted, capped at SNIPPET_MAX characters. */
+  snippet: string;
+}
+
+// Source extensions URL/IP extraction runs on, mirroring the scanner's walker
+// list. Compared against extname() output, so the leading dots are required.
+export const EGRESS_CODE_EXTENSIONS: ReadonlySet<string> = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.py',
+  '.java',
+  '.rb',
+  '.cs',
+  '.php',
+  '.go',
+  '.rs',
+]);
+
+const SNIPPET_MAX = 200;
+const MASK = '••••';
+
+// URL literals in raw source text. Template spans are admitted as explicit
+// alternatives so `${x}`, `{x}` and printf verbs do not terminate the match.
+const URL_CANDIDATE =
+  /(https?|wss?|sftp|grpcs?|smtp):\/\/(?:[^\s'"`<>()[\]{},;]|\$\{[^}\s]{1,64}\}|\{[A-Za-z_]\w{0,63}\}|%[sd])+/gi;
+
+// The placeholder spans above, collapsed to one token per candidate. Applied
+// as a single left-to-right pass so a replacement is never rewritten.
+const PLACEHOLDER = /\$\{[^}\s]{1,64}\}|\{[A-Za-z_]\w{0,63}\}|%[sd]/g;
+const VAR_TOKEN = '${var}';
+
+// Stand-in for VAR_TOKEN while the candidate goes through the URL parser:
+// lowercase alphanumerics survive both host lowercasing and path encoding
+// unchanged, so it can be swapped back verbatim afterwards.
+const VAR_SENTINEL = 'akaegressvar0';
+
+const TRAILING_PUNCTUATION = /[.,;:'"]+$/;
+
+// Scheme to transport. 'grpcs' collapses onto 'grpc'; the stored URL is
+// rebuilt from the transport so the two can never disagree.
+const TRANSPORT_BY_SCHEME: Readonly<Record<string, Transport>> = {
+  http: 'http',
+  https: 'https',
+  ws: 'ws',
+  wss: 'wss',
+  sftp: 'sftp',
+  grpc: 'grpc',
+  grpcs: 'grpc',
+  smtp: 'smtp',
+};
+
+// Method evidence. Windows are measured in raw characters and may cross
+// newlines: a call's URL and its options object routinely sit on different
+// lines.
+const BEFORE_WINDOW = 200;
+const AFTER_WINDOW = 300;
+const VERB_METHOD_OPENER = /\.\s*(get|post|put|delete)\s*\(\s*['"`]*$/i;
+const VERB_FIRST_ARGUMENT = /["'](GET|POST|PUT|DELETE)["']\s*,[^)]{0,150}$/i;
+const OPTIONS_METHOD = /method\s*[:=]\s*['"](GET|POST|PUT|DELETE)/i;
+const CLIENT_OPENER = /\b(fetch|urlopen|got|ky)\s*\(\s*['"`]*$/i;
+const ANY_METHOD_KEY = /\bmethod\s*[:=]/i;
+
+// Bare dotted-quad literals, with an optional port.
+const IPV4_CANDIDATE = /\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b/g;
+const IP_HOST_CONTEXT = /\b(host|hostname|server|address|endpoint|ip|url|uri)\b/i;
+const IP_SFTP_CONTEXT = /\bs(ftp|cp|sh)\b/i;
+const IP_SMTP_CONTEXT = /\b(smtp|mail)\b/i;
+
+// Redaction. Values are masked, keys are kept readable.
+const USERINFO = /:\/\/[^@/\s]+@/g;
+const SECRET_VALUE =
+  /((?:api[_-]?key|apikey|token|secret|password|passwd|authorization|access[_-]?key|access[_-]?token|sig|signature|sas|assertion)['"]?\s*[:=]\s*['"]?)(?!Bearer\b)[^\s'"&]+/gi;
+const BEARER_TOKEN = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
+
+const VENDORED_PATH = /(^|\/)(vendor|third_party|external)\//;
+
+/** True when a stored file path sits under a vendored dependency tree. */
+export function isVendoredPath(file: string): boolean {
+  return VENDORED_PATH.test(file);
+}
+
+/**
+ * Strip credentials and secret values out of one source line and cap it at
+ * SNIPPET_MAX characters. `Authorization: Bearer <token>` keeps the scheme
+ * keyword and masks the token.
+ */
+export function redactSnippet(line: string): string {
+  return line
+    .trim()
+    .replace(USERINFO, '://')
+    .replace(SECRET_VALUE, `$1${MASK}`)
+    .replace(BEARER_TOKEN, `Bearer ${MASK}`)
+    .slice(0, SNIPPET_MAX);
+}
+
+/**
+ * Pull every URL literal and bare public IPv4 reference out of one file's
+ * text, in line order.
+ */
+export function extractEgress(text: string): RawEndpointHit[] {
+  const lineStarts = lineStartOffsets(text);
+  const urlSpans: (readonly [number, number])[] = [];
+  const hits: RawEndpointHit[] = [];
+  // Derived once per line rather than once per hit: a minified bundle puts
+  // every hit in a file on a single very long line.
+  const lineTextOf = memoizeByLine((index) => lineTextAt(text, lineStarts, index));
+  const snippetOf = memoizeByLine((index) => redactSnippet(lineTextOf(index)));
+  const ipContextOf = memoizeByLine((index) => ipLineContext(lineTextOf(index)));
+
+  for (const match of text.matchAll(URL_CANDIDATE)) {
+    const start = match.index;
+    const matched = match[0];
+    urlSpans.push([start, start + matched.length]);
+
+    const scheme = match[1];
+    if (scheme === undefined) continue;
+    const candidate = matched.replace(TRAILING_PUNCTUATION, '');
+    if (candidate === '') continue;
+
+    const parsed = parseCandidate(candidate, scheme);
+    if (parsed === null) continue;
+
+    const index = lineIndexAt(lineStarts, start);
+    hits.push({
+      ...parsed,
+      method: inferMethod(text, start, start + matched.length),
+      line: index + 1,
+      snippet: snippetOf(index),
+    });
+  }
+
+  for (const match of text.matchAll(IPV4_CANDIDATE)) {
+    const start = match.index;
+    if (isInsideSpan(urlSpans, start)) continue;
+
+    const index = lineIndexAt(lineStarts, start);
+    const parsed = parseBareIp(match[0], ipContextOf(index));
+    if (parsed === null) continue;
+
+    hits.push({ ...parsed, method: 'REF', line: index + 1, snippet: snippetOf(index) });
+  }
+
+  return hits.sort(compareHits);
+}
+
+interface ParsedDestination {
+  url: string;
+  host: string;
+  port: number | null;
+  transport: Transport;
+  template: boolean;
+}
+
+// Normalize one raw URL candidate: collapse placeholder spans to `${var}`,
+// parse it, and rebuild it without userinfo, query, or fragment. Returns null
+// for an unparseable candidate or a placeholder in the authority (a fully
+// dynamic host names no destination).
+function parseCandidate(candidate: string, scheme: string): ParsedDestination | null {
+  const transport = TRANSPORT_BY_SCHEME[scheme.toLowerCase()];
+  if (transport === undefined) return null;
+
+  let placeholders = 0;
+  const normalized = candidate.replace(PLACEHOLDER, () => {
+    placeholders += 1;
+    return VAR_TOKEN;
+  });
+
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized.split(VAR_TOKEN).join(VAR_SENTINEL));
+  } catch {
+    return null;
+  }
+
+  // Non-special schemes (sftp, grpc, smtp) keep the authority's original
+  // case, so lowercasing is this pass's job rather than the parser's.
+  const host = parsed.hostname.toLowerCase();
+  if (host === '' || host.includes(VAR_SENTINEL)) return null;
+
+  const authority = parsed.host.toLowerCase();
+  const url = `${transport}://${authority}${parsed.pathname}`.split(VAR_SENTINEL).join(VAR_TOKEN);
+
+  return {
+    url,
+    host,
+    port: parsed.port === '' ? null : Number(parsed.port),
+    transport,
+    template: placeholders > 0,
+  };
+}
+
+// Keep a bare dotted-quad only when it is a valid public IPv4 literal named by
+// a host-ish keyword on the same line. Transport comes from that line's
+// context: no scheme means no TLS evidence, so plain http is the honest floor.
+function parseBareIp(candidate: string, context: IpLineContext): ParsedDestination | null {
+  const [address, port] = splitPort(candidate);
+  if (!isValidIPv4(address) || isPrivateOrReservedIPv4(address)) return null;
+  if (!context.named) return null;
+
+  const { transport } = context;
+  return {
+    url: `${transport}://${address}${port === null ? '' : `:${String(port)}`}`,
+    host: address,
+    port,
+    transport,
+    template: false,
+  };
+}
+
+// What one line says about the bare IPs on it: whether a host-ish keyword
+// names them at all, and which transport its context implies.
+interface IpLineContext {
+  named: boolean;
+  transport: Transport;
+}
+
+function ipLineContext(line: string): IpLineContext {
+  const context = identifierWords(line);
+  let transport: Transport = 'http';
+  if (IP_SFTP_CONTEXT.test(context)) transport = 'sftp';
+  else if (IP_SMTP_CONTEXT.test(context)) transport = 'smtp';
+  return { named: IP_HOST_CONTEXT.test(context), transport };
+}
+
+// URL spans are non-overlapping and in increasing order, so only the last span
+// starting at or before `offset` can contain it.
+function isInsideSpan(spans: (readonly [number, number])[], offset: number): boolean {
+  let low = 0;
+  let high = spans.length - 1;
+  let found = -1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const span = spans[mid];
+    if (span === undefined) break;
+    if (span[0] <= offset) {
+      found = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+  const span = found === -1 ? undefined : spans[found];
+  return span !== undefined && offset < span[1];
+}
+
+function splitPort(candidate: string): [string, number | null] {
+  const colon = candidate.indexOf(':');
+  if (colon === -1) return [candidate, null];
+  return [candidate.slice(0, colon), Number(candidate.slice(colon + 1))];
+}
+
+// Identifier separators and camelCase humps read as word boundaries, so
+// SFTP_SERVER and mailRelayHost match the context keywords above.
+function identifierWords(line: string): string {
+  return line.replace(/[_-]+/g, ' ').replace(/([a-z0-9])([A-Z])/g, '$1 $2');
+}
+
+// Methods are evidence, never fabrication: a bare client call counts as GET
+// only when the whole call is visible and carries no method key. Anything the
+// windows cannot prove is a plain reference.
+function inferMethod(text: string, start: number, end: number): HttpMethod {
+  const before = text.slice(Math.max(0, start - BEFORE_WINDOW), start);
+  const after = text.slice(end, end + AFTER_WINDOW);
+
+  const opener = VERB_METHOD_OPENER.exec(before);
+  if (opener?.[1] !== undefined) return verbOf(opener[1]);
+
+  const firstArgument = VERB_FIRST_ARGUMENT.exec(before);
+  if (firstArgument?.[1] !== undefined) return verbOf(firstArgument[1]);
+
+  const options = OPTIONS_METHOD.exec(after);
+  if (options?.[1] !== undefined) return verbOf(options[1]);
+
+  if (CLIENT_OPENER.test(before)) {
+    const close = callCloseIndex(after);
+    if (close !== -1 && !ANY_METHOD_KEY.test(after.slice(0, close))) return 'GET';
+  }
+
+  return 'REF';
+}
+
+function verbOf(raw: string): HttpMethod {
+  return raw.toUpperCase() as HttpMethod;
+}
+
+// Offset just past the ')' that closes the call the match sits inside, or -1
+// when the call does not close within `span`. Depth starts at 1 because the
+// span begins inside the argument list.
+function callCloseIndex(span: string): number {
+  let depth = 1;
+  for (let i = 0; i < span.length; i += 1) {
+    const char = span[i];
+    if (char === '(') depth += 1;
+    else if (char === ')') {
+      depth -= 1;
+      if (depth === 0) return i + 1;
+    }
+  }
+  return -1;
+}
+
+// Per-line derivations are computed on first use and reused by every later
+// hit on that line.
+function memoizeByLine<T>(compute: (index: number) => T): (index: number) => T {
+  const cache = new Map<number, T>();
+  return (index) => {
+    const cached = cache.get(index);
+    if (cached !== undefined) return cached;
+    const value = compute(index);
+    cache.set(index, value);
+    return value;
+  };
+}
+
+function lineStartOffsets(text: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === '\n') starts.push(i + 1);
+  }
+  return starts;
+}
+
+// Index of the line containing `offset`, by binary search over line starts.
+function lineIndexAt(starts: number[], offset: number): number {
+  let low = 0;
+  let high = starts.length - 1;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if ((starts[mid] ?? 0) <= offset) low = mid;
+    else high = mid - 1;
+  }
+  return low;
+}
+
+// Text of line `index`, without its terminator. A trailing '\r' is left for
+// redactSnippet's trim to drop.
+function lineTextAt(text: string, starts: number[], index: number): string {
+  const start = starts[index] ?? 0;
+  const next = starts[index + 1];
+  return next === undefined ? text.slice(start) : text.slice(start, next - 1);
+}
+
+function compareHits(a: RawEndpointHit, b: RawEndpointHit): number {
+  if (a.line !== b.line) return a.line - b.line;
+  if (a.url !== b.url) return a.url < b.url ? -1 : 1;
+  return 0;
+}

--- a/packages/detections/src/egress/extract.ts
+++ b/packages/detections/src/egress/extract.ts
@@ -85,7 +85,11 @@ const TRANSPORT_BY_SCHEME: Readonly<Record<string, Transport>> = {
 const BEFORE_WINDOW = 200;
 const AFTER_WINDOW = 300;
 const VERB_METHOD_OPENER = /\.\s*(get|post|put|delete)\s*\(\s*['"`]*$/i;
-const VERB_FIRST_ARGUMENT = /["'](GET|POST|PUT|DELETE)["']\s*,[^)]{0,150}$/i;
+// A closing bracket between the verb and the URL means the verb's own list or
+// call ended first, so the verb belongs to something else — a `['GET','POST']`
+// constant, a `case 'GET', 'POST':`, a SQL VALUES tuple. The capture feeds the
+// same statement-locality gate the after-window rule uses.
+const VERB_FIRST_ARGUMENT = /["'](GET|POST|PUT|DELETE)["']\s*,([^)\]};]{0,150})$/i;
 const OPTIONS_METHOD = /method\s*[:=]\s*['"](GET|POST|PUT|DELETE)/i;
 const CLIENT_OPENER = /\b(fetch|urlopen|got|ky)\s*\(\s*['"`]*$/i;
 const ANY_METHOD_KEY = /\bmethod\s*[:=]/i;
@@ -404,7 +408,9 @@ function inferMethod(text: string, start: number, end: number): HttpMethod {
   if (opener?.[1] !== undefined) return verbOf(opener[1]);
 
   const firstArgument = VERB_FIRST_ARGUMENT.exec(before);
-  if (firstArgument?.[1] !== undefined) return verbOf(firstArgument[1]);
+  if (firstArgument?.[1] !== undefined && !STATEMENT_BREAK.test(firstArgument[2] ?? '')) {
+    return verbOf(firstArgument[1]);
+  }
 
   const options = OPTIONS_METHOD.exec(after);
   if (options?.[1] !== undefined && !STATEMENT_BREAK.test(after.slice(0, options.index))) {

--- a/packages/detections/src/egress/fixtures/ip-extraction.json
+++ b/packages/detections/src/egress/fixtures/ip-extraction.json
@@ -60,7 +60,7 @@
     ]
   },
   {
-    "label": "a mail-context line yields the smtp transport",
+    "label": "a mail-context line yields the smtp transport (the Host keyword admits the line; mail alone is a transport keyword, not a host-context keyword)",
     "text": "const mailRelayHost = \"203.0.113.25\";",
     "expect": [
       {

--- a/packages/detections/src/egress/fixtures/ip-extraction.json
+++ b/packages/detections/src/egress/fixtures/ip-extraction.json
@@ -1,0 +1,211 @@
+[
+  {
+    "label": "a host: keyword line yields a public bare IPv4 as an http reference",
+    "text": "host: '198.51.100.23'",
+    "expect": [
+      {
+        "url": "http://198.51.100.23",
+        "host": "198.51.100.23",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an sftp-context line yields the sftp transport and keeps the port",
+    "text": "SFTP_SERVER = \"203.0.113.9:22\"",
+    "expect": [
+      {
+        "url": "sftp://203.0.113.9:22",
+        "host": "203.0.113.9",
+        "port": 22,
+        "transport": "sftp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an scp-context line yields the sftp transport",
+    "text": "SCP_TARGET_HOST = \"203.0.113.44\"",
+    "expect": [
+      {
+        "url": "sftp://203.0.113.44",
+        "host": "203.0.113.44",
+        "port": null,
+        "transport": "sftp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an ssh-context camelCase identifier yields the sftp transport",
+    "text": "const sshHost = '203.0.113.45';",
+    "expect": [
+      {
+        "url": "sftp://203.0.113.45",
+        "host": "203.0.113.45",
+        "port": null,
+        "transport": "sftp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a mail-context line yields the smtp transport",
+    "text": "const mailRelayHost = \"203.0.113.25\";",
+    "expect": [
+      {
+        "url": "smtp://203.0.113.25",
+        "host": "203.0.113.25",
+        "port": null,
+        "transport": "smtp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a camelCase host identifier is recognized as context",
+    "text": "const hostName = \"198.51.100.99\";",
+    "expect": [
+      {
+        "url": "http://198.51.100.99",
+        "host": "198.51.100.99",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a uri keyword with a port yields http and a separate port",
+    "text": "DB_URI = \"198.51.100.31:5432\"",
+    "expect": [
+      {
+        "url": "http://198.51.100.31:5432",
+        "host": "198.51.100.31",
+        "port": 5432,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a snake_case ip keyword is recognized as context",
+    "text": "client_ip = \"198.51.100.77\"",
+    "expect": [
+      {
+        "url": "http://198.51.100.77",
+        "host": "198.51.100.77",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an IP inside an already-captured URL is not emitted a second time",
+    "text": "const r = await fetch('http://198.51.100.23:8080/health');",
+    "expect": [
+      {
+        "url": "http://198.51.100.23:8080/health",
+        "host": "198.51.100.23",
+        "port": 8080,
+        "transport": "http",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a URL IP and a separate bare IP on one line yield one hit each",
+    "text": "const url = 'http://198.51.100.23/x'; const fallbackHost = '203.0.113.9';",
+    "expect": [
+      {
+        "url": "http://198.51.100.23/x",
+        "host": "198.51.100.23",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      },
+      {
+        "url": "http://203.0.113.9",
+        "host": "203.0.113.9",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "NEGATIVE: a dotted-quad version string has no host context keyword",
+    "text": "version = \"1.2.3.4\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a bare IP in prose has no host context keyword",
+    "text": "// bumped to 8.8.8.8 yesterday",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a private 10.* address is excluded",
+    "text": "server = \"10.0.0.8\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a private 192.168.* address is excluded",
+    "text": "endpoint = \"192.168.1.10\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a private 172.16-31.* address is excluded",
+    "text": "host = \"172.16.0.5\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a loopback address is excluded",
+    "text": "host = \"127.0.0.1\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a link-local metadata address is excluded",
+    "text": "const metadataHost = \"169.254.169.254\";",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: an unspecified 0.* address is excluded",
+    "text": "host = \"0.0.0.0\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a multicast address is excluded",
+    "text": "host = \"224.0.0.1\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: an octet above 255 is not a valid IPv4 literal",
+    "text": "host = \"256.1.1.1\"",
+    "expect": []
+  }
+]

--- a/packages/detections/src/egress/fixtures/method-inference.json
+++ b/packages/detections/src/egress/fixtures/method-inference.json
@@ -425,5 +425,95 @@
         "line": 1
       }
     ]
+  },
+  {
+    "label": "a verb list literal before an unrelated call is not method evidence",
+    "text": "const METHODS = ['GET', 'POST']; api('https://api.acme-corp.com/v1')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a verb list literal on an earlier line is not method evidence",
+    "text": "const METHODS = ['GET', 'POST'];\napi('https://api.acme-corp.com/v1')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a verb enum is not method evidence",
+    "text": "enum Method { GET = 'GET', POST = 'POST' }\nconst ENDPOINT = 'https://api.acme-corp.com/v1';",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a go verb slice is not method evidence",
+    "text": "var methods = []string{\"GET\",\"POST\"}\nurl := \"https://api.acme-corp.com/v1\"",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a verb list before a real verb-first call does not steal its verb",
+    "text": "const METHODS = ['GET', 'POST'];\nresp = requests.request('PUT', 'https://api.acme-corp.com/v1')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "PUT",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "verb-first argument: http.NewRequestWithContext(ctx, \"POST\", url) yields POST",
+    "text": "req, err := http.NewRequestWithContext(ctx, \"POST\", \"https://api.acme-corp.com/v1\", body)",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
   }
 ]

--- a/packages/detections/src/egress/fixtures/method-inference.json
+++ b/packages/detections/src/egress/fixtures/method-inference.json
@@ -295,5 +295,70 @@
     "label": "NEGATIVE: a verb-first argument with a fully dynamic url produces nothing",
     "text": "req, err := http.NewRequest(\"POST\", fmt.Sprintf(\"https://%s/v1\", host), body)",
     "expect": []
+  },
+  {
+    "label": "a bare client call with a second variable argument is not a proven bare call: REF, not a fabricated GET",
+    "text": "fetch('https://a.io/x', options);",
+    "expect": [
+      {
+        "url": "https://a.io/x",
+        "host": "a.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a bare client call with a second call-expression argument is not a proven bare call: REF, not a fabricated GET",
+    "text": "fetch('https://a.io/x', buildOpts(cfg));",
+    "expect": [
+      {
+        "url": "https://a.io/x",
+        "host": "a.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a multi-line bare client call with a second options argument is not a proven bare call: REF, not a fabricated GET",
+    "text": [
+      "fetch(",
+      " 'https://a.io/x',",
+      " requestOptions,",
+      ");"
+    ],
+    "expect": [
+      {
+        "url": "https://a.io/x",
+        "host": "a.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a trailing comma after the sole url argument is still a single-argument call: GET",
+    "text": "fetch('https://a.io/x',);",
+    "expect": [
+      {
+        "url": "https://a.io/x",
+        "host": "a.io",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
   }
 ]

--- a/packages/detections/src/egress/fixtures/method-inference.json
+++ b/packages/detections/src/egress/fixtures/method-inference.json
@@ -46,12 +46,7 @@
   },
   {
     "label": "verb-method opener reaches across a newline to a templated url",
-    "text": [
-      "axios.post(",
-      "  `https://api.acme-corp.com/v1/events/${id}`,",
-      "  payload,",
-      ")"
-    ],
+    "text": ["axios.post(", "  `https://api.acme-corp.com/v1/events/${id}`,", "  payload,", ")"],
     "expect": [
       {
         "url": "https://api.acme-corp.com/v1/events/${var}",
@@ -328,12 +323,7 @@
   },
   {
     "label": "a multi-line bare client call with a second options argument is not a proven bare call: REF, not a fabricated GET",
-    "text": [
-      "fetch(",
-      " 'https://a.io/x',",
-      " requestOptions,",
-      ");"
-    ],
+    "text": ["fetch(", " 'https://a.io/x',", " requestOptions,", ");"],
     "expect": [
       {
         "url": "https://a.io/x",

--- a/packages/detections/src/egress/fixtures/method-inference.json
+++ b/packages/detections/src/egress/fixtures/method-inference.json
@@ -1,0 +1,299 @@
+[
+  {
+    "label": "verb-method opener: axios.post( yields POST",
+    "text": "axios.post('https://api.acme-corp.com/v1/events', payload)",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/events",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "verb-method opener: axios.get( yields GET",
+    "text": "const { data } = await axios.get('https://api.acme-corp.com/v1/items');",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/items",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "verb-method opener: api.delete( yields DELETE",
+    "text": "await api.delete(\"https://api.acme-corp.com/v1/items/42\")",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/items/42",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "DELETE",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "verb-method opener reaches across a newline to a templated url",
+    "text": [
+      "axios.post(",
+      "  `https://api.acme-corp.com/v1/events/${id}`,",
+      "  payload,",
+      ")"
+    ],
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/events/${var}",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": true,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "options evidence three lines below the url yields POST",
+    "text": [
+      "const res = await fetch('https://api.acme-corp.com/v1/users',",
+      "  {",
+      "    method: 'POST',",
+      "    body: JSON.stringify(user),",
+      "  });"
+    ],
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/users",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "single-line options object still carries method evidence",
+    "text": "fetch('https://api.acme-corp.com/v1/items/42', { method: 'DELETE' })",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/items/42",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "DELETE",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a lowercase method value is normalized to the uppercase verb",
+    "text": "fetch('https://a.acme.io/x', { method: \"put\" })",
+    "expect": [
+      {
+        "url": "https://a.acme.io/x",
+        "host": "a.acme.io",
+        "port": null,
+        "transport": "https",
+        "method": "PUT",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "options evidence written with = rather than : still counts",
+    "text": "r = session.request(url='https://api.acme-corp.com/v1/x', method='POST')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/x",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "verb-first argument: http.NewRequest(\"POST\", url) yields POST",
+    "text": "req, err := http.NewRequest(\"POST\", \"https://api.twilio.com/2010-04-01/Messages.json\", body)",
+    "expect": [
+      {
+        "url": "https://api.twilio.com/2010-04-01/Messages.json",
+        "host": "api.twilio.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "verb-first argument: requests.request('PUT', url) yields PUT",
+    "text": "resp = requests.request('PUT', 'https://api.acme-corp.com/v1/items/42')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/items/42",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "PUT",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "proven bare fetch: the call closes in-window with no method key, so GET",
+    "text": "const r = await fetch('https://a.acme.io/x');",
+    "expect": [
+      {
+        "url": "https://a.acme.io/x",
+        "host": "a.acme.io",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "proven bare urlopen call yields GET",
+    "text": "body = urlopen('https://api.acme-corp.com/v1/ping').read()",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/ping",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "options object runs past the evidence window: REF, never a fabricated GET",
+    "text": [
+      "const r = await fetch('https://a.acme.io/x', {",
+      "  headers: {",
+      "    'X-Correlation-Id': 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',",
+      "  },",
+      "});"
+    ],
+    "expect": [
+      {
+        "url": "https://a.acme.io/x",
+        "host": "a.acme.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a method key whose value is not a literal verb blocks the bare-call GET",
+    "text": "fetch('https://a.acme.io/x', { method: verb })",
+    "expect": [
+      {
+        "url": "https://a.acme.io/x",
+        "host": "a.acme.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a bare constant assignment is a reference, not a call",
+    "text": "const URL = 'https://api.acme-corp.com/v1'",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a log call is not method evidence",
+    "text": "console.log('https://api.acme-corp.com/v1 failed')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a verb inside prose is not verb-first-argument evidence",
+    "text": "logger.info('POST to https://api.acme-corp.com/v1/x')",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/x",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a client-lookalike identifier is not a known client opener",
+    "text": "const r = prefetch('https://a.acme.io/x');",
+    "expect": [
+      {
+        "url": "https://a.acme.io/x",
+        "host": "a.acme.io",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "NEGATIVE: method evidence alone, with no url literal, produces nothing",
+    "text": "fetch(endpoint, { method: 'POST' })",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a verb-first argument with a fully dynamic url produces nothing",
+    "text": "req, err := http.NewRequest(\"POST\", fmt.Sprintf(\"https://%s/v1\", host), body)",
+    "expect": []
+  }
+]

--- a/packages/detections/src/egress/fixtures/method-inference.json
+++ b/packages/detections/src/egress/fixtures/method-inference.json
@@ -350,5 +350,80 @@
         "line": 1
       }
     ]
+  },
+  {
+    "label": "a method key past the URL's own statement is not evidence",
+    "text": "const ENDPOINT = 'https://api.acme-corp.com/v1';\nconst auditOptions = { method: 'POST' };",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a method key past a semicolon-less statement break is not evidence",
+    "text": "const endpoint = 'https://api.acme-corp.com/v1'\nconst auditOptions = { method: 'POST' }",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a constant inside a callback does not borrow a later sibling's method",
+    "text": "describe('suite', () => {\n  const ENDPOINT = 'https://api.acme-corp.com/v1';\n  const opts = { method: 'POST' };\n});",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a method key that is a sibling of the url key IS evidence",
+    "text": "const request = {\n  url: 'https://api.acme-corp.com/v1',\n  method: 'POST',\n};",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "a url wrapped in a helper call still takes its call's method",
+    "text": "fetch(buildUrl('https://api.acme-corp.com/v1'), { method: 'POST' });",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1
+      }
+    ]
   }
 ]

--- a/packages/detections/src/egress/fixtures/snippet-redaction.json
+++ b/packages/detections/src/egress/fixtures/snippet-redaction.json
@@ -103,5 +103,135 @@
     "label": "a Bearer-prefixed value joined by a dot, with no space delimiter, is still masked",
     "line": "Authorization: Bearer.abcdefgh",
     "expect": "Authorization: ••••"
+  },
+  {
+    "label": "a quoted Basic credential is masked and the Basic keyword survives",
+    "line": "const r = await fetch('https://api.acme.com/v1/x', { headers: { Authorization: 'Basic ZGV2OnMzY3JldFAhc3M=' } });",
+    "expect": "const r = await fetch('https://api.acme.com/v1/x', { headers: { Authorization: 'Basic ••••' } });"
+  },
+  {
+    "label": "a backtick-quoted Basic credential is masked the same way",
+    "line": "const h = {Authorization: `Basic ZGV2OnMzY3JldFAhc3M=`}",
+    "expect": "const h = {Authorization: `Basic ••••`}"
+  },
+  {
+    "label": "a double-quoted Basic credential is masked the same way",
+    "line": "headers: { \"Authorization\": \"Basic ZGV2OnMzY3JldFAhc3M=\" }",
+    "expect": "headers: { \"Authorization\": \"Basic ••••\" }"
+  },
+  {
+    "label": "a quoted Token scheme credential is masked and the Token keyword survives",
+    "line": "fetch('https://a.com', { headers: { Authorization: 'Token 9f8a7b6c5d4e3f2a1b0c' } })",
+    "expect": "fetch('https://a.com', { headers: { Authorization: 'Token ••••' } })"
+  },
+  {
+    "label": "a backtick-quoted Token scheme credential is masked the same way",
+    "line": "const h = {Authorization: `Token 9f8a7b6c5d4e3f2a1b0c`}",
+    "expect": "const h = {Authorization: `Token ••••`}"
+  },
+  {
+    "label": "a quoted Digest credential is masked and the Digest keyword survives",
+    "line": "headers: { Authorization: 'Digest dXNlcjpyZWFsbTpwYXNz' }",
+    "expect": "headers: { Authorization: 'Digest ••••' }"
+  },
+  {
+    "label": "a backtick-quoted Digest credential is masked the same way",
+    "line": "const h = {Authorization: `Digest dXNlcjpyZWFsbTpwYXNz`}",
+    "expect": "const h = {Authorization: `Digest ••••`}"
+  },
+  {
+    "label": "a quoted ApiKey scheme credential is masked and the ApiKey keyword survives",
+    "line": "headers: { Authorization: 'ApiKey k-9f8a7b6c5d4e' }",
+    "expect": "headers: { Authorization: 'ApiKey ••••' }"
+  },
+  {
+    "label": "a backtick-quoted ApiKey scheme credential is masked the same way",
+    "line": "const h = {Authorization: `ApiKey k-9f8a7b6c5d4e`}",
+    "expect": "const h = {Authorization: `ApiKey ••••`}"
+  },
+  {
+    "label": "a quoted SSWS credential is masked and the SSWS keyword survives",
+    "line": "headers: { Authorization: 'SSWS 00QCjAl4MlV-WPXM' }",
+    "expect": "headers: { Authorization: 'SSWS ••••' }"
+  },
+  {
+    "label": "a backtick-quoted SSWS credential is masked the same way",
+    "line": "const h = {Authorization: `SSWS 00QCjAl4MlV-WPXM`}",
+    "expect": "const h = {Authorization: `SSWS ••••`}"
+  },
+  {
+    "label": "a quoted AWS4-HMAC-SHA256 credential is masked and the scheme keyword survives",
+    "line": "headers: { Authorization: 'AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE' }",
+    "expect": "headers: { Authorization: 'AWS4-HMAC-SHA256 ••••' }"
+  },
+  {
+    "label": "a backtick-quoted AWS4-HMAC-SHA256 credential is masked the same way",
+    "line": "const h = {Authorization: `AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE`}",
+    "expect": "const h = {Authorization: `AWS4-HMAC-SHA256 ••••`}"
+  },
+  {
+    "label": "a camelCase privateKey value is masked",
+    "line": "const c = new Client({ endpoint: 'https://api.acme.com', privateKey: 'MIIEvQIBADANBgkq' });",
+    "expect": "const c = new Client({ endpoint: 'https://api.acme.com', privateKey: '••••' });"
+  },
+  {
+    "label": "a snake_case private_key value is masked",
+    "line": "{ private_key: 'MIIEvQIBADANBgkq' }",
+    "expect": "{ private_key: '••••' }"
+  },
+  {
+    "label": "a backtick-quoted private_key value is masked",
+    "line": "const k = `private_key=MIIEvQIBADANBgkq`;",
+    "expect": "const k = `private_key=••••`;"
+  },
+  {
+    "label": "a credential value is masked",
+    "line": "{ credential: 'abc123XYZ' }",
+    "expect": "{ credential: '••••' }"
+  },
+  {
+    "label": "a plural credentials value is masked",
+    "line": "credentials: \"abc123XYZ\"",
+    "expect": "credentials: \"••••\""
+  },
+  {
+    "label": "a pwd value is masked",
+    "line": "{ pwd: 'hunter2' }",
+    "expect": "{ pwd: '••••' }"
+  },
+  {
+    "label": "a Slack webhook path is masked down to its routing prefix",
+    "line": "const WEBHOOK = 'https://hooks.slack.com/services/EXAMPLE-WORKSPACE/EXAMPLE-CHANNEL/EXAMPLE-TOKEN-not-real';",
+    "expect": "const WEBHOOK = 'https://hooks.slack.com/services/••••';"
+  },
+  {
+    "label": "a backtick-quoted Slack webhook path is masked the same way",
+    "line": "await fetch(`https://hooks.slack.com/services/EXAMPLE-WORKSPACE/EXAMPLE-CHANNEL/EXAMPLE-TOKEN-not-real`);",
+    "expect": "await fetch(`https://hooks.slack.com/services/••••`);"
+  },
+  {
+    "label": "a Discord webhook id and token are masked",
+    "line": "const D = 'https://discord.com/api/webhooks/000000000000000000/EXAMPLE-WEBHOOK-token-not-real';",
+    "expect": "const D = 'https://discord.com/api/webhooks/••••';"
+  },
+  {
+    "label": "a Zapier catch-hook path is masked",
+    "line": "const Z = 'https://hooks.zapier.com/hooks/catch/000000/example-not-real/';",
+    "expect": "const Z = 'https://hooks.zapier.com/hooks/••••';"
+  },
+  {
+    "label": "a Teams inbound webhook path is masked",
+    "line": "const T = 'https://outlook.office.com/webhook/example-id/IncomingWebhook/EXAMPLE-not-real';",
+    "expect": "const T = 'https://outlook.office.com/webhook/••••';"
+  },
+  {
+    "label": "NEGATIVE: a non-webhook path on a webhook host keeps its segments",
+    "line": "const api = 'https://discord.com/api/v10/users/@me';",
+    "expect": "const api = 'https://discord.com/api/v10/users/@me';"
+  },
+  {
+    "label": "NEGATIVE: a scheme keyword opening an ordinary sentence keeps its next word",
+    "line": "// Basic auth is disabled; Digest handshakes are rejected outright",
+    "expect": "// Basic auth is disabled; Digest handshakes are rejected outright"
   }
 ]

--- a/packages/detections/src/egress/fixtures/snippet-redaction.json
+++ b/packages/detections/src/egress/fixtures/snippet-redaction.json
@@ -78,5 +78,30 @@
     "label": "an over-long line is truncated to 200 characters",
     "line": "// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "expect": "// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  },
+  {
+    "label": "a backtick-quoted bearer token in a template literal is masked, not leaked",
+    "line": "const h = {Authorization: `Bearer sk_live_51H8xyzABCDEFGHIJ`}",
+    "expect": "const h = {Authorization: `Bearer ••••`}"
+  },
+  {
+    "label": "an api_key value embedded in a backtick template literal is masked",
+    "line": "const u = `https://api.acme-corp.com/v1?api_key=abc123`;",
+    "expect": "const u = `https://api.acme-corp.com/v1?api_key=••••`;"
+  },
+  {
+    "label": "an apikey value wrapped in backticks is masked like the quoted forms",
+    "line": "apikey=`XYZ987`",
+    "expect": "apikey=`••••`"
+  },
+  {
+    "label": "a Bearer-prefixed value joined by a hyphen, with no space delimiter, is still masked",
+    "line": "Authorization: Bearer-prefixed-secret",
+    "expect": "Authorization: ••••"
+  },
+  {
+    "label": "a Bearer-prefixed value joined by a dot, with no space delimiter, is still masked",
+    "line": "Authorization: Bearer.abcdefgh",
+    "expect": "Authorization: ••••"
   }
 ]

--- a/packages/detections/src/egress/fixtures/snippet-redaction.json
+++ b/packages/detections/src/egress/fixtures/snippet-redaction.json
@@ -1,0 +1,82 @@
+[
+  {
+    "label": "userinfo credentials are stripped out of the authority",
+    "line": "curl https://svc:s3cr3t@api.acme-corp.com/v1/push",
+    "expect": "curl https://api.acme-corp.com/v1/push"
+  },
+  {
+    "label": "an api_key value is masked while the key itself stays readable",
+    "line": "const u = 'https://api.acme-corp.com/v1?api_key=abc123';",
+    "expect": "const u = 'https://api.acme-corp.com/v1?api_key=••••';"
+  },
+  {
+    "label": "an apikey value written without a separator is masked",
+    "line": "apikey='XYZ987'",
+    "expect": "apikey='••••'"
+  },
+  {
+    "label": "a bearer TOKEN is masked and the Bearer keyword survives",
+    "line": "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjMifQ.SflKxwRJSM",
+    "expect": "Authorization: Bearer ••••"
+  },
+  {
+    "label": "a quoted bearer token inside a headers object is masked the same way",
+    "line": "headers: { Authorization: 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.abc' }",
+    "expect": "headers: { Authorization: 'Bearer ••••' }"
+  },
+  {
+    "label": "a non-bearer authorization value is masked outright",
+    "line": "Authorization: abc123def",
+    "expect": "Authorization: ••••"
+  },
+  {
+    "label": "a sig value is masked and the following query parameter survives",
+    "line": "const url = 'https://acct.blob.core.windows.net/c/b?sig=aB3%2FxYz&se=2026';",
+    "expect": "const url = 'https://acct.blob.core.windows.net/c/b?sig=••••&se=2026';"
+  },
+  {
+    "label": "an X-Sas-Token header value is masked",
+    "line": "X-Sas-Token: abc.def.ghi",
+    "expect": "X-Sas-Token: ••••"
+  },
+  {
+    "label": "a quoted password value is masked inside its quotes",
+    "line": "password: \"hunter2\"",
+    "expect": "password: \"••••\""
+  },
+  {
+    "label": "an access_token value is masked",
+    "line": "access_token: 'ya29.a0AfH6SMBabc'",
+    "expect": "access_token: '••••'"
+  },
+  {
+    "label": "every secret on a line is masked, not just the first",
+    "line": "{ api_key: 'A1B2C3', token: 'D4E5F6' }",
+    "expect": "{ api_key: '••••', token: '••••' }"
+  },
+  {
+    "label": "leading and trailing whitespace is trimmed",
+    "line": "    const r = await fetch('https://api.stripe.com/v1/charges');   ",
+    "expect": "const r = await fetch('https://api.stripe.com/v1/charges');"
+  },
+  {
+    "label": "NEGATIVE: an ordinary source line passes through unchanged",
+    "line": "const r = await fetch('https://api.stripe.com/v1/charges');",
+    "expect": "const r = await fetch('https://api.stripe.com/v1/charges');"
+  },
+  {
+    "label": "NEGATIVE: a secret-like word with no assigned value is left alone",
+    "line": "// token bucket refill rate is 10/s",
+    "expect": "// token bucket refill rate is 10/s"
+  },
+  {
+    "label": "NEGATIVE: an email address is not mistaken for userinfo",
+    "line": "// owner: platform-team@acme-corp.com",
+    "expect": "// owner: platform-team@acme-corp.com"
+  },
+  {
+    "label": "an over-long line is truncated to 200 characters",
+    "line": "// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "expect": "// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+  }
+]

--- a/packages/detections/src/egress/fixtures/url-extraction.json
+++ b/packages/detections/src/egress/fixtures/url-extraction.json
@@ -1,0 +1,405 @@
+[
+  {
+    "label": "fetch of a literal https URL yields one hit with the host portless",
+    "text": "const charge = await fetch('https://api.stripe.com/v1/charges');",
+    "expect": [
+      {
+        "url": "https://api.stripe.com/v1/charges",
+        "host": "api.stripe.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "template literal keeps the ${var} token in the path and sets template",
+    "text": "const metricsUrl = `https://api.newrelic.com/v2/apps/${appId}/metrics.json`;",
+    "expect": [
+      {
+        "url": "https://api.newrelic.com/v2/apps/${var}/metrics.json",
+        "host": "api.newrelic.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": true,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "python f-string placeholder normalizes to ${var} and sets template",
+    "text": "url = f\"https://api.x.dev/v1/{user_id}\"",
+    "expect": [
+      {
+        "url": "https://api.x.dev/v1/${var}",
+        "host": "api.x.dev",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": true,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "printf-style placeholder normalizes to ${var} and sets template",
+    "text": "apiURL := fmt.Sprintf(\"https://api.acme-corp.com/v1/users/%s\", userID)",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/users/${var}",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": true,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "wss scheme maps to the wss transport",
+    "text": "const socket = new WebSocket('wss://stream.acme-corp.com/feed');",
+    "expect": [
+      {
+        "url": "wss://stream.acme-corp.com/feed",
+        "host": "stream.acme-corp.com",
+        "port": null,
+        "transport": "wss",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "ws scheme maps to the plaintext ws transport",
+    "text": "const dev = new WebSocket('ws://events.acme-corp.com/live');",
+    "expect": [
+      {
+        "url": "ws://events.acme-corp.com/live",
+        "host": "events.acme-corp.com",
+        "port": null,
+        "transport": "ws",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "sftp scheme maps to the sftp transport",
+    "text": "SFTP_URL = \"sftp://files.acme-corp.com/uploads\"",
+    "expect": [
+      {
+        "url": "sftp://files.acme-corp.com/uploads",
+        "host": "files.acme-corp.com",
+        "port": null,
+        "transport": "sftp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "grpcs collapses to the grpc transport and its port is a separate field",
+    "text": "conn, err := grpc.Dial(\"grpcs://svc.acme-corp.com:50051\")",
+    "expect": [
+      {
+        "url": "grpc://svc.acme-corp.com:50051",
+        "host": "svc.acme-corp.com",
+        "port": 50051,
+        "transport": "grpc",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "smtp scheme maps to the smtp transport and keeps its port",
+    "text": "MAIL_URL = \"smtp://mail.acme-corp.com:587\"",
+    "expect": [
+      {
+        "url": "smtp://mail.acme-corp.com:587",
+        "host": "mail.acme-corp.com",
+        "port": 587,
+        "transport": "smtp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "userinfo is stripped from both the stored url and the snippet",
+    "text": "fetch(\"https://svc:s3cr3t@api.acme-corp.com/v1/push\")",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/push",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1,
+        "snippet": "fetch(\"https://api.acme-corp.com/v1/push\")"
+      }
+    ]
+  },
+  {
+    "label": "query string is stripped from the url and its key value is masked in the snippet",
+    "text": "const r = await fetch('https://api.acme-corp.com/v1/search?api_key=SECRET123');",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/search",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1,
+        "snippet": "const r = await fetch('https://api.acme-corp.com/v1/search?api_key=••••');"
+      }
+    ]
+  },
+  {
+    "label": "fragment is stripped from the url",
+    "text": "// https://docs.acme-corp.com/guide#section-3",
+    "expect": [
+      {
+        "url": "https://docs.acme-corp.com/guide",
+        "host": "docs.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "trailing sentence punctuation is trimmed off the url",
+    "text": "# See https://api.acme-corp.com/v1/docs.",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1/docs",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "explicit non-default port lands in port, never in host",
+    "text": "const base = 'https://api.stripe.com:8443/v1/charges';",
+    "expect": [
+      {
+        "url": "https://api.stripe.com:8443/v1/charges",
+        "host": "api.stripe.com",
+        "port": 8443,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a scheme default port is dropped from both url and port",
+    "text": "const base = 'https://api.acme-corp.com:443/v1';",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "a bare origin normalizes to a single trailing slash path",
+    "text": "const r = await fetch('https://api.acme-corp.com');",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "line numbers track the raw text across several lines",
+    "text": [
+      "const a = 'https://api.stripe.com/v1/charges';",
+      "const b = 'https://api.twilio.com/2010-04-01/Accounts';"
+    ],
+    "expect": [
+      {
+        "url": "https://api.stripe.com/v1/charges",
+        "host": "api.stripe.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      },
+      {
+        "url": "https://api.twilio.com/2010-04-01/Accounts",
+        "host": "api.twilio.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2
+      }
+    ]
+  },
+  {
+    "label": "CRLF line endings do not shift line numbers or leak into the snippet",
+    "text": "const a = 'https://api.stripe.com/v1/charges';\r\nconst b = 'https://api.twilio.com/x';",
+    "expect": [
+      {
+        "url": "https://api.stripe.com/v1/charges",
+        "host": "api.stripe.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1,
+        "snippet": "const a = 'https://api.stripe.com/v1/charges';"
+      },
+      {
+        "url": "https://api.twilio.com/x",
+        "host": "api.twilio.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 2,
+        "snippet": "const b = 'https://api.twilio.com/x';"
+      }
+    ]
+  },
+  {
+    "label": "an uppercased host is lowercased",
+    "text": "const base = 'https://API.Acme-Corp.COM/v1';",
+    "expect": [
+      {
+        "url": "https://api.acme-corp.com/v1",
+        "host": "api.acme-corp.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an uppercased host on a non-special scheme is lowercased too",
+    "text": "SFTP_URL = \"sftp://Files.ACME-corp.com/uploads\"",
+    "expect": [
+      {
+        "url": "sftp://files.acme-corp.com/uploads",
+        "host": "files.acme-corp.com",
+        "port": null,
+        "transport": "sftp",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "NEGATIVE: a placeholder in the authority drops the hit (fully dynamic host)",
+    "text": "const url = `https://${base}/v1`;",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a templated subdomain is still an authority placeholder",
+    "text": "url = f\"https://{tenant}.acme-corp.com/v1\"",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a templated port cannot be parsed and is dropped",
+    "text": "const u = `https://api.acme-corp.com:${port}/v1`;",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a bare host literal with no scheme is not a URL",
+    "text": "const host = 'api.acme-corp.com/v1';",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE: a scheme this pass does not cover is ignored",
+    "text": "const conn = 'postgres://db.acme-corp.com:5432/app';",
+    "expect": []
+  },
+  {
+    "label": "NEGATIVE (known gap): bracketed IPv6 authorities are not matched",
+    "text": "const r = await fetch('http://[2001:db8::1]/health');",
+    "expect": []
+  },
+  {
+    "label": "localhost is extracted raw and excluded downstream by resolveHost",
+    "text": "const r = await fetch('http://localhost:3000/x');",
+    "resolvesToNull": true,
+    "expect": [
+      {
+        "url": "http://localhost:3000/x",
+        "host": "localhost",
+        "port": 3000,
+        "transport": "http",
+        "method": "GET",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "example.com is extracted raw and excluded downstream by resolveHost",
+    "text": "// https://example.com/docs",
+    "resolvesToNull": true,
+    "expect": [
+      {
+        "url": "https://example.com/docs",
+        "host": "example.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  },
+  {
+    "label": "an xmlns schema identifier is extracted raw and excluded downstream by resolveHost",
+    "text": "const svg = '<svg xmlns=\"http://www.w3.org/2000/svg\">';",
+    "resolvesToNull": true,
+    "expect": [
+      {
+        "url": "http://www.w3.org/2000/svg",
+        "host": "www.w3.org",
+        "port": null,
+        "transport": "http",
+        "method": "REF",
+        "template": false,
+        "line": 1
+      }
+    ]
+  }
+]

--- a/packages/detections/src/egress/fixtures/url-extraction.json
+++ b/packages/detections/src/egress/fixtures/url-extraction.json
@@ -401,5 +401,69 @@
         "line": 1
       }
     ]
+  },
+  {
+    "label": "a Slack webhook keeps its host and routing prefix but not the token segments",
+    "text": "const WEBHOOK = 'https://hooks.slack.com/services/EXAMPLE-WORKSPACE/EXAMPLE-CHANNEL/EXAMPLE-TOKEN-not-real';",
+    "expect": [
+      {
+        "url": "https://hooks.slack.com/services/••••",
+        "host": "hooks.slack.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1,
+        "snippet": "const WEBHOOK = 'https://hooks.slack.com/services/••••';"
+      }
+    ]
+  },
+  {
+    "label": "a Discord webhook keeps its host and routing prefix but not the id or token",
+    "text": "await fetch('https://discord.com/api/webhooks/000000000000000000/EXAMPLE-WEBHOOK-token-not-real', { method: 'POST' });",
+    "expect": [
+      {
+        "url": "https://discord.com/api/webhooks/••••",
+        "host": "discord.com",
+        "port": null,
+        "transport": "https",
+        "method": "POST",
+        "template": false,
+        "line": 1,
+        "snippet": "await fetch('https://discord.com/api/webhooks/••••', { method: 'POST' });"
+      }
+    ]
+  },
+  {
+    "label": "a Zapier catch hook keeps its host and routing prefix but not the hook path",
+    "text": "const Z = 'https://hooks.zapier.com/hooks/catch/000000/example-not-real/';",
+    "expect": [
+      {
+        "url": "https://hooks.zapier.com/hooks/••••",
+        "host": "hooks.zapier.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1,
+        "snippet": "const Z = 'https://hooks.zapier.com/hooks/••••';"
+      }
+    ]
+  },
+  {
+    "label": "a non-webhook path on a webhook host keeps every segment",
+    "text": "const me = 'https://discord.com/api/v10/users/@me';",
+    "expect": [
+      {
+        "url": "https://discord.com/api/v10/users/@me",
+        "host": "discord.com",
+        "port": null,
+        "transport": "https",
+        "method": "REF",
+        "template": false,
+        "line": 1,
+        "snippet": "const me = 'https://discord.com/api/v10/users/@me';"
+      }
+    ]
   }
 ]

--- a/packages/detections/test/egress/extract.test.ts
+++ b/packages/detections/test/egress/extract.test.ts
@@ -125,6 +125,28 @@ describe('extractEgress — general shape', () => {
     expect(hits).toHaveLength(1);
     expect(hits[0]?.snippet.length).toBe(SNIPPET_MAX);
   });
+
+  it('keeps the hit inside the snippet when it sits far along a long line', () => {
+    // A minified bundle puts a whole file on one line. Capping from the start
+    // of the line would store 200 characters that never mention the hit.
+    const padding = 'y'.repeat(400);
+    const hits = extractEgress(`// ${padding}; const u = 'https://api.acme-corp.com/v1';`);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.snippet.length).toBe(SNIPPET_MAX);
+    expect(hits[0]?.snippet).toContain('https://api.acme-corp.com/v1');
+  });
+
+  it('masks a secret that falls outside the snippet window', () => {
+    // Redaction runs over the whole line, so a credential the window never
+    // shows cannot reappear when the window moves.
+    const padding = 'y'.repeat(400);
+    const hits = extractEgress(
+      `const k = 'api_key=SUPERSECRET'; // ${padding}; const u = 'https://api.acme-corp.com/v1';`,
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.snippet).toContain('https://api.acme-corp.com/v1');
+    expect(hits[0]?.snippet).not.toContain('SUPERSECRET');
+  });
 });
 
 describe('redactSnippet — fixture corpus', () => {

--- a/packages/detections/test/egress/extract.test.ts
+++ b/packages/detections/test/egress/extract.test.ts
@@ -1,0 +1,191 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { HttpMethod, Transport } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import {
+  EGRESS_CODE_EXTENSIONS,
+  extractEgress,
+  isVendoredPath,
+  redactSnippet,
+} from '../../src/egress/extract.ts';
+import { resolveHost } from '../../src/egress/registry.ts';
+
+const fixturesDir = join(fileURLToPath(new URL('.', import.meta.url)), '../../src/egress/fixtures');
+
+const SNIPPET_MAX = 200;
+
+interface ExpectedHit {
+  url: string;
+  host: string;
+  port: number | null;
+  transport: Transport;
+  method: HttpMethod;
+  template: boolean;
+  line: number;
+  snippet?: string;
+}
+
+// `text` may be a single string or an array of lines joined with '\n', so
+// multi-line cases stay readable in the fixture. `resolvesToNull` marks hits
+// the extractor emits raw but the registry excludes downstream.
+interface ExtractionCase {
+  label: string;
+  text: string | string[];
+  expect: ExpectedHit[];
+  resolvesToNull?: boolean;
+}
+
+interface RedactionCase {
+  label: string;
+  line: string;
+  expect: string;
+}
+
+function loadCases<T>(file: string): T[] {
+  return JSON.parse(readFileSync(join(fixturesDir, file), 'utf8')) as T[];
+}
+
+function textOf(c: ExtractionCase): string {
+  return Array.isArray(c.text) ? c.text.join('\n') : c.text;
+}
+
+function comparable(hit: ExpectedHit): Omit<ExpectedHit, 'snippet'> {
+  return {
+    url: hit.url,
+    host: hit.host,
+    port: hit.port,
+    transport: hit.transport,
+    method: hit.method,
+    template: hit.template,
+    line: hit.line,
+  };
+}
+
+function describeExtractionCorpus(title: string, file: string): void {
+  const cases = loadCases<ExtractionCase>(file);
+
+  describe(title, () => {
+    it('carries at least 2 positive and 2 negative cases', () => {
+      expect(cases.filter((c) => c.expect.length > 0).length).toBeGreaterThanOrEqual(2);
+      expect(cases.filter((c) => c.expect.length === 0).length).toBeGreaterThanOrEqual(2);
+    });
+
+    it.each(cases.map((c) => [c.label, c] as const))('%s', (_label, c) => {
+      const hits = extractEgress(textOf(c));
+
+      expect(hits.map((h) => comparable(h))).toEqual(c.expect.map((e) => comparable(e)));
+
+      c.expect.forEach((want, i) => {
+        if (want.snippet !== undefined) expect(hits[i]?.snippet).toBe(want.snippet);
+      });
+
+      for (const hit of hits) {
+        expect(hit.snippet.length).toBeLessThanOrEqual(SNIPPET_MAX);
+        if (c.resolvesToNull === true) expect(resolveHost(hit.host)).toBeNull();
+      }
+    });
+  });
+}
+
+describeExtractionCorpus('extractEgress — url corpus', 'url-extraction.json');
+describeExtractionCorpus('extractEgress — method-inference corpus', 'method-inference.json');
+describeExtractionCorpus('extractEgress — bare-IP corpus', 'ip-extraction.json');
+
+describe('extractEgress — general shape', () => {
+  it('returns nothing for text with no destination literal', () => {
+    expect(extractEgress('export function add(a: number, b: number) {\n  return a + b;\n}\n')).toEqual(
+      [],
+    );
+  });
+
+  it('returns hits in line order', () => {
+    const hits = extractEgress(
+      [
+        "const c = 'https://api.stripe.com/v1/charges';",
+        "const t = 'https://api.twilio.com/2010-04-01/Accounts';",
+        "const s = 'https://sentry.io/api/1/store/';",
+      ].join('\n'),
+    );
+    expect(hits.map((h) => h.line)).toEqual([1, 2, 3]);
+  });
+
+  it('redacts the snippet it stores alongside a hit', () => {
+    const hits = extractEgress("fetch('https://api.acme-corp.com/v1?token=SUPERSECRET');");
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.snippet).toBe("fetch('https://api.acme-corp.com/v1?token=••••');");
+    expect(hits[0]?.snippet).not.toContain('SUPERSECRET');
+  });
+
+  it('never emits a snippet longer than the cap', () => {
+    const padding = 'y'.repeat(400);
+    const hits = extractEgress(`const u = 'https://api.acme-corp.com/v1'; // ${padding}`);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.snippet.length).toBe(SNIPPET_MAX);
+  });
+});
+
+describe('redactSnippet — fixture corpus', () => {
+  const cases = loadCases<RedactionCase>('snippet-redaction.json');
+
+  it('carries at least 2 masking and 2 pass-through cases', () => {
+    expect(cases.filter((c) => c.line.trim() !== c.expect).length).toBeGreaterThanOrEqual(2);
+    expect(cases.filter((c) => c.line.trim() === c.expect).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(cases.map((c) => [c.label, c] as const))('%s', (_label, c) => {
+    const redacted = redactSnippet(c.line);
+    expect(redacted).toBe(c.expect);
+    expect(redacted.length).toBeLessThanOrEqual(SNIPPET_MAX);
+  });
+});
+
+describe('EGRESS_CODE_EXTENSIONS', () => {
+  it('mirrors the scanner source-extension list, dots included', () => {
+    expect([...EGRESS_CODE_EXTENSIONS]).toEqual([
+      '.ts',
+      '.tsx',
+      '.js',
+      '.jsx',
+      '.mjs',
+      '.cjs',
+      '.py',
+      '.java',
+      '.rb',
+      '.cs',
+      '.php',
+      '.go',
+      '.rs',
+    ]);
+  });
+
+  it('matches extname output, so a dotless extension is not a member', () => {
+    expect(EGRESS_CODE_EXTENSIONS.has('.ts')).toBe(true);
+    expect(EGRESS_CODE_EXTENSIONS.has('ts')).toBe(false);
+    expect(EGRESS_CODE_EXTENSIONS.has('.md')).toBe(false);
+  });
+});
+
+describe('isVendoredPath', () => {
+  it.each([
+    ['vendor/lib/client.go', true],
+    ['src/vendor/aws/client.ts', true],
+    ['third_party/grpc/stub.py', true],
+    ['external/sdk/index.js', true],
+    ['a/b/vendor/c/d.rb', true],
+  ])('treats %s as vendored', (file, expected) => {
+    expect(isVendoredPath(file)).toBe(expected);
+  });
+
+  it.each([
+    ['src/vendored.ts', false],
+    ['src/myvendor/x.ts', false],
+    ['src/external.ts', false],
+    ['vendor.ts', false],
+    ['src/app/main.ts', false],
+  ])('treats %s as not vendored', (file, expected) => {
+    expect(isVendoredPath(file)).toBe(expected);
+  });
+});

--- a/packages/detections/test/egress/extract.test.ts
+++ b/packages/detections/test/egress/extract.test.ts
@@ -96,9 +96,9 @@ describeExtractionCorpus('extractEgress — bare-IP corpus', 'ip-extraction.json
 
 describe('extractEgress — general shape', () => {
   it('returns nothing for text with no destination literal', () => {
-    expect(extractEgress('export function add(a: number, b: number) {\n  return a + b;\n}\n')).toEqual(
-      [],
-    );
+    expect(
+      extractEgress('export function add(a: number, b: number) {\n  return a + b;\n}\n'),
+    ).toEqual([]);
   });
 
   it('returns hits in line order', () => {


### PR DESCRIPTION
**Stacked PR 4 of 13** — base: `egress-stack/03-registry`. Depends on #75.

extractEgress: raw-text URL/IP matching, per-candidate template normalization, a five-rule method ladder that emits REF rather than a fabricated GET when evidence is absent, and redactSnippet, which masks credentials for every auth scheme (Bearer/Basic/Token/…) and webhook path secrets.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).