### PR TITLE
docs: disclose that /aka:setup sends raw findings to the model API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,16 @@ The plugin **must never break a user's Claude session**. Every hook handler wrap
 
 ### 3. `process.env` is off by default
 
-ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. The few places that genuinely need the host environment (the plugin's LLM-provider resolution, the CLI spawning the dashboard server) opt out explicitly in their own ESLint config.
+ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Four places genuinely need the host environment and opt out:
+
+| Site                                      | Mechanism                         | Why                                         |
+| ----------------------------------------- | --------------------------------- | ------------------------------------------- |
+| `packages/plugin-sdk/src/provider.ts`     | file-scoped ESLint config         | LLM-provider resolution at SessionStart     |
+| `cli/src/commands/dashboard.ts`           | inline `eslint-disable-next-line` | spawning the dashboard server               |
+| `plugins/claude-code/src/backfill.ts`     | inline `eslint-disable-next-line` | resolving the transcript root               |
+| `plugins/claude-code/src/triage/judge.ts` | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth |
+
+Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a fifth site means updating this table.
 
 ### 4. No network calls
 
@@ -44,7 +53,7 @@ The OSS product is **local-only**: it runs on Node + the SQLite store under `~/.
 
 1. `@akasecurity/local-ops` shelling out to package managers (`npm`/`claude`) for update-and-apply.
 2. The Claude Code plugin's own `npm audit signatures` child process — run from inside the plugin's dependency closure (a plugin script or `@akasecurity/plugin-sdk`, since the plugin cannot import `@akasecurity/local-ops`).
-3. The `/aka:setup` wizard's judge subprocess (`plugins/claude-code/src/triage/judge.ts`), which spawns `claude -p` and **sends the raw, unmasked finding values to the model API** so it can rate false positives and severity. This runs only on the user's explicit, revocable opt-in during setup. It suppresses its own transcript (`CLAUDE_CODE_SKIP_PROMPT_HISTORY=1`), but that is transcript isolation, **not** network isolation — the raw values are not kept on the machine, because the whole point is to reach the model. Consent copy must say so plainly (see `plugins/claude-code/commands/setup.md`); it must never be described as staying "inside an isolated subprocess."
+3. The `/aka:setup` wizard's judge subprocess (`plugins/claude-code/src/triage/judge.ts`), which spawns `claude -p` and **sends raw, unmasked findings to the model API** so it can rate false positives and severity. The whole `TriageHit` crosses, not just the secret: `rawMatch`, `context` (a ±120-character window of the surrounding transcript text — see `plugins/claude-code/src/history/scan.ts`), and `filePath` (the source transcript's path). A large history is chunked, so this is several `claude -p` calls, not one. It runs only on the user's explicit opt-in during setup; the grant is revocable under Policies, which stops future scans but cannot recall what was already sent. The subprocess asks the CLI to suppress its transcript (`CLAUDE_CODE_SKIP_PROMPT_HISTORY=1`), but that is transcript isolation, **not** network isolation — a copy of the raw values leaves the machine, because the whole point is to reach the model. Consent copy must state the payload, the egress, and that limit on revocation plainly (see `plugins/claude-code/commands/setup.md`); it must never be described as staying "inside an isolated subprocess."
 
 ## Package dependency rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,10 @@ AI Traffic Control (`ai-tc`, by AKA Security — the `aka` CLI and plugin names 
 the company) is a **local-first** security control plane for AI coding agents. The whole surface
 runs on one machine with **no server, no Docker, and no database engine**: the Claude Code
 plugin and the `aka` CLI capture agent activity into a local SQLite store at
-`~/.aka/data/aka.db`, and the web dashboard reads that same store directly. Nothing leaves
-the machine — there is no account, no network hop, and no backend to stand up.
+`~/.aka/data/aka.db`, and the web dashboard reads that same store directly. There is no
+account and no AKA backend — nothing is sent to a service AKA runs. (A few narrow outbound
+paths do exist — package-manager installs and the opt-in `/aka:setup` calibration, which
+sends raw findings to the model API via the `claude` CLI — enumerated in §4.)
 
 ## Tech stack
 
@@ -38,7 +40,11 @@ ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace �
 
 ### 4. No network calls
 
-The OSS product is **local-only**: it runs on Node + the SQLite store under `~/.aka` and talks to **no AKA service** — no account, no backend, no HTTP hop. A direct `fetch()` must never appear in OSS source. The only network access is `@akasecurity/local-ops` shelling out to package managers (`npm`/`claude`) for update-and-apply, and the Claude Code plugin's own `npm audit signatures` child process — run from inside the plugin's dependency closure (a plugin script or `@akasecurity/plugin-sdk`, since the plugin cannot import `@akasecurity/local-ops`).
+The OSS product is **local-only**: it runs on Node + the SQLite store under `~/.aka` and talks to **no AKA service** — no account, no backend, no HTTP hop to anything AKA runs. A direct `fetch()` must never appear in OSS source. Network access happens **only through child processes**, and there are three such paths:
+
+1. `@akasecurity/local-ops` shelling out to package managers (`npm`/`claude`) for update-and-apply.
+2. The Claude Code plugin's own `npm audit signatures` child process — run from inside the plugin's dependency closure (a plugin script or `@akasecurity/plugin-sdk`, since the plugin cannot import `@akasecurity/local-ops`).
+3. The `/aka:setup` wizard's judge subprocess (`plugins/claude-code/src/triage/judge.ts`), which spawns `claude -p` and **sends the raw, unmasked finding values to the model API** so it can rate false positives and severity. This runs only on the user's explicit, revocable opt-in during setup. It suppresses its own transcript (`CLAUDE_CODE_SKIP_PROMPT_HISTORY=1`), but that is transcript isolation, **not** network isolation — the raw values are not kept on the machine, because the whole point is to reach the model. Consent copy must say so plainly (see `plugins/claude-code/commands/setup.md`); it must never be described as staying "inside an isolated subprocess."
 
 ## Package dependency rules
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **AKA Security — We secure agent harnesses at the source.**
 
-AI Traffic Control (`ai-tc`) is an open-source control plane for coding agents. It watches an agent session's traffic (prompts, tool calls, responses, file reads), scans each event against your rule packs, and decides what happens next: monitor, warn, redact, block, or a manual exception. Secrets and regulated data like PCI, PHI, and PII are caught and kept on your machine, not sent to a model or a third party.
+AI Traffic Control (`ai-tc`) is an open-source control plane for coding agents. It watches an agent session's traffic (prompts, tool calls, responses, file reads), scans each event against your rule packs, and decides what happens next: monitor, warn, redact, block, or a manual exception. Secrets and regulated data like PCI, PHI, and PII are caught and kept on your machine, not sent to a model or a third party.[^egress]
 
 ![Open source](https://img.shields.io/badge/Open_source-232F3E?style=flat-square)
 ![Local](https://img.shields.io/badge/Local-232F3E?style=flat-square)
@@ -63,7 +63,9 @@ In Claude Code:
 
 ### Claude Desktop
 
-Claude Desktop is supported too; the [installation guide](https://akasecurity.github.io/ai-tc-docs/getting-started/installation/) covers both. `ai-tc` runs locally alongside your agent. There's no backend to stand up, and nothing leaves your machine to scan it.
+Claude Desktop is supported too; the [installation guide](https://akasecurity.github.io/ai-tc-docs/getting-started/installation/) covers both. `ai-tc` runs locally alongside your agent. There's no backend to stand up, and nothing leaves your machine to scan it.[^egress]
+
+[^egress]: Detection and enforcement run locally — no AKA server, no account, no built-in network client (`fetch` is banned in the source). Three narrow paths do reach the network, all through child processes: package-manager installs/updates (`npm`/`claude`), the plugin's `npm audit signatures` supply-chain check, and the **opt-in** `/aka:setup` calibration, whose judge step sends the raw findings an initial history scan discovers — including any secrets — to the model API through the `claude` CLI to rate false positives and severity. That's the same model provider your agent already uses, and it happens only on explicit, revocable consent.
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **AKA Security — We secure agent harnesses at the source.**
 
-AI Traffic Control (`ai-tc`) is an open-source control plane for coding agents. It watches an agent session's traffic (prompts, tool calls, responses, file reads), scans each event against your rule packs, and decides what happens next: monitor, warn, redact, block, or a manual exception. Secrets and regulated data like PCI, PHI, and PII are caught and kept on your machine, not sent to a model or a third party.[^egress]
+AI Traffic Control (`ai-tc`) is an open-source control plane for coding agents. It watches an agent session's traffic (prompts, tool calls, responses, file reads), scans each event against your rule packs, and decides what happens next: monitor, warn, redact, block, or a manual exception. Secrets and regulated data like PCI, PHI, and PII are caught locally: live detection and enforcement never send them to a model or a third party. The one exception is the opt-in `/aka:setup` calibration, which does send what its history scan finds to the model API to be rated.[^egress]
 
 ![Open source](https://img.shields.io/badge/Open_source-232F3E?style=flat-square)
 ![Local](https://img.shields.io/badge/Local-232F3E?style=flat-square)
@@ -63,9 +63,9 @@ In Claude Code:
 
 ### Claude Desktop
 
-Claude Desktop is supported too; the [installation guide](https://akasecurity.github.io/ai-tc-docs/getting-started/installation/) covers both. `ai-tc` runs locally alongside your agent. There's no backend to stand up, and nothing leaves your machine to scan it.[^egress]
+Claude Desktop is supported too; the [installation guide](https://akasecurity.github.io/ai-tc-docs/getting-started/installation/) covers both. `ai-tc` runs locally alongside your agent. There's no backend to stand up, and no scanning happens off your machine.[^egress]
 
-[^egress]: Detection and enforcement run locally — no AKA server, no account, no built-in network client (`fetch` is banned in the source). Three narrow paths do reach the network, all through child processes: package-manager installs/updates (`npm`/`claude`), the plugin's `npm audit signatures` supply-chain check, and the **opt-in** `/aka:setup` calibration, whose judge step sends the raw findings an initial history scan discovers — including any secrets — to the model API through the `claude` CLI to rate false positives and severity. That's the same model provider your agent already uses, and it happens only on explicit, revocable consent.
+[^egress]: Detection and enforcement run locally — no AKA server, no account, and no built-in network client (the source uses no `fetch`). Three narrow paths do reach the network, all through child processes: package-manager installs/updates (`npm`/`claude`), the plugin's `npm audit signatures` supply-chain check, and the **opt-in** `/aka:setup` calibration. That last one is the only path that carries your data: to rate false positives and severity, its judge step sends what an initial history scan finds — for each finding, the raw unmasked value including any secret, roughly 120 characters of the surrounding transcript text on either side, and the path of the transcript file it came from — to the model API through the `claude` CLI. That's the same model provider your agent already uses, and it happens only after you explicitly opt in. You can withdraw the grant later to stop future scans, but data already sent cannot be recalled.
 
 ## Docs
 

--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -33,7 +33,14 @@ export const POLICY_CHOICES: Choice<WorkspaceSettings['policy']>[] = [
   },
 ];
 
-const HISTORICAL_CHOICES: Choice<WorkspaceSettings['historicalAccess']>[] = [
+// This is the same grant the /aka:setup wizard collects, and it is what gates
+// the wizard's history sweep. That sweep sends what it finds to the model API to
+// be rated, so the 'full' copy must disclose the egress here too — this is the
+// surface the wizard points at for scope and revocation.
+const HISTORICAL_SECTION_DESCRIPTION =
+  'Consent to inspect surfaces that existed before AKA was installed.';
+
+export const HISTORICAL_CHOICES: Choice<WorkspaceSettings['historicalAccess']>[] = [
   {
     value: 'session-only',
     label: 'Session only',
@@ -42,7 +49,11 @@ const HISTORICAL_CHOICES: Choice<WorkspaceSettings['historicalAccess']>[] = [
   {
     value: 'full',
     label: 'Full',
-    description: 'Pre-install surfaces (existing configs, history) may be scanned too.',
+    description:
+      'Pre-install surfaces (existing configs, history) may be scanned too. This also lets ' +
+      '/aka:setup send what that scan finds — raw values including any secrets, the ' +
+      'surrounding transcript text, and the source file path — to the model API to be rated. ' +
+      'Switching back to Session only stops future scans; it cannot recall data already sent.',
   },
 ];
 
@@ -121,9 +132,7 @@ export function WorkspaceSettingsFormView({
 
       <section className="rounded-xl border border-border bg-surface p-5">
         <SectionLabel>Historical access</SectionLabel>
-        <p className="mb-3 text-xs text-text-3">
-          Consent to inspect surfaces that existed before AKA was installed.
-        </p>
+        <p className="mb-3 text-xs text-text-3">{HISTORICAL_SECTION_DESCRIPTION}</p>
         <ChoiceGroup
           name="historicalAccess"
           choices={HISTORICAL_CHOICES}

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   HANDLING_SECTION_DESCRIPTION,
+  HISTORICAL_CHOICES,
   POLICY_CHOICES,
 } from '../../src/settings/WorkspaceSettingsFormView.tsx';
 
@@ -25,5 +26,38 @@ describe('WorkspaceSettingsFormView handling copy', () => {
   it('points enforcement at the per-category Policies', () => {
     expect(HANDLING_SECTION_DESCRIPTION).toMatch(/Policies/);
     expect(HANDLING_SECTION_DESCRIPTION).toMatch(/per-category/i);
+  });
+});
+
+// Granting 'full' here is the same consent the /aka:setup wizard collects, and it
+// is what gates the wizard's history sweep — whose judge step sends raw findings
+// to the model API. The wizard's own copy points users at this screen for scope
+// and revocation, so a description that stops at "may be scanned" would leave the
+// egress disclosed in one place and hidden in the other.
+describe('WorkspaceSettingsFormView historical-access copy', () => {
+  const full = HISTORICAL_CHOICES.find((c) => c.value === 'full');
+
+  it('offers the full grant', () => {
+    expect(full).toBeDefined();
+  });
+
+  it('discloses the model-API egress the grant enables', () => {
+    expect(full?.description).toMatch(/model API/i);
+    expect(full?.description).toMatch(/raw values/i);
+    expect(full?.description).toMatch(/secrets/i);
+  });
+
+  it('names the rest of the payload, not just the secret', () => {
+    expect(full?.description).toMatch(/transcript text/i);
+    expect(full?.description).toMatch(/file path/i);
+  });
+
+  it('does not present revocation as a recall', () => {
+    expect(full?.description).toMatch(/cannot recall/i);
+  });
+
+  it('leaves the session-only default free of any egress', () => {
+    const sessionOnly = HISTORICAL_CHOICES.find((c) => c.value === 'session-only');
+    expect(sessionOnly?.description).not.toMatch(/model API/i);
   });
 });

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -7,7 +7,9 @@
 
 The Claude Code plugin for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`). It hooks into a Claude Code session and inspects its traffic — prompts, tool calls, tool results, file reads — scanning each event against your rule packs and applying inline **warn / redact / block** policies. Every event is recorded to a local SQLite store at `~/.aka/data/aka.db`.
 
-Detection runs entirely on your machine. There's no account and no backend — nothing leaves your computer to be scanned.
+Detection runs entirely on your machine. There's no account and no backend — nothing leaves your computer to be scanned.[^egress]
+
+[^egress]: Live detection and enforcement run locally. The one exception is the **opt-in** `/aka:setup` calibration below: to rate what an initial history scan finds, its judge step sends the raw (unmasked) findings — including any secrets — to the model API through the `claude` CLI, the same provider your Claude session already uses. It runs only on explicit, revocable consent and keeps those values out of your local transcript, but they do leave the machine.
 
 ## Install
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -7,9 +7,9 @@
 
 The Claude Code plugin for **[AI Traffic Control](https://github.com/akasecurity/ai-tc)** (`ai-tc`). It hooks into a Claude Code session and inspects its traffic — prompts, tool calls, tool results, file reads — scanning each event against your rule packs and applying inline **warn / redact / block** policies. Every event is recorded to a local SQLite store at `~/.aka/data/aka.db`.
 
-Detection runs entirely on your machine. There's no account and no backend — nothing leaves your computer to be scanned.[^egress]
+Detection runs entirely on your machine. There's no account and no backend — nothing is sent anywhere to be scanned.[^egress]
 
-[^egress]: Live detection and enforcement run locally. The one exception is the **opt-in** `/aka:setup` calibration below: to rate what an initial history scan finds, its judge step sends the raw (unmasked) findings — including any secrets — to the model API through the `claude` CLI, the same provider your Claude session already uses. It runs only on explicit, revocable consent and keeps those values out of your local transcript, but they do leave the machine.
+[^egress]: Live detection and enforcement run locally. The one exception is the **opt-in** `/aka:setup` calibration below: to rate what an initial history scan finds, its judge step sends those findings to the model API through the `claude` CLI — the same provider your Claude session already uses. For each finding that means the raw (unmasked) value including any secret, roughly 120 characters of the surrounding transcript text on either side, and the path of the transcript file it came from. It runs only after you explicitly opt in, and it keeps those values out of your local Claude transcript — but a copy of them does leave the machine. Withdrawing the grant later stops future scans; it cannot recall what was already sent.
 
 ## Install
 

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -15,10 +15,14 @@ dashboard. Everything the user sees is derived from their _actual_ history — n
 a fabricated or demo number. When there isn't enough history to judge, the wizard
 falls back to a conservative severity-derived floor instead of guessing.
 
-The false-positive/severity judgment itself runs in a **separate, transient
-subprocess that writes no transcript** — the raw (unmasked) finding values are
-never read into this conversation or your scannable history. You act only on the
-raw-free plan that subprocess prints back.
+The false-positive/severity judgment needs the raw (unmasked) finding values to
+rate them accurately, so it **sends them to the model API** through a separate
+`claude` CLI subprocess. That subprocess writes no transcript, so the raw values
+never enter this conversation or your scannable history — but they **do leave the
+machine**, sent to the model provider like any other Claude prompt. You act only
+on the raw-free plan the subprocess prints back. The scan that produces those
+values is offered for explicit consent in step 1, and that consent must state the
+model-API egress plainly before it is given.
 
 Follow the steps below **in order**. Nothing is written to the policy store
 until step 5 (or a floor fallback in step 3 if the calibration can't complete).
@@ -63,8 +67,8 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/intro.js" "${CLAUDE_PLUGIN_ROOT}/.claude-plu
 Before showing any recommended posture — the start-light default table in
 step 2 or the calibrated posture in step 4 — look at the **current project's**
 working tree yourself, with your own Read/Glob tools. There is no script for
-this: it is your own reasoning over facts you read directly, not the isolated
-triage subprocess's raw-free plan, and it needs no user interaction.
+this: it is your own reasoning over facts you read directly, not the triage
+subprocess's raw-free plan, and it needs no user interaction.
 
 **In scope:** the manifest's declared frameworks/dependencies
 (`package.json` or equivalent), payment or other third-party API SDKs among
@@ -101,7 +105,7 @@ posture the user reads, not a separate write. Persisting a tightened level happe
 only where the wizard already writes a per-category override — the adjust fork's
 `onboard.js --posture` write (step 4b), where the user picks each category's level
 explicitly. The keep-defaults path writes the severity floor (`--floor`, step 2)
-and the calibrated accept path applies the isolated subprocess's saved plan
+and the calibrated accept path applies the triage subprocess's saved plan
 verbatim (`--confirmed --plan`, step 5); neither carries the tightening on its
 own, so a tightened level the user wants persisted is chosen through the adjust
 fork. Do **not** bolt on an extra `onboard.js --posture` overlay to auto-re-persist
@@ -124,18 +128,28 @@ interactive picker. The plugin can't draw its own selectable UI (it can't
 capture keystrokes), so do **not** print a fake option list or ask the user to
 "reply with a number"; let the picker collect the answer.
 
-**Want me to look over what Claude's been up to?** — "I'll review Claude's recent work — transcripts, temp files, agent memory — to tune what I bring to you next."
+**Disclose the model-API egress plainly before you show the picker — this is what
+the user is consenting to, so it must be visible before they choose.** State it in
+your own words, without softening it: if they say yes, AKA scans the last 30 days
+of Claude history, and to rate what it finds it **sends the raw, unmasked values —
+including any secrets — to the model API through the `claude` CLI**. That is real
+network egress to the model provider (the same one your Claude session already
+uses), not a purely local review. The raw values are kept out of your local Claude
+transcript, but they are **not** kept on the machine. (Findings are also recorded,
+masked, to the local store.) Do not present the picker until you have said this.
+
+**Want me to look over what Claude's been up to?** — "I'll scan Claude's recent work — transcripts, temp files, agent memory — and send what I find to the model to rate it, so I can tune what I bring you next."
 
 Offer exactly two options:
 
-- **Yes, take a look** — "tune what I bring you, based on Claude's real work here"
+- **Yes, take a look** — "scan my real work here; raw findings go to the model to be rated, then tune what you bring me"
 - **Not now** — "start light and I'll learn as we go"
 
 Choosing **Yes, take a look** records the same historical-review consent the wizard has
-always recorded — the identical scope, the one-time grant, and the
-revocable-under-Policies semantics — so the simpler question broadens nothing
-about what AKA may access. Those granular scope and revocation details stay
-inspectable on request and in the dashboard.
+always recorded — the identical scope (which includes the model-API judgment disclosed
+above), the one-time grant, and the revocable-under-Policies semantics — so the simpler
+question broadens nothing about what AKA may access. Those granular scope and revocation
+details stay inspectable on request and in the dashboard.
 
 ## 2. Save the answer, then branch
 
@@ -221,7 +235,7 @@ it.
      step 6 already follows when no calibration frame was emitted). Step 7
      then runs as written.
 
-## 3. Run the evidence triage — isolated judgment, nothing written yet
+## 3. Run the evidence triage — off-transcript judgment, nothing written yet
 
 Pipe the backfill's triage stream straight into the `apply-suppressions`
 adapter in **PREVIEW** mode (no `--confirmed`):
@@ -233,8 +247,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/backfill.js" --triage | node "${CLAUDE_PLUGI
 The backfill sweeps prior Claude Code transcripts (last 30 days, all projects)
 and streams one masked-plus-raw triage hit per line; masked findings are
 recorded to the local store as a side effect. The adapter runs the
-false-positive/severity **judgment in a separate transient subprocess** (no
-transcript), then prints back a **raw-free plan** you can safely show the user:
+false-positive/severity **judgment in a separate `claude` subprocess that sends
+the raw hits to the model API** (writing no local transcript), then prints back a
+**raw-free plan** you can safely show the user:
 the calibrated-result card (the real-count headline and the recommended posture),
 the per-category reasoning, the masked false positives it would suppress, any
 categories it skipped, and its notes.
@@ -269,7 +284,8 @@ names its pattern and count from — never invent either off-signal.
 
 Everything you show the user in step 4 comes from **this command's output**. You
 never read the raw finding values yourself — do not echo, quote, or reconstruct
-them; by design they stay inside the isolated subprocess.
+them; the judge subprocess sends them to the model API and returns only the
+raw-free plan, so they never enter this conversation.
 
 **Failed or truncated triage — never proceed silently (fallback).** If this
 command exits non-zero, or the adapter reports a truncated / sentinel-less

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -15,14 +15,18 @@ dashboard. Everything the user sees is derived from their _actual_ history — n
 a fabricated or demo number. When there isn't enough history to judge, the wizard
 falls back to a conservative severity-derived floor instead of guessing.
 
-The false-positive/severity judgment needs the raw (unmasked) finding values to
-rate them accurately, so it **sends them to the model API** through a separate
-`claude` CLI subprocess. That subprocess writes no transcript, so the raw values
-never enter this conversation or your scannable history — but they **do leave the
-machine**, sent to the model provider like any other Claude prompt. You act only
-on the raw-free plan the subprocess prints back. The scan that produces those
-values is offered for explicit consent in step 1, and that consent must state the
-model-API egress plainly before it is given.
+The false-positive/severity judgment needs the raw (unmasked) findings to rate
+them accurately, so it **sends them to the model API** through separate `claude`
+CLI subprocesses (a large history is judged in several batches). Three things
+cross for each finding: its **raw value**, about **120 characters of the
+surrounding transcript text** on either side of it, and the **path of the
+transcript file** it came from. Those subprocesses ask the `claude` CLI to write
+no transcript, so the raw values do not enter this conversation or your scannable
+history — but a copy of them **does leave the machine**, sent to the model
+provider like any other Claude prompt. You act only on the raw-free plan the
+subprocesses print back. The scan that produces those values is offered for
+explicit consent in step 1, and that consent must state the model-API egress
+plainly before it is given.
 
 Follow the steps below **in order**. Nothing is written to the policy store
 until step 5 (or a floor fallback in step 3 if the calibration can't complete).
@@ -132,11 +136,18 @@ capture keystrokes), so do **not** print a fake option list or ask the user to
 the user is consenting to, so it must be visible before they choose.** State it in
 your own words, without softening it: if they say yes, AKA scans the last 30 days
 of Claude history, and to rate what it finds it **sends the raw, unmasked values —
-including any secrets — to the model API through the `claude` CLI**. That is real
-network egress to the model provider (the same one your Claude session already
-uses), not a purely local review. The raw values are kept out of your local Claude
-transcript, but they are **not** kept on the machine. (Findings are also recorded,
-masked, to the local store.) Do not present the picker until you have said this.
+including any secrets — to the model API through the `claude` CLI**. Name what
+travels with each one: **its raw value, about 120 characters of the surrounding
+transcript text on either side, and the path of the transcript file it came
+from**. That is real network egress to the model provider (the same one your
+Claude session already uses), not a purely local review. **A copy of each value
+leaves the machine.** The transcripts those values came from stay on disk
+untouched — nothing here removes them; that is the separate redaction step in
+step 6. The values are kept out of your local Claude transcript, and the findings
+are also recorded, masked, to the local store. The grant is revocable from the
+dashboard's **Settings → Historical access**, which stops future scans — it
+cannot recall anything already sent. Do not present the picker until you have
+said this.
 
 **Want me to look over what Claude's been up to?** — "I'll scan Claude's recent work — transcripts, temp files, agent memory — and send what I find to the model to rate it, so I can tune what I bring you next."
 
@@ -147,9 +158,10 @@ Offer exactly two options:
 
 Choosing **Yes, take a look** records the same historical-review consent the wizard has
 always recorded — the identical scope (which includes the model-API judgment disclosed
-above), the one-time grant, and the revocable-under-Policies semantics — so the simpler
-question broadens nothing about what AKA may access. Those granular scope and revocation
-details stay inspectable on request and in the dashboard.
+above), the one-time grant, and the same revocation semantics — so the simpler question
+broadens nothing about what AKA may access. Those granular scope and revocation details
+stay inspectable on request and in the dashboard, under **Settings → Historical access**,
+whose own copy repeats the model-API disclosure.
 
 ## 2. Save the answer, then branch
 
@@ -247,9 +259,11 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/backfill.js" --triage | node "${CLAUDE_PLUGI
 The backfill sweeps prior Claude Code transcripts (last 30 days, all projects)
 and streams one masked-plus-raw triage hit per line; masked findings are
 recorded to the local store as a side effect. The adapter runs the
-false-positive/severity **judgment in a separate `claude` subprocess that sends
-the raw hits to the model API** (writing no local transcript), then prints back a
-**raw-free plan** you can safely show the user:
+false-positive/severity **judgment in separate `claude` subprocesses that send the
+raw hits — each one's value, its surrounding transcript text, and its source path
+— to the model API** (a large history is split into several batches; each asks
+the CLI to write no local transcript), then prints back a **raw-free plan** you
+can safely show the user:
 the calibrated-result card (the real-count headline and the recommended posture),
 the per-category reasoning, the masked false positives it would suppress, any
 categories it skipped, and its notes.
@@ -284,7 +298,7 @@ names its pattern and count from — never invent either off-signal.
 
 Everything you show the user in step 4 comes from **this command's output**. You
 never read the raw finding values yourself — do not echo, quote, or reconstruct
-them; the judge subprocess sends them to the model API and returns only the
+them; the judge subprocesses send them to the model API and return only the
 raw-free plan, so they never enter this conversation.
 
 **Failed or truncated triage — never proceed silently (fallback).** If this

--- a/plugins/claude-code/test/privacy-claims.test.ts
+++ b/plugins/claude-code/test/privacy-claims.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The READMEs are product surface: their privacy claims get quoted into security
+ * reviews and procurement answers long after anyone reads the footnote. Both make
+ * a locality claim about data, and both are qualified by an `[^egress]` footnote
+ * because one path — the opt-in `/aka:setup` judge — really does send raw
+ * findings to the model API.
+ *
+ * These guards keep the claim and the qualifier from drifting apart: an absolute
+ * "nothing leaves" sentence must not stand on its own, and the footnote that
+ * carries the correction must keep naming the whole payload.
+ */
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const READMES = [
+  { name: 'README.md', text: readFileSync(new URL('../../../README.md', import.meta.url), 'utf8') },
+  {
+    name: 'plugins/claude-code/README.md',
+    text: readFileSync(new URL('../README.md', import.meta.url), 'utf8'),
+  },
+] as const;
+
+// A footnote definition line — the place the correction lives. Everything else is
+// body prose a reader (or a quoter) sees first.
+const isFootnoteDefinition = (line: string): boolean => /^\[\^[^\]]+]:/.test(line);
+
+// Claims that data does not go anywhere. Each one needs its qualifier attached.
+const LOCALITY_CLAIM =
+  /nothing (?:leaves|is sent)|never (?:leaves|send)|not sent to a model|no scanning happens off|scanned off your/i;
+
+const paragraphs = (text: string): string[] =>
+  text
+    .split(/\n{2,}/)
+    .filter((p) => !p.split('\n').every(isFootnoteDefinition))
+    .filter((p) => p.trim() !== '');
+
+describe.each(READMES)('$name privacy claims', ({ text }) => {
+  it('attaches the egress footnote to every locality claim in the body', () => {
+    const unqualified = paragraphs(text).filter(
+      (p) => LOCALITY_CLAIM.test(p) && !p.includes('[^egress]'),
+    );
+    expect(unqualified).toEqual([]);
+  });
+
+  // A footnote marker is a superscript link to the bottom of the page. It is not
+  // enough on its own to carry a claim the calibration path contradicts outright,
+  // so the exception has to be readable without following the link.
+  it('names the exception inline, not only in the footnote', () => {
+    const body = paragraphs(text)
+      .filter((p) => LOCALITY_CLAIM.test(p))
+      .join('\n');
+    expect(body).toMatch(/\/aka:setup|calibration|scanned/i);
+  });
+
+  const footnote = text.split('\n').filter(isFootnoteDefinition).join(' ').replace(/\s+/g, ' ');
+
+  it('has an egress footnote', () => {
+    expect(footnote).toContain('[^egress]:');
+  });
+
+  it('says the judge reaches the model API', () => {
+    expect(footnote).toMatch(/model API/);
+    expect(footnote).toMatch(/opt.?in/i);
+  });
+
+  // The whole TriageHit crosses — rawMatch, a ±120-char context window, and the
+  // source transcript's path (see src/history/scan.ts). Copy that names only the
+  // secret understates what the user is consenting to.
+  it('names the whole payload, not just the secret', () => {
+    expect(footnote).toMatch(/secret/i);
+    expect(footnote).toMatch(/120 characters of the surrounding transcript text/);
+    expect(footnote).toMatch(/path of the transcript file/);
+  });
+
+  it('does not present withdrawal as a recall of what was already sent', () => {
+    expect(footnote).toMatch(/cannot be recalled|cannot recall/i);
+  });
+
+  // No lint rule bans `fetch` today (engineering#5) — the ban is a convention
+  // enforced by review. Claiming enforcement the CI does not provide is the same
+  // overclaim this footnote exists to retire.
+  it('does not claim `fetch` is enforced by tooling', () => {
+    expect(text).not.toMatch(/`?fetch`? is banned/i);
+    expect(text).not.toMatch(/`?fetch`? is blocked/i);
+  });
+});

--- a/plugins/claude-code/test/setup-copy.test.ts
+++ b/plugins/claude-code/test/setup-copy.test.ts
@@ -36,14 +36,48 @@ describe('setup.md 0.3 scan-offer copy', () => {
     expect(setupMd).toContain("start light and I'll learn as we go");
   });
 
-  it('discloses the model-API egress plainly before the consent picker', () => {
-    // Whitespace-normalized so the assertion is not coupled to prose line wrapping.
-    const flat = setupMd.replace(/\s+/g, ' ');
+  // Whitespace-normalized so these assertions are not coupled to prose line wrapping.
+  const flat = setupMd.replace(/\s+/g, ' ');
+
+  it('discloses the model-API egress plainly', () => {
     expect(flat).toContain(
       'sends the raw, unmasked values — including any secrets — to the model API through the `claude` CLI',
     );
-    expect(flat).toContain('they are **not** kept on the machine');
+    expect(flat).toContain('A copy of each value leaves the machine');
     expect(flat).toContain('Do not present the picker until you have said this');
+  });
+
+  // What crosses is the whole TriageHit, not just the matched secret: rawMatch,
+  // a ±120-char window of the surrounding transcript (history/scan.ts), and the
+  // source transcript's filePath. Copy that names only "the values" understates
+  // the payload, so pin all three.
+  it('names the whole payload, not just the secret', () => {
+    expect(flat).toContain('about 120 characters of the surrounding transcript text');
+    expect(flat).toContain('the path of the transcript file it came from');
+  });
+
+  it('does not present revocation as a recall of what was already sent', () => {
+    expect(flat).toContain('it cannot recall anything already sent');
+  });
+
+  // The transcripts the values were read out of are untouched by the scan — the
+  // earlier "not kept on the machine" phrasing read as a cleanup promise.
+  it('does not imply the scan removes the values from disk', () => {
+    expect(flat).toContain('The transcripts those values came from stay on disk untouched');
+    expect(flat).not.toContain('not kept on the machine');
+  });
+
+  // AC: the disclosure must be visible BEFORE consent is given. Presence alone
+  // would still pass if the paragraph were moved below the option list, so
+  // assert the actual ordering against the picker's own copy.
+  it('places the disclosure ahead of the consent picker', () => {
+    const disclosureAt = flat.indexOf('sends the raw, unmasked values');
+    const questionAt = flat.indexOf("Want me to look over what Claude's been up to?");
+    const yesOptionAt = flat.indexOf('scan my real work here');
+
+    expect(disclosureAt).toBeGreaterThan(-1);
+    expect(questionAt).toBeGreaterThan(disclosureAt);
+    expect(yesOptionAt).toBeGreaterThan(disclosureAt);
   });
 });
 

--- a/plugins/claude-code/test/setup-copy.test.ts
+++ b/plugins/claude-code/test/setup-copy.test.ts
@@ -16,20 +16,34 @@ const forkSection = setupMd.slice(forkStart, forkEnd === -1 ? undefined : forkEn
 
 // The prompt-authored 0.3 scan-offer copy lives in commands/setup.md, so a
 // regression is otherwise only visible in the manual walkthrough. These guards
-// pin the verbatim strings the wizard shows at the scan offer.
+// pin the verbatim strings the wizard shows at the scan offer — including the
+// privacy-critical disclosure that the scan sends raw, unmasked values to the
+// model API via the `claude` CLI, which must be stated before consent.
 describe('setup.md 0.3 scan-offer copy', () => {
-  it('carries the scope disclosure verbatim', () => {
+  it('carries the scan-offer question verbatim', () => {
     expect(setupMd).toContain(
-      "I'll review Claude's recent work — transcripts, temp files, agent memory — to tune what I bring to you next.",
+      "I'll scan Claude's recent work — transcripts, temp files, agent memory — and send what I find to the model to rate it, so I can tune what I bring you next.",
     );
   });
 
   it('carries the Yes-option subtitle verbatim', () => {
-    expect(setupMd).toContain("tune what I bring you, based on Claude's real work here");
+    expect(setupMd).toContain(
+      'scan my real work here; raw findings go to the model to be rated, then tune what you bring me',
+    );
   });
 
   it('carries the Not-now-option subtitle verbatim', () => {
     expect(setupMd).toContain("start light and I'll learn as we go");
+  });
+
+  it('discloses the model-API egress plainly before the consent picker', () => {
+    // Whitespace-normalized so the assertion is not coupled to prose line wrapping.
+    const flat = setupMd.replace(/\s+/g, ' ');
+    expect(flat).toContain(
+      'sends the raw, unmasked values — including any secrets — to the model API through the `claude` CLI',
+    );
+    expect(flat).toContain('they are **not** kept on the machine');
+    expect(flat).toContain('Do not present the picker until you have said this');
   });
 });
 

--- a/plugins/claude-code/test/triage/judge.test.ts
+++ b/plugins/claude-code/test/triage/judge.test.ts
@@ -141,6 +141,55 @@ describe('runJudge', () => {
     expect(rec.notes).toBe('ok');
   });
 
+  // The consent copy in commands/setup.md and both READMEs enumerates what
+  // crosses to the model API field by field. runJudge serializes the whole
+  // TriageHit, so a new field on that schema silently widens the payload past
+  // what the user was told. Pin the exact key set: adding one here is a
+  // deliberate act that forces the disclosure copy to be updated with it.
+  it('sends exactly the disclosed TriageHit fields — no undisclosed payload', () => {
+    let seenStdin = '';
+    runJudge([hit], {
+      spawn: (_argv, _env, stdin) => {
+        seenStdin = stdin;
+        return envelope(VERDICT_FENCE);
+      },
+      loadRubric: () => 'RUBRIC',
+    });
+
+    // The hits ride as JSONL inside the prompt's last fenced block.
+    const fenced = /```\n([\s\S]*?)\n```\n?$/.exec(seenStdin);
+    if (fenced?.[1] === undefined) throw new Error('no fenced hit block on stdin');
+    const lines = fenced[1].split('\n').filter((l) => l !== '');
+    expect(lines).toHaveLength(1);
+    const [hitLine] = lines;
+    if (hitLine === undefined) throw new Error('no hit line on stdin');
+
+    const sent = JSON.parse(hitLine) as Record<string, unknown>;
+    expect(Object.keys(sent).sort()).toEqual([
+      'category',
+      'confidence',
+      'context',
+      'maskedMatch',
+      'rawMatch',
+      'ruleId',
+      'severity',
+    ]);
+    // The three the disclosure calls out by name: the secret itself, the
+    // surrounding transcript window, and (when present) the source path.
+    expect(sent.rawMatch).toBe(hit.rawMatch);
+    expect(sent.context).toBe(hit.context);
+
+    let withPath = '';
+    runJudge([{ ...hit, filePath: '/Users/dev/.claude/projects/acme-api/session.jsonl' }], {
+      spawn: (_argv, _env, stdin) => {
+        withPath = stdin;
+        return envelope(VERDICT_FENCE);
+      },
+      loadRubric: () => 'RUBRIC',
+    });
+    expect(withPath).toContain('/Users/dev/.claude/projects/acme-api/session.jsonl');
+  });
+
   it('re-throws a spawn failure as raw-free metadata (execFileSync puts the prompt in .message)', () => {
     // execFileSync throws an error whose .message is `Command failed: claude … <argv>`,
     // and argv carries the raw hits in the prompt. Simulate that exact shape and


### PR DESCRIPTION
Closes akasecurity/engineering#10

## Root cause

`/aka:setup`'s judge step (`plugins/claude-code/src/triage/judge.ts`) sends **raw, unmasked findings** from a 30-day history sweep to the Anthropic API via `claude -p`. The code is honest about this, but the docs and consent copy were not — README/CLAUDE.md said *"nothing leaves the machine,"* and `setup.md` framed the judge as an *"isolated subprocess"* you *"review"* locally. That isolation is real, but it is **transcript** isolation, not **network** isolation — auth is deliberately retained so the process can reach the API. **The defect is disclosure, not code.**

## What changed

- **`commands/setup.md`** — the consent step now states plainly, **before the picker**, that the scan sends raw unmasked values (including secrets) to the model API via the `claude` CLI, and that they are **not** kept on the machine. Removed the *"isolated subprocess"* framing (4 sites) and reworded the local-only *"review"* question.
- **`CLAUDE.md`** — §4 now names `plugins/claude-code/src/triage/judge.ts` as the third network path and spells out transcript-vs-network isolation; the intro's absolute *"no network hop"* is softened.
- **`README.md`** + **`plugins/claude-code/README.md`** — the *"nothing leaves the machine"* claim is footnoted with the three subprocess egress paths (the plugin README sits directly above the `/aka:setup` call-to-action).
- **`test/setup-copy.test.ts`** — extended the existing copy guard to pin the new disclosure so it cannot silently regress.

## Acceptance criteria (engineering#10)

- [x] Consent prompt states raw values go to the model API via `claude`, before consent is given
- [x] `setup.md` no longer implies containment (*"isolated subprocess"*, *"review"*)
- [x] CLAUDE.md §4 names `plugins/claude-code/src/triage/judge.ts` as a network path
- [x] README's *"nothing leaves the machine"* is footnoted with the three paths
- [ ] AC5 (distinct opt-in for judging vs. history access) — filed separately as akasecurity/engineering#46

## Scope / coordination

- The §4 edit satisfies the **coordinated** *"§4 names the judge path"* box in #39 (CLAUDE.md drift); #39's other rows (§1, §3, header) are intentionally untouched.
- Does **not** touch #11 (judge egress boundary tests) — separate issue, already partially covered by existing `judge.test.ts`.
- Does **not** touch #5 (fetch lint rule) or #15 (no-network CI) — the enforcement follow-ups.
- `cli/README.md` left as-is on purpose: its claim is scoped to *"to be scanned,"* and the CLI's own scan is local; the judge egress is plugin-side.

## Verification

- `prettier --check` (changed files): clean
- `typecheck` / `lint` (plugin): pass
- `vitest` (full plugin suite): **828 pass**

## Release note

`setup.md` and the plugin README ship inside the plugin package (`0.9.1`). A publish should bump the plugin and keep `plugin.json` in sync; the CLI is unaffected by these doc edits. No release is needed to land this fix.


---

# Review follow-up (`9452a33`)

An adversarial review of the first commit found that the disclosure itself repeated the defect one level down. Fixed here.

## Disclosure was incomplete — the payload is wider than "the values"

`runJudge` serializes the **whole `TriageHit`**, not just the secret ([judge.ts:151](https://github.com/akasecurity/ai-tc/blob/main/plugins/claude-code/src/triage/judge.ts#L151), passed through unstripped by [adapter.ts:189](https://github.com/akasecurity/ai-tc/blob/main/plugins/claude-code/src/triage/adapter.ts#L189)). Three things cross per finding:

| Field | What it is |
| --- | --- |
| `rawMatch` | the unmasked secret |
| `context` | a **±120-character window of raw transcript text** ([scan.ts:82-95](https://github.com/akasecurity/ai-tc/blob/main/plugins/claude-code/src/history/scan.ts#L82)) — only *other* findings are redacted inside it |
| `filePath` | the transcript path, which encodes the OS username and every project directory name |

All four surfaces now name all three. A large history is also chunked into several `claude -p` calls, which the copy now says.

## Other corrections

- **`README.md:7`** — "not sent to a model or a third party" was flatly false for the setup path and repaired only by a footnote ~60 lines below. Now qualified inline. (AC4 permitted footnoting *"Nothing leaves the machine"*; it does not repair this stronger sentence.)
- **`README.md` footnote** — dropped "`fetch` is banned in the source". No such rule exists ([eslint-config](https://github.com/akasecurity/ai-tc/blob/main/packages/eslint-config/src/index.js) has 8 rules, no `no-restricted-globals`); that is engineering#5. A disclosure fix should not ship a fresh enforcement overclaim.
- **"not kept on the machine"** — read as reassurance ("AKA cleaned up"), and is wrong where it matters: the values are still in the `~/.claude/projects` transcripts the scan read them from. Replaced with the direct statement plus a pointer to the step-6 redaction.
- **"revocable"** — now says withdrawal stops future scans and cannot recall what was sent.
- **Dashboard consent copy** — `Historical access → Full` is the web twin of this grant and the surface `setup.md` points at for scope/revocation, but still described a purely local scan. It now carries the same disclosure. Also fixed the pointer: `setup.md` said *"revocable-under-Policies"*, but `historicalAccess` is only editable under **Settings**.
- **CLAUDE.md §3** — was stale (2 opt-outs "in their own ESLint config"; actually 4 sites, 3 inline, two of them `judge.ts` and `backfill.ts`). Replaced with the real table. Partial credit toward akasecurity/engineering#39.

## New guards

| Test | Proves |
| --- | --- |
| `test/privacy-claims.test.ts` (new) | every locality claim in either README carries its qualifier; the footnote names the whole payload; no "`fetch` is banned" |
| `test/triage/judge.test.ts` | pins the **exact key set** sent on stdin — a new `TriageHit` field can no longer widen the payload without forcing a copy update |
| `test/setup-copy.test.ts` | payload, revocation limit, and **disclosure-before-picker ordering** (the old test was titled "before the picker" but only ran `toContain`) |
| `dashboard-ui/.../WorkspaceSettingsFormView.test.ts` | `Full` carries the egress, `Session only` does not — extends the existing copy guard rather than adding a parallel one |

**These were verified red without the fix**, not just green with it: stashing the four source files turns **10 tests red**.

## Verification

`pnpm test` **26/26 tasks** (plugin 847, dashboard-ui 72) · `lint` · `typecheck` · `format:check` — all clean.

## Still deferred

- **AC5** (distinct opt-in for judging) — akasecurity/engineering#46. The durable enforcement (a consent record that stores the acknowledgement, with `apply-suppressions.js` refusing to judge without it) belongs there, not in a docs fix.
- **Versions untouched** — `setup.md` + plugin README ship in the plugin (`0.9.1`); the `dashboard-ui` change flows into the CLI via the bundled web-ui. Both need a bump on publish; release type is the maintainer's call.
