### PR TITLE
test(persistence): batch legacy-compat-views seed to fix Windows timeout

### DIFF
--- a/packages/persistence/test/legacy-compat-views.test.ts
+++ b/packages/persistence/test/legacy-compat-views.test.ts
@@ -340,9 +340,16 @@ describe('legacy events/findings compatibility views', () => {
     // More legacy events than one open's backfill budget, so the FIRST
     // openLocalDatabase call cannot finish draining — the drop must not run.
     const totalEvents = LEGACY_BACKFILL_MAX_ROWS_PER_CALL + 50;
+    // Seed the whole pre-cutover table in a single transaction: as individual
+    // auto-committed INSERTs the fixture pays one journal fsync per row (~1k of
+    // them), which on a slow-flush filesystem overruns the test timeout. The
+    // rows still land with sequential rowids, so the backfill's watermark paging
+    // is unchanged.
+    raw.exec('BEGIN');
     for (let i = 0; i < totalEvents; i += 1) {
       insertLegacyEvent(raw, `ev-${String(i)}`, i, null);
     }
+    raw.exec('COMMIT');
     raw.close();
 
     const first = openLocalDatabase(dir);


### PR DESCRIPTION
Stacked on top of #90 (base: `feat/audit-consolidation-schema-parity`).

## Problem

CI on #90 is red on exactly one check — **CI → "Windows · Unit tests (shipped surface)"**. Everything else (Linux/macOS tests, all four binary builds, lint/typecheck) is green.

```
FAIL packages/persistence/test/legacy-compat-views.test.ts
  > a store still mid-copy keeps its real legacy tables — the drop never fires on a partial drain
  Error: Test timed out in 20000ms.   (actual wall-clock ~188s)
```

## Root cause

The failing case seeds `LEGACY_BACKFILL_MAX_ROWS_PER_CALL + 50` (= 1050) legacy `events` rows through a **raw rollback-journal handle** as **individual auto-committed `INSERT`s** — ~1050 separate fsync-bearing commits. Two amplifiers turn that into a Windows-only failure:

- **Windows `FlushFileBuffers` is far slower** than Linux `fdatasync` on CI's virtualized disks, so those ~1050 commits cost ~188s on Windows vs. well under budget on Linux/macOS.
- **The test body is synchronous**, so vitest's 20s timer can't preempt it — the work runs to completion and is only *then* reported as "timed out in 20000ms" (hence the confusing 188s-vs-20s gap).

The production backfill is already correctly batched (`LEGACY_BACKFILL_BATCH_SIZE = 200`, commits per batch) — this is purely a **test-fixture** perf bug, no product change.

## Fix

Wrap the seed loop in a single transaction. Rows keep sequential rowids, so the backfill's watermark paging — and every assertion — are unchanged.

Measured seed cost for 1050 inserts (macOS, fast fsync — Windows amplifies the gap):

| Seed strategy | Time |
|---|---|
| delete-journal, un-batched (before) | 461 ms |
| **single transaction (after)** | **1.6 ms (~290× faster)** |

## Verification

- `vitest run test/legacy-compat-views.test.ts` → **11/11 pass**, file **1.73s** (was ~218s on Windows).
- `pnpm --filter @akasecurity/persistence run typecheck` → clean.
- `pnpm --filter @akasecurity/persistence run lint` → clean.
