### PR TITLE
test(persistence): pin an empty status selection as a no-op

### DIFF
--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -584,6 +584,20 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
       expect(res.items.map((g) => g.id)).toEqual(['open-rule']);
     });
 
+    it('treats an empty status selection as no filter at all', async () => {
+      // Pins the "empty array == filter absent" contract at the persistence
+      // boundary: every group returns, totals stay unscoped, and no group's
+      // instance preview is narrowed.
+      const res = await db.findings.listGroupedFindings({ status: [] });
+      expect(res.items.map((g) => g.id).sort()).toEqual([
+        'handled-rule',
+        'open-rule',
+        'resolved-rule',
+      ]);
+      expect(res.totals).toEqual({ findings: 3, groups: 3 });
+      expect(res.items.every((g) => g.instances.length === 1)).toBe(true);
+    });
+
     it('keeps the union when several statuses are requested', async () => {
       const res = await db.findings.listGroupedFindings({ status: ['open', 'resolved'] });
       expect(res.items.map((g) => g.id).sort()).toEqual(['open-rule', 'resolved-rule']);


### PR DESCRIPTION
Follow-up to #87, promised in [this review thread](https://github.com/akasecurity/ai-tc/pull/87#discussion_r3638657291): assert at the persistence boundary that `listGroupedFindings({ status: [] })` behaves exactly like an absent filter — every group returned, totals unscoped, instance previews un-narrowed. The schema layer already pins the same contract for `applyFindingFilters`; this makes it regression-proof where the query enters the store.

One test, no production code. `pnpm test --filter @akasecurity/persistence`: 479 pass.