### PR TITLE
feat(schema): add status as a grouped-findings filter dimension

### DIFF
--- a/packages/schema/src/zod/finding.ts
+++ b/packages/schema/src/zod/finding.ts
@@ -236,6 +236,9 @@ export const FindingFacets = z
     subtype: z.array(FindingFacetItem),
     provider: z.array(FindingFacetItem),
     action: z.array(FindingFacetItem),
+    // Counts by the group's derived status; groups with no status (legacy rows
+    // that predate the resolution feature) are counted under no value.
+    status: z.array(FindingFacetItem),
   })
   .meta({ id: 'FindingFacets' });
 export type FindingFacets = z.infer<typeof FindingFacets>;
@@ -263,6 +266,10 @@ export const ListGroupedFindingsQuery = z.object({
   subtype: z.array(z.string()).optional(),
   provider: z.array(FindingProvider).optional(),
   action: z.array(FindingAction).optional(),
+  // Matches a group's DERIVED status (see FindingGroup.status), not its
+  // individual instances' — so a filtered group's Status column always reads
+  // one of the requested values.
+  status: z.array(FindingStatus).optional(),
   q: z.string().optional(),
   // Scope to findings whose event carries this session id (the Activity page's
   // session → findings drilldown). Findings without a session never match.

--- a/packages/schema/src/zod/finding.ts
+++ b/packages/schema/src/zod/finding.ts
@@ -236,8 +236,10 @@ export const FindingFacets = z
     subtype: z.array(FindingFacetItem),
     provider: z.array(FindingFacetItem),
     action: z.array(FindingFacetItem),
-    // Counts by the group's derived status; groups with no status (legacy rows
-    // that predate the resolution feature) are counted under no value.
+    // Counts by the group's derived status. The SQLite store derives a status
+    // for every instance, so every group lands in a bucket; a status-less
+    // group (possible only for callers whose rows carry no statuses) is
+    // counted under no value.
     status: z.array(FindingFacetItem),
   })
   .meta({ id: 'FindingFacets' });

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -418,6 +418,7 @@ export interface FindingFilterOptions {
   severity?: string[] | undefined;
   providers?: string[] | undefined;
   actions?: string[] | undefined;
+  statuses?: string[] | undefined;
   q?: string | undefined;
   subtype?: string[] | undefined;
 }
@@ -506,6 +507,16 @@ export function applyFindingFilters(
     filtered = filtered.filter((g) => subtypeSet.has(g.subtype));
   }
 
+  // Status: matches the GROUP's folded status (see foldGroupStatus), not "any
+  // instance matches" as provider/action do — the Status column shows exactly
+  // this one value, so a filtered row's badge always reads a requested status.
+  // A group with no status (no instance carries one — legacy rows) matches no
+  // specific status.
+  if (opts.statuses && opts.statuses.length > 0) {
+    const statusSet = new Set(opts.statuses);
+    filtered = filtered.filter((g) => g.status !== undefined && statusSet.has(g.status));
+  }
+
   // q: case-insensitive substring over the group's cached search haystack
   // (subtype, category, maskedMatch, policy name, id, and each instance's
   // repo/file/id) — see groupHaystack.
@@ -548,6 +559,7 @@ export function computeFindingFacets(
   const forSeverity = applyFindingFilters(allGroups, {
     providers: opts.providers,
     actions: opts.actions,
+    statuses: opts.statuses,
     q: opts.q,
     subtype: opts.subtype,
   });
@@ -558,6 +570,7 @@ export function computeFindingFacets(
 
   const forProvider = applyFindingFilters(allGroups, {
     actions: opts.actions,
+    statuses: opts.statuses,
     q: opts.q,
     subtype: opts.subtype,
     severity: opts.severity,
@@ -569,6 +582,7 @@ export function computeFindingFacets(
 
   const forAction = applyFindingFilters(allGroups, {
     providers: opts.providers,
+    statuses: opts.statuses,
     q: opts.q,
     subtype: opts.subtype,
     severity: opts.severity,
@@ -581,11 +595,26 @@ export function computeFindingFacets(
   const forSubtype = applyFindingFilters(allGroups, {
     providers: opts.providers,
     actions: opts.actions,
+    statuses: opts.statuses,
     q: opts.q,
     severity: opts.severity,
   });
   const subtypeMap = new Map<string, number>();
   for (const g of forSubtype) subtypeMap.set(g.subtype, (subtypeMap.get(g.subtype) ?? 0) + 1);
+
+  // Groups with no status contribute to no bucket — the filter can't select
+  // them either, so a count they can never reach would misstate the dimension.
+  const forStatus = applyFindingFilters(allGroups, {
+    providers: opts.providers,
+    actions: opts.actions,
+    q: opts.q,
+    subtype: opts.subtype,
+    severity: opts.severity,
+  });
+  const statusMap = new Map<string, number>();
+  for (const g of forStatus) {
+    if (g.status !== undefined) statusMap.set(g.status, (statusMap.get(g.status) ?? 0) + 1);
+  }
 
   const toItems = (m: Map<string, number>): FindingFacetItem[] =>
     [...m.entries()].map(([value, count]) => ({ value, count }));
@@ -595,5 +624,6 @@ export function computeFindingFacets(
     provider: toItems(providerMap),
     action: toItems(actionMap),
     subtype: toItems(subtypeMap),
+    status: toItems(statusMap),
   };
 }

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -234,11 +234,18 @@ export interface FindingGroupAggregate {
   sourceTools: string[];
   /** Distinct raw findings.action_taken values across ALL instances. */
   actionsTaken: string[];
-  /** deriveFindingStatus inputs, one per distinct combination in the group. */
+  /**
+   * deriveFindingStatus inputs, one per distinct combination in the group.
+   * `count` is how many instances carry that combination — it powers
+   * countInstancesByStatus (status-scoped totals). Optional so callers that
+   * don't track counts keep compiling; without it the status-scoped count
+   * falls back to the whole-group instanceCount.
+   */
   statusInputs: {
     kind: string;
     findingKey: string | null;
     latestResolutionStatus: string | null;
+    count?: number;
   }[];
   /** Max occurredAt (ISO) across ALL instances. */
   latestDetectedAt: string;
@@ -424,10 +431,11 @@ export interface FindingFilterOptions {
 }
 
 // The lowercased free-text haystack for a group is immutable once the group is
-// built, but applyFindingFilters runs up to 5× per request (once per facet
-// dimension + the final filtered set). Memoise it per group object so the
-// join/lowercase happens once instead of once per pass. Keyed weakly so groups
-// are collected with the request that produced them (no cross-request leak).
+// built, but applyFindingFilters runs several times per request (once per facet
+// dimension in computeFindingFacets, plus the final filtered set). Memoise it
+// per group object so the join/lowercase happens once instead of once per pass.
+// Keyed weakly so groups are collected with the request that produced them (no
+// cross-request leak).
 const haystackCache = new WeakMap<FindingGroup, string>();
 
 /**
@@ -479,6 +487,29 @@ function groupActions(g: FindingGroup): FindingAction[] {
   return actions;
 }
 
+/**
+ * Instances in `statusInputs` whose DERIVED status is among `statuses` —
+ * the status-scoped complement of a group's whole-group instanceCount, so a
+ * status-filtered response can report how many instances actually carry a
+ * requested status rather than the group's full tally.
+ *
+ * Returns null when any entry lacks a `count` (a caller that doesn't track
+ * per-combination counts) — the caller falls back to the unscoped count
+ * rather than reporting a partial sum as exact.
+ */
+export function countInstancesByStatus(
+  statusInputs: FindingGroupAggregate['statusInputs'],
+  statuses: readonly string[],
+): number | null {
+  const statusSet = new Set(statuses);
+  let sum = 0;
+  for (const input of statusInputs) {
+    if (input.count === undefined) return null;
+    if (statusSet.has(deriveFindingStatus(input))) sum += input.count;
+  }
+  return sum;
+}
+
 export function applyFindingFilters(
   groups: FindingGroup[],
   opts: FindingFilterOptions,
@@ -510,8 +541,10 @@ export function applyFindingFilters(
   // Status: matches the GROUP's folded status (see foldGroupStatus), not "any
   // instance matches" as provider/action do — the Status column shows exactly
   // this one value, so a filtered row's badge always reads a requested status.
-  // A group with no status (no instance carries one — legacy rows) matches no
-  // specific status.
+  // The undefined guard is defensive for callers that build groups from rows
+  // without statuses (FindingGroup.status is optional in the contract); the
+  // SQLite store derives a status for every instance, so its groups always
+  // carry one.
   if (opts.statuses && opts.statuses.length > 0) {
     const statusSet = new Set(opts.statuses);
     filtered = filtered.filter((g) => g.status !== undefined && statusSet.has(g.status));
@@ -602,8 +635,10 @@ export function computeFindingFacets(
   const subtypeMap = new Map<string, number>();
   for (const g of forSubtype) subtypeMap.set(g.subtype, (subtypeMap.get(g.subtype) ?? 0) + 1);
 
-  // Groups with no status contribute to no bucket — the filter can't select
-  // them either, so a count they can never reach would misstate the dimension.
+  // A status-less group (possible only for callers whose rows carry no
+  // statuses — the SQLite store always derives one) contributes to no bucket:
+  // the filter can't select it either, so a count it can never reach would
+  // misstate the dimension.
   const forStatus = applyFindingFilters(allGroups, {
     providers: opts.providers,
     actions: opts.actions,

--- a/packages/schema/test/zod/findings-group-build.test.ts
+++ b/packages/schema/test/zod/findings-group-build.test.ts
@@ -113,6 +113,32 @@ const rows: GroupableFindingRow[] = [
   },
 ];
 
+// One status-carrying row — `rows` above carry none, so the status filter and
+// facet cases build their own groups from these.
+const statusRow = (id: string, ruleId: string, status?: FindingStatus): GroupableFindingRow => ({
+  id,
+  ruleId,
+  category: 'secret',
+  severity: 'critical',
+  maskedMatch: 'AKIA…1',
+  actionTaken: 'block',
+  confidence: 0.9,
+  occurredAt: '2026-01-01T00:00:00.000Z',
+  sourceTool: 'claude-code',
+  repo: 'acme/api',
+  file: 'a.ts',
+  ...(status === undefined ? {} : { status }),
+});
+
+// Three groups: one that folds to open (its handled sibling loses to
+// open-dominates), one resolved, and one legacy group carrying no status.
+const statusFilterRows: GroupableFindingRow[] = [
+  statusRow('s1', 'open-rule', 'open'),
+  statusRow('s2', 'open-rule', 'handled'),
+  statusRow('s3', 'resolved-rule', 'resolved'),
+  statusRow('s4', 'legacy-rule'),
+];
+
 // A finding captured from tool output (no filePath, only tool attribution).
 const toolAttributedRows: GroupableFindingRow[] = [
   {
@@ -266,6 +292,40 @@ describe('applyFindingFilters', () => {
     expect(ids(applyFindingFilters(groups, { q: 'acme/web' }))).toEqual(['aws-key']);
     expect(ids(applyFindingFilters(groups, { q: 'EMAIL' }))).toEqual(['email']);
   });
+
+  describe('status (the group’s own folded status, not any instance)', () => {
+    const statusGroups = buildFindingGroups(statusFilterRows);
+
+    it('keeps only groups whose folded status is selected', () => {
+      expect(ids(applyFindingFilters(statusGroups, { statuses: ['open'] }))).toEqual(['open-rule']);
+      expect(ids(applyFindingFilters(statusGroups, { statuses: ['resolved'] }))).toEqual([
+        'resolved-rule',
+      ]);
+    });
+
+    it('keeps the union when several statuses are selected', () => {
+      expect(ids(applyFindingFilters(statusGroups, { statuses: ['open', 'resolved'] }))).toEqual([
+        'open-rule',
+        'resolved-rule',
+      ]);
+    });
+
+    it('does not match a group on an instance status the fold discarded', () => {
+      // open-rule holds a handled instance, but folds to open — a "handled"
+      // filter must not surface a row whose Status column reads "Open".
+      expect(ids(applyFindingFilters(statusGroups, { statuses: ['handled'] }))).toEqual([]);
+    });
+
+    it('excludes a legacy group carrying no status', () => {
+      expect(ids(applyFindingFilters(statusGroups, { statuses: ['open'] }))).not.toContain(
+        'legacy-rule',
+      );
+    });
+
+    it('returns every group unchanged for an empty selection', () => {
+      expect(applyFindingFilters(statusGroups, { statuses: [] })).toEqual(statusGroups);
+    });
+  });
 });
 
 describe('computeFindingFacets', () => {
@@ -294,6 +354,33 @@ describe('computeFindingFacets', () => {
     expect(f.severity.map((s) => s.value).sort()).toEqual(['critical', 'low']);
     // …but the provider facet DOES apply the severity filter (only email → claudecode).
     expect(f.provider).toEqual([{ value: 'claudecode', count: 1 }]);
+  });
+
+  describe('status facet', () => {
+    const statusGroups = buildFindingGroups(statusFilterRows);
+
+    it('counts groups by their folded status, ignoring status-less groups', () => {
+      const f = computeFindingFacets(statusGroups, {});
+      // legacy-rule carries no status, so it lands in no bucket — the filter
+      // cannot select it either.
+      expect(new Map(f.status.map((s) => [s.value, s.count]))).toEqual(
+        new Map([
+          ['open', 1],
+          ['resolved', 1],
+        ]),
+      );
+    });
+
+    it('excludes its own filter but applies the status filter to the others', () => {
+      const f = computeFindingFacets(statusGroups, { statuses: ['open'] });
+      expect(f.status.map((s) => s.value).sort()).toEqual(['open', 'resolved']);
+      // …while the severity facet narrows to the one open group.
+      expect(f.severity).toEqual([{ value: 'critical', count: 1 }]);
+    });
+
+    it('reports no statuses for groups that carry none', () => {
+      expect(computeFindingFacets(groups, {}).status).toEqual([]);
+    });
   });
 });
 

--- a/packages/schema/test/zod/findings-group-build.test.ts
+++ b/packages/schema/test/zod/findings-group-build.test.ts
@@ -5,6 +5,7 @@ import {
   applyFindingFilters,
   buildFindingGroups,
   computeFindingFacets,
+  countInstancesByStatus,
   type GroupableFindingRow,
   sortFindingGroups,
   toApiAction,
@@ -381,6 +382,31 @@ describe('computeFindingFacets', () => {
     it('reports no statuses for groups that carry none', () => {
       expect(computeFindingFacets(groups, {}).status).toEqual([]);
     });
+  });
+});
+
+describe('countInstancesByStatus', () => {
+  // (kind, findingKey, latestResolutionStatus) → derived status:
+  // prompt/∅/∅ → handled · code_change/key/∅ → open · code_change/key/resolved → resolved
+  const inputs = [
+    { kind: 'prompt', findingKey: null, latestResolutionStatus: null, count: 200 },
+    { kind: 'code_change', findingKey: 'k', latestResolutionStatus: null, count: 3 },
+    { kind: 'code_change', findingKey: 'k', latestResolutionStatus: 'resolved', count: 5 },
+  ];
+
+  it('sums the counts of combinations whose derived status is selected', () => {
+    expect(countInstancesByStatus(inputs, ['open'])).toBe(3);
+    expect(countInstancesByStatus(inputs, ['handled'])).toBe(200);
+    expect(countInstancesByStatus(inputs, ['open', 'resolved'])).toBe(8);
+  });
+
+  it('returns 0 when no combination matches', () => {
+    expect(countInstancesByStatus(inputs, ['dismissed'])).toBe(0);
+  });
+
+  it('returns null when a combination carries no count (caller falls back to instanceCount)', () => {
+    const noCounts = [{ kind: 'prompt', findingKey: null, latestResolutionStatus: null }];
+    expect(countInstancesByStatus(noCounts, ['handled'])).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

First of a 3-PR stack that makes **Status** a first-class findings filter (a real, server-side filter dimension instead of a local in-table dropdown). This PR is the `@akasecurity/schema` contract + pure filter/facet logic only.

## Changes

- `ListGroupedFindingsQuery` gains `status: FindingStatus[]` (optional), alongside severity/subtype/provider/action.
- `FindingFacets` gains a `status` array.
- `applyFindingFilters` filters groups by their **derived (folded) group status** — matching what the Status column shows. A group with no status (legacy rows that predate the resolution feature) never matches a specific status.
- `computeFindingFacets` adds a per-filter-excluded `status` facet, ignoring status-less groups (the filter can't select them either).

## Notes

- Pure logic, no I/O — no consumer is required to change to keep compiling (the new query field is optional; the new facet is produced by `computeFindingFacets` itself). Persistence wiring and the UI ride on top in the next two PRs.

## Verification

- `pnpm typecheck` — 14/14 workspace tasks pass on this branch alone.
- `pnpm test --filter @akasecurity/schema` — 597 pass, including new `applyFindingFilters` status cases and `computeFindingFacets` status-facet cases.

## Stack

1. **→ `status-filter/01-schema` (this PR, base `main`)**
2. `status-filter/02-persistence` (base `01-schema`)
3. `status-filter/03-ui` (base `02-persistence`)


## Review response (64260d5)

- **Per-status instance counts**: each `statusInputs` combination now carries an optional `count`, and a new `countInstancesByStatus` helper sums the instances whose derived status was requested (null ⇒ caller falls back to `instanceCount`). Powers #87's status-scoped totals.
- **Comment accuracy**: the status-less-group guards stay (`FindingGroup.status` is optional in the published contract, so the pure helpers must handle it) but the comments now say they are defensive for row-path callers — the SQLite store derives a status for every instance, so no real store produces a status-less group.
- **Stale "5×"**: the haystackCache rationale no longer pins a pass count. The suggested single-pass facet rewrite is deliberately deferred — groups are bounded by rule count, so the redundant passes are cheap; happy to take it as follow-up cleanup.
