### PR TITLE
feat(dashboard): move findings status into the toolbar as a server-side filter

### DIFF
--- a/packages/dashboard-ui/src/findings/FindingDetailView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingDetailView.tsx
@@ -121,11 +121,14 @@ export function FindingDetailView({
                 />
               ))}
             </div>
-            {/* `instances` is the newest slice of a large group, not all of it. */}
+            {/* `instances` is the newest slice of a large group, not all of it —
+              and under a status filter the store narrows it further, possibly
+              to none (every matching location older than the preview). */}
             {finding.instances.length < finding.instanceCount && (
               <p className="pt-2 text-xs text-text-3">
-                Showing the {finding.instances.length} most recent of {finding.instanceCount}{' '}
-                locations.
+                {finding.instances.length === 0
+                  ? `No locations here match the current filters — the group has ${String(finding.instanceCount)} locations in total.`
+                  : `Showing the ${String(finding.instances.length)} most recent of ${String(finding.instanceCount)} locations.`}
               </p>
             )}
           </div>

--- a/packages/dashboard-ui/src/findings/FindingsTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsTableView.tsx
@@ -4,6 +4,7 @@ import type { FindingGroup, FindingInstance, FindingStatus } from '@akasecurity/
 import {
   Badge,
   Button,
+  Card,
   cn,
   SeverityBadge,
   Table,
@@ -13,7 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from '@akasecurity/ui-kit';
-import { Fragment, type ReactNode, useState } from 'react';
+import { Fragment, type ReactNode } from 'react';
 
 import { relativeTime } from '../lib/relativeTime.ts';
 import { ChevronRightIcon, KeyIcon } from '../shared/icons.tsx';
@@ -21,13 +22,11 @@ import { ActionTag, AggregateActionTag } from './ActionTag.tsx';
 import {
   CATEGORY_ICON_FALLBACK,
   categoryStyle,
-  filterGroupsByStatus,
   filterInstancesByStatus,
   FINDING_STATUS_META,
   type FindingColumn,
   instanceLocationLabel,
   type Selection,
-  STATUS_FILTER_OPTIONS,
 } from './meta.ts';
 import { ProviderChips, ProviderTag } from './ProviderChips.tsx';
 
@@ -50,6 +49,7 @@ export function FindingsTableView({
   error = null,
   emptyState,
   sessionFirings,
+  statusFilter,
 }: {
   groups: FindingGroup[];
   /** Visible columns, in display order (caller applies column visibility). */
@@ -75,175 +75,135 @@ export function FindingsTableView({
    * unscoped lists.
    */
   sessionFirings?: Record<string, number>;
+  /**
+   * The statuses the caller's Status filter selected (empty/absent ⇒ no status
+   * filter). The store already dropped every group whose status is not among
+   * them; this narrows an expanded group's instance rows to match.
+   */
+  statusFilter?: readonly string[];
 }) {
-  // Lifecycle-status filter — local to the table (not part of the shared
-  // severity/type/provider/action FindingsFilters, which round-trip through
-  // the app's server query). Narrows the already-fetched `groups` page
-  // client-side; 'all' is a no-op (see filterGroupsByStatus).
-  const [statusFilter, setStatusFilter] = useState<FindingStatus | 'all'>('all');
-  const visibleGroups = filterGroupsByStatus(groups, statusFilter);
-
   return (
-    <div className="rounded-xl border border-border bg-surface p-4 shadow-sm">
-      <div className="mb-3 flex items-center justify-end gap-2">
-        <label htmlFor="findings-status-filter" className="text-xs font-medium text-text-3">
-          Status
-        </label>
-        <select
-          id="findings-status-filter"
-          value={statusFilter}
-          onChange={(e) => {
-            setStatusFilter(e.target.value as FindingStatus | 'all');
-          }}
-          className="h-8 rounded-lg border border-border bg-surface px-2 text-sm text-text-2 focus:border-primary focus:outline-none"
-        >
-          {STATUS_FILTER_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </div>
-      {error ? (
-        <p className="py-8 text-center text-sm text-sev-critical">
-          Error loading findings: {error}
-        </p>
-      ) : isLoading ? (
-        <p className="py-8 text-center text-sm text-text-3">Loading findings…</p>
-      ) : visibleGroups.length === 0 ? (
-        // A local status filter narrows only the fetched page, so "nothing here"
-        // can mean "none on this page" rather than "none exist" (grouped rows are
-        // server-capped) — say so, instead of the caller's store-empty copy.
-        statusFilter !== 'all' ? (
-          <p className="py-8 text-center text-sm text-text-3">
-            No {FINDING_STATUS_META[statusFilter].label.toLowerCase()} findings on this page
-            {hasMore ? ' — more results may exist beyond the fetched limit.' : '.'}
+    <Card className="flex flex-col overflow-hidden shadow-sm h-full">
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {error ? (
+          <p className="py-8 text-center text-sm text-sev-critical px-4">
+            Error loading findings: {error}
           </p>
-        ) : (
+        ) : isLoading ? (
+          <p className="py-8 text-center text-sm text-text-3 px-4">Loading findings…</p>
+        ) : groups.length === 0 ? (
           (emptyState ?? (
-            <p className="py-8 text-center text-sm text-text-3">No findings match these filters.</p>
+            <p className="py-8 text-center text-sm text-text-3 px-4">
+              No findings match these filters.
+            </p>
           ))
-        )
-      ) : (
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-10" />
-              {columns.map((col) => (
-                <TableHead key={col.id}>{col.header}</TableHead>
-              ))}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {visibleGroups.map((group) => {
-              const expanded = expandedIds.has(group.id);
-              const isGroupSelected = selection?.finding.id === group.id && !selection.instance;
-              return (
-                <Fragment key={group.id}>
-                  <TableRow
-                    onClick={() => {
-                      onSelectGroup(group);
-                    }}
-                    aria-label={`View details for ${group.subtype} finding`}
-                    className={cn(
-                      'cursor-pointer hover:bg-surface-2',
-                      isGroupSelected && 'bg-surface-2',
-                    )}
-                  >
-                    <TableCell className="text-text-3">
-                      <Button
-                        aria-label={expanded ? 'Collapse' : 'Expand'}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onToggleExpand(group.id);
-                        }}
-                        size="icon"
-                        variant="ghost"
-                      >
-                        <ChevronRightIcon
-                          className={cn('size-4 transition-transform', expanded && 'rotate-90')}
-                        />
-                      </Button>
-                    </TableCell>
-                    {columns.map((col) => (
-                      <TableCell key={col.id}>{GROUP_CELL[col.id](group)}</TableCell>
-                    ))}
-                  </TableRow>
-                  {expanded &&
-                    filterInstancesByStatus(group.instances, statusFilter).map((instance) => (
-                      <TableRow
-                        key={instance.id}
-                        onClick={() => {
-                          onSelectInstance(group, instance);
-                        }}
-                        aria-label={`View details for ${group.subtype} finding in ${instance.repo}`}
-                        className={cn(
-                          'cursor-pointer hover:bg-surface-2',
-                          selection?.instance?.id === instance.id
-                            ? 'bg-surface-2'
-                            : 'bg-surface-2/50',
-                        )}
-                      >
-                        <TableCell />
-                        {columns.map((col) => (
-                          <TableCell key={col.id}>
-                            {INSTANCE_CELL[col.id](group, instance)}
-                          </TableCell>
-                        ))}
-                      </TableRow>
-                    ))}
-                  {/* On a session-scoped list, reconcile this group's deduped
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-10" />
+                {columns.map((col) => (
+                  <TableHead key={col.id}>{col.header}</TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {groups.map((group) => {
+                const expanded = expandedIds.has(group.id);
+                const isGroupSelected = selection?.finding.id === group.id && !selection.instance;
+                return (
+                  <Fragment key={group.id}>
+                    <TableRow
+                      onClick={() => {
+                        onSelectGroup(group);
+                      }}
+                      aria-label={`View details for ${group.subtype} finding`}
+                      className={cn(
+                        'cursor-pointer hover:bg-surface-2',
+                        isGroupSelected && 'bg-surface-2',
+                      )}
+                    >
+                      <TableCell className="text-text-3">
+                        <Button
+                          aria-label={expanded ? 'Collapse' : 'Expand'}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onToggleExpand(group.id);
+                          }}
+                          size="icon"
+                          variant="ghost"
+                        >
+                          <ChevronRightIcon
+                            className={cn('size-4 transition-transform', expanded && 'rotate-90')}
+                          />
+                        </Button>
+                      </TableCell>
+                      {columns.map((col) => (
+                        <TableCell key={col.id}>{GROUP_CELL[col.id](group)}</TableCell>
+                      ))}
+                    </TableRow>
+                    {expanded &&
+                      filterInstancesByStatus(group.instances, statusFilter).map((instance) => (
+                        <TableRow
+                          key={instance.id}
+                          onClick={() => {
+                            onSelectInstance(group, instance);
+                          }}
+                          aria-label={`View details for ${group.subtype} finding in ${instance.repo}`}
+                          className={cn(
+                            'cursor-pointer hover:bg-surface-2',
+                            selection?.instance?.id === instance.id
+                              ? 'bg-surface-2'
+                              : 'bg-surface-2/50',
+                          )}
+                        >
+                          <TableCell />
+                          {columns.map((col) => (
+                            <TableCell key={col.id}>
+                              {INSTANCE_CELL[col.id](group, instance)}
+                            </TableCell>
+                          ))}
+                        </TableRow>
+                      ))}
+                    {/* On a session-scoped list, reconcile this group's deduped
                       rows with the session's per-firing tally — the two counts
                       legitimately differ and the gap confuses otherwise. */}
-                  {expanded && sessionFirings && (
-                    <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
-                      <TableCell />
-                      <TableCell colSpan={columns.length} className="text-xs text-text-3">
-                        {(sessionFirings[group.id] ?? 0) > 0
-                          ? `Fired ${String(sessionFirings[group.id])} times in this session's transcript — the session's "triggered" tally counts every firing, this row counts unique values.`
-                          : `Caught by live enforcement only — not re-detected in this session's transcript.`}
-                      </TableCell>
-                    </TableRow>
-                  )}
-                  {/* `instances` is the newest slice of a large group, not all
+                    {expanded && sessionFirings && (
+                      <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
+                        <TableCell />
+                        <TableCell colSpan={columns.length} className="text-xs text-text-3">
+                          {(sessionFirings[group.id] ?? 0) > 0
+                            ? `Fired ${String(sessionFirings[group.id])} times in this session's transcript — the session's "triggered" tally counts every firing, this row counts unique values.`
+                            : `Caught by live enforcement only — not re-detected in this session's transcript.`}
+                        </TableCell>
+                      </TableRow>
+                    )}
+                    {/* `instances` is the newest slice of a large group, not all
                       of it — say so rather than ending the rows silently. */}
-                  {expanded && group.instances.length < group.instanceCount && (
-                    <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
-                      <TableCell />
-                      <TableCell colSpan={columns.length} className="text-xs text-text-3">
-                        Showing the {group.instances.length} most recent of {group.instanceCount}{' '}
-                        locations.
-                      </TableCell>
-                    </TableRow>
-                  )}
-                </Fragment>
-              );
-            })}
-          </TableBody>
-        </Table>
-      )}
+                    {expanded && group.instances.length < group.instanceCount && (
+                      <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
+                        <TableCell />
+                        <TableCell colSpan={columns.length} className="text-xs text-text-3">
+                          Showing the {group.instances.length} most recent of {group.instanceCount}{' '}
+                          locations.
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </Fragment>
+                );
+              })}
+            </TableBody>
+          </Table>
+        )}
 
-      {/* The "first N" hint describes the server's fetched-page cap over `groups`;
-          it's incoherent alongside the local status filter (which narrows to
-          `visibleGroups`), so it only counts the unfiltered page. A non-empty
-          filtered result still needs the SAME "more may exist beyond the fetched
-          page" caveat as the filtered empty-state above — the local filter only
-          ever narrows what was already fetched, so a page that hit the server
-          cap can under-represent a status's true count even when some matches
-          are visible. */}
-      {hasMore &&
-        (statusFilter === 'all' ? (
+        {/* The server's fetched-page cap over the full filtered set. */}
+        {hasMore && (
           <p className="mt-4 text-center text-xs text-text-3">
             Showing the first {groups.length} findings — refine the filters to narrow results.
           </p>
-        ) : (
-          <p className="mt-4 text-center text-xs text-text-3">
-            Showing {visibleGroups.length} {FINDING_STATUS_META[statusFilter].label.toLowerCase()}{' '}
-            findings from the first {groups.length} fetched — more may exist beyond the fetched
-            limit.
-          </p>
-        ))}
-    </div>
+        )}
+      </div>
+    </Card>
   );
 }
 

--- a/packages/dashboard-ui/src/findings/FindingsTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsTableView.tsx
@@ -35,6 +35,10 @@ import { ProviderChips, ProviderTag } from './ProviderChips.tsx';
  * Fully presentational: selection/expansion state is owned by the caller and
  * flows in as props. Loading/empty/error and the "showing first N" affordance
  * are rendered here so the page stays a thin composition.
+ *
+ * Layout contract: the card fills its container's height and scrolls the rows
+ * internally, so the caller must mount it in a height-constrained parent (an
+ * unbroken h-full/min-h-0 chain) — without one the card has no height to fill.
  */
 export function FindingsTableView({
   groups,

--- a/packages/dashboard-ui/src/findings/FindingsTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsTableView.tsx
@@ -77,8 +77,11 @@ export function FindingsTableView({
   sessionFirings?: Record<string, number>;
   /**
    * The statuses the caller's Status filter selected (empty/absent ⇒ no status
-   * filter). The store already dropped every group whose status is not among
-   * them; this narrows an expanded group's instance rows to match.
+   * filter). The store already dropped every non-matching group and pre-narrows
+   * each group's instance preview; this re-applies the same narrowing for
+   * callers that don't, and drives the explicit notice when a kept group's
+   * preview holds no matching instance (every match can be older than the
+   * preview window).
    */
   statusFilter?: readonly string[];
 }) {
@@ -86,16 +89,14 @@ export function FindingsTableView({
     <Card className="flex flex-col overflow-hidden shadow-sm h-full">
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
         {error ? (
-          <p className="py-8 text-center text-sm text-sev-critical px-4">
+          <p className="py-8 text-center text-sm text-sev-critical">
             Error loading findings: {error}
           </p>
         ) : isLoading ? (
-          <p className="py-8 text-center text-sm text-text-3 px-4">Loading findings…</p>
+          <p className="py-8 text-center text-sm text-text-3">Loading findings…</p>
         ) : groups.length === 0 ? (
           (emptyState ?? (
-            <p className="py-8 text-center text-sm text-text-3 px-4">
-              No findings match these filters.
-            </p>
+            <p className="py-8 text-center text-sm text-text-3">No findings match these filters.</p>
           ))
         ) : (
           <Table>
@@ -111,6 +112,7 @@ export function FindingsTableView({
               {groups.map((group) => {
                 const expanded = expandedIds.has(group.id);
                 const isGroupSelected = selection?.finding.id === group.id && !selection.instance;
+                const visibleInstances = filterInstancesByStatus(group.instances, statusFilter);
                 return (
                   <Fragment key={group.id}>
                     <TableRow
@@ -143,7 +145,7 @@ export function FindingsTableView({
                       ))}
                     </TableRow>
                     {expanded &&
-                      filterInstancesByStatus(group.instances, statusFilter).map((instance) => (
+                      visibleInstances.map((instance) => (
                         <TableRow
                           key={instance.id}
                           onClick={() => {
@@ -178,17 +180,32 @@ export function FindingsTableView({
                         </TableCell>
                       </TableRow>
                     )}
-                    {/* `instances` is the newest slice of a large group, not all
-                      of it — say so rather than ending the rows silently. */}
-                    {expanded && group.instances.length < group.instanceCount && (
+                    {/* The group's status folds over EVERY instance while the
+                      rows above are only the newest preview — under a status
+                      filter every matching instance can sit outside it. Say so
+                      rather than expanding to nothing. */}
+                    {expanded && visibleInstances.length === 0 && (
                       <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
                         <TableCell />
                         <TableCell colSpan={columns.length} className="text-xs text-text-3">
-                          Showing the {group.instances.length} most recent of {group.instanceCount}{' '}
-                          locations.
+                          No locations with the selected status among the most recently detected —
+                          the status column reflects all {group.instanceCount} locations.
                         </TableCell>
                       </TableRow>
                     )}
+                    {/* `instances` is the newest slice of a large group, not all
+                      of it — say so rather than ending the rows silently. */}
+                    {expanded &&
+                      visibleInstances.length > 0 &&
+                      visibleInstances.length < group.instanceCount && (
+                        <TableRow className="bg-surface-2/50 hover:bg-surface-2/50">
+                          <TableCell />
+                          <TableCell colSpan={columns.length} className="text-xs text-text-3">
+                            Showing the {visibleInstances.length} most recent of{' '}
+                            {group.instanceCount} locations.
+                          </TableCell>
+                        </TableRow>
+                      )}
                   </Fragment>
                 );
               })}
@@ -196,10 +213,12 @@ export function FindingsTableView({
           </Table>
         )}
 
-        {/* The server's fetched-page cap over the full filtered set. */}
+        {/* The server's fetched-page cap over the full filtered set. `groups`
+          are grouped rows, so the unit is types — the toolbar's findings tally
+          counts instances and would disagree with this number. */}
         {hasMore && (
           <p className="mt-4 text-center text-xs text-text-3">
-            Showing the first {groups.length} findings — refine the filters to narrow results.
+            Showing the first {groups.length} types — refine the filters to narrow results.
           </p>
         )}
       </div>

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -8,6 +8,8 @@ import { CheckIcon, ChevronDownIcon, SearchIcon, SlidersIcon } from '../shared/i
 import { PROVIDERS } from '../shared/Provider.tsx';
 import {
   type ColumnVisibility,
+  FINDING_STATUS_META,
+  FINDING_STATUSES,
   type FindingColumn,
   type FindingsFilters,
   SEVERITIES,
@@ -42,7 +44,7 @@ function withSelected(
   return [...options, ...missing];
 }
 
-/** Filter bar shown above the findings table — severity / type / provider / action. */
+/** Filter bar shown above the findings table — severity / type / provider / action / status. */
 export function FindingsToolbarView({
   facets,
   filters,
@@ -60,14 +62,21 @@ export function FindingsToolbarView({
   findingCount: number;
   typeCount: number;
 }) {
-  // Severities always render in display order; counts come from the facet
-  // (absent ⇒ 0). Type/provider/action are facet-driven, each run through
+  // Severities and statuses are closed enums, so they always render in display
+  // order with counts from the facet (absent ⇒ 0) — no value can drop out of
+  // the list. Type/provider/action are facet-driven, each run through
   // withSelected so a selected value the facet omits stays deselectable.
   const severityCount = new Map(facets.severity.map((f) => [f.value, f.count]));
   const severityOptions: Option[] = SEVERITIES.map((s) => ({
     value: s,
     label: capitalize(s),
     count: severityCount.get(s) ?? 0,
+  }));
+  const statusCount = new Map(facets.status.map((f) => [f.value, f.count]));
+  const statusOptions: Option[] = FINDING_STATUSES.map((s) => ({
+    value: s,
+    label: FINDING_STATUS_META[s].label,
+    count: statusCount.get(s) ?? 0,
   }));
   const typeOptions = withSelected(
     facets.subtype.map((f) => ({ value: f.value, label: f.value, count: f.count })),
@@ -134,6 +143,14 @@ export function FindingsToolbarView({
         selected={filters.action}
         onChange={(next) => {
           set('action', next);
+        }}
+      />
+      <MultiSelectFilter
+        label="Status"
+        options={statusOptions}
+        selected={filters.status}
+        onChange={(next) => {
+          set('status', next);
         }}
       />
       <span className="h-6 bg-border w-px" />

--- a/packages/dashboard-ui/src/findings/meta.ts
+++ b/packages/dashboard-ui/src/findings/meta.ts
@@ -142,56 +142,38 @@ export const FINDING_STATUS_META: Record<FindingStatus, FindingStatusMeta> = {
   dismissed: { label: 'Dismissed', badge: 'default' },
 };
 
-/** Status filter options in display order, 'all' first (the default/no-op filter). */
-export const STATUS_FILTER_OPTIONS: { value: FindingStatus | 'all'; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'open', label: 'Open' },
-  { value: 'handled', label: 'Handled' },
-  { value: 'resolved', label: 'Resolved' },
-  { value: 'dismissed', label: 'Dismissed' },
-];
+/** Statuses in display order — drives the Status filter. */
+export const FINDING_STATUSES: FindingStatus[] = ['open', 'handled', 'resolved', 'dismissed'];
 
 /**
- * Filters groups by their derived (group-level) status. 'all' or omitting the
- * filter returns every group unchanged; a specific status keeps only groups
- * whose `status` matches exactly — a group with no status (legacy, predates
- * the resolution feature) never matches a specific status filter.
- */
-export function filterGroupsByStatus(
-  groups: FindingGroup[],
-  status: FindingStatus | 'all' | undefined,
-): FindingGroup[] {
-  if (!status || status === 'all') return groups;
-  return groups.filter((g) => g.status === status);
-}
-
-/**
- * Filters a single group's instances by the SAME status filter that decided
- * the group itself is visible under `filterGroupsByStatus`. Without this, an
- * expanded group under an active filter shows every instance regardless of
- * status — including ones that don't match — which is confusing under a
- * filter that promised to narrow the view down to one status.
+ * Filters a single group's instances by the SAME statuses that decided the
+ * group itself is visible (the store matches a group's derived status against
+ * them — see applyFindingFilters). Without this, an expanded group under an
+ * active filter shows every instance regardless of status — including ones
+ * that don't match — which is confusing under a filter that promised to narrow
+ * the view down to those statuses. An empty/absent selection is a no-op.
  *
- * Never returns empty for a group `filterGroupsByStatus` already deemed
- * visible: `foldGroupStatus` (findings-group-build.ts) only ever assigns a
- * group's status to a candidate value when at least one instance actually
- * carries it, so a group whose status equals `status` is guaranteed to have
- * at least one matching instance.
+ * Never returns empty for a group the store already deemed visible:
+ * `foldGroupStatus` (findings-group-build.ts) only ever assigns a group's
+ * status to a candidate value when at least one instance actually carries it,
+ * so a group whose status is among `statuses` is guaranteed to have at least
+ * one matching instance.
  */
 export function filterInstancesByStatus(
   instances: FindingInstance[],
-  status: FindingStatus | 'all' | undefined,
+  statuses: readonly string[] | undefined,
 ): FindingInstance[] {
-  if (!status || status === 'all') return instances;
-  return instances.filter((i) => i.status === status);
+  if (!statuses || statuses.length === 0) return instances;
+  return instances.filter((i) => i.status !== undefined && statuses.includes(i.status));
 }
 
-/** The four multi-select filter dimensions of the findings toolbar. */
+/** The five multi-select filter dimensions of the findings toolbar. */
 export interface FindingsFilters {
   severity: string[];
   type: string[];
   provider: string[];
   action: string[];
+  status: string[];
 }
 
 export const EMPTY_FILTERS: FindingsFilters = {
@@ -199,6 +181,7 @@ export const EMPTY_FILTERS: FindingsFilters = {
   type: [],
   provider: [],
   action: [],
+  status: [],
 };
 
 /** Column-visibility map: column id → visible. Absent id ⇒ visible. */

--- a/packages/dashboard-ui/src/findings/meta.ts
+++ b/packages/dashboard-ui/src/findings/meta.ts
@@ -142,8 +142,13 @@ export const FINDING_STATUS_META: Record<FindingStatus, FindingStatusMeta> = {
   dismissed: { label: 'Dismissed', badge: 'default' },
 };
 
-/** Statuses in display order — drives the Status filter. */
-export const FINDING_STATUSES: FindingStatus[] = ['open', 'handled', 'resolved', 'dismissed'];
+/**
+ * Statuses in display order — drives the Status filter. Derived from
+ * FINDING_STATUS_META (an exhaustive Record over FindingStatus, so adding an
+ * enum member is a compile error there and automatically appears here); the
+ * literal's key order IS the display order.
+ */
+export const FINDING_STATUSES = Object.keys(FINDING_STATUS_META) as FindingStatus[];
 
 /**
  * Filters a single group's instances by the SAME statuses that decided the
@@ -153,11 +158,12 @@ export const FINDING_STATUSES: FindingStatus[] = ['open', 'handled', 'resolved',
  * that don't match — which is confusing under a filter that promised to narrow
  * the view down to those statuses. An empty/absent selection is a no-op.
  *
- * Never returns empty for a group the store already deemed visible:
- * `foldGroupStatus` (findings-group-build.ts) only ever assigns a group's
- * status to a candidate value when at least one instance actually carries it,
- * so a group whose status is among `statuses` is guaranteed to have at least
- * one matching instance.
+ * CAN return empty for a group the store correctly kept: the group's status
+ * folds over EVERY instance, while `group.instances` is only a preview of the
+ * newest — every instance carrying a requested status may be older than the
+ * preview window (the store pre-narrows the preview the same way, so this is
+ * a pass-through then). Views render an explicit notice for that case rather
+ * than an empty expansion.
  */
 export function filterInstancesByStatus(
   instances: FindingInstance[],

--- a/packages/dashboard-ui/test/findings/meta.test.ts
+++ b/packages/dashboard-ui/test/findings/meta.test.ts
@@ -1,9 +1,4 @@
-import type {
-  FindingAction,
-  FindingGroup,
-  FindingInstance,
-  FindingStatus,
-} from '@akasecurity/schema';
+import type { FindingAction, FindingInstance, FindingStatus } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { formatConfidence } from '../../src/findings/FindingDetailView.tsx';
@@ -11,30 +6,10 @@ import {
   ACTION_META,
   CATEGORY_LABEL,
   categoryStyle,
-  filterGroupsByStatus,
   filterInstancesByStatus,
+  FINDING_STATUSES,
   SEVERITIES,
 } from '../../src/findings/meta.ts';
-
-// Minimal FindingGroup fixture — only `id` and `status` vary per test; the rest
-// are placeholder values satisfying the required shape.
-function buildGroup(id: string, status?: FindingStatus): FindingGroup {
-  return {
-    id,
-    category: 'secret',
-    subtype: 'aws-key',
-    severity: 'high',
-    match: { maskedValue: '****', contextPrefix: '' },
-    detection: { id: 'aws-key', name: null },
-    policy: { id: 'category:secret', name: 'secret' },
-    instanceCount: 1,
-    providers: ['api'],
-    aggregateAction: 'allowed',
-    latestDetectedAt: '2026-01-01T00:00:00.000Z',
-    instances: [],
-    ...(status ? { status } : {}),
-  };
-}
 
 // Minimal FindingInstance fixture — only `id` and `status` vary per test.
 function buildInstance(id: string, status?: FindingStatus): FindingInstance {
@@ -80,11 +55,15 @@ describe('ACTION_META', () => {
   });
 });
 
-describe('CATEGORY_LABEL / SEVERITIES', () => {
+describe('CATEGORY_LABEL / SEVERITIES / FINDING_STATUSES', () => {
   it('labels categories and orders severities critical→low', () => {
     expect(CATEGORY_LABEL.secret).toBe('Secret');
     expect(CATEGORY_LABEL.pii).toBe('PII');
     expect(SEVERITIES).toEqual(['critical', 'high', 'medium', 'low']);
+  });
+
+  it('orders statuses open→dismissed for the Status filter', () => {
+    expect(FINDING_STATUSES).toEqual(['open', 'handled', 'resolved', 'dismissed']);
   });
 });
 
@@ -100,34 +79,6 @@ describe('formatConfidence', () => {
   });
 });
 
-describe('filterGroupsByStatus', () => {
-  const groups: FindingGroup[] = [
-    buildGroup('g-open', 'open'),
-    buildGroup('g-handled', 'handled'),
-    buildGroup('g-resolved', 'resolved'),
-    buildGroup('g-dismissed', 'dismissed'),
-    buildGroup('g-legacy'), // no status (predates the resolution feature)
-  ];
-
-  it('keeps only groups whose derived status matches the given status', () => {
-    expect(filterGroupsByStatus(groups, 'open')).toEqual([groups[0]]);
-    expect(filterGroupsByStatus(groups, 'resolved')).toEqual([groups[2]]);
-  });
-
-  it('excludes a legacy group with no status when filtering by a specific status', () => {
-    const legacyOnly = groups.filter((g) => g.id === 'g-legacy');
-    expect(filterGroupsByStatus(legacyOnly, 'open')).toEqual([]);
-  });
-
-  it('returns every group unchanged for "all"', () => {
-    expect(filterGroupsByStatus(groups, 'all')).toEqual(groups);
-  });
-
-  it('returns every group unchanged when no status filter is given', () => {
-    expect(filterGroupsByStatus(groups, undefined)).toEqual(groups);
-  });
-});
-
 describe('filterInstancesByStatus', () => {
   const instances: FindingInstance[] = [
     buildInstance('i-open', 'open'),
@@ -137,29 +88,36 @@ describe('filterInstancesByStatus', () => {
     buildInstance('i-legacy'), // no status (predates the resolution feature)
   ];
 
-  it('keeps only instances whose own status matches the given status', () => {
-    expect(filterInstancesByStatus(instances, 'open')).toEqual([instances[0]]);
-    expect(filterInstancesByStatus(instances, 'handled')).toEqual([instances[1]]);
+  it('keeps only instances whose own status is among the selected ones', () => {
+    expect(filterInstancesByStatus(instances, ['open'])).toEqual([instances[0]]);
+    expect(filterInstancesByStatus(instances, ['handled'])).toEqual([instances[1]]);
   });
 
-  it('excludes a legacy instance with no status when filtering by a specific status', () => {
+  it('keeps the union when several statuses are selected', () => {
+    expect(filterInstancesByStatus(instances, ['open', 'resolved'])).toEqual([
+      instances[0],
+      instances[2],
+    ]);
+  });
+
+  it('excludes a legacy instance with no status when a status is selected', () => {
     const legacyOnly = instances.filter((i) => i.id === 'i-legacy');
-    expect(filterInstancesByStatus(legacyOnly, 'open')).toEqual([]);
+    expect(filterInstancesByStatus(legacyOnly, ['open'])).toEqual([]);
   });
 
-  it('returns every instance unchanged for "all"', () => {
-    expect(filterInstancesByStatus(instances, 'all')).toEqual(instances);
+  it('returns every instance unchanged for an empty selection', () => {
+    expect(filterInstancesByStatus(instances, [])).toEqual(instances);
   });
 
   it('returns every instance unchanged when no status filter is given', () => {
     expect(filterInstancesByStatus(instances, undefined)).toEqual(instances);
   });
 
-  it('never empties out a group that filterGroupsByStatus already deemed visible', () => {
-    // deriveGroupStatus only assigns a candidate status to a group when at
+  it('never empties out a group the store already deemed visible', () => {
+    // foldGroupStatus only assigns a candidate status to a group when at
     // least one instance carries it — so filtering that SAME group's
     // instances by the SAME status can never yield an empty expanded list.
     const mixed = [buildInstance('i1', 'handled'), buildInstance('i2', 'dismissed')];
-    expect(filterInstancesByStatus(mixed, 'handled')).toHaveLength(1);
+    expect(filterInstancesByStatus(mixed, ['handled'])).toHaveLength(1);
   });
 });

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -382,6 +382,7 @@ export class SqliteFindingsRepository
       severity: query.severity,
       providers: query.provider,
       actions: query.action,
+      statuses: query.status,
       subtype: query.subtype,
       q: query.q,
     };

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -17,6 +17,7 @@ import {
   applyFindingFilters,
   buildFindingGroups,
   computeFindingFacets,
+  countInstancesByStatus,
   DEFAULT_GROUPED_FINDINGS_LIMIT,
   deriveFindingStatus,
   ENFORCEABLE_CATEGORIES,
@@ -42,9 +43,10 @@ const PREVIEW_INSTANCES_PER_GROUP = 200;
 // aggregate has a single argument, and DISTINCT already claims that slot, so the
 // default ',' is what the aggregate queries below emit.
 const CONCAT_SEP = ',';
-// Separates the fields of one encoded deriveFindingStatus input tuple. Both this
-// and CONCAT_SEP are absent from the enum values being encoded (event.kind,
-// finding_resolution.status).
+// Separates the fields of one encoded deriveFindingStatus input tuple (and its
+// trailing instance count). Both this and CONCAT_SEP are absent from the enum
+// values being encoded (event.kind, finding_resolution.status) and from the
+// count digits.
 const TUPLE_SEP = '|';
 
 function splitConcat(value: string | null): string[] {
@@ -297,7 +299,9 @@ export class SqliteFindingsRepository
    * applies the requested filters, and sorts by severity then recency. Filtering
    * and faceting run in JS via the shared @akasecurity/schema helpers. `totals`
    * reflect the full filtered set; `items` is the requested
-   * page (default 50); no cursor (nextCursor is always null).
+   * page (default 50); no cursor (nextCursor is always null). Under a `status`
+   * filter, `totals.findings` counts only instances whose derived status was
+   * requested, and each item's instance preview is narrowed the same way.
    *
    * Two reads, neither of which materializes a row per finding:
    *   1. one aggregate row per rule_id, folding EVERY instance into the numbers
@@ -391,13 +395,42 @@ export class SqliteFindingsRepository
     const facets = computeFindingFacets(allGroups, filterOpts);
     const sorted = sortFindingGroups(applyFindingFilters(allGroups, filterOpts));
 
+    // Under a status filter, `findings` counts only the instances whose DERIVED
+    // status was requested — a group folds to 'open' on the strength of a few
+    // open instances, and counting its whole tally would report instances the
+    // filter excluded. The per-status counts come from the aggregate's
+    // statusInputs; the whole-group instanceCount is the unfiltered total.
+    const statusFilter = query.status ?? [];
     const totals = {
-      findings: sorted.reduce((acc, g) => acc + g.instanceCount, 0),
+      findings: sorted.reduce((acc, g) => {
+        if (statusFilter.length === 0) return acc + g.instanceCount;
+        const agg = aggregates.get(g.id);
+        return (
+          acc +
+          (agg
+            ? (countInstancesByStatus(agg.statusInputs, statusFilter) ?? g.instanceCount)
+            : g.instanceCount)
+        );
+      }, 0),
       groups: sorted.length,
     };
 
     const limit = query.limit ?? DEFAULT_GROUPED_FINDINGS_LIMIT;
-    const items = sorted.slice(0, limit);
+    // Under a status filter, narrow each group's instance PREVIEW to the
+    // requested statuses so every rendered location matches the filter (the
+    // group-level folds still describe the whole group). The preview holds only
+    // the newest PREVIEW_INSTANCES_PER_GROUP rows, so it can end up EMPTY for a
+    // group the filter correctly kept — every matching instance may be older
+    // than the preview window; views render an explicit notice for that case.
+    const statusSet = statusFilter.length > 0 ? new Set<string>(statusFilter) : null;
+    const items = sorted.slice(0, limit).map((g) =>
+      statusSet
+        ? {
+            ...g,
+            instances: g.instances.filter((i) => i.status !== undefined && statusSet.has(i.status)),
+          }
+        : g,
+    );
 
     return Promise.resolve({
       totals,
@@ -413,22 +446,28 @@ export class SqliteFindingsRepository
    * buildFindingGroups cannot recover from a preview. Bounded by the number of
    * distinct rule_ids (the installed packs' rules), not by the store's size.
    *
-   * The per-instance sets ride back as group_concat lists of RAW DB values —
-   * source_tool, action_taken, and the (kind, has-key, latest-status) triples
-   * deriveFindingStatus consumes. Aggregating the status INPUTS rather than a
-   * status keeps the classifier itself in @akasecurity/schema, where
-   * severitySummary's SQL and this query can't drift apart on what 'resolved'
-   * means (see resolution-sql.ts). Each of those sets is bounded by an enum, so
+   * A single scan, folded in two levels: the inner SELECT groups by
+   * (rule_id, status tuple) so each (kind, has-key, latest-status) combination
+   * carries its instance count — countInstancesByStatus needs those counts for
+   * status-scoped totals — and the outer SELECT folds the tuples back to one
+   * row per rule. The per-instance sets ride back as group_concat lists of RAW
+   * DB values — source_tool, action_taken, and the tuples deriveFindingStatus
+   * consumes. Aggregating the status INPUTS rather than a status keeps the
+   * classifier itself in @akasecurity/schema, where severitySummary's SQL and
+   * this query can't drift apart on what 'resolved' means (see
+   * resolution-sql.ts). The concat-of-concats can repeat a value across
+   * tuples; the schema mappers dedupe, and each set is bounded by an enum, so
    * a group's row stays small however many findings it holds.
    *
    * `withSearchText` is the exception, and the one column here that does NOT
-   * stay small: the group's distinct repos/filePaths, whose size tracks how many
-   * distinct paths a rule fired across — for a rule hitting mostly-unique paths
-   * that is a string proportional to the store (~8MB over 200k distinct paths,
-   * and buildHaystack lowercases a second copy). It buys `q` the ability to
-   * match an instance outside the preview, which searching the preview alone
-   * would silently lose, so it is fetched only when the request actually
-   * carries a `q`.
+   * stay small: the group's per-tuple-distinct repos/filePaths, whose size
+   * tracks how many distinct paths a rule fired across — for a rule hitting
+   * mostly-unique paths that is a string proportional to the store (~8MB over
+   * 200k distinct paths, and buildHaystack lowercases a second copy). It buys
+   * `q` the ability to match an instance outside the preview, which searching
+   * the preview alone would silently lose, so it is fetched only when the
+   * request actually carries a `q`. (Substring matching is unaffected by a
+   * path repeating across tuples.)
    */
   private groupAggregates(
     withSearchText: boolean,
@@ -436,7 +475,7 @@ export class SqliteFindingsRepository
   ): Map<string, FindingGroupAggregate> {
     // Tool names ride as their display label ("via Bash") to mirror
     // buildHaystack — see its doc for why the bare name is not searched.
-    const searchTextColumns = withSearchText
+    const innerSearchColumns = withSearchText
       ? `, group_concat(DISTINCT json_extract(e.metadata, '$.repo')) AS repos,
            group_concat(DISTINCT json_extract(e.metadata, '$.filePath')) AS files,
            group_concat(DISTINCT 'via ' || json_extract(e.metadata, '$.toolName')) AS tool_names`
@@ -444,23 +483,33 @@ export class SqliteFindingsRepository
 
     const rows = this.db
       .prepare(
-        `SELECT f.rule_id AS rule_id,
-                count(*) AS instance_count,
-                max(e.occurred_at) AS latest_at,
-                group_concat(DISTINCT e.source_tool) AS source_tools,
-                group_concat(DISTINCT f.action_taken) AS actions_taken,
-                group_concat(DISTINCT (
-                  e.kind || '${TUPLE_SEP}' ||
-                  (CASE WHEN f.finding_key IS NULL THEN '' ELSE 'k' END) || '${TUPLE_SEP}' ||
-                  coalesce(latest.status, '')
-                )) AS status_inputs
-                ${searchTextColumns}
-           FROM findings f
-           JOIN events e ON e.id = f.event_id
-           LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
-             ON latest.finding_key = f.finding_key
-          ${scope.predicate}
-          GROUP BY f.rule_id`,
+        `SELECT rule_id,
+                sum(tuple_count) AS instance_count,
+                max(latest_at) AS latest_at,
+                group_concat(source_tools) AS source_tools,
+                group_concat(actions_taken) AS actions_taken,
+                group_concat(status_tuple || '${TUPLE_SEP}' || tuple_count) AS status_inputs,
+                group_concat(repos) AS repos,
+                group_concat(files) AS files,
+                group_concat(tool_names) AS tool_names
+           FROM (
+             SELECT f.rule_id AS rule_id,
+                    e.kind || '${TUPLE_SEP}' ||
+                      (CASE WHEN f.finding_key IS NULL THEN '' ELSE 'k' END) || '${TUPLE_SEP}' ||
+                      coalesce(latest.status, '') AS status_tuple,
+                    count(*) AS tuple_count,
+                    max(e.occurred_at) AS latest_at,
+                    group_concat(DISTINCT e.source_tool) AS source_tools,
+                    group_concat(DISTINCT f.action_taken) AS actions_taken
+                    ${innerSearchColumns}
+               FROM findings f
+               JOIN events e ON e.id = f.event_id
+               LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
+                 ON latest.finding_key = f.finding_key
+              ${scope.predicate}
+              GROUP BY f.rule_id, status_tuple
+           )
+          GROUP BY rule_id`,
       )
       .all(scope.params) as unknown as FindingAggregateRowJoined[];
 
@@ -472,13 +521,15 @@ export class SqliteFindingsRepository
           sourceTools: splitConcat(r.source_tools),
           actionsTaken: splitConcat(r.actions_taken),
           statusInputs: splitConcat(r.status_inputs).map((tuple) => {
-            const [kind = '', keyMarker = '', latestStatus = ''] = tuple.split(TUPLE_SEP);
+            const [kind = '', keyMarker = '', latestStatus = '', count = ''] =
+              tuple.split(TUPLE_SEP);
             return {
               // deriveFindingStatus only distinguishes null from non-null here,
               // so the marker stands in for the key itself (never rendered).
               kind,
               findingKey: keyMarker === '' ? null : keyMarker,
               latestResolutionStatus: latestStatus === '' ? null : latestStatus,
+              count: Number(count),
             };
           }),
           latestDetectedAt: epochMillisToIso(r.latest_at),

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -553,6 +553,79 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
     expect(group?.status).toBe('open');
   });
 
+  // The Status toolbar filter is a store-side filter like severity/provider —
+  // it must narrow items, totals AND the other facets, not just the page the
+  // caller already fetched.
+  describe('status filter', () => {
+    beforeEach(() => {
+      // in-flight ⇒ handled
+      record({
+        occurredAt: '2026-01-01T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'handled-rule',
+        repo: 'acme/api',
+        filePath: 'a.ts',
+      });
+      // at-rest, tracked, unresolved ⇒ open
+      recordAtRest({ findingKey: 'key-open', ruleId: 'open-rule' });
+      // at-rest, tracked, resolved ⇒ resolved
+      recordAtRest({ findingKey: 'key-resolved', ruleId: 'resolved-rule' });
+      db.resolutions.insertResolution({
+        findingKey: 'key-resolved',
+        status: 'resolved',
+        method: 'fixed-at-source',
+        resolvedAt: Date.parse('2026-01-02T00:00:00.000Z'),
+        evidence: '',
+      });
+    });
+
+    it('keeps only groups whose derived status was requested', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      expect(res.items.map((g) => g.id)).toEqual(['open-rule']);
+    });
+
+    it('keeps the union when several statuses are requested', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open', 'resolved'] });
+      expect(res.items.map((g) => g.id).sort()).toEqual(['open-rule', 'resolved-rule']);
+    });
+
+    it('narrows totals to the filtered set (not just the fetched page)', async () => {
+      expect((await db.findings.listGroupedFindings({})).totals).toEqual({
+        findings: 3,
+        groups: 3,
+      });
+      expect((await db.findings.listGroupedFindings({ status: ['open'] })).totals).toEqual({
+        findings: 1,
+        groups: 1,
+      });
+    });
+
+    it('reports a status facet excluding its own filter, and applies it to the others', async () => {
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      // The status facet still counts every status, so the user can switch…
+      expect(new Map(res.facets.status.map((f) => [f.value, f.count]))).toEqual(
+        new Map([
+          ['handled', 1],
+          ['open', 1],
+          ['resolved', 1],
+        ]),
+      );
+      // …while the action facet DOES honor the status filter (open-rule only).
+      expect(res.facets.action).toEqual([{ value: 'blocked', count: 1 }]);
+    });
+
+    it('composes with the other filters', async () => {
+      const res = await db.findings.listGroupedFindings({
+        status: ['open'],
+        severity: ['critical'],
+      });
+      expect(res.items.map((g) => g.id)).toEqual(['open-rule']);
+      expect(
+        (await db.findings.listGroupedFindings({ status: ['open'], severity: ['low'] })).items,
+      ).toEqual([]);
+    });
+  });
+
   it('a group with mixed instance statuses derives its group status via open-dominates precedence', async () => {
     // Same ruleId, two instances: one in-flight (handled), one at-rest and
     // still open — the group must read 'open' even though one instance is

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -624,6 +624,60 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
         (await db.findings.listGroupedFindings({ status: ['open'], severity: ['low'] })).items,
       ).toEqual([]);
     });
+
+    it('scopes totals and the instance preview to matching instances on a mixed-status group', async () => {
+      // Two more in-flight (handled) instances on open-rule: the group still
+      // folds to open (open dominates), but only ONE of its three instances IS
+      // open — the tally and the preview must not report the other two.
+      record({
+        occurredAt: '2026-01-04T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'open-rule',
+        repo: 'acme/api',
+        filePath: 'b.ts',
+      });
+      record({
+        occurredAt: '2026-01-05T00:00:00.000Z',
+        sourceTool: 'claude-code',
+        ruleId: 'open-rule',
+        repo: 'acme/api',
+        filePath: 'c.ts',
+      });
+
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      const group = res.items.find((g) => g.id === 'open-rule');
+      expect(group?.status).toBe('open');
+      // instanceCount stays the whole-group tally; the preview and the totals
+      // are status-scoped.
+      expect(group?.instanceCount).toBe(3);
+      expect(group?.instances.map((i) => i.status)).toEqual(['open']);
+      expect(res.totals).toEqual({ findings: 1, groups: 1 });
+    });
+
+    it('keeps a group whose matching instances all sit outside the preview (empty narrowed preview)', async () => {
+      // More in-flight (handled) instances than the preview holds, all NEWER
+      // than open-rule's one open instance: the preview window is entirely
+      // handled, yet the group folds to open on the strength of the older row.
+      // The filter must keep the group, totals must count only the open
+      // instance, and the narrowed preview is legitimately EMPTY — the view
+      // layer renders an explicit notice for this case.
+      for (let i = 0; i < 205; i++) {
+        record({
+          occurredAt: new Date(Date.parse('2026-02-01T00:00:00.000Z') + i * 1000).toISOString(),
+          sourceTool: 'claude-code',
+          ruleId: 'open-rule',
+          repo: 'acme/api',
+          filePath: `bulk/f${String(i)}.ts`,
+        });
+      }
+
+      const res = await db.findings.listGroupedFindings({ status: ['open'] });
+      const group = res.items.find((g) => g.id === 'open-rule');
+      expect(group?.status).toBe('open');
+      expect(group?.instanceCount).toBe(206);
+      expect(group?.instances).toEqual([]);
+      expect(res.totals).toEqual({ findings: 1, groups: 1 });
+    });
   });
 
   it('a group with mixed instance statuses derives its group status via open-dominates precedence', async () => {

--- a/web-ui/app/(app)/findings/FindingsClient.tsx
+++ b/web-ui/app/(app)/findings/FindingsClient.tsx
@@ -119,7 +119,8 @@ export function FindingsClient({
     filters.severity.length === 0 &&
     filters.type.length === 0 &&
     filters.provider.length === 0 &&
-    filters.action.length === 0;
+    filters.action.length === 0 &&
+    filters.status.length === 0;
 
   const toggleExpand = (groupId: string) => {
     setExpandedIds((prev) => {
@@ -146,7 +147,7 @@ export function FindingsClient({
     : [];
 
   return (
-    <div className="flex flex-col px-8 pb-10 pt-7">
+    <div className="flex h-full min-h-0 flex-col px-8 pb-10 pt-7">
       <PageHead
         title="Findings"
         sub="Every sensitive-data finding across providers"
@@ -201,7 +202,7 @@ export function FindingsClient({
         </div>
       )}
 
-      <div className="mt-4">
+      <div className="mt-4 min-h-0 flex-1">
         <FindingsTableView
           groups={data.items}
           columns={visibleColumns}
@@ -215,6 +216,7 @@ export function FindingsClient({
             setSelected({ finding: group, instance });
           }}
           hasMore={hasMore}
+          statusFilter={filters.status}
           {...(data.sessionFirings ? { sessionFirings: data.sessionFirings } : {})}
           emptyState={
             noActiveFilters ? (

--- a/web-ui/app/(app)/findings/filters.ts
+++ b/web-ui/app/(app)/findings/filters.ts
@@ -2,11 +2,12 @@ import type { FindingsFilters } from '@akasecurity/dashboard-ui';
 import {
   FindingAction,
   FindingProvider,
+  FindingStatus,
   type ListGroupedFindingsQuery,
   Severity,
 } from '@akasecurity/schema';
 
-// The findings filters ride in the URL (?severity=…&type=…&provider=…&action=…&q=…,
+// The findings filters ride in the URL (?severity=…&type=…&provider=…&action=…&status=…&q=…,
 // plus the Activity page's deep-link context: ?session=… scopes the list to one
 // session and ?finding=… opens the detail sheet) so the Server Component re-queries
 // the local store per filter change — the same mechanism as RangeSelect. These pure
@@ -25,10 +26,11 @@ const keepKnown = (values: string[], allowed: readonly string[]): string[] =>
   values.filter((v) => allowed.includes(v));
 
 /**
- * URL search params → the toolbar's four filter dimensions. Severity/provider/
- * action are validated against their schema enums here (the OSS Server-Component
- * path has no Fastify/Zod validation door), so a crafted `?severity=bogus` is
- * dropped rather than passed on to the store. `type`/subtype is a free string.
+ * URL search params → the toolbar's five filter dimensions. Severity/provider/
+ * action/status are validated against their schema enums here (the OSS
+ * Server-Component path has no Fastify/Zod validation door), so a crafted
+ * `?severity=bogus` is dropped rather than passed on to the store.
+ * `type`/subtype is a free string.
  */
 export function parseFindingsFilters(sp: FindingsSearchParams): FindingsFilters {
   return {
@@ -36,6 +38,7 @@ export function parseFindingsFilters(sp: FindingsSearchParams): FindingsFilters 
     type: asArray(sp.type),
     provider: keepKnown(asArray(sp.provider), FindingProvider.options),
     action: keepKnown(asArray(sp.action), FindingAction.options),
+    status: keepKnown(asArray(sp.status), FindingStatus.options),
   };
 }
 
@@ -76,6 +79,7 @@ export function toGroupedQuery(
     ...(filters.type.length ? { subtype: filters.type } : {}),
     ...(filters.provider.length ? { provider: filters.provider as FindingProvider[] } : {}),
     ...(filters.action.length ? { action: filters.action as FindingAction[] } : {}),
+    ...(filters.status.length ? { status: filters.status as FindingStatus[] } : {}),
     ...(trimmed ? { q: trimmed } : {}),
     ...(session ? { sessionId: session } : {}),
   };
@@ -97,6 +101,7 @@ export function buildFindingsParams(
   for (const t of filters.type) sp.append('type', t);
   for (const p of filters.provider) sp.append('provider', p);
   for (const a of filters.action) sp.append('action', a);
+  for (const s of filters.status) sp.append('status', s);
   const trimmed = q.trim();
   if (trimmed) sp.set('q', trimmed);
   if (session) sp.set('session', session);

--- a/web-ui/app/(app)/findings/filters.ts
+++ b/web-ui/app/(app)/findings/filters.ts
@@ -21,9 +21,13 @@ export type FindingsSearchParams = Record<string, ParamValue>;
 
 const asArray = (v: ParamValue): string[] => (Array.isArray(v) ? v : v ? [v] : []);
 
-/** Drop values not in the enum — hand-edited/stale URLs can't inject unknowns. */
+/**
+ * Drop values not in the enum and dedupe — hand-edited/stale URLs can't inject
+ * unknowns, and a double-appended value (?status=open&status=open) can't make
+ * the toolbar badge count one selection twice.
+ */
 const keepKnown = (values: string[], allowed: readonly string[]): string[] =>
-  values.filter((v) => allowed.includes(v));
+  [...new Set(values)].filter((v) => allowed.includes(v));
 
 /**
  * URL search params → the toolbar's five filter dimensions. Severity/provider/
@@ -35,7 +39,9 @@ const keepKnown = (values: string[], allowed: readonly string[]): string[] =>
 export function parseFindingsFilters(sp: FindingsSearchParams): FindingsFilters {
   return {
     severity: keepKnown(asArray(sp.severity), Severity.options),
-    type: asArray(sp.type),
+    // Free string, so no enum check — but deduped for the same badge-count
+    // reason as keepKnown.
+    type: [...new Set(asArray(sp.type))],
     provider: keepKnown(asArray(sp.provider), FindingProvider.options),
     action: keepKnown(asArray(sp.action), FindingAction.options),
     status: keepKnown(asArray(sp.status), FindingStatus.options),


### PR DESCRIPTION
## What

Final PR of a 3-PR stack making **Status** a first-class findings filter. This PR moves the control into the toolbar and wires it through the web-ui URL so the store (from #2) does the filtering.

**Stacked on `status-filter/02-persistence` — review/merge #1 and #2 first.**

## Why

Status was the odd filter out: a bare `<select>` rendered *inside the table*, backed by local `useState`, that only narrowed the page the server had already returned. That caused real bugs the old code carried comments apologizing for:

- The toolbar's "N findings · M types" tally **ignored** the status filter entirely.
- The empty state read "No open findings *on this page*" — matches could exist past the server's cap.
- The selection lived nowhere in the URL, so it was lost on reload, filter change, or a shared link.

## Changes

- **dashboard-ui** — add a fifth `MultiSelectFilter` ("Status") to `FindingsToolbarView`, built like Severity (closed enum, counts from the new `status` facet). `FindingsTableView` drops the in-table `<select>`, `useState`, and `filterGroupsByStatus`/`STATUS_FILTER_OPTIONS`; it now renders `groups` directly and takes a `statusFilter` prop only to narrow an expanded group's sub-rows. `meta.ts` adds `status` to `FindingsFilters`/`EMPTY_FILTERS` and replaces the single-select option list with a display-order `FINDING_STATUSES`.
- **web-ui** — `filters.ts` parses/validates/rebuilds `?status=` (validated against `FindingStatus.options`); `FindingsClient` passes `filters.status` through and counts it toward "active filters".

## Verification

- Full gate on this branch: `pnpm typecheck` 14/14, `pnpm lint` 14/14, `pnpm test` 26/26 tasks.
- Driven in the running dashboard against a real ~2.4k-finding store: Status sits in the toolbar; picking "Open" pushes `?status=open` and moves the tally (2,442·85 → 1,715·8); popover counts match the rows; a two-status URL restores both on cold reload; expanded sub-rows narrow to the selection; a zero-match status shows "No findings match these filters."
- Accessibility: the per-row `aria-label`s from #67 are preserved.

## Note on releasing

This stack touches `schema` + `persistence` (bundled into **both** the CLI and the plugin) and `dashboard-ui`/`web-ui` (bundled into the CLI). Per `CLAUDE.md`, publishing would need version bumps on both artifacts — **not** included here; land first, version on release.

## Stack

1. `status-filter/01-schema` (base `main`)
2. `status-filter/02-persistence` (base `01-schema`)
3. **→ `status-filter/03-ui` (this PR, base `02-persistence`)**


## Review response (7808ae0)

- **Empty narrowed previews are explicit**: an expanded group whose preview holds no location in the selected statuses renders "No locations with the selected status among the most recently detected — the status column reflects all N locations." instead of nothing; the "N most recent" footer is gated on the narrowed list. The detail drawer gets the same zero-case copy — and since #87 now narrows the preview store-side, the drawer's Locations list matches the table under a filter.
- **`filterInstancesByStatus` doc corrected**: it no longer promises a non-empty result; the preview-vs-whole-group fold divergence is documented, and the >200-instance repro is pinned by a test in #87.
- **Exhaustiveness**: `FINDING_STATUSES` is now derived from `FINDING_STATUS_META` (an exhaustive `Record<FindingStatus, …>`), so a new enum member is a compile error there and appears in the filter automatically — without importing a Zod value into dashboard-ui.
- **`keepKnown` dedupes** (and `type` too), so `?status=open&status=open` can't show a badge of 2.
- **Copy**: the fetched-page hint now says "types" (it counts grouped rows); the doubled `px-4` is gone so both empty states share one width.

## Scope disclosure: scrolling model

This PR also changes the findings page's scroll model — previously undisclosed, flagged by review: the table now lives in a full-height `Card` with an internal `overflow-y-auto` scroller (`FindingsTableView`), and `FindingsClient` constrains it with `flex h-full min-h-0`. Consequences to review deliberately:

- the list scrolls inside the card rather than with the page (headers are not sticky and can scroll out of view inside the box);
- the fetched-page hint sits at the bottom of the internal scroller;
- `FindingsTableView` now assumes a height-constrained parent (`AppShell`'s `<main>` provides one in this app).

The layout is intentional and was verified in the running dashboard; calling it out here so it gets reviewed on its merits rather than hiding in the re-indentation.
