### PR TITLE
test(persistence): keep legacy-compat-views under the Windows CI timeout

### DIFF
--- a/packages/persistence/test/legacy-compat-views.test.ts
+++ b/packages/persistence/test/legacy-compat-views.test.ts
@@ -22,7 +22,7 @@ import { DatabaseSync } from 'node:sqlite';
 
 import type { DetectedFinding, IngestEvent } from '@akasecurity/schema';
 import { SQLITE_MIGRATIONS } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { openLocalDatabase } from '../src/database.ts';
 import { schemaObjectExists } from '../src/db/migrations/introspection.ts';
@@ -32,6 +32,13 @@ import {
   LEGACY_BACKFILL_MAX_ROWS_PER_CALL,
 } from '../src/migrations.ts';
 import { DB_FILENAME } from '../src/paths.ts';
+
+// This suite drives real on-disk SQLite migrations, a batched history backfill,
+// and pre-drop backups against temp stores — all fsync-bound work. On a
+// slow-flush filesystem (e.g. Windows CI, where flushes are slow and highly
+// variable) the heaviest cases run past vitest's 20s default, so give the whole
+// file generous headroom rather than let legitimate slow-disk timing trip it.
+vi.setConfig({ testTimeout: 120_000, hookTimeout: 120_000 });
 
 let dir: string;
 
@@ -56,6 +63,12 @@ const MIGRATION_0014_TAG = '0014_drop_legacy_events_findings';
 function seedPreCutoverFile(): string {
   const file = join(dir, DB_FILENAME);
   const raw = new DatabaseSync(file);
+  // Throwaway temp store: skip the per-statement fsync the default durable
+  // journal does for every migration DDL. That fsync is what dominates this
+  // fixture's cost on a slow-flush filesystem; the rows still commit to the
+  // file, which is all the openLocalDatabase reopen below needs.
+  raw.exec('PRAGMA journal_mode = MEMORY');
+  raw.exec('PRAGMA synchronous = OFF');
   raw.exec('PRAGMA foreign_keys = ON');
   for (const migration of SQLITE_MIGRATIONS) {
     if (migration.tag === MIGRATION_0013_TAG) continue;


### PR DESCRIPTION
Completes the Windows-CI fix that #99 started. Base: `feat/audit-consolidation-schema-parity` (PR #90's branch).

## Why #99 wasn't enough

#99 batched the 1050-row seed and took the failing test from **188s → 32s** — but the Windows "Unit tests (shipped surface)" job is still red, now on **two** tests, both timing out at the 20s default:

| Test | Windows time | Uses `seedPreCutoverFile()`? |
|---|---|---|
| drains, backs up, drops (seeds only **2 rows**) | 13.6s | ✅ |
| the legacy drop completes (index absent) | 11.3s | ✅ |
| **re-running the legacy drop** ❌ | **20.6s** | ✅ |
| **a store still mid-copy** ❌ | **32.3s** | ✅ |
| (the three tests that don't seed) | <2.3s | ❌ |

The tell: the **2-row** "drains" test still takes 13.6s. The cost isn't the data — it's the shared **`seedPreCutoverFile()`**, which applies migrations 0001–0012 through a raw **durable** (rollback-journal, `synchronous=FULL`) handle: one fsync per DDL statement. The whole file runs in **0.49s on macOS but 88.6s on Windows (~180×)** — it's purely fsync-bound.

## Fix (test-only; no production change)

1. **Make the throwaway fixture non-durable** — `journal_mode=MEMORY` + `synchronous=OFF` on `seedPreCutoverFile()`'s handle. Removes the per-DDL fsync that dominates all four seed-based tests. Measured locally: fixture step **77ms → 6ms (~13×)**. Data still commits to the file, which is all the `openLocalDatabase` reopen needs.
2. **Raise this file's timeout to 120s.** The mid-copy case's two `openLocalDatabase` passes do a real 1050-row backfill through the **production WAL handle** — irreducible from the test — and on slow, high-variance Windows flushes that can still near 20s. This gives legitimate heavy I/O headroom.

## Evidence

Phase breakdown (macOS), durable vs. non-durable fixture:
```
durable      seedMigrations=77ms  insert1050=2ms  open1=23ms  open2=10ms
non-durable  seedMigrations= 6ms  insert1050=2ms  open1=20ms  open2=10ms
```

## Verification

- `vitest run test/legacy-compat-views.test.ts` → **11/11 pass**, ~0.49s → ~0.25s.
- Confirmed a 21s test passes under the raised file timeout (fails at the 20s default).
- typecheck + lint clean.

> Note: the "CI" workflow only triggers on PRs into `main`, so this PR (base = the feat branch) runs just the binary builds. The Windows unit-test job re-runs on **#90** once this merges into the feat branch — same path #99 took.
