### PR TITLE
feat(egress) [13/13]: test(local-ops) — egress acceptance corpus across eight ecosystems

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,5 +19,10 @@ pnpm-lock.yaml
 # drizzle-kit generated migration metadata (journals/snapshots) — not prettier-managed
 **/drizzle/**/meta
 
+# Scanner-input fixture corpora. These files are data, not sources: their exact
+# byte layout is what the extraction assertions read (line numbers, snippets,
+# manifest scoping), so reformatting one silently changes the test's subject.
+packages/local-ops/test/fixtures
+
 .wolf/
 .gitattributes

--- a/packages/local-ops/eslint.config.mjs
+++ b/packages/local-ops/eslint.config.mjs
@@ -2,6 +2,11 @@
 import { base } from '@akasecurity/eslint-config';
 
 export default [
+  // Test fixture corpora are scanner INPUT, not compiled sources: they are
+  // excluded from the tsconfig project, so the type-aware rules cannot resolve
+  // them, and their contents are deliberately shaped for the extractor rather
+  // than for the lint rules.
+  { ignores: ['test/fixtures/**'] },
   ...base,
   {
     languageOptions: {

--- a/packages/local-ops/test/egress-e2e.test.ts
+++ b/packages/local-ops/test/egress-e2e.test.ts
@@ -1,0 +1,423 @@
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { openLocalDatabase } from '@akasecurity/persistence';
+import type {
+  DataClass,
+  DestinationKind,
+  ReviewReason,
+  ShareDestinationSummary,
+  ShareTrustLevel,
+  Transport,
+} from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { recordProjectEgress } from '../src/egress-record.ts';
+import { scanPathIntoStore } from '../src/fs-scan.ts';
+
+// End-to-end acceptance for the CLI/web egress pipeline: walk a planted corpus
+// with `scanPathIntoStore`, record it with `recordProjectEgress`, then read the
+// store back through the Data Shares read port the dashboard uses.
+//
+// The corpus under fixtures/egress-corpus/ carries one dependency manifest per
+// supported ecosystem (npm, PyPI, Go, Maven, Gradle, RubyGems, Cargo, Composer,
+// NuGet) plus URL and bare-IP literals in five languages, and a planted
+// look-alike negative beside almost every positive: a provider SDK in
+// devDependencies, a plugin coordinate in pom.xml's <build> block, a
+// commented-out gem and PackageReference, a provider in Cargo's
+// [dev-dependencies] and Composer's require-dev, provider hosts inside a
+// lockfile, and a non-excluded host in a Markdown file.
+//
+// EXPECTED_LEDGER below is asserted as an EXACT equality, not a subset. A
+// missing provider is a recall failure and an extra host is a precision
+// failure, and one assertion catches both.
+
+const CORPUS = join(import.meta.dirname, 'fixtures', 'egress-corpus');
+const REMOTE_URL = 'https://github.com/acme/settlement.git';
+
+// Every destination the corpus must produce, and nothing else. `endpoints`
+// entries are `<method> <transport> <url> x<call sites>`.
+interface ExpectedDestination {
+  host: string;
+  kind: DestinationKind;
+  trust: ShareTrustLevel;
+  name: string;
+  category: string;
+  transports: Transport[];
+  dataClasses: DataClass[];
+  endpoints: string[];
+}
+
+const EXPECTED_LEDGER: ExpectedDestination[] = [
+  {
+    // src/transfer.rb — a bare public IPv4 named by an SFTP host constant.
+    host: '198.51.100.23',
+    kind: 'ip',
+    trust: 'ip',
+    name: '198.51.100.23',
+    category: 'Unresolved host',
+    transports: ['sftp'],
+    dataClasses: ['none'],
+    endpoints: ['REF sftp sftp://198.51.100.23:22 x1'],
+  },
+  {
+    // src/partner.ts — the corpus's only plaintext destination, carrying both
+    // an http endpoint and a ws one.
+    host: 'api.acme-partner.com',
+    kind: 'external',
+    trust: 'unverified',
+    name: 'api.acme-partner.com',
+    category: 'External domain',
+    transports: ['http', 'ws'],
+    dataClasses: ['none'],
+    endpoints: [
+      'POST http http://api.acme-partner.com/upload x1',
+      'POST ws ws://api.acme-partner.com/status x1',
+    ],
+  },
+  {
+    // requirements.txt (PyPI).
+    host: 'api.datadoghq.com',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Datadog',
+    category: 'Observability',
+    transports: ['https'],
+    dataClasses: ['logs'],
+    endpoints: ['SDK https https://api.datadoghq.com x1'],
+  },
+  {
+    // src/pay.py — verb-first client API, the method is the first argument.
+    host: 'api.segment.io',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Segment',
+    category: 'Analytics',
+    transports: ['https'],
+    dataClasses: ['customer'],
+    endpoints: ['POST https https://api.segment.io/v1/track x1'],
+  },
+  {
+    // src/app.ts (multi-line fetch) plus four manifests: package.json (npm),
+    // pom.xml (Maven), composer.json (Composer), Api.csproj (NuGet).
+    host: 'api.stripe.com',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Stripe',
+    category: 'Payments',
+    transports: ['https'],
+    dataClasses: ['customer'],
+    endpoints: [
+      'POST https https://api.stripe.com/v1/charges x1',
+      'SDK https https://api.stripe.com x4',
+    ],
+  },
+  {
+    // services/go/main.go — verb-first client API, the Go spelling.
+    host: 'api.twilio.com',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Twilio',
+    category: 'Communications',
+    transports: ['https'],
+    dataClasses: ['pii'],
+    endpoints: ['POST https https://api.twilio.com/2010-04-01/Messages.json x1'],
+  },
+  {
+    // src/intra.ts — an internal TLD, and a bare client call with the URL as
+    // its only argument, which is the one shape that proves a GET.
+    host: 'db.internal',
+    kind: 'internal',
+    trust: 'internal',
+    name: 'db.internal',
+    category: 'Internal services',
+    transports: ['https'],
+    dataClasses: ['none'],
+    endpoints: ['GET https https://db.internal/health x1'],
+  },
+  {
+    // go.mod (Go) — matched by module-path prefix.
+    host: 's3.amazonaws.com',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Amazon S3',
+    category: 'Cloud storage',
+    transports: ['https'],
+    dataClasses: ['secrets'],
+    endpoints: ['SDK https https://s3.amazonaws.com x1'],
+  },
+  {
+    // build.gradle x2 (a platform() BOM and a plain coordinate), Gemfile,
+    // Cargo.toml — plus a URL literal in the vendored client.
+    host: 'sentry.io',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'Sentry',
+    category: 'Error tracking',
+    transports: ['https'],
+    dataClasses: ['source'],
+    endpoints: ['REF https https://sentry.io/api/1/store/ x1', 'SDK https https://sentry.io x4'],
+  },
+  {
+    // src/app.ts — an encrypted websocket to an unrecognized host.
+    host: 'stream.acme-telemetry-live.com',
+    kind: 'external',
+    trust: 'unverified',
+    name: 'stream.acme-telemetry-live.com',
+    category: 'External domain',
+    transports: ['wss'],
+    dataClasses: ['none'],
+    endpoints: ['REF wss wss://stream.acme-telemetry-live.com/v1/events x1'],
+  },
+  {
+    // packages/nested/package.json — a manifest below the corpus root.
+    host: 'us.i.posthog.com',
+    kind: 'provider',
+    trust: 'recognized',
+    name: 'PostHog',
+    category: 'Analytics',
+    transports: ['https'],
+    dataClasses: ['customer'],
+    endpoints: ['SDK https https://us.i.posthog.com x1'],
+  },
+];
+
+// Hosts planted in the corpus that must never reach the store. Each one is
+// reachable only through a rule the extractor is required to apply: a scope
+// exclusion (devDependencies, require-dev, [dev-dependencies], pom <build>), a
+// comment, a lockfile, or the doc-extension gate.
+const EXPECTED_ABSENT: Record<string, string> = {
+  'api.openai.com': 'package.json devDependencies',
+  'storage.googleapis.com': "pom.xml <build> plugin group id 'com.google.cloud.tools'",
+  'api.mixpanel.com': 'a commented-out line in the Gemfile',
+  'cloud.mongodb.com': 'Cargo.toml [dev-dependencies]',
+  'login.auth0.com': 'composer.json require-dev',
+  'login.okta.com': 'a commented-out PackageReference in Api.csproj',
+  'registry.npmjs.org': 'resolved URLs in package-lock.json',
+  'api.acme-docs-example-live.com': 'a non-excluded host in README.md',
+};
+
+// A minimal on-disk git repo: a `.git` DIRECTORY (what the identity resolver
+// detects) whose `config` carries the remote the identity is derived from.
+// Nothing on this path ever spawns git, so the config file is the whole repo
+// as far as the pipeline is concerned.
+function initRepo(root: string): void {
+  mkdirSync(join(root, '.git'));
+  writeFileSync(join(root, '.git', 'config'), `[remote "origin"]\n\turl = ${REMOTE_URL}\n`);
+}
+
+// Walk `target` and record whatever egress the walk produced — the exact
+// two-call sequence the CLI and the web-ui Scan action perform.
+function scanAndRecord(db: LocalDatabase, target: string, base: string) {
+  const result = scanPathIntoStore(db, target, { rules: [] });
+  return recordProjectEgress(db, target, result.egress, base);
+}
+
+// Flatten the grouped listing into the comparable ledger shape. Transports are
+// sorted because their stored order follows endpoint insertion, which is walk
+// order rather than anything the contract fixes.
+function toLedger(items: ShareDestinationSummary[]): ExpectedDestination[] {
+  return items
+    .map((d) => ({
+      host: d.host,
+      kind: d.kind,
+      trust: d.trust,
+      name: d.name,
+      category: d.category,
+      transports: [...d.transports].sort(),
+      dataClasses: d.dataClasses,
+      endpoints: d.endpoints
+        .map((e) => `${e.method} ${e.transport} ${e.url} x${String(e.callSiteCount)}`)
+        .sort(),
+    }))
+    .sort((a, b) => a.host.localeCompare(b.host));
+}
+
+async function readLedger(db: LocalDatabase): Promise<ExpectedDestination[]> {
+  const { groups } = await db.shares.listDestinations({ groupBy: 'destination', review: false });
+  return toLedger(groups.flatMap((g) => g.items));
+}
+
+let root: string;
+let store: string;
+let base: string;
+let db: LocalDatabase;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'aka-corpus-'));
+  store = mkdtempSync(join(tmpdir(), 'aka-corpus-db-'));
+  base = mkdtempSync(join(tmpdir(), 'aka-corpus-home-'));
+  cpSync(CORPUS, root, { recursive: true });
+  initRepo(root);
+  db = openLocalDatabase(store);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(root, { recursive: true, force: true });
+  rmSync(store, { recursive: true, force: true });
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('egress acceptance corpus — destination ledger', () => {
+  it('records exactly the expected destinations across eight ecosystems', async () => {
+    const recorded = scanAndRecord(db, root, base);
+
+    expect(recorded).toEqual({
+      project: 'settlement',
+      destinations: EXPECTED_LEDGER.length,
+      endpoints: 14,
+      callSites: 20,
+      truncated: false,
+    });
+    expect(await readLedger(db)).toEqual(EXPECTED_LEDGER);
+  });
+
+  it('groups the ledger provider → internal → external → ip', async () => {
+    scanAndRecord(db, root, base);
+
+    const { groups } = await db.shares.listDestinations({ groupBy: 'destination', review: false });
+    // KIND_ORDER filters the grouped response, so a kind missing from it is
+    // dropped from the listing entirely while still counting in stats(). Both
+    // are asserted so a filter regression cannot hide behind the other.
+    expect(groups.map((g) => [g.kind, g.total])).toEqual([
+      ['provider', 7],
+      ['internal', 1],
+      ['external', 2],
+      ['ip', 1],
+    ]);
+
+    const stats = await db.shares.stats();
+    expect(stats.destinations).toBe(EXPECTED_LEDGER.length);
+    expect(stats.byKind).toEqual({ provider: 7, internal: 1, external: 2, ip: 1 });
+    expect(stats.byTrust).toEqual({ recognized: 7, internal: 1, unverified: 2, ip: 1 });
+    expect(stats.endpoints).toBe(14);
+    expect(stats.callSites).toBe(20);
+  });
+
+  it('records none of the planted look-alike hosts', async () => {
+    scanAndRecord(db, root, base);
+
+    const hosts = new Set((await readLedger(db)).map((d) => d.host));
+    for (const [host, why] of Object.entries(EXPECTED_ABSENT)) {
+      expect(hosts.has(host), `${host} must not be recorded — it appears only in ${why}`).toBe(
+        false,
+      );
+    }
+  });
+
+  it('marks the vendored call site and relativizes every path to the repo root', async () => {
+    scanAndRecord(db, root, base);
+
+    const { groups } = await db.shares.listDestinations({ groupBy: 'destination', review: false });
+    const sentry = groups.flatMap((g) => g.items).find((d) => d.host === 'sentry.io')?.id;
+    expect(sentry).toBeDefined();
+
+    const detail = await db.shares.getDestination(sentry ?? '');
+    const sites = (detail?.endpoints ?? []).flatMap((e) => e.sites);
+    expect(sites.map((s) => `${s.file}:${String(s.vendored)}`).sort()).toEqual([
+      'Cargo.toml:false',
+      'Gemfile:false',
+      'build.gradle:false',
+      'build.gradle:false',
+      'vendor/lib/client.rb:true',
+    ]);
+  });
+});
+
+describe('egress acceptance corpus — review posture', () => {
+  it('agrees between the review read port and the stats counters', async () => {
+    scanAndRecord(db, root, base);
+
+    // needsReview() runs the SQL review pre-filter AND the schema's
+    // buildReviewInfo; stats() counts the same posture through independent raw
+    // SQL. Asserting both catches the two mirrors drifting apart.
+    const { items } = await db.shares.needsReview();
+    const byHost = new Map(items.map((i) => [i.host, i.review.reasons]));
+    expect(new Set(byHost.keys())).toEqual(
+      new Set(['198.51.100.23', 'api.acme-partner.com', 'stream.acme-telemetry-live.com']),
+    );
+    expect(byHost.get('198.51.100.23')).toEqual<ReviewReason[]>(['raw_ip']);
+    expect(byHost.get('stream.acme-telemetry-live.com')).toEqual<ReviewReason[]>([
+      'unverified_domain',
+    ]);
+    expect(byHost.get('api.acme-partner.com')).toEqual<ReviewReason[]>([
+      'unverified_domain',
+      'plaintext_transport',
+    ]);
+
+    const stats = await db.shares.stats();
+    expect(stats.needsReview).toBe(items.length);
+    // The wss stream is secure and the IP's endpoint is sftp; only the partner
+    // host carries a plaintext endpoint.
+    expect(stats.insecure).toBe(1);
+  });
+});
+
+describe('egress acceptance corpus — reconciliation', () => {
+  it('is idempotent across a re-run of the unchanged corpus', async () => {
+    const first = scanAndRecord(db, root, base);
+    const before = await readLedger(db);
+
+    const second = scanAndRecord(db, root, base);
+
+    expect(second).toEqual(first);
+    expect(await readLedger(db)).toEqual(before);
+    expect((await db.shares.stats()).destinations).toBe(EXPECTED_LEDGER.length);
+  });
+
+  it('drops the partner destination when its only source file is deleted', async () => {
+    scanAndRecord(db, root, base);
+    expect((await readLedger(db)).map((d) => d.host)).toContain('api.acme-partner.com');
+
+    rmSync(join(root, 'src', 'partner.ts'));
+    const recorded = scanAndRecord(db, root, base);
+
+    const hosts = (await readLedger(db)).map((d) => d.host);
+    expect(hosts).not.toContain('api.acme-partner.com');
+    expect(hosts).toEqual(
+      EXPECTED_LEDGER.map((d) => d.host).filter((h) => h !== 'api.acme-partner.com'),
+    );
+    expect(recorded?.destinations).toBe(EXPECTED_LEDGER.length - 1);
+
+    const stats = await db.shares.stats();
+    expect(stats.destinations).toBe(EXPECTED_LEDGER.length - 1);
+    expect(stats.byKind.external).toBe(1);
+    // The partner host was the only plaintext one, and the only source of two
+    // of the three review reasons it carried.
+    expect(stats.insecure).toBe(0);
+  });
+});
+
+describe('egress acceptance corpus — plaintext posture covers ws', () => {
+  // The corpus's ws endpoint shares a destination with an http one, so it
+  // cannot on its own prove that 'ws' is in the plaintext predicate. This case
+  // isolates it: a destination whose ONLY transport is ws.
+  it('flags a destination reached over ws with no other plaintext evidence', async () => {
+    const solo = mkdtempSync(join(tmpdir(), 'aka-ws-'));
+    try {
+      mkdirSync(join(solo, 'src'));
+      writeFileSync(
+        join(solo, 'src', 'feed.ts'),
+        "export const FEED = 'ws://feed.acme-quotes-live.com/v1/ticks';\n",
+      );
+
+      scanAndRecord(db, solo, base);
+
+      const ledger = await readLedger(db);
+      expect(ledger.map((d) => [d.host, d.transports])).toEqual([
+        ['feed.acme-quotes-live.com', ['ws']],
+      ]);
+
+      const { items } = await db.shares.needsReview();
+      expect(items.map((i) => i.review.reasons)).toEqual<ReviewReason[][]>([
+        ['unverified_domain', 'plaintext_transport'],
+      ]);
+      expect((await db.shares.stats()).insecure).toBe(1);
+    } finally {
+      rmSync(solo, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/local-ops/test/egress-e2e.test.ts
+++ b/packages/local-ops/test/egress-e2e.test.ts
@@ -21,14 +21,20 @@ import { scanPathIntoStore } from '../src/fs-scan.ts';
 // with `scanPathIntoStore`, record it with `recordProjectEgress`, then read the
 // store back through the Data Shares read port the dashboard uses.
 //
-// The corpus under fixtures/egress-corpus/ carries one dependency manifest per
-// supported ecosystem (npm, PyPI, Go, Maven, Gradle, RubyGems, Cargo, Composer,
-// NuGet) plus URL and bare-IP literals in five languages, and a planted
+// The corpus under fixtures/egress-corpus/ covers all eight supported
+// ecosystems across nine manifest formats — package.json (npm),
+// requirements.txt (PyPI), go.mod (Go), pom.xml and build.gradle (both Maven),
+// Gemfile (RubyGems), Cargo.toml (Cargo), composer.json (Composer) and
+// Api.csproj (NuGet) — plus URL and bare-IP literals in five languages, and a
+// planted
 // look-alike negative beside almost every positive: a provider SDK in
 // devDependencies, a plugin coordinate in pom.xml's <build> block, a
 // commented-out gem and PackageReference, a provider in Cargo's
 // [dev-dependencies] and Composer's require-dev, provider hosts inside a
-// lockfile, and a non-excluded host in a Markdown file.
+// lockfile, and a non-excluded host in a Markdown file. go.mod's `exclude`
+// directive is the one negative that cannot sit in EXPECTED_ABSENT — it names
+// the same provider as its `require` sibling — so it is guarded instead by the
+// s3.amazonaws.com SDK endpoint staying at x1.
 //
 // EXPECTED_LEDGER below is asserted as an EXACT equality, not a subset. A
 // missing provider is a recall failure and an extra host is a precision
@@ -73,8 +79,10 @@ const EXPECTED_LEDGER: ExpectedDestination[] = [
     transports: ['http', 'ws'],
     dataClasses: ['none'],
     endpoints: [
-      'POST http http://api.acme-partner.com/upload x1',
-      'POST ws ws://api.acme-partner.com/status x1',
+      // Both are bare `const` literals; the fetch below them uses the binding,
+      // not the literal, so no verb is proven at either site.
+      'REF http http://api.acme-partner.com/upload x1',
+      'REF ws ws://api.acme-partner.com/status x1',
     ],
   },
   {
@@ -85,7 +93,7 @@ const EXPECTED_LEDGER: ExpectedDestination[] = [
     name: 'Datadog',
     category: 'Observability',
     transports: ['https'],
-    dataClasses: ['logs'],
+    dataClasses: ['telemetry'],
     endpoints: ['SDK https https://api.datadoghq.com x1'],
   },
   {
@@ -108,7 +116,7 @@ const EXPECTED_LEDGER: ExpectedDestination[] = [
     name: 'Stripe',
     category: 'Payments',
     transports: ['https'],
-    dataClasses: ['customer'],
+    dataClasses: ['pii'],
     endpoints: [
       'POST https https://api.stripe.com/v1/charges x1',
       'SDK https https://api.stripe.com x4',
@@ -142,8 +150,8 @@ const EXPECTED_LEDGER: ExpectedDestination[] = [
     host: 's3.amazonaws.com',
     kind: 'provider',
     trust: 'recognized',
-    name: 'Amazon S3',
-    category: 'Cloud storage',
+    name: 'Amazon Web Services',
+    category: 'Cloud platform',
     transports: ['https'],
     dataClasses: ['secrets'],
     endpoints: ['SDK https https://s3.amazonaws.com x1'],

--- a/packages/local-ops/test/egress-e2e.test.ts
+++ b/packages/local-ops/test/egress-e2e.test.ts
@@ -271,6 +271,7 @@ describe('egress acceptance corpus — destination ledger', () => {
       endpoints: 14,
       callSites: 20,
       truncated: false,
+      droppedFiles: [],
     });
     expect(await readLedger(db)).toEqual(EXPECTED_LEDGER);
   });

--- a/packages/local-ops/test/fixtures/egress-corpus/Api.csproj
+++ b/packages/local-ops/test/fixtures/egress-corpus/Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Stripe.net" Version="46.2.0" />
+    <!-- Re-enable once the identity migration lands.
+    <PackageReference Include="Okta.Sdk" Version="8.0.4" />
+    -->
+  </ItemGroup>
+
+</Project>

--- a/packages/local-ops/test/fixtures/egress-corpus/Cargo.toml
+++ b/packages/local-ops/test/fixtures/egress-corpus/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "settlement-ingest"
+version = "0.3.0"
+edition = "2021"
+
+[dependencies]
+sentry = "0.34"
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+mongodb = "3.1"

--- a/packages/local-ops/test/fixtures/egress-corpus/Gemfile
+++ b/packages/local-ops/test/fixtures/egress-corpus/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'rails', '~> 7.2'
+gem 'sentry-ruby', '~> 5.19'
+# gem 'mixpanel-ruby', '~> 2.2'

--- a/packages/local-ops/test/fixtures/egress-corpus/README.md
+++ b/packages/local-ops/test/fixtures/egress-corpus/README.md
@@ -1,0 +1,15 @@
+# Settlement service
+
+Batch settlement, card capture, and partner file drops.
+
+The partner integration guide lives at https://api.acme-docs-example-live.com/guide —
+read the "Uploads" section before changing `src/partner.ts`.
+
+## Layout
+
+| Path                | Purpose                                  |
+| ------------------- | ---------------------------------------- |
+| `src/`              | Node services                            |
+| `services/go/`      | The receipt sender                       |
+| `vendor/lib/`       | Vendored upstream clients                |
+| `packages/nested/`  | The analytics workspace package          |

--- a/packages/local-ops/test/fixtures/egress-corpus/build.gradle
+++ b/packages/local-ops/test/fixtures/egress-corpus/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id 'java'
+}
+
+dependencies {
+    implementation platform("io.sentry:sentry-bom:7.14.0")
+    implementation "io.sentry:sentry"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.11.0"
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/composer.json
+++ b/packages/local-ops/test/fixtures/egress-corpus/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "acme/settlement-web",
+  "type": "project",
+  "require": {
+    "php": "^8.3",
+    "stripe/stripe-php": "^15.6"
+  },
+  "require-dev": {
+    "auth0/auth0-php": "^8.11",
+    "phpunit/phpunit": "^11.3"
+  }
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/go.mod
+++ b/packages/local-ops/test/fixtures/egress-corpus/go.mod
@@ -1,0 +1,10 @@
+module github.com/acme/settlement
+
+go 1.24
+
+require (
+	github.com/aws/aws-sdk-go-v2/service/s3 v1.66.0
+	github.com/google/uuid v1.6.0
+)
+
+exclude github.com/aws/aws-sdk-go v1.44.0

--- a/packages/local-ops/test/fixtures/egress-corpus/go.mod
+++ b/packages/local-ops/test/fixtures/egress-corpus/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/google/uuid v1.6.0
 )
 
-exclude github.com/aws/aws-sdk-go v1.44.0
+exclude github.com/aws/aws-sdk-go v1.44.0 // planted negative: an exclude names no dependency, so this must not add a second s3.amazonaws.com call site

--- a/packages/local-ops/test/fixtures/egress-corpus/package-lock.json
+++ b/packages/local-ops/test/fixtures/egress-corpus/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "acme-settlement",
+  "version": "1.4.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "acme-settlement",
+      "version": "1.4.0",
+      "dependencies": {
+        "stripe": "^14.25.0"
+      },
+      "devDependencies": {
+        "openai": "^4.68.0",
+        "prettier": "^3.3.3"
+      }
+    },
+    "node_modules/openai": {
+      "version": "4.68.4",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.68.4.tgz",
+      "integrity": "sha512-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    },
+    "node_modules/stripe": {
+      "version": "14.25.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-14.25.0.tgz",
+      "integrity": "sha512-1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
+    }
+  }
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/package.json
+++ b/packages/local-ops/test/fixtures/egress-corpus/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "acme-settlement",
+  "version": "1.4.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "stripe": "^14.25.0"
+  },
+  "devDependencies": {
+    "openai": "^4.68.0",
+    "prettier": "^3.3.3"
+  }
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/packages/nested/package.json
+++ b/packages/local-ops/test/fixtures/egress-corpus/packages/nested/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@acme/analytics",
+  "version": "0.2.0",
+  "private": true,
+  "dependencies": {
+    "posthog-node": "^4.2.0"
+  }
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/pom.xml
+++ b/packages/local-ops/test/fixtures/egress-corpus/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.acme.settlement</groupId>
+  <artifactId>ledger-service</artifactId>
+  <version>1.4.0</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.stripe</groupId>
+      <artifactId>stripe-java</artifactId>
+      <version>26.12.0</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>3.4.3</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/packages/local-ops/test/fixtures/egress-corpus/requirements.txt
+++ b/packages/local-ops/test/fixtures/egress-corpus/requirements.txt
@@ -1,0 +1,4 @@
+# Runtime dependencies for the settlement worker.
+-r constraints.txt
+datadog==0.49.1
+requests>=2.32,<3

--- a/packages/local-ops/test/fixtures/egress-corpus/services/go/main.go
+++ b/packages/local-ops/test/fixtures/egress-corpus/services/go/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Verb-first client API, the Go spelling: the method is the first argument to
+// http.NewRequest.
+func sendReceipt(form string) (*http.Response, error) {
+	req, err := http.NewRequest("POST", "https://api.twilio.com/2010-04-01/Messages.json", strings.NewReader(form))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return http.DefaultClient.Do(req)
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/src/app.ts
+++ b/packages/local-ops/test/fixtures/egress-corpus/src/app.ts
@@ -1,0 +1,19 @@
+// Multi-line call: the URL literal and the options object that carries the
+// method sit on different lines.
+export async function chargeCard(form: URLSearchParams, secretKey: string): Promise<unknown> {
+  const response = await fetch('https://api.stripe.com/v1/charges', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${secretKey}`,
+      'content-type': 'application/x-www-form-urlencoded',
+    },
+    body: form,
+  });
+  return response.json();
+}
+
+// Settlement events arrive over an encrypted socket held open for the life of
+// the worker.
+export function openSettlementStream(): WebSocket {
+  return new WebSocket('wss://stream.acme-telemetry-live.com/v1/events');
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/src/intra.ts
+++ b/packages/local-ops/test/fixtures/egress-corpus/src/intra.ts
@@ -1,0 +1,6 @@
+// Readiness probe against the internal database proxy. A bare client call with
+// the URL as its only argument and no options object.
+export async function databaseIsReady(): Promise<boolean> {
+  const res = await fetch('https://db.internal/health');
+  return res.ok;
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/src/partner.ts
+++ b/packages/local-ops/test/fixtures/egress-corpus/src/partner.ts
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises';
+
+// The partner's ingest endpoint still terminates plaintext, and its job feed is
+// an unencrypted socket on the same host.
+const UPLOAD_ENDPOINT = 'http://api.acme-partner.com/upload';
+const STATUS_STREAM = 'ws://api.acme-partner.com/status';
+
+export async function uploadManifest(path: string): Promise<Response> {
+  const body = await readFile(path);
+  return fetch(UPLOAD_ENDPOINT, { method: 'POST', body });
+}
+
+export function watchStatus(): WebSocket {
+  return new WebSocket(STATUS_STREAM);
+}

--- a/packages/local-ops/test/fixtures/egress-corpus/src/pay.py
+++ b/packages/local-ops/test/fixtures/egress-corpus/src/pay.py
@@ -1,0 +1,10 @@
+"""Customer event forwarding for the settlement worker."""
+
+import requests
+
+
+def track(payload):
+    """Verb-first client API: the method is the call's first argument."""
+    resp = requests.request('POST', 'https://api.segment.io/v1/track', json=payload)
+    resp.raise_for_status()
+    return resp.json()

--- a/packages/local-ops/test/fixtures/egress-corpus/src/transfer.rb
+++ b/packages/local-ops/test/fixtures/egress-corpus/src/transfer.rb
@@ -1,0 +1,10 @@
+# Nightly settlement drop to the clearing house. The counterparty publishes a
+# bare address rather than a hostname.
+SFTP_HOST = '198.51.100.23:22'
+
+def upload_settlement(path)
+  host, port = SFTP_HOST.split(':')
+  Net::SFTP.start(host, sftp_user, port: port.to_i) do |sftp|
+    sftp.upload!(path, "/inbound/#{File.basename(path)}")
+  end
+end

--- a/packages/local-ops/test/fixtures/egress-corpus/vendor/lib/client.rb
+++ b/packages/local-ops/test/fixtures/egress-corpus/vendor/lib/client.rb
@@ -1,0 +1,13 @@
+# Vendored copy of the upstream error-reporting client, kept in-tree so the
+# build does not depend on the gem being resolvable.
+module Acme
+  module Vendor
+    class ReportingClient
+      INGEST_URL = 'https://sentry.io/api/1/store/'
+
+      def report(event)
+        post(INGEST_URL, event.to_json)
+      end
+    end
+  end
+end

--- a/packages/local-ops/tsconfig.json
+++ b/packages/local-ops/tsconfig.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test"],
+  "exclude": ["test/fixtures"]
 }


### PR DESCRIPTION
**Stacked PR 13 of 13** — base: `egress-stack/12-scanner`. Depends on #84.

An eight-ecosystem corpus asserting an exact destination ledger (recall AND precision in one equality), with planted negatives (doc-extension host, lockfile, devDependency, pom own-groupId/plugin).

---
Part of the Data Shares in-place egress feature, split into 13 stacked PRs (one per implementation task) to be reviewed and merged in order. Each PR builds green on its own (typecheck 14/14, format, owning-package tests); the full stack's tip is tree-identical to the single-PR version. Merge from #1 upward. The umbrella description lives in the original #72 (now superseded).