### PR TITLE
test(web-ui): cover addException raw-secret handling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ plugins/claude-code → @akasecurity/plugin-runtime, plugin-sdk
 - No `process.env` reads except the few spots that explicitly opt out of `n/no-process-env` (the plugin's provider resolution, the CLI spawning the dashboard).
 - No `fetch()` anywhere in the OSS surface — it makes no network calls. Every store-reading package (`persistence`, `local-ops`, `dashboard-ui`, `ui-kit`, `detections`, `scanner`, `web-ui`, `cli`) reads the local store directly.
 - Drizzle is imported **only** by `@akasecurity/schema`, which uses it to _define_ the local-store and registry schemas. Packages that read the store do so via `node:sqlite` through `@akasecurity/persistence` — they must not import Drizzle.
+- The graph above lists **runtime** edges. Test suites may additionally take `@akasecurity/plugin-sdk` as a **dev-only** dependency for fixture seeding — the bundled detection packs (`bundledDetections()` / `registerBundledPacks`) live only there, so a test that must seed `installed_packs` or the engine registry needs it. Both `cli` and `web-ui` do this in their exception tests. A dev-only test dependency is not a runtime package-wall crossing.
 
 ## Comment & string hygiene
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -529,6 +529,9 @@ importers:
       '@akasecurity/eslint-config':
         specifier: workspace:*
         version: link:../packages/eslint-config
+      '@akasecurity/plugin-sdk':
+        specifier: workspace:*
+        version: link:../packages/plugin-sdk
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2
@@ -553,6 +556,9 @@ importers:
       typescript-eslint:
         specifier: ^8.64.0
         version: 8.64.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app middleware.ts",
+    "lint": "eslint app middleware.ts test",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@akasecurity/eslint-config": "workspace:*",
+    "@akasecurity/plugin-sdk": "workspace:*",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
@@ -34,6 +36,7 @@
     "eslint": "^9.0.0",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.8.0",
-    "typescript-eslint": "^8.64.0"
+    "typescript-eslint": "^8.64.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/web-ui/package.json
+++ b/web-ui/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint app middleware.ts test",
+    "lint": "eslint app middleware.ts test next.config.ts postcss.config.mjs vitest.config.ts",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -1,0 +1,397 @@
+import { createHash, createHmac } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  dataDir,
+  loadOrCreateFingerprintKey,
+  type LocalDatabase,
+  openLocalDatabase,
+} from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { DetectionException } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ActionResult, addException } from '../../app/(app)/exceptions/actions.ts';
+
+// `addException` is the ONLY web-ui code that handles a raw secret value. It
+// must verify the ruleId exists in the installed snapshot, verify the value
+// scan-matches that rule, require exactly one distinct span, reduce it to a
+// masked preview + keyed-HMAC fingerprint, and discard the raw — never
+// persisting it, never echoing it in an error. A bug here either creates a
+// dangling grant or leaks the secret, so this suite pins BOTH properties on
+// every branch. It mirrors cli/test/commands/exception.test.ts: a real
+// node:sqlite store, a real fingerprint key file, no mocking of the store.
+//
+// The action resolves its store and key location from `homedir()` (never
+// process.env), so the whole test is redirected into a temp home by mocking
+// `node:os`; `next/cache` is stubbed because revalidatePath needs a Next render
+// context that does not exist under vitest.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
+
+// The test values come from the bundled rule's own `examples` fixture, so no
+// secret-shaped literal lives in this file and the values stay in step with the
+// rule definition (mirrors the CLI suite's rationale).
+const RULE_ID = 'secrets/aws-access-key';
+const PACK = bundledDetections().find((p) => p.rules.some((r) => r.id === RULE_ID));
+const example = PACK?.rules.find((r) => r.id === RULE_ID)?.examples?.[0];
+if (PACK === undefined || example === undefined) {
+  throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+}
+// The rule's own example — legitimately present in the seeded installed_packs
+// snapshot, so it is used for grant-shape assertions, not for the at-rest scan.
+const VALUE: string = example;
+// A SECOND, distinct value matching the SAME rule (a different valid prefix from
+// the pattern's alternation). It is NOT any rule's example, so its absence from
+// the store on disk proves the raw was discarded, not merely never present.
+const SECOND = `ASIA${VALUE.slice(4)}`;
+
+let home: string;
+let dir: string;
+
+// web-ui memoizes the open DB handle on globalThis (app/lib/db.ts). Close and
+// drop it between tests so the next addException reopens against the fresh home.
+function resetSingleton(): void {
+  const store = globalThis as unknown as { __akaDb?: LocalDatabase };
+  store.__akaDb?.close();
+  delete store.__akaDb;
+}
+
+// Every grant ever written, including terminal rows — so a rejection that
+// wrongly wrote a dangling grant is caught even if the grant is already expired.
+async function grants(): Promise<DetectionException[]> {
+  const db = openLocalDatabase(dir);
+  try {
+    return await db.exceptions.list({ includeTerminal: true });
+  } finally {
+    db.close();
+  }
+}
+
+// The raw bytes of the store on disk (main DB + WAL/SHM sidecars), so an
+// at-rest leak is caught even if it only ever reached the write-ahead log.
+function storeBytes(): string {
+  const parts: Buffer[] = [];
+  for (const name of ['aka.db', 'aka.db-wal', 'aka.db-shm']) {
+    try {
+      parts.push(readFileSync(join(dir, name)));
+    } catch {
+      // sidecar absent — nothing to fold in
+    }
+  }
+  return Buffer.concat(parts).toString('latin1');
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-ex-'));
+  osHome.dir = home;
+  dir = dataDir();
+  // Seed the installed ruleset the way the plugin/CLI do on open — addException
+  // scans against this DB snapshot, not the engine's process-global registry.
+  const db = openLocalDatabase(dir);
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+  } finally {
+    db.close();
+  }
+  resetSingleton();
+});
+
+afterEach(() => {
+  resetSingleton();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('addException — the only web code touching a raw secret', () => {
+  describe('input validation rejects before any grant is written', () => {
+    it('rejects an empty reason — the reason is the audit trail', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'once',
+        reason: '   ',
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects an empty value — nothing to except', async () => {
+      const res = await addException({ ruleId: RULE_ID, value: '', scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects an unresolvable scope without echoing the value', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'forever',
+        reason: 'x',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error).not.toContain(VALUE);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects an unknown ruleId (not in the installed ruleset)', async () => {
+      const res = await addException({
+        ruleId: 'nope/not-a-rule',
+        value: VALUE,
+        scope: 'once',
+        reason: 'x',
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('nope/not-a-rule');
+      expect(res.error).not.toContain(VALUE);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects a rule whose pack is disabled — the snapshot is the scan authority', async () => {
+      const db = openLocalDatabase(dir);
+      try {
+        db.installedPacks.setEnabled(PACK.namespace, PACK.packId, false);
+      } finally {
+        db.close();
+      }
+      resetSingleton();
+
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects a value that does not scan-match the rule — no dangling grant', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: 'not-a-credential',
+        scope: 'once',
+        reason: 'x',
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects a value matching multiple distinct spans — supply exactly one', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: `${VALUE} and ${SECOND}`,
+        scope: 'once',
+        reason: 'x',
+      });
+      expect(res.ok).toBe(false);
+      // The count is safe to surface; the values themselves must not be.
+      expect(res.error).not.toContain(VALUE);
+      expect(res.error).not.toContain(SECOND);
+      expect(await grants()).toHaveLength(0);
+    });
+  });
+
+  describe('permanent scope re-checks the confirmation server-side', () => {
+    it('rejects permanent scope when the confirmation is missing', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'permanent',
+        reason: 'x',
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects permanent scope when confirmation !== value (not just the dialog)', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation: `${VALUE}-typo`,
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error).not.toContain(VALUE);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('accepts permanent scope when confirmation === value', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'permanent',
+        reason: 'deliberate',
+        confirmation: VALUE,
+      });
+      expect(res).toEqual({ ok: true });
+      const all = await grants();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.scope).toBe('permanent');
+    });
+  });
+
+  describe('a successful grant records only the derived, non-reversible fields', () => {
+    it('creates a once grant: masked preview + keyed-HMAC fingerprint, raw discarded', async () => {
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: 'once',
+        reason: 'rotating today',
+      });
+      expect(res).toEqual({ ok: true });
+
+      const grant = (await grants())[0];
+      expect(grant?.ruleId).toBe(RULE_ID);
+      expect(grant?.category).toBe('secret');
+      expect(grant?.scope).toBe('once');
+      expect(grant?.maxUses).toBe(1);
+      expect(grant?.createdVia).toBe('web-add');
+      expect(grant?.justification).toBe('rotating today');
+      // Nothing recoverable at rest: the preview is masked and no persisted
+      // field carries the raw value.
+      expect(grant?.maskedValue).not.toBe(VALUE);
+      expect(JSON.stringify(grant)).not.toContain(VALUE);
+    });
+
+    it('binds the grant to the detected span, not the whole input', async () => {
+      // The rule span (SECOND) is embedded in surrounding text; the grant must
+      // bind to the detected span so it applies at enforcement time.
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: `key = ${SECOND} ;`,
+        scope: 'once',
+        reason: 'x',
+      });
+      expect(res).toEqual({ ok: true });
+
+      const grant = (await grants())[0];
+      const key = loadOrCreateFingerprintKey(dir);
+      const spanFingerprint = createHmac('sha256', key.material)
+        .update(SECOND, 'utf8')
+        .digest('hex');
+      expect(grant?.valueFingerprint).toBe(spanFingerprint);
+    });
+
+    it('rejects a duplicate active grant with a friendly message, keeping one grant', async () => {
+      const first = await addException({ ruleId: RULE_ID, value: VALUE, scope: '1h', reason: 'a' });
+      expect(first).toEqual({ ok: true });
+
+      const second = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: '1h',
+        reason: 'b',
+      });
+      expect(second.ok).toBe(false);
+      expect(second.error).toMatch(/already exists/i);
+      expect(second.error).not.toContain(VALUE);
+      expect(await grants()).toHaveLength(1);
+    });
+  });
+
+  describe('the raw value never reaches the store', () => {
+    it('persists only masked_value + a keyed HMAC, not a plain hash', async () => {
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+
+      const grant = (await grants())[0];
+      const key = loadOrCreateFingerprintKey(dir);
+      const keyed = createHmac('sha256', key.material).update(VALUE, 'utf8').digest('hex');
+      const plain = createHash('sha256').update(VALUE, 'utf8').digest('hex');
+      // Keyed so a stolen DB copy leaks nothing about low-entropy values; a
+      // plain hash would be dictionary-attackable offline.
+      expect(grant?.valueFingerprint).toBe(keyed);
+      expect(grant?.valueFingerprint).not.toBe(plain);
+    });
+
+    it('leaves no trace of the raw value in the database file on disk', async () => {
+      // Guard: SECOND is not any rule's example, so it is absent from the seeded
+      // snapshot — its post-add absence proves addException discarded the raw,
+      // not that it was never written.
+      expect(storeBytes()).not.toContain(SECOND);
+
+      const res = await addException({
+        ruleId: RULE_ID,
+        value: SECOND,
+        scope: 'once',
+        reason: 'x',
+      });
+      expect(res).toEqual({ ok: true });
+
+      resetSingleton(); // close the handle so the WAL is checkpointed into the file
+      expect(storeBytes()).not.toContain(SECOND);
+    });
+  });
+
+  describe('failure is secure', () => {
+    it('a corrupt exception.key yields recovery guidance and no grant', async () => {
+      writeFileSync(join(dir, 'exception.key'), 'this is not a valid key file\n');
+
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('exception.key'); // recovery guidance, not a stack trace
+      expect(res.error).not.toContain(VALUE); // fails secure without echoing the secret
+      expect(await grants()).toHaveLength(0);
+    });
+  });
+
+  describe('no rejection path echoes the raw value (the exemplary property)', () => {
+    it('omits every raw value from every rejection error', async () => {
+      const errors: string[] = [];
+      const record = (r: ActionResult): void => {
+        expect(r.ok).toBe(false);
+        if (r.error !== undefined) errors.push(r.error);
+      };
+
+      record(
+        await addException({
+          ruleId: RULE_ID,
+          value: 'not-a-credential',
+          scope: 'once',
+          reason: 'x',
+        }),
+      );
+      record(
+        await addException({
+          ruleId: RULE_ID,
+          value: `${VALUE} and ${SECOND}`,
+          scope: 'once',
+          reason: 'x',
+        }),
+      );
+      record(
+        await addException({
+          ruleId: RULE_ID,
+          value: VALUE,
+          scope: 'permanent',
+          reason: 'x',
+          confirmation: 'wrong',
+        }),
+      );
+
+      // Duplicate: create one, then collide.
+      const created = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: '1h',
+        reason: 'x',
+      });
+      expect(created).toEqual({ ok: true });
+      record(await addException({ ruleId: RULE_ID, value: VALUE, scope: '1h', reason: 'x' }));
+
+      // Corrupt key (isolated to the end so it cannot poison the cases above).
+      writeFileSync(join(dir, 'exception.key'), 'corrupt\n');
+      resetSingleton();
+      record(await addException({ ruleId: RULE_ID, value: SECOND, scope: 'once', reason: 'x' }));
+
+      expect(errors).toHaveLength(5);
+      for (const err of errors) {
+        expect(err).not.toContain(VALUE);
+        expect(err).not.toContain(SECOND);
+      }
+    });
+  });
+});

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -1,5 +1,5 @@
 import { createHash, createHmac } from 'node:crypto';
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -128,6 +128,16 @@ describe('addException — the only web code touching a raw secret', () => {
       expect(await grants()).toHaveLength(0);
     });
 
+    it('rejects a whitespace-only value — the empty guard is strict, the scan rejects the rest', async () => {
+      // The empty-value guard is a strict `=== ''`, deliberately not trimmed (a
+      // raw value is never mutated). A whitespace-only value therefore falls
+      // through to the scan step, which matches nothing and rejects it — still
+      // no grant. Pin that boundary so neither guard can silently soften.
+      const res = await addException({ ruleId: RULE_ID, value: '   ', scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
     it('rejects an unresolvable scope without echoing the value', async () => {
       const res = await addException({
         ruleId: RULE_ID,
@@ -230,6 +240,8 @@ describe('addException — the only web code touching a raw secret', () => {
       const all = await grants();
       expect(all).toHaveLength(1);
       expect(all[0]?.scope).toBe('permanent');
+      // A permanent grant has no expiry — it lives until explicitly revoked.
+      expect(all[0]?.expiresAt).toBeNull();
     });
   });
 
@@ -248,6 +260,9 @@ describe('addException — the only web code touching a raw secret', () => {
       expect(grant?.category).toBe('secret');
       expect(grant?.scope).toBe('once');
       expect(grant?.maxUses).toBe(1);
+      // A `once` grant carries the 30-minute backstop expiry so an unused grant
+      // cannot dangle forever, even if nothing ever consumes it.
+      expect(grant?.expiresAt).not.toBeNull();
       expect(grant?.createdVia).toBe('web-add');
       expect(grant?.justification).toBe('rotating today');
       // Nothing recoverable at rest: the preview is masked and no persisted
@@ -273,6 +288,30 @@ describe('addException — the only web code touching a raw secret', () => {
         .update(SECOND, 'utf8')
         .digest('hex');
       expect(grant?.valueFingerprint).toBe(spanFingerprint);
+    });
+
+    it('lands in the active evaluation bundle under the current key — a real detection would match it', async () => {
+      // The enforcement gateway ships exactly `activeBundleEntries(key.version)`
+      // to the hook (plugin-runtime standalone-gateway); at evaluation a detected
+      // value is fingerprinted under the same key and matched against those
+      // entries. A grant present here, keyed to fingerprint(VALUE), is therefore
+      // one a live detection of VALUE will actually downgrade — the "no dangling
+      // grant" property at the web layer, against the very query enforcement
+      // reads (the full processText loop is pinned by the CLI suite).
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: '1h', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+
+      const key = loadOrCreateFingerprintKey(dir);
+      const wanted = createHmac('sha256', key.material).update(VALUE, 'utf8').digest('hex');
+      const db = openLocalDatabase(dir);
+      try {
+        const bundle = await db.exceptions.activeBundleEntries(key.version);
+        expect(bundle.some((e) => e.ruleId === RULE_ID && e.valueFingerprint === wanted)).toBe(
+          true,
+        );
+      } finally {
+        db.close();
+      }
     });
 
     it('rejects a duplicate active grant with a friendly message, keeping one grant', async () => {
@@ -323,6 +362,17 @@ describe('addException — the only web code touching a raw secret', () => {
 
       resetSingleton(); // close the handle so the WAL is checkpointed into the file
       expect(storeBytes()).not.toContain(SECOND);
+    });
+
+    it('locks the minted exception.key to 0600 — it is what keeps the fingerprints non-reversible', async () => {
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+      // The add path mints the fingerprint key on first use. A looser mode would
+      // let another local account read the key and reverse the stored HMACs, so
+      // pin 0600 (POSIX only — Windows ACLs do not carry these mode bits).
+      if (process.platform !== 'win32') {
+        expect(statSync(join(dir, 'exception.key')).mode & 0o777).toBe(0o600);
+      }
     });
   });
 

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -77,9 +77,15 @@ async function grants(): Promise<DetectionException[]> {
 
 // The raw bytes of the store on disk (main DB + WAL/SHM sidecars), so an
 // at-rest leak is caught even if it only ever reached the write-ahead log.
+//
+// The main DB read is deliberately NOT guarded: if `dir` ever stops resolving to
+// the real store (a layout change, a renamed file, a broken homedir() mock) the
+// leak scan must fail loudly rather than return '' — an empty string contains no
+// secret, so a swallowed error would turn every caller into a silent no-op. Only
+// the two sidecars are optional; SQLite may not have created them yet.
 function storeBytes(): string {
-  const parts: Buffer[] = [];
-  for (const name of ['aka.db', 'aka.db-wal', 'aka.db-shm']) {
+  const parts: Buffer[] = [readFileSync(join(dir, 'aka.db'))];
+  for (const name of ['aka.db-wal', 'aka.db-shm']) {
     try {
       parts.push(readFileSync(join(dir, name)));
     } catch {
@@ -361,6 +367,14 @@ describe('addException — the only web code touching a raw secret', () => {
       expect(res).toEqual({ ok: true });
 
       resetSingleton(); // close the handle so the WAL is checkpointed into the file
+
+      // Positive control FIRST: the grant's fingerprint is stored as TEXT, so its
+      // hex must appear in the bytes just read. This proves the scan below is
+      // reading the actual store that received the write — without it, a reader
+      // that came back empty would satisfy `not.toContain` while proving nothing.
+      const fingerprint = (await grants())[0]?.valueFingerprint;
+      expect(fingerprint).toBeDefined();
+      expect(storeBytes()).toContain(fingerprint);
       expect(storeBytes()).not.toContain(SECOND);
     });
 

--- a/web-ui/test/setup/server-only-stub.ts
+++ b/web-ui/test/setup/server-only-stub.ts
@@ -1,0 +1,7 @@
+// Empty stand-in for the `server-only` package under vitest.
+//
+// The real package throws at import time unless it is loaded through a React
+// Server bundler (Next). The Server Actions under test import it transitively
+// via app/lib/db, so vitest aliases the specifier here to let the real store
+// logic run in a plain Node test process. See vitest.config.ts.
+export {};

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+// web-ui's first test runner. The Server Action suites exercise the REAL
+// node:sqlite store and the REAL fingerprint key file (no database mocking —
+// the repository's house style), which runs slowly under Turbo's parallel task
+// load, so raise the per-test AND per-hook timeouts above vitest's 5s/10s
+// defaults (mirrors cli/vitest.config.ts and packages/persistence/vitest.config.ts).
+//
+// `server-only` is aliased to an empty module: app/lib/db imports it, and the
+// real package throws at import time when loaded outside a React Server bundler.
+export default defineConfig({
+  test: {
+    environment: 'node',
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
+    alias: {
+      'server-only': fileURLToPath(new URL('./test/setup/server-only-stub.ts', import.meta.url)),
+    },
+  },
+});


### PR DESCRIPTION
Adds test coverage for `addException`, the only web-ui code that handles a raw secret value. `web-ui` was 5,646 LOC with **no test runner and zero coverage** — this establishes both.

## What changed
- **web-ui's first test runner** — `web-ui/vitest.config.ts` + a `test` script. `node` env, raised timeouts (real `node:sqlite` I/O), and a `server-only` → empty-module alias (app/lib/db imports it, and the real package throws outside a React Server bundler).
- **`web-ui/test/actions/exceptions.test.ts`** (17 tests) — pins `addException`'s security properties on every branch. Uses a real store + real fingerprint key, **no store mocking** (mirrors `cli/test/commands/exception.test.ts`); values derive from the rule's own `examples` fixture, so no secret-shaped literal lives in the file. The store is redirected into a temp home by mocking `os.homedir()` (the web action has no `--home` seam); `installed_packs` is seeded via `bundledDetections()` because the web path scans the DB snapshot, not the engine's global registry.
- **package.json** — adds the `test` script, extends `lint` to cover `test`, and adds `vitest` + `@akasecurity/plugin-sdk` as **dev** deps (test-only; not bundled into the app — same precedent as `cli`).

`app/(app)/exceptions/actions.ts` is **not modified** — it was audited and found correct; this is the coverage that keeps it correct.

## Properties covered
- Empty reason / empty value → rejected
- Unknown **and disabled** ruleId → rejected (the installed DB snapshot is the scan authority)
- No scan-match / multiple distinct spans → rejected, **no grant**
- Permanent scope re-checks `confirmation === value` **server-side** (missing / wrong / correct)
- Raw never at rest: only `masked_value` + a **keyed HMAC** (proven keyed, not a plain hash); raw value **absent from the DB file + WAL** on disk
- Corrupt `exception.key` → recovery guidance, fails secure
- **No error ever echoes the raw value** (per-branch + a consolidated 5-branch test)
- Beyond the happy path: **no dangling grant on any rejection**, span-binding, and duplicate-active-grant handling

## Verification
- `pnpm --filter @akasecurity/web-ui test` → **17/17 pass**; `typecheck` + `lint` clean
- Tests proven to have teeth: two injected regressions (an error echoing the raw span; persisting the raw as the masked preview) each turned tests red, then reverted
- CLI exception suite still green (9/9); pre-push workspace lint green (14/14)

## Follow-ups (not in this PR)
- The shared vitest harness added here unblocks coverage for `middleware.ts` (the DNS-rebinding gate) and coverage-tooling/floors — left as separate work.
- `rotateKey` and `approveBlocked` live in the same `actions.ts` and can be covered in this **same test file** — the suite is structured so they slot in as sibling `describe` blocks reusing this harness.
- web-ui Server Actions do no whole-input schema validation (per-scalar only); a broader hardening that spans all the actions, out of scope here.