### PR TITLE
chore(release): merge release/0.9.1 back to main

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Merge the tagged `release/0.9.1` branch back to main.

Contains the `chore(release): 0.9.1` version bump (`cli/package.json`, `plugins/claude-code/package.json`, `plugins/claude-code/.claude-plugin/plugin.json`). The 0.9.1 artifacts (cli-v0.9.1, plugin-v0.9.1, bin-v0.9.1) are already tagged and published to npm `latest`; this PR only lands the release commit on main.