### PR TITLE
feat(persistence): apply the status filter in listGroupedFindings

### DIFF
--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -382,6 +382,7 @@ export class SqliteFindingsRepository
       severity: query.severity,
       providers: query.provider,
       actions: query.action,
+      statuses: query.status,
       subtype: query.subtype,
       q: query.q,
     };

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -17,6 +17,7 @@ import {
   applyFindingFilters,
   buildFindingGroups,
   computeFindingFacets,
+  countInstancesByStatus,
   DEFAULT_GROUPED_FINDINGS_LIMIT,
   deriveFindingStatus,
   ENFORCEABLE_CATEGORIES,
@@ -42,9 +43,10 @@ const PREVIEW_INSTANCES_PER_GROUP = 200;
 // aggregate has a single argument, and DISTINCT already claims that slot, so the
 // default ',' is what the aggregate queries below emit.
 const CONCAT_SEP = ',';
-// Separates the fields of one encoded deriveFindingStatus input tuple. Both this
-// and CONCAT_SEP are absent from the enum values being encoded (event.kind,
-// finding_resolution.status).
+// Separates the fields of one encoded deriveFindingStatus input tuple (and its
+// trailing instance count). Both this and CONCAT_SEP are absent from the enum
+// values being encoded (event.kind, finding_resolution.status) and from the
+// count digits.
 const TUPLE_SEP = '|';
 
 function splitConcat(value: string | null): string[] {
@@ -297,7 +299,9 @@ export class SqliteFindingsRepository
    * applies the requested filters, and sorts by severity then recency. Filtering
    * and faceting run in JS via the shared @akasecurity/schema helpers. `totals`
    * reflect the full filtered set; `items` is the requested
-   * page (default 50); no cursor (nextCursor is always null).
+   * page (default 50); no cursor (nextCursor is always null). Under a `status`
+   * filter, `totals.findings` counts only instances whose derived status was
+   * requested, and each item's instance preview is narrowed the same way.
    *
    * Two reads, neither of which materializes a row per finding:
    *   1. one aggregate row per rule_id, folding EVERY instance into the numbers
@@ -391,13 +395,42 @@ export class SqliteFindingsRepository
     const facets = computeFindingFacets(allGroups, filterOpts);
     const sorted = sortFindingGroups(applyFindingFilters(allGroups, filterOpts));
 
+    // Under a status filter, `findings` counts only the instances whose DERIVED
+    // status was requested — a group folds to 'open' on the strength of a few
+    // open instances, and counting its whole tally would report instances the
+    // filter excluded. The per-status counts come from the aggregate's
+    // statusInputs; the whole-group instanceCount is the unfiltered total.
+    const statusFilter = query.status ?? [];
     const totals = {
-      findings: sorted.reduce((acc, g) => acc + g.instanceCount, 0),
+      findings: sorted.reduce((acc, g) => {
+        if (statusFilter.length === 0) return acc + g.instanceCount;
+        const agg = aggregates.get(g.id);
+        return (
+          acc +
+          (agg
+            ? (countInstancesByStatus(agg.statusInputs, statusFilter) ?? g.instanceCount)
+            : g.instanceCount)
+        );
+      }, 0),
       groups: sorted.length,
     };
 
     const limit = query.limit ?? DEFAULT_GROUPED_FINDINGS_LIMIT;
-    const items = sorted.slice(0, limit);
+    // Under a status filter, narrow each group's instance PREVIEW to the
+    // requested statuses so every rendered location matches the filter (the
+    // group-level folds still describe the whole group). The preview holds only
+    // the newest PREVIEW_INSTANCES_PER_GROUP rows, so it can end up EMPTY for a
+    // group the filter correctly kept — every matching instance may be older
+    // than the preview window; views render an explicit notice for that case.
+    const statusSet = statusFilter.length > 0 ? new Set<string>(statusFilter) : null;
+    const items = sorted.slice(0, limit).map((g) =>
+      statusSet
+        ? {
+            ...g,
+            instances: g.instances.filter((i) => i.status !== undefined && statusSet.has(i.status)),
+          }
+        : g,
+    );
 
     return Promise.resolve({
       totals,
@@ -413,22 +446,28 @@ export class SqliteFindingsRepository
    * buildFindingGroups cannot recover from a preview. Bounded by the number of
    * distinct rule_ids (the installed packs' rules), not by the store's size.
    *
-   * The per-instance sets ride back as group_concat lists of RAW DB values —
-   * source_tool, action_taken, and the (kind, has-key, latest-status) triples
-   * deriveFindingStatus consumes. Aggregating the status INPUTS rather than a
-   * status keeps the classifier itself in @akasecurity/schema, where
-   * severitySummary's SQL and this query can't drift apart on what 'resolved'
-   * means (see resolution-sql.ts). Each of those sets is bounded by an enum, so
+   * A single scan, folded in two levels: the inner SELECT groups by
+   * (rule_id, status tuple) so each (kind, has-key, latest-status) combination
+   * carries its instance count — countInstancesByStatus needs those counts for
+   * status-scoped totals — and the outer SELECT folds the tuples back to one
+   * row per rule. The per-instance sets ride back as group_concat lists of RAW
+   * DB values — source_tool, action_taken, and the tuples deriveFindingStatus
+   * consumes. Aggregating the status INPUTS rather than a status keeps the
+   * classifier itself in @akasecurity/schema, where severitySummary's SQL and
+   * this query can't drift apart on what 'resolved' means (see
+   * resolution-sql.ts). The concat-of-concats can repeat a value across
+   * tuples; the schema mappers dedupe, and each set is bounded by an enum, so
    * a group's row stays small however many findings it holds.
    *
    * `withSearchText` is the exception, and the one column here that does NOT
-   * stay small: the group's distinct repos/filePaths, whose size tracks how many
-   * distinct paths a rule fired across — for a rule hitting mostly-unique paths
-   * that is a string proportional to the store (~8MB over 200k distinct paths,
-   * and buildHaystack lowercases a second copy). It buys `q` the ability to
-   * match an instance outside the preview, which searching the preview alone
-   * would silently lose, so it is fetched only when the request actually
-   * carries a `q`.
+   * stay small: the group's per-tuple-distinct repos/filePaths, whose size
+   * tracks how many distinct paths a rule fired across — for a rule hitting
+   * mostly-unique paths that is a string proportional to the store (~8MB over
+   * 200k distinct paths, and buildHaystack lowercases a second copy). It buys
+   * `q` the ability to match an instance outside the preview, which searching
+   * the preview alone would silently lose, so it is fetched only when the
+   * request actually carries a `q`. (Substring matching is unaffected by a
+   * path repeating across tuples.)
    */
   private groupAggregates(
     withSearchText: boolean,
@@ -436,7 +475,7 @@ export class SqliteFindingsRepository
   ): Map<string, FindingGroupAggregate> {
     // Tool names ride as their display label ("via Bash") to mirror
     // buildHaystack — see its doc for why the bare name is not searched.
-    const searchTextColumns = withSearchText
+    const innerSearchColumns = withSearchText
       ? `, group_concat(DISTINCT json_extract(e.metadata, '$.repo')) AS repos,
            group_concat(DISTINCT json_extract(e.metadata, '$.filePath')) AS files,
            group_concat(DISTINCT 'via ' || json_extract(e.metadata, '$.toolName')) AS tool_names`
@@ -444,23 +483,33 @@ export class SqliteFindingsRepository
 
     const rows = this.db
       .prepare(
-        `SELECT f.rule_id AS rule_id,
-                count(*) AS instance_count,
-                max(e.occurred_at) AS latest_at,
-                group_concat(DISTINCT e.source_tool) AS source_tools,
-                group_concat(DISTINCT f.action_taken) AS actions_taken,
-                group_concat(DISTINCT (
-                  e.kind || '${TUPLE_SEP}' ||
-                  (CASE WHEN f.finding_key IS NULL THEN '' ELSE 'k' END) || '${TUPLE_SEP}' ||
-                  coalesce(latest.status, '')
-                )) AS status_inputs
-                ${searchTextColumns}
-           FROM findings f
-           JOIN events e ON e.id = f.event_id
-           LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
-             ON latest.finding_key = f.finding_key
-          ${scope.predicate}
-          GROUP BY f.rule_id`,
+        `SELECT rule_id,
+                sum(tuple_count) AS instance_count,
+                max(latest_at) AS latest_at,
+                group_concat(source_tools) AS source_tools,
+                group_concat(actions_taken) AS actions_taken,
+                group_concat(status_tuple || '${TUPLE_SEP}' || tuple_count) AS status_inputs,
+                group_concat(repos) AS repos,
+                group_concat(files) AS files,
+                group_concat(tool_names) AS tool_names
+           FROM (
+             SELECT f.rule_id AS rule_id,
+                    e.kind || '${TUPLE_SEP}' ||
+                      (CASE WHEN f.finding_key IS NULL THEN '' ELSE 'k' END) || '${TUPLE_SEP}' ||
+                      coalesce(latest.status, '') AS status_tuple,
+                    count(*) AS tuple_count,
+                    max(e.occurred_at) AS latest_at,
+                    group_concat(DISTINCT e.source_tool) AS source_tools,
+                    group_concat(DISTINCT f.action_taken) AS actions_taken
+                    ${innerSearchColumns}
+               FROM findings f
+               JOIN events e ON e.id = f.event_id
+               LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
+                 ON latest.finding_key = f.finding_key
+              ${scope.predicate}
+              GROUP BY f.rule_id, status_tuple
+           )
+          GROUP BY rule_id`,
       )
       .all(scope.params) as unknown as FindingAggregateRowJoined[];
 
@@ -472,13 +521,15 @@ export class SqliteFindingsRepository
           sourceTools: splitConcat(r.source_tools),
           actionsTaken: splitConcat(r.actions_taken),
           statusInputs: splitConcat(r.status_inputs).map((tuple) => {
-            const [kind = '', keyMarker = '', latestStatus = ''] = tuple.split(TUPLE_SEP);
+            const [kind = '', keyMarker = '', latestStatus = '', count = ''] =
+              tuple.split(TUPLE_SEP);
             return {
               // deriveFindingStatus only distinguishes null from non-null here,
               // so the marker stands in for the key itself (never rendered).
               kind,
               findingKey: keyMarker === '' ? null : keyMarker,
               latestResolutionStatus: latestStatus === '' ? null : latestStatus,
+              count: Number(count),
             };
           }),
           latestDetectedAt: epochMillisToIso(r.latest_at),

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -553,6 +553,79 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
     expect(group?.status).toBe('open');
   });
 
+  // The Status toolbar filter is a store-side filter like severity/provider —
+  // it must narrow items, totals AND the other facets, not just the page the
+  // caller already fetched.
+  describe('status filter', () => {
+    beforeEach(() => {
+      // in-flight ⇒ handled
+      record({
+        occurredAt: '2026-01-01T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'handled-rule',
+        repo: 'acme/api',
+        filePath: 'a.ts',
+      });
+      // at-rest, tracked, unresolved ⇒ open
+      recordAtRest({ findingKey: 'key-open', ruleId: 'open-rule' });
+      // at-rest, tracked, resolved ⇒ resolved
+      recordAtRest({ findingKey: 'key-resolved', ruleId: 'resolved-rule' });
+      db.resolutions.insertResolution({
+        findingKey: 'key-resolved',
+        status: 'resolved',
+        method: 'fixed-at-source',
+        resolvedAt: Date.parse('2026-01-02T00:00:00.000Z'),
+        evidence: '',
+      });
+    });
+
+    it('keeps only groups whose derived status was requested', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      expect(res.items.map((g) => g.id)).toEqual(['open-rule']);
+    });
+
+    it('keeps the union when several statuses are requested', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open', 'resolved'] });
+      expect(res.items.map((g) => g.id).sort()).toEqual(['open-rule', 'resolved-rule']);
+    });
+
+    it('narrows totals to the filtered set (not just the fetched page)', async () => {
+      expect((await db.findings.listGroupedFindings({})).totals).toEqual({
+        findings: 3,
+        groups: 3,
+      });
+      expect((await db.findings.listGroupedFindings({ status: ['open'] })).totals).toEqual({
+        findings: 1,
+        groups: 1,
+      });
+    });
+
+    it('reports a status facet excluding its own filter, and applies it to the others', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      // The status facet still counts every status, so the user can switch…
+      expect(new Map(res.facets.status.map((f) => [f.value, f.count]))).toEqual(
+        new Map([
+          ['handled', 1],
+          ['open', 1],
+          ['resolved', 1],
+        ]),
+      );
+      // …while the action facet DOES honor the status filter (open-rule only).
+      expect(res.facets.action).toEqual([{ value: 'blocked', count: 1 }]);
+    });
+
+    it('composes with the other filters', async () => {
+      const res = await db.findings.listGroupedFindings({
+        status: ['open'],
+        severity: ['critical'],
+      });
+      expect(res.items.map((g) => g.id)).toEqual(['open-rule']);
+      expect(
+        (await db.findings.listGroupedFindings({ status: ['open'], severity: ['low'] })).items,
+      ).toEqual([]);
+    });
+  });
+
   it('a group with mixed instance statuses derives its group status via open-dominates precedence', async () => {
     // Same ruleId, two instances: one in-flight (handled), one at-rest and
     // still open — the group must read 'open' even though one instance is

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -624,6 +624,60 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
         (await db.findings.listGroupedFindings({ status: ['open'], severity: ['low'] })).items,
       ).toEqual([]);
     });
+
+    it('scopes totals and the instance preview to matching instances on a mixed-status group', async () => {
+      // Two more in-flight (handled) instances on open-rule: the group still
+      // folds to open (open dominates), but only ONE of its three instances IS
+      // open — the tally and the preview must not report the other two.
+      record({
+        occurredAt: '2026-01-04T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'open-rule',
+        repo: 'acme/api',
+        filePath: 'b.ts',
+      });
+      record({
+        occurredAt: '2026-01-05T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'open-rule',
+        repo: 'acme/api',
+        filePath: 'c.ts',
+      });
+
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      const group = res.items.find((g) => g.id === 'open-rule');
+      expect(group?.status).toBe('open');
+      // instanceCount stays the whole-group tally; the preview and the totals
+      // are status-scoped.
+      expect(group?.instanceCount).toBe(3);
+      expect(group?.instances.map((i) => i.status)).toEqual(['open']);
+      expect(res.totals).toEqual({ findings: 1, groups: 1 });
+    });
+
+    it('keeps a group whose matching instances all sit outside the preview (empty narrowed preview)', async () => {
+      // More in-flight (handled) instances than the preview holds, all NEWER
+      // than open-rule's one open instance: the preview window is entirely
+      // handled, yet the group folds to open on the strength of the older row.
+      // The filter must keep the group, totals must count only the open
+      // instance, and the narrowed preview is legitimately EMPTY — the view
+      // layer renders an explicit notice for this case.
+      for (let i = 0; i < 205; i++) {
+        record({
+          occurredAt: new Date(Date.parse('2026-02-01T00:00:00.000Z') + i * 1000).toISOString(),
+          sourceTool: 'claude-code',
+          ruleId: 'open-rule',
+          repo: 'acme/api',
+          filePath: `bulk/f${String(i)}.ts`,
+        });
+      }
+
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      const group = res.items.find((g) => g.id === 'open-rule');
+      expect(group?.status).toBe('open');
+      expect(group?.instanceCount).toBe(206);
+      expect(group?.instances).toEqual([]);
+      expect(res.totals).toEqual({ findings: 1, groups: 1 });
+    });
   });
 
   it('a group with mixed instance statuses derives its group status via open-dominates precedence', async () => {


### PR DESCRIPTION
## What

Second of a 3-PR stack making **Status** a first-class findings filter. This PR wires the schema contract from #1 into the local store so `listGroupedFindings` actually applies it.

**Stacked on `status-filter/01-schema` — review/merge that first.**

## Changes

- `SqliteFindingsRepository.listGroupedFindings` threads `query.status` into the shared filter options, so `items`, `totals`, and every facet honor the Status filter.
- **No SQL change.** The group aggregate already folds each instance's status-derivation inputs over the whole group, so filtering and faceting stay entirely in the shared `@akasecurity/schema` helpers — the two reads are untouched.

## Verification

- `pnpm typecheck` — 14/14 workspace tasks pass on this branch.
- `pnpm test --filter @akasecurity/persistence` — 476 pass, including new cases: `status` narrows `items` and `totals` (not just the fetched page), the union of two statuses, composition with other filters, and the per-filter-excluded `status` facet.

## Stack

1. `status-filter/01-schema` (base `main`)
2. **→ `status-filter/02-persistence` (this PR, base `01-schema`)**
3. `status-filter/03-ui` (base `02-persistence`)


## Review response (58d100c)

- **Totals no longer overcount**: the aggregate now folds in two levels — per (rule, status tuple) with a count, then per rule — still a single scan. Under a `status` filter, `totals.findings` sums only the instances whose derived status was requested (a group folding open on 3 of 400 instances contributes 3, not 400). Against a real ~2.5k-finding store, `status=open` went from ~1,700 to the true 30.
- **Instance previews are status-narrowed**: each returned group's `instances` now contains only matching instances, so every rendered location matches the filter. The preview can legitimately end up empty (every matching instance older than the 200-row window) — #88 renders an explicit notice for that case.
- **Coverage gap closed**: new tests cover a mixed-status group (scoped totals + narrowed preview) and the >200-instance shape where the matching status exists only among older rows — the group stays listed, totals count only the matches, and the empty narrowed preview is pinned as intended behavior.
