### PR TITLE
fix(persistence): surface every affected path when a secret is duplicated across files

### DIFF
--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -281,7 +281,11 @@ export function openLocalDatabase(dir: string): LocalDatabase {
       // same session never duplicates it. All four capture kinds
       // (prompt/response/code_change/tool_use) map onto AuditEventType as
       // themselves — see the superset invariant documented there.
-      const auditEventId = captureId(sessionId ?? null, event.contentHash);
+      const auditEventId = captureId(
+        sessionId ?? null,
+        event.contentHash,
+        event.metadata?.filePath ?? null,
+      );
       auditEvents.insertAuditEvent({
         id: auditEventId,
         eventType: event.kind,

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -323,6 +323,7 @@ export function openLocalDatabase(dir: string): LocalDatabase {
             finding.maskedMatch,
             finding.span.start,
             finding.span.end,
+            finding.findingKey ?? null,
           )
         ) {
           continue;

--- a/packages/persistence/src/ids.ts
+++ b/packages/persistence/src/ids.ts
@@ -109,14 +109,28 @@ export function promptId(sessionId: string, promptUuid: string): string {
 // rather than being dropped from the join.
 const NO_SESSION = 'no_session';
 
-// sha256(session_id + content_hash): a capture (a prompt/response/code-change/
-// tool-use record) is content-addressed on the hash of its own text, scoped to
-// the session it belongs to so identical content captured in two different
-// sessions never collapses onto one row. `sessionId` is `null` for a
-// session-less capture, which folds onto the fixed `NO_SESSION` sentinel above
-// instead of shortening the join.
-export function captureId(sessionId: string | null, contentHash: string): string {
-  return sha256Hex(canonicalIdentity(['capture', sessionId ?? NO_SESSION, contentHash]));
+// Folded into `captureId`'s identity in place of a real file path. A capture
+// with no path (a prompt/response, or a Bash/WebFetch tool_use) still needs a
+// stable tuple length, so the missing component becomes this fixed literal
+// rather than being dropped from the join — mirroring NO_SESSION above.
+const NO_FILE = 'no_file';
+
+// sha256(session_id + content_hash + file_path): a capture (a prompt/response/
+// code-change/tool-use record) is content-addressed on the hash of its own
+// text, scoped to the session it belongs to so identical content captured in
+// two different sessions never collapses onto one row, AND to its file path so
+// the SAME bytes at two different paths (a secret duplicated across files) get
+// two rows rather than collapsing onto the first-written one. `sessionId` /
+// `filePath` are `null` for a session-less / path-less capture, each folding
+// onto its fixed sentinel above instead of shortening the join.
+export function captureId(
+  sessionId: string | null,
+  contentHash: string,
+  filePath: string | null,
+): string {
+  return sha256Hex(
+    canonicalIdentity(['capture', sessionId ?? NO_SESSION, contentHash, filePath ?? NO_FILE]),
+  );
 }
 
 // Data Shares dimensions — id derivations for share destinations,

--- a/packages/persistence/src/repositories/inspection-findings.ts
+++ b/packages/persistence/src/repositories/inspection-findings.ts
@@ -112,7 +112,7 @@ export class SqliteInspectionFindingsRepository {
     // a fresh random `id` and carries no `finding_key` (nothing to re-scan
     // against), so neither of insertStmt's ON CONFLICT clauses ever fires for
     // it — unlike a content-addressed audit event (captureId(sessionId,
-    // contentHash)), which resolves an exact resubmission onto the SAME row
+    // contentHash, filePath)), which resolves an exact resubmission onto the SAME row
     // via INSERT OR IGNORE, a resubmitted in-flight finding would otherwise
     // duplicate on every replay of the identical capture. This check restores
     // that idempotency at the finding level: scoped to one audit event (never
@@ -121,14 +121,14 @@ export class SqliteInspectionFindingsRepository {
     // distinct hits of the same value within one capture (e.g. a secret
     // pasted twice in one prompt) are still both kept.
     //
-    // The `finding_key` guard keeps that intra-event idempotency from
-    // OVER-reaching. The audit id is content-addressed, so identical bytes
-    // captured at two DIFFERENT paths (a secret duplicated across files)
-    // collapse onto ONE audit_events row — yet each hit carries its own
-    // path-scoped `finding_key`. Matching on the key too stops the second path
-    // from being taken for a replay of the first and dropped. An in-flight
-    // finding carries no key, so `:findingKey IS NULL` leaves the guard inert
-    // and the span-keyed behavior above unchanged.
+    // The `finding_key` guard narrows this within-event check to the incoming
+    // finding's own key. captureId folds the file path into the audit id (see
+    // ids.ts), so identical bytes at two DIFFERENT paths already resolve to
+    // DISTINCT audit rows — this guard is not what separates them. It still
+    // earns its keep WITHIN one audit row: a keyed at-rest re-detection matches
+    // only its own finding_key, not another key's hit at the same span, while a
+    // keyless in-flight finding passes `:findingKey IS NULL` and keeps the
+    // span-keyed behavior above unchanged.
     this.eventDupStmt = db.prepare(
       `SELECT 1 FROM inspection_findings f
          JOIN inspection_definitions d ON d.id = f.inspection_definition_id
@@ -150,10 +150,11 @@ export class SqliteInspectionFindingsRepository {
 
   // True when this exact detection (rule + masked value + span) is already
   // recorded against the given audit event. When the finding carries a
-  // `finding_key`, the match is scoped to it too, so identical content captured
-  // at two paths (which collapse onto one content-addressed audit event) is not
-  // deduped away; a keyless in-flight finding passes `null` and keeps the
-  // span-only behavior.
+  // `finding_key`, the match is scoped to it too, so two distinct keys on the
+  // same audit row are kept apart; a keyless in-flight finding passes `null`
+  // and keeps the span-only behavior. (Identical bytes at two DIFFERENT paths
+  // land on distinct audit events — captureId folds the path — so they never
+  // reach this same-event check.)
   isEventDuplicate(
     auditEventId: string,
     ruleId: string,

--- a/packages/persistence/src/repositories/inspection-findings.ts
+++ b/packages/persistence/src/repositories/inspection-findings.ts
@@ -120,12 +120,22 @@ export class SqliteInspectionFindingsRepository {
     // reconciliation is for), and keyed on span too, so two genuinely
     // distinct hits of the same value within one capture (e.g. a secret
     // pasted twice in one prompt) are still both kept.
+    //
+    // The `finding_key` guard keeps that intra-event idempotency from
+    // OVER-reaching. The audit id is content-addressed, so identical bytes
+    // captured at two DIFFERENT paths (a secret duplicated across files)
+    // collapse onto ONE audit_events row — yet each hit carries its own
+    // path-scoped `finding_key`. Matching on the key too stops the second path
+    // from being taken for a replay of the first and dropped. An in-flight
+    // finding carries no key, so `:findingKey IS NULL` leaves the guard inert
+    // and the span-keyed behavior above unchanged.
     this.eventDupStmt = db.prepare(
       `SELECT 1 FROM inspection_findings f
          JOIN inspection_definitions d ON d.id = f.inspection_definition_id
         WHERE f.audit_event_id = :auditEventId AND d.rule_id = :ruleId
           AND f.masked_match = :maskedMatch
           AND f.span_start = :spanStart AND f.span_end = :spanEnd
+          AND (:findingKey IS NULL OR f.finding_key = :findingKey)
         LIMIT 1`,
     );
   }
@@ -139,16 +149,28 @@ export class SqliteInspectionFindingsRepository {
   }
 
   // True when this exact detection (rule + masked value + span) is already
-  // recorded against the given audit event.
+  // recorded against the given audit event. When the finding carries a
+  // `finding_key`, the match is scoped to it too, so identical content captured
+  // at two paths (which collapse onto one content-addressed audit event) is not
+  // deduped away; a keyless in-flight finding passes `null` and keeps the
+  // span-only behavior.
   isEventDuplicate(
     auditEventId: string,
     ruleId: string,
     maskedMatch: string,
     spanStart: number,
     spanEnd: number,
+    findingKey: string | null,
   ): boolean {
     return (
-      this.eventDupStmt.get({ auditEventId, ruleId, maskedMatch, spanStart, spanEnd }) !== undefined
+      this.eventDupStmt.get({
+        auditEventId,
+        ruleId,
+        maskedMatch,
+        spanStart,
+        spanEnd,
+        findingKey,
+      }) !== undefined
     );
   }
 

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -157,7 +157,7 @@ describe('recordCapture', () => {
     // audit event, not the write's) since the write's repeats were dropped.
     const findings = await db.findings.recentFindings();
     expect(findings).toHaveLength(2);
-    const promptAuditEventId = captureId(sessionId, 'hash-prompt');
+    const promptAuditEventId = captureId(sessionId, 'hash-prompt', null);
     expect(findings.every((f) => f.eventId === promptAuditEventId)).toBe(true);
     expect(new Set(findings.map((f) => f.ruleId))).toEqual(
       new Set(['core-pii/email', 'core-pii/ssn']),

--- a/packages/persistence/test/ids.test.ts
+++ b/packages/persistence/test/ids.test.ts
@@ -137,26 +137,39 @@ describe('promptId (run-grouping key)', () => {
 });
 
 // `captureId` content-addresses a capture on its own text hash, scoped to the
-// owning session so identical content in two sessions never collapses onto one
-// row. A `null` session (a capture taken outside any harness session) folds
-// onto a fixed sentinel instead of shortening the join.
-describe('captureId (content-addressed, session-scoped)', () => {
-  it('is stable / deterministic for the same (session, contentHash)', () => {
-    const id = captureId('sess_abc123', 'contenthash123');
-    expect(id).toBe('ea59d6af9254316e6ecde67786230b0ca0d2f6f7434bdaf4261c2d2a786e0502');
-    expect(captureId('sess_abc123', 'contenthash123')).toBe(id);
+// owning session AND its file path, so identical content in two sessions — or
+// the same bytes at two different paths (a secret duplicated across files) —
+// never collapses onto one row. A `null` session or `null` path folds onto a
+// fixed sentinel instead of shortening the join.
+describe('captureId (content-addressed; session- and path-scoped)', () => {
+  it('is stable / deterministic for the same (session, contentHash, path)', () => {
+    const id = captureId('sess_abc123', 'contenthash123', null);
+    expect(id).toBe('f526a0273e164ac92df66131c3b020c96c5ad39f52f4139166e64506b0e4bc43');
+    expect(captureId('sess_abc123', 'contenthash123', null)).toBe(id);
   });
 
-  it('a null session folds onto the fixed sentinel rather than being dropped', () => {
-    expect(captureId(null, 'contenthash123')).toBe(
-      '36331fde9271bda6dfd25c812eab2a6b3624069ccfd2ed8a7f2df465edc2e099',
+  it('a null session and null path fold onto fixed sentinels rather than being dropped', () => {
+    expect(captureId(null, 'contenthash123', null)).toBe(
+      'e8c744efbc9118506a33b518172f478acd8323c5d52659187bae72bbd7da2da9',
     );
   });
 
   it('a different content hash yields a different id', () => {
-    expect(captureId('sess_abc123', 'contenthash456')).toBe(
-      'd11a7703f7bd6c8f7b9494aee3447f940adab9d8a0028ab8ac2cc80bbf2d6555',
+    expect(captureId('sess_abc123', 'contenthash456', null)).toBe(
+      'ffb66881265eac2054d53471637d396ac302dcc8ee2ab93f0ec4077a0339dc56',
     );
+  });
+
+  it('the file path folds into the id: same (session, contentHash), different path → different id', () => {
+    const withPath = captureId('sess_abc123', 'contenthash123', 'src/config.ts');
+    expect(withPath).toBe('e74c748bdc5a9f37425a268b26585281932e658110eedecd47fe4ed60e496cac');
+    // Distinct from the path-less capture of the same content...
+    expect(withPath).not.toBe(captureId('sess_abc123', 'contenthash123', null));
+    // ...and from the same content at another path (the duplicate-file case).
+    expect(captureId('sess_abc123', 'contenthash123', 'src/other.ts')).toBe(
+      'efe5c464154dd878aec64ee02477d68cb80a6cae3c00e6b59dfaaac7c5cd913b',
+    );
+    expect(captureId('sess_abc123', 'contenthash123', 'src/other.ts')).not.toBe(withPath);
   });
 });
 

--- a/packages/persistence/test/record-capture.test.ts
+++ b/packages/persistence/test/record-capture.test.ts
@@ -70,7 +70,7 @@ describe('recordCapture — audit/inspection trio', () => {
     const ev = event({ kind: 'code_change', contentHash: 'hash-1' });
     db.recordCapture(ev, [finding()]);
 
-    const auditEventId = captureId(null, 'hash-1');
+    const auditEventId = captureId(null, 'hash-1', null);
     const r = raw();
     expect(count(r, 'audit_events')).toBe(1);
     expect(count(r, 'inspection_findings')).toBe(1);
@@ -112,7 +112,7 @@ describe('recordCapture — audit/inspection trio', () => {
       const ev = event({ kind, contentHash: `hash-${kind}` });
       db.recordCapture(ev, []);
 
-      const auditEventId = captureId(null, `hash-${kind}`);
+      const auditEventId = captureId(null, `hash-${kind}`, null);
       const r = raw();
       const row = r
         .prepare('SELECT event_type FROM audit_events WHERE id = ?')
@@ -153,7 +153,7 @@ describe('recordCapture — audit/inspection trio', () => {
     });
     db.recordCapture(ev, []);
 
-    const auditEventId = captureId(sessionId, 'hash-attrs');
+    const auditEventId = captureId(sessionId, 'hash-attrs', 'src/index.ts');
     const r = raw();
     const row = r.prepare('SELECT attributes FROM audit_events WHERE id = ?').get(auditEventId) as {
       attributes: string;
@@ -194,11 +194,11 @@ describe('recordCapture — audit/inspection trio', () => {
       metadata: { sessionId },
     });
     db.recordCapture(withSession, []);
-    const withSessionId = captureId(sessionId, 'hash-with-session');
+    const withSessionId = captureId(sessionId, 'hash-with-session', null);
 
     const withoutSession = event({ kind: 'prompt', contentHash: 'hash-no-session' });
     db.recordCapture(withoutSession, []);
-    const withoutSessionId = captureId(null, 'hash-no-session');
+    const withoutSessionId = captureId(null, 'hash-no-session', null);
 
     const r = raw();
     const a = r
@@ -235,7 +235,7 @@ describe('recordCapture — orphan-session FK trap', () => {
       db.recordCapture(ev, [finding({ findingKey: 'fk-orphan-1' })]);
     }).not.toThrow();
 
-    const auditEventId = captureId(sessionId, 'hash-orphan');
+    const auditEventId = captureId(sessionId, 'hash-orphan', null);
     const r = raw();
     // The capture itself persisted — not silently dropped by a rolled-back txn.
     const captureRow = r
@@ -358,7 +358,7 @@ describe('recordCapture — finding_key reconciliation', () => {
     expect(row.masked_match).toBe('AKIA…NEW'); // refreshed
     expect(row.action_taken).toBe('redact'); // refreshed
     expect(row.confidence).toBe(0.5); // refreshed
-    expect(row.audit_event_id).toBe(captureId(sessionId, 'hash-v2')); // refreshed to latest capture
+    expect(row.audit_event_id).toBe(captureId(sessionId, 'hash-v2', 'src/config.ts')); // refreshed to latest capture
     expect(row.first_detected_at).toBe(new Date(first.occurredAt).getTime()); // preserved
     r.close();
     db.close();
@@ -373,6 +373,82 @@ describe('recordCapture — finding_key reconciliation', () => {
 
     const r = raw();
     expect(count(r, 'inspection_findings')).toBe(2); // NULL never conflicts in a unique index
+    r.close();
+    db.close();
+  });
+});
+
+// A secret duplicated across two files (a .env copied to .env.local, a config
+// vendored into two packages, a cloned fixture) hashes to ONE contentHash.
+// captureId folds the file path into the audit-event id so the two files get
+// DISTINCT audit rows and the store surfaces BOTH affected paths — not just the
+// first-written one that INSERT OR IGNORE would otherwise keep.
+describe('recordCapture — identical content at distinct paths', () => {
+  function filePaths(r: DatabaseSync): (string | null)[] {
+    return (
+      r
+        .prepare(`SELECT json_extract(attributes, '$.file_path') AS p FROM audit_events ORDER BY p`)
+        .all() as { p: string | null }[]
+    ).map((x) => x.p);
+  }
+
+  it('mints a DISTINCT audit_events row per path for byte-identical content', () => {
+    const db = openLocalDatabase(dir);
+    const a = event({
+      kind: 'code_change',
+      contentHash: 'dup-hash',
+      metadata: { filePath: 'src/a.env' },
+    });
+    const b = event({
+      kind: 'code_change',
+      contentHash: 'dup-hash',
+      metadata: { filePath: 'src/b.env' },
+    });
+    db.recordCapture(a, [finding({ findingKey: 'fk-dup-a' })]);
+    db.recordCapture(b, [finding({ findingKey: 'fk-dup-b' })]);
+
+    const r = raw();
+    // Two rows, each carrying its OWN path — not one row keeping only the first.
+    expect(count(r, 'audit_events')).toBe(2);
+    expect(filePaths(r)).toEqual(['src/a.env', 'src/b.env']);
+    expect(count(r, 'inspection_findings')).toBe(2);
+    r.close();
+    db.close();
+  });
+
+  it('keeps ONE row when identical content is re-captured at the SAME path (idempotent)', () => {
+    const db = openLocalDatabase(dir);
+    const mk = (): IngestEvent =>
+      event({ kind: 'code_change', contentHash: 'same-hash', metadata: { filePath: 'src/x.env' } });
+    db.recordCapture(mk(), [finding({ findingKey: 'fk-same' })]);
+    db.recordCapture(mk(), [finding({ findingKey: 'fk-same' })]);
+
+    const r = raw();
+    expect(count(r, 'audit_events')).toBe(1);
+    r.close();
+    db.close();
+  });
+
+  it('folds pathless captures onto a fixed sentinel so identical-content pathless captures still collapse', () => {
+    const db = openLocalDatabase(dir);
+    const sessionId = randomUUID();
+    db.auditEvents.insertAuditEvent({
+      id: sessionId,
+      eventType: 'session',
+      startedAt: new Date().toISOString(),
+    });
+    // Two pathless captures (no filePath), same session, same bytes → one row:
+    // both fold onto the no-file sentinel, so Option A does not over-split them.
+    const p1 = event({ kind: 'prompt', contentHash: 'pathless-hash', metadata: { sessionId } });
+    const p2 = event({ kind: 'prompt', contentHash: 'pathless-hash', metadata: { sessionId } });
+    db.recordCapture(p1, []);
+    db.recordCapture(p2, []);
+
+    const r = raw();
+    const captures = r
+      .prepare(`SELECT count(*) AS n FROM audit_events WHERE event_type = 'prompt'`)
+      .get() as { n: number };
+    expect(captures.n).toBe(1);
     r.close();
     db.close();
   });

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -415,11 +415,12 @@ function recordAtRest(opts: {
   };
   db.recordCapture(event, [finding]);
   // recordCapture mints the audit_events row's own id as a content-address of
-  // (sessionId, contentHash) — NOT the caller-supplied event.id — so a raw
-  // read of inspection_findings.audit_event_id must be compared against this,
-  // not against eventId. This helper never sets metadata.sessionId, so the
-  // session component is always the null/no-session case.
-  const auditEventId = captureId(null, contentHash);
+  // (sessionId, contentHash, filePath) — NOT the caller-supplied event.id — so
+  // a raw read of inspection_findings.audit_event_id must be compared against
+  // this, not against eventId. This helper never sets metadata.sessionId, so the
+  // session component is always the null/no-session case; the path component is
+  // the same filePath written into the event metadata above.
+  const auditEventId = captureId(null, contentHash, opts.filePath ?? 'src/a.ts');
   return { eventId, findingId, auditEventId };
 }
 
@@ -508,14 +509,13 @@ describe('insertFindings — finding_key upsert (re-scan reconciliation)', () =>
 });
 
 // A secret duplicated across two files (`.env` copied to `.env.local`, a config
-// vendored into two packages, a fixture cloned) hashes to ONE contentHash, so
-// recordCapture content-addresses both captures onto a SINGLE audit_events row.
-// The two hits still carry DISTINCT finding_keys (the key is path-scoped), so
-// the event-level dedup must key on finding_key: otherwise the second file's
-// finding is taken for a replay of the first and silently dropped — never
-// counted, tracked, or remediable.
+// vendored into two packages, a fixture cloned) hashes to ONE contentHash. With
+// the file path folded into captureId, the two captures land on DISTINCT audit
+// events, so the Findings view surfaces BOTH affected paths by name — not just
+// the first-written one — and each finding stays independently tracked by its
+// own path-scoped finding_key.
 describe('insertFindings — duplicate content at distinct paths', () => {
-  it('keeps both findings when identical content at two paths collapses onto one audit event', async () => {
+  it('surfaces both paths as distinct audit events for byte-identical content', async () => {
     const contentHash = randomUUID();
     const keyA = findingKeyFor('aws-key', 'src/a.env', 'fp-1');
     const keyB = findingKeyFor('aws-key', 'src/b.env', 'fp-1');
@@ -528,21 +528,20 @@ describe('insertFindings — duplicate content at distinct paths', () => {
       occurredAt: '2026-01-02T00:00:00.000Z',
     });
 
-    // Both files collapse onto ONE content-addressed audit event...
+    // captureId folds in the path, so identical content at two paths no longer
+    // collapses onto the first-written row — each path owns its audit event.
     const rowsA = findingRowsByKey(keyA);
     const rowsB = findingRowsByKey(keyB);
     expect(rowsA).toHaveLength(1);
     expect(rowsB).toHaveLength(1);
-    expect(rowsA[0]?.event_id).toBe(rowsB[0]?.event_id);
+    expect(rowsA[0]?.event_id).not.toBe(rowsB[0]?.event_id);
 
-    // ...but each path keeps its own finding row, so neither is dropped. (The
-    // displayed file path is the shared audit event's — both instances read
-    // 'src/a.env' — because file_path lives on that content-collapsed row, not
-    // on the finding; surfacing the second path by name is a captureId concern,
-    // out of scope for this finding-level dedup fix.)
+    // Both findings are kept AND both paths surface by name (each finding reads
+    // its own audit event's file_path, not a shared collapsed row's).
     const res = await db.findings.listGroupedFindings({});
     expect(res.totals).toEqual({ findings: 2, groups: 1 });
     expect(res.items[0]?.instanceCount).toBe(2);
+    expect(res.items[0]?.instances.map((i) => i.file).sort()).toEqual(['src/a.env', 'src/b.env']);
   });
 });
 

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -383,10 +383,14 @@ function recordAtRest(opts: {
   maskedMatch?: string;
   actionTaken?: ActionTaken;
   occurredAt?: string;
+  // Pass the SAME contentHash to two calls to model identical bytes captured at
+  // two paths: recordCapture content-addresses the audit row on (session,
+  // contentHash), so both calls then resolve onto ONE audit_events row.
+  contentHash?: string;
 }): { eventId: string; findingId: string; auditEventId: string } {
   const eventId = randomUUID();
   const findingId = randomUUID();
-  const contentHash = randomUUID();
+  const contentHash = opts.contentHash ?? randomUUID();
   const metadata: EventMetadata = { filePath: opts.filePath ?? 'src/a.ts' };
   const event: IngestEvent = {
     id: eventId,
@@ -500,6 +504,45 @@ describe('insertFindings — finding_key upsert (re-scan reconciliation)', () =>
     } finally {
       raw.close();
     }
+  });
+});
+
+// A secret duplicated across two files (`.env` copied to `.env.local`, a config
+// vendored into two packages, a fixture cloned) hashes to ONE contentHash, so
+// recordCapture content-addresses both captures onto a SINGLE audit_events row.
+// The two hits still carry DISTINCT finding_keys (the key is path-scoped), so
+// the event-level dedup must key on finding_key: otherwise the second file's
+// finding is taken for a replay of the first and silently dropped — never
+// counted, tracked, or remediable.
+describe('insertFindings — duplicate content at distinct paths', () => {
+  it('keeps both findings when identical content at two paths collapses onto one audit event', async () => {
+    const contentHash = randomUUID();
+    const keyA = findingKeyFor('aws-key', 'src/a.env', 'fp-1');
+    const keyB = findingKeyFor('aws-key', 'src/b.env', 'fp-1');
+
+    recordAtRest({ contentHash, filePath: 'src/a.env', findingKey: keyA });
+    recordAtRest({
+      contentHash,
+      filePath: 'src/b.env',
+      findingKey: keyB,
+      occurredAt: '2026-01-02T00:00:00.000Z',
+    });
+
+    // Both files collapse onto ONE content-addressed audit event...
+    const rowsA = findingRowsByKey(keyA);
+    const rowsB = findingRowsByKey(keyB);
+    expect(rowsA).toHaveLength(1);
+    expect(rowsB).toHaveLength(1);
+    expect(rowsA[0]?.event_id).toBe(rowsB[0]?.event_id);
+
+    // ...but each path keeps its own finding row, so neither is dropped. (The
+    // displayed file path is the shared audit event's — both instances read
+    // 'src/a.env' — because file_path lives on that content-collapsed row, not
+    // on the finding; surfacing the second path by name is a captureId concern,
+    // out of scope for this finding-level dedup fix.)
+    const res = await db.findings.listGroupedFindings({});
+    expect(res.totals).toEqual({ findings: 2, groups: 1 });
+    expect(res.items[0]?.instanceCount).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Problem

`aka scan` over a repo that holds the same secret in **duplicated files** (a `.env`
copied to `.env.local`, a config vendored into two packages, a cloned fixture)
silently reported **only the first path** as affected.

Root cause: `recordCapture` content-addressed each `audit_events` row on
`(sessionId, contentHash)` only. Two byte-identical files hash the same, so they
collapsed onto **one** audit row (`INSERT OR IGNORE` keeps the first), and the
finding-level dedup then treated the second file as a replay of the first and
dropped it — even though `fs-scan` had computed a distinct, path-scoped
`finding_key` for it.

## The change (two commits)

- **`fix(persistence): scope capture-path finding dedup by finding_key`** — the
  event-level dedup (`eventDupStmt` / `isEventDuplicate`) now keys on
  `finding_key` when the incoming finding has one, so a distinct-key finding is
  no longer suppressed as a replay. This stops the *silent drop* (the finding is
  kept, counted, and independently tracked), but both instances still displayed
  the first path, because `file_path` lives on the shared collapsed audit row.

- **`fix(persistence): fold file path into captureId's content-addressed id`** —
  `captureId(sessionId, contentHash, filePath)` folds the file path into the id
  (appending `filePath ?? 'no_file'`, mirroring the existing `NO_SESSION`
  sentinel). Two byte-identical files at different paths now get **distinct audit
  rows**, so **both paths surface by name**. `recordCapture` folds the raw
  `event.metadata?.filePath` — byte-identical to what is stored as
  `attributes.file_path` and shown by the Findings view — so the id⟷path relation
  is 1:1. A re-scan at the *same* path stays idempotent; path-less captures fold
  onto the sentinel.

The two are complementary: folding the path removes the collapse at the source
for at-rest captures; the `finding_key` guard still carries **same-path re-scan
reconciliation** and keyless in-flight idempotency.

Pure id-derivation change — **no schema, no migration**. Existing path-less audit
rows orphan harmlessly and at-rest findings re-parent onto the new id via
`ON CONFLICT(finding_key)`. Golden vectors were re-frozen (independently
recomputed via `node:crypto`).

## Verification

- **persistence:** 527 tests pass; `typecheck` + `lint` clean.
- **all consumers pass:** detections (1214), plugin-sdk (228), scanner (75),
  plugin-runtime (49), dashboard-ui (67). No consumer recomputes `captureId`
  (repo-wide grep: only `packages/persistence` defines/calls it).
- **Adversarial review** (independent agents, executed probes) confirmed the
  session-less `aka scan` fix and found **no blockers**; probes proved Option A
  is load-bearing (finding_key dedup alone keeps both findings but on one
  path-less row).

## Known follow-ups (out of scope for this change)

- **Live-session gap:** `isSessionDuplicate` is path-blind and fires before
  insert, so writing the same secret to two files *within one harness session*
  still drops the second finding. The reported `aka scan` path is session-less,
  so it is fully fixed; the live path needs a separate `isSessionDuplicate`
  change.
- **`NO_FILE` sentinel** collides with a literal path `'no_file'` (unreachable —
  producers emit absolute paths; and dropping the component can only merge, never
  split, so no lost row). Mirrors the existing `NO_SESSION` idiom.
- **Raw vs normalized path:** `captureId` folds the raw path while
  `computeFindingKey` folds the posix-normalized one; a single-OS scan emits
  consistent separators, so unreachable in practice. Worth normalizing both in
  lockstep later.

## Notes for the reviewer

- **PR base is behind:** `origin/feat/audit-consolidation-cutover` is at `1d6f17a`,
  but this branch is built on the local tip `d2fba98` (which merged
  `feat/audit-consolidation-fs-scan-key`). Until cutover is advanced on origin,
  the diff/commits here also show that merge — **the only commits to review are
  the top two** (`fold file path…`, `scope capture-path finding dedup…`).
- **Pre-existing CI red (not from this change):** base `d2fba98` ships a broken
  `local-ops` test — `test/fs-scan.test.ts:321` reads `event.metadata` from an
  `audit_events` row that only has `attributes`. It reproduces on `d2fba98`
  without these commits (which touch `persistence/` only). Left for the
  `fs-scan-key` author; happy to fix separately.
