### PR TITLE
test(eslint-config): guard every workspace package ships a network-guarded config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,15 @@ skills/               agent skills (e.g. write-detection-rule)
 2. Extend `../../tsconfig.base.json`
 3. Add an `eslint.config.mjs` extending `@akasecurity/eslint-config`
 4. Export from `src/index.ts`
-5. Add `"lint"` and `"typecheck"` scripts
+5. Add `"lint"` and `"typecheck"` scripts — the `lint` script must run `eslint` and
+   name every source dir the package ships (`src`, `app`, `test`). Turbo silently
+   skips a package with no `lint` script, so a config nothing points ESLint at
+   enforces nothing. A `scripts/` dir needs its own `eslint.scripts.config.mjs`
+   plus a second pass (`eslint --no-config-lookup -c eslint.scripts.config.mjs scripts`).
+6. Add the package name to `EXPECTED_WORKSPACE_PACKAGE_NAMES` in
+   `packages/eslint-config/test/effective-config.test.js` — that suite enumerates
+   the workspace and fails when the set drifts, which is what stops a new package
+   from shipping unguarded for network calls.
 
 ## Commit messages
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,9 @@ Keep these package boundaries intact — a forbidden import across a package wal
                      the project-inventory pass; network ONLY via package-manager
                      shell-outs — no fetch)
 @akasecurity/detections    → @akasecurity/schema (pure rule engine; no I/O, no Node-API deps)
+@akasecurity/extract       → (no dependencies; pure CSV/tabular parsing — `extractCsv`.
+                     Consumed by @akasecurity/detections' tabular suite as a
+                     dev-only dependency, so it crosses no runtime package wall)
 @akasecurity/dashboard-ui  → @akasecurity/ui-kit, @akasecurity/schema (types, plus the pure
                      shared constants and formatters — no I/O)
                      (bundler-agnostic presentational views; props-driven, no data fetching)
@@ -157,7 +160,7 @@ cli/                  the `aka` CLI (self-contained npm bundle; ships the web-ui
 web-ui/               the OSS Next.js dashboard (Server Components read ~/.aka; Server Actions mutate it)
 plugins/claude-code/  the Claude Code plugin (hooks + commands; self-contained npm bundle)
 packages/             the workspace libraries (schema · persistence · local-ops · detections ·
-                      dashboard-ui · ui-kit · plugin-runtime · plugin-sdk · scanner …)
+                      extract · dashboard-ui · ui-kit · plugin-runtime · plugin-sdk · scanner …)
 rules/                the built-in detection packs (rule JSON + fixtures)
 skills/               agent skills (e.g. write-detection-rule)
 ```
@@ -168,11 +171,12 @@ skills/               agent skills (e.g. write-detection-rule)
 2. Extend `../../tsconfig.base.json`
 3. Add an `eslint.config.mjs` extending `@akasecurity/eslint-config`
 4. Export from `src/index.ts`
-5. Add `"lint"` and `"typecheck"` scripts — the `lint` script must run `eslint` and
-   name every source dir the package ships (`src`, `app`, `test`). Turbo silently
-   skips a package with no `lint` script, so a config nothing points ESLint at
-   enforces nothing. A `scripts/` dir needs its own `eslint.scripts.config.mjs`
-   plus a second pass (`eslint --no-config-lookup -c eslint.scripts.config.mjs scripts`).
+5. Add `"lint"` and `"typecheck"` scripts — the `lint` script must run `eslint` over
+   **every directory the package ships code in**, whatever they are named (a bare `.`
+   counts; naming individual files does not). Turbo silently skips a package with no
+   `lint` script, so a config nothing points ESLint at enforces nothing. A `scripts/`
+   dir needs its own `eslint.scripts.config.mjs` plus a second pass
+   (`eslint --no-config-lookup -c eslint.scripts.config.mjs scripts`).
 6. Add the package name to `EXPECTED_WORKSPACE_PACKAGE_NAMES` in
    `packages/eslint-config/test/effective-config.test.js` — that suite enumerates
    the workspace and fails when the set drifts, which is what stops a new package

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,12 +175,21 @@ skills/               agent skills (e.g. write-detection-rule)
    **every directory the package ships code in**, whatever they are named (a bare `.`
    counts; naming individual files does not). Turbo silently skips a package with no
    `lint` script, so a config nothing points ESLint at enforces nothing. A `scripts/`
-   dir needs its own `eslint.scripts.config.mjs` plus a second pass
-   (`eslint --no-config-lookup -c eslint.scripts.config.mjs scripts`).
+   dir of **hand-written (git-tracked)** scripts needs its own
+   `eslint.scripts.config.mjs` plus a second pass
+   (`eslint --no-config-lookup -c eslint.scripts.config.mjs scripts`) — a generated
+   `scripts/` dir (the plugin's bundled hooks) is build output and is exempt.
+
+   Note the current limit: the guard checks **directories only**, so top-level files
+   at a package root (`tsup.config.ts`, `vitest.config.ts`, …) are outside it and are
+   not linted today. Point the `lint` script at them if you can; several need a
+   `tsconfig`/`allowDefaultProject` change before ESLint can parse them.
+
 6. Add the package name to `EXPECTED_WORKSPACE_PACKAGE_NAMES` in
-   `packages/eslint-config/test/effective-config.test.js` — that suite enumerates
-   the workspace and fails when the set drifts, which is what stops a new package
-   from shipping unguarded for network calls.
+   `packages/eslint-config/test/effective-config.test.js`. That pinned list only
+   forces a human to notice the new package — what actually stops it shipping
+   unguarded are the assertions next to it (a missing config, a config that never
+   extends the shared one, a `lint` script that misses a directory).
 
 ## Commit messages
 

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,5 +1,6 @@
+import { execFileSync } from 'node:child_process';
 import { existsSync, globSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ESLint, Linter } from 'eslint';
@@ -7,20 +8,19 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 // This file guards the per-package ESLint configs two ways.
 //
-//  1. STRUCTURAL (the `#50` block): every workspace package — enumerated from
-//     pnpm-workspace.yaml, not a hand-maintained glob — must ship an
-//     eslint.config.mjs that extends `@akasecurity/eslint-config`, unless it is
-//     on an explicit, reasoned opt-out list. A package with NO config at all is
-//     invisible to `pnpm lint` (nothing points ESLint at it) AND to a glob that
-//     only ever matched existing config files, so it would ship UNGUARDED for
-//     network calls with CI green. Enumerating from the manifest and pinning the
-//     result as an EXACT set catches a package that was never in a config glob's
-//     universe — which a floor over "configs that already exist" cannot.
+//  1. STRUCTURAL: every workspace package — enumerated from pnpm-workspace.yaml,
+//     not a hand-maintained glob — must ship an eslint.config.mjs that extends
+//     `@akasecurity/eslint-config`, must have a `lint` script that actually runs
+//     eslint over its source dirs, and must ship an eslint.scripts.config.mjs if
+//     it has a scripts/ dir. A package missing any of these is invisible to
+//     `pnpm lint` and to a glob that only ever matched existing config files, so
+//     it would ship UNGUARDED for network calls with CI green. Enumerating from
+//     the manifest and pinning the result as an EXACT set catches a package that
+//     was never in a config glob's universe.
 //
-//  2. BEHAVIORAL (the composition / last-wins block): resolve each real
-//     eslint.config.mjs through ESLint and assert the four network rules still
-//     fire on real code. Flat config resolves "last wins": the final block
-//     matching a file overrides earlier ones for a given rule, and
+//  2. BEHAVIORAL: resolve each real config through ESLint and assert the network
+//     rules still fire on real code. Flat config resolves "last wins": the final
+//     block matching a file overrides earlier ones for a given rule, and
 //     no-restricted-imports never merges across blocks. So a package that layers
 //     a second config on top of base (web-ui: react + noEnterpriseImports;
 //     persistence / local-ops: base + noEnterpriseImports; cli: base + the
@@ -44,19 +44,69 @@ const CONFIG_OPT_OUT = [
   {
     name: '@akasecurity/eslint-config',
     reason:
-      'Defines the shared config; it cannot extend itself, and its own `lint` script is a no-op.',
+      'Defines the shared config. Its `lint` script is a deliberate no-op, so requiring a config ' +
+      'that eslint is never pointed at would assert nothing.',
   },
 ];
 const OPT_OUT_NAMES = new Set(CONFIG_OPT_OUT.map((o) => o.name));
 
+// Directories a package may ship lintable code under. Used both to pick the
+// behavioral probe paths and to check the `lint` script names every one of them.
+const SOURCE_DIRS = /** @type {const} */ (['src', 'app']);
+const LINT_TARGET_DIRS = /** @type {const} */ (['src', 'app', 'test']);
+
+// Every path git tracks, used to tell hand-written source from build output. A
+// scripts/ dir on disk is not necessarily source: the plugin's build emits its
+// bundled hooks to scripts/ (declared in turbo.json `build.outputs` and ignored
+// by git), and demanding a lint config for generated bundles would be wrong.
+// Tracked-ness is the only reliable signal here, so this meta-test asks git
+// rather than guessing from the directory listing.
+const TRACKED_FILES = (() => {
+  try {
+    return new Set(
+      execFileSync('git', ['ls-files'], { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 << 20 })
+        .split('\n')
+        .filter(Boolean),
+    );
+  } catch (cause) {
+    throw new Error(
+      'Could not list tracked files with `git ls-files`. This suite audits the real workspace ' +
+        'layout, so it must run inside a git checkout.',
+      { cause },
+    );
+  }
+})();
+
+/** Whether `<dir>/<sub>` holds at least one git-tracked file (i.e. real source). */
+const hasTrackedSource = (dir, sub) => {
+  const prefix = `${dir}/${sub}/`;
+  for (const f of TRACKED_FILES) if (f.startsWith(prefix)) return true;
+  return false;
+};
+
+/**
+ * Strip line and block comments so a commented-out import is not mistaken for a
+ * live one. Without this, `// import { base } from '@akasecurity/eslint-config'`
+ * satisfies the "extends" check and the structural guard reports nothing, leaving
+ * the behavioral suite to report it as "the ban does not fire" — which sends the
+ * reader hunting a composition bug instead of a missing import.
+ * @param {string} source
+ */
+function stripComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
 // "Extends `@akasecurity/eslint-config`" = imports it (the root entry or the
 // `/react` sub-entry) via `import ... from` or `require(...)`. This is the fast,
-// readable statement of intent for the acceptance criterion; the BEHAVIORAL
-// suite below is what actually proves the import wires all four network rules,
-// so a config that imports the package but forgets to spread `...base` is caught
-// there, not here.
+// readable statement of intent; the BEHAVIORAL suite is what proves the import
+// wires the network rules, so a config that imports the package but forgets to
+// spread `...base` is caught there, not here.
 const IMPORTS_SHARED_CONFIG =
   /(?:import[^;]*from[ \t]*|require\([ \t]*)['"]@akasecurity\/eslint-config(?:\/[\w.-]+)?['"]/;
+
+/** Whether a config file's live (non-comment) source imports the shared config. */
+const extendsSharedConfig = (abs) =>
+  IMPORTS_SHARED_CONFIG.test(stripComments(readFileSync(abs, 'utf8')));
 
 /**
  * Parse the package globs declared under `packages:` in a pnpm-workspace.yaml
@@ -68,11 +118,13 @@ const IMPORTS_SHARED_CONFIG =
  * blank and comment lines inside the block, and stop at the next column-0 key.
  * Flow style (`packages: [ … ]`) is intentionally NOT parsed — it yields an
  * empty list, which the vacuous-pass guard turns into a loud failure rather than
- * a silent under-enumeration.
+ * a silent under-enumeration. An exclusion glob throws for the same reason:
+ * globSync would treat `!pkg` as a literal pattern that matches nothing, leaving
+ * the excluded directory in the enumeration under a misleading failure.
  * @param {string} rawYaml
  * @returns {string[]}
  */
-export function parseWorkspaceGlobs(rawYaml) {
+function parseWorkspaceGlobs(rawYaml) {
   const globs = [];
   let inBlock = false;
   // Normalize CRLF → LF first so a Windows checkout (core.autocrlf) does not
@@ -87,7 +139,16 @@ export function parseWorkspaceGlobs(rawYaml) {
     }
     if (/^\S/.test(line)) break; // a new column-0 key ends the packages block
     const m = line.match(/^[ \t]+-[ \t]*['"]?([^'"\n]+?)['"]?[ \t]*$/);
-    if (m) globs.push(m[1].trim());
+    if (!m) continue;
+    const glob = m[1].trim();
+    if (glob.startsWith('!')) {
+      throw new Error(
+        `pnpm-workspace.yaml declares the exclusion glob "${glob}", which this parser does not ` +
+          'model. Teach parseWorkspaceGlobs/discoverWorkspacePackages to honour negation before ' +
+          'relying on the enumeration.',
+      );
+    }
+    globs.push(glob);
   }
   return globs;
 }
@@ -102,9 +163,16 @@ function workspaceGlobs() {
 
 /**
  * Every workspace package on disk, resolved from pnpm-workspace.yaml: expand each
- * glob and keep the directories that hold a package.json. (The current manifest
- * declares no `!` exclusion globs; pnpm's negation semantics are not modeled.)
- * @returns {{ name: string, dir: string, configRel: string, hasConfig: boolean, extendsShared: boolean }[]}
+ * glob and keep the directories that hold a package.json. `label` is what every
+ * failure message prints — a package.json may legally omit `name`, and a bare
+ * `undefined` in a violation list tells the reader nothing about which directory
+ * to fix.
+ * @returns {{
+ *   name: string, dir: string, label: string, lintScript: string,
+ *   configRel: string, hasConfig: boolean, extendsShared: boolean,
+ *   sourceDirs: string[], hasScriptsDir: boolean,
+ *   scriptsConfigRel: string, hasScriptsConfig: boolean, scriptsExtendsShared: boolean,
+ * }[]}
  */
 function discoverWorkspacePackages() {
   const dirs = [
@@ -115,16 +183,32 @@ function discoverWorkspacePackages() {
     ),
   ].sort();
   return dirs.map((dir) => {
+    // git reports posix paths on every platform; globSync yields native ones.
+    const posixDir = dir.split(sep).join('/');
     const pkg = JSON.parse(readFileSync(join(REPO_ROOT, dir, 'package.json'), 'utf8'));
+    const name = typeof pkg.name === 'string' && pkg.name ? pkg.name : posixDir;
     const configRel = join(dir, 'eslint.config.mjs');
     const configAbs = join(REPO_ROOT, configRel);
     const hasConfig = existsSync(configAbs);
+    const scriptsConfigRel = join(dir, 'eslint.scripts.config.mjs');
+    const scriptsConfigAbs = join(REPO_ROOT, scriptsConfigRel);
+    const hasScriptsConfig = existsSync(scriptsConfigAbs);
     return {
-      name: pkg.name,
+      name,
       dir,
+      label: name === posixDir ? posixDir : `${name} (${posixDir})`,
+      lintScript: pkg.scripts?.lint ?? '',
       configRel,
       hasConfig,
-      extendsShared: hasConfig && IMPORTS_SHARED_CONFIG.test(readFileSync(configAbs, 'utf8')),
+      extendsShared: hasConfig && extendsSharedConfig(configAbs),
+      // Tracked source only — a dir that exists purely as build output is not
+      // something lint should be pointed at.
+      sourceDirs: SOURCE_DIRS.filter((d) => hasTrackedSource(posixDir, d)),
+      lintTargetDirs: LINT_TARGET_DIRS.filter((d) => hasTrackedSource(posixDir, d)),
+      hasScriptsDir: hasTrackedSource(posixDir, 'scripts'),
+      scriptsConfigRel,
+      hasScriptsConfig,
+      scriptsExtendsShared: hasScriptsConfig && extendsSharedConfig(scriptsConfigAbs),
     };
   });
 }
@@ -132,13 +216,11 @@ function discoverWorkspacePackages() {
 const WORKSPACE_PACKAGES = discoverWorkspacePackages();
 
 // The exact set of workspace packages expected on disk, pinned by name (sorted).
-// This is the anti-vacuous drift guard for the enumeration: a hand-rolled
-// pnpm-workspace.yaml parse that silently dropped ONE package would still clear a
-// `>=` floor, and the `CONFIG_FILES.length === GUARDED_PACKAGES.length` equality
-// cannot catch it either (a package absent from discovery is absent from both
-// sides). An exact set fails loudly on any add / drop / rename — the same rigor
-// CONFIG_OPT_OUT uses. Adding or removing a workspace package is a deliberate
-// edit here (and, for a new package, of its eslint.config.mjs).
+// This is the drift guard for the enumeration: a hand-rolled pnpm-workspace.yaml
+// parse that silently dropped ONE package would still clear a `>=` floor, and no
+// derived-vs-derived equality can catch it either (a package absent from
+// discovery is absent from both sides). An exact set fails loudly on any add /
+// drop / rename.
 const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
   '@akasecurity/ai-tc-claude-code',
   '@akasecurity/cli',
@@ -164,22 +246,33 @@ const GUARDED_PACKAGES = WORKSPACE_PACKAGES.filter((p) => !OPT_OUT_NAMES.has(p.n
  * Split the guarded packages by how they fail the config requirement. Pure over
  * its input so the failure paths are testable with synthetic packages — a real,
  * healthy tree produces none by construction.
- * @param {{ name: string, hasConfig: boolean, extendsShared: boolean }[]} guarded
- * @returns {{ missing: string[], notExtending: string[] }}
+ * @param {ReturnType<typeof discoverWorkspacePackages>} guarded
  */
 function configViolations(guarded) {
   return {
-    missing: guarded.filter((p) => !p.hasConfig).map((p) => p.name),
-    notExtending: guarded.filter((p) => p.hasConfig && !p.extendsShared).map((p) => p.name),
+    missing: guarded.filter((p) => !p.hasConfig).map((p) => p.label),
+    notExtending: guarded.filter((p) => p.hasConfig && !p.extendsShared).map((p) => p.label),
+    // A config eslint is never pointed at enforces nothing: `pnpm lint` is
+    // `turbo run lint`, and turbo SKIPS a package with no `lint` script (exit 0,
+    // "No tasks were executed"). The script must also name every source dir the
+    // package actually ships, or those files go unlinted by construction.
+    lintNotWired: guarded
+      .filter(
+        (p) =>
+          !/\beslint\b/.test(p.lintScript) ||
+          (p.lintTargetDirs ?? []).some((d) => !new RegExp(`\\b${d}\\b`).test(p.lintScript)),
+      )
+      .map((p) => p.label),
+    // `eslint <src> <test>` never reaches scripts/, so a scripts/ dir needs its
+    // own network-guard config (run with --no-config-lookup as a second pass).
+    missingScriptsConfig: guarded
+      .filter((p) => p.hasScriptsDir && !p.hasScriptsConfig)
+      .map((p) => p.label),
+    scriptsNotExtending: guarded
+      .filter((p) => p.hasScriptsConfig && !p.scriptsExtendsShared)
+      .map((p) => p.label),
   };
 }
-
-// The per-package configs the BEHAVIORAL suite resolves through ESLint. Derived
-// from the workspace enumeration (not a hand-maintained glob with `cli`/`web-ui`
-// spelled out) so a new package's config is behaviorally verified the moment it
-// is added — and the structural guard guarantees every guarded package
-// contributes exactly one entry here.
-const CONFIG_FILES = GUARDED_PACKAGES.filter((p) => p.hasConfig).map((p) => p.configRel);
 
 // --- Behavioral resolution helpers (shared by the composition suite) ---------
 
@@ -199,6 +292,37 @@ const NETWORK_SNIPPET = [
   'globalThis.fetch();',
 ].join('\n');
 
+// Every module specifier the shared ban lists, probed individually. NETWORK_SNIPPET
+// only proves `no-restricted-imports` fires via `axios`, so a composition that
+// redeclared the rule and narrowed its module list — keeping the npm clients while
+// dropping the node builtins, or keeping the `node:` forms while dropping the bare
+// ones — would still pass it. The bare specifiers matter most: they are the
+// documented bypass the shared config lists both forms to close.
+const NETWORK_MODULE_PROBES = [
+  'node:http',
+  'http',
+  'node:https',
+  'https',
+  'node:http2',
+  'http2',
+  'node:net',
+  'net',
+  'node:dgram',
+  'dgram',
+  'node:tls',
+  'tls',
+  'node:dns',
+  'dns',
+  'node:dns/promises',
+  'dns/promises',
+  'axios',
+  'undici',
+  'got',
+  'node-fetch',
+  // A deep import into an npm client, closed by the `<client>/*` pattern ban.
+  'axios/lib/adapters/http.js',
+];
+
 const linter = new Linter();
 const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
 
@@ -211,15 +335,18 @@ const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
 const RESOLVE_TIMEOUT_MS = 120_000;
 
 /**
- * Resolve the effective config a package's real eslint.config.mjs produces for
- * `relFile`, and return just the four network rules from it. calculateConfigForFile
- * runs the full flat-config cascade without parsing the file, so it needs no
- * type information and the probe path need not exist.
+ * Resolve the effective config a package's real config produces for `relFile`,
+ * and return just the four network rules from it. calculateConfigForFile runs the
+ * full flat-config cascade without parsing the file, so it needs no type
+ * information and the probe path need not exist. Passing `configName` explicitly
+ * is what `--no-config-lookup -c eslint.scripts.config.mjs` does in the lint
+ * script: resolve against that config alone.
  * @param {string} pkgDir absolute package directory
  * @param {string} relFile path within the package to resolve config for
+ * @param {string} configName the config file to resolve against
  */
-async function resolveNetworkRules(pkgDir, relFile) {
-  const eslint = new ESLint({ cwd: pkgDir, overrideConfigFile: join(pkgDir, 'eslint.config.mjs') });
+async function resolveNetworkRules(pkgDir, relFile, configName = 'eslint.config.mjs') {
+  const eslint = new ESLint({ cwd: pkgDir, overrideConfigFile: join(pkgDir, configName) });
   const config = await eslint.calculateConfigForFile(join(pkgDir, relFile));
   return Object.fromEntries(KEYS.map((k) => [k, config.rules?.[k]]));
 }
@@ -229,38 +356,51 @@ function firedRuleIds(code, rules) {
   return new Set(linter.verify(code, { languageOptions: LANG, rules }).map((m) => m.ruleId));
 }
 
-// The source directories a package may ship code under, most-specific first.
-const SOURCE_DIRS = /** @type {const} */ (['src', 'app']);
+const importOf = (specifier) => `import probe from ${JSON.stringify(specifier)};`;
 
-/**
- * A probe file path under the directory a package actually ships code in, so the
- * behavioral resolution exercises the config where its `files`-scoped blocks
- * apply. web-ui ships `app/` (no `src/`), so a hardcoded `src/` probe would
- * resolve a path web-ui never lints — the very last-wins/path-scoping mistake
- * this suite exists to catch. The file need not exist (config is computed, not
- * parsed); fall back to `src/` for the source-less case.
- * @param {string} pkgDir absolute package directory
- */
-function probeRelPath(pkgDir) {
-  const dir = SOURCE_DIRS.find((d) => existsSync(join(pkgDir, d))) ?? 'src';
-  return `${dir}/__network_ban_probe__.ts`;
-}
+// Every (config, path) pair the behavioral suite resolves. A package is probed in
+// EVERY source dir it ships, not just the first match: web-ui ships app/ and no
+// src/, and a package could ship both, so picking one dir would leave a
+// path-scoped block unexercised — the last-wins mistake this suite exists to
+// catch. Packages with a scripts/ dir contribute their scripts config too.
+const PROBE_TARGETS = GUARDED_PACKAGES.flatMap((p) => {
+  const targets = p.hasConfig
+    ? (p.sourceDirs.length ? p.sourceDirs : ['src']).map((d) => ({
+        id: `${p.configRel} @ ${d}/`,
+        pkgDir: join(REPO_ROOT, p.dir),
+        configName: 'eslint.config.mjs',
+        relFile: `${d}/__network_ban_probe__.ts`,
+      }))
+    : [];
+  if (p.hasScriptsConfig) {
+    targets.push({
+      id: `${p.scriptsConfigRel} @ scripts/`,
+      pkgDir: join(REPO_ROOT, p.dir),
+      configName: 'eslint.scripts.config.mjs',
+      relFile: 'scripts/__network_ban_probe__.mjs',
+    });
+  }
+  return targets;
+});
 
-// --- Structural guard: every package ships a network-guarded config (#50) -----
+// --- Structural guard: every package ships a network-guarded config ----------
 
-describe('every workspace package ships a network-guarded eslint config (#50)', () => {
+describe('every workspace package ships a network-guarded eslint config', () => {
   it('enumerates exactly the expected workspace packages (drift guard)', () => {
-    // Pinned as an EXACT set, not a `>=` floor: a hand-rolled pnpm-workspace.yaml
-    // parse that silently dropped one package would clear a floor AND the
-    // behavioral CONFIG_FILES===GUARDED equality (both derive from the same parse
-    // and drop it together), so that package would ship UNGUARDED with CI green —
-    // the exact failure this file exists to prevent, through its least-tested
-    // code. The explicit `workspaceGlobs()` check keeps the failure legible when
-    // the parser is the culprit (empty ⇒ manifest reformatted / flow-style).
+    // The explicit `workspaceGlobs()` check keeps the failure legible when the
+    // parser is the culprit (empty ⇒ manifest reformatted / flow-style).
     expect(workspaceGlobs().length, 'pnpm-workspace.yaml parsed to zero globs').toBeGreaterThan(0);
-    expect([...WORKSPACE_PACKAGES.map((p) => p.name)].sort()).toEqual(
-      [...EXPECTED_WORKSPACE_PACKAGE_NAMES].sort(),
-    );
+    const found = [...WORKSPACE_PACKAGES.map((p) => p.name)].sort();
+    const expected = [...EXPECTED_WORKSPACE_PACKAGE_NAMES].sort();
+    expect(
+      found,
+      'The set of workspace packages changed. If a package was added or renamed, update ' +
+        'EXPECTED_WORKSPACE_PACKAGE_NAMES here AND make sure the package ships an ' +
+        'eslint.config.mjs extending @akasecurity/eslint-config plus a `lint` script that runs ' +
+        'eslint over its source dirs (see CLAUDE.md "Adding a new workspace package"). If nothing ' +
+        'was added, the pnpm-workspace.yaml parse has regressed and packages are silently missing ' +
+        'from the guard.',
+    ).toEqual(expected);
   });
 
   it('no guarded package is missing its eslint.config.mjs', () => {
@@ -288,13 +428,49 @@ describe('every workspace package ships a network-guarded eslint config (#50)', 
         : undefined,
     ).toEqual([]);
   });
+
+  it('every guarded package has a lint script that runs eslint over its source dirs', () => {
+    const { lintNotWired } = configViolations(GUARDED_PACKAGES);
+    expect(
+      lintNotWired,
+      lintNotWired.length
+        ? 'A config file only enforces the ban if eslint is pointed at the package. `pnpm lint` is ' +
+            '`turbo run lint`, which SKIPS a package with no `lint` script (exit 0, "No tasks were ' +
+            'executed"), so these packages ship an unenforced config. Add a `lint` script that runs ' +
+            `eslint over every source dir the package ships:\n  ${lintNotWired.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+  });
+
+  it('every package with a scripts/ dir ships a network-guarded scripts config', () => {
+    const { missingScriptsConfig, scriptsNotExtending } = configViolations(GUARDED_PACKAGES);
+    expect(
+      missingScriptsConfig,
+      missingScriptsConfig.length
+        ? 'These packages have a scripts/ dir that `eslint src test` never reaches, and no ' +
+            'eslint.scripts.config.mjs to cover it — so their dev/CI scripts are unguarded for ' +
+            'network calls. Add one (see cli/eslint.scripts.config.mjs) and a second lint pass: ' +
+            `eslint --no-config-lookup -c eslint.scripts.config.mjs scripts:\n  ${missingScriptsConfig.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+    expect(
+      scriptsNotExtending,
+      scriptsNotExtending.length
+        ? 'These eslint.scripts.config.mjs files never import @akasecurity/eslint-config, so they ' +
+            `do not wire the shared network guard (spread ...networkGuard):\n  ${scriptsNotExtending.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+  });
 });
 
 describe('CONFIG_OPT_OUT hygiene', () => {
   const names = new Set(WORKSPACE_PACKAGES.map((p) => p.name));
 
-  it.each(CONFIG_OPT_OUT)('$name is a real workspace package (no stale opt-out)', ({ name }) => {
+  it.each(CONFIG_OPT_OUT)('$name is a real workspace package with a reason', ({ name, reason }) => {
     expect(names).toContain(name);
+    // The reason is the whole point of the list — an entry without one is an
+    // undocumented hole in the no-network enforcement.
+    expect(reason?.trim(), `${name} has no reason`).toBeTruthy();
   });
 
   it('stays minimal — only @akasecurity/eslint-config is exempt today', () => {
@@ -307,39 +483,110 @@ describe('CONFIG_OPT_OUT hygiene', () => {
 
 describe('configViolations (the guard mechanism, tested on synthetic packages)', () => {
   // The real tree is healthy, so the failure paths above never execute against
-  // it. Exercise them directly to prove the guard fails LOUDLY and NAMES the
-  // offending package — the second acceptance criterion of #50.
+  // it. Exercise them directly to prove the guard fails LOUDLY and NAMES every
+  // offending package.
+  /** @param {object} over */
+  const pkg = (over) => ({
+    name: '@akasecurity/newpkg',
+    dir: 'packages/newpkg',
+    label: '@akasecurity/newpkg (packages/newpkg)',
+    lintScript: 'eslint src test',
+    hasConfig: true,
+    extendsShared: true,
+    sourceDirs: ['src'],
+    lintTargetDirs: ['src', 'test'],
+    hasScriptsDir: false,
+    hasScriptsConfig: false,
+    scriptsExtendsShared: false,
+    ...over,
+  });
+
   it('names a package that ships no config', () => {
-    const v = configViolations([
-      { name: '@akasecurity/newpkg', hasConfig: false, extendsShared: false },
-    ]);
-    expect(v.missing).toEqual(['@akasecurity/newpkg']);
+    const v = configViolations([pkg({ hasConfig: false, extendsShared: false })]);
+    expect(v.missing).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
     expect(v.notExtending).toEqual([]);
   });
 
   it('names a package whose config does not extend the shared config', () => {
-    const v = configViolations([
-      { name: '@akasecurity/newpkg', hasConfig: true, extendsShared: false },
-    ]);
-    expect(v.notExtending).toEqual(['@akasecurity/newpkg']);
+    const v = configViolations([pkg({ extendsShared: false })]);
+    expect(v.notExtending).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
     expect(v.missing).toEqual([]);
   });
 
-  it('clears a package that ships a config extending the shared config', () => {
-    const v = configViolations([{ name: '@akasecurity/ok', hasConfig: true, extendsShared: true }]);
-    expect(v.missing).toEqual([]);
-    expect(v.notExtending).toEqual([]);
+  it('names a package with no lint script (turbo would skip it silently)', () => {
+    const v = configViolations([pkg({ lintScript: '' })]);
+    expect(v.lintNotWired).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
+  });
+
+  it('names a package whose lint script does not invoke eslint', () => {
+    const v = configViolations([pkg({ lintScript: "echo 'no self-lint'" })]);
+    expect(v.lintNotWired).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
+  });
+
+  it('names a package with a scripts/ dir and no scripts config', () => {
+    const v = configViolations([pkg({ hasScriptsDir: true, hasScriptsConfig: false })]);
+    expect(v.missingScriptsConfig).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
+  });
+
+  it('names a scripts config that does not extend the shared config', () => {
+    const v = configViolations([
+      pkg({ hasScriptsDir: true, hasScriptsConfig: true, scriptsExtendsShared: false }),
+    ]);
+    expect(v.scriptsNotExtending).toEqual(['@akasecurity/newpkg (packages/newpkg)']);
+  });
+
+  it('falls back to the directory when package.json omits a name', () => {
+    const v = configViolations([
+      pkg({ name: 'packages/anon', label: 'packages/anon', hasConfig: false }),
+    ]);
+    expect(v.missing).toEqual(['packages/anon']);
+  });
+
+  it('clears a healthy package', () => {
+    const v = configViolations([pkg({})]);
+    expect(v).toEqual({
+      missing: [],
+      notExtending: [],
+      lintNotWired: [],
+      missingScriptsConfig: [],
+      scriptsNotExtending: [],
+    });
   });
 
   it('reports every offender in a mixed set (fails loudly, not on the first)', () => {
     const v = configViolations([
-      { name: '@akasecurity/a', hasConfig: false, extendsShared: false },
-      { name: '@akasecurity/b', hasConfig: true, extendsShared: true },
-      { name: '@akasecurity/c', hasConfig: true, extendsShared: false },
-      { name: '@akasecurity/d', hasConfig: false, extendsShared: false },
+      pkg({ name: 'a', label: 'a', hasConfig: false, extendsShared: false }),
+      pkg({ name: 'b', label: 'b' }),
+      pkg({ name: 'c', label: 'c', extendsShared: false }),
+      pkg({ name: 'd', label: 'd', hasConfig: false, extendsShared: false }),
     ]);
-    expect(v.missing).toEqual(['@akasecurity/a', '@akasecurity/d']);
-    expect(v.notExtending).toEqual(['@akasecurity/c']);
+    expect(v.missing).toEqual(['a', 'd']);
+    expect(v.notExtending).toEqual(['c']);
+  });
+});
+
+describe('the config-file checks (tested on synthetic source)', () => {
+  it('does not mistake a commented-out import for extending the shared config', () => {
+    const commented = "// import { base } from '@akasecurity/eslint-config';\nexport default [];\n";
+    expect(IMPORTS_SHARED_CONFIG.test(stripComments(commented))).toBe(false);
+    const blockCommented =
+      "/* import { base } from '@akasecurity/eslint-config'; */\nexport default [];\n";
+    expect(IMPORTS_SHARED_CONFIG.test(stripComments(blockCommented))).toBe(false);
+  });
+
+  it('still recognises a live import (root entry, /react sub-entry, require)', () => {
+    for (const src of [
+      "import { base } from '@akasecurity/eslint-config';",
+      "import { react } from '@akasecurity/eslint-config/react';",
+      "const { base } = require('@akasecurity/eslint-config');",
+    ]) {
+      expect(IMPORTS_SHARED_CONFIG.test(stripComments(src)), src).toBe(true);
+    }
+  });
+
+  it('does not strip a URL inside a live import', () => {
+    const src = "import { base } from '@akasecurity/eslint-config'; // see https://example.com";
+    expect(IMPORTS_SHARED_CONFIG.test(stripComments(src))).toBe(true);
   });
 });
 
@@ -389,6 +636,15 @@ describe('parseWorkspaceGlobs (the manifest parser, tested on synthetic YAML)', 
     expect(parseWorkspaceGlobs(reordered)).toEqual(['packages/*']);
   });
 
+  it('throws on an exclusion glob rather than silently over-including', () => {
+    // globSync treats `!packages/legacy` as a literal pattern matching nothing,
+    // so the excluded dir would stay in the enumeration and surface as a
+    // confusing EXPECTED_WORKSPACE_PACKAGE_NAMES diff.
+    expect(() =>
+      parseWorkspaceGlobs("packages:\n  - 'packages/*'\n  - '!packages/legacy'\n"),
+    ).toThrow(/exclusion glob/);
+  });
+
   it('returns [] for flow style rather than silently mis-parsing (vacuous-pass guard then trips)', () => {
     expect(parseWorkspaceGlobs("packages: ['packages/*', 'cli']\n")).toEqual([]);
   });
@@ -400,53 +656,38 @@ describe('parseWorkspaceGlobs (the manifest parser, tested on synthetic YAML)', 
 
 // --- Behavioral guard: each config actually enforces the ban -----------------
 
-// A representative sample of the Node core network builtins the ban must cover.
-// NETWORK_SNIPPET proves `no-restricted-imports` fires via the `axios` npm client
-// only — a config that redeclared the rule and kept `axios` while dropping the
-// `node:*` modules would still pass that check. Probing these directly asserts
-// the denylist stays COMPLETE through per-package composition, not just that the
-// rule fires on something. `node:net` is excluded: cli opts it out in dashboard.ts.
-const NETWORK_CORE_MODULES = ['node:http', 'node:https', 'node:dgram', 'node:tls'];
-
 describe('effective per-package config (composition / last-wins)', () => {
-  /** @type {Map<string, Record<string, import('eslint').Linter.RuleEntry>>} configRel -> resolved network rules */
-  const rulesByConfig = new Map();
+  /** @type {Map<string, Record<string, import('eslint').Linter.RuleEntry>>} */
+  const rulesById = new Map();
 
   beforeAll(async () => {
-    for (const configRel of CONFIG_FILES) {
-      const pkgDir = join(REPO_ROOT, dirname(configRel));
-      // Probe at a path the package actually ships code under (web-ui uses app/),
-      // so a config that scopes the ban to its real source dir is exercised. The
-      // path need not exist — config is computed, not parsed.
-      rulesByConfig.set(configRel, await resolveNetworkRules(pkgDir, probeRelPath(pkgDir)));
+    for (const t of PROBE_TARGETS) {
+      rulesById.set(t.id, await resolveNetworkRules(t.pkgDir, t.relFile, t.configName));
     }
   }, RESOLVE_TIMEOUT_MS);
 
-  it('resolved a config for every guarded package (no behavioral gap)', () => {
-    // The structural guard guarantees every guarded package ships a config;
-    // pin that the behavioral suite actually resolved one for each, so a package
-    // can never be present-but-unverified.
-    expect(CONFIG_FILES.length).toBe(GUARDED_PACKAGES.length);
+  it('resolved rules for every probe target (no behavioral gap)', () => {
+    // Asserts the thing that can genuinely be short: a resolution that threw or
+    // was skipped leaves the map smaller than the target list.
+    expect(rulesById.size).toBe(PROBE_TARGETS.length);
+    expect(PROBE_TARGETS.length).toBeGreaterThanOrEqual(GUARDED_PACKAGES.length);
   });
 
-  it.each(CONFIG_FILES)('bans every network form in %s', (configRel) => {
-    const fired = firedRuleIds(NETWORK_SNIPPET, rulesByConfig.get(configRel));
+  it.each(PROBE_TARGETS.map((t) => t.id))('bans every network form in %s', (id) => {
+    const fired = firedRuleIds(NETWORK_SNIPPET, rulesById.get(id));
     for (const key of KEYS) {
-      expect(fired, `${configRel} :: ${key}`).toContain(key);
+      expect(fired, `${id} :: ${key}`).toContain(key);
     }
   });
 
-  it.each(CONFIG_FILES)(
-    'bans the node:* core network modules in %s (denylist stays complete)',
-    (configRel) => {
-      const rules = rulesByConfig.get(configRel);
-      for (const mod of NETWORK_CORE_MODULES) {
-        expect(firedRuleIds(`import m from '${mod}';`, rules), `${configRel} :: ${mod}`).toContain(
-          'no-restricted-imports',
-        );
-      }
-    },
-  );
+  it.each(PROBE_TARGETS.map((t) => t.id))('bans every listed module in %s', (id) => {
+    const rules = rulesById.get(id);
+    for (const mod of NETWORK_MODULE_PROBES) {
+      expect(firedRuleIds(importOf(mod), rules), `${id} :: ${mod}`).toContain(
+        'no-restricted-imports',
+      );
+    }
+  });
 });
 
 describe('cli dashboard.ts file-scoped opt-out (real config)', () => {
@@ -478,6 +719,33 @@ describe('cli dashboard.ts file-scoped opt-out (real config)', () => {
 
   it('does NOT leak the node:net opt-out to other cli files', () => {
     expect(firedRuleIds("import { createServer } from 'node:net';", resolved.otherFile)).toContain(
+      'no-restricted-imports',
+    );
+  });
+});
+
+describe('cli scripts-config file-scoped opt-out (real config)', () => {
+  const cliDir = join(REPO_ROOT, 'cli');
+  const CONFIG = 'eslint.scripts.config.mjs';
+  const resolved = { smoke: undefined, otherScript: undefined };
+
+  beforeAll(async () => {
+    resolved.smoke = await resolveNetworkRules(cliDir, 'scripts/smoke-dashboard.mjs', CONFIG);
+    resolved.otherScript = await resolveNetworkRules(cliDir, 'scripts/__other__.mjs', CONFIG);
+  }, RESOLVE_TIMEOUT_MS);
+
+  it('allows node:http in smoke-dashboard.mjs (the loopback health check)', () => {
+    expect(firedRuleIds(importOf('node:http'), resolved.smoke).size).toBe(0);
+    expect(firedRuleIds("await import('node:http');", resolved.smoke).size).toBe(0);
+  });
+
+  it('still bans every OTHER network module in smoke-dashboard.mjs', () => {
+    expect(firedRuleIds(importOf('node:https'), resolved.smoke)).toContain('no-restricted-imports');
+    expect(firedRuleIds("fetch('/x');", resolved.smoke)).toContain('no-restricted-globals');
+  });
+
+  it('does NOT leak the node:http opt-out to other cli scripts', () => {
+    expect(firedRuleIds(importOf('node:http'), resolved.otherScript)).toContain(
       'no-restricted-imports',
     );
   });

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -442,10 +442,33 @@ const RESOLVE_TIMEOUT_MS = 120_000;
  * @param {string} relFile path within the package to resolve config for
  * @param {string} configName the config file to resolve against
  */
-async function resolveNetworkRules(pkgDir, relFile, configName = 'eslint.config.mjs') {
+async function resolveConfig(pkgDir, relFile, configName = 'eslint.config.mjs') {
   const eslint = new ESLint({ cwd: pkgDir, overrideConfigFile: join(pkgDir, configName) });
   const config = await eslint.calculateConfigForFile(join(pkgDir, relFile));
-  return Object.fromEntries(KEYS.map((k) => [k, config.rules?.[k]]));
+  if (!config) {
+    // calculateConfigForFile yields undefined when no block matches the path —
+    // the "imports the shared config but never spreads it" case. Reported as
+    // that, rather than crashing the suite on a property of undefined.
+    throw new Error(
+      'ESLint resolved no config block for this path. The config most likely imports ' +
+        '@akasecurity/eslint-config without spreading it (…base / …react / …networkGuard).',
+    );
+  }
+  return config;
+}
+
+/** Just the four network rules out of a resolved config. */
+const networkRulesOf = (config) => Object.fromEntries(KEYS.map((k) => [k, config?.rules?.[k]]));
+
+/** A rule's resolved severity, normalized out of the `[severity, …options]` form. */
+const severityOf = (config, ruleId) => {
+  const entry = config?.rules?.[ruleId];
+  return Array.isArray(entry) ? entry[0] : entry;
+};
+
+/** Resolve a config and return only its four network rules. */
+async function resolveNetworkRules(pkgDir, relFile, configName = 'eslint.config.mjs') {
+  return networkRulesOf(await resolveConfig(pkgDir, relFile, configName));
 }
 
 /** Which network rule ids fire when `code` is linted with `rules`. */
@@ -825,31 +848,59 @@ describe('parseWorkspaceGlobs (the manifest parser, tested on synthetic YAML)', 
 // --- Behavioral guard: each config actually enforces the ban -----------------
 
 describe('effective per-package config (composition / last-wins)', () => {
-  /** @type {Map<string, Record<string, import('eslint').Linter.RuleEntry>>} */
-  const rulesById = new Map();
+  /** @type {Map<string, import('eslint').Linter.Config>} */
+  const configById = new Map();
+  /** @type {Map<string, Error>} */
+  const failureById = new Map();
 
+  // Each resolution is caught PER TARGET. An uncaught throw here would abort
+  // beforeAll, and vitest then SKIPS every test in this describe — reporting
+  // zero failures, naming no package, and silently dropping the behavioral
+  // verification of the whole workspace. Capturing lets the assertion below
+  // report which target failed and why.
   beforeAll(async () => {
     for (const t of PROBE_TARGETS) {
-      rulesById.set(t.id, await resolveNetworkRules(t.pkgDir, t.relFile, t.configName));
+      try {
+        configById.set(t.id, await resolveConfig(t.pkgDir, t.relFile, t.configName));
+      } catch (cause) {
+        failureById.set(t.id, /** @type {Error} */ (cause));
+      }
     }
   }, RESOLVE_TIMEOUT_MS);
 
-  it('resolved rules for every probe target (no behavioral gap)', () => {
-    // Asserts the thing that can genuinely be short: a resolution that threw or
-    // was skipped leaves the map smaller than the target list.
-    expect(rulesById.size).toBe(PROBE_TARGETS.length);
+  it('probes at least one target per guarded package', () => {
     expect(PROBE_TARGETS.length).toBeGreaterThanOrEqual(GUARDED_PACKAGES.length);
   });
 
+  it.each(PROBE_TARGETS.map((t) => t.id))('resolves an effective config for %s', (id) => {
+    expect(failureById.get(id)?.message, `${id} did not resolve`).toBeUndefined();
+  });
+
   it.each(PROBE_TARGETS.map((t) => t.id))('bans every network form in %s', (id) => {
-    const fired = firedRuleIds(NETWORK_SNIPPET, rulesById.get(id));
+    const fired = firedRuleIds(NETWORK_SNIPPET, networkRulesOf(configById.get(id)));
     for (const key of KEYS) {
       expect(fired, `${id} :: ${key}`).toContain(key);
     }
   });
 
+  // The workspace ban has two halves: the network rules above and
+  // `n/no-process-env`, which CLAUDE.md pins to an exact table of opt-out sites.
+  // Without this, a package could switch the rule off in its own config and add
+  // an unreviewed fifth site while every other assertion here stayed green.
+  // Asserted as a resolved severity rather than by adding it to KEYS, because
+  // the standalone Linter has no `n` plugin registered and cannot run the rule.
+  // Main configs only: networkGuard (the scripts pass) deliberately omits it.
+  it.each(PROBE_TARGETS.filter((t) => t.configName === 'eslint.config.mjs').map((t) => t.id))(
+    'keeps n/no-process-env at error in %s',
+    (id) => {
+      expect([2, 'error'], `${id} :: n/no-process-env`).toContain(
+        severityOf(configById.get(id), 'n/no-process-env'),
+      );
+    },
+  );
+
   it.each(PROBE_TARGETS.map((t) => t.id))('bans every listed module in %s', (id) => {
-    const rules = rulesById.get(id);
+    const rules = networkRulesOf(configById.get(id));
     for (const mod of NETWORK_MODULE_PROBES) {
       expect(firedRuleIds(importOf(mod), rules), `${id} :: ${mod}`).toContain(
         'no-restricted-imports',

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,22 +1,134 @@
-import { existsSync, globSync } from 'node:fs';
+import { existsSync, globSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { ESLint, Linter } from 'eslint';
 import { beforeAll, describe, expect, it } from 'vitest';
 
-// These tests exercise the ASSEMBLED per-package configs on disk — not the
-// exported building blocks (base / noEnterpriseImports / the helpers) that
-// no-network.test.js covers in isolation. Flat config resolves "last wins":
-// the final block matching a file overrides earlier ones for a given rule, and
-// no-restricted-imports never merges across blocks. So a package that layers a
-// second config on top of base (web-ui: react + noEnterpriseImports; persistence
-// / local-ops: base + noEnterpriseImports; cli: base + the dashboard opt-out)
-// could silently drop a network ban with the unit suite still green. Here we
-// resolve each real eslint.config.mjs through ESLint itself and assert the ban
-// still fires on real code — the composition, not the components.
+// This file guards the per-package ESLint configs two ways.
+//
+//  1. STRUCTURAL (the `#50` block): every workspace package — enumerated from
+//     pnpm-workspace.yaml, not a hand-maintained glob — must ship an
+//     eslint.config.mjs that extends `@akasecurity/eslint-config`, unless it is
+//     on an explicit, reasoned opt-out list. A package with NO config at all is
+//     invisible to `pnpm lint` (nothing points ESLint at it) AND to a glob that
+//     only ever matched existing config files, so it would ship UNGUARDED for
+//     network calls with CI green. The floor assertion alone cannot catch a
+//     package that was never in the glob's universe — this block can.
+//
+//  2. BEHAVIORAL (the composition / last-wins block): resolve each real
+//     eslint.config.mjs through ESLint and assert the four network rules still
+//     fire on real code. Flat config resolves "last wins": the final block
+//     matching a file overrides earlier ones for a given rule, and
+//     no-restricted-imports never merges across blocks. So a package that layers
+//     a second config on top of base (web-ui: react + noEnterpriseImports;
+//     persistence / local-ops: base + noEnterpriseImports; cli: base + the
+//     dashboard opt-out) could silently drop a network ban with the unit suite
+//     still green. Here we assert the composition, not the components.
+//
+// The two compose into a closed loop: (1) guarantees every package ships a
+// config, (2) is fed the same derived list and proves each config enforces the
+// ban. A new package that forgets its config fails (1); one whose config fails
+// to wire the ban fails (2).
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+// --- Workspace package enumeration (derived from pnpm-workspace.yaml) --------
+
+// Packages exempt from shipping a network-guarded eslint.config.mjs, keyed by
+// package name. Keep this list TINY — every entry is a hole in the no-network
+// enforcement and must be a deliberate, reviewed decision, so each carries its
+// reason. A package that ships lintable source belongs behind the ban, not here.
+const CONFIG_OPT_OUT = [
+  {
+    name: '@akasecurity/eslint-config',
+    reason:
+      'Defines the shared config; it cannot extend itself, and its own `lint` script is a no-op.',
+  },
+];
+const OPT_OUT_NAMES = new Set(CONFIG_OPT_OUT.map((o) => o.name));
+
+// "Extends `@akasecurity/eslint-config`" = imports it (the root entry or the
+// `/react` sub-entry) via `import ... from` or `require(...)`. This is the fast,
+// readable statement of intent for the acceptance criterion; the BEHAVIORAL
+// suite below is what actually proves the import wires all four network rules,
+// so a config that imports the package but forgets to spread `...base` is caught
+// there, not here.
+const IMPORTS_SHARED_CONFIG =
+  /(?:import[^;]*from[ \t]*|require\([ \t]*)['"]@akasecurity\/eslint-config(?:\/[\w.-]+)?['"]/;
+
+/**
+ * The package globs declared under `packages:` in pnpm-workspace.yaml. Parsed
+ * without a YAML dependency: capture the `packages:` line plus the consecutive
+ * indented `- …` sequence entries that follow it (stopping at the next key that
+ * starts in column 0), then pull each quoted-or-bare scalar.
+ * @returns {string[]}
+ */
+function workspaceGlobs() {
+  // Normalize CRLF → LF up front: the block/scalar regexes anchor on `\n`, and a
+  // Windows checkout (core.autocrlf) would otherwise capture a trailing `\r` into
+  // each glob and break globSync.
+  const raw = readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8').replace(/\r\n/g, '\n');
+  const block = raw.match(/^packages:[ \t]*\n((?:[ \t]+-.*\n?)+)/m)?.[1] ?? '';
+  return [...block.matchAll(/^[ \t]+-[ \t]*['"]?([^'"\n#]+?)['"]?[ \t]*$/gm)].map((m) => m[1]);
+}
+
+/**
+ * Every workspace package on disk, resolved from pnpm-workspace.yaml exactly as
+ * pnpm does: expand each glob, keep the directories that hold a package.json.
+ * @returns {{ name: string, dir: string, configRel: string, hasConfig: boolean, extendsShared: boolean }[]}
+ */
+function discoverWorkspacePackages() {
+  const dirs = [
+    ...new Set(
+      workspaceGlobs()
+        .flatMap((g) => globSync(g, { cwd: REPO_ROOT }))
+        .filter((rel) => existsSync(join(REPO_ROOT, rel, 'package.json'))),
+    ),
+  ].sort();
+  return dirs.map((dir) => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, dir, 'package.json'), 'utf8'));
+    const configRel = join(dir, 'eslint.config.mjs');
+    const configAbs = join(REPO_ROOT, configRel);
+    const hasConfig = existsSync(configAbs);
+    return {
+      name: pkg.name,
+      dir,
+      configRel,
+      hasConfig,
+      extendsShared: hasConfig && IMPORTS_SHARED_CONFIG.test(readFileSync(configAbs, 'utf8')),
+    };
+  });
+}
+
+const WORKSPACE_PACKAGES = discoverWorkspacePackages();
+
+// The packages that MUST ship a network-guarded config (everything except the
+// opt-outs). Fed to both the structural guard and the behavioral suite.
+const GUARDED_PACKAGES = WORKSPACE_PACKAGES.filter((p) => !OPT_OUT_NAMES.has(p.name));
+
+/**
+ * Split the guarded packages by how they fail the config requirement. Pure over
+ * its input so the failure paths are testable with synthetic packages — a real,
+ * healthy tree produces none by construction.
+ * @param {{ name: string, hasConfig: boolean, extendsShared: boolean }[]} guarded
+ * @returns {{ missing: string[], notExtending: string[] }}
+ */
+function configViolations(guarded) {
+  return {
+    missing: guarded.filter((p) => !p.hasConfig).map((p) => p.name),
+    notExtending: guarded.filter((p) => p.hasConfig && !p.extendsShared).map((p) => p.name),
+  };
+}
+
+// The per-package configs the BEHAVIORAL suite resolves through ESLint. Derived
+// from the workspace enumeration (not a hand-maintained glob with `cli`/`web-ui`
+// spelled out) so a new package's config is behaviorally verified the moment it
+// is added — and the structural guard guarantees every guarded package
+// contributes exactly one entry here.
+const CONFIG_FILES = GUARDED_PACKAGES.filter((p) => p.hasConfig).map((p) => p.configRel);
+
+// --- Behavioral resolution helpers (shared by the composition suite) ---------
 
 const KEYS = /** @type {const} */ ([
   'no-restricted-globals',
@@ -36,19 +148,6 @@ const NETWORK_SNIPPET = [
 
 const linter = new Linter();
 const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
-
-// Every workspace glob from pnpm-workspace.yaml that can hold a package config.
-// Discovering them (rather than hard-coding a list) means a NEW package that
-// forgets to extend `base` fails this suite instead of slipping through
-// unlinted for network calls.
-const CONFIG_FILES = [
-  ...globSync('packages/*/eslint.config.mjs', { cwd: REPO_ROOT }),
-  ...globSync('plugins/*/eslint.config.mjs', { cwd: REPO_ROOT }),
-  ...globSync('tools/*/eslint.config.mjs', { cwd: REPO_ROOT }),
-  ...['cli/eslint.config.mjs', 'web-ui/eslint.config.mjs'].filter((p) =>
-    existsSync(join(REPO_ROOT, p)),
-  ),
-].sort();
 
 // Resolving a real config through ESLint (`new ESLint` + `calculateConfigForFile`)
 // is slow on a cold runner: the first call loads the whole typescript-eslint +
@@ -77,6 +176,115 @@ function firedRuleIds(code, rules) {
   return new Set(linter.verify(code, { languageOptions: LANG, rules }).map((m) => m.ruleId));
 }
 
+// --- Structural guard: every package ships a network-guarded config (#50) -----
+
+describe('every workspace package ships a network-guarded eslint config (#50)', () => {
+  it('discovered the workspace packages (guard against a vacuous pass)', () => {
+    // A broken pnpm-workspace.yaml parse would leave the enumeration empty and
+    // every assertion in this file would pass vacuously. 14 workspace packages
+    // exist today; 13 ship a config (all but @akasecurity/eslint-config).
+    expect(workspaceGlobs().length).toBeGreaterThan(0);
+    expect(WORKSPACE_PACKAGES.length).toBeGreaterThanOrEqual(12);
+    expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(11);
+  });
+
+  it('enumeration includes the non-packages/* roots (cli, web-ui, plugin)', () => {
+    // The gap this test removed was a hand-maintained list that spelled out
+    // `cli`/`web-ui` and globbed only three parent dirs. Pin that the derived
+    // enumeration reaches the roots outside `packages/*`, so a parser regression
+    // that dropped them fails here rather than silently under-covering.
+    const names = new Set(WORKSPACE_PACKAGES.map((p) => p.name));
+    for (const anchor of [
+      '@akasecurity/cli',
+      '@akasecurity/web-ui',
+      '@akasecurity/ai-tc-claude-code',
+    ]) {
+      expect(names, anchor).toContain(anchor);
+    }
+  });
+
+  it('no guarded package is missing its eslint.config.mjs', () => {
+    const { missing } = configViolations(GUARDED_PACKAGES);
+    expect(
+      missing,
+      missing.length
+        ? 'These workspace packages ship no eslint.config.mjs, so `pnpm lint` never points ESLint at ' +
+            'them and they would ship UNGUARDED for network calls with CI green. Add an ' +
+            'eslint.config.mjs extending @akasecurity/eslint-config (see any sibling package), or — ' +
+            'only if the package genuinely ships no self-lintable source — add it to CONFIG_OPT_OUT ' +
+            `with a reason:\n  ${missing.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+  });
+
+  it('every shipped config extends @akasecurity/eslint-config', () => {
+    const { notExtending } = configViolations(GUARDED_PACKAGES);
+    expect(
+      notExtending,
+      notExtending.length
+        ? 'These packages ship an eslint.config.mjs that never imports @akasecurity/eslint-config, ' +
+            'so the shared no-network ban is not wired in. Extend the shared config (spread ' +
+            `...base / ...noEnterpriseImports / ...react):\n  ${notExtending.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+  });
+});
+
+describe('CONFIG_OPT_OUT hygiene', () => {
+  const names = new Set(WORKSPACE_PACKAGES.map((p) => p.name));
+
+  it.each(CONFIG_OPT_OUT)('$name is a real workspace package (no stale opt-out)', ({ name }) => {
+    expect(names).toContain(name);
+  });
+
+  it('stays minimal — only @akasecurity/eslint-config is exempt today', () => {
+    // Hard-coded so ANY addition to the opt-out is a reviewed change here rather
+    // than a silent hole in the no-network enforcement (mirrors the ban-set
+    // drift guards in no-network.test.js).
+    expect(CONFIG_OPT_OUT.map((o) => o.name)).toEqual(['@akasecurity/eslint-config']);
+  });
+});
+
+describe('configViolations (the guard mechanism, tested on synthetic packages)', () => {
+  // The real tree is healthy, so the failure paths above never execute against
+  // it. Exercise them directly to prove the guard fails LOUDLY and NAMES the
+  // offending package — the second acceptance criterion of #50.
+  it('names a package that ships no config', () => {
+    const v = configViolations([
+      { name: '@akasecurity/newpkg', hasConfig: false, extendsShared: false },
+    ]);
+    expect(v.missing).toEqual(['@akasecurity/newpkg']);
+    expect(v.notExtending).toEqual([]);
+  });
+
+  it('names a package whose config does not extend the shared config', () => {
+    const v = configViolations([
+      { name: '@akasecurity/newpkg', hasConfig: true, extendsShared: false },
+    ]);
+    expect(v.notExtending).toEqual(['@akasecurity/newpkg']);
+    expect(v.missing).toEqual([]);
+  });
+
+  it('clears a package that ships a config extending the shared config', () => {
+    const v = configViolations([{ name: '@akasecurity/ok', hasConfig: true, extendsShared: true }]);
+    expect(v.missing).toEqual([]);
+    expect(v.notExtending).toEqual([]);
+  });
+
+  it('reports every offender in a mixed set (fails loudly, not on the first)', () => {
+    const v = configViolations([
+      { name: '@akasecurity/a', hasConfig: false, extendsShared: false },
+      { name: '@akasecurity/b', hasConfig: true, extendsShared: true },
+      { name: '@akasecurity/c', hasConfig: true, extendsShared: false },
+      { name: '@akasecurity/d', hasConfig: false, extendsShared: false },
+    ]);
+    expect(v.missing).toEqual(['@akasecurity/a', '@akasecurity/d']);
+    expect(v.notExtending).toEqual(['@akasecurity/c']);
+  });
+});
+
+// --- Behavioral guard: each config actually enforces the ban -----------------
+
 describe('effective per-package config (composition / last-wins)', () => {
   /** @type {Map<string, Set<string>>} configRel -> rule ids the snippet trips */
   const firedByConfig = new Map();
@@ -91,11 +299,11 @@ describe('effective per-package config (composition / last-wins)', () => {
     }
   }, RESOLVE_TIMEOUT_MS);
 
-  it('discovered the workspace package configs (guard against a vacuous pass)', () => {
-    // A broken glob would leave it.each empty and every enforcement test would
-    // silently not run. Pin the floor: 11 packages ship an eslint.config.mjs
-    // today (all of packages/* except eslint-config, plus cli, web-ui, plugin).
-    expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(11);
+  it('resolved a config for every guarded package (no behavioral gap)', () => {
+    // The structural guard guarantees every guarded package ships a config;
+    // pin that the behavioral suite actually resolved one for each, so a package
+    // can never be present-but-unverified.
+    expect(CONFIG_FILES.length).toBe(GUARDED_PACKAGES.length);
   });
 
   it.each(CONFIG_FILES)('bans every network form in %s', (configRel) => {

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -10,13 +10,15 @@ import { beforeAll, describe, expect, it } from 'vitest';
 //
 //  1. STRUCTURAL: every workspace package — enumerated from pnpm-workspace.yaml,
 //     not a hand-maintained glob — must ship an eslint.config.mjs that extends
-//     `@akasecurity/eslint-config`, must have a `lint` script that actually runs
-//     eslint over its source dirs, and must ship an eslint.scripts.config.mjs if
-//     it has a scripts/ dir. A package missing any of these is invisible to
-//     `pnpm lint` and to a glob that only ever matched existing config files, so
-//     it would ship UNGUARDED for network calls with CI green. Enumerating from
-//     the manifest and pinning the result as an EXACT set catches a package that
-//     was never in a config glob's universe.
+//     `@akasecurity/eslint-config`, must have a `lint` script that points eslint
+//     at every directory it ships code in, and must ship an
+//     eslint.scripts.config.mjs if it ships a scripts/ dir. A package missing any
+//     of these is invisible to `pnpm lint` and to a glob that only ever matched
+//     existing config files, so it would ship UNGUARDED for network calls with CI
+//     green. Both the package set and each package's code directories are DERIVED
+//     (from the manifest and from git-tracked lintable files), so a new package —
+//     or an existing one growing a new source dir — cannot fall outside the guard
+//     without the pinned expectations failing loudly.
 //
 //  2. BEHAVIORAL: resolve each real config through ESLint and assert the network
 //     rules still fire on real code. Flat config resolves "last wins": the final
@@ -50,24 +52,30 @@ const CONFIG_OPT_OUT = [
 ];
 const OPT_OUT_NAMES = new Set(CONFIG_OPT_OUT.map((o) => o.name));
 
-// Directories a package may ship lintable code under. Used both to pick the
-// behavioral probe paths and to check the `lint` script names every one of them.
-const SOURCE_DIRS = /** @type {const} */ (['src', 'app']);
-const LINT_TARGET_DIRS = /** @type {const} */ (['src', 'app', 'test']);
+// The extensions ESLint actually lints here. This is what separates a code
+// directory from a data one: packages/schema/drizzle holds only .sql/.json
+// migrations, so there is nothing there for the ban to guard, while
+// plugins/claude-code/eval ships a real .ts file and belongs behind it.
+const LINTABLE_EXT = /\.[cm]?[jt]sx?$/;
 
-// Every path git tracks, used to tell hand-written source from build output. A
-// scripts/ dir on disk is not necessarily source: the plugin's build emits its
-// bundled hooks to scripts/ (declared in turbo.json `build.outputs` and ignored
+// Which directories hold code is DERIVED per package, never hardcoded. A fixed
+// ['src', 'app', 'test'] list would be the same hand-maintained hole this file
+// exists to close, one level down: a package putting source in lib/ or eval/
+// would clear every assertion below while shipping unguarded. Tracked-ness is
+// also what separates source from build output — the plugin's build emits
+// bundled hooks into scripts/ (declared in turbo.json `build.outputs`, ignored
 // by git), and demanding a lint config for generated bundles would be wrong.
-// Tracked-ness is the only reliable signal here, so this meta-test asks git
-// rather than guessing from the directory listing.
-const TRACKED_FILES = (() => {
+//
+// Indexed once as parent dir -> immediate child dirs holding a lintable tracked
+// file at any depth, so each lookup is O(1) instead of a scan over every path.
+const LINTABLE_CHILD_DIRS = (() => {
+  let tracked;
   try {
-    return new Set(
-      execFileSync('git', ['ls-files'], { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 << 20 })
-        .split('\n')
-        .filter(Boolean),
-    );
+    tracked = execFileSync('git', ['ls-files'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 << 20,
+    }).split('\n');
   } catch (cause) {
     throw new Error(
       'Could not list tracked files with `git ls-files`. This suite audits the real workspace ' +
@@ -75,14 +83,28 @@ const TRACKED_FILES = (() => {
       { cause },
     );
   }
+  /** @type {Map<string, Set<string>>} */
+  const index = new Map();
+  for (const file of tracked) {
+    if (!file || !LINTABLE_EXT.test(file)) continue;
+    const parts = file.split('/');
+    for (let i = 0; i < parts.length - 1; i++) {
+      const parent = parts.slice(0, i).join('/');
+      let children = index.get(parent);
+      if (!children) index.set(parent, (children = new Set()));
+      children.add(parts[i]);
+    }
+  }
+  return index;
 })();
 
-/** Whether `<dir>/<sub>` holds at least one git-tracked file (i.e. real source). */
-const hasTrackedSource = (dir, sub) => {
-  const prefix = `${dir}/${sub}/`;
-  for (const f of TRACKED_FILES) if (f.startsWith(prefix)) return true;
-  return false;
-};
+/** The immediate subdirectories of `dir` that hold lintable tracked source. */
+const lintableChildDirs = (dir) => [...(LINTABLE_CHILD_DIRS.get(dir) ?? [])].sort();
+
+// Scripts live behind a SEPARATE second lint pass (`--no-config-lookup -c
+// eslint.scripts.config.mjs scripts`), so they are excluded from the main
+// config's probe set and handled by their own structural check.
+const SCRIPTS_DIR = 'scripts';
 
 /**
  * Strip line and block comments so a commented-out import is not mistaken for a
@@ -193,6 +215,7 @@ function discoverWorkspacePackages() {
     const scriptsConfigRel = join(dir, 'eslint.scripts.config.mjs');
     const scriptsConfigAbs = join(REPO_ROOT, scriptsConfigRel);
     const hasScriptsConfig = existsSync(scriptsConfigAbs);
+    const codeDirs = lintableChildDirs(posixDir);
     return {
       name,
       dir,
@@ -201,11 +224,13 @@ function discoverWorkspacePackages() {
       configRel,
       hasConfig,
       extendsShared: hasConfig && extendsSharedConfig(configAbs),
-      // Tracked source only — a dir that exists purely as build output is not
-      // something lint should be pointed at.
-      sourceDirs: SOURCE_DIRS.filter((d) => hasTrackedSource(posixDir, d)),
-      lintTargetDirs: LINT_TARGET_DIRS.filter((d) => hasTrackedSource(posixDir, d)),
-      hasScriptsDir: hasTrackedSource(posixDir, 'scripts'),
+      // Derived, not hardcoded: every child dir holding lintable tracked source.
+      // `codeDirs` is what the lint script must cover (scripts/ included — its
+      // second pass is an eslint invocation too); `sourceDirs` is what the MAIN
+      // config is probed at, so scripts/ drops out.
+      codeDirs,
+      sourceDirs: codeDirs.filter((d) => d !== SCRIPTS_DIR),
+      hasScriptsDir: codeDirs.includes(SCRIPTS_DIR),
       scriptsConfigRel,
       hasScriptsConfig,
       scriptsExtendsShared: hasScriptsConfig && extendsSharedConfig(scriptsConfigAbs),
@@ -242,6 +267,78 @@ const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
 // opt-outs). Fed to both the structural guard and the behavioral suite.
 const GUARDED_PACKAGES = WORKSPACE_PACKAGES.filter((p) => !OPT_OUT_NAMES.has(p.name));
 
+// eslint flags that consume the NEXT argument, so its value is not mistaken for
+// a lint target (`-c eslint.scripts.config.mjs scripts` targets scripts, not the
+// config file). Boolean flags are skipped by the leading-dash test alone.
+const ESLINT_VALUE_FLAGS = new Set([
+  '-c',
+  '--config',
+  '--ext',
+  '--rulesdir',
+  '--plugin',
+  '--rule',
+  '--parser',
+  '--parser-options',
+  '--resolve-plugins-relative-to',
+  '--ignore-pattern',
+  '--ignore-path',
+  '--format',
+  '-f',
+  '--output-file',
+  '-o',
+  '--max-warnings',
+  '--global',
+  '--flag',
+  '--concurrency',
+]);
+
+const unquote = (token) => token.replace(/^['"]|['"]$/g, '');
+
+/**
+ * The positional path targets of every eslint invocation in a `lint` script.
+ * Asserting on these rather than substring-matching the raw command string is
+ * what makes the coverage check mean something: `eslint .` is broader than
+ * `eslint src test` (a substring match wrongly rejects it), while
+ * `eslint src/index.ts` lints one file (a substring match wrongly accepts it as
+ * covering src/).
+ * @param {string} lintScript
+ * @returns {string[]}
+ */
+function eslintTargets(lintScript) {
+  const targets = [];
+  for (const command of lintScript.split(/&&|\|\||;/)) {
+    const tokens = command.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
+    const start = tokens.findIndex((t) => /(?:^|\/)eslint$/.test(unquote(t)));
+    if (start === -1) continue;
+    for (let i = start + 1; i < tokens.length; i++) {
+      const token = unquote(tokens[i]);
+      if (token.startsWith('-')) {
+        if (ESLINT_VALUE_FLAGS.has(token)) i++;
+        continue;
+      }
+      targets.push(token);
+    }
+  }
+  return targets;
+}
+
+/**
+ * Whether an eslint path target lints everything in `dir`. A target covers the
+ * directory when it IS the directory, an ancestor of it, or `.`; a target that
+ * merely points at a file inside it does not. A glob is reduced to its literal
+ * prefix, so `src/**\/*.ts` still covers `src`.
+ * @param {string} target
+ * @param {string} dir
+ */
+function targetCoversDir(target, dir) {
+  const normalized = target.replace(/^\.\//, '').replace(/\/+$/, '');
+  if (normalized === '.' || normalized === '') return true;
+  const globAt = normalized.search(/[*?[{]/);
+  const base = (globAt === -1 ? normalized : normalized.slice(0, globAt)).replace(/\/+$/, '');
+  if (base === '') return true;
+  return dir === base || dir.startsWith(`${base}/`);
+}
+
 /**
  * Split the guarded packages by how they fail the config requirement. Pure over
  * its input so the failure paths are testable with synthetic packages — a real,
@@ -257,11 +354,11 @@ function configViolations(guarded) {
     // "No tasks were executed"). The script must also name every source dir the
     // package actually ships, or those files go unlinted by construction.
     lintNotWired: guarded
-      .filter(
-        (p) =>
-          !/\beslint\b/.test(p.lintScript) ||
-          (p.lintTargetDirs ?? []).some((d) => !new RegExp(`\\b${d}\\b`).test(p.lintScript)),
-      )
+      .filter((p) => {
+        const targets = eslintTargets(p.lintScript);
+        if (!targets.length) return true;
+        return (p.codeDirs ?? []).some((d) => !targets.some((t) => targetCoversDir(t, d)));
+      })
       .map((p) => p.label),
     // `eslint <src> <test>` never reaches scripts/, so a scripts/ dir needs its
     // own network-guard config (run with --no-config-lookup as a second pass).
@@ -429,15 +526,16 @@ describe('every workspace package ships a network-guarded eslint config', () => 
     ).toEqual([]);
   });
 
-  it('every guarded package has a lint script that runs eslint over its source dirs', () => {
+  it('every guarded package has a lint script covering every dir it ships code in', () => {
     const { lintNotWired } = configViolations(GUARDED_PACKAGES);
     expect(
       lintNotWired,
       lintNotWired.length
-        ? 'A config file only enforces the ban if eslint is pointed at the package. `pnpm lint` is ' +
+        ? 'A config file only enforces the ban if eslint is pointed at the code. `pnpm lint` is ' +
             '`turbo run lint`, which SKIPS a package with no `lint` script (exit 0, "No tasks were ' +
-            'executed"), so these packages ship an unenforced config. Add a `lint` script that runs ' +
-            `eslint over every source dir the package ships:\n  ${lintNotWired.join('\n  ')}`
+            'executed"), and a script that lists only some directories leaves the rest unlinted. ' +
+            'Point the `lint` script at every directory the package ships code in (a bare `.` ' +
+            `counts; naming individual files does not):\n  ${lintNotWired.join('\n  ')}`
         : undefined,
     ).toEqual([]);
   });
@@ -493,8 +591,8 @@ describe('configViolations (the guard mechanism, tested on synthetic packages)',
     lintScript: 'eslint src test',
     hasConfig: true,
     extendsShared: true,
+    codeDirs: ['src', 'test'],
     sourceDirs: ['src'],
-    lintTargetDirs: ['src', 'test'],
     hasScriptsDir: false,
     hasScriptsConfig: false,
     scriptsExtendsShared: false,
@@ -587,6 +685,76 @@ describe('the config-file checks (tested on synthetic source)', () => {
   it('does not strip a URL inside a live import', () => {
     const src = "import { base } from '@akasecurity/eslint-config'; // see https://example.com";
     expect(IMPORTS_SHARED_CONFIG.test(stripComments(src))).toBe(true);
+  });
+});
+
+describe('eslintTargets / targetCoversDir (the lint-coverage check)', () => {
+  // The predicate this replaces was a substring match on the command string,
+  // which rejected a broader-and-correct `eslint .` and accepted
+  // `eslint src/index.ts` as covering src/. Pin both directions.
+  it('extracts the positional targets of every eslint invocation', () => {
+    expect(eslintTargets('eslint src test')).toEqual(['src', 'test']);
+    expect(
+      eslintTargets(
+        'eslint src test && eslint --no-config-lookup -c eslint.scripts.config.mjs scripts',
+      ),
+    ).toEqual(['src', 'test', 'scripts']);
+  });
+
+  it('does not mistake a value-taking flag argument for a target', () => {
+    // `-c <file>`: the config path must not be read as something to lint.
+    expect(eslintTargets('eslint -c other.config.mjs src')).toEqual(['src']);
+    expect(eslintTargets('eslint --max-warnings 0 src')).toEqual(['src']);
+    expect(eslintTargets('eslint --ext .ts,.tsx src')).toEqual(['src']);
+  });
+
+  it('ignores boolean flags and the --flag=value form', () => {
+    expect(eslintTargets('eslint --no-error-on-unmatched-pattern --config=x.mjs src')).toEqual([
+      'src',
+    ]);
+  });
+
+  it('returns nothing when the script never invokes eslint', () => {
+    expect(eslintTargets("echo 'no self-lint for eslint-config'")).toEqual([]);
+    expect(eslintTargets('')).toEqual([]);
+  });
+
+  it('treats a directory, an ancestor, and `.` as covering the directory', () => {
+    expect(targetCoversDir('src', 'src')).toBe(true);
+    expect(targetCoversDir('.', 'src')).toBe(true);
+    expect(targetCoversDir('./', 'src')).toBe(true);
+    expect(targetCoversDir('packages', 'packages/inner')).toBe(true);
+  });
+
+  it('does NOT treat a file inside the directory as covering it', () => {
+    // The false negative: lints one file, but every dir-name substring matches.
+    expect(targetCoversDir('src/index.ts', 'src')).toBe(false);
+    expect(targetCoversDir('middleware.ts', 'app')).toBe(false);
+  });
+
+  it('reduces a glob to its literal prefix', () => {
+    expect(targetCoversDir('src/**/*.ts', 'src')).toBe(true);
+    expect(targetCoversDir('**/*.ts', 'src')).toBe(true);
+  });
+
+  it('accepts the real repo forms, and rejects a narrowed one', () => {
+    const covers = (script, dirs) => {
+      const targets = eslintTargets(script);
+      return dirs.every((d) => targets.some((t) => targetCoversDir(t, d)));
+    };
+    expect(covers('eslint src test eval', ['src', 'test', 'eval'])).toBe(true);
+    expect(
+      covers('eslint app middleware.ts test next.config.ts postcss.config.mjs vitest.config.ts', [
+        'app',
+        'test',
+      ]),
+    ).toBe(true);
+    // `eslint .` is broader than the dirs it must cover — must NOT be flagged.
+    expect(covers('eslint .', ['src', 'test'])).toBe(true);
+    // Naming files instead of the dir must be flagged.
+    expect(covers('eslint src/index.ts test/a.test.ts', ['src', 'test'])).toBe(false);
+    // A dir the package ships but the script forgets must be flagged.
+    expect(covers('eslint src test', ['src', 'test', 'eval'])).toBe(false);
   });
 });
 

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -13,8 +13,9 @@ import { beforeAll, describe, expect, it } from 'vitest';
 //     on an explicit, reasoned opt-out list. A package with NO config at all is
 //     invisible to `pnpm lint` (nothing points ESLint at it) AND to a glob that
 //     only ever matched existing config files, so it would ship UNGUARDED for
-//     network calls with CI green. The floor assertion alone cannot catch a
-//     package that was never in the glob's universe — this block can.
+//     network calls with CI green. Enumerating from the manifest and pinning the
+//     result as an EXACT set catches a package that was never in a config glob's
+//     universe — which a floor over "configs that already exist" cannot.
 //
 //  2. BEHAVIORAL (the composition / last-wins block): resolve each real
 //     eslint.config.mjs through ESLint and assert the four network rules still
@@ -58,24 +59,51 @@ const IMPORTS_SHARED_CONFIG =
   /(?:import[^;]*from[ \t]*|require\([ \t]*)['"]@akasecurity\/eslint-config(?:\/[\w.-]+)?['"]/;
 
 /**
- * The package globs declared under `packages:` in pnpm-workspace.yaml. Parsed
- * without a YAML dependency: capture the `packages:` line plus the consecutive
- * indented `- …` sequence entries that follow it (stopping at the next key that
- * starts in column 0), then pull each quoted-or-bare scalar.
+ * Parse the package globs declared under `packages:` in a pnpm-workspace.yaml
+ * document, without a YAML dependency. Pure over its input string so the parse —
+ * the most fragile part of this file — is unit-tested on synthetic YAML below
+ * (CRLF, interspersed comments, quoting) rather than only against the one real
+ * on-disk manifest. Walks line by line: enter the block at a bare `packages:`
+ * line, collect each `- <scalar>` sequence entry (quoted or bare), tolerate
+ * blank and comment lines inside the block, and stop at the next column-0 key.
+ * Flow style (`packages: [ … ]`) is intentionally NOT parsed — it yields an
+ * empty list, which the vacuous-pass guard turns into a loud failure rather than
+ * a silent under-enumeration.
+ * @param {string} rawYaml
  * @returns {string[]}
  */
-function workspaceGlobs() {
-  // Normalize CRLF → LF up front: the block/scalar regexes anchor on `\n`, and a
-  // Windows checkout (core.autocrlf) would otherwise capture a trailing `\r` into
-  // each glob and break globSync.
-  const raw = readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8').replace(/\r\n/g, '\n');
-  const block = raw.match(/^packages:[ \t]*\n((?:[ \t]+-.*\n?)+)/m)?.[1] ?? '';
-  return [...block.matchAll(/^[ \t]+-[ \t]*['"]?([^'"\n#]+?)['"]?[ \t]*$/gm)].map((m) => m[1]);
+export function parseWorkspaceGlobs(rawYaml) {
+  const globs = [];
+  let inBlock = false;
+  // Normalize CRLF → LF first so a Windows checkout (core.autocrlf) does not
+  // trail a `\r` into each glob (which would break globSync).
+  for (const rawLine of rawYaml.replace(/\r\n/g, '\n').split('\n')) {
+    // Strip comments up front (workspace globs never contain `#`), so an inline
+    // or whole-line comment neither terminates the block nor pollutes an entry.
+    const line = rawLine.replace(/#.*$/, '');
+    if (!inBlock) {
+      if (/^packages:[ \t]*$/.test(line)) inBlock = true;
+      continue;
+    }
+    if (/^\S/.test(line)) break; // a new column-0 key ends the packages block
+    const m = line.match(/^[ \t]+-[ \t]*['"]?([^'"\n]+?)['"]?[ \t]*$/);
+    if (m) globs.push(m[1].trim());
+  }
+  return globs;
 }
 
 /**
- * Every workspace package on disk, resolved from pnpm-workspace.yaml exactly as
- * pnpm does: expand each glob, keep the directories that hold a package.json.
+ * The package globs from the repo's real pnpm-workspace.yaml.
+ * @returns {string[]}
+ */
+function workspaceGlobs() {
+  return parseWorkspaceGlobs(readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8'));
+}
+
+/**
+ * Every workspace package on disk, resolved from pnpm-workspace.yaml: expand each
+ * glob and keep the directories that hold a package.json. (The current manifest
+ * declares no `!` exclusion globs; pnpm's negation semantics are not modeled.)
  * @returns {{ name: string, dir: string, configRel: string, hasConfig: boolean, extendsShared: boolean }[]}
  */
 function discoverWorkspacePackages() {
@@ -102,6 +130,31 @@ function discoverWorkspacePackages() {
 }
 
 const WORKSPACE_PACKAGES = discoverWorkspacePackages();
+
+// The exact set of workspace packages expected on disk, pinned by name (sorted).
+// This is the anti-vacuous drift guard for the enumeration: a hand-rolled
+// pnpm-workspace.yaml parse that silently dropped ONE package would still clear a
+// `>=` floor, and the `CONFIG_FILES.length === GUARDED_PACKAGES.length` equality
+// cannot catch it either (a package absent from discovery is absent from both
+// sides). An exact set fails loudly on any add / drop / rename — the same rigor
+// CONFIG_OPT_OUT uses. Adding or removing a workspace package is a deliberate
+// edit here (and, for a new package, of its eslint.config.mjs).
+const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
+  '@akasecurity/ai-tc-claude-code',
+  '@akasecurity/cli',
+  '@akasecurity/dashboard-ui',
+  '@akasecurity/detections',
+  '@akasecurity/eslint-config',
+  '@akasecurity/extract',
+  '@akasecurity/local-ops',
+  '@akasecurity/persistence',
+  '@akasecurity/plugin-runtime',
+  '@akasecurity/plugin-sdk',
+  '@akasecurity/scanner',
+  '@akasecurity/schema',
+  '@akasecurity/ui-kit',
+  '@akasecurity/web-ui',
+];
 
 // The packages that MUST ship a network-guarded config (everything except the
 // opt-outs). Fed to both the structural guard and the behavioral suite.
@@ -176,31 +229,38 @@ function firedRuleIds(code, rules) {
   return new Set(linter.verify(code, { languageOptions: LANG, rules }).map((m) => m.ruleId));
 }
 
+// The source directories a package may ship code under, most-specific first.
+const SOURCE_DIRS = /** @type {const} */ (['src', 'app']);
+
+/**
+ * A probe file path under the directory a package actually ships code in, so the
+ * behavioral resolution exercises the config where its `files`-scoped blocks
+ * apply. web-ui ships `app/` (no `src/`), so a hardcoded `src/` probe would
+ * resolve a path web-ui never lints — the very last-wins/path-scoping mistake
+ * this suite exists to catch. The file need not exist (config is computed, not
+ * parsed); fall back to `src/` for the source-less case.
+ * @param {string} pkgDir absolute package directory
+ */
+function probeRelPath(pkgDir) {
+  const dir = SOURCE_DIRS.find((d) => existsSync(join(pkgDir, d))) ?? 'src';
+  return `${dir}/__network_ban_probe__.ts`;
+}
+
 // --- Structural guard: every package ships a network-guarded config (#50) -----
 
 describe('every workspace package ships a network-guarded eslint config (#50)', () => {
-  it('discovered the workspace packages (guard against a vacuous pass)', () => {
-    // A broken pnpm-workspace.yaml parse would leave the enumeration empty and
-    // every assertion in this file would pass vacuously. 14 workspace packages
-    // exist today; 13 ship a config (all but @akasecurity/eslint-config).
-    expect(workspaceGlobs().length).toBeGreaterThan(0);
-    expect(WORKSPACE_PACKAGES.length).toBeGreaterThanOrEqual(12);
-    expect(CONFIG_FILES.length).toBeGreaterThanOrEqual(11);
-  });
-
-  it('enumeration includes the non-packages/* roots (cli, web-ui, plugin)', () => {
-    // The gap this test removed was a hand-maintained list that spelled out
-    // `cli`/`web-ui` and globbed only three parent dirs. Pin that the derived
-    // enumeration reaches the roots outside `packages/*`, so a parser regression
-    // that dropped them fails here rather than silently under-covering.
-    const names = new Set(WORKSPACE_PACKAGES.map((p) => p.name));
-    for (const anchor of [
-      '@akasecurity/cli',
-      '@akasecurity/web-ui',
-      '@akasecurity/ai-tc-claude-code',
-    ]) {
-      expect(names, anchor).toContain(anchor);
-    }
+  it('enumerates exactly the expected workspace packages (drift guard)', () => {
+    // Pinned as an EXACT set, not a `>=` floor: a hand-rolled pnpm-workspace.yaml
+    // parse that silently dropped one package would clear a floor AND the
+    // behavioral CONFIG_FILES===GUARDED equality (both derive from the same parse
+    // and drop it together), so that package would ship UNGUARDED with CI green —
+    // the exact failure this file exists to prevent, through its least-tested
+    // code. The explicit `workspaceGlobs()` check keeps the failure legible when
+    // the parser is the culprit (empty ⇒ manifest reformatted / flow-style).
+    expect(workspaceGlobs().length, 'pnpm-workspace.yaml parsed to zero globs').toBeGreaterThan(0);
+    expect([...WORKSPACE_PACKAGES.map((p) => p.name)].sort()).toEqual(
+      [...EXPECTED_WORKSPACE_PACKAGE_NAMES].sort(),
+    );
   });
 
   it('no guarded package is missing its eslint.config.mjs', () => {
@@ -283,19 +343,82 @@ describe('configViolations (the guard mechanism, tested on synthetic packages)',
   });
 });
 
+describe('parseWorkspaceGlobs (the manifest parser, tested on synthetic YAML)', () => {
+  // The real tree is parsed from one well-formed LF file on a Unix runner, so the
+  // parser's edge-case handling (CRLF, interspersed comments, quoting, block
+  // termination) is otherwise never exercised — including on Windows, where the
+  // CRLF branch matters and this package is absent from the CI filter. Pin it
+  // here so a parser regression fails loudly instead of silently under-counting.
+  const BLOCK = `packages:\n  - 'packages/*'\n  - 'cli'\n  - 'web-ui'\n\nonlyBuiltDependencies:\n  - esbuild\n`;
+
+  it('parses the block-sequence form (bare + quoted entries)', () => {
+    expect(parseWorkspaceGlobs(BLOCK)).toEqual(['packages/*', 'cli', 'web-ui']);
+  });
+
+  it('stops at the next column-0 key (does not bleed into onlyBuiltDependencies)', () => {
+    expect(parseWorkspaceGlobs(BLOCK)).not.toContain('esbuild');
+  });
+
+  it('normalizes CRLF so no glob trails a \\r (Windows core.autocrlf)', () => {
+    const crlf = BLOCK.replace(/\n/g, '\r\n');
+    expect(parseWorkspaceGlobs(crlf)).toEqual(['packages/*', 'cli', 'web-ui']);
+  });
+
+  it('tolerates whole-line and inline comments inside the block', () => {
+    const withComments =
+      'packages:\n' +
+      '  # first the libraries\n' +
+      "  - 'packages/*'\n" +
+      "  - 'cli'  # the CLI root\n" +
+      "  - 'web-ui'\n";
+    expect(parseWorkspaceGlobs(withComments)).toEqual(['packages/*', 'cli', 'web-ui']);
+  });
+
+  it('tolerates blank lines interspersed between entries', () => {
+    const withBlanks = "packages:\n  - 'packages/*'\n\n  - 'cli'\n";
+    expect(parseWorkspaceGlobs(withBlanks)).toEqual(['packages/*', 'cli']);
+  });
+
+  it('accepts double-quoted, single-quoted, and bare scalars alike', () => {
+    const mixed = 'packages:\n  - "packages/*"\n  - \'cli\'\n  - web-ui\n';
+    expect(parseWorkspaceGlobs(mixed)).toEqual(['packages/*', 'cli', 'web-ui']);
+  });
+
+  it('is unaffected by the order of top-level keys', () => {
+    const reordered = "onlyBuiltDependencies:\n  - esbuild\npackages:\n  - 'packages/*'\n";
+    expect(parseWorkspaceGlobs(reordered)).toEqual(['packages/*']);
+  });
+
+  it('returns [] for flow style rather than silently mis-parsing (vacuous-pass guard then trips)', () => {
+    expect(parseWorkspaceGlobs("packages: ['packages/*', 'cli']\n")).toEqual([]);
+  });
+
+  it('returns [] when there is no packages block at all', () => {
+    expect(parseWorkspaceGlobs('onlyBuiltDependencies:\n  - esbuild\n')).toEqual([]);
+  });
+});
+
 // --- Behavioral guard: each config actually enforces the ban -----------------
 
+// A representative sample of the Node core network builtins the ban must cover.
+// NETWORK_SNIPPET proves `no-restricted-imports` fires via the `axios` npm client
+// only — a config that redeclared the rule and kept `axios` while dropping the
+// `node:*` modules would still pass that check. Probing these directly asserts
+// the denylist stays COMPLETE through per-package composition, not just that the
+// rule fires on something. `node:net` is excluded: cli opts it out in dashboard.ts.
+const NETWORK_CORE_MODULES = ['node:http', 'node:https', 'node:dgram', 'node:tls'];
+
 describe('effective per-package config (composition / last-wins)', () => {
-  /** @type {Map<string, Set<string>>} configRel -> rule ids the snippet trips */
-  const firedByConfig = new Map();
+  /** @type {Map<string, Record<string, import('eslint').Linter.RuleEntry>>} configRel -> resolved network rules */
+  const rulesByConfig = new Map();
 
   beforeAll(async () => {
     for (const configRel of CONFIG_FILES) {
       const pkgDir = join(REPO_ROOT, dirname(configRel));
-      // A source path base applies to; it need not exist (config is computed,
-      // not parsed). Avoids each package's real layout while still hitting base.
-      const rules = await resolveNetworkRules(pkgDir, 'src/__network_ban_probe__.ts');
-      firedByConfig.set(configRel, firedRuleIds(NETWORK_SNIPPET, rules));
+      // Probe at a path the package actually ships code under (web-ui uses app/),
+      // so a config that scopes the ban to its real source dir is exercised. The
+      // path need not exist — config is computed, not parsed.
+      rulesByConfig.set(configRel, await resolveNetworkRules(pkgDir, probeRelPath(pkgDir)));
     }
   }, RESOLVE_TIMEOUT_MS);
 
@@ -307,11 +430,23 @@ describe('effective per-package config (composition / last-wins)', () => {
   });
 
   it.each(CONFIG_FILES)('bans every network form in %s', (configRel) => {
-    const fired = firedByConfig.get(configRel);
+    const fired = firedRuleIds(NETWORK_SNIPPET, rulesByConfig.get(configRel));
     for (const key of KEYS) {
       expect(fired, `${configRel} :: ${key}`).toContain(key);
     }
   });
+
+  it.each(CONFIG_FILES)(
+    'bans the node:* core network modules in %s (denylist stays complete)',
+    (configRel) => {
+      const rules = rulesByConfig.get(configRel);
+      for (const mod of NETWORK_CORE_MODULES) {
+        expect(firedRuleIds(`import m from '${mod}';`, rules), `${configRel} :: ${mod}`).toContain(
+          'no-restricted-imports',
+        );
+      }
+    },
+  );
 });
 
 describe('cli dashboard.ts file-scoped opt-out (real config)', () => {

--- a/turbo.json
+++ b/turbo.json
@@ -22,6 +22,28 @@
       "dependsOn": ["build", "^build", "^typecheck"],
       "outputs": ["coverage/**"]
     },
+    // The eslint-config suite asserts a workspace-wide invariant: every package
+    // ships an eslint.config.mjs wiring the no-network ban. Its default inputs
+    // cover only packages/eslint-config/**, and the package has no workspace
+    // dependencies — so ADDING A PACKAGE ANYWHERE ELSE leaves the task hash
+    // untouched and turbo replays a cached pass, which is exactly the moment the
+    // guard exists to fire. Declare the cross-package files it actually reads so
+    // the hash busts when the workspace shape changes. A stale hit here is a
+    // false-green CI for the no-network guarantee.
+    "@akasecurity/eslint-config#test": {
+      "dependsOn": ["build", "^build", "^typecheck"],
+      "outputs": ["coverage/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/pnpm-workspace.yaml",
+        "$TURBO_ROOT$/*/package.json",
+        "$TURBO_ROOT$/*/eslint.config.mjs",
+        "$TURBO_ROOT$/*/eslint.scripts.config.mjs",
+        "$TURBO_ROOT$/*/*/package.json",
+        "$TURBO_ROOT$/*/*/eslint.config.mjs",
+        "$TURBO_ROOT$/*/*/eslint.scripts.config.mjs"
+      ]
+    },
     "clean": {
       "cache": false
     }

--- a/turbo.json
+++ b/turbo.json
@@ -23,13 +23,22 @@
       "outputs": ["coverage/**"]
     },
     // The eslint-config suite asserts a workspace-wide invariant: every package
-    // ships an eslint.config.mjs wiring the no-network ban. Its default inputs
-    // cover only packages/eslint-config/**, and the package has no workspace
-    // dependencies — so ADDING A PACKAGE ANYWHERE ELSE leaves the task hash
-    // untouched and turbo replays a cached pass, which is exactly the moment the
-    // guard exists to fire. Declare the cross-package files it actually reads so
-    // the hash busts when the workspace shape changes. A stale hit here is a
-    // false-green CI for the no-network guarantee.
+    // ships an eslint.config.mjs wiring the no-network ban, points its `lint`
+    // script at every directory it holds code in, and covers scripts/ with a
+    // second pass. Its default inputs cover only packages/eslint-config/**, and
+    // the package has no workspace dependencies — so ADDING A PACKAGE (or a new
+    // source directory) ANYWHERE ELSE leaves the task hash untouched and turbo
+    // replays a cached pass, which is exactly the moment the guard exists to
+    // fire. A stale hit here is a false-green CI for the no-network guarantee.
+    //
+    // So the inputs mirror everything the suite reads: the manifest, every
+    // package.json and eslint config, and every lintable source file in the
+    // workspace (the suite derives each package's code directories from them).
+    // Explicit input globs are NOT filtered by .gitignore, so generated trees
+    // are excluded by hand — without that, node_modules alone adds ~23k files to
+    // the hash and every install perturbs it. This trades cache hits for
+    // correctness: the suite runs in ~1s, and a guard that does not run is worth
+    // nothing.
     "@akasecurity/eslint-config#test": {
       "dependsOn": ["build", "^build", "^typecheck"],
       "outputs": ["coverage/**"],
@@ -41,7 +50,15 @@
         "$TURBO_ROOT$/*/eslint.scripts.config.mjs",
         "$TURBO_ROOT$/*/*/package.json",
         "$TURBO_ROOT$/*/*/eslint.config.mjs",
-        "$TURBO_ROOT$/*/*/eslint.scripts.config.mjs"
+        "$TURBO_ROOT$/*/*/eslint.scripts.config.mjs",
+        "$TURBO_ROOT$/*/**/*.{ts,tsx,js,jsx,mjs,cjs}",
+        "$TURBO_ROOT$/*/*/**/*.{ts,tsx,js,jsx,mjs,cjs}",
+        "!$TURBO_ROOT$/**/node_modules/**",
+        "!$TURBO_ROOT$/**/.next/**",
+        "!$TURBO_ROOT$/**/dist/**",
+        "!$TURBO_ROOT$/**/coverage/**",
+        "!$TURBO_ROOT$/cli/web-ui/**",
+        "!$TURBO_ROOT$/plugins/claude-code/scripts/**"
       ]
     },
     "clean": {

--- a/turbo.json
+++ b/turbo.json
@@ -38,7 +38,9 @@
     // are excluded by hand — without that, node_modules alone adds ~23k files to
     // the hash and every install perturbs it. This trades cache hits for
     // correctness: the suite runs in ~1s, and a guard that does not run is worth
-    // nothing.
+    // nothing. The exclusion list has to track the tree's .gitignore files; a
+    // generated path that slips through costs a cache miss (a build-output file
+    // enters the hash), never a false pass.
     "@akasecurity/eslint-config#test": {
       "dependsOn": ["build", "^build", "^typecheck"],
       "outputs": ["coverage/**"],
@@ -57,6 +59,10 @@
         "!$TURBO_ROOT$/**/.next/**",
         "!$TURBO_ROOT$/**/dist/**",
         "!$TURBO_ROOT$/**/coverage/**",
+        "!$TURBO_ROOT$/**/dist-sea/**",
+        "!$TURBO_ROOT$/**/sea-dist/**",
+        "!$TURBO_ROOT$/web-ui/out/**",
+        "!$TURBO_ROOT$/web-ui/next-env.d.ts",
         "!$TURBO_ROOT$/cli/web-ui/**",
         "!$TURBO_ROOT$/plugins/claude-code/scripts/**"
       ]


### PR DESCRIPTION
## Problem

The no-network lint ban is enforced per-package via each `eslint.config.mjs` extending `@akasecurity/eslint-config`. A **new package added with no `eslint.config.mjs` at all** is invisible both to `pnpm lint` (nothing points ESLint at it) and to the effective-config discovery glob (which only ever matched configs that already exist) — so it would ship **unguarded for network calls with CI green**. The `>= 11` floor could not catch a package that was never in the glob's universe.

## Change

Extends `packages/eslint-config/test/effective-config.test.js` (no shipped source changes):

- **Enumerate** every workspace package from `pnpm-workspace.yaml` (expanded exactly as pnpm does — no YAML dep, CRLF-normalized).
- **Assert** each ships an `eslint.config.mjs` extending `@akasecurity/eslint-config`, with an explicit, reasoned opt-out list (`@akasecurity/eslint-config` itself — it can't extend itself).
- **Fail loudly, naming the package(s)**, with remediation text.
- **Derive** the behavioral composition suite's `CONFIG_FILES` from the same enumeration, removing the hardcoded `cli`/`web-ui` roots and the magic floor — a new package's config is now behaviorally verified the moment it's added.
- Pure `configViolations()` with synthetic failure-path unit tests proving the guard reports **every** offender, not just the first.

### Scope note (deliberate)

Guards **all** workspace packages minus the opt-out, rather than only packages "that have a `src/`": `web-ui` (the highest network-risk package) uses `app/`, not `src/`, so a literal `src/` filter would exempt exactly the package that most needs the guard. "All minus explicit opt-out" is strictly stronger and forces any source-less future package to be a reviewed opt-out decision.

## Verification

- `pnpm --filter @akasecurity/eslint-config test` → **137 passed**
- typecheck + prettier clean; pre-push lint (14 packages) green
- Confirmed end-to-end: a temporary config-less package made the guard fail naming it; cleaned up after

## Follow-up surfaced (not in scope here)

`@akasecurity/extract` is a real workspace package **absent from CLAUDE.md's package graph** — untracked doc drift. The new guard now enumerates it, keeping such drift visible.