### PR TITLE
feat(egress) [10/13]: web-ui — record egress from the Scan action regardless of pack state

### DIFF
--- a/web-ui/app/(app)/scan/ScanClient.tsx
+++ b/web-ui/app/(app)/scan/ScanClient.tsx
@@ -65,6 +65,21 @@ export function ScanClient({ enabledRuleCount }: { enabledRuleCount: number }) {
             )}
           </div>
         )}
+        {/* Outside the ok/error branches above: egress extraction does not read
+            the ruleset, so destinations are recorded — and worth surfacing —
+            even when the scan had no usable packs to run. */}
+        {result?.egress && (
+          <p className="mt-2 text-xs text-text-2">
+            Data shares: {String(result.egress.destinations)} destination
+            {result.egress.destinations === 1 ? '' : 's'} · {String(result.egress.endpoints)}{' '}
+            endpoint{result.egress.endpoints === 1 ? '' : 's'} · {String(result.egress.callSites)}{' '}
+            call site{result.egress.callSites === 1 ? '' : 's'} recorded
+            {result.egress.truncated ? ' (capped)' : ''}.{' '}
+            <Link href="/data-shares" className="font-semibold text-primary underline">
+              View data shares
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   );

--- a/web-ui/app/(app)/scan/actions.ts
+++ b/web-ui/app/(app)/scan/actions.ts
@@ -70,8 +70,13 @@ export async function runScan(path: string): Promise<ScanResult> {
   revalidatePath('/findings');
   revalidatePath('/security');
   revalidatePath('/inventory');
+  revalidatePath('/data-shares');
 
-  if (noPacksError !== undefined) return { ok: false, error: noPacksError };
+  // The walk and the egress write already ran — egress extraction does not
+  // depend on the ruleset — so the recorded destinations ride along with the
+  // pack-state error rather than being dropped.
+  if (noPacksError !== undefined)
+    return { ok: false, error: noPacksError, egress: egress ?? undefined };
 
   return {
     ok: true,

--- a/web-ui/app/(app)/scan/actions.ts
+++ b/web-ui/app/(app)/scan/actions.ts
@@ -4,7 +4,12 @@ import { readdirSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, dirname, join, sep } from 'node:path';
 
-import { recordProjectInventory, scanPathIntoStore } from '@akasecurity/local-ops';
+import {
+  recordProjectEgress,
+  recordProjectInventory,
+  scanPathIntoStore,
+} from '@akasecurity/local-ops';
+import type { EgressWriteSummary } from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
 import { db } from '../../lib/db';
@@ -18,6 +23,7 @@ export interface ScanResult {
   ok: boolean;
   scanned?: number;
   findings?: number;
+  egress?: EgressWriteSummary;
   error?: string;
 }
 
@@ -33,19 +39,19 @@ export async function runScan(path: string): Promise<ScanResult> {
 
   // The installed snapshot is the scan authority — the validated
   // enabled ruleset from the DB, passed explicitly (the engine's process-global
-  // registry stays untouched in this long-lived server).
+  // registry stays untouched in this long-lived server). An empty ruleset
+  // (no packs installed/enabled) still walks the target: egress extraction
+  // does not depend on detection rules, so the no-packs guidance below is
+  // surfaced after recording rather than skipping the walk.
   const ruleset = db().installedPacks.installedRuleset();
-  if (ruleset.rules.length === 0) {
-    return {
-      ok: false,
-      error:
-        ruleset.installedPacks === 0
-          ? 'No detection packs installed — run `aka init` first.'
-          : ruleset.enabledPacks === 0
-            ? 'Every detection pack is disabled — enable one on the Detections page.'
-            : 'The installed rule snapshot is unusable — reinstall with `aka init`.',
-    };
-  }
+  const noPacksError =
+    ruleset.rules.length === 0
+      ? ruleset.installedPacks === 0
+        ? 'No detection packs installed — run `aka init` first.'
+        : ruleset.enabledPacks === 0
+          ? 'Every detection pack is disabled — enable one on the Detections page.'
+          : 'The installed rule snapshot is unusable — reinstall with `aka init`.'
+      : undefined;
 
   const result = scanPathIntoStore(db(), target, {
     rules: ruleset.rules,
@@ -57,10 +63,22 @@ export async function runScan(path: string): Promise<ScanResult> {
   // Keep the Inventory page's project + file tree fresh for the repo just
   // scanned (fail-open, no-op outside a git repo).
   recordProjectInventory(db(), target);
+  // Record the destinations/endpoints/call sites the walk extracted into the
+  // Data Shares store (fail-open; null when the toggle is off, the target has
+  // no resolvable project, or the write failed).
+  const egress = recordProjectEgress(db(), target, result.egress);
   revalidatePath('/findings');
   revalidatePath('/security');
   revalidatePath('/inventory');
-  return { ok: true, scanned: result.scanned, findings: result.findings };
+
+  if (noPacksError !== undefined) return { ok: false, error: noPacksError };
+
+  return {
+    ok: true,
+    scanned: result.scanned,
+    findings: result.findings,
+    egress: egress ?? undefined,
+  };
 }
 
 export interface DirEntry {


### PR DESCRIPTION
**Stacked PR 10 of 13** — base: `egress-stack/09-cli`. Depends on #81.

Restructures the Scan Server Action so the walk, inventory, and egress recording all run even with zero detection packs installed — the Scan page is the only re-scan affordance for dashboard users.

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).