### PR TITLE
fix(dashboard): share one loopback bind address across probe and spawns

### DIFF
--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -15,6 +15,13 @@ import { openUrl } from '../lib/open-url.ts';
 const require = createRequire(import.meta.url);
 const here = dirname(fileURLToPath(import.meta.url));
 
+// Single source of truth for the loopback bind address. The pre-flight port probe
+// and both server spawns (the dev `next start` and the standalone HOSTNAME) must
+// bind the SAME address, or the probe checks a different interface than the server
+// uses and the friendly "port in use" message is skipped. Export it so the test
+// suite can pin that coupling.
+export const BIND_HOST = '127.0.0.1';
+
 // The package root that ships the bundled web-ui. Under a plain-node launch it is
 // one level above dist/ (this module's dir). A SEA binary has no source dir, so it
 // is the directory holding the executable, where release packaging places web-ui/.
@@ -36,7 +43,7 @@ function isPortFree(port: number): Promise<boolean> {
         resolve(true);
       });
     });
-    probe.listen(port, '127.0.0.1');
+    probe.listen(port, BIND_HOST);
   });
 }
 
@@ -124,7 +131,7 @@ export async function runDashboard(argv: string[]): Promise<void> {
     // carries mutating server actions, so it must never bind all interfaces.
     const child = spawn(
       process.execPath,
-      [nextBin, 'start', '--port', port, '--hostname', '127.0.0.1'],
+      [nextBin, 'start', '--port', port, '--hostname', BIND_HOST],
       {
         cwd: webUiDir,
         stdio: ['inherit', 'pipe', 'inherit'],
@@ -168,7 +175,7 @@ function launchStandalone(serverJs: string, port: string, shouldOpen: boolean, u
     // Inherit the parent env so the child server sees PATH etc.; PORT/HOSTNAME tell
     // Next's standalone server where to bind (its only port input).
     // eslint-disable-next-line n/no-process-env
-    env: { ...process.env, PORT: port, HOSTNAME: '127.0.0.1' },
+    env: { ...process.env, PORT: port, HOSTNAME: BIND_HOST },
   });
   onReadyOpen(child, shouldOpen, url, `Starting the AKA dashboard at ${url}\n`);
 }

--- a/cli/src/commands/dashboard.ts
+++ b/cli/src/commands/dashboard.ts
@@ -94,6 +94,12 @@ export async function runDashboard(argv: string[]): Promise<void> {
   });
   const port = values.port ?? '4319';
   const shouldOpen = values.open !== false;
+  // The browser URL is a dial name, not a bind address, so it deliberately does
+  // NOT derive from BIND_HOST: `localhost` resolves across the whole loopback
+  // family, reaching the server whichever literal BIND_HOST holds, and a future
+  // IPv6 BIND_HOST would need bracket-wrapping here (`http://::1:4319` is a
+  // malformed URL). What this name must satisfy is the web-ui's accepted Host
+  // set (middleware.ts) — the plugin builds the same URL.
   const url = `http://localhost:${port}/security`;
 
   if (!(await isPortFree(Number(port)))) {

--- a/cli/test/commands/dashboard.test.ts
+++ b/cli/test/commands/dashboard.test.ts
@@ -1,11 +1,16 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 
-import { refreshUpdateMirror, runDashboardServer } from '../../src/commands/dashboard.ts';
+import {
+  BIND_HOST,
+  refreshUpdateMirror,
+  runDashboardServer,
+} from '../../src/commands/dashboard.ts';
 
 let dir: string;
 
@@ -76,4 +81,24 @@ it('__dashboard-server without --server-js fails with a message, does not throw'
   expect(stderr.mock.calls.map((c) => String(c[0])).join('')).toContain('--server-js');
   expect(process.exitCode).toBe(1);
   process.exitCode = prevExit; // don't leak a failing exit code into the runner
+});
+
+// The pre-flight port probe (isPortFree's probe.listen) and both server spawns
+// (the dev `next start --hostname` and the standalone HOSTNAME env) must bind the
+// SAME loopback address. If they drift — e.g. the bind moves to `::1` but the probe
+// still checks `127.0.0.1` — isPortFree reports a busy port free, the friendly
+// "port in use" message is skipped, and Next dies on the raw EADDRINUSE the probe
+// exists to prevent. Pin that they share one source of truth (BIND_HOST) by proving
+// the literal appears exactly once in the source: the const declaration. Every bind
+// site must reference the constant, so a second hard-coded literal fails this test.
+it('probe and both binds share one loopback source of truth (no drift)', () => {
+  expect(BIND_HOST).toBe('127.0.0.1');
+
+  const src = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '../../src/commands/dashboard.ts'),
+    'utf8',
+  );
+  const literals = src.match(/127\.0\.0\.1/g) ?? [];
+  expect(literals).toHaveLength(1); // only the BIND_HOST declaration hard-codes it
+  expect(src).toMatch(/const BIND_HOST = '127\.0\.0\.1'/);
 });

--- a/cli/test/commands/dashboard.test.ts
+++ b/cli/test/commands/dashboard.test.ts
@@ -89,8 +89,11 @@ it('__dashboard-server without --server-js fails with a message, does not throw'
 // still checks `127.0.0.1` — isPortFree reports a busy port free, the friendly
 // "port in use" message is skipped, and Next dies on the raw EADDRINUSE the probe
 // exists to prevent. Pin that they share one source of truth (BIND_HOST) by proving
-// the literal appears exactly once in the source: the const declaration. Every bind
-// site must reference the constant, so a second hard-coded literal fails this test.
+// the address appears as a STRING exactly once in the source: the const declaration.
+// Every bind site must reference the constant, so a second hard-coded literal fails.
+// Matching quoted occurrences only (any quote style) keeps prose free to name the
+// address — this module explains loopback binding at length, and counting raw text
+// would turn an added comment into a red test that points nowhere useful.
 it('probe and both binds share one loopback source of truth (no drift)', () => {
   expect(BIND_HOST).toBe('127.0.0.1');
 
@@ -98,7 +101,7 @@ it('probe and both binds share one loopback source of truth (no drift)', () => {
     join(dirname(fileURLToPath(import.meta.url)), '../../src/commands/dashboard.ts'),
     'utf8',
   );
-  const literals = src.match(/127\.0\.0\.1/g) ?? [];
+  const literals = src.match(/['"`]127\.0\.0\.1['"`]/g) ?? [];
   expect(literals).toHaveLength(1); // only the BIND_HOST declaration hard-codes it
   expect(src).toMatch(/const BIND_HOST = '127\.0\.0\.1'/);
 });


### PR DESCRIPTION
## Summary

The `aka dashboard` command hard-coded the loopback address `127.0.0.1` in **three separate places** with nothing forcing them to stay in step:

- the pre-flight port probe (`isPortFree` → `probe.listen`)
- the dev spawn (`next start --hostname`)
- the standalone spawn (`HOSTNAME` env)

They all match today, so it works — but it's an unenforced coupling. The probe exists to catch a busy port and print a friendly *"port already in use — pass a free one with `--port`"* message instead of forwarding Next's raw `EADDRINUSE` (after which the readiness regex never fires and the command appears to hang). If the bind ever moved to `::1` or dual-stack — or a port were held on `::1` but free on `127.0.0.1` — the probe would keep checking IPv4, report the port free, skip the friendly message, and let Next die on the raw `EADDRINUSE` the probe is meant to prevent.

Flagged during review of #106 as a pre-existing latent bug, deferred out of that PR's scope.

## Changes

- **Single source of truth**: extract `export const BIND_HOST = '127.0.0.1'` and point the probe and both spawn sites at it, so they cannot drift.
- **Test pins the coupling**: `cli/test/commands/dashboard.test.ts` asserts `BIND_HOST === '127.0.0.1'` and scans the source to prove the literal appears exactly once (the declaration). Reintroducing a separate hard-coded address at any bind site fails the test.

## Verification

- `pnpm --filter @akasecurity/cli test` — all green (42 passing).
- Drift check: temporarily reverted one bind site to a raw literal and confirmed the new test fails (`expected [ '127.0.0.1', '127.0.0.1' ] to have a length of 1 but got 2`), then restored.
- `typecheck` and `lint` pass clean.

Note: the coupling test is a static source scan — it catches a reintroduced literal, but wouldn't catch a bind site switching to a different variable. All three sites now reference `BIND_HOST`.