### PR TITLE
feat(egress) [8/13]: local-ops — gated collection and stable-key recording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,8 @@ Keep these package boundaries intact — a forbidden import across a package wal
                      (SQLite adapter + read/view ports, plus the shared ~/.aka
                      layout/settings/fingerprint file I/O — NO fetch client, NO Drizzle)
 @akasecurity/local-ops     → @akasecurity/schema, @akasecurity/persistence, @akasecurity/detections,
-                     @akasecurity/plugin-sdk (repo-identity + project-file walkers only)
+                     @akasecurity/plugin-sdk (repo-identity, project-file walkers, and posix
+                     path normalization only)
                      (shared CLI/web-ui operations: update report + apply via npm/claude
                      child processes, the agent-plugin registry, the fs scan pipeline,
                      the project-inventory pass; network ONLY via package-manager

--- a/packages/local-ops/src/egress-record.ts
+++ b/packages/local-ops/src/egress-record.ts
@@ -1,11 +1,11 @@
 import { realpathSync, statSync } from 'node:fs';
-import { basename, dirname, relative, resolve, sep } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 
 import type { FileEgressHits } from '@akasecurity/detections';
 import { isVendoredPath, resolveEgress } from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
 import { defaultDataDir, readWorkspaceSettings } from '@akasecurity/persistence';
-import { resolveRepoIdentity, resolveWorktreeRoot } from '@akasecurity/plugin-sdk';
+import { resolveRepoIdentity, resolveWorktreeRoot, toPosix } from '@akasecurity/plugin-sdk';
 import type { EgressWriteSummary } from '@akasecurity/schema';
 
 // The egress-recording pass shared by `aka scan` and the web-ui's Scan page:
@@ -25,10 +25,6 @@ import type { EgressWriteSummary } from '@akasecurity/schema';
 
 /** What one egress-recording pass wrote, for host display (`aka scan`). */
 export type EgressRecordResult = EgressWriteSummary & { project: string };
-
-function toPosix(path: string): string {
-  return path.split(sep).join('/');
-}
 
 /**
  * Record the egress `scanPathIntoStore` collected for `target`. Returns the
@@ -62,6 +58,10 @@ export function recordProjectEgress(
     let projectId: string | null;
 
     if (identity && worktreeRoot) {
+      // A linked worktree's identity resolves to its HEAD repo (resolveRepoIdentity),
+      // but paths are relativized against worktreeRoot, which is the CURRENT
+      // worktree's own root — so a linked-worktree scan shares its head repo's
+      // project key while its stored file paths are relative to its own checkout.
       root = worktreeRoot;
       // identity.url is the remote URL, or the worktree root PATH when the repo
       // has no remote. The 'git:' prefix keeps that path-shaped fallback from
@@ -90,6 +90,15 @@ export function recordProjectEgress(
       // Outside the resolved root: reconciliation is scoped to paths under it,
       // so a row keyed on a '../' path could never be replaced or cleared.
       if (file === '' || file.startsWith('../')) continue;
+      // The walk-mode reconciler's delete excludes dot-paths (`file NOT LIKE
+      // '.%' AND file NOT LIKE '%/.%'`), on the premise that this walk never
+      // descends into dot-directories. That premise does not hold — a
+      // root-level dot-file, an `.akaignore` `!` negation, or a directly-named
+      // dot-file target can all put one here — so a stored dot-path row would
+      // be one no future walk-mode scan could ever clear. Skip it instead: this
+      // pipeline simply does not record dot-path egress; the plugin scanner's
+      // ledger mode owns those files.
+      if (file.startsWith('.') || file.includes('/.')) continue;
       // `vendored` describes the path being stored — an absolute path can pick
       // up a vendor/ segment from an ancestor outside the project entirely.
       files.push({ ...hit, file, vendored: isVendoredPath(file) });

--- a/packages/local-ops/src/egress-record.ts
+++ b/packages/local-ops/src/egress-record.ts
@@ -1,0 +1,109 @@
+import { realpathSync, statSync } from 'node:fs';
+import { basename, dirname, relative, resolve, sep } from 'node:path';
+
+import type { FileEgressHits } from '@akasecurity/detections';
+import { isVendoredPath, resolveEgress } from '@akasecurity/detections';
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { defaultDataDir, readWorkspaceSettings } from '@akasecurity/persistence';
+import { resolveRepoIdentity, resolveWorktreeRoot } from '@akasecurity/plugin-sdk';
+import type { EgressWriteSummary } from '@akasecurity/schema';
+
+// The egress-recording pass shared by `aka scan` and the web-ui's Scan page:
+// take the raw per-file extraction the walk produced, anchor it to a stable
+// project identity, and hand it to the store writer.
+//
+// The walk that produced these hits is complete under the scan target, so the
+// write reconciles in 'walk' mode: stored call sites under the walked prefix
+// are replaced wholesale. The prefix is the scan target's own path relative to
+// the project root — '' for a root scan, 'src' for a subtree, and the file's
+// own path for a single-file scan, which is what keeps a one-file scan from
+// clearing the rest of the project.
+//
+// Fail-open like every store write on the scan path: recording egress is a
+// side benefit of a scan, so any failure returns null and never breaks the
+// scan that triggered it.
+
+/** What one egress-recording pass wrote, for host display (`aka scan`). */
+export type EgressRecordResult = EgressWriteSummary & { project: string };
+
+function toPosix(path: string): string {
+  return path.split(sep).join('/');
+}
+
+/**
+ * Record the egress `scanPathIntoStore` collected for `target`. Returns the
+ * project's live totals, or null when the Data Shares kill-switch is off, the
+ * target does not exist, or any step fails (fail-open). `base` is the `~/.aka`
+ * base the kill-switch is read from. The caller owns the database handle.
+ */
+export function recordProjectEgress(
+  db: LocalDatabase,
+  target: string,
+  egress: { files: FileEgressHits[] },
+  base: string = defaultDataDir(),
+): EgressRecordResult | null {
+  try {
+    if (!readWorkspaceSettings(base).dataSharesInPlace) return null;
+
+    // The identity resolvers walk UP from the target, so they need an absolute
+    // path. A nonexistent target must not resolve through its existing
+    // ancestors into a repo walk — statSync throws into the catch below.
+    const abs = resolve(target);
+    const targetDir = statSync(abs).isDirectory() ? abs : dirname(abs);
+
+    const identity = resolveRepoIdentity(abs);
+    const worktreeRoot = resolveWorktreeRoot(abs);
+
+    // The root every stored path is relative to, and the key every stored row
+    // reconciles on.
+    let root: string;
+    let projectKey: string;
+    let project: string;
+    let projectId: string | null;
+
+    if (identity && worktreeRoot) {
+      root = worktreeRoot;
+      // identity.url is the remote URL, or the worktree root PATH when the repo
+      // has no remote. The 'git:' prefix keeps that path-shaped fallback from
+      // aliasing the 'path:' key a non-git walk of the same directory produces.
+      projectKey = `git:${identity.url}`;
+      project = identity.name;
+      projectId = db.sourceProject.upsert({
+        url: identity.url,
+        name: identity.name,
+        attributes: {},
+      });
+    } else {
+      root = targetDir;
+      // Keyed on the realpath so two symlinked routes to one directory share a
+      // key, and so two directories with the same basename never collide.
+      // Relativization still uses `root` as the walker saw it.
+      const realRoot = realpathSync(targetDir);
+      projectKey = `path:${realRoot}`;
+      project = basename(realRoot);
+      projectId = null;
+    }
+
+    const files: FileEgressHits[] = [];
+    for (const hit of egress.files) {
+      const file = toPosix(relative(root, hit.file));
+      // Outside the resolved root: reconciliation is scoped to paths under it,
+      // so a row keyed on a '../' path could never be replaced or cleared.
+      if (file === '' || file.startsWith('../')) continue;
+      // `vendored` describes the path being stored — an absolute path can pick
+      // up a vendor/ segment from an ancestor outside the project entirely.
+      files.push({ ...hit, file, vendored: isVendoredPath(file) });
+    }
+
+    const summary = db.shares.recordProjectEgress({
+      projectKey,
+      project,
+      projectId,
+      reconcile: { mode: 'walk', walkedPrefix: toPosix(relative(root, abs)) },
+      hits: resolveEgress(files),
+    });
+    return { ...summary, project };
+  } catch {
+    return null;
+  }
+}

--- a/packages/local-ops/src/fs-scan.ts
+++ b/packages/local-ops/src/fs-scan.ts
@@ -8,6 +8,7 @@ import {
   extractEgress,
   extractManifestSdks,
   isVendoredPath,
+  LOCKFILE_BASENAMES,
   manifestKindOf,
   maskMatch,
   redact,
@@ -214,7 +215,17 @@ export interface ScanPathResult {
 function extractFileEgress(file: string, text: string): FileEgressHits | null {
   if (text.includes('\u0000')) return null;
 
-  const kind = manifestKindOf(basename(file));
+  const name = basename(file);
+  // Lockfiles are regenerated dependency-resolution output — every transitive
+  // package's registry URL is packaging noise, not egress. manifestKindOf
+  // already returns null for these basenames, and none of them currently
+  // carry a code extension, so this early-out changes nothing observable
+  // today; it exists so the exclusion still holds if a future lockfile
+  // basename ever does carry one, instead of relying on that gap staying
+  // empty by chance.
+  if (LOCKFILE_BASENAMES.has(name)) return null;
+
+  const kind = manifestKindOf(name);
   const sdkHits = kind === null ? [] : extractManifestSdks(text, kind);
   // A manifest is never also scanned for URL literals: package.json's own
   // registry/repository URLs are packaging metadata, not egress.

--- a/packages/local-ops/src/fs-scan.ts
+++ b/packages/local-ops/src/fs-scan.ts
@@ -1,8 +1,18 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { basename, extname, join, relative, sep } from 'node:path';
 
-import { maskMatch, redact, scan } from '@akasecurity/detections';
+import type { FileEgressHits } from '@akasecurity/detections';
+import {
+  EGRESS_CODE_EXTENSIONS,
+  extractEgress,
+  extractManifestSdks,
+  isVendoredPath,
+  manifestKindOf,
+  maskMatch,
+  redact,
+  scan,
+} from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
 import type {
   ActionTaken,
@@ -190,6 +200,29 @@ export interface ScanPathResult {
   scanned: number;
   findings: number;
   files: ScannedFileFindings[];
+  // Raw per-file egress extraction for every walked file that produced a hit.
+  // `file` is the ABSOLUTE walked path here; the recording pass relativizes it
+  // to the project root before anything reaches the store.
+  egress: { files: FileEgressHits[] };
+}
+
+// What the egress pass extracts from one already-read file, or null when the
+// file is out of scope. URL/IP extraction runs on code extensions only;
+// manifests go through manifestKindOf, which returns null for lockfiles so
+// their registry URLs are never extracted; a file carrying a NUL byte is
+// treated as binary and yields nothing.
+function extractFileEgress(file: string, text: string): FileEgressHits | null {
+  if (text.includes('\u0000')) return null;
+
+  const kind = manifestKindOf(basename(file));
+  const sdkHits = kind === null ? [] : extractManifestSdks(text, kind);
+  // A manifest is never also scanned for URL literals: package.json's own
+  // registry/repository URLs are packaging metadata, not egress.
+  const endpoints =
+    kind === null && EGRESS_CODE_EXTENSIONS.has(extname(file)) ? extractEgress(text) : [];
+
+  if (endpoints.length === 0 && sdkHits.length === 0) return null;
+  return { file, vendored: isVendoredPath(file), endpoints, sdkHits };
 }
 
 /**
@@ -204,6 +237,7 @@ export function scanPathIntoStore(
   let scanned = 0;
   let findingCount = 0;
   const files: ScannedFileFindings[] = [];
+  const egressFiles: FileEgressHits[] = [];
   for (const { path: file, gitignored } of collectFiles(target)) {
     let text: string;
     try {
@@ -212,6 +246,11 @@ export function scanPathIntoStore(
       continue; // unreadable / binary — skip
     }
     scanned++;
+    // Egress rides every file whose content was read, before the finding
+    // early-out below — a file with no detection match still has destinations.
+    const fileEgress = extractFileEgress(file, text);
+    if (fileEgress) egressFiles.push(fileEgress);
+
     const matches = scan(text, opts.rules);
     if (matches.length === 0) continue;
 
@@ -245,5 +284,5 @@ export function scanPathIntoStore(
     files.push({ path: file, gitignored, findings });
     findingCount += findings.length;
   }
-  return { scanned, findings: findingCount, files };
+  return { scanned, findings: findingCount, files, egress: { files: egressFiles } };
 }

--- a/packages/local-ops/src/index.ts
+++ b/packages/local-ops/src/index.ts
@@ -6,6 +6,8 @@ export {
   installClaudePlugin,
   updateClaudePlugin,
 } from './claude-plugin.ts';
+export type { EgressRecordResult } from './egress-record.ts';
+export { recordProjectEgress } from './egress-record.ts';
 export type { RunResult } from './exec.ts';
 export { binExists, runCapture, runInherit } from './exec.ts';
 export type {

--- a/packages/local-ops/test/egress-record.test.ts
+++ b/packages/local-ops/test/egress-record.test.ts
@@ -1,0 +1,345 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { DB_FILENAME, type LocalDatabase, openLocalDatabase } from '@akasecurity/persistence';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { recordProjectEgress } from '../src/egress-record.ts';
+import { scanPathIntoStore } from '../src/fs-scan.ts';
+
+const REMOTE_URL = 'https://github.com/acme/payments-api.git';
+
+// A minimal on-disk git repo: a `.git` DIRECTORY (what the identity resolver
+// detects) whose `config` carries the remote the identity is derived from.
+// Omitting the remote exercises the path-shaped identity fallback.
+function initRepo(root: string, remoteUrl?: string): void {
+  mkdirSync(join(root, '.git'));
+  writeFileSync(
+    join(root, '.git', 'config'),
+    remoteUrl ? `[remote "origin"]\n\turl = ${remoteUrl}\n` : '',
+  );
+}
+
+// One source file whose only egress is a POST to `host`.
+function writeCall(file: string, host: string): void {
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `fetch('https://${host}/v1/go', { method: 'POST' });\n`);
+}
+
+// Settings under a ~/.aka-shaped base, so the toggle is read through the real
+// loader rather than a hand-built object.
+function writeSettings(base: string, dataSharesInPlace: boolean): void {
+  mkdirSync(join(base, 'settings'), { recursive: true });
+  writeFileSync(
+    join(base, 'settings', 'settings.json'),
+    JSON.stringify({ dataSharesInPlace }, null, 2),
+  );
+}
+
+interface StoredSite {
+  projectKey: string;
+  project: string;
+  projectId: string | null;
+  file: string;
+  host: string;
+  method: string;
+  url: string;
+  vendored: number;
+}
+
+// Raw at-rest rows, straight from the store file — the assertions are on what
+// actually hit disk, independent of any read port.
+function storedSites(dir: string): StoredSite[] {
+  const raw = new DatabaseSync(join(dir, DB_FILENAME), { readOnly: true });
+  try {
+    return raw
+      .prepare(
+        `SELECT c.project_key AS projectKey, c.project AS project, c.project_id AS projectId,
+                c.file AS file, d.host AS host, e.method AS method, e.url AS url,
+                c.vendored AS vendored
+           FROM share_call_site c
+           JOIN share_endpoint e ON e.id = c.endpoint_id
+           JOIN share_destination d ON d.id = e.destination_id
+          ORDER BY c.project_key, c.file, e.url`,
+      )
+      .all() as unknown as StoredSite[];
+  } finally {
+    raw.close();
+  }
+}
+
+// Walk `target` and record whatever egress the walk produced — the exact
+// two-call sequence the CLI and the web-ui Scan action perform.
+function scanAndRecord(db: LocalDatabase, target: string, base: string) {
+  const result = scanPathIntoStore(db, target, { rules: [] });
+  return recordProjectEgress(db, target, result.egress, base);
+}
+
+let root: string;
+let store: string;
+let base: string;
+let db: LocalDatabase;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'aka-egress-'));
+  store = mkdtempSync(join(tmpdir(), 'aka-egress-db-'));
+  base = mkdtempSync(join(tmpdir(), 'aka-egress-home-'));
+  db = openLocalDatabase(store);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+  rmSync(store, { recursive: true, force: true });
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('recordProjectEgress — git project', () => {
+  it('keys on the remote identity and stores repo-relative posix paths', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.stripe.com');
+    writeFileSync(
+      join(root, 'package.json'),
+      `${JSON.stringify({ name: 'demo', dependencies: { stripe: '^14.0.0' } }, null, 2)}\n`,
+    );
+
+    const recorded = scanAndRecord(db, root, base);
+
+    // Display name is the remote slug; the reconcile key is the prefixed
+    // identity, never the bare one.
+    expect(recorded).toEqual({
+      project: 'payments-api',
+      destinations: 1,
+      endpoints: 2,
+      callSites: 2,
+      truncated: false,
+    });
+
+    const sites = storedSites(store);
+    expect(sites.map((s) => s.file)).toEqual(['package.json', 'src/pay.ts']);
+    expect(new Set(sites.map((s) => s.projectKey))).toEqual(new Set([`git:${REMOTE_URL}`]));
+    expect(sites.every((s) => s.project === 'payments-api')).toBe(true);
+    // The Inventory deep-link is populated on the git path.
+    expect(sites.every((s) => typeof s.projectId === 'string' && s.projectId.length > 0)).toBe(
+      true,
+    );
+    expect(sites.map((s) => s.method).sort()).toEqual(['POST', 'SDK']);
+  });
+
+  it('records the same key and paths when a subdirectory is the scan target', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, join(root, 'src'), base);
+
+    const sites = storedSites(store);
+    // Relativized against the worktree root, not the scan target: a subtree
+    // scan and a root scan agree on the stored path.
+    expect(sites.map((s) => s.file)).toEqual(['src/pay.ts']);
+    expect(sites[0]?.projectKey).toBe(`git:${REMOTE_URL}`);
+  });
+
+  it('is idempotent across repeated scans of an unchanged tree', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    const first = scanAndRecord(db, root, base);
+    const second = scanAndRecord(db, root, base);
+
+    expect(second).toEqual(first);
+    expect(storedSites(store)).toHaveLength(1);
+  });
+});
+
+describe('recordProjectEgress — walk-mode reconciliation', () => {
+  function twoDirCorpus(): void {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    writeCall(join(root, 'lib', 'old.ts'), 'api.beta-corp.com');
+  }
+
+  it('replaces only the scanned subtree, leaving sibling directories intact', () => {
+    twoDirCorpus();
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(2);
+
+    // Re-point src/ at a different host, then scan ONLY src/.
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    scanAndRecord(db, join(root, 'src'), base);
+
+    const sites = storedSites(store);
+    // src/ was replaced in place; lib/ was never walked and survives.
+    expect(sites.map((s) => `${s.file}:${s.host}`)).toEqual([
+      'lib/old.ts:api.beta-corp.com',
+      'src/pay.ts:api.gamma-corp.com',
+    ]);
+  });
+
+  it('replaces exactly one file when the scan target is that file', () => {
+    twoDirCorpus();
+    writeCall(join(root, 'src', 'other.ts'), 'api.delta-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(3);
+
+    // A single-file target must scope the replacement to that file's own path
+    // — never to its directory, and never to the whole project.
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    const recorded = scanAndRecord(db, join(root, 'src', 'pay.ts'), base);
+
+    const sites = storedSites(store);
+    expect(sites.map((s) => `${s.file}:${s.host}`)).toEqual([
+      'lib/old.ts:api.beta-corp.com',
+      'src/other.ts:api.delta-corp.com',
+      'src/pay.ts:api.gamma-corp.com',
+    ]);
+    // The summary reports live per-project totals, not just this walk's rows.
+    expect(recorded?.callSites).toBe(3);
+  });
+
+  it('does not let a single-file target delete a same-prefixed sibling', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    // Shares the 'src/pay.ts' string prefix; a prefix-only delete would take it.
+    writeCall(join(root, 'src', 'pay.ts.bak.ts'), 'api.beta-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(2);
+
+    writeCall(join(root, 'src', 'pay.ts'), 'api.gamma-corp.com');
+    scanAndRecord(db, join(root, 'src', 'pay.ts'), base);
+
+    expect(storedSites(store).map((s) => `${s.file}:${s.host}`)).toEqual([
+      'src/pay.ts:api.gamma-corp.com',
+      'src/pay.ts.bak.ts:api.beta-corp.com',
+    ]);
+  });
+
+  it('clears rows for a walked file whose egress is gone', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    scanAndRecord(db, root, base);
+    expect(storedSites(store)).toHaveLength(1);
+
+    writeFileSync(join(root, 'src', 'pay.ts'), 'export const n = 1;\n');
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(storedSites(store)).toEqual([]);
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+  });
+
+  it('marks vendored call sites from the stored repo-relative path', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'vendor', 'lib', 'client.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, root, base);
+
+    const sites = storedSites(store);
+    expect(sites[0]?.file).toBe('vendor/lib/client.ts');
+    expect(sites[0]?.vendored).toBe(1);
+  });
+});
+
+describe('recordProjectEgress — non-git target', () => {
+  it('keys on the realpath of the walked directory and records no project id', () => {
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(recorded?.project).toBe(basename(root));
+    const sites = storedSites(store);
+    expect(sites[0]?.projectKey).toBe(`path:${realpathSync(root)}`);
+    expect(sites[0]?.projectId).toBeNull();
+    expect(sites[0]?.file).toBe('src/pay.ts');
+  });
+
+  it('gives two same-basename directories distinct keys', () => {
+    const a = join(root, 'a', 'app');
+    const b = join(root, 'b', 'app');
+    writeCall(join(a, 'pay.ts'), 'api.alpha-corp.com');
+    writeCall(join(b, 'pay.ts'), 'api.beta-corp.com');
+
+    scanAndRecord(db, a, base);
+    scanAndRecord(db, b, base);
+
+    const sites = storedSites(store);
+    expect(sites).toHaveLength(2);
+    expect(new Set(sites.map((s) => s.projectKey))).toEqual(
+      new Set([`path:${realpathSync(a)}`, `path:${realpathSync(b)}`]),
+    );
+    // Both are named 'app'; neither walk clobbered the other's rows.
+    expect(sites.every((s) => s.project === 'app')).toBe(true);
+    expect(new Set(sites.map((s) => s.host))).toEqual(
+      new Set(['api.alpha-corp.com', 'api.beta-corp.com']),
+    );
+  });
+
+  it('keys a single-file target on its containing directory', () => {
+    writeCall(join(root, 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, join(root, 'pay.ts'), base);
+
+    const sites = storedSites(store);
+    expect(sites[0]?.projectKey).toBe(`path:${realpathSync(root)}`);
+    expect(sites[0]?.file).toBe('pay.ts');
+  });
+});
+
+describe('recordProjectEgress — key collision safety', () => {
+  it('never aliases a remote-less repo onto the non-git key for the same path', () => {
+    // A repo with no remote falls back to a PATH-shaped identity, which is
+    // exactly the shape the non-git key is built from. The prefixes are what
+    // keep the two universes apart.
+    const repo = join(root, 'repo');
+    mkdirSync(repo);
+    initRepo(repo);
+    writeCall(join(repo, 'pay.ts'), 'api.alpha-corp.com');
+
+    scanAndRecord(db, repo, base);
+
+    const key = storedSites(store)[0]?.projectKey;
+    expect(key?.startsWith('git:')).toBe(true);
+    expect(key).not.toBe(`path:${realpathSync(repo)}`);
+    // The identity is the worktree root path, so only the prefix distinguishes
+    // it from a non-git walk of the same directory.
+    expect(key).toBe(`git:${repo}`);
+  });
+});
+
+describe('recordProjectEgress — fail-open', () => {
+  it('returns null and writes nothing when the kill-switch is off', () => {
+    writeSettings(base, false);
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    expect(scanAndRecord(db, root, base)).toBeNull();
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('records normally when the kill-switch is explicitly on', () => {
+    writeSettings(base, true);
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+
+    expect(scanAndRecord(db, root, base)).toMatchObject({ callSites: 1 });
+  });
+
+  it('returns null for a target that does not exist', () => {
+    const missing = join(root, 'nope', 'gone');
+    expect(recordProjectEgress(db, missing, { files: [] }, base)).toBeNull();
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('returns null instead of throwing when the store is closed', () => {
+    initRepo(root, REMOTE_URL);
+    writeCall(join(root, 'src', 'pay.ts'), 'api.alpha-corp.com');
+    const result = scanPathIntoStore(db, root, { rules: [] });
+    db.close();
+
+    expect(() => recordProjectEgress(db, root, result.egress, base)).not.toThrow();
+    expect(recordProjectEgress(db, root, result.egress, base)).toBeNull();
+
+    // Reopened for the afterEach close.
+    db = openLocalDatabase(store);
+  });
+});

--- a/packages/local-ops/test/egress-record.test.ts
+++ b/packages/local-ops/test/egress-record.test.ts
@@ -289,8 +289,13 @@ describe('recordProjectEgress — key collision safety', () => {
   it('never aliases a remote-less repo onto the non-git key for the same path', () => {
     // A repo with no remote falls back to a PATH-shaped identity, which is
     // exactly the shape the non-git key is built from. The prefixes are what
-    // keep the two universes apart.
-    const repo = join(root, 'repo');
+    // keep the two universes apart. Built under root's OWN realpath (macOS
+    // temp dirs live under a symlink, e.g. /var/folders -> /private/var/folders)
+    // so `repo` and `realpathSync(repo)` are already the same string — without
+    // this, the assertion below would pass for the unrelated reason that the
+    // two paths differ by the symlink prefix alone, never actually exercising
+    // the 'git:' / 'path:' prefix that is the thing under test.
+    const repo = join(realpathSync(root), 'repo');
     mkdirSync(repo);
     initRepo(repo);
     writeCall(join(repo, 'pay.ts'), 'api.alpha-corp.com');
@@ -303,6 +308,38 @@ describe('recordProjectEgress — key collision safety', () => {
     // The identity is the worktree root path, so only the prefix distinguishes
     // it from a non-git walk of the same directory.
     expect(key).toBe(`git:${repo}`);
+  });
+});
+
+describe('recordProjectEgress — dot-path exclusion', () => {
+  it('does not store egress from a root-level dot-file', () => {
+    initRepo(root, REMOTE_URL);
+    // fs-scan's entry.isFile() branch has no dot check, so a root-level
+    // dot-file like a real .releaserc.js IS walked and read.
+    writeCall(join(root, '.releaserc.js'), 'api.acme-webhooks.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    // The reconciler's walk-mode delete excludes dot-paths ('file NOT LIKE
+    // '.%''), so a stored row here could never be cleared by a later scan.
+    // The collector must therefore never store one in the first place.
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+    expect(storedSites(store)).toEqual([]);
+  });
+
+  it('does not store egress from a dot-directory reached via an .akaignore negation', () => {
+    initRepo(root, REMOTE_URL);
+    // A bare '!' re-include beats the default dot-directory skip (fs-scan.ts),
+    // so this nested file IS walked despite living under a dot-directory —
+    // proving the exclusion below is a second, independent gate, not just a
+    // restatement of the walker's own default dot-directory skip.
+    writeFileSync(join(root, '.akaignore'), '!.github/\n');
+    writeCall(join(root, '.github', 'scripts', 'notify.js'), 'api.acme-webhooks.com');
+
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(recorded).toMatchObject({ destinations: 0, endpoints: 0, callSites: 0 });
+    expect(storedSites(store)).toEqual([]);
   });
 });
 

--- a/packages/local-ops/test/fs-scan.test.ts
+++ b/packages/local-ops/test/fs-scan.test.ts
@@ -156,7 +156,7 @@ describe('scanPathIntoStore', () => {
     const db = openLocalDatabase(store);
     try {
       const result = scanPathIntoStore(db, root, { rules: RULES });
-      expect(result).toEqual({ scanned: 1, findings: 0, files: [] });
+      expect(result).toEqual({ scanned: 1, findings: 0, files: [], egress: { files: [] } });
       expect(storedEvents(store)).toEqual([]);
     } finally {
       db.close();
@@ -213,6 +213,131 @@ describe('scanPathIntoStore', () => {
         filePath: join(root, 'scratch.env'),
         gitignored: true,
       });
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// The egress collection pass rides the same walk as detection scanning. What it
+// runs on is decided entirely here — the walker has no extension filter — so
+// these cases pin the gating: code extensions get URL/IP extraction, manifests
+// get SDK extraction, lockfiles and prose files get neither, and a file
+// carrying a NUL byte is treated as binary and skipped.
+describe('scanPathIntoStore — egress collection', () => {
+  // A NUL byte written as an escape so this source file stays plain text.
+  const NUL = '\u0000';
+
+  function writeCorpus(): void {
+    mkdirSync(join(root, 'src'));
+    writeFileSync(
+      join(root, 'src', 'pay.ts'),
+      `export async function charge() {\n  return fetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n}\n`,
+    );
+    writeFileSync(
+      join(root, 'package.json'),
+      `${JSON.stringify({ name: 'demo', dependencies: { stripe: '^14.0.0' } }, null, 2)}\n`,
+    );
+    // Prose: this URL extracts fine in isolation, so its absence proves the
+    // extension gate excludes it rather than the extractor failing to see it.
+    writeFileSync(join(root, 'README.md'), 'See https://api.acme-live.com/x for details.\n');
+    // Lockfile: manifestKindOf returns null and .json is not a code extension.
+    writeFileSync(
+      join(root, 'package-lock.json'),
+      `${JSON.stringify(
+        {
+          packages: {
+            'node_modules/stripe': {
+              resolved: 'https://registry.npmjs.org/stripe/-/stripe-14.0.0.tgz',
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    // Binary guard: an otherwise-extractable URL alongside a NUL byte.
+    writeFileSync(join(root, 'blob.ts'), `${NUL}const u = 'https://api.stripe.com/v1/x';\n`);
+  }
+
+  it('extracts from code files and manifests, skipping prose, lockfiles, and NUL-bearing files', () => {
+    writeCorpus();
+
+    const db = openLocalDatabase(store);
+    try {
+      // No rules at all, so every file takes the "no matches" path: a pass that
+      // only ran after the finding early-out would collect nothing here.
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.findings).toBe(0);
+
+      const byFile = new Map(result.egress.files.map((f) => [f.file, f]));
+      expect([...byFile.keys()].sort()).toEqual(
+        [join(root, 'package.json'), join(root, 'src', 'pay.ts')].sort(),
+      );
+
+      const pay = byFile.get(join(root, 'src', 'pay.ts'));
+      expect(pay?.sdkHits).toEqual([]);
+      expect(pay?.endpoints).toHaveLength(1);
+      expect(pay?.endpoints[0]).toMatchObject({
+        host: 'api.stripe.com',
+        url: 'https://api.stripe.com/v1/charges',
+        method: 'POST',
+        transport: 'https',
+        line: 2,
+      });
+
+      const manifest = byFile.get(join(root, 'package.json'));
+      expect(manifest?.endpoints).toEqual([]);
+      expect(manifest?.sdkHits).toHaveLength(1);
+      expect(manifest?.sdkHits[0]).toMatchObject({ ecosystem: 'npm', pkg: 'stripe' });
+    } finally {
+      db.close();
+    }
+  });
+
+  it('collects egress for files that produce findings too', () => {
+    writeFileSync(
+      join(root, 'app.ts'),
+      `const key = '${SECRET}';\nfetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n`,
+    );
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: RULES });
+      expect(result.findings).toBe(1);
+      expect(result.egress.files).toHaveLength(1);
+      expect(result.egress.files[0]?.endpoints[0]?.host).toBe('api.stripe.com');
+    } finally {
+      db.close();
+    }
+  });
+
+  it('omits files whose extraction yields nothing', () => {
+    writeFileSync(join(root, 'plain.ts'), 'export const n = 1;\n');
+    writeFileSync(join(root, 'notes.txt'), 'https://api.stripe.com/v1/charges\n');
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.scanned).toBe(2);
+      expect(result.egress.files).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('marks vendored call sites from the walked path', () => {
+    mkdirSync(join(root, 'vendor', 'lib'), { recursive: true });
+    writeFileSync(
+      join(root, 'vendor', 'lib', 'client.ts'),
+      `fetch('https://api.stripe.com/v1/charges', { method: 'POST' });\n`,
+    );
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: [] });
+      expect(result.egress.files).toHaveLength(1);
+      expect(result.egress.files[0]?.vendored).toBe(true);
     } finally {
       db.close();
     }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -35,6 +35,7 @@ export { resolveInventoryContext } from './inventory-resolver.ts';
 export type { ScanFinding } from './mask.ts';
 export { maskText, scanText } from './mask.ts';
 export { claimOnboardingNudge, claimSessionStart } from './nudge.ts';
+export { toPosix } from './paths.ts';
 export type { PostureChange } from './posture.ts';
 export { applyCategoryPosture, detectPostureChanges, severityFloorPosture } from './posture.ts';
 export { resolveProjectFiles } from './project-files.ts';

--- a/packages/plugin-sdk/src/paths.ts
+++ b/packages/plugin-sdk/src/paths.ts
@@ -1,0 +1,12 @@
+import { sep } from 'node:path';
+
+// Shared by every writer that stores or compares repo-relative paths (the
+// CLI/web-ui scan pipeline and the plugin scan pipeline both key stored rows
+// on paths built this way), so the two pipelines produce byte-identical path
+// keys for the same file instead of drifting apart under two hand-written
+// copies of the same one-liner.
+
+/** Normalize a filesystem path to posix-style forward slashes. A no-op outside win32. */
+export function toPosix(path: string): string {
+  return path.split(sep).join('/');
+}

--- a/packages/plugin-sdk/src/paths.ts
+++ b/packages/plugin-sdk/src/paths.ts
@@ -1,11 +1,5 @@
 import { sep } from 'node:path';
 
-// Shared by every writer that stores or compares repo-relative paths (the
-// CLI/web-ui scan pipeline and the plugin scan pipeline both key stored rows
-// on paths built this way), so the two pipelines produce byte-identical path
-// keys for the same file instead of drifting apart under two hand-written
-// copies of the same one-liner.
-
 /** Normalize a filesystem path to posix-style forward slashes. A no-op outside win32. */
 export function toPosix(path: string): string {
   return path.split(sep).join('/');


### PR DESCRIPTION
**Stacked PR 8 of 13** — base: `egress-stack/07-writer`. Depends on #79.

Collects egress during the fs-scan walk (code files only, lockfiles/NUL/dot-paths skipped) and records it under a collision-free projectKey (git identity or path root), with the dataSharesInPlace toggle and single-file scan scoping.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).