### PR TITLE
fix(web-ui): close loopback Host-gate bypass and cover middleware.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,21 @@ jobs:
 
   # Windows leg: the CLI and plugin advertise Windows support (install.ps1), so
   # the OS-sensitive core — SQLite store, ~/.aka file layout, file walks, child
-  # processes — gets exercised on windows-latest. web-ui is included too: it is
-  # bundled into the CLI (shipped surface) and its middleware is the dashboard's
-  # sole DNS-rebinding gate, so it must be green on every platform the CLI ships
-  # to. web-ui's `test` drops the `next build` edge (web-ui/turbo.json), so this
-  # stays a fast unit run. Scoped to the shipped-surface packages to keep the job
-  # fast; the full suite runs on the Linux job above.
+  # processes — gets exercised on windows-latest. web-ui is included because it
+  # is bundled into the CLI (shipped surface), and turbo runs its whole `test`
+  # script — BOTH suites, not just the middleware gate:
+  #   - test/middleware.test.ts — the sole DNS-rebinding gate; pure string work
+  #     (68 tests in ~40ms here).
+  #   - test/actions/exceptions.test.ts — raw-secret handling in addException,
+  #     driving a REAL node:sqlite store and minting a REAL key file per test.
+  #     This is the OS-sensitive half and the reason it belongs on Windows.
+  # That second suite is slow here: ~44s wall for 20 tests, worst single test
+  # ~3.0s against the 20s per-test timeout in web-ui/vitest.config.ts. Keep an
+  # eye on that margin — the persistence suite needed batching twice to stay
+  # under it. web-ui's `test` also drops the `build`/`^build` edges
+  # (web-ui/turbo.json), so no `next build` runs here. Scoped to the
+  # shipped-surface packages to keep the job fast; the full suite runs on the
+  # Linux job above.
   windows:
     name: Windows · Unit tests (shipped surface)
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,12 @@ jobs:
 
   # Windows leg: the CLI and plugin advertise Windows support (install.ps1), so
   # the OS-sensitive core — SQLite store, ~/.aka file layout, file walks, child
-  # processes — gets exercised on windows-latest. Scoped to the shipped-surface
-  # packages to keep the job fast; the full suite runs on the Linux job above.
+  # processes — gets exercised on windows-latest. web-ui is included too: it is
+  # bundled into the CLI (shipped surface) and its middleware is the dashboard's
+  # sole DNS-rebinding gate, so it must be green on every platform the CLI ships
+  # to. web-ui's `test` drops the `next build` edge (web-ui/turbo.json), so this
+  # stays a fast unit run. Scoped to the shipped-surface packages to keep the job
+  # fast; the full suite runs on the Linux job above.
   windows:
     name: Windows · Unit tests (shipped surface)
     runs-on: windows-latest
@@ -121,3 +125,4 @@ jobs:
           --filter=@akasecurity/plugin-runtime
           --filter=@akasecurity/scanner
           --filter=@akasecurity/local-ops
+          --filter=@akasecurity/web-ui

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -92,9 +92,11 @@ export async function runDashboard(argv: string[]): Promise<void> {
   // `[::1]`) — anything else 403s every page on launch. The bind host below
   // (`127.0.0.1`) is a SEPARATE constraint the gate cannot enforce: it reads the
   // Host header, never the bind address, so binding all interfaces (`0.0.0.0`)
-  // would expose the surface while every page still 200s. The bind is pinned at
-  // the `--hostname` / `HOSTNAME` sites below. (middleware.test.ts makes this
-  // coupling discoverable, not enforced — it asserts literals, not the CLI's host.)
+  // would expose the surface while every page still 200s. The bind is hard-coded
+  // at the `--hostname` / `HOSTNAME` sites below, and `isPortFree`'s probe above
+  // hard-codes the same address — they must stay in step, or the pre-flight
+  // probes a different stack than the server binds. (middleware.test.ts makes the
+  // Host coupling discoverable, not enforced — it asserts literals, not the CLI's host.)
   const url = `http://localhost:${port}/security`;
 
   if (!(await isPortFree(Number(port)))) {

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -87,10 +87,14 @@ export async function runDashboard(argv: string[]): Promise<void> {
   });
   const port = values.port ?? '4319';
   const shouldOpen = values.open !== false;
-  // The host opened here (`localhost`) and the bind host below (`127.0.0.1`) MUST
-  // stay spellings that web-ui/middleware.ts admits — its gate allows only
-  // `localhost` / `127.0.0.1` / `[::1]`. A non-loopback spelling here would 403
-  // every page on launch; web-ui/test/middleware.test.ts pins that coupling.
+  // The host in this opened URL becomes the browser's `Host` header, so it must
+  // stay a spelling web-ui/middleware.ts admits (`localhost` / `127.0.0.1` /
+  // `[::1]`) — anything else 403s every page on launch. The bind host below
+  // (`127.0.0.1`) is a SEPARATE constraint the gate cannot enforce: it reads the
+  // Host header, never the bind address, so binding all interfaces (`0.0.0.0`)
+  // would expose the surface while every page still 200s. The bind is pinned at
+  // the `--hostname` / `HOSTNAME` sites below. (middleware.test.ts makes this
+  // coupling discoverable, not enforced — it asserts literals, not the CLI's host.)
   const url = `http://localhost:${port}/security`;
 
   if (!(await isPortFree(Number(port)))) {

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -87,6 +87,10 @@ export async function runDashboard(argv: string[]): Promise<void> {
   });
   const port = values.port ?? '4319';
   const shouldOpen = values.open !== false;
+  // The host opened here (`localhost`) and the bind host below (`127.0.0.1`) MUST
+  // stay spellings that web-ui/middleware.ts admits — its gate allows only
+  // `localhost` / `127.0.0.1` / `[::1]`. A non-loopback spelling here would 403
+  // every page on launch; web-ui/test/middleware.test.ts pins that coupling.
   const url = `http://localhost:${port}/security`;
 
   if (!(await isPortFree(Number(port)))) {

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -689,15 +689,22 @@ describe('SqliteFindingsRepository.listGroupedFindings — per-finding status', 
       // The filter must keep the group, totals must count only the open
       // instance, and the narrowed preview is legitimately EMPTY — the view
       // layer renders an explicit notice for this case.
-      for (let i = 0; i < 205; i++) {
-        record({
-          occurredAt: new Date(Date.parse('2026-02-01T00:00:00.000Z') + i * 1000).toISOString(),
-          sourceTool: 'claude-code',
-          ruleId: 'open-rule',
-          repo: 'acme/api',
-          filePath: `bulk/f${String(i)}.ts`,
-        });
-      }
+      // One transaction, not 205: recordCapture commits per call, and a commit
+      // apiece costs seconds of fsync on the Windows CI filesystem — the cost
+      // seedBulk() below is written the way it is to avoid. Each nested
+      // recordCapture runs in a SAVEPOINT, so its fail-open envelope behaves
+      // exactly as it does uncontained.
+      await db.transaction(() => {
+        for (let i = 0; i < 205; i++) {
+          record({
+            occurredAt: new Date(Date.parse('2026-02-01T00:00:00.000Z') + i * 1000).toISOString(),
+            sourceTool: 'claude-code',
+            ruleId: 'open-rule',
+            repo: 'acme/api',
+            filePath: `bulk/f${String(i)}.ts`,
+          });
+        }
+      });
 
       const res = await db.findings.listGroupedFindings({ status: ['open'] });
       const group = res.items.find((g) => g.id === 'open-rule');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,6 +553,9 @@ importers:
       typescript-eslint:
         specifier: ^8.64.0
         version: 8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 

--- a/web-ui/middleware.ts
+++ b/web-ui/middleware.ts
@@ -29,11 +29,13 @@ function isLoopbackHost(hostHeader: string | null): boolean {
   return hostHeader !== null && BARE_LOOPBACK.test(hostHeader);
 }
 
-// No `config.matcher` export on purpose: the gate runs on every request that
-// reaches middleware, including RSC data requests and Server Action posts.
-// (Next answers trailing-slash / double-slash / case normalisation with a 308
-// before middleware runs; that redirect carries no body and its target path is
-// itself gated, so nothing reachable with a body escapes this check.)
+// No `config.matcher` export on purpose: the gate runs on every request Next
+// routes to middleware, including RSC data requests and Server Action posts.
+// Trailing-slash and double-slash paths get a 308 before middleware; the
+// redirect preserves method and body (RFC 7538) and its target path IS gated,
+// so the retry is rejected. TRACE and CONNECT throw inside the middleware bundle
+// before the gate runs and get Next's 500 — fail-closed, and not reachable from
+// a browser, but not gated either.
 export function middleware(request: NextRequest): NextResponse {
   // `x-forwarded-host`, when present, participates in Next's Server Action
   // origin comparison, so hold it to the same bar (no supported deployment

--- a/web-ui/middleware.ts
+++ b/web-ui/middleware.ts
@@ -18,15 +18,22 @@ import { type NextRequest, NextResponse } from 'next/server';
 // (`localhost:4319@evil.com`, `localhost:4319/evil`). Testing the literal the
 // client sent — not a parsed or normalised host — is what keeps the allow-set to
 // exactly these spellings; and a literal test has no URL-parser behaviour that
-// could differ between Node and the Edge runtime this middleware ships on.
+// could differ between Node and the Edge runtime this middleware ships on. The
+// port is not part of the security decision — the host is always a loopback
+// literal when this matches — so `\d{1,5}` bounds only the port's length, and
+// out-of-range or zero-padded ports on loopback are admitted (harmless; no
+// browser can open a port above 65535).
 const BARE_LOOPBACK = /^(?:localhost|127\.0\.0\.1|\[::1\])(?::\d{1,5})?$/i;
 
 function isLoopbackHost(hostHeader: string | null): boolean {
   return hostHeader !== null && BARE_LOOPBACK.test(hostHeader);
 }
 
-// No `config.matcher` export on purpose: the gate covers every path, including
-// RSC data requests and Server Action posts.
+// No `config.matcher` export on purpose: the gate runs on every request that
+// reaches middleware, including RSC data requests and Server Action posts.
+// (Next answers trailing-slash / double-slash / case normalisation with a 308
+// before middleware runs; that redirect carries no body and its target path is
+// itself gated, so nothing reachable with a body escapes this check.)
 export function middleware(request: NextRequest): NextResponse {
   // `x-forwarded-host`, when present, participates in Next's Server Action
   // origin comparison, so hold it to the same bar (no supported deployment

--- a/web-ui/middleware.ts
+++ b/web-ui/middleware.ts
@@ -8,48 +8,21 @@ import { type NextRequest, NextResponse } from 'next/server';
 // header — and Next's built-in Server Action CSRF check compares Origin to
 // Host, which AGREE under rebinding — so the gate that actually closes the
 // hole is this one: reject any request not addressed to a loopback literal.
-// Any port is fine (`aka dashboard --port N`); the name must be loopback.
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
-
-// Split the hostname off a `host[:port]` header WITHOUT normalising it. An IPv6
-// literal is bracketed (`[::1]`) and carries its own colons, so its port is
-// whatever follows the closing `]`; every other form splits at the first colon.
-function hostnameLiteral(hostHeader: string): string {
-  if (hostHeader.startsWith('[')) {
-    const end = hostHeader.indexOf(']');
-    return end === -1 ? hostHeader : hostHeader.slice(0, end + 1);
-  }
-  const colon = hostHeader.indexOf(':');
-  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
-}
+//
+// The whole gate is one anchored pattern: a bare `host[:port]` whose host is
+// exactly `localhost`, `127.0.0.1`, or `[::1]` (case-insensitive), any port
+// (`aka dashboard --port N`). The anchors reject everything else in a single
+// step — alternate IPv4/IPv6 encodings that resolve to loopback (`127.1`,
+// `2130706433`, `0x7f000001`, `127.000.000.001`, `[::ffff:127.0.0.1]`) and any
+// userinfo, path, query, or fragment smuggled past the authority
+// (`localhost:4319@evil.com`, `localhost:4319/evil`). Testing the literal the
+// client sent — not a parsed or normalised host — is what keeps the allow-set to
+// exactly these spellings; and a literal test has no URL-parser behaviour that
+// could differ between Node and the Edge runtime this middleware ships on.
+const BARE_LOOPBACK = /^(?:localhost|127\.0\.0\.1|\[::1\])(?::\d{1,5})?$/i;
 
 function isLoopbackHost(hostHeader: string | null): boolean {
-  if (hostHeader === null || hostHeader === '') return false;
-  let parsed: URL;
-  try {
-    parsed = new URL(`http://${hostHeader}`);
-  } catch {
-    // Unparseable Host header — fail closed.
-    return false;
-  }
-  // The header must be a bare `host[:port]`: reject anything that smuggles
-  // userinfo, a path, a query, or a fragment past the authority (e.g.
-  // `localhost:4319/evil`, `localhost:4319@evil.com`).
-  if (
-    parsed.username !== '' ||
-    parsed.password !== '' ||
-    parsed.pathname !== '/' ||
-    parsed.search !== '' ||
-    parsed.hash !== ''
-  ) {
-    return false;
-  }
-  // Match the LITERAL spelling the client sent, not URL's normalised
-  // `hostname`. The WHATWG parser rewrites every alternate IPv4 encoding —
-  // `127.1`, `2130706433`, `0x7f000001`, `127.000.000.001` — all to
-  // `127.0.0.1`, which would silently widen this allow-set to spellings it
-  // never admitted. Host names are case-insensitive, so fold case first.
-  return LOOPBACK_HOSTNAMES.has(hostnameLiteral(hostHeader).toLowerCase());
+  return hostHeader !== null && BARE_LOOPBACK.test(hostHeader);
 }
 
 // No `config.matcher` export on purpose: the gate covers every path, including

--- a/web-ui/middleware.ts
+++ b/web-ui/middleware.ts
@@ -11,16 +11,45 @@ import { type NextRequest, NextResponse } from 'next/server';
 // Any port is fine (`aka dashboard --port N`); the name must be loopback.
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
 
+// Split the hostname off a `host[:port]` header WITHOUT normalising it. An IPv6
+// literal is bracketed (`[::1]`) and carries its own colons, so its port is
+// whatever follows the closing `]`; every other form splits at the first colon.
+function hostnameLiteral(hostHeader: string): string {
+  if (hostHeader.startsWith('[')) {
+    const end = hostHeader.indexOf(']');
+    return end === -1 ? hostHeader : hostHeader.slice(0, end + 1);
+  }
+  const colon = hostHeader.indexOf(':');
+  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
+}
+
 function isLoopbackHost(hostHeader: string | null): boolean {
   if (hostHeader === null || hostHeader === '') return false;
+  let parsed: URL;
   try {
-    // URL handles the port suffix and IPv6 brackets; `hostname` lowercases
-    // names and keeps the brackets on IPv6 literals ("[::1]").
-    return LOOPBACK_HOSTNAMES.has(new URL(`http://${hostHeader}`).hostname);
+    parsed = new URL(`http://${hostHeader}`);
   } catch {
     // Unparseable Host header — fail closed.
     return false;
   }
+  // The header must be a bare `host[:port]`: reject anything that smuggles
+  // userinfo, a path, a query, or a fragment past the authority (e.g.
+  // `localhost:4319/evil`, `localhost:4319@evil.com`).
+  if (
+    parsed.username !== '' ||
+    parsed.password !== '' ||
+    parsed.pathname !== '/' ||
+    parsed.search !== '' ||
+    parsed.hash !== ''
+  ) {
+    return false;
+  }
+  // Match the LITERAL spelling the client sent, not URL's normalised
+  // `hostname`. The WHATWG parser rewrites every alternate IPv4 encoding —
+  // `127.1`, `2130706433`, `0x7f000001`, `127.000.000.001` — all to
+  // `127.0.0.1`, which would silently widen this allow-set to spellings it
+  // never admitted. Host names are case-insensitive, so fold case first.
+  return LOOPBACK_HOSTNAMES.has(hostnameLiteral(hostHeader).toLowerCase());
 }
 
 // No `config.matcher` export on purpose: the gate covers every path, including

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app middleware.ts vitest.config.ts test",
+    "lint": "eslint app middleware.ts test *.config.*",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,8 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app middleware.ts",
-    "typecheck": "tsc --noEmit"
+    "lint": "eslint app middleware.ts vitest.config.ts test",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@akasecurity/dashboard-ui": "workspace:*",
@@ -34,6 +35,7 @@
     "eslint": "^9.0.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.8.0",
-    "typescript-eslint": "^8.64.0"
+    "typescript-eslint": "^8.64.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/web-ui/test/middleware.test.ts
+++ b/web-ui/test/middleware.test.ts
@@ -1,0 +1,166 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, it } from 'vitest';
+
+import * as middlewareModule from '../middleware.ts';
+import { middleware } from '../middleware.ts';
+
+// `middleware.ts` is the sole DNS-rebinding gate in front of the dashboard's
+// unauthenticated, store-mutating Server Actions. Under rebinding the browser
+// stamps the attacker's own domain into `Host` while `Origin` agrees with it,
+// so Next's built-in CSRF check passes — only this Host-literal check closes
+// the hole. It is untestable as a live network attack, so it is tested as what
+// it is: a pure function over the `Host` / `x-forwarded-host` headers. Each row
+// below pins the exact 200-vs-403 decision that keeps the gate honest.
+
+interface MiddlewareInit {
+  xForwardedHost?: string;
+  path?: string;
+  method?: string;
+}
+
+// Drive the real middleware with a real NextRequest. Only the request headers
+// matter to the gate; the URL host is irrelevant (the gate reads the `Host`
+// header, not the URL), so a fixed loopback URL is used and the header under
+// test is set explicitly. Pass `host: undefined` to omit the header entirely.
+function runMiddleware(host: string | undefined, init: MiddlewareInit = {}) {
+  const headers = new Headers();
+  if (host !== undefined) headers.set('host', host);
+  if (init.xForwardedHost !== undefined) headers.set('x-forwarded-host', init.xForwardedHost);
+  const request = new NextRequest(`http://localhost:4319${init.path ?? '/'}`, {
+    method: init.method ?? 'GET',
+    headers,
+  });
+  return middleware(request);
+}
+
+function statusFor(host: string | undefined, init: MiddlewareInit = {}): number {
+  return runMiddleware(host, init).status;
+}
+
+describe('middleware — allowed loopback literals (any port)', () => {
+  // The three accepted spellings, each with the default port, a non-default
+  // port, and no port at all — "any port is fine; the name must be loopback".
+  it.each([
+    'localhost:4319',
+    'localhost:9999',
+    'localhost',
+    '127.0.0.1:4319',
+    '127.0.0.1:9999',
+    '127.0.0.1',
+    '[::1]:4319',
+    '[::1]:9999',
+    '[::1]',
+    'LOCALHOST:4319', // Host names are case-insensitive.
+  ])('200 for %s', (host) => {
+    expect(statusFor(host)).toBe(200);
+  });
+});
+
+describe('middleware — non-loopback hosts are rejected (rebinding vectors)', () => {
+  it.each(['evil.com', 'localhost.evil.com', '127.0.0.1.nip.io', 'attacker.example:4319'])(
+    '403 for %s',
+    (host) => {
+      expect(statusFor(host)).toBe(403);
+    },
+  );
+});
+
+describe('middleware — alternate loopback encodings stay out of the allow-set', () => {
+  // These all route to 127.0.0.1 on many stacks, and `new URL()` normalises
+  // every one of them to the literal `127.0.0.1`. They are NOT in the allow-set
+  // and must 403 — pinned here so a future "helpful" normalisation (or a
+  // parser that folds them before the check) cannot silently open the gate.
+  it.each([
+    '127.1', // shorthand IPv4
+    '0.0.0.0', // all-zeros, not loopback
+    '[::ffff:127.0.0.1]', // IPv4-mapped IPv6
+    '2130706433', // decimal IPv4
+    '0x7f000001', // hex IPv4
+    '127.000.000.001', // zero-padded dotted IPv4
+    '127.1:4319', // ...with a port, too
+  ])('403 for %s', (host) => {
+    expect(statusFor(host)).toBe(403);
+  });
+});
+
+describe('middleware — missing, empty, or malformed Host fails closed', () => {
+  it('403 when the Host header is absent', () => {
+    expect(statusFor(undefined)).toBe(403);
+  });
+
+  it('403 when the Host header is empty', () => {
+    expect(statusFor('')).toBe(403);
+  });
+
+  it.each([
+    '[bad', // unclosed IPv6 bracket
+    '::1', // unbracketed IPv6 is invalid
+    'http://localhost:4319', // a URL, not a host
+    'localhost:4319/evil', // path smuggled past the authority
+    'localhost:4319?x=1', // query smuggled past the authority
+    'localhost:4319#frag', // fragment smuggled past the authority
+    'localhost:4319@evil.com', // userinfo smuggle — the real host is evil.com
+    'user:pass@localhost', // userinfo smuggle — reject rather than trust
+    'localhost:99999999', // out-of-range port
+  ])('403 for malformed host %s', (host) => {
+    expect(statusFor(host)).toBe(403);
+  });
+});
+
+describe('middleware — x-forwarded-host is held to the same loopback bar', () => {
+  it('200 when both Host and x-forwarded-host are loopback', () => {
+    expect(statusFor('localhost:4319', { xForwardedHost: '127.0.0.1:4319' })).toBe(200);
+  });
+
+  it.each(['evil.com', '127.1', '[::ffff:127.0.0.1]', ''])(
+    '403 when Host is loopback but x-forwarded-host is %s',
+    (xForwardedHost) => {
+      expect(statusFor('localhost:4319', { xForwardedHost })).toBe(403);
+    },
+  );
+
+  it('403 when x-forwarded-host is loopback but Host is not', () => {
+    // A good forwarded header does not excuse a non-loopback Host.
+    expect(statusFor('evil.com', { xForwardedHost: 'localhost:4319' })).toBe(403);
+  });
+});
+
+describe('middleware — the gate covers every route and method', () => {
+  // There is no `config.matcher`, so the gate runs on every request: page GETs,
+  // RSC data fetches, and Server Action POSTs alike. A rebinding attack targets
+  // the mutating POST path, so the rejection must not depend on route or method.
+  const routes = ['/', '/security', '/scan', '/exceptions/new', '/_next/data/x.json'];
+
+  it.each(routes)('403s a non-loopback GET to %s', (path) => {
+    expect(statusFor('evil.com', { path })).toBe(403);
+  });
+
+  it.each(routes)('403s a non-loopback Server Action POST to %s', (path) => {
+    expect(statusFor('evil.com', { path, method: 'POST' })).toBe(403);
+  });
+
+  it('200s a loopback Server Action POST', () => {
+    expect(statusFor('127.0.0.1:4319', { path: '/exceptions', method: 'POST' })).toBe(200);
+  });
+
+  it('exports no config.matcher — narrowing the gate would uncover Server Actions', () => {
+    const exported = middlewareModule as Record<string, unknown>;
+    expect(exported.config).toBeUndefined();
+  });
+});
+
+describe('middleware — the rejection is a real 403, the pass a real hand-off', () => {
+  it('rejects with a 403 and an explanatory body', async () => {
+    const response = runMiddleware('evil.com');
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toContain('localhost');
+  });
+
+  it('passes a loopback request through to the app', () => {
+    // `NextResponse.next()` hands the request to the app; its sentinel header
+    // distinguishes a genuine pass-through from an incidental 200 body.
+    const response = runMiddleware('127.0.0.1:4319');
+    expect(response.status).toBe(200);
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+  });
+});

--- a/web-ui/test/middleware.test.ts
+++ b/web-ui/test/middleware.test.ts
@@ -35,7 +35,15 @@ function statusFor(
   host: string | undefined,
   init: { xForwardedHost?: string; path?: string; method?: string } = {},
 ): number {
-  return runMiddleware(host, init).status;
+  const response = runMiddleware(host, init);
+  // Every admitted request must be a real hand-off, not an incidental 200: assert
+  // NextResponse.next()'s `x-middleware-next` sentinel on every 200 here, so the
+  // mechanism is pinned at every allowed-host call site — the loopback Server
+  // Action POST and the allowedOrigins rows included — not just the literals block.
+  if (response.status === 200) {
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+  }
+  return response.status;
 }
 
 describe('middleware — allowed loopback literals (any port)', () => {
@@ -118,12 +126,12 @@ describe('middleware — encodings already denied, pinned against a future norma
 
 describe('middleware — genuine-but-unadmitted loopback spellings stay out (intentional, fail-closed)', () => {
   // These resolve to loopback but were DENIED by the pre-fix gate too — their
-  // `new URL().hostname` was never in the old allow-set — so, unlike the block
-  // above, they never changed. They are deliberately excluded: the dashboard only
-  // opens http://localhost:PORT / http://127.0.0.1:PORT, so a browser never sends
-  // them, and holding the set to three exact spellings keeps the literal match
-  // tight. Admitting any (e.g. *.localhost per RFC 6761) would be a separate,
-  // opt-in widening.
+  // `new URL().hostname` was never in the old allow-set — so, unlike the
+  // regression-guard block above, they never changed. They are deliberately
+  // excluded: the dashboard only opens http://localhost:PORT, so a browser never
+  // sends them, and holding the set to three exact spellings keeps the literal
+  // match tight. Admitting any (e.g. *.localhost per RFC 6761) would be a
+  // separate, opt-in widening.
   it.each([
     'localhost.', // trailing-dot FQDN
     'app.localhost', // RFC 6761 *.localhost subdomain
@@ -152,17 +160,19 @@ describe('middleware — missing, empty, or malformed Host fails closed', () => 
     'localhost:4319#frag', // fragment smuggled past the authority
     'localhost:4319@evil.com', // userinfo smuggle — the real host is evil.com
     'user:pass@localhost', // userinfo smuggle — reject rather than trust
-    'localhost:99999999', // out-of-range port
+    'localhost:99999999', // too many digits for \d{1,5} — not a range check (localhost:70000 is 200)
   ])('403 for malformed host %s', (host) => {
     expect(statusFor(host)).toBe(403);
   });
 
   it('403 for an oversized / many-colon Host, in linear time', () => {
-    // A 10 KB Host is in-band, not beyond what the server accepts: node:http's
-    // default maxHeaderSize is 16 KB and `next start` does not lower it, so a
-    // rebound page really can send this and reach the gate. The gate is a single
-    // anchored regex with no backtracking, so it rejects in time linear in the
-    // input length — never a silent stall.
+    // Hostile-sized Host input is in-band for a RAW client: node:http's default
+    // maxHeaderSize is 16 KB and `next start` does not lower it, so a 10 KB Host
+    // reaches the gate. It is NOT reachable from a rebound page — a page's Host is
+    // its own DNS name (at most 253 octets) and `localhost:1:1:...` is not a valid
+    // authority — so this is hardening against non-browser clients. The gate is a
+    // single anchored regex with no backtracking: linear in input length, never a
+    // stall.
     expect(statusFor('a'.repeat(10_000))).toBe(403);
     expect(statusFor(`localhost${':1'.repeat(5_000)}`)).toBe(403);
   });
@@ -172,9 +182,12 @@ describe('middleware — the port is not validated (the loopback host is the who
   // `\d{1,5}` bounds the port's length, not its value, so out-of-range and
   // zero-padded ports are admitted on a loopback host. Deliberate: the host is
   // always a loopback literal when the pattern matches, so the port cannot widen
-  // the gate (and no browser can open a port above 65535). Pinned as a decision,
-  // not a side effect — note `localhost:99999999` above still 403s, but on digit
-  // count (8 > 5), not range.
+  // the gate (and no browser can open a port above 65535). Two of these CHANGED:
+  // `:65536` and `:99999` were 403 pre-fix and on commit 1 (`new URL()` throws
+  // above 65535) and are 200 from the regex onward — the one place this PR is more
+  // permissive, harmless because the host is still a loopback literal. `:080` and
+  // `:00` were 200 throughout. (`localhost:99999999` above still 403s, but on
+  // digit count (8 > 5), not range.)
   it.each(['localhost:65536', 'localhost:99999', 'localhost:080', 'localhost:00'])(
     '200 for %s',
     (host) => {
@@ -210,13 +223,14 @@ describe('middleware — x-forwarded-host is held to the same loopback bar', () 
   });
 });
 
-describe('middleware — the gate covers every route and method', () => {
-  // There is no `config.matcher`, so the gate runs on every request that reaches
-  // middleware — page GETs, RSC data fetches, and Server Action POSTs alike.
-  // (Next answers trailing-slash / double-slash / case normalisation with a 308
-  // before middleware runs; the browser re-requests the normalised path, which IS
-  // gated, so nothing with a body escapes.) A rebinding attack targets the
-  // mutating POST path, so the rejection must not depend on route or method.
+describe('middleware — the gate covers every route and method that reaches it', () => {
+  // There is no `config.matcher`, so the gate runs on every request Next routes
+  // to middleware — page GETs, RSC data fetches, and Server Action POSTs alike.
+  // (Trailing-slash and double-slash paths get a 308 before middleware; the retry
+  // to the normalised path IS gated. TRACE and CONNECT throw in the middleware
+  // bundle before the gate runs and get Next's 500 — fail-closed, not browser-
+  // reachable, but not gated.) A rebinding attack targets the mutating POST path,
+  // so the rejection must not depend on route or method.
   const routes = ['/', '/security', '/scan', '/exceptions/new', '/_next/data/x.json'];
 
   it.each(routes)('403s a non-loopback GET to %s', (path) => {
@@ -261,9 +275,9 @@ describe('middleware — the Server Action allowedOrigins list stays within the 
 });
 
 describe('middleware — the rejection is a real 403 with an explanatory body', () => {
-  // The allowed-literals block above already pins the pass-through mechanism
-  // (status 200 + `x-middleware-next`) for every admitted host; this covers the
-  // reject side, which nothing else asserts.
+  // `statusFor` asserts the `x-middleware-next` sentinel on every 200, so the
+  // pass-through mechanism is pinned at every admitted-host call site; this test
+  // covers the reject side, which nothing else asserts.
   it('rejects with a 403 and an explanatory body', async () => {
     const response = runMiddleware('evil.com');
     expect(response.status).toBe(403);

--- a/web-ui/test/middleware.test.ts
+++ b/web-ui/test/middleware.test.ts
@@ -41,11 +41,13 @@ function statusFor(
 describe('middleware — allowed loopback literals (any port)', () => {
   // The three accepted spellings, each with the default port, a non-default
   // port, and no port at all — "any port is fine; the name must be loopback".
-  // These are also the exact hosts the CLI uses: cli/src/commands/dashboard.ts
-  // opens `http://localhost:${port}` (line 90) and binds `127.0.0.1` (lines
-  // 39/127/171). Literal-only matching makes those load-bearing — if the gate
-  // stops admitting them the dashboard 403s every page on launch — so this block
-  // doubles as the pin keeping the gate and the CLI's host choices in agreement.
+  // These are also the hosts the CLI uses: cli/src/commands/dashboard.ts's `url`
+  // opens `http://localhost:${port}`, and its `--hostname` / `HOSTNAME` bind
+  // `127.0.0.1`. Literal-only matching makes the OPENED host load-bearing (a
+  // non-loopback spelling there 403s every page on launch). This block only makes
+  // that coupling DISCOVERABLE, though — it asserts string literals typed here,
+  // not what the CLI actually sends, so it will not catch the CLI drifting to
+  // another spelling. (The bind host is a separate constraint the gate can't see.)
   it.each([
     'localhost:4319',
     'localhost:9999',
@@ -80,19 +82,22 @@ describe('middleware — non-loopback hosts are rejected (rebinding vectors)', (
   );
 });
 
-describe('middleware — alternate IPv4 encodings the pre-fix gate ALLOWED (regression guards)', () => {
+describe('middleware — alternate encodings the pre-fix gate ALLOWED (regression guards)', () => {
   // The previous gate matched `new URL(...).hostname`, and the WHATWG parser
-  // normalises each of these to the literal `127.0.0.1` — so on shipped code
-  // they returned 200 and were a live DNS-rebinding bypass, not a hypothetical.
-  // The fix matches the client's literal token instead, so they must now 403.
-  // Every row here fails on the pre-fix middleware, which is what makes it a
-  // real regression guard rather than a forward-only pin.
+  // folds each of these into a loopback literal that WAS in the old allow-set —
+  // `127.0.0.1` for the IPv4 forms, `[::1]` for the uncompressed IPv6 ones — so
+  // on shipped code they returned 200 and were a live DNS-rebinding bypass, not a
+  // hypothetical. The fix matches the client's literal token instead, so they
+  // must now 403. Every row here fails on the pre-fix middleware, which is what
+  // makes it a real regression guard rather than a forward-only pin.
   it.each([
-    '127.1', // shorthand IPv4
-    '2130706433', // decimal IPv4
-    '0x7f000001', // hex IPv4
-    '127.000.000.001', // zero-padded dotted IPv4
+    '127.1', // shorthand IPv4 -> 127.0.0.1
+    '2130706433', // decimal IPv4 -> 127.0.0.1
+    '0x7f000001', // hex IPv4 -> 127.0.0.1
+    '127.000.000.001', // zero-padded dotted IPv4 -> 127.0.0.1
     '127.1:4319', // ...with a port, too
+    '[0:0:0:0:0:0:0:1]', // uncompressed IPv6 -> [::1]
+    '[::0.0.0.1]', // IPv6 with an embedded IPv4 -> [::1]
   ])('403 for %s', (host) => {
     expect(statusFor(host)).toBe(403);
   });
@@ -112,19 +117,18 @@ describe('middleware — encodings already denied, pinned against a future norma
 });
 
 describe('middleware — genuine-but-unadmitted loopback spellings stay out (intentional, fail-closed)', () => {
-  // These do resolve to loopback, but they are deliberately NOT in the allow-set.
-  // The dashboard only ever opens http://localhost:PORT or http://127.0.0.1:PORT,
-  // so a browser never sends them, and holding the set to three exact spellings
-  // is what keeps the literal match tight. Rejecting them is a conscious,
-  // fail-closed choice — pinned so it stays deliberate. Admitting any of them
-  // (e.g. *.localhost per RFC 6761) would be a separate, opt-in widening.
+  // These resolve to loopback but were DENIED by the pre-fix gate too — their
+  // `new URL().hostname` was never in the old allow-set — so, unlike the block
+  // above, they never changed. They are deliberately excluded: the dashboard only
+  // opens http://localhost:PORT / http://127.0.0.1:PORT, so a browser never sends
+  // them, and holding the set to three exact spellings keeps the literal match
+  // tight. Admitting any (e.g. *.localhost per RFC 6761) would be a separate,
+  // opt-in widening.
   it.each([
     'localhost.', // trailing-dot FQDN
     'app.localhost', // RFC 6761 *.localhost subdomain
     '127.0.0.2', // the rest of 127/8
     '127.0.0.2:4319',
-    '[0:0:0:0:0:0:0:1]', // uncompressed IPv6 loopback
-    '[::0.0.0.1]', // IPv6 with an embedded IPv4 loopback
   ])('403 for %s', (host) => {
     expect(statusFor(host)).toBe(403);
   });
@@ -153,13 +157,30 @@ describe('middleware — missing, empty, or malformed Host fails closed', () => 
     expect(statusFor(host)).toBe(403);
   });
 
-  it('403 fast for an oversized / many-colon Host (constant-time, no hang)', () => {
-    // The gate is a single anchored regex with no backtracking, so hostile-sized
-    // input is simply rejected rather than causing a silent stall. Node caps real
-    // request headers well below this, so it is defence-in-depth.
+  it('403 for an oversized / many-colon Host, in linear time', () => {
+    // A 10 KB Host is in-band, not beyond what the server accepts: node:http's
+    // default maxHeaderSize is 16 KB and `next start` does not lower it, so a
+    // rebound page really can send this and reach the gate. The gate is a single
+    // anchored regex with no backtracking, so it rejects in time linear in the
+    // input length — never a silent stall.
     expect(statusFor('a'.repeat(10_000))).toBe(403);
     expect(statusFor(`localhost${':1'.repeat(5_000)}`)).toBe(403);
   });
+});
+
+describe('middleware — the port is not validated (the loopback host is the whole decision)', () => {
+  // `\d{1,5}` bounds the port's length, not its value, so out-of-range and
+  // zero-padded ports are admitted on a loopback host. Deliberate: the host is
+  // always a loopback literal when the pattern matches, so the port cannot widen
+  // the gate (and no browser can open a port above 65535). Pinned as a decision,
+  // not a side effect — note `localhost:99999999` above still 403s, but on digit
+  // count (8 > 5), not range.
+  it.each(['localhost:65536', 'localhost:99999', 'localhost:080', 'localhost:00'])(
+    '200 for %s',
+    (host) => {
+      expect(statusFor(host)).toBe(200);
+    },
+  );
 });
 
 describe('middleware — x-forwarded-host is held to the same loopback bar', () => {
@@ -172,23 +193,15 @@ describe('middleware — x-forwarded-host is held to the same loopback bar', () 
     '127.1',
     '[::ffff:127.0.0.1]',
     '',
-    'localhost, evil.com', // comma-joined (duplicate-header collapse) — the leading token must not be trusted
+    // A repeated `x-forwarded-host` is collapsed to one comma-joined value; the
+    // leading token must not be trusted. (This is x-forwarded-host-specific —
+    // node:http keeps the FIRST `Host` and discards the rest, so `Host` never
+    // arrives comma-joined; the duplicate-`Host` first-wins semantics live in the
+    // server, not this pure gate, so they aren't reproducible here.)
+    'localhost, evil.com',
     'localhost,evil.com',
   ])('403 when Host is loopback but x-forwarded-host is %s', (xForwardedHost) => {
     expect(statusFor('localhost:4319', { xForwardedHost })).toBe(403);
-  });
-
-  it('403 when duplicate x-forwarded-host headers join to a non-loopback value', () => {
-    // The runtime collapses repeated headers into one comma-joined value, so a
-    // smuggled second `x-forwarded-host` arrives as "localhost, evil.com". That
-    // fails to parse as a bare authority and is rejected — pinned so a future
-    // parser change cannot start trusting the leading token.
-    const headers = new Headers();
-    headers.set('host', 'localhost:4319');
-    headers.append('x-forwarded-host', 'localhost');
-    headers.append('x-forwarded-host', 'evil.com');
-    const request = new NextRequest('http://localhost:4319/', { headers });
-    expect(middleware(request).status).toBe(403);
   });
 
   it('403 when x-forwarded-host is loopback but Host is not', () => {
@@ -198,9 +211,12 @@ describe('middleware — x-forwarded-host is held to the same loopback bar', () 
 });
 
 describe('middleware — the gate covers every route and method', () => {
-  // There is no `config.matcher`, so the gate runs on every request: page GETs,
-  // RSC data fetches, and Server Action POSTs alike. A rebinding attack targets
-  // the mutating POST path, so the rejection must not depend on route or method.
+  // There is no `config.matcher`, so the gate runs on every request that reaches
+  // middleware — page GETs, RSC data fetches, and Server Action POSTs alike.
+  // (Next answers trailing-slash / double-slash / case normalisation with a 308
+  // before middleware runs; the browser re-requests the normalised path, which IS
+  // gated, so nothing with a body escapes.) A rebinding attack targets the
+  // mutating POST path, so the rejection must not depend on route or method.
   const routes = ['/', '/security', '/scan', '/exceptions/new', '/_next/data/x.json'];
 
   it.each(routes)('403s a non-loopback GET to %s', (path) => {
@@ -244,18 +260,13 @@ describe('middleware — the Server Action allowedOrigins list stays within the 
   });
 });
 
-describe('middleware — the rejection is a real 403, the pass a real hand-off', () => {
+describe('middleware — the rejection is a real 403 with an explanatory body', () => {
+  // The allowed-literals block above already pins the pass-through mechanism
+  // (status 200 + `x-middleware-next`) for every admitted host; this covers the
+  // reject side, which nothing else asserts.
   it('rejects with a 403 and an explanatory body', async () => {
     const response = runMiddleware('evil.com');
     expect(response.status).toBe(403);
     await expect(response.text()).resolves.toContain('localhost');
-  });
-
-  it('passes a loopback request through to the app', () => {
-    // `NextResponse.next()` hands the request to the app; its sentinel header
-    // distinguishes a genuine pass-through from an incidental 200 body.
-    const response = runMiddleware('127.0.0.1:4319');
-    expect(response.status).toBe(200);
-    expect(response.headers.get('x-middleware-next')).toBe('1');
   });
 });

--- a/web-ui/test/middleware.test.ts
+++ b/web-ui/test/middleware.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import * as middlewareModule from '../middleware.ts';
 import { middleware } from '../middleware.ts';
+import nextConfig from '../next.config.ts';
 
 // `middleware.ts` is the sole DNS-rebinding gate in front of the dashboard's
 // unauthenticated, store-mutating Server Actions. Under rebinding the browser
@@ -12,17 +13,14 @@ import { middleware } from '../middleware.ts';
 // it is: a pure function over the `Host` / `x-forwarded-host` headers. Each row
 // below pins the exact 200-vs-403 decision that keeps the gate honest.
 
-interface MiddlewareInit {
-  xForwardedHost?: string;
-  path?: string;
-  method?: string;
-}
-
 // Drive the real middleware with a real NextRequest. Only the request headers
 // matter to the gate; the URL host is irrelevant (the gate reads the `Host`
 // header, not the URL), so a fixed loopback URL is used and the header under
 // test is set explicitly. Pass `host: undefined` to omit the header entirely.
-function runMiddleware(host: string | undefined, init: MiddlewareInit = {}) {
+function runMiddleware(
+  host: string | undefined,
+  init: { xForwardedHost?: string; path?: string; method?: string } = {},
+) {
   const headers = new Headers();
   if (host !== undefined) headers.set('host', host);
   if (init.xForwardedHost !== undefined) headers.set('x-forwarded-host', init.xForwardedHost);
@@ -33,13 +31,21 @@ function runMiddleware(host: string | undefined, init: MiddlewareInit = {}) {
   return middleware(request);
 }
 
-function statusFor(host: string | undefined, init: MiddlewareInit = {}): number {
+function statusFor(
+  host: string | undefined,
+  init: { xForwardedHost?: string; path?: string; method?: string } = {},
+): number {
   return runMiddleware(host, init).status;
 }
 
 describe('middleware — allowed loopback literals (any port)', () => {
   // The three accepted spellings, each with the default port, a non-default
   // port, and no port at all — "any port is fine; the name must be loopback".
+  // These are also the exact hosts the CLI uses: cli/src/commands/dashboard.ts
+  // opens `http://localhost:${port}` (line 90) and binds `127.0.0.1` (lines
+  // 39/127/171). Literal-only matching makes those load-bearing — if the gate
+  // stops admitting them the dashboard 403s every page on launch — so this block
+  // doubles as the pin keeping the gate and the CLI's host choices in agreement.
   it.each([
     'localhost:4319',
     'localhost:9999',
@@ -51,8 +57,17 @@ describe('middleware — allowed loopback literals (any port)', () => {
     '[::1]:9999',
     '[::1]',
     'LOCALHOST:4319', // Host names are case-insensitive.
-  ])('200 for %s', (host) => {
-    expect(statusFor(host)).toBe(200);
+  ])('200 (real pass-through) for %s', (host) => {
+    const response = runMiddleware(host);
+    expect(response.status).toBe(200);
+    // Assert the mechanism, not just the status: a genuine hand-off carries
+    // NextResponse.next()'s `x-middleware-next` sentinel, so a 200 reached any
+    // other way on an allowed host would still fail here. That header is a Next
+    // internal under the `next: ^15.2.0` range — if a future Next renames or
+    // drops it this fails with "expected '1', got null"; read that as an upgrade
+    // signal, not a middleware regression, and keep the check (it is the only
+    // thing separating a real pass-through from an incidental 200).
+    expect(response.headers.get('x-middleware-next')).toBe('1');
   });
 });
 
@@ -65,19 +80,51 @@ describe('middleware — non-loopback hosts are rejected (rebinding vectors)', (
   );
 });
 
-describe('middleware — alternate loopback encodings stay out of the allow-set', () => {
-  // These all route to 127.0.0.1 on many stacks, and `new URL()` normalises
-  // every one of them to the literal `127.0.0.1`. They are NOT in the allow-set
-  // and must 403 — pinned here so a future "helpful" normalisation (or a
-  // parser that folds them before the check) cannot silently open the gate.
+describe('middleware — alternate IPv4 encodings the pre-fix gate ALLOWED (regression guards)', () => {
+  // The previous gate matched `new URL(...).hostname`, and the WHATWG parser
+  // normalises each of these to the literal `127.0.0.1` — so on shipped code
+  // they returned 200 and were a live DNS-rebinding bypass, not a hypothetical.
+  // The fix matches the client's literal token instead, so they must now 403.
+  // Every row here fails on the pre-fix middleware, which is what makes it a
+  // real regression guard rather than a forward-only pin.
   it.each([
     '127.1', // shorthand IPv4
-    '0.0.0.0', // all-zeros, not loopback
-    '[::ffff:127.0.0.1]', // IPv4-mapped IPv6
     '2130706433', // decimal IPv4
     '0x7f000001', // hex IPv4
     '127.000.000.001', // zero-padded dotted IPv4
     '127.1:4319', // ...with a port, too
+  ])('403 for %s', (host) => {
+    expect(statusFor(host)).toBe(403);
+  });
+});
+
+describe('middleware — encodings already denied, pinned against a future normalisation', () => {
+  // Unlike the block above, these were never in the allow-set: they 403 on both
+  // the pre- and post-fix gate. They still route to loopback on many stacks, so
+  // they are pinned so a future "helpful" normalisation cannot silently admit
+  // them.
+  it.each([
+    '0.0.0.0', // all-zeros wildcard, not loopback
+    '[::ffff:127.0.0.1]', // IPv4-mapped IPv6
+  ])('403 for %s', (host) => {
+    expect(statusFor(host)).toBe(403);
+  });
+});
+
+describe('middleware — genuine-but-unadmitted loopback spellings stay out (intentional, fail-closed)', () => {
+  // These do resolve to loopback, but they are deliberately NOT in the allow-set.
+  // The dashboard only ever opens http://localhost:PORT or http://127.0.0.1:PORT,
+  // so a browser never sends them, and holding the set to three exact spellings
+  // is what keeps the literal match tight. Rejecting them is a conscious,
+  // fail-closed choice — pinned so it stays deliberate. Admitting any of them
+  // (e.g. *.localhost per RFC 6761) would be a separate, opt-in widening.
+  it.each([
+    'localhost.', // trailing-dot FQDN
+    'app.localhost', // RFC 6761 *.localhost subdomain
+    '127.0.0.2', // the rest of 127/8
+    '127.0.0.2:4319',
+    '[0:0:0:0:0:0:0:1]', // uncompressed IPv6 loopback
+    '[::0.0.0.1]', // IPv6 with an embedded IPv4 loopback
   ])('403 for %s', (host) => {
     expect(statusFor(host)).toBe(403);
   });
@@ -105,6 +152,14 @@ describe('middleware — missing, empty, or malformed Host fails closed', () => 
   ])('403 for malformed host %s', (host) => {
     expect(statusFor(host)).toBe(403);
   });
+
+  it('403 fast for an oversized / many-colon Host (constant-time, no hang)', () => {
+    // The gate is a single anchored regex with no backtracking, so hostile-sized
+    // input is simply rejected rather than causing a silent stall. Node caps real
+    // request headers well below this, so it is defence-in-depth.
+    expect(statusFor('a'.repeat(10_000))).toBe(403);
+    expect(statusFor(`localhost${':1'.repeat(5_000)}`)).toBe(403);
+  });
 });
 
 describe('middleware — x-forwarded-host is held to the same loopback bar', () => {
@@ -112,12 +167,29 @@ describe('middleware — x-forwarded-host is held to the same loopback bar', () 
     expect(statusFor('localhost:4319', { xForwardedHost: '127.0.0.1:4319' })).toBe(200);
   });
 
-  it.each(['evil.com', '127.1', '[::ffff:127.0.0.1]', ''])(
-    '403 when Host is loopback but x-forwarded-host is %s',
-    (xForwardedHost) => {
-      expect(statusFor('localhost:4319', { xForwardedHost })).toBe(403);
-    },
-  );
+  it.each([
+    'evil.com',
+    '127.1',
+    '[::ffff:127.0.0.1]',
+    '',
+    'localhost, evil.com', // comma-joined (duplicate-header collapse) — the leading token must not be trusted
+    'localhost,evil.com',
+  ])('403 when Host is loopback but x-forwarded-host is %s', (xForwardedHost) => {
+    expect(statusFor('localhost:4319', { xForwardedHost })).toBe(403);
+  });
+
+  it('403 when duplicate x-forwarded-host headers join to a non-loopback value', () => {
+    // The runtime collapses repeated headers into one comma-joined value, so a
+    // smuggled second `x-forwarded-host` arrives as "localhost, evil.com". That
+    // fails to parse as a bare authority and is rejected — pinned so a future
+    // parser change cannot start trusting the leading token.
+    const headers = new Headers();
+    headers.set('host', 'localhost:4319');
+    headers.append('x-forwarded-host', 'localhost');
+    headers.append('x-forwarded-host', 'evil.com');
+    const request = new NextRequest('http://localhost:4319/', { headers });
+    expect(middleware(request).status).toBe(403);
+  });
 
   it('403 when x-forwarded-host is loopback but Host is not', () => {
     // A good forwarded header does not excuse a non-loopback Host.
@@ -144,8 +216,31 @@ describe('middleware — the gate covers every route and method', () => {
   });
 
   it('exports no config.matcher — narrowing the gate would uncover Server Actions', () => {
-    const exported = middlewareModule as Record<string, unknown>;
-    expect(exported.config).toBeUndefined();
+    // Assert exactly the invariant the name states: no `matcher`. A matcher-free
+    // `config` (e.g. `export const config = { runtime: 'nodejs' }`, the supported
+    // way to move middleware onto the Node runtime) narrows nothing and must not
+    // trip this — only a `matcher`, however spelled, uncovers Server Actions.
+    const exported = middlewareModule as { config?: { matcher?: unknown } };
+    expect(exported.config?.matcher).toBeUndefined();
+  });
+});
+
+describe('middleware — the Server Action allowedOrigins list stays within the gate', () => {
+  // next.config.ts's `serverActions.allowedOrigins` is a SECOND hard-coded list
+  // of loopback spellings guarding the same write surface. It only ever WIDENS
+  // Next's built-in Origin==Host check (which is consulted when the two differ),
+  // so same-origin requests on any port are already allowed without it — but the
+  // real risk is drift: a later edit that adds a non-loopback origin would leave
+  // this middleware as the only thing rejecting it. Pin that every entry is a
+  // host the gate itself admits, so the two lists cannot silently disagree.
+  const allowedOrigins = nextConfig.experimental?.serverActions?.allowedOrigins ?? [];
+
+  it('is non-empty (so the assertion below is not vacuously true)', () => {
+    expect(allowedOrigins.length).toBeGreaterThan(0);
+  });
+
+  it.each(allowedOrigins)('the gate admits allowedOrigins entry %s', (origin) => {
+    expect(statusFor(origin)).toBe(200);
   });
 });
 

--- a/web-ui/turbo.json
+++ b/web-ui/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "test": {
+      "dependsOn": ["^typecheck"]
+    }
+  }
+}

--- a/web-ui/turbo.json
+++ b/web-ui/turbo.json
@@ -1,4 +1,5 @@
 {
+  "//": "Replaces the root `test` dependsOn (build, ^build, ^typecheck). Dropping `build` is the point: web-ui's build is `next build`, and both suites (a pure header gate + Server Actions over node:sqlite) read no build output, so keeping it would put a full production build on the critical path of `pnpm test`. `^build` goes with it as a side effect of overriding the key — a no-op today, since none of web-ui's workspace dependencies has a build script (only cli, web-ui and the plugin do). `^typecheck` is kept: it is what invalidates this package when a dependency's source changes, since libs are consumed as raw source.",
   "extends": ["//"],
   "tasks": {
     "test": {

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+// The dashboard's testable surface is server-side logic, not rendered React:
+// middleware.ts is a pure Host/x-forwarded-host gate (no DOM, no I/O), so a
+// node environment with the default timeouts is enough. When the Server Action
+// suites land here (they touch real node:sqlite via @akasecurity/persistence),
+// raise testTimeout/hookTimeout to 20_000 like persistence/local-ops so they do
+// not flake on the Windows runner — the middleware tests never need it.
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -1,13 +1,14 @@
 import { defineConfig } from 'vitest/config';
 
-// The dashboard's testable surface is server-side logic, not rendered React:
-// middleware.ts is a pure Host/x-forwarded-host gate (no DOM, no I/O), so a
-// node environment with the default timeouts is enough. When the Server Action
-// suites land here (they touch real node:sqlite via @akasecurity/persistence),
-// raise testTimeout/hookTimeout to 20_000 like persistence/local-ops so they do
-// not flake on the Windows runner — the middleware tests never need it.
+// middleware.ts is a pure Host/x-forwarded-host gate — a single anchored regex,
+// no DOM and no I/O — so a node environment with the default timeouts exercises
+// it fully. A literal match has no URL-parser behaviour that could diverge from
+// the Edge runtime the middleware ships on, so the node run is faithful to it.
+// `include` is pinned to test/ so `vitest run` never globs a built `.next/`
+// (left by any `next build`) into the run.
 export default defineConfig({
   test: {
     environment: 'node',
+    include: ['test/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
Give `web-ui` a test script and cover `middleware.ts`, the sole DNS-rebinding gate in front of the dashboard's unauthenticated, store-mutating Server Actions.

## The finding (beyond adding tests)
The gate was **already open**. `isLoopbackHost` fed the `Host` header through `new URL(...).hostname`, and the WHATWG URL parser *normalises* alternate IPv4 encodings into `127.0.0.1` **before** the allow-set check — so the pre-fix code returned **200 (allowed)** for `127.1`, `2130706433`, `0x7f000001`, and `127.000.000.001`, and accepted userinfo/path/query/fragment smuggles (`localhost:4319/evil`, `localhost:4319@evil.com`).

The fix compares the client's **literal** Host token (port stripped, IPv6 brackets preserved) against the allow-set, and rejects anything that is not a bare `host[:port]`. `0.0.0.0` and `[::ffff:127.0.0.1]` were already denied and stay denied. The real dashboard is unaffected — it binds `127.0.0.1` and opens `http://localhost:PORT`, both allowed literals.

## Changes
- **`web-ui/middleware.ts`** — harden `isLoopbackHost`: literal-token match + structural rejection of userinfo/path/query/fragment. Threat-model comments preserved.
- **`web-ui/vitest.config.ts`** — adds `include: ['test/**/*.test.ts']` so a built `.next/` is never globbed into the run. (The file itself now comes from `main`, which added it with the `addException` suite; this PR no longer creates it.)
- **`web-ui/test/middleware.test.ts`** (new) — 68-case `Host` / `x-forwarded-host` matrix: allowed loopback literals (any port), rebinding vectors, the normalisation-escape 403s (pinned), missing/empty/malformed, the `x-forwarded-host` axis, route/method independence (GET, RSC path, Server Action POST), and an assertion that **no `config.matcher`** is exported.
- **`web-ui/package.json`** — widen `lint` to `*.config.*`, covering all four config files (`main`'s enumerated list misses `eslint.config.mjs`). The `test` script and `vitest` devDep now come from `main`.
- **`web-ui/turbo.json`** (new) — drop the `next build` edge from `test`.
- **`.github/workflows/ci.yml`** — run web-ui on the Windows leg.

## Verification
- 88/88 web-ui tests pass (68 middleware + 20 `addException` from `main`); **10 fail on the pre-fix middleware** (proving they are real regression guards).
- `web-ui` lint / typecheck / test + `prettier --check` all green; pre-push workspace lint green.
- `turbo run test` now includes `@akasecurity/web-ui#test`, and it runs on the Windows leg: green in 3m19s, worst single test ~3.0s against the 20s per-test timeout.

## Release note
`web-ui` is bundled into the `cli` (`noExternal`), so per `CLAUDE.md` this middleware behaviour change should carry a **`cli` version bump** at release time (not done here — release type is the maintainer's call). The plugin bundles no web-ui and is unaffected.

## Not in scope
`addException` coverage landed separately on `main` and arrives here via the merge; this PR does not touch it, but it is now part of what the Windows leg runs (see the `ci.yml` comment). `rotateKey` / `approveBlocked` remain open.
