### PR TITLE
feat(egress) [7/13]: persistence — transactional project egress writer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ Keep these package boundaries intact — a forbidden import across a package wal
                      (SQLite adapter + read/view ports, plus the shared ~/.aka
                      layout/settings/fingerprint file I/O — NO fetch client, NO Drizzle)
 @akasecurity/local-ops     → @akasecurity/schema, @akasecurity/persistence, @akasecurity/detections,
-                     @akasecurity/plugin-sdk (repo-identity + project-file walkers only)
+                     @akasecurity/plugin-sdk (repo-identity, project-file walkers, and posix
+                     path normalization only)
                      (shared CLI/web-ui operations: update report + apply via npm/claude
                      child processes, the agent-plugin registry, the fs scan pipeline,
                      the project-inventory pass; network ONLY via package-manager

--- a/packages/local-ops/src/egress-record.ts
+++ b/packages/local-ops/src/egress-record.ts
@@ -1,11 +1,11 @@
 import { realpathSync, statSync } from 'node:fs';
-import { basename, dirname, relative, resolve, sep } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 
 import type { FileEgressHits } from '@akasecurity/detections';
 import { isVendoredPath, resolveEgress } from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
 import { defaultDataDir, readWorkspaceSettings } from '@akasecurity/persistence';
-import { resolveRepoIdentity, resolveWorktreeRoot } from '@akasecurity/plugin-sdk';
+import { resolveRepoIdentity, resolveWorktreeRoot, toPosix } from '@akasecurity/plugin-sdk';
 import type { EgressWriteSummary } from '@akasecurity/schema';
 
 // The egress-recording pass shared by `aka scan` and the web-ui's Scan page:
@@ -25,10 +25,6 @@ import type { EgressWriteSummary } from '@akasecurity/schema';
 
 /** What one egress-recording pass wrote, for host display (`aka scan`). */
 export type EgressRecordResult = EgressWriteSummary & { project: string };
-
-function toPosix(path: string): string {
-  return path.split(sep).join('/');
-}
 
 /**
  * Record the egress `scanPathIntoStore` collected for `target`. Returns the
@@ -62,6 +58,10 @@ export function recordProjectEgress(
     let projectId: string | null;
 
     if (identity && worktreeRoot) {
+      // A linked worktree's identity resolves to its HEAD repo (resolveRepoIdentity),
+      // but paths are relativized against worktreeRoot, which is the CURRENT
+      // worktree's own root — so a linked-worktree scan shares its head repo's
+      // project key while its stored file paths are relative to its own checkout.
       root = worktreeRoot;
       // identity.url is the remote URL, or the worktree root PATH when the repo
       // has no remote. The 'git:' prefix keeps that path-shaped fallback from
@@ -90,6 +90,15 @@ export function recordProjectEgress(
       // Outside the resolved root: reconciliation is scoped to paths under it,
       // so a row keyed on a '../' path could never be replaced or cleared.
       if (file === '' || file.startsWith('../')) continue;
+      // The walk-mode reconciler's delete excludes dot-paths (`file NOT LIKE
+      // '.%' AND file NOT LIKE '%/.%'`), on the premise that this walk never
+      // descends into dot-directories. That premise does not hold — a
+      // root-level dot-file, an `.akaignore` `!` negation, or a directly-named
+      // dot-file target can all put one here — so a stored dot-path row would
+      // be one no future walk-mode scan could ever clear. Skip it instead: this
+      // pipeline simply does not record dot-path egress; the plugin scanner's
+      // ledger mode owns those files.
+      if (file.startsWith('.') || file.includes('/.')) continue;
       // `vendored` describes the path being stored — an absolute path can pick
       // up a vendor/ segment from an ancestor outside the project entirely.
       files.push({ ...hit, file, vendored: isVendoredPath(file) });

--- a/packages/local-ops/src/egress-record.ts
+++ b/packages/local-ops/src/egress-record.ts
@@ -1,0 +1,109 @@
+import { realpathSync, statSync } from 'node:fs';
+import { basename, dirname, relative, resolve, sep } from 'node:path';
+
+import type { FileEgressHits } from '@akasecurity/detections';
+import { isVendoredPath, resolveEgress } from '@akasecurity/detections';
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { defaultDataDir, readWorkspaceSettings } from '@akasecurity/persistence';
+import { resolveRepoIdentity, resolveWorktreeRoot } from '@akasecurity/plugin-sdk';
+import type { EgressWriteSummary } from '@akasecurity/schema';
+
+// The egress-recording pass shared by `aka scan` and the web-ui's Scan page:
+// take the raw per-file extraction the walk produced, anchor it to a stable
+// project identity, and hand it to the store writer.
+//
+// The walk that produced these hits is complete under the scan target, so the
+// write reconciles in 'walk' mode: stored call sites under the walked prefix
+// are replaced wholesale. The prefix is the scan target's own path relative to
+// the project root — '' for a root scan, 'src' for a subtree, and the file's
+// own path for a single-file scan, which is what keeps a one-file scan from
+// clearing the rest of the project.
+//
+// Fail-open like every store write on the scan path: recording egress is a
+// side benefit of a scan, so any failure returns null and never breaks the
+// scan that triggered it.
+
+/** What one egress-recording pass wrote, for host display (`aka scan`). */
+export type EgressRecordResult = EgressWriteSummary & { project: string };
+
+function toPosix(path: string): string {
+  return path.split(sep).join('/');
+}
+
+/**
+ * Record the egress `scanPathIntoStore` collected for `target`. Returns the
+ * project's live totals, or null when the Data Shares kill-switch is off, the
+ * target does not exist, or any step fails (fail-open). `base` is the `~/.aka`
+ * base the kill-switch is read from. The caller owns the database handle.
+ */
+export function recordProjectEgress(
+  db: LocalDatabase,
+  target: string,
+  egress: { files: FileEgressHits[] },
+  base: string = defaultDataDir(),
+): EgressRecordResult | null {
+  try {
+    if (!readWorkspaceSettings(base).dataSharesInPlace) return null;
+
+    // The identity resolvers walk UP from the target, so they need an absolute
+    // path. A nonexistent target must not resolve through its existing
+    // ancestors into a repo walk — statSync throws into the catch below.
+    const abs = resolve(target);
+    const targetDir = statSync(abs).isDirectory() ? abs : dirname(abs);
+
+    const identity = resolveRepoIdentity(abs);
+    const worktreeRoot = resolveWorktreeRoot(abs);
+
+    // The root every stored path is relative to, and the key every stored row
+    // reconciles on.
+    let root: string;
+    let projectKey: string;
+    let project: string;
+    let projectId: string | null;
+
+    if (identity && worktreeRoot) {
+      root = worktreeRoot;
+      // identity.url is the remote URL, or the worktree root PATH when the repo
+      // has no remote. The 'git:' prefix keeps that path-shaped fallback from
+      // aliasing the 'path:' key a non-git walk of the same directory produces.
+      projectKey = `git:${identity.url}`;
+      project = identity.name;
+      projectId = db.sourceProject.upsert({
+        url: identity.url,
+        name: identity.name,
+        attributes: {},
+      });
+    } else {
+      root = targetDir;
+      // Keyed on the realpath so two symlinked routes to one directory share a
+      // key, and so two directories with the same basename never collide.
+      // Relativization still uses `root` as the walker saw it.
+      const realRoot = realpathSync(targetDir);
+      projectKey = `path:${realRoot}`;
+      project = basename(realRoot);
+      projectId = null;
+    }
+
+    const files: FileEgressHits[] = [];
+    for (const hit of egress.files) {
+      const file = toPosix(relative(root, hit.file));
+      // Outside the resolved root: reconciliation is scoped to paths under it,
+      // so a row keyed on a '../' path could never be replaced or cleared.
+      if (file === '' || file.startsWith('../')) continue;
+      // `vendored` describes the path being stored — an absolute path can pick
+      // up a vendor/ segment from an ancestor outside the project entirely.
+      files.push({ ...hit, file, vendored: isVendoredPath(file) });
+    }
+
+    const summary = db.shares.recordProjectEgress({
+      projectKey,
+      project,
+      projectId,
+      reconcile: { mode: 'walk', walkedPrefix: toPosix(relative(root, abs)) },
+      hits: resolveEgress(files),
+    });
+    return { ...summary, project };
+  } catch {
+    return null;
+  }
+}

--- a/packages/local-ops/src/fs-scan.ts
+++ b/packages/local-ops/src/fs-scan.ts
@@ -8,6 +8,7 @@ import {
   extractEgress,
   extractManifestSdks,
   isVendoredPath,
+  LOCKFILE_BASENAMES,
   manifestKindOf,
   maskMatch,
   redact,
@@ -214,7 +215,17 @@ export interface ScanPathResult {
 function extractFileEgress(file: string, text: string): FileEgressHits | null {
   if (text.includes('\u0000')) return null;
 
-  const kind = manifestKindOf(basename(file));
+  const name = basename(file);
+  // Lockfiles are regenerated dependency-resolution output — every transitive
+  // package's registry URL is packaging noise, not egress. manifestKindOf
+  // already returns null for these basenames, and none of them currently
+  // carry a code extension, so this early-out changes nothing observable
+  // today; it exists so the exclusion still holds if a future lockfile
+  // basename ever does carry one, instead of relying on that gap staying
+  // empty by chance.
+  if (LOCKFILE_BASENAMES.has(name)) return null;
+
+  const kind = manifestKindOf(name);
   const sdkHits = kind === null ? [] : extractManifestSdks(text, kind);
   // A manifest is never also scanned for URL literals: package.json's own
   // registry/repository URLs are packaging metadata, not egress.

--- a/packages/local-ops/src/fs-scan.ts
+++ b/packages/local-ops/src/fs-scan.ts
@@ -1,8 +1,18 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { basename, extname, join, relative, sep } from 'node:path';
 
-import { maskMatch, redact, scan } from '@akasecurity/detections';
+import type { FileEgressHits } from '@akasecurity/detections';
+import {
+  EGRESS_CODE_EXTENSIONS,
+  extractEgress,
+  extractManifestSdks,
+  isVendoredPath,
+  manifestKindOf,
+  maskMatch,
+  redact,
+  scan,
+} from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
 import type {
   ActionTaken,
@@ -190,6 +200,29 @@ export interface ScanPathResult {
   scanned: number;
   findings: number;
   files: ScannedFileFindings[];
+  // Raw per-file egress extraction for every walked file that produced a hit.
+  // `file` is the ABSOLUTE walked path here; the recording pass relativizes it
+  // to the project root before anything reaches the store.
+  egress: { files: FileEgressHits[] };
+}
+
+// What the egress pass extracts from one already-read file, or null when the
+// file is out of scope. URL/IP extraction runs on code extensions only;
+// manifests go through manifestKindOf, which returns null for lockfiles so
+// their registry URLs are never extracted; a file carrying a NUL byte is
+// treated as binary and yields nothing.
+function extractFileEgress(file: string, text: string): FileEgressHits | null {
+  if (text.includes('\u0000')) return null;
+
+  const kind = manifestKindOf(basename(file));
+  const sdkHits = kind === null ? [] : extractManifestSdks(text, kind);
+  // A manifest is never also scanned for URL literals: package.json's own
+  // registry/repository URLs are packaging metadata, not egress.
+  const endpoints =
+    kind === null && EGRESS_CODE_EXTENSIONS.has(extname(file)) ? extractEgress(text) : [];
+
+  if (endpoints.length === 0 && sdkHits.length === 0) return null;
+  return { file, vendored: isVendoredPath(file), endpoints, sdkHits };
 }
 
 /**
@@ -204,6 +237,7 @@ export function scanPathIntoStore(
   let scanned = 0;
   let findingCount = 0;
   const files: ScannedFileFindings[] = [];
+  const egressFiles: FileEgressHits[] = [];
   for (const { path: file, gitignored } of collectFiles(target)) {
     let text: string;
     try {
@@ -212,6 +246,11 @@ export function scanPathIntoStore(
       continue; // unreadable / binary — skip
     }
     scanned++;
+    // Egress rides every file whose content was read, before the finding
+    // early-out below — a file with no detection match still has destinations.
+    const fileEgress = extractFileEgress(file, text);
+    if (fileEgress) egressFiles.push(fileEgress);
+
     const matches = scan(text, opts.rules);
     if (matches.length === 0) continue;
 
@@ -245,5 +284,5 @@ export function scanPathIntoStore(
     files.push({ path: file, gitignored, findings });
     findingCount += findings.length;
   }
-  return { scanned, findings: findingCount, files };
+  return { scanned, findings: findingCount, files, egress: { files: egressFiles } };
 }

--- a/packages/local-ops/src/index.ts
+++ b/packages/local-ops/src/index.ts
@@ -6,6 +6,8 @@ export {
   installClaudePlugin,
   updateClaudePlugin,
 } from './claude-plugin.ts';
+export type { EgressRecordResult } from './egress-record.ts';
+export { recordProjectEgress } from './egress-record.ts';
 export type { RunResult } from './exec.ts';
 export { binExists, runCapture, runInherit } from './exec.ts';
 export type {

--- a/packages/local-ops/test/egress-record.test.ts
+++ b/packages/local-ops/test/egress-record.test.ts
@@ -1,0 +1,345 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { DB_FILENAME, type LocalDatabase, openLocalDatabase } from '@akasecurity/persistence';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { recordProjectEgress } from '../src/egress-record.ts';
+import { scanPathIntoStore } from '../src/fs-scan.ts';
+
+const REMOTE_URL = 'https://github.com/acme/payments-api.git';
+
+// A minimal on-disk git repo: a `.git` DIRECTORY (what the identity resolver
+// detects) whose `config` carries the remote the identity is derived from.
+// Omitting the remote exercises the path-shaped identity fallback.
+function initRepo(root: string, remoteUrl?: string): void {
+  mkdirSync(join(root, '.git'));
+  writeFileSync(
+    join(root, '.git', 'config'),
+    remoteUrl ? `[remote "origin"]\n\turl = ${remoteUrl}\n` : '',
+  );
+}
+
+// One source file whose only egress is a POST to `host`.
+function writeCall(file: string, host: string): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `fetch('https://${host}/v1/go', { method: 'POST' });\n`);
+}
+
+// Settings under a ~/.aka-shaped base, so the toggle is read through the real
+// loader rather than a hand-built object.
+function writeSettings(base: string, dataSharesInPlace: boolean): void {
+  mkdirSync(join(base, 'settings'), { recursive: true });
+  writeFileSync(
+    join(base, 'settings', 'settings.json'),
+    JSON.stringify({ dataSharesInPlace }, null, 2),
+  );
+}
+
+interface StoredSite {
+  projectKey: string;
+  project: string;
+  projectId: string | null;
+  file: string;
+  host: string;
+  method: string;
+  url: string;
+  vendored: number;
+}
+
+// Raw at-rest rows, straight from the store file — the assertions are on what
+// actually hit disk, independent of any read port.
+function storedSites(dir: string): StoredSite[] {
+  const raw = new DatabaseSync(join(dir, DB_FILENAME), { readOnly: true });
+  try {
+    return raw
+      .prepare(
+        `SELECT c.project_key AS projectKey, c.project AS project, c.project_id AS projectId,
+                c.file AS file, d.host AS host, e.method AS method, e.url AS url,
+                c.vendored AS vendored
+           FROM share_call_site c
+           JOIN share_endpoint e ON e.id = c.endpoint_id
+           JOIN share_destination d ON d.id = e.destination_id
+          ORDER BY c.project_key, c.file, e.url`,
+      )
+      .all() as unknown as StoredSite[];
+  } finally {
+    raw.close();
+  }
+}
+
+// Walk `target` and record whatever egress the walk produced — the exact
+// two-call sequence the CLI and the web-ui Scan action perform.
+function scanAndRecord(db: LocalDatabase, target: string, base: string) {
+  const result = scanPathIntoStore(db, target, { rules: [] });
+  return recordProjectEgress(db, target, result.egress, base);
+}
+
+let root: string;
+let store: string;
+let base: string;
+let db: LocalDatabase;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'aka-egress-'));
+  store = mkdtempSync(join(tmpdir(), 'aka-egress-db-'));
+  base = mkdtempSync(join(tmpdir(), 'aka-egress-home-'));
+  db = openLocalDatabase(store);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+  rmSync(store, { recursive: true, force: true });
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('recordProjectEgress — git project', () => {
+  it('keys on the remote identity and stores repo-relative posix paths', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.stripe.com');
+    writeFileSync(
+      join(root, 'package.json'),
+      `${JSON.stringify({ name: 'demo', dependencies: { stripe: '^14.0.0' } }, null, 2)}\n`,
+    );
+
+    const recorded = scanAndRecord(db, root, base);
+
+    // Display name is the remote slug; the reconcile key is the prefixed
+    // identity, never the bare one.
+    expect(recorded).toEqual({
+      project: 'payments-api',
+      destinations: 1,
+      endpoints: 2,
+      callSites: 2,
+      truncated: false,
+    });
+
+    const sites = storedSites(store);
+    expect(sites.map((s) => s.file)).toEqual(['package.json', 'src/pay.ts']);
+    expect(new Set(sites.map((s) => s.projectKey))).toEqual(new Set([`git:${REMOTE_URL}`]));
+    expect(sites.every((s) => s.project === 'payments-api')).toBe(true);
+    // The Inventory deep-link is populated on the git path.
+    expect(sites.every((s) => typeof s.projectId === 'string' && s.projectId.length > 0)).toBe(
+      true,
+    );
+    expect(sites.map((s) => s.method).sort()).toEqual(['POST', 'SDK']);
+  });
+
+  it('records the same key and paths when a subdirectory is the scan target', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, join(root, 'src'), base);
+
+    const sites = storedSites(store);
+    // Relativized against the worktree root, not the scan target: a subtree
+    // scan and a root scan agree on the stored path.
+    expect(sites.map((s) => s.file)).toEqual(['src/pay.ts']);
+    expect(sites[0]?.projectKey).toBe(`git:${REMOTE_URL}`);
+  });
+
+  it('is idempotent across repeated scans of an unchanged tree', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    const first = scanAndRecord(db, root, base);
+    const second = scanAndRecord(db, root, base);
+
+    expect(second).toEqual(first);
+    expect(storedSites(store)).toHaveLength(1);
+  });
+});
+
+describe('recordProjectEgress — walk-mode reconciliation', () => {
+  function twoDirCorpus(): void {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    writeCall(join(root, 'lib', 'old.ts'), 'api.beta-corp.com');
+  }
+
+  it('replaces only the scanned subtree, leaving sibling directories intact', () => {
+    twoDirCorpus();
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(2);
+
+    // Re-point src/ at a different host, then scan ONLY src/.
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    scanAndRecord(db, join(root, 'src'), base);
+
+    const sites = storedSites(store);
+    // src/ was replaced in place; lib/ was never walked and survives.
+    expect(sites.map((s) => `${s.file}:${s.host}`)).toEqual([
+      'lib/old.ts:api.beta-corp.com',
+      'src/pay.ts:api.gamma-corp.com',
+    ]);
+  });
+
+  it('replaces exactly one file when the scan target is that file', () => {
+    twoDirCorpus();
+    writeCall(join(root, 'src', 'other.ts'), 'api.delta-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(3);
+
+    // A single-file target must scope the replacement to that file's own path
+    // — never to its directory, and never to the whole project.
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    const recorded = scanAndRecord(db, join(root, 'src', 'pay.ts'), base);
+
+    const sites = storedSites(store);
+    expect(sites.map((s) => `${s.file}:${s.host}`)).toEqual([
+      'lib/old.ts:api.beta-corp.com',
+      'src/other.ts:api.delta-corp.com',
+      'src/pay.ts:api.gamma-corp.com',
+    ]);
+    // The summary reports live per-project totals, not just this walk's rows.
+    expect(recorded?.callSites).toBe(3);
+  });
+
+  it('does not let a single-file target delete a same-prefixed sibling', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    // Shares the 'src/pay.ts' string prefix; a prefix-only delete would take it.
+    writeCall(join(root, 'src', 'pay.ts.bak.ts'), 'api.beta-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(2);
+
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    scanAndRecord(db, join(root, 'src', 'pay.ts'), base);
+
+    expect(storedSites(store).map((s) => `${s.file}:${s.host}`)).toEqual([
+      'src/pay.ts:api.gamma-corp.com',
+      'src/pay.ts.bak.ts:api.beta-corp.com',
+    ]);
+  });
+
+  it('clears rows for a walked file whose egress is gone', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(1);
+
+    writeFileSync(join(root, 'src', 'pay.ts'), 'export const n = 1;\n');
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(storedSites(store)).toEqual([]);
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+  });
+
+  it('marks vendored call sites from the stored repo-relative path', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'vendor', 'lib', 'client.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, root, base);
+
+    const sites = storedSites(store);
+    expect(sites[0]?.file).toBe('vendor/lib/client.ts');
+    expect(sites[0]?.vendored).toBe(1);
+  });
+});
+
+describe('recordProjectEgress — non-git target', () => {
+  it('keys on the realpath of the walked directory and records no project id', () => {
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(recorded?.project).toBe(basename(root));
+    const sites = storedSites(store);
+    expect(sites[0]?.projectKey).toBe(`path:${realpathSync(root)}`);
+    expect(sites[0]?.projectId).toBeNull();
+    expect(sites[0]?.file).toBe('src/pay.ts');
+  });
+
+  it('gives two same-basename directories distinct keys', () => {
+    const a = join(root, 'a', 'app');
+    const b = join(root, 'b', 'app');
+    writeCall(join(a, 'pay.ts'), 'api.alpha-corp.com');
+    writeCall(join(b, 'pay.ts'), 'api.beta-corp.com');
+
+    scanAndRecord(db, a, base);
+    scanAndRecord(db, b, base);
+
+    const sites = storedSites(store);
+    expect(sites).toHaveLength(2);
+    expect(new Set(sites.map((s) => s.projectKey))).toEqual(
+      new Set([`path:${realpathSync(a)}`, `path:${realpathSync(b)}`]),
+    );
+    // Both are named 'app'; neither walk clobbered the other's rows.
+    expect(sites.every((s) => s.project === 'app')).toBe(true);
+    expect(new Set(sites.map((s) => s.host))).toEqual(
+      new Set(['api.alpha-corp.com', 'api.beta-corp.com']),
+    );
+  });
+
+  it('keys a single-file target on its containing directory', () => {
+    writeCall(join(root, 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, join(root, 'pay.ts'), base);
+
+    const sites = storedSites(store);
+    expect(sites[0]?.projectKey).toBe(`path:${realpathSync(root)}`);
+    expect(sites[0]?.file).toBe('pay.ts');
+  });
+});
+
+describe('recordProjectEgress — key collision safety', () => {
+  it('never aliases a remote-less repo onto the non-git key for the same path', () => {
+    // A repo with no remote falls back to a PATH-shaped identity, which is
+    // exactly the shape the non-git key is built from. The prefixes are what
+    // keep the two universes apart.
+    const repo = join(root, 'repo');
+    mkdirSync(repo);
+    initRepo(repo);
+    writeCall(join(repo, 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, repo, base);
+
+    const key = storedSites(store)[0]?.projectKey;
+    expect(key?.startsWith('git:')).toBe(true);
+    expect(key).not.toBe(`path:${realpathSync(repo)}`);
+    // The identity is the worktree root path, so only the prefix distinguishes
+    // it from a non-git walk of the same directory.
+    expect(key).toBe(`git:${repo}`);
+  });
+});
+
+describe('recordProjectEgress — fail-open', () => {
+  it('returns null and writes nothing when the kill-switch is off', () => {
+    writeSettings(base, false);
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    expect(scanAndRecord(db, root, base)).toBeNull();
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('records normally when the kill-switch is explicitly on', () => {
+    writeSettings(base, true);
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    expect(scanAndRecord(db, root, base)).toMatchObject({ callSites: 1 });
+  });
+
+  it('returns null for a target that does not exist', () => {
+    const missing = join(root, 'nope', 'gone');
+    expect(recordProjectEgress(db, missing, { files: [] }, base)).toBeNull();
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('returns null instead of throwing when the store is closed', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    const result = scanPathIntoStore(db, root, { rules: [] });
+    db.close();
+
+    expect(() => recordProjectEgress(db, root, result.egress, base)).not.toThrow();
+    expect(recordProjectEgress(db, root, result.egress, base)).toBeNull();
+
+    // Reopened for the afterEach close.
+    db = openLocalDatabase(store);
+  });
+});

--- a/packages/local-ops/test/egress-record.test.ts
+++ b/packages/local-ops/test/egress-record.test.ts
@@ -289,8 +289,13 @@ describe('recordProjectEgress — key collision safety', () => {
   it('never aliases a remote-less repo onto the non-git key for the same path', () => {
     // A repo with no remote falls back to a PATH-shaped identity, which is
     // exactly the shape the non-git key is built from. The prefixes are what
-    // keep the two universes apart.
-    const repo = join(root, 'repo');
+    // keep the two universes apart. Built under root's OWN realpath (macOS
+    // temp dirs live under a symlink, e.g. /var/folders -> /private/var/folders)
+    // so `repo` and `realpathSync(repo)` are already the same string — without
+    // this, the assertion below would pass for the unrelated reason that the
+    // two paths differ by the symlink prefix alone, never actually exercising
+    // the 'git:' / 'path:' prefix that is the thing under test.
+    const repo = join(realpathSync(root), 'repo');
     mkdirSync(repo);
     initRepo(repo);
     writeCall(join(repo, 'pay.ts'), 'api.alpha-corp.com');
@@ -303,6 +308,38 @@ describe('recordProjectEgress — key collision safety', () => {
     // The identity is the worktree root path, so only the prefix distinguishes
     // it from a non-git walk of the same directory.
     expect(key).toBe(`git:${repo}`);
+  });
+});
+
+describe('recordProjectEgress — dot-path exclusion', () => {
+  it('does not store egress from a root-level dot-file', () => {
+    initRepo(root, REMOTE_URL);
+    // fs-scan's entry.isFile() branch has no dot check, so a root-level
+    // dot-file like a real .releaserc.js IS walked and read.
+    writeCall(join(root, '.releaserc.js'), 'api.acme-webhooks.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    // The reconciler's walk-mode delete excludes dot-paths ('file NOT LIKE
+    // '.%''), so a stored row here could never be cleared by a later scan.
+    // The collector must therefore never store one in the first place.
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('does not store egress from a dot-directory reached via an .akaignore negation', () => {
+    initRepo(root, REMOTE_URL);
+    // A bare '!' re-include beats the default dot-directory skip (fs-scan.ts),
+    // so this nested file IS walked despite living under a dot-directory —
+    // proving the exclusion below is a second, independent gate, not just a
+    // restatement of the walker's own default dot-directory skip.
+    writeFileSync(join(root, '.akaignore'), '!.github/\n');
+    writeCall(join(root, '.github', 'scripts', 'notify.js'), 'api.acme-webhooks.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+    expect(storedSites(store)).toEqual([]);
   });
 });
 

--- a/packages/local-ops/test/fs-scan.test.ts
+++ b/packages/local-ops/test/fs-scan.test.ts
@@ -156,7 +156,7 @@ describe('scanPathIntoStore', () => {
     const db = openLocalDatabase(store);
     try {
       const result = scanPathIntoStore(db, root, { rules: RULES });
-      expect(result).toEqual({ scanned: 1, findings: 0, files: [] });
+      expect(result).toEqual({ scanned: 1, findings: 0, files: [], egress: { files: [] } });
       expect(storedEvents(store)).toEqual([]);
     } finally {
       db.close();
@@ -213,6 +213,131 @@ describe('scanPathIntoStore', () => {
         filePath: join(root, 'scratch.env'),
         gitignored: true,
       });
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// The egress collection pass rides the same walk as detection scanning. What it
+// runs on is decided entirely here — the walker has no extension filter — so
+// these cases pin the gating: code extensions get URL/IP extraction, manifests
+// get SDK extraction, lockfiles and prose files get neither, and a file
+// carrying a NUL byte is treated as binary and skipped.
+describe('scanPathIntoStore — egress collection', () => {
+  // A NUL byte written as an escape so this source file stays plain text.
+  const NUL = '\u0000';
+
+  function writeCorpus(): void {
+    mkdirSync(join(root, 'src'));
+    writeFileSync(
+      join(root, 'src', 'pay.ts'),
+      `export async function charge() {\n  return fetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n}\n`,
+    );
+    writeFileSync(
+      join(root, 'package.json'),
+      `${JSON.stringify({ name: 'demo', dependencies: { stripe: '^14.0.0' } }, null, 2)}\n`,
+    );
+    // Prose: this URL extracts fine in isolation, so its absence proves the
+    // extension gate excludes it rather than the extractor failing to see it.
+    writeFileSync(join(root, 'README.md'), 'See https://api.acme-live.com/x for details.\n');
+    // Lockfile: manifestKindOf returns null and .json is not a code extension.
+    writeFileSync(
+      join(root, 'package-lock.json'),
+      `${JSON.stringify(
+        {
+          packages: {
+            'node_modules/stripe': {
+              resolved: 'https://registry.npmjs.org/stripe/-/stripe-14.0.0.tgz',
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    // Binary guard: an otherwise-extractable URL alongside a NUL byte.
+    writeFileSync(join(root, 'blob.ts'), `${NUL}const u = 'https://api.stripe.com/v1/x';\n`);
+  }
+
+  it('extracts from code files and manifests, skipping prose, lockfiles, and NUL-bearing files', () => {
+    writeCorpus();
+
+    const db = openLocalDatabase(store);
+    try {
+      // No rules at all, so every file takes the "no matches" path: a pass that
+      // only ran after the finding early-out would collect nothing here.
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.findings).toBe(0);
+
+      const byFile = new Map(result.egress.files.map((f) => [f.file, f]));
+      expect([...byFile.keys()].sort()).toEqual(
+        [join(root, 'package.json'), join(root, 'src', 'pay.ts')].sort(),
+      );
+
+      const pay = byFile.get(join(root, 'src', 'pay.ts'));
+      expect(pay?.sdkHits).toEqual([]);
+      expect(pay?.endpoints).toHaveLength(1);
+      expect(pay?.endpoints[0]).toMatchObject({
+        host: 'api.stripe.com',
+        url: 'https://api.stripe.com/v1/charges',
+        method: 'POST',
+        transport: 'https',
+        line: 2,
+      });
+
+      const manifest = byFile.get(join(root, 'package.json'));
+      expect(manifest?.endpoints).toEqual([]);
+      expect(manifest?.sdkHits).toHaveLength(1);
+      expect(manifest?.sdkHits[0]).toMatchObject({ ecosystem: 'npm', pkg: 'stripe' });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('collects egress for files that produce findings too', () => {
+    writeFileSync(
+      join(root, 'app.ts'),
+      `const key = '${SECRET}';\nfetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n`,
+    );
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: RULES });
+      expect(result.findings).toBe(1);
+      expect(result.egress.files).toHaveLength(1);
+      expect(result.egress.files[0]?.endpoints[0]?.host).toBe('api.stripe.com');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('omits files whose extraction yields nothing', () => {
+    writeFileSync(join(root, 'plain.ts'), 'export const n = 1;\n');
+    writeFileSync(join(root, 'notes.txt'), 'https://api.stripe.com/v1/charges\n');
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.scanned).toBe(2);
+      expect(result.egress.files).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('marks vendored call sites from the walked path', () => {
+    mkdirSync(join(root, 'vendor', 'lib'), { recursive: true });
+    writeFileSync(
+      join(root, 'vendor', 'lib', 'client.ts'),
+      `fetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n`,
+    );
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.egress.files).toHaveLength(1);
+      expect(result.egress.files[0]?.vendored).toBe(true);
     } finally {
       db.close();
     }

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -81,7 +81,10 @@ export { SqliteResolutionsRepository } from './repositories/resolutions.ts';
 export type { ScanLedgerEntry, ScanLedgerState } from './repositories/scan-ledger.ts';
 export { SqliteScanLedgerRepository } from './repositories/scan-ledger.ts';
 export { SqliteSecurityRepository } from './repositories/security.ts';
-export { SqliteSharesRepository } from './repositories/shares.ts';
+export {
+  MAX_EGRESS_CALL_SITES_PER_PROJECT,
+  SqliteSharesRepository,
+} from './repositories/shares.ts';
 export { SqliteSourceProjectRepository } from './repositories/source-project.ts';
 export { compareBinaryVersions } from './semver.ts';
 export { applyOnboarding, readWorkspaceSettings } from './settings.ts';

--- a/packages/persistence/src/repositories/shares.ts
+++ b/packages/persistence/src/repositories/shares.ts
@@ -6,11 +6,15 @@ import type {
   DataClass,
   DestinationKind,
   EgressDecision,
+  EgressReconcile,
+  EgressWriteSummary,
   EndpointSummary,
   HttpMethod,
   ListShareDestinationsQuery,
   ListShareDestinationsResponse,
   NeedsReviewResponse,
+  RecordProjectEgressInput,
+  ResolvedEgressHit,
   ReviewDestination,
   ShareDestinationDetail,
   ShareDestinationGroup,
@@ -30,10 +34,20 @@ import {
 } from '@akasecurity/schema';
 
 import { safeJson } from '../internal/json.ts';
-import { allRows, countBy, countScalar, getRow } from '../internal/rows.ts';
-import { containsPattern, placeholders } from '../internal/sql-text.ts';
+import { allRows, boolToInt, countBy, countScalar, getRow } from '../internal/rows.ts';
+import { containsPattern, escapeLikePattern, placeholders } from '../internal/sql-text.ts';
 import { withTransaction } from '../internal/transactions.ts';
 import type { SharesReadPort } from '../ports.ts';
+
+/**
+ * Upper bound on the call sites one write records for a project. Hits past it
+ * are dropped in input order and the write reports `truncated: true`, so a
+ * runaway project is capped visibly instead of silently.
+ */
+export const MAX_EGRESS_CALL_SITES_PER_PROJECT = 5000;
+
+/** Bind variables per `IN (…)` delete; longer file lists are split across statements. */
+const IN_CHUNK = 500;
 
 // Section order for the grouped listing — provider → internal → external → ip.
 // A kind missing here is dropped from the response, not just left unlabelled.
@@ -375,6 +389,285 @@ export class SqliteSharesRepository implements SharesReadPort {
       'IMMEDIATE',
     );
     return existed;
+  }
+
+  /**
+   * Record one project's statically-extracted egress: reconcile the previously
+   * stored call sites against this scan, upsert destination → endpoint → call
+   * site for every hit, confirm `last_seen` on everything the project still
+   * references, and drop what no longer has evidence.
+   *
+   * Reconciliation keys on `projectKey` alone; `project` and `projectId` are
+   * display payload and never scope a delete. The whole write is one
+   * transaction: a failure leaves the project's previous inventory exactly as
+   * it was, and THROWS rather than reporting a partial write — callers decide
+   * their own fail-open behavior, and the scanner additionally withholds its
+   * ledger commit so the next scan retries.
+   */
+  recordProjectEgress(input: RecordProjectEgressInput): EgressWriteSummary {
+    const truncated = input.hits.length > MAX_EGRESS_CALL_SITES_PER_PROJECT;
+    const hits = truncated ? input.hits.slice(0, MAX_EGRESS_CALL_SITES_PER_PROJECT) : input.hits;
+    const now = Date.now();
+
+    let summary: EgressWriteSummary = {
+      destinations: 0,
+      endpoints: 0,
+      callSites: 0,
+      truncated,
+    };
+    withTransaction(
+      this.db,
+      () => {
+        this.reconcileCallSites(input.projectKey, input.reconcile);
+        this.upsertHits(input, hits, now);
+        this.confirmLastSeen(input.projectKey, now);
+        this.pruneOrphans();
+        summary = { ...this.projectTotals(input.projectKey), truncated };
+      },
+      'IMMEDIATE',
+    );
+    return summary;
+  }
+
+  // ─── Egress write internals ──────────────────────────────────────────────────
+
+  /**
+   * Clear the stored call sites this scan is responsible for re-creating.
+   *
+   * Each pipeline may only delete rows its own walker could have produced. The
+   * fs walk behind 'walk' mode never descends into dot-directories, so its
+   * delete excludes dot-path files — those rows are the plugin scanner's to
+   * reconcile, and deleting them here would make the two pipelines erase each
+   * other's rows on every alternating scan. 'ledger' mode names its files
+   * outright and never mass-deletes, so rows the fs walk contributed for files
+   * the scanner skips (vendored, oversize) survive it.
+   */
+  private reconcileCallSites(projectKey: string, reconcile: EgressReconcile): void {
+    if (reconcile.mode === 'walk') {
+      const prefix = reconcile.walkedPrefix.replace(/\/+$/, '');
+      this.db
+        .prepare(
+          `DELETE FROM share_call_site
+           WHERE project_key = :key
+             AND (:prefix = '' OR file = :prefix OR file LIKE :subtree ESCAPE '\\')
+             AND file NOT LIKE '.%'
+             AND file NOT LIKE '%/.%'`,
+        )
+        // The prefix is a path, so '_' and '%' in a directory name must match
+        // literally rather than as LIKE wildcards over a sibling directory.
+        .run({ key: projectKey, prefix, subtree: `${escapeLikePattern(prefix)}/%` });
+      return;
+    }
+
+    const files = [...new Set([...reconcile.scannedFiles, ...reconcile.deletedFiles])];
+    for (let i = 0; i < files.length; i += IN_CHUNK) {
+      const chunk = files.slice(i, i + IN_CHUNK);
+      this.db
+        .prepare(
+          `DELETE FROM share_call_site
+           WHERE project_key = ? AND file IN (${placeholders(chunk.length)})`,
+        )
+        .run(projectKey, ...chunk);
+    }
+  }
+
+  /**
+   * Upsert every hit as destination → endpoint → call site. Destinations key on
+   * `host` and endpoints on `(destination_id, method, url)`, both shared across
+   * projects; only the call site carries `project_key`. A destination's `note`
+   * is user-owned and never overwritten. The id caches keep one upsert per
+   * distinct host and endpoint, so the first hit for a host supplies its
+   * classification for this batch.
+   */
+  private upsertHits(
+    input: RecordProjectEgressInput,
+    hits: ResolvedEgressHit[],
+    now: number,
+  ): void {
+    if (hits.length === 0) return;
+
+    const destStmt = this.db.prepare(
+      `INSERT INTO share_destination
+         (id, kind, name, host, category, trust, network_json, last_seen, provenance,
+          created_at, updated_at)
+       VALUES (:id, :kind, :name, :host, :category, :trust, :networkJson, :now, 'scan', :now, :now)
+       ON CONFLICT (host) DO UPDATE SET
+         kind = excluded.kind,
+         name = excluded.name,
+         category = excluded.category,
+         trust = excluded.trust,
+         network_json = excluded.network_json,
+         last_seen = excluded.last_seen,
+         updated_at = excluded.updated_at`,
+    );
+    const destIdStmt = this.db.prepare('SELECT id FROM share_destination WHERE host = ?');
+    const endpointStmt = this.db.prepare(
+      `INSERT INTO share_endpoint
+         (id, destination_id, method, transport, url, template, data_class, last_seen,
+          created_at, updated_at)
+       VALUES (:id, :destinationId, :method, :transport, :url, :template, :dataClass, :now,
+               :now, :now)
+       ON CONFLICT (destination_id, method, url) DO UPDATE SET
+         transport = excluded.transport,
+         template = excluded.template,
+         data_class = excluded.data_class,
+         last_seen = excluded.last_seen,
+         updated_at = excluded.updated_at`,
+    );
+    const endpointIdStmt = this.db.prepare(
+      'SELECT id FROM share_endpoint WHERE destination_id = ? AND method = ? AND url = ?',
+    );
+    // ON CONFLICT, not a plain INSERT: two hits can land on the same endpoint,
+    // file and line, and a UNIQUE failure would abort the whole scan's egress.
+    const siteStmt = this.db.prepare(
+      `INSERT INTO share_call_site
+         (id, endpoint_id, project, project_key, file, line, snippet, dynamic, vendored,
+          project_id, created_at, updated_at)
+       VALUES (:id, :endpointId, :project, :projectKey, :file, :line, :snippet, :dynamic,
+               :vendored, :projectId, :now, :now)
+       ON CONFLICT (endpoint_id, project_key, file, line) DO UPDATE SET
+         snippet = excluded.snippet,
+         dynamic = excluded.dynamic,
+         vendored = excluded.vendored,
+         project = excluded.project,
+         project_id = excluded.project_id,
+         updated_at = excluded.updated_at`,
+    );
+
+    const destIds = new Map<string, string>();
+    const endpointIds = new Map<string, string>();
+
+    for (const hit of hits) {
+      let destinationId = destIds.get(hit.host);
+      if (destinationId === undefined) {
+        destStmt.run({
+          id: randomUUID(),
+          kind: hit.kind,
+          name: hit.name,
+          host: hit.host,
+          category: hit.category,
+          trust: hit.trust,
+          networkJson: hit.network === null ? null : JSON.stringify(hit.network),
+          now,
+        });
+        destinationId = getRow<{ id: string }>(destIdStmt, [hit.host])?.id ?? '';
+        destIds.set(hit.host, destinationId);
+      }
+
+      const endpointKey = `${destinationId}\x00${hit.method}\x00${hit.url}`;
+      let endpointId = endpointIds.get(endpointKey);
+      if (endpointId === undefined) {
+        endpointStmt.run({
+          id: randomUUID(),
+          destinationId,
+          method: hit.method,
+          transport: hit.transport,
+          url: hit.url,
+          template: boolToInt(hit.template),
+          dataClass: hit.dataClass,
+          now,
+        });
+        endpointId =
+          getRow<{ id: string }>(endpointIdStmt, [destinationId, hit.method, hit.url])?.id ?? '';
+        endpointIds.set(endpointKey, endpointId);
+      }
+
+      siteStmt.run({
+        id: randomUUID(),
+        endpointId,
+        project: input.project,
+        projectKey: input.projectKey,
+        file: hit.site.file,
+        line: hit.site.line,
+        snippet: hit.site.snippet,
+        dynamic: boolToInt(hit.site.dynamic),
+        vendored: boolToInt(hit.site.vendored),
+        projectId: input.projectId,
+        now,
+      });
+    }
+  }
+
+  /**
+   * Stamp `last_seen` on every endpoint and destination this project still
+   * references — including rows the scan preserved rather than re-wrote, so a
+   * ledger-skipped file's references don't decay into "stale" on the page.
+   */
+  private confirmLastSeen(projectKey: string, now: number): void {
+    this.db
+      .prepare(
+        `UPDATE share_endpoint SET last_seen = :now, updated_at = :now
+         WHERE id IN (SELECT DISTINCT endpoint_id FROM share_call_site WHERE project_key = :key)`,
+      )
+      .run({ now, key: projectKey });
+    this.db
+      .prepare(
+        `UPDATE share_destination SET last_seen = :now, updated_at = :now
+         WHERE id IN (SELECT DISTINCT e.destination_id
+                      FROM share_endpoint e
+                      JOIN share_call_site c ON c.endpoint_id = e.id
+                      WHERE c.project_key = :key)`,
+      )
+      .run({ now, key: projectKey });
+  }
+
+  /**
+   * Drop rows left without evidence: endpoints with no call site, then
+   * destinations with no endpoint. Call sites are the only evidence either one
+   * has, so a row that lost its last one belongs to no project any more.
+   *
+   * Overrides are deleted between the two steps, and only the ones written
+   * before the host column existed. Those match a destination by id alone;
+   * because the id link is released on delete rather than cascading, leaving
+   * them would accumulate rows that match neither join arm and that nothing can
+   * reach again. Host-bearing rows deliberately survive — the host is what
+   * re-attaches a user's decision when the destination comes back.
+   */
+  private pruneOrphans(): void {
+    this.db.exec(
+      `DELETE FROM share_endpoint
+       WHERE NOT EXISTS (SELECT 1 FROM share_call_site c WHERE c.endpoint_id = share_endpoint.id)`,
+    );
+    this.db.exec(
+      `DELETE FROM egress_decision_override
+       WHERE host IS NULL
+         AND destination_id IN (
+           SELECT d.id FROM share_destination d
+           WHERE NOT EXISTS (SELECT 1 FROM share_endpoint e WHERE e.destination_id = d.id))`,
+    );
+    this.db.exec(
+      `DELETE FROM share_destination
+       WHERE NOT EXISTS (
+         SELECT 1 FROM share_endpoint e WHERE e.destination_id = share_destination.id)`,
+    );
+  }
+
+  /**
+   * Live totals for one project. Destinations and endpoints are shared across
+   * projects and carry no project column, so both are counted through the call
+   * sites that reference them.
+   */
+  private projectTotals(projectKey: string): Omit<EgressWriteSummary, 'truncated'> {
+    return {
+      destinations: countScalar(
+        this.db,
+        `SELECT count(DISTINCT e.destination_id) AS n
+         FROM share_endpoint e
+         JOIN share_call_site c ON c.endpoint_id = e.id
+         WHERE c.project_key = ?`,
+        [projectKey],
+      ),
+      endpoints: countScalar(
+        this.db,
+        'SELECT count(DISTINCT endpoint_id) AS n FROM share_call_site WHERE project_key = ?',
+        [projectKey],
+      ),
+      callSites: countScalar(
+        this.db,
+        'SELECT count(*) AS n FROM share_call_site WHERE project_key = ?',
+        [projectKey],
+      ),
+    };
   }
 
   // ─── Raw fetchers ────────────────────────────────────────────────────────────

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -13,6 +13,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'DATA_FILE_MODE',
   'DB_FILENAME',
   'DuplicateActiveExceptionError',
+  'MAX_EGRESS_CALL_SITES_PER_PROJECT',
   'SqliteActivityRepository',
   'SqliteAuditEventsRepository',
   'SqliteClassifiedDataRepository',

--- a/packages/persistence/test/repositories/shares-write.test.ts
+++ b/packages/persistence/test/repositories/shares-write.test.ts
@@ -1,0 +1,693 @@
+import { randomUUID } from 'node:crypto';
+import { DatabaseSync } from 'node:sqlite';
+
+import type {
+  DataClass,
+  DestinationKind,
+  DestinationNetwork,
+  EgressWriteSummary,
+  HttpMethod,
+  ResolvedEgressHit,
+  ShareTrustLevel,
+  Transport,
+} from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { applyMigrations } from '../../src/migrations.ts';
+import {
+  MAX_EGRESS_CALL_SITES_PER_PROJECT,
+  SqliteSharesRepository,
+} from '../../src/repositories/shares.ts';
+
+let db: DatabaseSync;
+let shares: SqliteSharesRepository;
+
+beforeEach(() => {
+  db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+  applyMigrations(db);
+  shares = new SqliteSharesRepository(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+// ─── Builders ────────────────────────────────────────────────────────────────
+
+interface HitOptions {
+  host?: string;
+  kind?: DestinationKind;
+  name?: string;
+  category?: string;
+  trust?: ShareTrustLevel;
+  network?: DestinationNetwork | null;
+  method?: HttpMethod;
+  transport?: Transport;
+  url?: string;
+  template?: boolean;
+  dataClass?: DataClass;
+  file?: string;
+  line?: number;
+  snippet?: string;
+  dynamic?: boolean;
+  vendored?: boolean;
+}
+
+/** One resolved hit with recognized-provider defaults; every field is overridable. */
+function hit(o: HitOptions = {}): ResolvedEgressHit {
+  const host = o.host ?? 'api.stripe.com';
+  return {
+    host,
+    kind: o.kind ?? 'provider',
+    name: o.name ?? host,
+    category: o.category ?? 'Payments',
+    trust: o.trust ?? 'recognized',
+    network: o.network ?? null,
+    method: o.method ?? 'POST',
+    transport: o.transport ?? 'https',
+    url: o.url ?? `https://${host}/v1/charges`,
+    template: o.template ?? false,
+    dataClass: o.dataClass ?? 'pii',
+    site: {
+      file: o.file ?? 'src/pay.ts',
+      line: o.line ?? 12,
+      snippet: o.snippet ?? `fetch('https://${host}/v1/charges')`,
+      dynamic: o.dynamic ?? false,
+      vendored: o.vendored ?? false,
+    },
+  };
+}
+
+/** A walk-mode write for one project; `walkedPrefix` defaults to the whole project. */
+function walk(
+  projectKey: string,
+  hits: ResolvedEgressHit[],
+  walkedPrefix = '',
+  projectId: string | null = null,
+): EgressWriteSummary {
+  return shares.recordProjectEgress({
+    projectKey,
+    project: projectKey,
+    projectId,
+    reconcile: { mode: 'walk', walkedPrefix },
+    hits,
+  });
+}
+
+/** A ledger-mode write for one project. */
+function ledger(
+  projectKey: string,
+  hits: ResolvedEgressHit[],
+  scannedFiles: string[],
+  deletedFiles: string[] = [],
+): EgressWriteSummary {
+  return shares.recordProjectEgress({
+    projectKey,
+    project: projectKey,
+    projectId: null,
+    reconcile: { mode: 'ledger', scannedFiles, deletedFiles },
+    hits,
+  });
+}
+
+// ─── Raw store readers (assertions state the stored rows, not a view) ────────
+
+function callSites(projectKey?: string): { projectKey: string; file: string; line: number }[] {
+  const sql =
+    projectKey === undefined
+      ? `SELECT project_key AS projectKey, file, line FROM share_call_site
+         ORDER BY project_key, file, line`
+      : `SELECT project_key AS projectKey, file, line FROM share_call_site
+         WHERE project_key = ? ORDER BY file, line`;
+  const stmt = db.prepare(sql);
+  const rows = projectKey === undefined ? stmt.all() : stmt.all(projectKey);
+  return rows as unknown as { projectKey: string; file: string; line: number }[];
+}
+
+function hosts(): string[] {
+  const rows = db.prepare('SELECT host FROM share_destination ORDER BY host').all();
+  return (rows as unknown as { host: string }[]).map((r) => r.host);
+}
+
+function urls(): string[] {
+  const rows = db.prepare('SELECT url FROM share_endpoint ORDER BY url').all();
+  return (rows as unknown as { url: string }[]).map((r) => r.url);
+}
+
+function destinationId(host: string): string {
+  const row = db.prepare('SELECT id FROM share_destination WHERE host = ?').get(host);
+  return (row as unknown as { id: string } | undefined)?.id ?? '';
+}
+
+function overrides(): { destinationId: string | null; host: string | null; decision: string }[] {
+  const rows = db
+    .prepare(
+      `SELECT destination_id AS destinationId, host, decision FROM egress_decision_override
+       ORDER BY coalesce(host, ''), decision`,
+    )
+    .all();
+  return rows as unknown as {
+    destinationId: string | null;
+    host: string | null;
+    decision: string;
+  }[];
+}
+
+function lastSeen(table: 'share_destination' | 'share_endpoint'): number[] {
+  const rows = db.prepare(`SELECT last_seen AS lastSeen FROM ${table} ORDER BY id`).all();
+  return (rows as unknown as { lastSeen: number }[]).map((r) => r.lastSeen);
+}
+
+// ─── Fresh writes ────────────────────────────────────────────────────────────
+
+describe('recordProjectEgress — fresh write', () => {
+  it('inserts destinations, endpoints and call sites and summarizes them', () => {
+    const summary = walk('git:alpha', [
+      hit({ file: 'src/pay.ts', line: 12 }),
+      hit({
+        method: 'GET',
+        url: 'https://api.stripe.com/v1/customers',
+        file: 'src/cust.ts',
+        line: 4,
+      }),
+    ]);
+
+    expect(summary).toEqual({ destinations: 1, endpoints: 2, callSites: 2, truncated: false });
+    expect(hosts()).toEqual(['api.stripe.com']);
+    expect(urls()).toEqual([
+      'https://api.stripe.com/v1/charges',
+      'https://api.stripe.com/v1/customers',
+    ]);
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/cust.ts', line: 4 },
+      { projectKey: 'git:alpha', file: 'src/pay.ts', line: 12 },
+    ]);
+  });
+
+  it('round-trips the destination payload through the read view', async () => {
+    walk('git:alpha', [
+      hit({
+        host: '10.1.2.3',
+        kind: 'ip',
+        name: '10.1.2.3',
+        category: 'Unresolved host',
+        trust: 'ip',
+        network: { port: 8080, geo: null, ptr: null },
+        method: 'REF',
+        transport: 'http',
+        url: 'http://10.1.2.3:8080/ingest',
+        template: true,
+        dataClass: 'logs',
+        file: 'src/ship.ts',
+        line: 9,
+        snippet: 'post("http://10.1.2.3:8080/ingest")',
+        dynamic: true,
+        vendored: true,
+      }),
+    ]);
+
+    const detail = await shares.getDestination(destinationId('10.1.2.3'));
+    expect(detail?.kind).toBe('ip');
+    expect(detail?.trust).toBe('ip');
+    expect(detail?.network).toEqual({ port: 8080, geo: null, ptr: null });
+    expect(detail?.endpoints[0]?.method).toBe('REF');
+    expect(detail?.endpoints[0]?.transport).toBe('http');
+    expect(detail?.endpoints[0]?.template).toBe(true);
+    expect(detail?.endpoints[0]?.dataClass).toBe('logs');
+    const site = detail?.endpoints[0]?.sites[0];
+    expect(site?.file).toBe('src/ship.ts');
+    expect(site?.line).toBe(9);
+    expect(site?.dynamic).toBe(true);
+    expect(site?.vendored).toBe(true);
+    expect(site?.project).toBe('git:alpha');
+  });
+
+  it('records nothing and reports zeroes for an empty hit list', () => {
+    const summary = walk('git:alpha', []);
+    expect(summary).toEqual({ destinations: 0, endpoints: 0, callSites: 0, truncated: false });
+    expect(hosts()).toEqual([]);
+  });
+});
+
+// ─── Idempotency ─────────────────────────────────────────────────────────────
+
+describe('recordProjectEgress — idempotency', () => {
+  it('produces the same rows and summary when the same input is written twice', () => {
+    const hits = [
+      hit({ file: 'src/pay.ts', line: 12 }),
+      hit({ host: 'api.openai.com', category: 'LLM provider', file: 'src/ai.ts', line: 3 }),
+    ];
+    const first = walk('git:alpha', hits);
+    const second = walk('git:alpha', hits);
+
+    expect(second).toEqual(first);
+    expect(hosts()).toEqual(['api.openai.com', 'api.stripe.com']);
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/ai.ts', line: 3 },
+      { projectKey: 'git:alpha', file: 'src/pay.ts', line: 12 },
+    ]);
+  });
+
+  it('keeps destination ids stable across writes so decisions and deep links survive', () => {
+    walk('git:alpha', [hit()]);
+    const before = destinationId('api.stripe.com');
+    walk('git:alpha', [hit()]);
+    expect(destinationId('api.stripe.com')).toBe(before);
+  });
+
+  it('tolerates duplicate hits for the same endpoint, file and line in one batch', () => {
+    const summary = walk('git:alpha', [hit({ line: 12 }), hit({ line: 12 })]);
+    expect(summary.callSites).toBe(1);
+  });
+});
+
+// ─── Walk-mode reconciliation ────────────────────────────────────────────────
+
+describe('recordProjectEgress — walk mode', () => {
+  it('prunes the dropped endpoint and its now-empty destination on a root re-scan', () => {
+    walk('git:alpha', [
+      hit({ file: 'src/pay.ts', line: 12 }),
+      hit({ host: 'api.openai.com', category: 'LLM provider', file: 'src/ai.ts', line: 3 }),
+    ]);
+    expect(hosts()).toEqual(['api.openai.com', 'api.stripe.com']);
+
+    const summary = walk('git:alpha', [hit({ file: 'src/pay.ts', line: 12 })]);
+
+    expect(summary).toEqual({ destinations: 1, endpoints: 1, callSites: 1, truncated: false });
+    expect(hosts()).toEqual(['api.stripe.com']);
+    expect(urls()).toEqual(['https://api.stripe.com/v1/charges']);
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/pay.ts', line: 12 },
+    ]);
+  });
+
+  it('replaces only the walked subtree', () => {
+    walk('git:alpha', [
+      hit({ file: 'src/a.ts', line: 1 }),
+      hit({ host: 'api.openai.com', file: 'lib/b.ts', line: 2 }),
+    ]);
+
+    walk('git:alpha', [], 'src');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'lib/b.ts', line: 2 },
+    ]);
+    expect(hosts()).toEqual(['api.openai.com']);
+  });
+
+  it('replaces exactly the file a single-file walk targeted', () => {
+    walk('git:alpha', [
+      hit({ file: 'src/a.ts', line: 1 }),
+      hit({ host: 'api.openai.com', file: 'src/b.ts', line: 2 }),
+    ]);
+
+    walk('git:alpha', [], 'src/a.ts');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/b.ts', line: 2 },
+    ]);
+  });
+
+  it('treats the walked prefix literally, not as a LIKE pattern', () => {
+    // `_` is a LIKE single-character wildcard: an unescaped prefix would delete
+    // the sibling directory's rows too.
+    walk('git:alpha', [
+      hit({ file: 'src_a/x.ts', line: 1 }),
+      hit({ host: 'api.openai.com', file: 'srcXa/y.ts', line: 2 }),
+    ]);
+
+    walk('git:alpha', [], 'src_a');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'srcXa/y.ts', line: 2 },
+    ]);
+  });
+
+  it('leaves dot-path rows alone — only the ledger walker can re-create them', () => {
+    walk('git:alpha', [
+      hit({ file: '.github/scripts/deploy.ts', line: 7 }),
+      hit({ host: 'api.openai.com', file: 'src/ai.ts', line: 3 }),
+    ]);
+
+    walk('git:alpha', [], '');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: '.github/scripts/deploy.ts', line: 7 },
+    ]);
+    expect(hosts()).toEqual(['api.stripe.com']);
+  });
+
+  it('leaves a dot-file at the project root alone', () => {
+    walk('git:alpha', [hit({ file: '.eslintrc.js', line: 2 })]);
+    walk('git:alpha', [], '');
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: '.eslintrc.js', line: 2 },
+    ]);
+  });
+
+  it('leaves a nested dot-directory under the walked prefix alone', () => {
+    walk('git:alpha', [
+      hit({ file: 'src/.generated/client.ts', line: 5 }),
+      hit({ host: 'api.openai.com', file: 'src/ai.ts', line: 3 }),
+    ]);
+
+    walk('git:alpha', [], 'src');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/.generated/client.ts', line: 5 },
+    ]);
+  });
+
+  it('does not clear stale rows under a dot-path prefix — ledger mode owns them', () => {
+    // Accepted gap of the walker-universe rule: the exclusion is by stored path,
+    // so even a walk aimed straight at a dot-directory leaves its rows for the
+    // pipeline that can see the whole subtree.
+    walk('git:alpha', [hit({ file: '.github/deploy.ts', line: 7 })]);
+
+    walk('git:alpha', [], '.github');
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: '.github/deploy.ts', line: 7 },
+    ]);
+  });
+
+  it('still updates a dot-path row the walker did reach', () => {
+    walk('git:alpha', [hit({ file: '.github/deploy.ts', line: 7, snippet: 'old' })]);
+    walk('git:alpha', [hit({ file: '.github/deploy.ts', line: 7, snippet: 'new' })]);
+
+    const row = db
+      .prepare('SELECT snippet FROM share_call_site WHERE file = ?')
+      .get('.github/deploy.ts');
+    expect((row as unknown as { snippet: string }).snippet).toBe('new');
+    expect(callSites('git:alpha')).toHaveLength(1);
+  });
+});
+
+// ─── Ledger-mode reconciliation ──────────────────────────────────────────────
+
+describe('recordProjectEgress — ledger mode', () => {
+  it('replaces exactly the scanned and deleted files, preserving the rest', () => {
+    walk('git:alpha', [
+      hit({ file: 'a.ts', line: 1 }),
+      hit({ host: 'api.openai.com', file: 'b.ts', line: 2 }),
+      hit({ host: 'api.anthropic.com', file: 'c.ts', line: 3 }),
+    ]);
+
+    ledger('git:alpha', [hit({ file: 'a.ts', line: 9 })], ['a.ts'], ['b.ts']);
+
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'a.ts', line: 9 },
+      { projectKey: 'git:alpha', file: 'c.ts', line: 3 },
+    ]);
+    expect(hosts()).toEqual(['api.anthropic.com', 'api.stripe.com']);
+  });
+
+  it('never mass-deletes: rows outside the ledger lists survive an empty run', () => {
+    walk('git:alpha', [
+      hit({ file: 'vendor/dep.ts', line: 1 }),
+      hit({ host: 'api.openai.com', file: 'huge.ts', line: 2 }),
+    ]);
+
+    const summary = ledger('git:alpha', [], [], []);
+
+    expect(summary).toEqual({ destinations: 2, endpoints: 2, callSites: 2, truncated: false });
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'huge.ts', line: 2 },
+      { projectKey: 'git:alpha', file: 'vendor/dep.ts', line: 1 },
+    ]);
+  });
+
+  it('removes a dot-path row when the ledger names it', () => {
+    walk('git:alpha', [hit({ file: '.github/deploy.ts', line: 7 })]);
+
+    ledger('git:alpha', [], [], ['.github/deploy.ts']);
+
+    expect(callSites('git:alpha')).toEqual([]);
+    expect(hosts()).toEqual([]);
+  });
+
+  it('chunks large ledger file lists', () => {
+    const many = Array.from({ length: 1200 }, (_, i) => `src/f${String(i)}.ts`);
+    walk(
+      'git:alpha',
+      many.map((file, i) => hit({ file, line: i + 1 })),
+    );
+    expect(callSites('git:alpha')).toHaveLength(1200);
+
+    ledger('git:alpha', [], [], many);
+
+    expect(callSites('git:alpha')).toEqual([]);
+  });
+});
+
+// ─── Override survival ───────────────────────────────────────────────────────
+
+describe('recordProjectEgress — decision overrides', () => {
+  it('re-attaches a host-keyed block decision after the destination is pruned', async () => {
+    walk('git:alpha', [hit()]);
+    const firstId = destinationId('api.stripe.com');
+    expect(shares.setEgressDecision(firstId, 'block')).toBe(true);
+
+    // Prune: a root re-scan that no longer sees the host.
+    walk('git:alpha', []);
+    expect(hosts()).toEqual([]);
+
+    // The host-keyed row survives the prune, with its destination link released.
+    expect(overrides()).toEqual([
+      { destinationId: null, host: 'api.stripe.com', decision: 'block' },
+    ]);
+
+    walk('git:alpha', [hit()]);
+    const secondId = destinationId('api.stripe.com');
+    expect(secondId).not.toBe(firstId);
+
+    const detail = await shares.getDestination(secondId);
+    expect(detail?.status).toBe('blocked');
+    expect(detail?.isCustom).toBe(true);
+  });
+
+  it('removes legacy host-NULL override rows when their destination is pruned', () => {
+    walk('git:alpha', [hit()]);
+    const id = destinationId('api.stripe.com');
+    db.prepare(
+      `INSERT INTO egress_decision_override (id, destination_id, host, decision, created_at, updated_at)
+       VALUES (?, ?, NULL, 'block', ?, ?)`,
+    ).run(randomUUID(), id, Date.now(), Date.now());
+
+    walk('git:alpha', []);
+
+    expect(hosts()).toEqual([]);
+    expect(overrides()).toEqual([]);
+  });
+
+  it('keeps override rows for destinations that survive the write', () => {
+    walk('git:alpha', [hit(), hit({ host: 'api.openai.com', file: 'src/ai.ts', line: 3 })]);
+    shares.setEgressDecision(destinationId('api.openai.com'), 'allow');
+
+    walk('git:alpha', [hit()]);
+
+    expect(hosts()).toEqual(['api.stripe.com']);
+    expect(overrides()).toEqual([
+      { destinationId: null, host: 'api.openai.com', decision: 'allow' },
+    ]);
+  });
+});
+
+// ─── Cross-project isolation ─────────────────────────────────────────────────
+
+describe('recordProjectEgress — project isolation', () => {
+  it('a walk-mode wipe of one project leaves the other project and the shared destination', () => {
+    walk('git:alpha', [hit({ file: 'src/a.ts', line: 1 })]);
+    walk('git:beta', [hit({ file: 'src/b.ts', line: 2 })]);
+    expect(callSites()).toHaveLength(2);
+
+    const summary = walk('git:alpha', []);
+
+    expect(summary).toEqual({ destinations: 0, endpoints: 0, callSites: 0, truncated: false });
+    expect(callSites()).toEqual([{ projectKey: 'git:beta', file: 'src/b.ts', line: 2 }]);
+    expect(hosts()).toEqual(['api.stripe.com']);
+    expect(urls()).toEqual(['https://api.stripe.com/v1/charges']);
+  });
+
+  it('summarizes only the written project', () => {
+    walk('git:beta', [
+      hit({ file: 'src/b.ts', line: 2 }),
+      hit({ host: 'api.openai.com', file: 'src/c.ts', line: 3 }),
+    ]);
+
+    const summary = walk('git:alpha', [hit({ file: 'src/a.ts', line: 1 })]);
+
+    expect(summary).toEqual({ destinations: 1, endpoints: 1, callSites: 1, truncated: false });
+  });
+
+  it('two projects on the same file path keep separate call sites', () => {
+    walk('git:alpha', [hit({ file: 'src/a.ts', line: 1 })]);
+    walk('git:beta', [hit({ file: 'src/a.ts', line: 1 })]);
+
+    expect(callSites()).toEqual([
+      { projectKey: 'git:alpha', file: 'src/a.ts', line: 1 },
+      { projectKey: 'git:beta', file: 'src/a.ts', line: 1 },
+    ]);
+  });
+
+  it('a ledger write for one project never touches the other project’s same-named file', () => {
+    walk('git:alpha', [hit({ file: 'src/a.ts', line: 1 })]);
+    walk('git:beta', [hit({ file: 'src/a.ts', line: 1 })]);
+
+    ledger('git:alpha', [], [], ['src/a.ts']);
+
+    expect(callSites()).toEqual([{ projectKey: 'git:beta', file: 'src/a.ts', line: 1 }]);
+  });
+});
+
+// ─── lastSeen confirmation ───────────────────────────────────────────────────
+
+describe('recordProjectEgress — lastSeen', () => {
+  it('bumps last_seen for every surviving endpoint and destination', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      walk('git:alpha', [
+        hit({ file: 'a.ts', line: 1 }),
+        hit({ host: 'api.openai.com', file: 'b.ts', line: 2 }),
+      ]);
+      const first = Date.now();
+      expect(lastSeen('share_endpoint')).toEqual([first, first]);
+
+      // A ledger run that re-confirms nothing still confirms what it preserved.
+      vi.setSystemTime(new Date('2026-02-02T00:00:00.000Z'));
+      ledger('git:alpha', [], [], []);
+      const second = Date.now();
+
+      expect(lastSeen('share_endpoint')).toEqual([second, second]);
+      expect(lastSeen('share_destination')).toEqual([second, second]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not bump another project’s untouched rows', () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      walk('git:beta', [hit({ host: 'api.openai.com', file: 'b.ts', line: 2 })]);
+      const betaStamp = Date.now();
+
+      vi.setSystemTime(new Date('2026-02-02T00:00:00.000Z'));
+      walk('git:alpha', [hit({ file: 'a.ts', line: 1 })]);
+
+      const row = db
+        .prepare('SELECT last_seen AS lastSeen FROM share_destination WHERE host = ?')
+        .get('api.openai.com');
+      expect((row as unknown as { lastSeen: number }).lastSeen).toBe(betaStamp);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+// ─── Mutable payload refresh ─────────────────────────────────────────────────
+
+describe('recordProjectEgress — payload refresh', () => {
+  it('refreshes destination classification and endpoint transport on re-record', async () => {
+    walk('git:alpha', [
+      hit({
+        host: 'egress.acme.io',
+        kind: 'external',
+        name: 'egress.acme.io',
+        category: 'External domain',
+        trust: 'unverified',
+        transport: 'http',
+        url: 'http://egress.acme.io/v1',
+      }),
+    ]);
+
+    walk('git:alpha', [
+      hit({
+        host: 'egress.acme.io',
+        kind: 'internal',
+        name: 'Acme egress',
+        category: 'Internal services',
+        trust: 'internal',
+        transport: 'http',
+        url: 'http://egress.acme.io/v1',
+      }),
+    ]);
+
+    const detail = await shares.getDestination(destinationId('egress.acme.io'));
+    expect(detail?.kind).toBe('internal');
+    expect(detail?.name).toBe('Acme egress');
+    expect(detail?.category).toBe('Internal services');
+    expect(detail?.trust).toBe('internal');
+  });
+
+  it('refreshes the call-site display payload without changing the reconcile key', () => {
+    walk('git:alpha', [hit({ file: 'a.ts', line: 1, snippet: 'old', vendored: false })], '', 'p1');
+    walk('git:alpha', [hit({ file: 'a.ts', line: 1, snippet: 'new', vendored: true })], '', 'p2');
+
+    const row = db
+      .prepare(
+        `SELECT project, project_id AS projectId, snippet, vendored
+         FROM share_call_site WHERE project_key = ?`,
+      )
+      .get('git:alpha');
+    expect(row).toMatchObject({ projectId: 'p2', snippet: 'new', vendored: 1 });
+    expect(callSites('git:alpha')).toHaveLength(1);
+  });
+});
+
+// ─── Cap ─────────────────────────────────────────────────────────────────────
+
+describe('recordProjectEgress — cap', () => {
+  it('keeps the first MAX call sites in input order and reports truncation', () => {
+    const many = Array.from({ length: MAX_EGRESS_CALL_SITES_PER_PROJECT + 1 }, (_, i) =>
+      hit({ file: 'src/big.ts', line: i + 1 }),
+    );
+
+    const summary = walk('git:alpha', many);
+
+    expect(summary.truncated).toBe(true);
+    expect(summary.callSites).toBe(MAX_EGRESS_CALL_SITES_PER_PROJECT);
+    expect(callSites('git:alpha')).toHaveLength(MAX_EGRESS_CALL_SITES_PER_PROJECT);
+    const dropped = db
+      .prepare('SELECT count(*) AS n FROM share_call_site WHERE line = ?')
+      .get(MAX_EGRESS_CALL_SITES_PER_PROJECT + 1);
+    expect((dropped as unknown as { n: number }).n).toBe(0);
+  });
+
+  it('does not report truncation at exactly the cap', () => {
+    const many = Array.from({ length: MAX_EGRESS_CALL_SITES_PER_PROJECT }, (_, i) =>
+      hit({ file: 'src/big.ts', line: i + 1 }),
+    );
+    expect(walk('git:alpha', many).truncated).toBe(false);
+  });
+});
+
+// ─── Atomicity ───────────────────────────────────────────────────────────────
+
+describe('recordProjectEgress — failure handling', () => {
+  it('throws and rolls the whole write back, leaving the prior inventory intact', () => {
+    walk('git:alpha', [hit({ file: 'src/a.ts', line: 1 })]);
+
+    // A hit the driver cannot bind: it fails after the reconcile delete has run,
+    // so a non-atomic writer would leave the project with no rows at all.
+    const broken = hit({ file: 'src/b.ts', line: 2 });
+    (broken.site as { snippet: unknown }).snippet = undefined;
+
+    expect(() =>
+      walk('git:alpha', [
+        hit({ file: 'src/a.ts', line: 1 }),
+        hit({ host: 'api.openai.com', file: 'src/ai.ts', line: 3 }),
+        broken,
+      ]),
+    ).toThrow();
+
+    // The reconcile delete and the two good hits are both rolled back: the
+    // project keeps exactly the rows it had, and nothing new is left behind.
+    expect(callSites('git:alpha')).toEqual([
+      { projectKey: 'git:alpha', file: 'src/a.ts', line: 1 },
+    ]);
+    expect(hosts()).toEqual(['api.stripe.com']);
+  });
+});

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -35,6 +35,7 @@ export { resolveInventoryContext } from './inventory-resolver.ts';
 export type { ScanFinding } from './mask.ts';
 export { maskText, scanText } from './mask.ts';
 export { claimOnboardingNudge, claimSessionStart } from './nudge.ts';
+export { toPosix } from './paths.ts';
 export type { PostureChange } from './posture.ts';
 export { applyCategoryPosture, detectPostureChanges, severityFloorPosture } from './posture.ts';
 export { resolveProjectFiles } from './project-files.ts';

--- a/packages/plugin-sdk/src/paths.ts
+++ b/packages/plugin-sdk/src/paths.ts
@@ -1,0 +1,12 @@
+import { sep } from 'node:path';
+
+// Shared by every writer that stores or compares repo-relative paths (the
+// CLI/web-ui scan pipeline and the plugin scan pipeline both key stored rows
+// on paths built this way), so the two pipelines produce byte-identical path
+// keys for the same file instead of drifting apart under two hand-written
+// copies of the same one-liner.
+
+/** Normalize a filesystem path to posix-style forward slashes. A no-op outside win32. */
+export function toPosix(path: string): string {
+  return path.split(sep).join('/');
+}

--- a/packages/plugin-sdk/src/paths.ts
+++ b/packages/plugin-sdk/src/paths.ts
@@ -1,11 +1,5 @@
 import { sep } from 'node:path';
 
-// Shared by every writer that stores or compares repo-relative paths (the
-// CLI/web-ui scan pipeline and the plugin scan pipeline both key stored rows
-// on paths built this way), so the two pipelines produce byte-identical path
-// keys for the same file instead of drifting apart under two hand-written
-// copies of the same one-liner.
-
 /** Normalize a filesystem path to posix-style forward slashes. A no-op outside win32. */
 export function toPosix(path: string): string {
   return path.split(sep).join('/');


### PR DESCRIPTION
**Stacked PR 7 of 13** — base: `egress-stack/06-resolution`. Depends on #78.

SqliteSharesRepository.recordProjectEgress: the walk/ledger reconciliation modes with the walker-universe invariant (dot-path exclusion), three upserts keyed on project_key, an override-preserving prune, a per-project join summary, and a 5000-call-site cap — all inside withTransaction, throwing on failure.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).