### PR TITLE
feat(egress) [6/13]: detections — resolution, dedupe, and public surface

### DIFF
--- a/packages/detections/src/egress/resolve.ts
+++ b/packages/detections/src/egress/resolve.ts
@@ -1,0 +1,148 @@
+// Composes one project's raw extraction output — URL/IP hits per file plus
+// manifest SDK hits per file — with the provider registry into the resolved,
+// deduplicated shape the store writer consumes.
+//
+// Pure like everything in @akasecurity/detections: no I/O, no Node-API
+// imports.
+import type { HttpMethod, ResolvedEgressHit } from '@akasecurity/schema';
+
+import type { RawEndpointHit } from './extract.ts';
+import type { ManifestSdkHit } from './manifests.ts';
+import { resolveHost, resolveSdk } from './registry.ts';
+
+/** One file's raw extraction output, ready for resolution. */
+export interface FileEgressHits {
+  /** A posix path relative to the project root, as recorded by the caller. */
+  file: string;
+  vendored: boolean;
+  endpoints: RawEndpointHit[];
+  sdkHits: ManifestSdkHit[];
+}
+
+const VERB_METHODS: ReadonlySet<HttpMethod> = new Set(['GET', 'POST', 'PUT', 'DELETE']);
+
+/**
+ * Resolve every file's raw URL/IP and SDK hits into fully resolved egress
+ * observations, ready for the store writer. A URL/IP hit whose host
+ * `resolveHost` excludes, or an SDK hit for a package `resolveSdk` does not
+ * recognize, is dropped. The remaining hits are then deduplicated: exact
+ * `(host, method, url, file, line)` duplicates collapse, and a `REF` hit is
+ * dropped when a verb-method hit shares its `(host, url)` anywhere in the
+ * batch.
+ */
+export function resolveEgress(
+  files: FileEgressHits[],
+  opts?: { internalDomains?: string[] },
+): ResolvedEgressHit[] {
+  const resolved: ResolvedEgressHit[] = [];
+
+  for (const file of files) {
+    for (const endpoint of file.endpoints) {
+      const hit = resolveEndpointHit(file, endpoint, opts);
+      if (hit !== null) resolved.push(hit);
+    }
+    for (const sdkHit of file.sdkHits) {
+      const hit = resolveSdkHit(file, sdkHit);
+      if (hit !== null) resolved.push(hit);
+    }
+  }
+
+  return dropRefsWithVerbSibling(dedupeExact(resolved));
+}
+
+// A URL/IP hit's host decides kind/trust/name/category via the registry.
+// Provider hits take the registry's most-sensitive default data class and
+// carry no network shape; every other kind carries the observed port with no
+// geo/PTR enrichment (this pass performs no DNS or geo lookup).
+function resolveEndpointHit(
+  file: FileEgressHits,
+  endpoint: RawEndpointHit,
+  opts?: { internalDomains?: string[] },
+): ResolvedEgressHit | null {
+  const resolution = resolveHost(endpoint.host, opts);
+  if (resolution === null) return null;
+
+  const isProvider = resolution.kind === 'provider';
+  return {
+    host: endpoint.host,
+    kind: resolution.kind,
+    name: resolution.name,
+    category: resolution.category,
+    trust: resolution.trust,
+    network: isProvider ? null : { port: endpoint.port, geo: null, ptr: null },
+    method: endpoint.method,
+    transport: endpoint.transport,
+    url: endpoint.url,
+    template: endpoint.template,
+    dataClass: isProvider ? (resolution.entry?.defaultDataClasses[0] ?? 'none') : 'none',
+    site: {
+      file: file.file,
+      line: endpoint.line,
+      snippet: endpoint.snippet,
+      dynamic: endpoint.template,
+      vendored: file.vendored,
+    },
+  };
+}
+
+// A manifest SDK dependency the registry recognizes becomes a synthetic
+// endpoint at the provider's canonical API base — there is no URL literal to
+// observe, so the manifest declaration line stands in for the call site.
+function resolveSdkHit(file: FileEgressHits, sdkHit: ManifestSdkHit): ResolvedEgressHit | null {
+  const entry = resolveSdk(sdkHit.ecosystem, sdkHit.pkg);
+  if (entry === null) return null;
+
+  return {
+    host: new URL(entry.apiBase).hostname,
+    kind: 'provider',
+    name: entry.name,
+    category: entry.category,
+    trust: 'recognized',
+    network: null,
+    method: 'SDK',
+    transport: 'https',
+    url: entry.apiBase,
+    template: false,
+    dataClass: entry.defaultDataClasses[0] ?? 'none',
+    site: {
+      file: file.file,
+      line: sdkHit.line,
+      snippet: sdkHit.snippet,
+      dynamic: false,
+      vendored: file.vendored,
+    },
+  };
+}
+
+// Exact-duplicate collapse: same host, method, url, file, and line.
+function dedupeExact(hits: ResolvedEgressHit[]): ResolvedEgressHit[] {
+  const seen = new Set<string>();
+  const deduped: ResolvedEgressHit[] = [];
+  for (const hit of hits) {
+    const key = exactKey(hit);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(hit);
+  }
+  return deduped;
+}
+
+function exactKey(hit: ResolvedEgressHit): string {
+  return JSON.stringify([hit.host, hit.method, hit.url, hit.site.file, hit.site.line]);
+}
+
+// A REF hit is a URL reference with no method evidence of its own. Once a
+// verb-method hit proves the same (host, url) pair really is called, the REF
+// hit adds nothing and is dropped — checked across the whole batch, not just
+// the file that produced it.
+function dropRefsWithVerbSibling(hits: ResolvedEgressHit[]): ResolvedEgressHit[] {
+  const verbPairs = new Set<string>();
+  for (const hit of hits) {
+    if (VERB_METHODS.has(hit.method)) verbPairs.add(pairKey(hit));
+  }
+  return hits.filter((hit) => hit.method !== 'REF' || !verbPairs.has(pairKey(hit)));
+}
+
+function pairKey(hit: ResolvedEgressHit): string {
+  return JSON.stringify([hit.host, hit.url]);
+}

--- a/packages/detections/src/index.ts
+++ b/packages/detections/src/index.ts
@@ -1,3 +1,21 @@
+export type { RawEndpointHit } from './egress/extract.ts';
+export {
+  EGRESS_CODE_EXTENSIONS,
+  extractEgress,
+  isVendoredPath,
+  redactSnippet,
+} from './egress/extract.ts';
+export type { ManifestKind, ManifestSdkHit } from './egress/manifests.ts';
+export { extractManifestSdks, LOCKFILE_BASENAMES, manifestKindOf } from './egress/manifests.ts';
+export type { HostResolution } from './egress/registry.ts';
+export {
+  EGRESS_VERSION_MATERIAL,
+  PROVIDER_REGISTRY,
+  resolveHost,
+  resolveSdk,
+} from './egress/registry.ts';
+export type { FileEgressHits } from './egress/resolve.ts';
+export { resolveEgress } from './egress/resolve.ts';
 export type { ScanContext } from './engine.ts';
 export { getLoadedRules, redact, registerPack, scan } from './engine.ts';
 export { maskMatch } from './mask.ts';

--- a/packages/detections/test/egress/resolve.test.ts
+++ b/packages/detections/test/egress/resolve.test.ts
@@ -1,0 +1,268 @@
+import { ResolvedEgressHit } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import type { RawEndpointHit } from '../../src/egress/extract.ts';
+import type { ManifestSdkHit } from '../../src/egress/manifests.ts';
+import { type FileEgressHits, resolveEgress } from '../../src/egress/resolve.ts';
+
+function endpointHit(overrides: Partial<RawEndpointHit> = {}): RawEndpointHit {
+  return {
+    url: 'https://api.stripe.com/v1/charges',
+    host: 'api.stripe.com',
+    port: null,
+    transport: 'https',
+    method: 'REF',
+    template: false,
+    line: 1,
+    snippet: "fetch('https://api.stripe.com/v1/charges')",
+    ...overrides,
+  };
+}
+
+function fileHits(overrides: Partial<FileEgressHits> = {}): FileEgressHits {
+  return {
+    file: 'src/billing.ts',
+    vendored: false,
+    endpoints: [],
+    sdkHits: [],
+    ...overrides,
+  };
+}
+
+function sdkHit(overrides: Partial<ManifestSdkHit> = {}): ManifestSdkHit {
+  return {
+    ecosystem: 'npm',
+    pkg: 'stripe',
+    line: 12,
+    snippet: '"stripe": "^14.0.0"',
+    ...overrides,
+  };
+}
+
+describe('resolveEgress — URL/IP hit resolution', () => {
+  it('resolves a provider URL hit into a provider row: top data class, null network', () => {
+    const hits = resolveEgress([fileHits({ endpoints: [endpointHit({ method: 'GET' })] })]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.host).toBe('api.stripe.com');
+    expect(hits[0]?.kind).toBe('provider');
+    expect(hits[0]?.trust).toBe('recognized');
+    expect(hits[0]?.dataClass).toBe('customer');
+    expect(hits[0]?.network).toBeNull();
+  });
+
+  it('resolves an unrecognized public-domain hit as external/unverified with populated network', () => {
+    const hits = resolveEgress([
+      fileHits({
+        endpoints: [
+          endpointHit({
+            url: 'https://api.acme-partner.com/v1/orders',
+            host: 'api.acme-partner.com',
+            port: 8443,
+          }),
+        ],
+      }),
+    ]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('external');
+    expect(hits[0]?.trust).toBe('unverified');
+    expect(hits[0]?.dataClass).toBe('none');
+    expect(hits[0]?.network).toEqual({ port: 8443, geo: null, ptr: null });
+  });
+
+  it('resolves a bare public IP reference as ip/ip with populated network', () => {
+    const hits = resolveEgress([
+      fileHits({
+        endpoints: [
+          endpointHit({
+            url: 'http://203.0.113.10:8080',
+            host: '203.0.113.10',
+            port: 8080,
+            transport: 'http',
+            method: 'REF',
+          }),
+        ],
+      }),
+    ]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('ip');
+    expect(hits[0]?.trust).toBe('ip');
+    expect(hits[0]?.dataClass).toBe('none');
+    expect(hits[0]?.network).toEqual({ port: 8080, geo: null, ptr: null });
+  });
+
+  it('drops a hit whose host resolveHost excludes', () => {
+    const hits = resolveEgress([
+      fileHits({
+        endpoints: [
+          endpointHit({
+            url: 'http://localhost:3000/health',
+            host: 'localhost',
+            port: 3000,
+            transport: 'http',
+          }),
+        ],
+      }),
+    ]);
+    expect(hits).toEqual([]);
+  });
+
+  it('honors caller-supplied internalDomains when resolving a host', () => {
+    const hits = resolveEgress(
+      [
+        fileHits({
+          endpoints: [
+            endpointHit({
+              url: 'https://svc.mycorp.dev/api',
+              host: 'svc.mycorp.dev',
+              method: 'GET',
+            }),
+          ],
+        }),
+      ],
+      { internalDomains: ['mycorp.dev'] },
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.kind).toBe('internal');
+    expect(hits[0]?.trust).toBe('internal');
+  });
+
+  it('carries the call site through from the file and hit: file, line, snippet, dynamic, vendored', () => {
+    const hits = resolveEgress([
+      fileHits({
+        file: 'vendor/lib/client.ts',
+        vendored: true,
+        endpoints: [
+          endpointHit({
+            method: 'GET',
+            template: true,
+            line: 7,
+            snippet: "fetch('https://api.stripe.com/v1/${id}')",
+          }),
+        ],
+      }),
+    ]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.template).toBe(true);
+    expect(hits[0]?.site).toEqual({
+      file: 'vendor/lib/client.ts',
+      line: 7,
+      snippet: "fetch('https://api.stripe.com/v1/${id}')",
+      dynamic: true,
+      vendored: true,
+    });
+  });
+});
+
+describe('resolveEgress — SDK hit resolution', () => {
+  it('resolves a recognized SDK dependency into a synthetic endpoint at the provider apiBase', () => {
+    const hits = resolveEgress([fileHits({ file: 'package.json', sdkHits: [sdkHit()] })]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.host).toBe('api.stripe.com');
+    expect(hits[0]?.kind).toBe('provider');
+    expect(hits[0]?.method).toBe('SDK');
+    expect(hits[0]?.transport).toBe('https');
+    expect(hits[0]?.url).toBe('https://api.stripe.com');
+    expect(hits[0]?.template).toBe(false);
+    expect(hits[0]?.network).toBeNull();
+    expect(hits[0]?.dataClass).toBe('customer');
+    expect(hits[0]?.site.file).toBe('package.json');
+    expect(hits[0]?.site.line).toBe(12);
+  });
+
+  it('drops an SDK hit for a package the registry does not recognize', () => {
+    const hits = resolveEgress([
+      fileHits({ file: 'package.json', sdkHits: [sdkHit({ pkg: 'left-pad' })] }),
+    ]);
+    expect(hits).toEqual([]);
+  });
+});
+
+describe('resolveEgress — dedupe', () => {
+  it('collapses exact-duplicate hits on (host, method, url, file, line)', () => {
+    const dup = endpointHit({ method: 'GET' });
+    const hits = resolveEgress([fileHits({ endpoints: [dup, { ...dup }] })]);
+    expect(hits).toHaveLength(1);
+  });
+
+  it('drops a REF hit when a verb-method hit shares its (host, url)', () => {
+    const refHit = endpointHit({ method: 'REF', line: 5 });
+    const getHit = endpointHit({ method: 'GET', line: 9 });
+    const hits = resolveEgress([fileHits({ endpoints: [refHit, getHit] })]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.method).toBe('GET');
+    expect(hits[0]?.site.line).toBe(9);
+  });
+
+  it('drops a REF hit for a verb-method sibling anywhere in the batch, not only the same file', () => {
+    const refHit = endpointHit({ method: 'REF' });
+    const getHit = endpointHit({ method: 'GET' });
+    const hits = resolveEgress([
+      fileHits({ file: 'src/a.ts', endpoints: [refHit] }),
+      fileHits({ file: 'src/b.ts', endpoints: [getHit] }),
+    ]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.method).toBe('GET');
+    expect(hits[0]?.site.file).toBe('src/b.ts');
+  });
+
+  it('keeps a REF hit when no verb-method hit shares its (host, url)', () => {
+    const hits = resolveEgress([fileHits({ endpoints: [endpointHit({ method: 'REF' })] })]);
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.method).toBe('REF');
+  });
+
+  it('keeps a REF hit against a verb-method hit for a different url on the same host', () => {
+    const refHit = endpointHit({ method: 'REF', url: 'https://api.stripe.com/v1/refunds' });
+    const getHit = endpointHit({ method: 'GET', url: 'https://api.stripe.com/v1/charges' });
+    const hits = resolveEgress([fileHits({ endpoints: [refHit, getHit] })]);
+    expect(hits).toHaveLength(2);
+    expect(new Set(hits.map((h) => h.method))).toEqual(new Set(['REF', 'GET']));
+  });
+
+  it('lets an SDK synthetic endpoint coexist with a literal endpoint of the same provider', () => {
+    const hits = resolveEgress([
+      fileHits({
+        file: 'src/billing.ts',
+        endpoints: [endpointHit({ method: 'GET', url: 'https://api.stripe.com/v1/charges' })],
+      }),
+      fileHits({ file: 'package.json', sdkHits: [sdkHit()] }),
+    ]);
+    expect(hits).toHaveLength(2);
+    expect(new Set(hits.map((h) => h.host))).toEqual(new Set(['api.stripe.com']));
+    expect(new Set(hits.map((h) => h.method))).toEqual(new Set(['GET', 'SDK']));
+  });
+});
+
+describe('resolveEgress — schema conformance', () => {
+  it('every resolved hit parses as ResolvedEgressHit', () => {
+    const hits = resolveEgress([
+      fileHits({
+        file: 'src/billing.ts',
+        vendored: true,
+        endpoints: [
+          endpointHit({ method: 'GET' }),
+          endpointHit({
+            url: 'https://api.acme-partner.com/v1',
+            host: 'api.acme-partner.com',
+            method: 'POST',
+            line: 4,
+          }),
+          endpointHit({
+            url: 'http://203.0.113.10:8080',
+            host: '203.0.113.10',
+            port: 8080,
+            transport: 'http',
+            method: 'REF',
+            line: 6,
+          }),
+        ],
+      }),
+      fileHits({ file: 'package.json', sdkHits: [sdkHit()] }),
+    ]);
+
+    expect(hits.length).toBeGreaterThan(0);
+    for (const hit of hits) {
+      expect(() => ResolvedEgressHit.parse(hit)).not.toThrow();
+    }
+  });
+});

--- a/packages/detections/test/egress/resolve.test.ts
+++ b/packages/detections/test/egress/resolve.test.ts
@@ -46,7 +46,7 @@ describe('resolveEgress — URL/IP hit resolution', () => {
     expect(hits[0]?.host).toBe('api.stripe.com');
     expect(hits[0]?.kind).toBe('provider');
     expect(hits[0]?.trust).toBe('recognized');
-    expect(hits[0]?.dataClass).toBe('customer');
+    expect(hits[0]?.dataClass).toBe('pii');
     expect(hits[0]?.network).toBeNull();
   });
 
@@ -164,7 +164,7 @@ describe('resolveEgress — SDK hit resolution', () => {
     expect(hits[0]?.url).toBe('https://api.stripe.com');
     expect(hits[0]?.template).toBe(false);
     expect(hits[0]?.network).toBeNull();
-    expect(hits[0]?.dataClass).toBe('customer');
+    expect(hits[0]?.dataClass).toBe('pii');
     expect(hits[0]?.site.file).toBe('package.json');
     expect(hits[0]?.site.line).toBe(12);
   });


### PR DESCRIPTION
**Stacked PR 6 of 13** — base: `egress-stack/05-manifests`. Depends on #77.

resolveEgress composes extraction + registry into ResolvedEgressHit[] with batch-wide REF-vs-verb dedupe, and the package index re-exports the full egress surface consumed downstream.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).