### PR TITLE
feat(eslint-config): enforce the no-network guarantee in lint

### DIFF
--- a/cli/eslint.config.mjs
+++ b/cli/eslint.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { base } from '@akasecurity/eslint-config';
+import { base, noNetworkImports, noNetworkSyntax } from '@akasecurity/eslint-config';
 
 export default [
   ...base,
@@ -9,6 +9,18 @@ export default [
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+  },
+  {
+    // dashboard.ts's isPortFree() binds a probe server on 127.0.0.1 to detect an
+    // in-use port before launching the dashboard — a local bind, not a network
+    // call. Allow node:net in this one file; every other network import (and the
+    // bare `net` specifier) stays banned here. The static and dynamic bans opt
+    // out together so the exception holds whichever import form the file uses.
+    files: ['src/commands/dashboard.ts'],
+    rules: {
+      'no-restricted-imports': noNetworkImports({ allow: ['node:net'] }),
+      'no-restricted-syntax': noNetworkSyntax({ allow: ['node:net'] }),
     },
   },
 ];

--- a/cli/eslint.scripts.config.mjs
+++ b/cli/eslint.scripts.config.mjs
@@ -1,0 +1,20 @@
+// @ts-check
+// Network-only guard for the CLI's dev/CI scripts (scripts/), which the main
+// `eslint src test` pass never reaches. It enforces just the no-network bans —
+// not the source-only conventions — so build/smoke tooling is not dragged into
+// the full ruleset. Run with `--no-config-lookup` so `eslint.config.mjs` (which
+// pulls in `base`) does not also apply here.
+import { networkGuard, noNetworkImports } from '@akasecurity/eslint-config';
+
+export default [
+  ...networkGuard,
+  {
+    // smoke-dashboard.mjs polls the launched dashboard over loopback HTTP in a
+    // CI smoke test — a local health check, not egress. Allow node:http here
+    // only; the guard still bans every other network module and dynamic import.
+    files: ['**/smoke-dashboard.mjs'],
+    rules: {
+      'no-restricted-imports': noNetworkImports({ allow: ['node:http'] }),
+    },
+  },
+];

--- a/cli/eslint.scripts.config.mjs
+++ b/cli/eslint.scripts.config.mjs
@@ -4,17 +4,20 @@
 // not the source-only conventions — so build/smoke tooling is not dragged into
 // the full ruleset. Run with `--no-config-lookup` so `eslint.config.mjs` (which
 // pulls in `base`) does not also apply here.
-import { networkGuard, noNetworkImports } from '@akasecurity/eslint-config';
+import { networkGuard, noNetworkImports, noNetworkSyntax } from '@akasecurity/eslint-config';
 
 export default [
   ...networkGuard,
   {
     // smoke-dashboard.mjs polls the launched dashboard over loopback HTTP in a
     // CI smoke test — a local health check, not egress. Allow node:http here
-    // only; the guard still bans every other network module and dynamic import.
+    // only; the guard still bans every other network module. The static and
+    // dynamic bans opt out together so the exception holds whichever import form
+    // the file uses (mirrors cli's dashboard.ts opt-out).
     files: ['**/smoke-dashboard.mjs'],
     rules: {
       'no-restricted-imports': noNetworkImports({ allow: ['node:http'] }),
+      'no-restricted-syntax': noNetworkSyntax({ allow: ['node:http'] }),
     },
   },
 ];

--- a/cli/package.json
+++ b/cli/package.json
@@ -35,7 +35,7 @@
     "archive:sea": "node scripts/archive-sea.mjs",
     "bundle:web-ui": "node scripts/bundle-web-ui.mjs",
     "prepack": "tsup && node scripts/bundle-web-ui.mjs",
-    "lint": "eslint src test",
+    "lint": "eslint src test && eslint --no-config-lookup -c eslint.scripts.config.mjs scripts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "lint": "echo 'no self-lint for eslint-config'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@eslint/js": "^10.0.1",
@@ -20,6 +21,10 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "typescript-eslint": "^8.64.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0",
+    "vitest": "^4.1.10"
   },
   "peerDependencies": {
     "eslint": "^9.0.0",

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -5,6 +5,154 @@ import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
 
+// ai-tc is local-first: the OSS surface makes no network calls and talks to no
+// AKA service — all data lives in the local SQLite store under ~/.aka. Banning
+// the network primitives keeps that guarantee enforced by lint instead of by
+// convention. A genuinely local-only use (e.g. a 127.0.0.1 bind probe) may add
+// a narrow, file-scoped opt-out in its own eslint config.
+const NO_NETWORK_MESSAGE =
+  'ai-tc is local-first and makes no network calls — all data lives in the local SQLite store under ~/.aka. ' +
+  'Do not use network primitives here; a genuinely local-only use (e.g. a 127.0.0.1 bind probe) may add a ' +
+  'file-scoped opt-out. See CLAUDE.md "No network calls".';
+
+// Client-side network globals. `no-restricted-globals` flags only a bare
+// reference that resolves to the global — never a property access such as
+// `db.fetch()` or a local variable of the same name — so ordinary method names
+// are unaffected.
+const NETWORK_GLOBALS = ['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource', 'WebTransport'];
+
+// The container-global objects those primitives also hang off of. Banning the
+// bare global alone would let `globalThis.fetch(...)` slip through, so the
+// member forms are restricted too. Only the network properties below are
+// touched — `window.location` and friends are unaffected.
+const NETWORK_GLOBAL_CONTAINERS = ['globalThis', 'window', 'self', 'global'];
+
+// Host-object egress methods that do not fit the container-by-primitive grid
+// above: navigator.sendBeacon is a fire-and-forget POST (a genuine exfil path).
+const NETWORK_MEMBER_CALLS = [{ object: 'navigator', property: 'sendBeacon' }];
+
+// Node network builtins plus the common third-party HTTP clients. Both the
+// `node:`-prefixed and the bare specifier are listed so `import 'http'` cannot
+// slip past the ban that `import 'node:http'` would trip.
+const NETWORK_MODULES = [
+  'node:http',
+  'http',
+  'node:https',
+  'https',
+  'node:http2',
+  'http2',
+  'node:net',
+  'net',
+  'node:dgram',
+  'dgram',
+  'node:tls',
+  'tls',
+  'node:dns',
+  'dns',
+  'node:dns/promises',
+  'dns/promises',
+  'axios',
+  'undici',
+  'got',
+  'node-fetch',
+];
+
+// Escape a specifier for embedding in the esquery attribute regexes below. The
+// character class includes `/` so a subpath specifier like `node:dns/promises`
+// cannot close the `/…/` regex literal early.
+/** @param {string} specifier */
+const escapeForSelector = (specifier) => specifier.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&');
+
+/**
+ * The `no-restricted-globals` rule value that bans the network client globals.
+ * @returns {import('eslint').Linter.RuleEntry}
+ */
+export function noNetworkGlobals() {
+  return /** @type {import('eslint').Linter.RuleEntry} */ ([
+    'error',
+    ...NETWORK_GLOBALS.map((name) => ({ name, message: NO_NETWORK_MESSAGE })),
+  ]);
+}
+
+/**
+ * The `no-restricted-properties` rule value that bans container-global access to
+ * the network primitives (e.g. `globalThis.fetch`, `window.WebSocket`), closing
+ * the member-access bypass that `no-restricted-globals` cannot see.
+ * @returns {import('eslint').Linter.RuleEntry}
+ */
+export function noNetworkProperties() {
+  return /** @type {import('eslint').Linter.RuleEntry} */ ([
+    'error',
+    ...NETWORK_GLOBAL_CONTAINERS.flatMap((object) =>
+      NETWORK_GLOBALS.map((property) => ({ object, property, message: NO_NETWORK_MESSAGE })),
+    ),
+    ...NETWORK_MEMBER_CALLS.map(({ object, property }) => ({
+      object,
+      property,
+      message: NO_NETWORK_MESSAGE,
+    })),
+  ]);
+}
+
+/**
+ * The `no-restricted-imports` rule value that bans the network modules, merged
+ * with any caller-supplied `paths`/`patterns`. Flat config never merges two
+ * `no-restricted-imports` entries — the last one matching a file wins outright —
+ * so a config layered on top of `base` must fold its extra restrictions in here
+ * rather than declaring a second entry. `allow` drops specific specifiers so a
+ * file with a genuine local-only use can opt out of just those.
+ * @param {{
+ *   allow?: readonly string[],
+ *   paths?: { name: string, message: string }[],
+ *   patterns?: { group: string[], message: string }[],
+ * }} [opts]
+ * @returns {import('eslint').Linter.RuleEntry}
+ */
+export function noNetworkImports(opts = {}) {
+  const { allow = [], paths = [], patterns = [] } = opts;
+  return /** @type {import('eslint').Linter.RuleEntry} */ ([
+    'error',
+    {
+      paths: [
+        ...NETWORK_MODULES.filter((name) => !allow.includes(name)).map((name) => ({
+          name,
+          message: NO_NETWORK_MESSAGE,
+        })),
+        ...paths,
+      ],
+      patterns,
+    },
+  ]);
+}
+
+/**
+ * The `no-restricted-syntax` rule value that bans *dynamic* access to the
+ * network modules — `import('node:http')` and `require('axios')` — which the
+ * static `no-restricted-imports` rule cannot see. A non-literal specifier
+ * (`import(url)`) and `require.resolve(...)` are intentionally not matched.
+ * `allow` drops specific specifiers, symmetric with `noNetworkImports`, so a
+ * file that opts out of a static import can opt out of the dynamic form too.
+ * @param {{ allow?: readonly string[] }} [opts]
+ * @returns {import('eslint').Linter.RuleEntry}
+ */
+export function noNetworkSyntax(opts = {}) {
+  const { allow = [] } = opts;
+  const pattern = NETWORK_MODULES.filter((name) => !allow.includes(name))
+    .map(escapeForSelector)
+    .join('|');
+  return /** @type {import('eslint').Linter.RuleEntry} */ ([
+    'error',
+    {
+      selector: `ImportExpression[source.value=/^(${pattern})$/]`,
+      message: NO_NETWORK_MESSAGE,
+    },
+    {
+      selector: `CallExpression[callee.name='require'] > Literal[value=/^(${pattern})$/]`,
+      message: NO_NETWORK_MESSAGE,
+    },
+  ]);
+}
+
 /** @type {import('typescript-eslint').ConfigArray} */
 export const base = tseslint.config(
   js.configs.recommended,
@@ -19,6 +167,16 @@ export const base = tseslint.config(
       // Forbid direct process.env access by default; packages that must read env
       // (e.g. the plugin's provider resolution) opt out in their own eslint config.
       'n/no-process-env': 'error',
+
+      // Enforce the no-network guarantee: ban the client-side network globals
+      // (bare and container-global forms), the HTTP/socket modules (static and
+      // dynamic import / require), across the whole workspace. Files with a
+      // genuine local-only use opt out in their own eslint config (see cli's
+      // dashboard bind probe).
+      'no-restricted-globals': noNetworkGlobals(),
+      'no-restricted-properties': noNetworkProperties(),
+      'no-restricted-imports': noNetworkImports(),
+      'no-restricted-syntax': noNetworkSyntax(),
 
       // Import discipline
       'simple-import-sort/imports': 'error',
@@ -46,24 +204,45 @@ export const base = tseslint.config(
 const ENTERPRISE_IMPORT_MESSAGE =
   'OSS packages must never import enterprise-only modules (this keeps tenancy/auth/Postgres code out of the public oss/ tree). See CLAUDE.md "Package dependency rules".';
 
+// This carries the network import bans forward alongside the enterprise ones.
+// `no-restricted-imports` does not merge across flat-config entries, and this is
+// layered on top of `base` in the packages that use it, so declaring the
+// enterprise restrictions on their own would silently drop base's network bans
+// for exactly those packages.
 /** @type {import('typescript-eslint').ConfigArray} */
 export const noEnterpriseImports = tseslint.config({
   rules: {
-    'no-restricted-imports': [
-      'error',
-      {
-        paths: [
-          { name: '@akasecurity/client', message: ENTERPRISE_IMPORT_MESSAGE },
-          { name: 'drizzle-orm', message: ENTERPRISE_IMPORT_MESSAGE },
-          { name: '@akasecurity/schema-enterprise', message: ENTERPRISE_IMPORT_MESSAGE },
-        ],
-        patterns: [
-          { group: ['drizzle-orm/*'], message: ENTERPRISE_IMPORT_MESSAGE },
-          { group: ['@akasecurity/schema-enterprise/*'], message: ENTERPRISE_IMPORT_MESSAGE },
-        ],
-      },
-    ],
+    'no-restricted-imports': noNetworkImports({
+      paths: [
+        { name: '@akasecurity/client', message: ENTERPRISE_IMPORT_MESSAGE },
+        { name: 'drizzle-orm', message: ENTERPRISE_IMPORT_MESSAGE },
+        { name: '@akasecurity/schema-enterprise', message: ENTERPRISE_IMPORT_MESSAGE },
+      ],
+      patterns: [
+        { group: ['drizzle-orm/*'], message: ENTERPRISE_IMPORT_MESSAGE },
+        { group: ['@akasecurity/schema-enterprise/*'], message: ENTERPRISE_IMPORT_MESSAGE },
+      ],
+    }),
   },
 });
+
+// A standalone config that enforces ONLY the no-network guarantee — the four
+// bans above and nothing else. Point a second lint pass at it (see cli's
+// `eslint.scripts.config.mjs`) to cover files that are not compiled sources:
+// the dev/CI scripts under `scripts/`, which `src`/`test` linting never reaches
+// and where the full `base` ruleset (type-aware rules, import sorting,
+// no-console, no-process-env) would only produce noise. It carries no
+// TypeScript-project requirement, so it lints plain .js/.mjs/.cjs directly.
+/** @type {import('eslint').Linter.Config[]} */
+export const networkGuard = [
+  {
+    rules: {
+      'no-restricted-globals': noNetworkGlobals(),
+      'no-restricted-properties': noNetworkProperties(),
+      'no-restricted-imports': noNetworkImports(),
+      'no-restricted-syntax': noNetworkSyntax(),
+    },
+  },
+];
 
 export default base;

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -57,6 +57,13 @@ const NETWORK_MODULES = [
   'node-fetch',
 ];
 
+// The npm HTTP clients from NETWORK_MODULES. `no-restricted-imports` `paths`
+// matches only the exact specifier, so a deep import (`axios/lib/adapters/http.js`)
+// would slip the root ban; a `<client>/*` pattern closes every subpath. Node
+// builtins need no equivalent — they expose no deep network specifier beyond the
+// `node:dns/promises` form already listed above.
+const NETWORK_PACKAGE_CLIENTS = ['axios', 'undici', 'got', 'node-fetch'];
+
 // Escape a specifier for embedding in the esquery attribute regexes below. The
 // character class includes `/` so a subpath specifier like `node:dns/promises`
 // cannot close the `/…/` regex literal early.
@@ -77,7 +84,13 @@ export function noNetworkGlobals() {
 /**
  * The `no-restricted-properties` rule value that bans container-global access to
  * the network primitives (e.g. `globalThis.fetch`, `window.WebSocket`), closing
- * the member-access bypass that `no-restricted-globals` cannot see.
+ * the member-access bypass that `no-restricted-globals` cannot see. It also
+ * covers computed indexing (`globalThis['fetch']`) and destructuring
+ * (`const { fetch } = globalThis`) — `no-restricted-properties` matches those
+ * forms too. The one residual is a false positive, not a bypass: the rule keys
+ * on the identifier name, so a local variable named `window`/`self`/`global`/
+ * `globalThis`/`navigator` carrying a `.fetch`/`.sendBeacon` property would be
+ * flagged (none exist today).
  * @returns {import('eslint').Linter.RuleEntry}
  */
 export function noNetworkProperties() {
@@ -99,8 +112,10 @@ export function noNetworkProperties() {
  * with any caller-supplied `paths`/`patterns`. Flat config never merges two
  * `no-restricted-imports` entries — the last one matching a file wins outright —
  * so a config layered on top of `base` must fold its extra restrictions in here
- * rather than declaring a second entry. `allow` drops specific specifiers so a
- * file with a genuine local-only use can opt out of just those.
+ * rather than declaring a second entry — including caller `patterns`, which the
+ * npm-client subpath bans below are prepended to. `allow` drops specific
+ * specifiers (and the matching `<client>/*` subpath group) so a file with a
+ * genuine local-only use can opt out of just those.
  * @param {{
  *   allow?: readonly string[],
  *   paths?: { name: string, message: string }[],
@@ -120,26 +135,41 @@ export function noNetworkImports(opts = {}) {
         })),
         ...paths,
       ],
-      patterns,
+      patterns: [
+        ...NETWORK_PACKAGE_CLIENTS.filter((name) => !allow.includes(name)).map((name) => ({
+          group: [`${name}/*`],
+          message: NO_NETWORK_MESSAGE,
+        })),
+        ...patterns,
+      ],
     },
   ]);
 }
 
 /**
  * The `no-restricted-syntax` rule value that bans *dynamic* access to the
- * network modules — `import('node:http')` and `require('axios')` — which the
- * static `no-restricted-imports` rule cannot see. A non-literal specifier
- * (`import(url)`) and `require.resolve(...)` are intentionally not matched.
- * `allow` drops specific specifiers, symmetric with `noNetworkImports`, so a
- * file that opts out of a static import can opt out of the dynamic form too.
+ * network modules — `import('node:http')` and `require('axios')`, plus any npm-
+ * client subpath (`import('axios/lib/adapters/http.js')`) — which the static
+ * `no-restricted-imports` rule cannot see. Intentionally NOT matched, since an
+ * esquery selector cannot follow a binding and the ban targets accidents rather
+ * than deliberate evasion: a non-literal specifier (`import(url)`, a template
+ * literal), `require.resolve(...)`, and an aliased/indirected require
+ * (`const req = createRequire(...); req('node:http')`). `allow` drops specific
+ * specifiers, symmetric with `noNetworkImports`, so a file that opts out of a
+ * static import can opt out of the dynamic form too.
  * @param {{ allow?: readonly string[] }} [opts]
  * @returns {import('eslint').Linter.RuleEntry}
  */
 export function noNetworkSyntax(opts = {}) {
   const { allow = [] } = opts;
-  const pattern = NETWORK_MODULES.filter((name) => !allow.includes(name))
-    .map(escapeForSelector)
-    .join('|');
+  const exact = NETWORK_MODULES.filter((name) => !allow.includes(name)).map(escapeForSelector);
+  // The npm clients also match any subpath, mirroring the `<client>/*` static
+  // ban. `escapeForSelector` escapes the trailing `/` so it cannot close the
+  // `/…/` regex literal early.
+  const clientSubpaths = NETWORK_PACKAGE_CLIENTS.filter((name) => !allow.includes(name)).map(
+    (name) => `${escapeForSelector(`${name}/`)}.*`,
+  );
+  const pattern = [...exact, ...clientSubpaths].join('|');
   return /** @type {import('eslint').Linter.RuleEntry} */ ([
     'error',
     {

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,0 +1,114 @@
+import { existsSync, globSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint, Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+// These tests exercise the ASSEMBLED per-package configs on disk — not the
+// exported building blocks (base / noEnterpriseImports / the helpers) that
+// no-network.test.js covers in isolation. Flat config resolves "last wins":
+// the final block matching a file overrides earlier ones for a given rule, and
+// no-restricted-imports never merges across blocks. So a package that layers a
+// second config on top of base (web-ui: react + noEnterpriseImports; persistence
+// / local-ops: base + noEnterpriseImports; cli: base + the dashboard opt-out)
+// could silently drop a network ban with the unit suite still green. Here we
+// resolve each real eslint.config.mjs through ESLint itself and assert the ban
+// still fires on real code — the composition, not the components.
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+const KEYS = /** @type {const} */ ([
+  'no-restricted-globals',
+  'no-restricted-properties',
+  'no-restricted-imports',
+  'no-restricted-syntax',
+]);
+
+// One snippet that must trip all four network rules at once: a banned import, a
+// bare global, a dynamic import, and the container-global member bypass.
+const NETWORK_SNIPPET = [
+  "import x from 'axios';",
+  "fetch('/x');",
+  "await import('undici');",
+  'globalThis.fetch();',
+].join('\n');
+
+const linter = new Linter();
+const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
+
+// Every workspace glob from pnpm-workspace.yaml that can hold a package config.
+// Discovering them (rather than hard-coding a list) means a NEW package that
+// forgets to extend `base` fails this suite instead of slipping through
+// unlinted for network calls.
+const CONFIG_FILES = [
+  ...globSync('packages/*/eslint.config.mjs', { cwd: REPO_ROOT }),
+  ...globSync('plugins/*/eslint.config.mjs', { cwd: REPO_ROOT }),
+  ...globSync('tools/*/eslint.config.mjs', { cwd: REPO_ROOT }),
+  ...['cli/eslint.config.mjs', 'web-ui/eslint.config.mjs'].filter((p) =>
+    existsSync(join(REPO_ROOT, p)),
+  ),
+].sort();
+
+/**
+ * Resolve the effective config a package's real eslint.config.mjs produces for
+ * `relFile`, and return just the four network rules from it. calculateConfigForFile
+ * runs the full flat-config cascade without parsing the file, so it needs no
+ * type information and the probe path need not exist.
+ * @param {string} pkgDir absolute package directory
+ * @param {string} relFile path within the package to resolve config for
+ */
+async function resolveNetworkRules(pkgDir, relFile) {
+  const eslint = new ESLint({ cwd: pkgDir, overrideConfigFile: join(pkgDir, 'eslint.config.mjs') });
+  const config = await eslint.calculateConfigForFile(join(pkgDir, relFile));
+  return Object.fromEntries(KEYS.map((k) => [k, config.rules?.[k]]));
+}
+
+/** Which network rule ids fire when `code` is linted with `rules`. */
+function firedRuleIds(code, rules) {
+  return new Set(linter.verify(code, { languageOptions: LANG, rules }).map((m) => m.ruleId));
+}
+
+describe('effective per-package config (composition / last-wins)', () => {
+  it('discovered the workspace package configs (guard against a vacuous pass)', () => {
+    // A broken glob would leave it.each empty and every enforcement test would
+    // silently not run. Pin the floor: 11 packages ship an eslint.config.mjs
+    // today (all of packages/* except eslint-config, plus cli, web-ui, plugin).
+    expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(11);
+  });
+
+  it.each(CONFIG_FILES)('bans every network form in %s', async (configRel) => {
+    const pkgDir = join(REPO_ROOT, dirname(configRel));
+    // A source path base applies to; it need not exist (config is computed, not
+    // parsed). Avoids each package's real layout while still hitting base rules.
+    const rules = await resolveNetworkRules(pkgDir, 'src/__network_ban_probe__.ts');
+    const fired = firedRuleIds(NETWORK_SNIPPET, rules);
+    for (const key of KEYS) {
+      expect(fired, `${configRel} :: ${key}`).toContain(key);
+    }
+  });
+});
+
+describe('cli dashboard.ts file-scoped opt-out (real config)', () => {
+  const cliDir = join(REPO_ROOT, 'cli');
+
+  it('allows node:net in dashboard.ts (the 127.0.0.1 bind probe)', async () => {
+    const rules = await resolveNetworkRules(cliDir, 'src/commands/dashboard.ts');
+    expect(firedRuleIds("import { createServer } from 'node:net';", rules).size).toBe(0);
+    // Symmetric: the dynamic form is opted out too.
+    expect(firedRuleIds("await import('node:net');", rules).size).toBe(0);
+  });
+
+  it('still bans every OTHER network module in dashboard.ts', async () => {
+    const rules = await resolveNetworkRules(cliDir, 'src/commands/dashboard.ts');
+    expect(firedRuleIds("import http from 'node:http';", rules)).toContain('no-restricted-imports');
+    expect(firedRuleIds("fetch('/x');", rules)).toContain('no-restricted-globals');
+  });
+
+  it('does NOT leak the node:net opt-out to other cli files', async () => {
+    const rules = await resolveNetworkRules(cliDir, 'src/lib/open-url.ts');
+    expect(firedRuleIds("import { createServer } from 'node:net';", rules)).toContain(
+      'no-restricted-imports',
+    );
+  });
+});

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ESLint, Linter } from 'eslint';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 // These tests exercise the ASSEMBLED per-package configs on disk — not the
 // exported building blocks (base / noEnterpriseImports / the helpers) that
@@ -50,6 +50,14 @@ const CONFIG_FILES = [
   ),
 ].sort();
 
+// Resolving a real config through ESLint (`new ESLint` + `calculateConfigForFile`)
+// is slow on a cold runner: the first call loads the whole typescript-eslint +
+// plugin stack and, for a large package like cli, can take several seconds —
+// past a default per-test timeout. So every resolution happens in a `beforeAll`
+// with a generous budget, and the tests themselves are fast assertions on the
+// cached result.
+const RESOLVE_TIMEOUT_MS = 120_000;
+
 /**
  * Resolve the effective config a package's real eslint.config.mjs produces for
  * `relFile`, and return just the four network rules from it. calculateConfigForFile
@@ -70,6 +78,19 @@ function firedRuleIds(code, rules) {
 }
 
 describe('effective per-package config (composition / last-wins)', () => {
+  /** @type {Map<string, Set<string>>} configRel -> rule ids the snippet trips */
+  const firedByConfig = new Map();
+
+  beforeAll(async () => {
+    for (const configRel of CONFIG_FILES) {
+      const pkgDir = join(REPO_ROOT, dirname(configRel));
+      // A source path base applies to; it need not exist (config is computed,
+      // not parsed). Avoids each package's real layout while still hitting base.
+      const rules = await resolveNetworkRules(pkgDir, 'src/__network_ban_probe__.ts');
+      firedByConfig.set(configRel, firedRuleIds(NETWORK_SNIPPET, rules));
+    }
+  }, RESOLVE_TIMEOUT_MS);
+
   it('discovered the workspace package configs (guard against a vacuous pass)', () => {
     // A broken glob would leave it.each empty and every enforcement test would
     // silently not run. Pin the floor: 11 packages ship an eslint.config.mjs
@@ -77,12 +98,8 @@ describe('effective per-package config (composition / last-wins)', () => {
     expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(11);
   });
 
-  it.each(CONFIG_FILES)('bans every network form in %s', async (configRel) => {
-    const pkgDir = join(REPO_ROOT, dirname(configRel));
-    // A source path base applies to; it need not exist (config is computed, not
-    // parsed). Avoids each package's real layout while still hitting base rules.
-    const rules = await resolveNetworkRules(pkgDir, 'src/__network_ban_probe__.ts');
-    const fired = firedRuleIds(NETWORK_SNIPPET, rules);
+  it.each(CONFIG_FILES)('bans every network form in %s', (configRel) => {
+    const fired = firedByConfig.get(configRel);
     for (const key of KEYS) {
       expect(fired, `${configRel} :: ${key}`).toContain(key);
     }
@@ -91,23 +108,33 @@ describe('effective per-package config (composition / last-wins)', () => {
 
 describe('cli dashboard.ts file-scoped opt-out (real config)', () => {
   const cliDir = join(REPO_ROOT, 'cli');
+  // Resolved network rules for two cli files, populated in beforeAll (see the
+  // RESOLVE_TIMEOUT_MS note): dashboard.ts carries the node:net opt-out, the
+  // other file must not.
+  const resolved = { dashboard: undefined, otherFile: undefined };
 
-  it('allows node:net in dashboard.ts (the 127.0.0.1 bind probe)', async () => {
-    const rules = await resolveNetworkRules(cliDir, 'src/commands/dashboard.ts');
-    expect(firedRuleIds("import { createServer } from 'node:net';", rules).size).toBe(0);
+  beforeAll(async () => {
+    resolved.dashboard = await resolveNetworkRules(cliDir, 'src/commands/dashboard.ts');
+    resolved.otherFile = await resolveNetworkRules(cliDir, 'src/lib/open-url.ts');
+  }, RESOLVE_TIMEOUT_MS);
+
+  it('allows node:net in dashboard.ts (the 127.0.0.1 bind probe)', () => {
+    expect(firedRuleIds("import { createServer } from 'node:net';", resolved.dashboard).size).toBe(
+      0,
+    );
     // Symmetric: the dynamic form is opted out too.
-    expect(firedRuleIds("await import('node:net');", rules).size).toBe(0);
+    expect(firedRuleIds("await import('node:net');", resolved.dashboard).size).toBe(0);
   });
 
-  it('still bans every OTHER network module in dashboard.ts', async () => {
-    const rules = await resolveNetworkRules(cliDir, 'src/commands/dashboard.ts');
-    expect(firedRuleIds("import http from 'node:http';", rules)).toContain('no-restricted-imports');
-    expect(firedRuleIds("fetch('/x');", rules)).toContain('no-restricted-globals');
+  it('still bans every OTHER network module in dashboard.ts', () => {
+    expect(firedRuleIds("import http from 'node:http';", resolved.dashboard)).toContain(
+      'no-restricted-imports',
+    );
+    expect(firedRuleIds("fetch('/x');", resolved.dashboard)).toContain('no-restricted-globals');
   });
 
-  it('does NOT leak the node:net opt-out to other cli files', async () => {
-    const rules = await resolveNetworkRules(cliDir, 'src/lib/open-url.ts');
-    expect(firedRuleIds("import { createServer } from 'node:net';", rules)).toContain(
+  it('does NOT leak the node:net opt-out to other cli files', () => {
+    expect(firedRuleIds("import { createServer } from 'node:net';", resolved.otherFile)).toContain(
       'no-restricted-imports',
     );
   });

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -1,0 +1,292 @@
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+import {
+  base,
+  networkGuard,
+  noEnterpriseImports,
+  noNetworkGlobals,
+  noNetworkImports,
+  noNetworkProperties,
+  noNetworkSyntax,
+} from '../src/index.js';
+
+// These tests lint snippets with the SHIPPED rule values (imported from the
+// config, not re-declared here), so a regression that weakens the ban — a
+// dropped specifier, a lost merge, a silenced message — fails the suite. They
+// assert observable lint output (ruleId + message), not the config's shape.
+
+const linter = new Linter();
+const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
+
+/** Lint `code` with the network-ban rules, wired from the config helpers. */
+function lintNetwork(code, importOpts) {
+  return linter.verify(code, {
+    languageOptions: LANG,
+    rules: {
+      'no-restricted-globals': noNetworkGlobals(),
+      'no-restricted-properties': noNetworkProperties(),
+      'no-restricted-imports': noNetworkImports(importOpts),
+      'no-restricted-syntax': noNetworkSyntax(importOpts),
+    },
+  });
+}
+
+/** Lint `code` with a single rule value (for the merge / base-surface checks). */
+function lintWithRules(code, rules) {
+  return linter.verify(code, { languageOptions: LANG, rules });
+}
+
+// The exact ban set base must enforce — hard-coded so ANY add/drop in the
+// shipped list (src/index.js) forces a matching, reviewed change here rather
+// than silently shrinking coverage.
+const EXPECTED_MODULES = [
+  'node:http',
+  'http',
+  'node:https',
+  'https',
+  'node:http2',
+  'http2',
+  'node:net',
+  'net',
+  'node:dgram',
+  'dgram',
+  'node:tls',
+  'tls',
+  'node:dns',
+  'dns',
+  'node:dns/promises',
+  'dns/promises',
+  'axios',
+  'undici',
+  'got',
+  'node-fetch',
+];
+const EXPECTED_GLOBALS = ['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource', 'WebTransport'];
+
+describe('ban set (drift guards)', () => {
+  it('no-restricted-imports bans exactly the expected module set', () => {
+    const actual = noNetworkImports()[1].paths.map((p) => p.name);
+    expect([...actual].sort()).toEqual([...EXPECTED_MODULES].sort());
+  });
+
+  it('no-restricted-globals bans exactly the expected global set', () => {
+    const actual = noNetworkGlobals()
+      .slice(1)
+      .map((g) => g.name);
+    expect([...actual].sort()).toEqual([...EXPECTED_GLOBALS].sort());
+  });
+});
+
+describe('base config (the real enforcement surface)', () => {
+  // Every workspace package lints with `...base`, so the rules must be wired
+  // HERE, not merely returned by the helpers. Deleting the wiring from base
+  // fails these tests — the helper-only tests would stay green.
+  const ruleBlock = base.find((c) => c.rules?.['no-restricted-globals']);
+  const KEYS = [
+    'no-restricted-globals',
+    'no-restricted-properties',
+    'no-restricted-imports',
+    'no-restricted-syntax',
+  ];
+
+  it('wires all four network rules', () => {
+    expect(ruleBlock).toBeDefined();
+    for (const key of KEYS) expect(ruleBlock?.rules?.[key], key).toBeDefined();
+  });
+
+  it('actually fires every rule on real code', () => {
+    const rules = Object.fromEntries(KEYS.map((k) => [k, ruleBlock?.rules?.[k]]));
+    const code = [
+      "import http from 'node:http';",
+      "fetch('/x');",
+      "await import('node:https');",
+      'globalThis.fetch();',
+    ].join('\n');
+    const fired = new Set(lintWithRules(code, rules).map((m) => m.ruleId));
+    for (const key of KEYS) expect(fired, key).toContain(key);
+  });
+});
+
+describe('no-network globals', () => {
+  it('flags a bare fetch() call with a local-first message', () => {
+    const messages = lintNetwork("const r = fetch('https://api.example.com/v1');");
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe('no-restricted-globals');
+    expect(messages[0].message).toContain('local-first');
+  });
+
+  it.each(EXPECTED_GLOBALS)('flags the %s global', (name) => {
+    // `new X()` covers the constructor globals; `fetch` is called instead.
+    const code = name === 'fetch' ? `${name}('/x');` : `new ${name}('/x');`;
+    expect(lintNetwork(code).map((m) => m.ruleId)).toContain('no-restricted-globals');
+  });
+
+  it('does NOT flag a property named fetch (member access, not the global)', () => {
+    const messages = lintNetwork('const db = { fetch() { return 1; } };\ndb.fetch();\n');
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does NOT flag a locally declared binding named fetch', () => {
+    const messages = lintNetwork('function fetch() { return 1; }\nfetch();\n');
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe('no-network container-global properties', () => {
+  it.each([
+    'globalThis.fetch()',
+    'window.fetch("/x")',
+    'self.fetch("/x")',
+    'new global.WebSocket("/x")',
+    'new globalThis.EventSource("/x")',
+    'new window.XMLHttpRequest()',
+    'new globalThis.WebTransport("/x")',
+  ])('flags %s (the member-access bypass)', (code) => {
+    const messages = lintNetwork(code);
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-properties');
+    expect(messages[0].message).toContain('local-first');
+  });
+
+  it('flags navigator.sendBeacon (a fire-and-forget POST)', () => {
+    const messages = lintNetwork('navigator.sendBeacon("/x", data);');
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-properties');
+  });
+
+  it('does NOT flag an unrelated container-global property (window.location)', () => {
+    const messages = lintNetwork('const href = window.location.href;');
+    expect(messages).toHaveLength(0);
+  });
+
+  it('does NOT flag an unrelated navigator property (navigator.clipboard)', () => {
+    const messages = lintNetwork('await navigator.clipboard.readText();');
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe('no-network static imports', () => {
+  it.each(EXPECTED_MODULES)('flags a static import of %s', (mod) => {
+    const messages = lintNetwork(`import x from '${mod}';`);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe('no-restricted-imports');
+    expect(messages[0].message).toContain('local-first');
+  });
+
+  it('flags a namespace import (import * as http)', () => {
+    const messages = lintNetwork("import * as http from 'node:http';");
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-imports');
+  });
+
+  it('does NOT flag a local-store import', () => {
+    const messages = lintNetwork("import { openLocalDatabase } from '@akasecurity/persistence';");
+    expect(messages).toHaveLength(0);
+  });
+
+  describe('file-scoped allow opt-out', () => {
+    it('permits an allowed specifier (the dashboard bind probe)', () => {
+      const messages = lintNetwork("import { createServer } from 'node:net';", {
+        allow: ['node:net'],
+      });
+      expect(messages).toHaveLength(0);
+    });
+
+    it('still bans every other module under the same opt-out', () => {
+      const messages = lintNetwork("import http from 'node:http';", { allow: ['node:net'] });
+      expect(messages.map((m) => m.ruleId)).toContain('no-restricted-imports');
+    });
+
+    it('bans node:net by default (justifying the dashboard opt-out)', () => {
+      const messages = lintNetwork("import { createServer } from 'node:net';");
+      expect(messages).toHaveLength(1);
+      expect(messages[0].ruleId).toBe('no-restricted-imports');
+    });
+  });
+});
+
+describe('no-network dynamic imports and require', () => {
+  it.each(EXPECTED_MODULES)("flags a dynamic import('%s')", (mod) => {
+    const messages = lintNetwork(`await import('${mod}');`);
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-syntax');
+    expect(messages[0].message).toContain('local-first');
+  });
+
+  it.each(EXPECTED_MODULES)("flags a require('%s')", (mod) => {
+    const messages = lintNetwork(`require('${mod}');`);
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-syntax');
+  });
+
+  it.each([
+    // Non-literal specifier — the runtime dashboard server import.
+    'await import(serverUrl.href);',
+    // require.resolve is a path lookup, not a module load.
+    "require.resolve('next/dist/bin/next');",
+    // Local / workspace modules are fine.
+    "await import('@akasecurity/web-ui');",
+    "require('./local.js');",
+  ])('does NOT flag %s', (code) => {
+    const messages = lintNetwork(code);
+    expect(messages).toHaveLength(0);
+  });
+
+  it('opt-out is symmetric: allowing node:net clears the dynamic form too', () => {
+    expect(lintNetwork("await import('node:net');", { allow: ['node:net'] })).toHaveLength(0);
+    expect(lintNetwork("require('node:net');", { allow: ['node:net'] })).toHaveLength(0);
+    // but a different module stays banned under the same opt-out
+    expect(lintNetwork("await import('node:http');", { allow: ['node:net'] })).toHaveLength(1);
+  });
+});
+
+describe('networkGuard (the scripts/ pass)', () => {
+  // networkGuard is the standalone config used to lint dev/CI scripts. It must
+  // catch every network form but NOT the source-only conventions (no-console,
+  // n/no-process-env, import sorting), which would be noise on dev tooling.
+  it.each([
+    ['static import', "import http from 'node:http';", 'no-restricted-imports'],
+    ['dynamic import', "await import('undici');", 'no-restricted-syntax'],
+    ['require', "require('got');", 'no-restricted-syntax'],
+    ['global', "fetch('/x');", 'no-restricted-globals'],
+    ['container global', 'globalThis.fetch();', 'no-restricted-properties'],
+  ])('flags a %s', (_label, code, ruleId) => {
+    const messages = linter.verify(code, networkGuard);
+    expect(messages.map((m) => m.ruleId)).toContain(ruleId);
+  });
+
+  it('does NOT enforce source-only conventions (console / process.env / import order)', () => {
+    const code = [
+      "import b from 'b';",
+      "import a from 'a';",
+      'console.log(process.env.HOME);',
+      'const unused = 1;',
+    ].join('\n');
+    const messages = linter.verify(code, networkGuard);
+    expect(messages).toHaveLength(0);
+  });
+});
+
+describe('noEnterpriseImports merge', () => {
+  // The enterprise config is layered on top of `base` in some packages. Flat
+  // config does not merge two no-restricted-imports entries, so this config must
+  // carry the network bans forward or those packages would silently lose them.
+  const entry = noEnterpriseImports.find((c) => c.rules?.['no-restricted-imports']);
+  const ruleValue = entry?.rules?.['no-restricted-imports'];
+
+  it('is present', () => {
+    expect(ruleValue).toBeDefined();
+  });
+
+  it('still bans network modules (the merge preserved base coverage)', () => {
+    const messages = lintWithRules("import axios from 'axios';", {
+      'no-restricted-imports': ruleValue,
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].ruleId).toBe('no-restricted-imports');
+  });
+
+  it('also bans the enterprise HTTP client', () => {
+    const messages = lintWithRules("import c from '@akasecurity/client';", {
+      'no-restricted-imports': ruleValue,
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('enterprise-only');
+  });
+});

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -63,11 +63,20 @@ const EXPECTED_MODULES = [
   'node-fetch',
 ];
 const EXPECTED_GLOBALS = ['fetch', 'XMLHttpRequest', 'WebSocket', 'EventSource', 'WebTransport'];
+// The npm HTTP clients whose subpaths must also be banned (`paths` is exact, so
+// a deep import like `axios/lib/adapters/http.js` slips the root ban). Pinned so
+// dropping a `<client>/*` group is a reviewed change, not a silent shrink.
+const EXPECTED_MODULE_PATTERNS = ['axios/*', 'undici/*', 'got/*', 'node-fetch/*'];
 
 describe('ban set (drift guards)', () => {
   it('no-restricted-imports bans exactly the expected module set', () => {
     const actual = noNetworkImports()[1].paths.map((p) => p.name);
     expect([...actual].sort()).toEqual([...EXPECTED_MODULES].sort());
+  });
+
+  it('no-restricted-imports bans exactly the expected subpath patterns', () => {
+    const actual = noNetworkImports()[1].patterns.map((p) => p.group[0]);
+    expect([...actual].sort()).toEqual([...EXPECTED_MODULE_PATTERNS].sort());
   });
 
   it('no-restricted-globals bans exactly the expected global set', () => {
@@ -203,6 +212,46 @@ describe('no-network static imports', () => {
   });
 });
 
+describe('no-network subpath imports (npm HTTP clients)', () => {
+  // `paths` is exact-match, so the root ban misses a deep import; a `<client>/*`
+  // pattern closes it. These pin that the subpath ban fires in every import form.
+  it.each([
+    'axios/lib/adapters/http.js',
+    'undici/types/dispatcher',
+    'got/dist/source',
+    'node-fetch/lib/index.js',
+  ])('flags a deep static import of %s', (mod) => {
+    const messages = lintNetwork(`import x from '${mod}';`);
+    expect(messages.map((m) => m.ruleId)).toContain('no-restricted-imports');
+  });
+
+  it('flags a deep dynamic import and a deep require of a client subpath', () => {
+    expect(
+      lintNetwork("await import('axios/lib/adapters/http.js');").map((m) => m.ruleId),
+    ).toContain('no-restricted-syntax');
+    expect(lintNetwork("require('undici/types/dispatcher');").map((m) => m.ruleId)).toContain(
+      'no-restricted-syntax',
+    );
+  });
+
+  it('does NOT flag a package that merely shares a name prefix, or a local subpath', () => {
+    // `got/*` must not match `got-cha`; a local-store subpath is fine.
+    expect(lintNetwork("import g from 'got-cha/client';")).toHaveLength(0);
+    expect(lintNetwork("import { x } from '@akasecurity/persistence/read';")).toHaveLength(0);
+  });
+
+  it('the subpath ban is allow-aware (opting out a client clears its subpaths)', () => {
+    expect(
+      lintNetwork("import x from 'axios/lib/adapters/http.js';", { allow: ['axios'] }),
+    ).toHaveLength(0);
+    expect(lintNetwork("await import('axios/lib/x.js');", { allow: ['axios'] })).toHaveLength(0);
+    // but a different client stays banned under the same opt-out
+    expect(
+      lintNetwork("import u from 'undici/x.js';", { allow: ['axios'] }).map((m) => m.ruleId),
+    ).toContain('no-restricted-imports');
+  });
+});
+
 describe('no-network dynamic imports and require', () => {
   it.each(EXPECTED_MODULES)("flags a dynamic import('%s')", (mod) => {
     const messages = lintNetwork(`await import('${mod}');`);
@@ -288,5 +337,19 @@ describe('noEnterpriseImports merge', () => {
     });
     expect(messages).toHaveLength(1);
     expect(messages[0].message).toContain('enterprise-only');
+  });
+
+  it('keeps BOTH pattern groups (network subpaths + enterprise) after the merge', () => {
+    // The network `<client>/*` groups are prepended to noEnterpriseImports' own
+    // `patterns` (drizzle-orm/*, schema-enterprise/*). A regressed merge that
+    // declared only enterprise patterns would drop the network subpath ban.
+    const deep = lintWithRules("import x from 'axios/lib/adapters/http.js';", {
+      'no-restricted-imports': ruleValue,
+    });
+    expect(deep.map((m) => m.ruleId)).toContain('no-restricted-imports');
+    const ent = lintWithRules("import s from 'drizzle-orm/sqlite-core';", {
+      'no-restricted-imports': ruleValue,
+    });
+    expect(ent.map((m) => m.ruleId)).toContain('no-restricted-imports');
   });
 });

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/packages/plugin-sdk/eslint.scripts.config.mjs
+++ b/packages/plugin-sdk/eslint.scripts.config.mjs
@@ -1,0 +1,8 @@
+// @ts-check
+// Network-only guard for this package's dev/build scripts (scripts/), which the
+// main `eslint src test` pass never reaches. It enforces just the no-network
+// bans so the guarantee is uniform across every scripts/ dir in the workspace.
+// Run with `--no-config-lookup` so `eslint.config.mjs` (base) does not apply.
+import { networkGuard } from '@akasecurity/eslint-config';
+
+export default networkGuard;

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "gen:bundled-packs": "node scripts/gen-bundled-packs.mjs",
-    "lint": "eslint src test",
+    "lint": "eslint src test && eslint --no-config-lookup -c eslint.scripts.config.mjs scripts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/schema/eslint.scripts.config.mjs
+++ b/packages/schema/eslint.scripts.config.mjs
@@ -1,0 +1,8 @@
+// @ts-check
+// Network-only guard for this package's dev/build scripts (scripts/), which the
+// main `eslint src test` pass never reaches. It enforces just the no-network
+// bans so the guarantee is uniform across every scripts/ dir in the workspace.
+// Run with `--no-config-lookup` so `eslint.config.mjs` (base) does not apply.
+import { networkGuard } from '@akasecurity/eslint-config';
+
+export default networkGuard;

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -9,7 +9,7 @@
     "./drizzle": "./src/drizzle/index.ts"
   },
   "scripts": {
-    "lint": "eslint src test",
+    "lint": "eslint src test && eslint --no-config-lookup -c eslint.scripts.config.mjs scripts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "gen:sqlite-ddl": "drizzle-kit generate --config drizzle.config.local.ts && node scripts/gen-sqlite-ddl.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@9.39.4(jiti@2.7.0))
-      eslint:
-        specifier: ^9.0.0
-        version: 9.39.4(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.0.0
         version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
@@ -196,6 +193,13 @@ importers:
       typescript-eslint:
         specifier: ^8.64.0
         version: 8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+    devDependencies:
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.7.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(vite@8.0.16(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/extract:
     devDependencies:


### PR DESCRIPTION
## Summary

Makes the product's **local-first, no-network** guarantee enforced by ESLint + CI instead of by convention. Previously nothing stopped `fetch('https://…')`, an HTTP/socket import, or a dynamic `import('node:http')` from landing in any package and passing lint.

## What changed

- **`base` bans network primitives workspace-wide:**
  - `no-restricted-globals` — `fetch`, `XMLHttpRequest`, `WebSocket`, `EventSource`, `WebTransport`
  - `no-restricted-properties` — the container-global forms (`globalThis.fetch`, `window.WebSocket`, …) plus `navigator.sendBeacon`
  - `no-restricted-imports` — `node:http/https/http2/net/dgram/tls/dns[/promises]` (+ bare specifiers), `axios`, `undici`, `got`, `node-fetch`
  - `no-restricted-syntax` — the dynamic `import('…')` / `require('…')` forms of those modules
- Messages explain **why** ("ai-tc is local-first…") and point to the escape hatch.
- **Merged the bans into `noEnterpriseImports`** so flat-config "last wins" can't silently drop the network `no-restricted-imports` in the packages that layer it.
- **File-scoped opt-outs** (config-based, not inline disables): `dashboard.ts` → `node:net` (127.0.0.1 bind probe, static + dynamic); `smoke-dashboard.mjs` → `node:http` (loopback poll).
- **Scripts coverage:** a standalone `networkGuard` config enforces *only* the network bans on dev/CI `scripts/` in `cli`, `plugin-sdk`, and `schema` — without dragging tooling into the full ruleset.
- **Tests:** new vitest suite (101 assertions) that fires the rules through the **real `base` config**, with drift guards pinning the exact ban set. Also makes `@akasecurity/eslint-config` testable (vitest + eslint devDeps).

## Verification

- `pnpm format:check` · `pnpm lint` (14/14) · `pnpm typecheck` (14/14) · `pnpm test` (27/27) · `pnpm build` (15/15) — all green.
- Negative controls confirmed real enforcement (planted `import('node:https')` + `fetch()` in `scripts/` fails lint; removing the dashboard opt-out fails `dashboard.ts`).
- Hardened via an adversarial multi-agent review: added `http2`/`dns`/`WebTransport`/`navigator.sendBeacon` coverage, a symmetric dynamic-import opt-out, and a `base`-surface integration test after the review found gaps.

## Residual (documented, out of scope)

**Not matched** (static lint can't see these; the ban targets accidents, not evasion): build/dev config files (`next.config.ts`, `tsup.config.ts`, …) outside the linted globs; non-literal dynamic-import specifiers (a variable or template literal); `require.resolve(...)`; and an aliased/indirected `require` (`const req = createRequire(…); req('node:http')`).

**Covered**: computed member access (`globalThis['fetch']`), destructuring (`const { fetch } = globalThis`), namespace/re-export imports, and every subpath of the npm HTTP clients (`axios/lib/…`, static + dynamic). The one `no-restricted-properties` caveat is a false positive, not a bypass — it keys on identifier name (a local `window`/`self`/`global`/`globalThis`/`navigator` with a `.fetch`/`.sendBeacon` property; none exist today).
