### PR TITLE
test(persistence): add store test harness and fault injectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,14 +273,19 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
 - `withTwoWriters(fn)` / `withWriters(n, fn)` — N independent `LocalDatabase` handles on
   one file, the shape the product runs in (hooks, CLI and dashboard share `aka.db` with
   only WAL and `busy_timeout` between them).
-- `fault-injection.ts` — `corruptStore`, `readOnlyStore`, `lockStore`, `fillStore`, plus
-  the `SQLITE_*` result codes, `sqliteErrcode()` and `primaryCode()`. Each injector
-  produces a real error code from the real engine and reports when it could not take
-  effect (`chmod` is a no-op for directories on Windows, and root bypasses modes), so a
-  fault test cannot pass against a healthy store. Pass the store's `onCleanup` to any
-  injector that has to be undone before the tree can be removed.
+- `fault-injection.ts` — `corruptStore`, `readOnlyStore` and `lockStore`, plus the
+  `SQLITE_*` result codes, `sqliteErrcode()` and `primaryCode()`. Each injector produces a
+  real error code from the real engine and refuses to run rather than take effect
+  vacuously — an absent store, a live handle, a `chmod` the platform ignored — so a fault
+  test cannot pass against a healthy store. Pass the store's `onCleanup` to any injector
+  that has to be undone before the tree can be removed, and the store itself to any that
+  needs no live connection.
+  `fillStore` is in the same file but **not yet a peer of the other three**: the page cap
+  is connection-scoped and `LocalDatabase` exposes no raw handle, so it can only reach
+  `node:sqlite`, not the repository writes built on it. It waits on a raw-handle seam.
 - `assertNoOpenTransaction(db)` — a fault that leaves a transaction open is worse than the
-  fault; assert this after injecting one.
+  fault; assert this after injecting one. It reads `db.isTransaction` rather than probing
+  with a transaction of its own, so it cannot disturb the handle it is inspecting.
 
 Assert the result code, not an error message or an elapsed time — Windows CI runs several
 times slower, and a timing assertion there is a flake. Compare with `primaryCode()`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,10 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
 Assert the result code, not an error message or an elapsed time — Windows CI runs several
 times slower, and a timing assertion there is a flake. Compare with `primaryCode()`:
 `errcode` carries the **extended** code, so `SQLITE_READONLY` also arrives as
-`SQLITE_READONLY_DIRECTORY`. Do not add vitest `retry`. Where a platform or a privilege
-makes an assertion meaningless, `ctx.skip(reason)` — never an early `return`, which
-reports as a pass.
+`SQLITE_READONLY_DIRECTORY`. Do not add vitest `retry`.
+
+Inside `test/helpers/` and its own suites, where a platform or a privilege makes an
+assertion meaningless, use `ctx.skip(reason)` — never an early `return`, which reports as
+a pass. **This is scoped deliberately**: the rest of the workspace uses
+`if (process.platform === 'win32') return;`, and the QA backlog asks for that form by
+name, so match the file you are in rather than converting a neighbour in passing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,10 +276,11 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
 - `fault-injection.ts` — `corruptStore`, `readOnlyStore` and `lockStore`, plus the
   `SQLITE_*` result codes, `sqliteErrcode()` and `primaryCode()`. Each injector produces a
   real error code from the real engine and refuses to run rather than take effect
-  vacuously — an absent store, a live handle, a `chmod` the platform ignored — so a fault
-  test cannot pass against a healthy store. Pass the store's `onCleanup` to any injector
-  that has to be undone before the tree can be removed, and the store itself to any that
-  needs no live connection.
+  vacuously — an absent store, a live handle. Where the platform or the privilege decides
+  instead of the helper, `readOnlyStore` reports it as `effective: false` and **the caller
+  must gate**: `if (!readOnly.effective) ctx.skip(reason)`. Pass the store's `onCleanup` to
+  any injector that has to be undone before the tree can be removed, and the store itself
+  to any that needs no live connection.
   `fillStore` is in the same file but **not yet a peer of the other three**: the page cap
   is connection-scoped and `LocalDatabase` exposes no raw handle, so it can only reach
   `node:sqlite`, not the repository writes built on it. It waits on a raw-handle seam.
@@ -292,8 +293,8 @@ times slower, and a timing assertion there is a flake. Compare with `primaryCode
 `errcode` carries the **extended** code, so `SQLITE_READONLY` also arrives as
 `SQLITE_READONLY_DIRECTORY`. Do not add vitest `retry`.
 
-Inside `test/helpers/` and its own suites, where a platform or a privilege makes an
-assertion meaningless, use `ctx.skip(reason)` — never an early `return`, which reports as
-a pass. **This is scoped deliberately**: the rest of the workspace uses
-`if (process.platform === 'win32') return;`, and the QA backlog asks for that form by
-name, so match the file you are in rather than converting a neighbour in passing.
+Where a platform or a privilege makes an assertion meaningless, use `ctx.skip(reason)`.
+An early `return` reports as a pass, which is the failure mode the store harness exists
+to remove. Some older suites in this package still use
+`if (process.platform === 'win32') return;` — leave them be unless you are already
+changing that test for another reason, and do not convert a neighbour in passing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,3 +256,24 @@ pnpm test                                    # all workspaces
 pnpm test --filter @akasecurity/detections   # just the detection engine + fixtures
 pnpm test --filter @akasecurity/persistence  # just the local-store adapter + repositories
 ```
+
+Never mock `node:sqlite` or the filesystem — every store test runs against a real
+database in a real temp dir, which is what catches real SQLite semantics.
+
+`packages/persistence/test/helpers/` holds the shared store harness; **import it rather
+than re-rolling the `mkdtempSync` + `openLocalDatabase` + cleanup dance**:
+
+- `withTempStore(fn)` / `useTempStore(prefix)` — a disposable `~/.aka` (`settings/` +
+  `data/`) whose handles are closed and tree removed for you. Use `useTempStore` when the
+  suite shares setup across hooks, `withTempStore` when one test body owns the store.
+- `withTwoWriters(fn)` / `withWriters(n, fn)` — N independent `LocalDatabase` handles on
+  one file, the shape the product runs in (hooks, CLI and dashboard share `aka.db` with
+  only WAL and `busy_timeout` between them).
+- `fault-injection.ts` — `corruptStore`, `readOnlyStore`, `lockStore`, `fillStore`, plus
+  the `SQLITE_*` extended result codes and `sqliteErrcode()`. Each injector produces a
+  real error code from the real engine and reports when it could not take effect
+  (`chmod` is a no-op on Windows, and root bypasses modes), so a fault test cannot pass
+  against a healthy store.
+
+Assert the extended result code, not an error message or an elapsed time — Windows CI runs
+several times slower, and a timing assertion there is a flake. Do not add vitest `retry`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,20 +260,30 @@ pnpm test --filter @akasecurity/persistence  # just the local-store adapter + re
 Never mock `node:sqlite` or the filesystem — every store test runs against a real
 database in a real temp dir, which is what catches real SQLite semantics.
 
-`packages/persistence/test/helpers/` holds the shared store harness; **import it rather
-than re-rolling the `mkdtempSync` + `openLocalDatabase` + cleanup dance**:
+`packages/persistence/test/helpers/` holds the shared store harness. Tests **in this
+package** import it rather than re-rolling the `mkdtempSync` + `openLocalDatabase` +
+cleanup dance; it is not reachable across a package wall, so store tests in `cli`,
+`local-ops`, `plugin-runtime` and `plugins/claude-code` still roll their own.
 
 - `withTempStore(fn)` / `useTempStore(prefix)` — a disposable `~/.aka` (`settings/` +
   `data/`) whose handles are closed and tree removed for you. Use `useTempStore` when the
-  suite shares setup across hooks, `withTempStore` when one test body owns the store.
+  suite shares setup across hooks, `withTempStore` when one test body owns the store. An
+  async body is awaited before teardown.
 - `withTwoWriters(fn)` / `withWriters(n, fn)` — N independent `LocalDatabase` handles on
   one file, the shape the product runs in (hooks, CLI and dashboard share `aka.db` with
   only WAL and `busy_timeout` between them).
 - `fault-injection.ts` — `corruptStore`, `readOnlyStore`, `lockStore`, `fillStore`, plus
-  the `SQLITE_*` extended result codes and `sqliteErrcode()`. Each injector produces a
-  real error code from the real engine and reports when it could not take effect
-  (`chmod` is a no-op on Windows, and root bypasses modes), so a fault test cannot pass
-  against a healthy store.
+  the `SQLITE_*` result codes, `sqliteErrcode()` and `primaryCode()`. Each injector
+  produces a real error code from the real engine and reports when it could not take
+  effect (`chmod` is a no-op for directories on Windows, and root bypasses modes), so a
+  fault test cannot pass against a healthy store. Pass the store's `onCleanup` to any
+  injector that has to be undone before the tree can be removed.
+- `assertNoOpenTransaction(db)` — a fault that leaves a transaction open is worse than the
+  fault; assert this after injecting one.
 
-Assert the extended result code, not an error message or an elapsed time — Windows CI runs
-several times slower, and a timing assertion there is a flake. Do not add vitest `retry`.
+Assert the result code, not an error message or an elapsed time — Windows CI runs several
+times slower, and a timing assertion there is a flake. Compare with `primaryCode()`:
+`errcode` carries the **extended** code, so `SQLITE_READONLY` also arrives as
+`SQLITE_READONLY_DIRECTORY`. Do not add vitest `retry`. Where a platform or a privilege
+makes an assertion meaningless, `ctx.skip(reason)` — never an early `return`, which
+reports as a pass.

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -74,11 +74,16 @@ describe('sqliteErrcode / primaryCode', () => {
   it('reads the result code off a node:sqlite error', () => {
     withTempStore((store) => {
       seedStore(store);
+      const db = new DatabaseSync(store.dbFile);
       let err: unknown;
       try {
-        new DatabaseSync(store.dbFile).exec('SELECT * FROM no_such_table');
+        db.exec('SELECT * FROM no_such_table');
       } catch (caught) {
         err = caught;
+      } finally {
+        // Windows will not delete a file another handle still holds, so a
+        // handle a test opens is a handle a test closes.
+        db.close();
       }
       expect(sqliteErrcode(err)).toBeTypeOf('number');
       expect(primaryCode(err)).toBeTypeOf('number');
@@ -241,11 +246,14 @@ describe('readOnlyStore', () => {
       });
       if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
+      const db = new DatabaseSync(store.dbFile);
       let err: unknown;
       try {
-        new DatabaseSync(store.dbFile).exec('PRAGMA journal_mode = WAL');
+        db.exec('PRAGMA journal_mode = WAL');
       } catch (caught) {
         err = caught;
+      } finally {
+        db.close();
       }
       // The one place the refinement is the point: it names the directory, not
       // the file, as what SQLite could not write.
@@ -444,8 +452,14 @@ describe('fillStore', () => {
       const other = new DatabaseSync(store.dbFile);
       const insert = other.prepare('INSERT INTO bulk (v) VALUES (?)');
       const payload = 'x'.repeat(200);
+      // One transaction, not one per row: in autocommit each row is its own WAL
+      // commit, and 500 of those runs for tens of seconds on the Windows runner.
+      // The point is that this handle grows past the other's cap, not how many
+      // commits it takes to get there.
       expect(() => {
+        other.exec('BEGIN');
         for (let i = 0; i < 500; i += 1) insert.run(payload);
+        other.exec('COMMIT');
       }).not.toThrow();
 
       other.close();

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -326,11 +326,16 @@ describe('readOnlyStore', () => {
   it('restore() gives the modes back, and says so only once', () => {
     withTempStore((store) => {
       seedStore(store);
+      const before = statSync(store.dbFile).mode & 0o7777;
       const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
       readOnly.restore();
       readOnly.restore();
 
       expect(attemptWrite(store.dbFile)).toBeUndefined();
+      // The exact bits, not just "writable again": the mode is captured with
+      // `& 0o7777`, and restoring anything wider than the permission bits would
+      // still let this write through.
+      expect(statSync(store.dbFile).mode & 0o7777).toBe(before);
     });
   });
 });

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -57,16 +57,6 @@ function attemptWrite(file: string, busyTimeoutMs = 250): number | undefined {
   }
 }
 
-function integrityOf(file: string): string | undefined {
-  const db = new DatabaseSync(file);
-  try {
-    return (db.prepare('PRAGMA integrity_check').get() as { integrity_check?: string })
-      .integrity_check;
-  } finally {
-    db.close();
-  }
-}
-
 const MODES_IGNORED =
   'this host ignores the mode change — a root process, or a filesystem without POSIX modes';
 
@@ -148,9 +138,20 @@ describe('corruptStore', () => {
       const db = store.openRaw();
       expect(() => db.prepare('SELECT count(*) AS n FROM rule_probe_cache').get()).not.toThrow();
       assertNoOpenTransaction(db);
-      db.close();
 
-      expect(integrityOf(store.dbFile)).not.toBe('ok');
+      // What separates 'page' from the other two modes, as a result code rather
+      // than a message: a full scan reaches the damaged page and raises
+      // SQLITE_CORRUPT, where truncate and header never open at all. Asserting
+      // `integrity_check !== 'ok'` here would only re-run corruptStore's own
+      // postcondition, which it already refuses to return without.
+      let err: unknown;
+      try {
+        db.prepare('PRAGMA integrity_check').all();
+      } catch (caught) {
+        err = caught;
+      }
+      expect(primaryCode(err)).toBe(SQLITE_CORRUPT);
+      db.close();
     });
   });
 
@@ -163,7 +164,6 @@ describe('corruptStore', () => {
       expect(() => {
         corruptStore(store.dbFile, 'page', { store });
       }).toThrow(/still reads as a healthy store/);
-      expect(integrityOf(store.dbFile)).toBe('ok');
     });
   });
 
@@ -372,6 +372,29 @@ describe('lockStore', () => {
       // doing its job, and the reason the SQLITE_BUSY case above is a limit
       // rather than the normal outcome.
       expect(attemptWrite(store.dbFile, 5000)).toBeUndefined();
+    });
+  });
+
+  it('locks a store that is not in WAL, and leaves its journal mode alone', () => {
+    withTempStore((store) => {
+      const seed = store.openRaw();
+      seed.exec('PRAGMA journal_mode = delete');
+      seed.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      seed.close();
+
+      const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+      // BEGIN IMMEDIATE takes a write lock in any journal mode, so the holder
+      // has no reason to touch the mode — and every reason not to: the mode
+      // change is the one statement busy_timeout cannot govern, and converting
+      // the store is a side effect a fault injector must not have.
+      expect(attemptWrite(store.dbFile, 250)).toBe(SQLITE_BUSY);
+      lock.release();
+
+      const after = store.openRaw();
+      expect(
+        (after.prepare('PRAGMA journal_mode').get() as { journal_mode: string }).journal_mode,
+      ).toBe('delete');
+      after.close();
     });
   });
 

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -74,7 +74,7 @@ describe('sqliteErrcode / primaryCode', () => {
   it('reads the result code off a node:sqlite error', () => {
     withTempStore((store) => {
       seedStore(store);
-      const db = new DatabaseSync(store.dbFile);
+      const db = store.openRaw();
       let err: unknown;
       try {
         db.exec('SELECT * FROM no_such_table');
@@ -112,7 +112,7 @@ describe('corruptStore', () => {
   it('truncate: the header survives, the pages do not — SQLITE_CORRUPT', () => {
     withTempStore((store) => {
       seedStore(store);
-      corruptStore(store.dbFile, 'truncate');
+      corruptStore(store.dbFile, 'truncate', { store });
 
       let err: unknown;
       try {
@@ -127,7 +127,7 @@ describe('corruptStore', () => {
   it('header: SQLite refuses the file outright — SQLITE_NOTADB', () => {
     withTempStore((store) => {
       seedStore(store);
-      corruptStore(store.dbFile, 'header');
+      corruptStore(store.dbFile, 'header', { store });
 
       let err: unknown;
       try {
@@ -142,10 +142,10 @@ describe('corruptStore', () => {
   it('page: the store still opens and reads — only integrity_check notices', () => {
     withTempStore((store) => {
       seedStore(store);
-      corruptStore(store.dbFile, 'page');
+      corruptStore(store.dbFile, 'page', { store });
 
       // The quiet failure: nothing throws, so a fail-open caller carries on.
-      const db = new DatabaseSync(store.dbFile);
+      const db = store.openRaw();
       expect(() => db.prepare('SELECT count(*) AS n FROM rule_probe_cache').get()).not.toThrow();
       assertNoOpenTransaction(db);
       db.close();
@@ -157,11 +157,11 @@ describe('corruptStore', () => {
   it('changes the same bytes every run', () => {
     withTempStore((store) => {
       seedStore(store);
-      corruptStore(store.dbFile, 'page');
+      corruptStore(store.dbFile, 'page', { store });
       // A second flip at the same offset undoes the first, so the store reads
       // healthy again and the injector refuses to claim it damaged it.
       expect(() => {
-        corruptStore(store.dbFile, 'page');
+        corruptStore(store.dbFile, 'page', { store });
       }).toThrow(/still reads as a healthy store/);
       expect(integrityOf(store.dbFile)).toBe('ok');
     });
@@ -173,7 +173,7 @@ describe('corruptStore', () => {
       for (const sidecar of walSidecars(store.dbFile)) {
         writeFileSync(sidecar, 'stale');
       }
-      corruptStore(store.dbFile, 'truncate');
+      corruptStore(store.dbFile, 'truncate', { store });
       for (const sidecar of walSidecars(store.dbFile)) {
         expect(existsSync(sidecar)).toBe(false);
       }
@@ -193,9 +193,40 @@ describe('corruptStore', () => {
       }).toThrow(/write to the store first/);
     });
   });
+
+  it('refuses to run while a handle is still open on the store', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const live = store.open();
+      // Removing the WAL from under a live connection makes the damage depend
+      // on that connection's cached pages — the one thing this injector
+      // promises not to do. Enforced, not just documented.
+      expect(() => {
+        corruptStore(store.dbFile, 'truncate', { store });
+      }).toThrow(/still open/);
+
+      live.close();
+      expect(() => {
+        corruptStore(store.dbFile, 'truncate', { store });
+      }).not.toThrow();
+    });
+  });
 });
 
 describe('readOnlyStore', () => {
+  it('refuses a store that is not there rather than reporting it effective', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      // An absent file tightens nothing, and `every` over nothing is true — so
+      // without the guard this hands back `effective: true` for a store the
+      // caller can freely write, which is the exact vacuous pass the helper
+      // exists to prevent.
+      expect(() => {
+        readOnlyStore(join(store.dataDir, 'nope.db'), { onCleanup: store.onCleanup });
+      }).toThrow(/no store at/);
+    });
+  });
+
   it('reports exactly whether the mode change denies writes', () => {
     withTempStore((store) => {
       seedStore(store);
@@ -209,7 +240,7 @@ describe('readOnlyStore', () => {
     });
   });
 
-  it('denies the write without widening the file to the world', (ctx) => {
+  it('denies the write, on every platform', (ctx) => {
     // No platform guard: Node maps the write bit to the read-only attribute on
     // Windows too — only directory modes are the no-op there — and Windows is
     // the platform where the store has no other at-rest protection.
@@ -218,21 +249,29 @@ describe('readOnlyStore', () => {
       const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
       if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
-      const code = attemptWrite(store.dbFile);
-      const mode = statSync(store.dbFile).mode & 0o777;
+      expect(attemptWrite(store.dbFile)).toBeDefined();
       // No write bit anywhere, whatever the platform calls it.
-      expect(mode & 0o222).toBe(0);
-      if (process.platform === 'win32') {
-        // The mode does bite here, but Windows reports a read-only file as
-        // 0444 whatever was asked for, and which code SQLite raises for it is
-        // not pinned — only that the write is refused.
-        expect(code).toBeDefined();
-        return;
-      }
-      expect(code).toBe(SQLITE_READONLY);
+      expect(statSync(store.dbFile).mode & 0o222).toBe(0);
+    });
+  });
+
+  // Split from the case above rather than branched inside it: the mode
+  // assertion is meaningless on Windows, which reports a read-only file as 0444
+  // whatever was asked for, and which result code it raises for one is not
+  // pinned. Branching would report the whole thing as a pass there.
+  it('raises SQLITE_READONLY without widening the file to the world', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('Windows reports a read-only file as 0444 whatever mode was asked for');
+    }
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+      if (!readOnly.effective) ctx.skip(MODES_IGNORED);
+
+      expect(attemptWrite(store.dbFile)).toBe(SQLITE_READONLY);
       // 0400, not 0444: denying the write must not hand the prompt corpus to
       // every other account on the machine on the way.
-      expect(mode & 0o077).toBe(0);
+      expect(statSync(store.dbFile).mode & 0o077).toBe(0);
     });
   });
 
@@ -246,7 +285,7 @@ describe('readOnlyStore', () => {
       });
       if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
-      const db = new DatabaseSync(store.dbFile);
+      const db = store.openRaw();
       let err: unknown;
       try {
         db.exec('PRAGMA journal_mode = WAL');
@@ -302,7 +341,7 @@ describe('lockStore', () => {
       seedStore(store);
       lockStore(store.dbFile, { onCleanup: store.onCleanup });
 
-      const victim = new DatabaseSync(store.dbFile);
+      const victim = store.openRaw();
       victim.exec('PRAGMA busy_timeout = 250');
       let err: unknown;
       try {
@@ -407,7 +446,7 @@ describe('fillStore', () => {
   it('raises SQLITE_FULL from the engine, leaving the store intact', () => {
     withTempStore((store) => {
       seedStore(store);
-      const db = new DatabaseSync(store.dbFile);
+      const db = store.openRaw();
       db.exec('PRAGMA journal_mode = WAL');
       db.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
       const filled = fillStore(db);
@@ -444,12 +483,12 @@ describe('fillStore', () => {
   it('caps the handle it was given, not the file', () => {
     withTempStore((store) => {
       seedStore(store);
-      const capped = new DatabaseSync(store.dbFile);
+      const capped = store.openRaw();
       capped.exec('PRAGMA journal_mode = WAL');
       capped.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
       fillStore(capped);
 
-      const other = new DatabaseSync(store.dbFile);
+      const other = store.openRaw();
       const insert = other.prepare('INSERT INTO bulk (v) VALUES (?)');
       const payload = 'x'.repeat(200);
       // One transaction, not one per row: in autocommit each row is its own WAL

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -10,6 +10,7 @@ import {
   corruptStore,
   fillStore,
   lockStore,
+  primaryCode,
   readOnlyStore,
   SQLITE_BUSY,
   SQLITE_CORRUPT,
@@ -21,10 +22,13 @@ import {
 } from './fault-injection.ts';
 import type { TempStore } from './temp-store.ts';
 import { withTempStore } from './temp-store.ts';
+import { assertNoOpenTransaction } from './transactions.ts';
 
-// Each injector is asserted by the extended result code it produces, not by a
-// message or a timing: the codes are what the store's error handling does not
-// currently distinguish, and they are the reason these helpers exist.
+// Each injector is asserted by the result code it produces, not by a message or
+// a timing: the codes are what the store's error handling does not currently
+// distinguish, and they are the reason these helpers exist. `primaryCode`
+// asserts the class of failure; `sqliteErrcode` is for the cases where the
+// extended refinement is itself the point.
 
 /** Create and migrate the store, then let go of it — the file is left on disk. */
 function seedStore(store: TempStore): void {
@@ -43,7 +47,7 @@ function attemptWrite(file: string, busyTimeoutMs = 250): number | undefined {
     db.exec('INSERT INTO fault_probe (id) VALUES (1)');
     return undefined;
   } catch (err) {
-    return sqliteErrcode(err);
+    return primaryCode(err);
   } finally {
     try {
       db?.close();
@@ -63,8 +67,11 @@ function integrityOf(file: string): string | undefined {
   }
 }
 
-describe('sqliteErrcode', () => {
-  it('reads the extended result code off a node:sqlite error', () => {
+const MODES_IGNORED =
+  'this host ignores the mode change — a root process, or a filesystem without POSIX modes';
+
+describe('sqliteErrcode / primaryCode', () => {
+  it('reads the result code off a node:sqlite error', () => {
     withTempStore((store) => {
       seedStore(store);
       let err: unknown;
@@ -74,13 +81,25 @@ describe('sqliteErrcode', () => {
         err = caught;
       }
       expect(sqliteErrcode(err)).toBeTypeOf('number');
+      expect(primaryCode(err)).toBeTypeOf('number');
     });
   });
 
-  it('is undefined for anything that is not a node:sqlite error', () => {
+  it('primaryCode strips the refinement an extended code carries', () => {
+    // SQLITE_READONLY_DIRECTORY is SQLITE_READONLY with 6 in its high bits.
+    // Asserting the class must not depend on which refinement SQLite picked.
+    const err = Object.assign(new Error('readonly directory'), {
+      errcode: SQLITE_READONLY_DIRECTORY,
+    });
+    expect(sqliteErrcode(err)).toBe(SQLITE_READONLY_DIRECTORY);
+    expect(primaryCode(err)).toBe(SQLITE_READONLY);
+  });
+
+  it('both are undefined for anything that is not a node:sqlite error', () => {
     expect(sqliteErrcode(new Error('plain'))).toBeUndefined();
+    expect(primaryCode(new Error('plain'))).toBeUndefined();
     expect(sqliteErrcode('not an error')).toBeUndefined();
-    expect(sqliteErrcode(undefined)).toBeUndefined();
+    expect(primaryCode(undefined)).toBeUndefined();
   });
 });
 
@@ -96,7 +115,7 @@ describe('corruptStore', () => {
       } catch (caught) {
         err = caught;
       }
-      expect(sqliteErrcode(err)).toBe(SQLITE_CORRUPT);
+      expect(primaryCode(err)).toBe(SQLITE_CORRUPT);
     });
   });
 
@@ -111,7 +130,7 @@ describe('corruptStore', () => {
       } catch (caught) {
         err = caught;
       }
-      expect(sqliteErrcode(err)).toBe(SQLITE_NOTADB);
+      expect(primaryCode(err)).toBe(SQLITE_NOTADB);
     });
   });
 
@@ -123,6 +142,7 @@ describe('corruptStore', () => {
       // The quiet failure: nothing throws, so a fail-open caller carries on.
       const db = new DatabaseSync(store.dbFile);
       expect(() => db.prepare('SELECT count(*) AS n FROM rule_probe_cache').get()).not.toThrow();
+      assertNoOpenTransaction(db);
       db.close();
 
       expect(integrityOf(store.dbFile)).not.toBe('ok');
@@ -174,10 +194,7 @@ describe('readOnlyStore', () => {
   it('reports exactly whether the mode change denies writes', () => {
     withTempStore((store) => {
       seedStore(store);
-      const readOnly = readOnlyStore(store.dbFile);
-      store.onCleanup(() => {
-        readOnly.restore();
-      });
+      const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
 
       // The contract, asserted on every platform: `effective` is true when and
       // only when a write is actually refused. Windows ignores modes on
@@ -187,29 +204,42 @@ describe('readOnlyStore', () => {
     });
   });
 
-  it('a write to a read-only store raises SQLITE_READONLY', () => {
-    if (process.platform === 'win32') return;
+  it('denies the write without widening the file to the world', (ctx) => {
+    // No platform guard: Node maps the write bit to the read-only attribute on
+    // Windows too — only directory modes are the no-op there — and Windows is
+    // the platform where the store has no other at-rest protection.
     withTempStore((store) => {
       seedStore(store);
-      const readOnly = readOnlyStore(store.dbFile);
-      store.onCleanup(() => {
-        readOnly.restore();
-      });
-      if (!readOnly.effective) return;
+      const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+      if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
-      expect(attemptWrite(store.dbFile)).toBe(SQLITE_READONLY);
+      const code = attemptWrite(store.dbFile);
+      const mode = statSync(store.dbFile).mode & 0o777;
+      // No write bit anywhere, whatever the platform calls it.
+      expect(mode & 0o222).toBe(0);
+      if (process.platform === 'win32') {
+        // The mode does bite here, but Windows reports a read-only file as
+        // 0444 whatever was asked for, and which code SQLite raises for it is
+        // not pinned — only that the write is refused.
+        expect(code).toBeDefined();
+        return;
+      }
+      expect(code).toBe(SQLITE_READONLY);
+      // 0400, not 0444: denying the write must not hand the prompt corpus to
+      // every other account on the machine on the way.
+      expect(mode & 0o077).toBe(0);
     });
   });
 
-  it('includeDir fails at open instead: WAL cannot create its sidecars', () => {
-    if (process.platform === 'win32') return;
+  it('includeDir fails at open instead: WAL cannot create its sidecars', (ctx) => {
+    if (process.platform === 'win32') ctx.skip('chmod is a no-op for directories on Windows');
     withTempStore((store) => {
       seedStore(store);
-      const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
-      store.onCleanup(() => {
-        readOnly.restore();
+      const readOnly = readOnlyStore(store.dbFile, {
+        includeDir: true,
+        onCleanup: store.onCleanup,
       });
-      if (!readOnly.effective) return;
+      if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
       let err: unknown;
       try {
@@ -217,19 +247,21 @@ describe('readOnlyStore', () => {
       } catch (caught) {
         err = caught;
       }
+      // The one place the refinement is the point: it names the directory, not
+      // the file, as what SQLite could not write.
       expect(sqliteErrcode(err)).toBe(SQLITE_READONLY_DIRECTORY);
     });
   });
 
-  it('openLocalDatabase widens the data dir again, so only the file mode bites', () => {
-    if (process.platform === 'win32') return;
+  it('openLocalDatabase widens the data dir again, so only the file mode bites', (ctx) => {
+    if (process.platform === 'win32') ctx.skip('chmod is a no-op for directories on Windows');
     withTempStore((store) => {
       seedStore(store);
-      const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
-      store.onCleanup(() => {
-        readOnly.restore();
+      const readOnly = readOnlyStore(store.dbFile, {
+        includeDir: true,
+        onCleanup: store.onCleanup,
       });
-      if (!readOnly.effective) return;
+      if (!readOnly.effective) ctx.skip(MODES_IGNORED);
 
       // ensureDataDirSync chmods the dir back to 0700 before SQLite opens the
       // file, so the directory fault never reaches the engine on this path.
@@ -239,7 +271,7 @@ describe('readOnlyStore', () => {
       } catch (caught) {
         err = caught;
       }
-      expect(sqliteErrcode(err)).toBe(SQLITE_READONLY);
+      expect(primaryCode(err)).toBe(SQLITE_READONLY);
       expect(statSync(store.dataDir).mode & 0o777).toBe(0o700);
     });
   });
@@ -260,19 +292,30 @@ describe('lockStore', () => {
   it('a hold that outlasts busy_timeout makes the other writer fail with SQLITE_BUSY', () => {
     withTempStore((store) => {
       seedStore(store);
-      const lock = lockStore(store.dbFile);
+      lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+      const victim = new DatabaseSync(store.dbFile);
+      victim.exec('PRAGMA busy_timeout = 250');
+      let err: unknown;
       try {
-        expect(attemptWrite(store.dbFile, 250)).toBe(SQLITE_BUSY);
-      } finally {
-        lock.release();
+        victim.exec('CREATE TABLE IF NOT EXISTS fault_probe (id INTEGER PRIMARY KEY)');
+      } catch (caught) {
+        err = caught;
       }
+      expect(primaryCode(err)).toBe(SQLITE_BUSY);
+      // Losing the write must not leave the victim inside a transaction.
+      assertNoOpenTransaction(victim);
+      victim.close();
     });
   });
 
   it('a hold that ends inside busy_timeout lets the other writer through', () => {
     withTempStore((store) => {
       seedStore(store);
-      lockStore(store.dbFile, { holdMs: 150 });
+      // The lock is kept and released rather than left to expire on its own:
+      // release() waits for the holder to close its handle, and on Windows the
+      // tree cannot be removed while that handle is open.
+      lockStore(store.dbFile, { holdMs: 150, onCleanup: store.onCleanup });
       // The victim waits out the hold rather than failing: this is the timeout
       // doing its job, and the reason the SQLITE_BUSY case above is a limit
       // rather than the normal outcome.
@@ -294,17 +337,60 @@ describe('lockStore', () => {
   it('gives up loudly when the lock cannot be taken', () => {
     withTempStore((store) => {
       seedStore(store);
-      const held = lockStore(store.dbFile);
+      lockStore(store.dbFile, { onCleanup: store.onCleanup });
+      // busyTimeoutMs is what makes the second holder give up quickly;
+      // readyTimeoutMs stays generous so a slow worker start can never be
+      // mistaken for a lock it could not take.
+      expect(() => lockStore(store.dbFile, { readyTimeoutMs: 10_000, busyTimeoutMs: 100 })).toThrow(
+        /could not take the write lock/,
+      );
+    });
+  });
+});
+
+// What the injectors do to the package, rather than to node:sqlite. Both of
+// these cost a full busy_timeout (2000 ms) by construction — that is the
+// measurement, not an accident of the test.
+describe('lockStore against the product write path', () => {
+  it('openLocalDatabase cannot open under a held lock: open the writers first', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+      // Opening is itself a write — the WAL pragma, then the migration and
+      // ensure* passes — so a handle taken after the lock does not merely
+      // block, it fails. withWriters opens up front for exactly this reason.
+      let err: unknown;
       try {
-        // busyTimeoutMs is what makes the second holder give up quickly;
-        // readyTimeoutMs stays generous so a slow worker start can never be
-        // mistaken for a lock it could not take.
-        expect(() =>
-          lockStore(store.dbFile, { readyTimeoutMs: 10_000, busyTimeoutMs: 100 }),
-        ).toThrow(/could not take the write lock/);
-      } finally {
-        held.release();
+        openLocalDatabase(store.dataDir);
+      } catch (caught) {
+        err = caught;
       }
+      expect(primaryCode(err)).toBe(SQLITE_BUSY);
+    });
+  });
+
+  it('a LocalDatabase write under the lock is dropped in silence, not raised', () => {
+    withTempStore((store) => {
+      const db = store.open();
+      const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+      // The behaviour the fail-open contract produces today, pinned so a change
+      // to it is a decision: failOpenTransaction swallows the SQLITE_BUSY, so
+      // the caller is told nothing and the event is simply gone.
+      expect(() => {
+        db.ruleProbeCache.setVerdict('lost-to-contention', 'safe', 1);
+      }).not.toThrow();
+      expect(db.ruleProbeCache.getVerdict('lost-to-contention')).toBeUndefined();
+
+      // And the handle survives it: the swallowed failure left no transaction
+      // open, so the next write once the lock is gone still lands.
+      lock.release();
+      db.ruleProbeCache.setVerdict('after-contention', 'safe', 2);
+      expect(db.ruleProbeCache.getVerdict('after-contention')).toEqual({
+        verdict: 'safe',
+        worstProbeMs: 2,
+      });
     });
   });
 });
@@ -331,12 +417,13 @@ describe('fillStore', () => {
         err = caught;
       }
 
-      expect(sqliteErrcode(err)).toBe(SQLITE_FULL);
+      expect(primaryCode(err)).toBe(SQLITE_FULL);
       expect(written).toBeGreaterThan(0);
       // Out of room is not the same as damaged: every committed row is still
-      // there and nothing was left half-written.
+      // there, nothing was left half-written, and no transaction stayed open.
       expect((db.prepare('SELECT count(*) AS n FROM bulk').get() as { n: number }).n).toBe(written);
       expect(db.prepare('PRAGMA integrity_check').get()).toEqual({ integrity_check: 'ok' });
+      assertNoOpenTransaction(db);
 
       filled.restore();
       expect(() => {

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -1,0 +1,368 @@
+import { existsSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, expect, it } from 'vitest';
+
+import { openLocalDatabase } from '../../src/database.ts';
+import { walSidecars } from '../../src/paths.ts';
+import {
+  corruptStore,
+  fillStore,
+  lockStore,
+  readOnlyStore,
+  SQLITE_BUSY,
+  SQLITE_CORRUPT,
+  SQLITE_FULL,
+  SQLITE_NOTADB,
+  SQLITE_READONLY,
+  SQLITE_READONLY_DIRECTORY,
+  sqliteErrcode,
+} from './fault-injection.ts';
+import type { TempStore } from './temp-store.ts';
+import { withTempStore } from './temp-store.ts';
+
+// Each injector is asserted by the extended result code it produces, not by a
+// message or a timing: the codes are what the store's error handling does not
+// currently distinguish, and they are the reason these helpers exist.
+
+/** Create and migrate the store, then let go of it — the file is left on disk. */
+function seedStore(store: TempStore): void {
+  const db = store.open();
+  db.ruleProbeCache.setVerdict('seeded', 'safe', 1);
+  db.close();
+}
+
+/** The errcode raised by a write on a fresh raw handle, or undefined if it worked. */
+function attemptWrite(file: string, busyTimeoutMs = 250): number | undefined {
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(file);
+    db.exec(`PRAGMA busy_timeout = ${String(busyTimeoutMs)}`);
+    db.exec('CREATE TABLE IF NOT EXISTS fault_probe (id INTEGER PRIMARY KEY)');
+    db.exec('INSERT INTO fault_probe (id) VALUES (1)');
+    return undefined;
+  } catch (err) {
+    return sqliteErrcode(err);
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // The failure above may already have torn the handle down.
+    }
+  }
+}
+
+function integrityOf(file: string): string | undefined {
+  const db = new DatabaseSync(file);
+  try {
+    return (db.prepare('PRAGMA integrity_check').get() as { integrity_check?: string })
+      .integrity_check;
+  } finally {
+    db.close();
+  }
+}
+
+describe('sqliteErrcode', () => {
+  it('reads the extended result code off a node:sqlite error', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      let err: unknown;
+      try {
+        new DatabaseSync(store.dbFile).exec('SELECT * FROM no_such_table');
+      } catch (caught) {
+        err = caught;
+      }
+      expect(sqliteErrcode(err)).toBeTypeOf('number');
+    });
+  });
+
+  it('is undefined for anything that is not a node:sqlite error', () => {
+    expect(sqliteErrcode(new Error('plain'))).toBeUndefined();
+    expect(sqliteErrcode('not an error')).toBeUndefined();
+    expect(sqliteErrcode(undefined)).toBeUndefined();
+  });
+});
+
+describe('corruptStore', () => {
+  it('truncate: the header survives, the pages do not — SQLITE_CORRUPT', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      corruptStore(store.dbFile, 'truncate');
+
+      let err: unknown;
+      try {
+        openLocalDatabase(store.dataDir);
+      } catch (caught) {
+        err = caught;
+      }
+      expect(sqliteErrcode(err)).toBe(SQLITE_CORRUPT);
+    });
+  });
+
+  it('header: SQLite refuses the file outright — SQLITE_NOTADB', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      corruptStore(store.dbFile, 'header');
+
+      let err: unknown;
+      try {
+        openLocalDatabase(store.dataDir);
+      } catch (caught) {
+        err = caught;
+      }
+      expect(sqliteErrcode(err)).toBe(SQLITE_NOTADB);
+    });
+  });
+
+  it('page: the store still opens and reads — only integrity_check notices', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      corruptStore(store.dbFile, 'page');
+
+      // The quiet failure: nothing throws, so a fail-open caller carries on.
+      const db = new DatabaseSync(store.dbFile);
+      expect(() => db.prepare('SELECT count(*) AS n FROM rule_probe_cache').get()).not.toThrow();
+      db.close();
+
+      expect(integrityOf(store.dbFile)).not.toBe('ok');
+    });
+  });
+
+  it('changes the same bytes every run', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      corruptStore(store.dbFile, 'page');
+      // A second flip at the same offset undoes the first, so the store reads
+      // healthy again and the injector refuses to claim it damaged it.
+      expect(() => {
+        corruptStore(store.dbFile, 'page');
+      }).toThrow(/still reads as a healthy store/);
+      expect(integrityOf(store.dbFile)).toBe('ok');
+    });
+  });
+
+  it('clears the WAL sidecars so they cannot replay over the damage', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      for (const sidecar of walSidecars(store.dbFile)) {
+        writeFileSync(sidecar, 'stale');
+      }
+      corruptStore(store.dbFile, 'truncate');
+      for (const sidecar of walSidecars(store.dbFile)) {
+        expect(existsSync(sidecar)).toBe(false);
+      }
+    });
+  });
+
+  it('refuses a store that is not there, or too small to damage as asked', () => {
+    withTempStore((store) => {
+      expect(() => {
+        corruptStore(join(store.dataDir, 'absent.db'));
+      }).toThrow(/no store at/);
+
+      const tiny = join(store.home, 'tiny.db');
+      writeFileSync(tiny, 'x'.repeat(64));
+      expect(() => {
+        corruptStore(tiny, 'truncate');
+      }).toThrow(/write to the store first/);
+    });
+  });
+});
+
+describe('readOnlyStore', () => {
+  it('reports exactly whether the mode change denies writes', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile);
+      store.onCleanup(() => {
+        readOnly.restore();
+      });
+
+      // The contract, asserted on every platform: `effective` is true when and
+      // only when a write is actually refused. Windows ignores modes on
+      // directories and a root process ignores them everywhere, so predicting
+      // the value would be wrong — reporting it honestly is the point.
+      expect(readOnly.effective).toBe(attemptWrite(store.dbFile) !== undefined);
+    });
+  });
+
+  it('a write to a read-only store raises SQLITE_READONLY', () => {
+    if (process.platform === 'win32') return;
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile);
+      store.onCleanup(() => {
+        readOnly.restore();
+      });
+      if (!readOnly.effective) return;
+
+      expect(attemptWrite(store.dbFile)).toBe(SQLITE_READONLY);
+    });
+  });
+
+  it('includeDir fails at open instead: WAL cannot create its sidecars', () => {
+    if (process.platform === 'win32') return;
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
+      store.onCleanup(() => {
+        readOnly.restore();
+      });
+      if (!readOnly.effective) return;
+
+      let err: unknown;
+      try {
+        new DatabaseSync(store.dbFile).exec('PRAGMA journal_mode = WAL');
+      } catch (caught) {
+        err = caught;
+      }
+      expect(sqliteErrcode(err)).toBe(SQLITE_READONLY_DIRECTORY);
+    });
+  });
+
+  it('openLocalDatabase widens the data dir again, so only the file mode bites', () => {
+    if (process.platform === 'win32') return;
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
+      store.onCleanup(() => {
+        readOnly.restore();
+      });
+      if (!readOnly.effective) return;
+
+      // ensureDataDirSync chmods the dir back to 0700 before SQLite opens the
+      // file, so the directory fault never reaches the engine on this path.
+      let err: unknown;
+      try {
+        openLocalDatabase(store.dataDir);
+      } catch (caught) {
+        err = caught;
+      }
+      expect(sqliteErrcode(err)).toBe(SQLITE_READONLY);
+      expect(statSync(store.dataDir).mode & 0o777).toBe(0o700);
+    });
+  });
+
+  it('restore() gives the modes back, and says so only once', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const readOnly = readOnlyStore(store.dbFile, { includeDir: true });
+      readOnly.restore();
+      readOnly.restore();
+
+      expect(attemptWrite(store.dbFile)).toBeUndefined();
+    });
+  });
+});
+
+describe('lockStore', () => {
+  it('a hold that outlasts busy_timeout makes the other writer fail with SQLITE_BUSY', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const lock = lockStore(store.dbFile);
+      try {
+        expect(attemptWrite(store.dbFile, 250)).toBe(SQLITE_BUSY);
+      } finally {
+        lock.release();
+      }
+    });
+  });
+
+  it('a hold that ends inside busy_timeout lets the other writer through', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      lockStore(store.dbFile, { holdMs: 150 });
+      // The victim waits out the hold rather than failing: this is the timeout
+      // doing its job, and the reason the SQLITE_BUSY case above is a limit
+      // rather than the normal outcome.
+      expect(attemptWrite(store.dbFile, 5000)).toBeUndefined();
+    });
+  });
+
+  it('releases the lock, and does not mind being released twice', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const lock = lockStore(store.dbFile);
+      lock.release();
+      lock.release();
+
+      expect(attemptWrite(store.dbFile, 2000)).toBeUndefined();
+    });
+  });
+
+  it('gives up loudly when the lock cannot be taken', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const held = lockStore(store.dbFile);
+      try {
+        // busyTimeoutMs is what makes the second holder give up quickly;
+        // readyTimeoutMs stays generous so a slow worker start can never be
+        // mistaken for a lock it could not take.
+        expect(() =>
+          lockStore(store.dbFile, { readyTimeoutMs: 10_000, busyTimeoutMs: 100 }),
+        ).toThrow(/could not take the write lock/);
+      } finally {
+        held.release();
+      }
+    });
+  });
+});
+
+describe('fillStore', () => {
+  it('raises SQLITE_FULL from the engine, leaving the store intact', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const db = new DatabaseSync(store.dbFile);
+      db.exec('PRAGMA journal_mode = WAL');
+      db.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
+      const filled = fillStore(db);
+
+      const insert = db.prepare('INSERT INTO bulk (v) VALUES (?)');
+      const payload = 'x'.repeat(200);
+      let written = 0;
+      let err: unknown;
+      try {
+        for (let i = 0; i < 20_000; i += 1) {
+          insert.run(payload);
+          written += 1;
+        }
+      } catch (caught) {
+        err = caught;
+      }
+
+      expect(sqliteErrcode(err)).toBe(SQLITE_FULL);
+      expect(written).toBeGreaterThan(0);
+      // Out of room is not the same as damaged: every committed row is still
+      // there and nothing was left half-written.
+      expect((db.prepare('SELECT count(*) AS n FROM bulk').get() as { n: number }).n).toBe(written);
+      expect(db.prepare('PRAGMA integrity_check').get()).toEqual({ integrity_check: 'ok' });
+
+      filled.restore();
+      expect(() => {
+        insert.run(payload);
+      }).not.toThrow();
+      db.close();
+    });
+  });
+
+  it('caps the handle it was given, not the file', () => {
+    withTempStore((store) => {
+      seedStore(store);
+      const capped = new DatabaseSync(store.dbFile);
+      capped.exec('PRAGMA journal_mode = WAL');
+      capped.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
+      fillStore(capped);
+
+      const other = new DatabaseSync(store.dbFile);
+      const insert = other.prepare('INSERT INTO bulk (v) VALUES (?)');
+      const payload = 'x'.repeat(200);
+      expect(() => {
+        for (let i = 0; i < 500; i += 1) insert.run(payload);
+      }).not.toThrow();
+
+      other.close();
+      capped.close();
+    });
+  });
+});

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -1,0 +1,388 @@
+/**
+ * Store faults a test can inject on purpose: a damaged file, a store it cannot
+ * write, a write lock held by someone else, and a store with no room left.
+ *
+ * The store's own error classification reads one extended result code
+ * (SQLITE_CONSTRAINT_UNIQUE), so every other SQLite failure arrives at the
+ * fail-open paths as an indistinguishable `Error`. These injectors produce the
+ * real codes from the real engine — nothing here mocks node:sqlite or the
+ * filesystem — so a test can pin which failure it is actually exercising.
+ *
+ * Every injector either takes effect or says so: `corruptStore` verifies the
+ * damage landed, and `readOnlyStore` reports whether the mode change actually
+ * denies writes. On Windows chmod is a no-op for directories, and a process
+ * running as root bypasses modes entirely; without that signal a read-only
+ * test would pass on a store it could still write.
+ */
+import {
+  accessSync,
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  openSync,
+  readSync,
+  rmSync,
+  statSync,
+  truncateSync,
+  writeSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { Worker } from 'node:worker_threads';
+
+import { walSidecars } from '../../src/paths.ts';
+
+/** Extended result codes node:sqlite attaches to an error as `errcode`. */
+export const SQLITE_BUSY = 5;
+export const SQLITE_READONLY = 8;
+export const SQLITE_CORRUPT = 11;
+export const SQLITE_FULL = 13;
+export const SQLITE_NOTADB = 26;
+/** SQLITE_READONLY_DIRECTORY — the db is fine, its directory is not writable. */
+export const SQLITE_READONLY_DIRECTORY = 1544;
+
+/** The `errcode` node:sqlite carries on an error, or undefined for anything else. */
+export function sqliteErrcode(err: unknown): number | undefined {
+  return err instanceof Error ? (err as { errcode?: number }).errcode : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Corruption
+// ---------------------------------------------------------------------------
+
+/**
+ * How to damage a store. Each mode fails at a different point, which is the
+ * reason to have all three:
+ *
+ * - `truncate` — the file keeps a valid header but loses its pages, so a read
+ *   raises SQLITE_CORRUPT.
+ * - `header` — the magic string is gone, so SQLite refuses the file outright
+ *   with SQLITE_NOTADB, before any query runs.
+ * - `page` — the b-tree page header of the store's second page changes, so the
+ *   page no longer declares a valid type. The store opens, and rows outside
+ *   the damaged page still read, so only `PRAGMA integrity_check` notices.
+ *   This is the quiet one, and the one a fail-open caller is most likely to
+ *   carry on through.
+ */
+export type CorruptionMode = 'truncate' | 'header' | 'page';
+
+/** Bytes kept by `truncate` — enough for the 100-byte header, not the pages. */
+const TRUNCATE_TO_BYTES = 1024;
+/** SQLite stores the page size at header offset 16, big-endian, 2 bytes. */
+const PAGE_SIZE_OFFSET = 16;
+
+function readPageSize(file: string): number {
+  const fd = openSync(file, 'r');
+  try {
+    const header = Buffer.alloc(2);
+    readSync(fd, header, 0, 2, PAGE_SIZE_OFFSET);
+    const encoded = header.readUInt16BE(0);
+    // A page size of 65536 is stored as 1.
+    return encoded === 1 ? 65536 : encoded;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function flipByteAt(file: string, offset: number): void {
+  const fd = openSync(file, 'r+');
+  try {
+    const byte = Buffer.alloc(1);
+    readSync(fd, byte, 0, 1, offset);
+    writeSync(fd, Buffer.from([byte.readUInt8(0) ^ 0xff]), 0, 1, offset);
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/** True when the store is damaged in a way SQLite will report. */
+function isDamaged(file: string): boolean {
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(file);
+    const row = db.prepare('PRAGMA integrity_check').get() as
+      { integrity_check?: string } | undefined;
+    return row?.integrity_check !== 'ok';
+  } catch {
+    // Refused at open or at the first read — damaged, and loudly so.
+    return true;
+  } finally {
+    try {
+      db?.close();
+    } catch {
+      // Already torn down by the failure above.
+    }
+  }
+}
+
+/**
+ * Damage a real store at a fixed offset — same input, same bytes changed, every
+ * run. The store must have no open handle: the WAL sidecars are removed first,
+ * because a WAL still holding the live pages would replay over the damage.
+ *
+ * Throws if the damage did not take, so a corrupted-store test can never pass
+ * against a healthy store.
+ */
+export function corruptStore(file: string, mode: CorruptionMode = 'truncate'): void {
+  if (!existsSync(file)) {
+    throw new Error(`corruptStore(): no store at ${file}`);
+  }
+  for (const sidecar of walSidecars(file)) {
+    if (existsSync(sidecar)) rmSync(sidecar);
+  }
+
+  switch (mode) {
+    case 'truncate': {
+      const size = statSync(file).size;
+      if (size <= TRUNCATE_TO_BYTES) {
+        throw new Error(
+          `corruptStore('truncate'): ${file} is ${String(size)} bytes, already at or below the ${String(TRUNCATE_TO_BYTES)}-byte target — write to the store first.`,
+        );
+      }
+      truncateSync(file, TRUNCATE_TO_BYTES);
+      break;
+    }
+    case 'header': {
+      // Byte 0 of the "SQLite format 3\0" magic string.
+      flipByteAt(file, 0);
+      break;
+    }
+    case 'page': {
+      const pageSize = readPageSize(file);
+      // Byte 0 of page 2 — the b-tree page type. Page 1 is left alone: damaging
+      // it would take the file header with it and fail at open instead.
+      const offset = pageSize;
+      if (statSync(file).size <= offset) {
+        throw new Error(
+          `corruptStore('page'): ${file} is a single page — write enough rows to reach a second page first.`,
+        );
+      }
+      flipByteAt(file, offset);
+      break;
+    }
+  }
+
+  if (!isDamaged(file)) {
+    throw new Error(`corruptStore('${mode}'): ${file} still reads as a healthy store.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read-only
+// ---------------------------------------------------------------------------
+
+export interface ReadOnlyStore {
+  /**
+   * Whether the mode change actually denies writes. False where the platform
+   * ignores POSIX modes, or the process can write regardless — a test that
+   * asserts read-only behaviour should skip rather than pass on a writable
+   * store.
+   */
+  readonly effective: boolean;
+  /** Put the original modes back. Idempotent. */
+  restore(): void;
+}
+
+/**
+ * Make a store unwritable by mode. The db and any WAL sidecars go to 0444.
+ *
+ * With `includeDir`, the containing directory goes to 0555 as well, which is
+ * the harsher case: in WAL mode SQLite needs to create the -wal/-shm sidecars,
+ * so it fails at open with SQLITE_READONLY_DIRECTORY rather than at the first
+ * write. Without it, reads keep working and only writes raise SQLITE_READONLY.
+ *
+ * `includeDir` reaches a raw handle, not `openLocalDatabase`: that path calls
+ * `ensureDataDirSync` first, which chmods the data dir back to 0700 — an owner
+ * can always widen their own directory again — so only the file mode is left
+ * to bite by the time SQLite sees it.
+ *
+ * `restore()` must run before the tree is deleted — register it with the temp
+ * store's `onCleanup`, which `withTempStore` already drains.
+ */
+export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {}): ReadOnlyStore {
+  const targets = [file, ...walSidecars(file)].filter((path) => existsSync(path));
+  const dir = dirname(file);
+  const original = new Map<string, number>();
+
+  const tighten = (path: string, mode: number): void => {
+    original.set(path, statSync(path).mode);
+    chmodSync(path, mode);
+  };
+
+  for (const path of targets) tighten(path, 0o444);
+  if (opts.includeDir) tighten(dir, 0o555);
+
+  // A mode that still permits writing protects nothing; report that rather
+  // than let a caller assert against a store it can freely write.
+  const denied = (path: string): boolean => {
+    try {
+      accessSync(path, constants.W_OK);
+      return false;
+    } catch {
+      return true;
+    }
+  };
+  const effective = [...original.keys()].every(denied);
+
+  let restored = false;
+  return {
+    effective,
+    restore(): void {
+      if (restored) return;
+      restored = true;
+      // The directory first: everything else lives inside it.
+      if (opts.includeDir) {
+        const mode = original.get(dir);
+        if (mode !== undefined) chmodSync(dir, mode);
+      }
+      for (const path of targets) {
+        const mode = original.get(path);
+        try {
+          if (mode !== undefined) chmodSync(path, mode);
+        } catch {
+          // Already gone, or a platform that never applied the mode.
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Write lock held elsewhere
+// ---------------------------------------------------------------------------
+
+const STATE = 0;
+const RELEASE = 1;
+
+const STATE_HELD = 1;
+const STATE_FAILED = 3;
+
+export interface StoreLock {
+  /**
+   * Give the write lock back and wait until the holder has let go. Idempotent,
+   * and a no-op once `holdMs` has already elapsed.
+   *
+   * It returns only after the holder has closed its handle, so a temp store
+   * torn down straight afterwards has no connection left on the file —
+   * Windows refuses to delete one that is still open.
+   */
+  release(): void;
+}
+
+export interface LockStoreOptions {
+  /**
+   * Hold for this long, then release without being asked. Leave it out to hold
+   * until `release()`.
+   *
+   * A hold longer than the store's `busy_timeout` makes another writer fail
+   * with SQLITE_BUSY; a shorter one makes it wait and then succeed. Both are
+   * worth pinning — one proves the timeout has a limit, the other proves it
+   * does its job.
+   */
+  holdMs?: number;
+  /** How long to wait for the lock to be taken before giving up. */
+  readyTimeoutMs?: number;
+  /** `busy_timeout` for the holder's own handle while it takes the lock. */
+  busyTimeoutMs?: number;
+}
+
+/**
+ * Take the store's write lock (`BEGIN IMMEDIATE`) on another thread and return
+ * once it is held.
+ *
+ * node:sqlite is synchronous, so a lock held on the calling thread could never
+ * be contended — the thread would be inside the holder, not the victim. A
+ * worker thread holds it instead, and the handshake is a blocking
+ * `Atomics.wait` rather than a poll or a sleep, so "the lock is up" is settled
+ * before this function returns and the victim can never start early.
+ */
+export function lockStore(file: string, opts: LockStoreOptions = {}): StoreLock {
+  const readyTimeoutMs = opts.readyTimeoutMs ?? 10_000;
+  const shared = new SharedArrayBuffer(2 * Int32Array.BYTES_PER_ELEMENT);
+  const signal = new Int32Array(shared);
+
+  const worker = new Worker(new URL('./lock-worker.ts', import.meta.url), {
+    workerData: {
+      file,
+      busyTimeoutMs: opts.busyTimeoutMs ?? 2000,
+      holdMs: opts.holdMs ?? null,
+      shared,
+    },
+  });
+  // The lock must not be what keeps the test process alive.
+  worker.unref();
+  worker.on('error', () => {
+    // The state slots carry every failure this helper reports. Without a
+    // listener Node re-raises a worker error on this thread instead, long
+    // after the call that started it returned.
+    void worker.terminate();
+  });
+
+  Atomics.wait(signal, STATE, 0, readyTimeoutMs);
+  const state = Atomics.load(signal, STATE);
+  if (state !== STATE_HELD) {
+    void worker.terminate();
+    throw new Error(
+      state === STATE_FAILED
+        ? `lockStore(): the holder could not take the write lock on ${file}`
+        : `lockStore(): the write lock on ${file} was not taken within ${String(readyTimeoutMs)}ms`,
+    );
+  }
+
+  let released = false;
+  return {
+    release(): void {
+      if (released) return;
+      released = true;
+      Atomics.store(signal, RELEASE, 1);
+      Atomics.notify(signal, RELEASE);
+      // Returns immediately once the holder has moved off STATE_HELD, including
+      // when it already released itself after holdMs.
+      Atomics.wait(signal, STATE, STATE_HELD, readyTimeoutMs);
+      void worker.terminate();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// No room left
+// ---------------------------------------------------------------------------
+
+export interface FilledStore {
+  /** Lift the cap. Idempotent. */
+  restore(): void;
+}
+
+/**
+ * Cap how far a store may grow on this handle, so the next write that needs a
+ * new page raises SQLITE_FULL from the engine itself — no mount, no elevated
+ * privileges, and no stand-in for node:sqlite.
+ *
+ * The cap belongs to the connection, not the file: another handle on the same
+ * store is unaffected, so this fills the store for the handle passed in and
+ * that handle only. A genuinely full filesystem stays out of reach in CI.
+ */
+export function fillStore(db: DatabaseSync, opts: { headroomPages?: number } = {}): FilledStore {
+  const readPragma = (name: string): number => {
+    const row = db.prepare(`PRAGMA ${name}`).get() as Record<string, unknown> | undefined;
+    const value = row?.[name];
+    if (typeof value !== 'number') {
+      throw new Error(`fillStore(): PRAGMA ${name} returned no value`);
+    }
+    return value;
+  };
+
+  const previousMax = readPragma('max_page_count');
+  const cap = readPragma('page_count') + (opts.headroomPages ?? 2);
+  db.prepare(`PRAGMA max_page_count = ${String(cap)}`).get();
+
+  let restored = false;
+  return {
+    restore(): void {
+      if (restored) return;
+      restored = true;
+      db.prepare(`PRAGMA max_page_count = ${String(previousMax)}`).get();
+    },
+  };
+}

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -32,6 +32,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { Worker } from 'node:worker_threads';
 
 import { walSidecars } from '../../src/paths.ts';
+import type { TempStore } from './temp-store.ts';
 
 /**
  * Primary result codes — the low byte of the code node:sqlite reports.
@@ -44,7 +45,6 @@ import { walSidecars } from '../../src/paths.ts';
  * only when the refinement itself is the point.
  */
 export const SQLITE_BUSY = 5;
-export const SQLITE_LOCKED = 6;
 export const SQLITE_READONLY = 8;
 export const SQLITE_CORRUPT = 11;
 export const SQLITE_FULL = 13;
@@ -135,17 +135,37 @@ function isDamaged(file: string): boolean {
   }
 }
 
+export interface CorruptStoreOptions {
+  /**
+   * The store the file belongs to. Given one, the no-open-handle precondition
+   * below is checked rather than described — pass it wherever you have it.
+   */
+  store?: Pick<TempStore, 'openHandleCount'>;
+}
+
 /**
  * Damage a real store at a fixed offset — same input, same bytes changed, every
  * run. The store must have no open handle: the WAL sidecars are removed first,
- * because a WAL still holding the live pages would replay over the damage.
+ * and pulling them out from under a live connection makes the resulting damage
+ * depend on that connection's cached pages, which costs the determinism above.
+ * Pass `store` and that precondition is enforced.
  *
  * Throws if the damage did not take, so a corrupted-store test can never pass
  * against a healthy store.
  */
-export function corruptStore(file: string, mode: CorruptionMode = 'truncate'): void {
+export function corruptStore(
+  file: string,
+  mode: CorruptionMode = 'truncate',
+  opts: CorruptStoreOptions = {},
+): void {
   if (!existsSync(file)) {
     throw new Error(`corruptStore(): no store at ${file}`);
+  }
+  const live = opts.store?.openHandleCount() ?? 0;
+  if (live > 0) {
+    throw new Error(
+      `corruptStore(): ${String(live)} handle(s) still open on ${file} — close them first, or the WAL removed below is pulled out from under a live connection.`,
+    );
   }
   for (const sidecar of walSidecars(file)) {
     if (existsSync(sidecar)) rmSync(sidecar);
@@ -240,6 +260,13 @@ const READ_ONLY_DIR_MODE = 0o500;
  * yourself from a `finally`.
  */
 export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): ReadOnlyStore {
+  // Without this, an absent file tightens nothing, `original` stays empty, and
+  // `[].every(...)` reports `effective: true` — the vacuous pass this helper
+  // exists to prevent, handed to a caller that then asserts read-only
+  // behaviour against a store it can freely write.
+  if (!existsSync(file)) {
+    throw new Error(`readOnlyStore(): no store at ${file}`);
+  }
   const targets = [file, ...walSidecars(file)].filter((path) => existsSync(path));
   const dir = dirname(file);
   const original = new Map<string, number>();
@@ -312,8 +339,11 @@ export interface StoreLock {
    * and a no-op once `holdMs` has already elapsed.
    *
    * It returns only after the holder has closed its handle, so a temp store
-   * torn down straight afterwards has no connection left on the file —
-   * Windows refuses to delete one that is still open.
+   * torn down straight afterwards has no connection left on the file — Windows
+   * refuses to delete one that is still open. If the holder does not report
+   * back within `readyTimeoutMs` this throws rather than return, because the
+   * handle may still be open and a silent return would hand back exactly the
+   * guarantee it failed to keep.
    */
   release(): void;
 }
@@ -412,8 +442,13 @@ export function lockStore(file: string, opts: LockStoreOptions = {}): StoreLock 
       Atomics.notify(signal, RELEASE);
       // Returns immediately once the holder has moved off STATE_HELD, including
       // when it already released itself after holdMs.
-      Atomics.wait(signal, STATE, STATE_HELD, readyTimeoutMs);
+      const settled = Atomics.wait(signal, STATE, STATE_HELD, readyTimeoutMs);
       void worker.terminate();
+      if (settled === 'timed-out') {
+        throw new Error(
+          `lockStore(): the holder on ${file} did not report letting go within ${String(readyTimeoutMs)}ms — its handle may still be open on the store.`,
+        );
+      }
     },
   };
   opts.onCleanup?.(() => {

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -272,7 +272,11 @@ export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): Re
   const original = new Map<string, number>();
 
   const tighten = (path: string, mode: number): void => {
-    original.set(path, statSync(path).mode);
+    // Permission bits only: `st_mode` carries the file-type bits too, and
+    // POSIX leaves chmod's behaviour for those unspecified. Linux and macOS
+    // mask them, so handing the whole thing back happens to work — but 0o7777
+    // is what the API actually takes.
+    original.set(path, statSync(path).mode & 0o7777);
     chmodSync(path, mode);
   };
 

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -33,8 +33,18 @@ import { Worker } from 'node:worker_threads';
 
 import { walSidecars } from '../../src/paths.ts';
 
-/** Extended result codes node:sqlite attaches to an error as `errcode`. */
+/**
+ * Primary result codes — the low byte of the code node:sqlite reports.
+ *
+ * `errcode` carries the **extended** code, which is the primary code plus a
+ * refinement in its high bits: SQLITE_READONLY (8) also arrives as
+ * SQLITE_READONLY_DIRECTORY (1544) or SQLITE_READONLY_DBMOVED (1032), and
+ * SQLITE_BUSY (5) as SQLITE_BUSY_SNAPSHOT (517). So compare with
+ * `primaryCode()` to assert the class of failure, and with `sqliteErrcode()`
+ * only when the refinement itself is the point.
+ */
 export const SQLITE_BUSY = 5;
+export const SQLITE_LOCKED = 6;
 export const SQLITE_READONLY = 8;
 export const SQLITE_CORRUPT = 11;
 export const SQLITE_FULL = 13;
@@ -45,6 +55,15 @@ export const SQLITE_READONLY_DIRECTORY = 1544;
 /** The `errcode` node:sqlite carries on an error, or undefined for anything else. */
 export function sqliteErrcode(err: unknown): number | undefined {
   return err instanceof Error ? (err as { errcode?: number }).errcode : undefined;
+}
+
+/**
+ * The primary result code behind whatever refinement SQLite attached — the
+ * comparison to use against the `SQLITE_*` constants above.
+ */
+export function primaryCode(err: unknown): number | undefined {
+  const code = sqliteErrcode(err);
+  return code === undefined ? undefined : code & 0xff;
 }
 
 // ---------------------------------------------------------------------------
@@ -184,10 +203,30 @@ export interface ReadOnlyStore {
   restore(): void;
 }
 
+export interface ReadOnlyStoreOptions {
+  /** Tighten the containing directory too — see below. */
+  includeDir?: boolean;
+  /**
+   * Register `restore()` for teardown, most conveniently the temp store's own
+   * `onCleanup`. Without it the caller owns the restore, and a body that
+   * throws leaves a tree that cannot be deleted.
+   */
+  onCleanup?: (fn: () => void) => void;
+}
+
+/** Read-only for the owner, and nobody else: the 0600 store stays owner-only. */
+const READ_ONLY_FILE_MODE = 0o400;
+/** The directory equivalent — owner may traverse and list, not create. */
+const READ_ONLY_DIR_MODE = 0o500;
+
 /**
- * Make a store unwritable by mode. The db and any WAL sidecars go to 0444.
+ * Make a store unwritable by mode. The db and any WAL sidecars go to 0400.
  *
- * With `includeDir`, the containing directory goes to 0555 as well, which is
+ * Read-only for the owner alone, not 0444: `aka.db` holds prompt and file
+ * content and the package writes it 0600 everywhere else, so a test has no
+ * reason to widen it to the world on the way to denying a write.
+ *
+ * With `includeDir`, the containing directory goes to 0500 as well, which is
  * the harsher case: in WAL mode SQLite needs to create the -wal/-shm sidecars,
  * so it fails at open with SQLITE_READONLY_DIRECTORY rather than at the first
  * write. Without it, reads keep working and only writes raise SQLITE_READONLY.
@@ -197,10 +236,10 @@ export interface ReadOnlyStore {
  * can always widen their own directory again — so only the file mode is left
  * to bite by the time SQLite sees it.
  *
- * `restore()` must run before the tree is deleted — register it with the temp
- * store's `onCleanup`, which `withTempStore` already drains.
+ * `restore()` must run before the tree is deleted: pass `onCleanup`, or call it
+ * yourself from a `finally`.
  */
-export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {}): ReadOnlyStore {
+export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): ReadOnlyStore {
   const targets = [file, ...walSidecars(file)].filter((path) => existsSync(path));
   const dir = dirname(file);
   const original = new Map<string, number>();
@@ -210,8 +249,8 @@ export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {})
     chmodSync(path, mode);
   };
 
-  for (const path of targets) tighten(path, 0o444);
-  if (opts.includeDir) tighten(dir, 0o555);
+  for (const path of targets) tighten(path, READ_ONLY_FILE_MODE);
+  if (opts.includeDir) tighten(dir, READ_ONLY_DIR_MODE);
 
   // A mode that still permits writing protects nothing; report that rather
   // than let a caller assert against a store it can freely write.
@@ -226,7 +265,7 @@ export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {})
   const effective = [...original.keys()].every(denied);
 
   let restored = false;
-  return {
+  const readOnly: ReadOnlyStore = {
     effective,
     restore(): void {
       if (restored) return;
@@ -234,7 +273,12 @@ export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {})
       // The directory first: everything else lives inside it.
       if (opts.includeDir) {
         const mode = original.get(dir);
-        if (mode !== undefined) chmodSync(dir, mode);
+        try {
+          if (mode !== undefined) chmodSync(dir, mode);
+        } catch {
+          // A directory left tightened would strand the whole temp tree, but
+          // there is nothing further to try here.
+        }
       }
       for (const path of targets) {
         const mode = original.get(path);
@@ -246,6 +290,10 @@ export function readOnlyStore(file: string, opts: { includeDir?: boolean } = {})
       }
     },
   };
+  opts.onCleanup?.(() => {
+    readOnly.restore();
+  });
+  return readOnly;
 }
 
 // ---------------------------------------------------------------------------
@@ -279,12 +327,24 @@ export interface LockStoreOptions {
    * with SQLITE_BUSY; a shorter one makes it wait and then succeed. Both are
    * worth pinning — one proves the timeout has a limit, the other proves it
    * does its job.
+   *
+   * On this path the holder lets go on its own, and the caller is not told
+   * when: the victim's write goes through the moment the ROLLBACK lands, one
+   * statement before the holder closes its handle. Deleting the tree in that
+   * window fails on Windows, where an open file cannot be unlinked. Call
+   * `release()` — which waits for the close — or pass `onCleanup`.
    */
   holdMs?: number;
   /** How long to wait for the lock to be taken before giving up. */
   readyTimeoutMs?: number;
   /** `busy_timeout` for the holder's own handle while it takes the lock. */
   busyTimeoutMs?: number;
+  /**
+   * Register `release()` for teardown, most conveniently the temp store's own
+   * `onCleanup`. Without it, a body that throws while the lock is held leaks
+   * the holder thread and its open handle on the store.
+   */
+  onCleanup?: (fn: () => void) => void;
 }
 
 /**
@@ -296,6 +356,16 @@ export interface LockStoreOptions {
  * worker thread holds it instead, and the handshake is a blocking
  * `Atomics.wait` rather than a poll or a sleep, so "the lock is up" is settled
  * before this function returns and the victim can never start early.
+ *
+ * Two things to know before pointing this at the product's own paths:
+ *
+ * - **Open the victim's handle first.** `openLocalDatabase` writes on the way
+ *   in (`PRAGMA journal_mode = WAL`, then the migration and `ensure*` passes),
+ *   so opening under a held lock does not merely block — it fails with
+ *   SQLITE_BUSY once `busy_timeout` runs out.
+ * - **Each contended write costs the full `busy_timeout`**, 2000 ms for a
+ *   `LocalDatabase`. A suite that contends often enough will outrun vitest's
+ *   per-test timeout long before it runs out of assertions.
  */
 export function lockStore(file: string, opts: LockStoreOptions = {}): StoreLock {
   const readyTimeoutMs = opts.readyTimeoutMs ?? 10_000;
@@ -326,12 +396,15 @@ export function lockStore(file: string, opts: LockStoreOptions = {}): StoreLock 
     throw new Error(
       state === STATE_FAILED
         ? `lockStore(): the holder could not take the write lock on ${file}`
-        : `lockStore(): the write lock on ${file} was not taken within ${String(readyTimeoutMs)}ms`,
+        : // This thread was parked in Atomics.wait the whole time, so the
+          // worker's 'error' event could not be delivered — a holder that
+          // never loaded and one that never got the lock look identical here.
+          `lockStore(): no word from the holder for ${file} within ${String(readyTimeoutMs)}ms — it never took the write lock, or the worker failed to start.`,
     );
   }
 
   let released = false;
-  return {
+  const lock: StoreLock = {
     release(): void {
       if (released) return;
       released = true;
@@ -343,6 +416,10 @@ export function lockStore(file: string, opts: LockStoreOptions = {}): StoreLock 
       void worker.terminate();
     },
   };
+  opts.onCleanup?.(() => {
+    lock.release();
+  });
+  return lock;
 }
 
 // ---------------------------------------------------------------------------
@@ -362,6 +439,13 @@ export interface FilledStore {
  * The cap belongs to the connection, not the file: another handle on the same
  * store is unaffected, so this fills the store for the handle passed in and
  * that handle only. A genuinely full filesystem stays out of reach in CI.
+ *
+ * That connection scope is also the limit of this injector. It takes a raw
+ * `DatabaseSync`, and `LocalDatabase` exposes none, so no disk-full fault can
+ * be aimed at `recordCapture` or any other repository write today — this
+ * injector currently reaches node:sqlite, not the package built on it. Closing
+ * that gap needs either a raw-handle seam on `LocalDatabase` or repositories
+ * driven over a raw handle, as `activity.test.ts` already does.
  */
 export function fillStore(db: DatabaseSync, opts: { headroomPages?: number } = {}): FilledStore {
   const readPragma = (name: string): number => {

--- a/packages/persistence/test/helpers/lock-worker.ts
+++ b/packages/persistence/test/helpers/lock-worker.ts
@@ -1,0 +1,80 @@
+/**
+ * Holds `BEGIN IMMEDIATE` on a store from a thread of its own, so the thread
+ * that started it can go on to attempt a write and meet a real write lock.
+ *
+ * The two sides talk through one Int32Array in shared memory rather than
+ * messages: the starting thread blocks in `Atomics.wait` until this worker
+ * reports the lock is held, which makes "the lock is up before the victim
+ * writes" an ordering guarantee instead of a race. Slot 0 carries this
+ * worker's state, slot 1 carries the release request.
+ *
+ * Failure is reported through slot 0 and never thrown. A throw here escapes as
+ * an uncaught exception on the thread that started the worker, arriving after
+ * whichever test caused it has already finished — the starting thread reads
+ * the slot and raises its own error instead.
+ *
+ * This file is loaded by Node directly, outside the test runner's transform,
+ * so it stays on node: builtins and plain type annotations.
+ */
+import { DatabaseSync } from 'node:sqlite';
+import { workerData } from 'node:worker_threads';
+
+const STATE = 0;
+const RELEASE = 1;
+
+const STATE_HELD = 1;
+const STATE_RELEASED = 2;
+const STATE_FAILED = 3;
+
+interface LockWorkerData {
+  file: string;
+  busyTimeoutMs: number;
+  holdMs: number | null;
+  shared: SharedArrayBuffer;
+}
+
+const { file, busyTimeoutMs, holdMs, shared } = workerData as LockWorkerData;
+const signal = new Int32Array(shared);
+
+function announce(state: number): void {
+  Atomics.store(signal, STATE, state);
+  Atomics.notify(signal, STATE);
+}
+
+function takeLock(): DatabaseSync | undefined {
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(file);
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec(`PRAGMA busy_timeout = ${String(busyTimeoutMs)}`);
+    // BEGIN IMMEDIATE takes the write lock up front rather than on first write,
+    // so the lock is held the instant this returns — no statement needed.
+    db.exec('BEGIN IMMEDIATE');
+    return db;
+  } catch {
+    try {
+      db?.close();
+    } catch {
+      // The handle never opened, or already tore itself down.
+    }
+    return undefined;
+  }
+}
+
+const held = takeLock();
+if (!held) {
+  announce(STATE_FAILED);
+} else {
+  announce(STATE_HELD);
+
+  // Park until the starting thread asks for the lock back, or until the hold
+  // elapses. Blocking here rather than on a timer keeps the lock on this
+  // thread's stack for exactly as long as it is meant to be held.
+  Atomics.wait(signal, RELEASE, 0, holdMs ?? Infinity);
+
+  // ROLLBACK, not COMMIT: the lock existed to block another writer, and the
+  // transaction is not meant to leave anything behind.
+  held.exec('ROLLBACK');
+  held.close();
+  announce(STATE_RELEASED);
+}

--- a/packages/persistence/test/helpers/lock-worker.ts
+++ b/packages/persistence/test/helpers/lock-worker.ts
@@ -41,6 +41,14 @@ function announce(state: number): void {
   Atomics.notify(signal, STATE);
 }
 
+// The starting thread is parked in Atomics.wait and cannot receive this
+// worker's 'error' event, so anything that escapes below has to reach it
+// through the state slot or not at all — otherwise the caller waits out its
+// whole ready timeout and reports a lock that was never taken.
+process.on('uncaughtException', () => {
+  announce(STATE_FAILED);
+});
+
 function takeLock(): DatabaseSync | undefined {
   let db: DatabaseSync | undefined;
   try {

--- a/packages/persistence/test/helpers/lock-worker.ts
+++ b/packages/persistence/test/helpers/lock-worker.ts
@@ -53,12 +53,14 @@ function takeLock(): DatabaseSync | undefined {
   let db: DatabaseSync | undefined;
   try {
     db = new DatabaseSync(file);
-    // busy_timeout first: SQLite's default is 0, so anything set after it runs
-    // uncontended-or-fail. journal_mode needs an exclusive lock, and on a store
-    // not already in WAL it would give up instantly against another writer —
-    // reported as a BEGIN IMMEDIATE that was never attempted.
     db.exec(`PRAGMA busy_timeout = ${String(busyTimeoutMs)}`);
-    db.exec('PRAGMA journal_mode = WAL');
+    // No journal_mode here. The write lock does not need WAL — BEGIN IMMEDIATE
+    // takes one in any journal mode — and the mode change is the one statement
+    // busy_timeout cannot govern: SQLite refuses it outright against another
+    // writer rather than retrying, so it can only add a failure this helper
+    // would then misreport as a lock it could not take. Setting it would also
+    // convert the store under test, which a fault injector has no business
+    // doing.
     // BEGIN IMMEDIATE takes the write lock up front rather than on first write,
     // so the lock is held the instant this returns — no statement needed.
     db.exec('BEGIN IMMEDIATE');

--- a/packages/persistence/test/helpers/lock-worker.ts
+++ b/packages/persistence/test/helpers/lock-worker.ts
@@ -53,8 +53,12 @@ function takeLock(): DatabaseSync | undefined {
   let db: DatabaseSync | undefined;
   try {
     db = new DatabaseSync(file);
-    db.exec('PRAGMA journal_mode = WAL');
+    // busy_timeout first: SQLite's default is 0, so anything set after it runs
+    // uncontended-or-fail. journal_mode needs an exclusive lock, and on a store
+    // not already in WAL it would give up instantly against another writer —
+    // reported as a BEGIN IMMEDIATE that was never attempted.
     db.exec(`PRAGMA busy_timeout = ${String(busyTimeoutMs)}`);
+    db.exec('PRAGMA journal_mode = WAL');
     // BEGIN IMMEDIATE takes the write lock up front rather than on first write,
     // so the lock is held the instant this returns — no statement needed.
     db.exec('BEGIN IMMEDIATE');

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -9,6 +9,9 @@ import { createTempStore, useTempStore, withTempStore } from './temp-store.ts';
 // The helper's own gate: every store test that adopts it inherits these
 // guarantees, so a regression here is a regression in all of them.
 
+const MODES_IGNORED =
+  'this host ignores the mode change — a root process, or a filesystem without POSIX modes';
+
 describe('withTempStore', () => {
   it('lays the temp tree out like the real home', () => {
     withTempStore((store) => {
@@ -56,7 +59,12 @@ describe('withTempStore', () => {
     });
   });
 
-  it('keeps a failing teardown from speaking over the body failure', () => {
+  // The teardown failure this forces is a mode `removeTree` cannot delete
+  // through, so the whole case rests on the mode biting. On Windows a
+  // directory's mode is ignored, `removeTree` succeeds, and there is no
+  // teardown failure left to assert.
+  it('keeps a failing teardown from speaking over the body failure', (ctx) => {
+    if (process.platform === 'win32') ctx.skip('chmod is a no-op for directories on Windows');
     let home = '';
     let caught: Error | undefined;
     try {
@@ -71,8 +79,15 @@ describe('withTempStore', () => {
     } catch (err) {
       caught = err as Error;
     }
-    chmodSync(home, 0o700);
-    rmSync(home, { recursive: true, force: true });
+    // removeTree only ever swallows on Windows, which is already skipped above,
+    // so past this point a surviving tree means the rm threw and destroy() with
+    // it. A root process writes through the mode, leaving nothing to assert.
+    const teardownFailed = existsSync(home);
+    if (teardownFailed) {
+      chmodSync(home, 0o700);
+      rmSync(home, { recursive: true, force: true });
+    }
+    if (!teardownFailed) ctx.skip(MODES_IGNORED);
 
     expect(caught?.message).toBe('THE-REAL-FAILURE');
     // The teardown failure is not dropped either — it travels as the cause.

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -1,7 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createTempStore, useTempStore, withTempStore } from './temp-store.ts';
 
@@ -187,5 +187,35 @@ describe('useTempStore', () => {
     expect(store.home).not.toBe(firstHome);
     expect(existsSync(firstHome)).toBe(false);
     expect(store.open().ruleProbeCache.getVerdict('carried-over')).toBeUndefined();
+  });
+});
+
+// The guard behind vitest.config.ts's `sequence.hooks: 'stack'`. Without it the
+// pin can be deleted, inverted, or lost to a vitest upgrade and nothing notices
+// until someone writes the first teardown that reads the store — where it
+// arrives as a use-after-destroy rather than as "the hook order changed".
+describe('useTempStore teardown ordering', () => {
+  const store = useTempStore('aka-hook-order-');
+  let dbFile = '';
+  let aliveInTeardown: boolean | undefined;
+
+  // Registered after useTempStore's own afterEach. Only 'stack' runs "after"
+  // hooks in reverse, which is what puts this one first, while the store is
+  // still standing; 'list' and 'parallel' destroy it before this runs.
+  afterEach(() => {
+    // The path is captured in the test body, not read from the store here:
+    // after a destroy, `store.dbFile` throws rather than returning a stale
+    // path, and this has to fail as a plain assertion, not a hook exception.
+    aliveInTeardown = existsSync(dbFile);
+  });
+
+  it('opens a store the suite teardown can still see', () => {
+    dbFile = store.dbFile;
+    store.open();
+    expect(existsSync(dbFile)).toBe(true);
+  });
+
+  it('found the store alive in the previous test teardown', () => {
+    expect(aliveInTeardown).toBe(true);
   });
 });

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -1,5 +1,6 @@
-import { existsSync, statSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -14,11 +15,68 @@ describe('withTempStore', () => {
       expect(store.settingsDir).toBe(join(store.home, 'settings'));
       expect(store.dataDir).toBe(join(store.home, 'data'));
       expect(store.dbFile).toBe(join(store.home, 'data', 'aka.db'));
-      // settings/ exists from the start — nothing else creates it until a
-      // settings writer runs, and a test that writes settings.json by hand
-      // should not have to know that.
-      expect(existsSync(store.settingsDir)).toBe(true);
+      // Both exist from the start. `data/` would otherwise appear only on the
+      // first open(), and settings/ not until a settings writer ran — a test
+      // seeding either by hand should not have to know that.
+      expect({
+        settings: existsSync(store.settingsDir),
+        data: existsSync(store.dataDir),
+      }).toEqual({ settings: true, data: true });
     });
+  });
+
+  it('hands out raw handles that close themselves at teardown', () => {
+    let home = '';
+    let raw: DatabaseSync | undefined;
+    withTempStore((store) => {
+      home = store.home;
+      raw = store.openRaw();
+      raw.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      expect(raw.isOpen).toBe(true);
+      // Deliberately not closed: a test that fails mid-body never reaches its
+      // own close, which is where Windows then refuses to delete the tree.
+    });
+    expect(raw?.isOpen).toBe(false);
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('counts the handles that are still open, however they were opened', () => {
+    withTempStore((store) => {
+      expect(store.openHandleCount()).toBe(0);
+
+      const db = store.open();
+      const raw = store.openRaw();
+      expect(store.openHandleCount()).toBe(2);
+
+      // A close the test performs itself counts, not just teardown's.
+      db.close();
+      expect(store.openHandleCount()).toBe(1);
+      raw.close();
+      expect(store.openHandleCount()).toBe(0);
+    });
+  });
+
+  it('keeps a failing teardown from speaking over the body failure', () => {
+    let home = '';
+    let caught: Error | undefined;
+    try {
+      withTempStore((store) => {
+        home = store.home;
+        // A mode the test never restores: removeTree rethrows on POSIX, which
+        // must not replace the assertion that actually broke.
+        mkdirSync(join(store.home, 'locked'));
+        chmodSync(store.home, 0o500);
+        throw new Error('THE-REAL-FAILURE');
+      });
+    } catch (err) {
+      caught = err as Error;
+    }
+    chmodSync(home, 0o700);
+    rmSync(home, { recursive: true, force: true });
+
+    expect(caught?.message).toBe('THE-REAL-FAILURE');
+    // The teardown failure is not dropped either — it travels as the cause.
+    expect(caught?.cause).toBeDefined();
   });
 
   it('opens a usable store under data/', () => {

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -173,17 +173,26 @@ describe('withTempStore', () => {
     expect(existsSync(home)).toBe(false);
   });
 
-  it('keeps a cleanup that throws from stranding the tree', () => {
+  it('removes the tree when a cleanup throws, and still reports the failure', () => {
     let home = '';
-    expect(() => {
+    let caught: unknown;
+    try {
       withTempStore((store) => {
         home = store.home;
         store.onCleanup(() => {
           throw new Error('cleanup failed');
         });
       });
-    }).not.toThrow();
+    } catch (err) {
+      caught = err;
+    }
+    // The tree still goes — a cleanup that cannot run must not strand it.
     expect(existsSync(home)).toBe(false);
+    // But it is no longer discarded. Swallowing here is how an injector's own
+    // loud failure went silent: `lockStore` and `readOnlyStore` both recommend
+    // `onCleanup` as the wiring, so a throw from either landed in a bare catch.
+    expect(caught).toBeInstanceOf(AggregateError);
+    expect((caught as AggregateError).errors[0]).toMatchObject({ message: 'cleanup failed' });
   });
 
   it('honours a caller-supplied temp-dir prefix', () => {

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -1,0 +1,154 @@
+import { existsSync, statSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createTempStore, useTempStore, withTempStore } from './temp-store.ts';
+
+// The helper's own gate: every store test that adopts it inherits these
+// guarantees, so a regression here is a regression in all of them.
+
+describe('withTempStore', () => {
+  it('lays the temp tree out like the real home', () => {
+    withTempStore((store) => {
+      expect(store.settingsDir).toBe(join(store.home, 'settings'));
+      expect(store.dataDir).toBe(join(store.home, 'data'));
+      expect(store.dbFile).toBe(join(store.home, 'data', 'aka.db'));
+    });
+  });
+
+  it('opens a usable store under data/', () => {
+    withTempStore((store) => {
+      const db = store.open();
+      db.ruleProbeCache.setVerdict('rule-a', 'safe', 1.5);
+      expect(db.ruleProbeCache.getVerdict('rule-a')).toEqual({
+        verdict: 'safe',
+        worstProbeMs: 1.5,
+      });
+      expect(existsSync(store.dbFile)).toBe(true);
+      expect(dirname(store.dbFile)).toBe(store.dataDir);
+    });
+  });
+
+  it('closes its handles and removes the tree when the body returns', () => {
+    let home = '';
+    withTempStore((store) => {
+      home = store.home;
+      store.open();
+      store.open();
+    });
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('removes the tree when the body throws, and rethrows', () => {
+    let home = '';
+    expect(() => {
+      withTempStore((store) => {
+        home = store.home;
+        store.open();
+        throw new Error('boom');
+      });
+    }).toThrow('boom');
+    expect(home).not.toBe('');
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('tolerates a handle the body closed itself', () => {
+    let home = '';
+    expect(() => {
+      withTempStore((store) => {
+        home = store.home;
+        store.open().close();
+      });
+    }).not.toThrow();
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('opens independent handles that see one another writes', () => {
+    withTempStore((store) => {
+      const a = store.open();
+      const b = store.open();
+      expect(a).not.toBe(b);
+      a.ruleProbeCache.setVerdict('shared', 'quarantined', 250);
+      expect(b.ruleProbeCache.getVerdict('shared')).toEqual({
+        verdict: 'quarantined',
+        worstProbeMs: 250,
+      });
+    });
+  });
+
+  it('runs cleanups most-recent-first, while the tree still exists', () => {
+    const order: string[] = [];
+    let seen = false;
+    let home = '';
+    withTempStore((store) => {
+      home = store.home;
+      store.onCleanup(() => {
+        order.push('first');
+        seen = existsSync(store.home);
+      });
+      store.onCleanup(() => {
+        order.push('second');
+      });
+    });
+    expect(order).toEqual(['second', 'first']);
+    expect(seen).toBe(true);
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('keeps a cleanup that throws from stranding the tree', () => {
+    let home = '';
+    expect(() => {
+      withTempStore((store) => {
+        home = store.home;
+        store.onCleanup(() => {
+          throw new Error('cleanup failed');
+        });
+      });
+    }).not.toThrow();
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('honours a caller-supplied temp-dir prefix', () => {
+    withTempStore((store) => {
+      expect(basename(store.home).startsWith('aka-custom-prefix-')).toBe(true);
+    }, 'aka-custom-prefix-');
+  });
+});
+
+describe('createTempStore', () => {
+  it('destroys once, however many times it is asked', () => {
+    const store = createTempStore();
+    store.open();
+    store.destroy();
+    expect(existsSync(store.home)).toBe(false);
+    expect(() => {
+      store.destroy();
+    }).not.toThrow();
+  });
+
+  it('creates the data dir owner-only where modes apply', () => {
+    if (process.platform === 'win32') return;
+    withTempStore((store) => {
+      store.open();
+      expect(statSync(store.dataDir).mode & 0o777).toBe(0o700);
+    });
+  });
+});
+
+describe('useTempStore', () => {
+  const store = useTempStore('aka-use-temp-store-');
+  let firstHome = '';
+
+  it('hands the first test an empty store', () => {
+    firstHome = store.home;
+    expect(store.open().ruleProbeCache.getVerdict('carried-over')).toBeUndefined();
+    store.open().ruleProbeCache.setVerdict('carried-over', 'safe', 1);
+  });
+
+  it('hands the next test a different, equally empty store', () => {
+    expect(store.home).not.toBe(firstHome);
+    expect(existsSync(firstHome)).toBe(false);
+    expect(store.open().ruleProbeCache.getVerdict('carried-over')).toBeUndefined();
+  });
+});

--- a/packages/persistence/test/helpers/temp-store.test.ts
+++ b/packages/persistence/test/helpers/temp-store.test.ts
@@ -14,6 +14,10 @@ describe('withTempStore', () => {
       expect(store.settingsDir).toBe(join(store.home, 'settings'));
       expect(store.dataDir).toBe(join(store.home, 'data'));
       expect(store.dbFile).toBe(join(store.home, 'data', 'aka.db'));
+      // settings/ exists from the start — nothing else creates it until a
+      // settings writer runs, and a test that writes settings.json by hand
+      // should not have to know that.
+      expect(existsSync(store.settingsDir)).toBe(true);
     });
   });
 
@@ -114,6 +118,38 @@ describe('withTempStore', () => {
       expect(basename(store.home).startsWith('aka-custom-prefix-')).toBe(true);
     }, 'aka-custom-prefix-');
   });
+
+  // A `try/finally` would destroy the store the moment an async body returned
+  // its pending promise, and everything after the first await would run against
+  // closed handles and a deleted tree — passing, and asserting nothing.
+  it('waits for an async body before tearing down', async () => {
+    let home = '';
+    await withTempStore(async (store) => {
+      home = store.home;
+      const db = store.open();
+      await Promise.resolve();
+      db.ruleProbeCache.setVerdict('after-await', 'safe', 3);
+      expect(db.ruleProbeCache.getVerdict('after-await')).toEqual({
+        verdict: 'safe',
+        worstProbeMs: 3,
+      });
+      expect(existsSync(store.dbFile)).toBe(true);
+    });
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it('removes the tree when an async body rejects, and rethrows', async () => {
+    let home = '';
+    await expect(
+      withTempStore(async (store) => {
+        home = store.home;
+        store.open();
+        await Promise.resolve();
+        throw new Error('async boom');
+      }),
+    ).rejects.toThrow('async boom');
+    expect(existsSync(home)).toBe(false);
+  });
 });
 
 describe('createTempStore', () => {
@@ -127,11 +163,12 @@ describe('createTempStore', () => {
     }).not.toThrow();
   });
 
-  it('creates the data dir owner-only where modes apply', () => {
-    if (process.platform === 'win32') return;
+  it('creates the data dir owner-only where modes apply', (ctx) => {
+    if (process.platform === 'win32') ctx.skip('chmod is a no-op for directories on Windows');
     withTempStore((store) => {
       store.open();
       expect(statSync(store.dataDir).mode & 0o777).toBe(0o700);
+      expect(statSync(store.settingsDir).mode & 0o777).toBe(0o700);
     });
   });
 });

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -101,9 +101,31 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
           // handle itself — an already-closed handle is the expected case here.
         }
       }
-      rmSync(home, { recursive: true, force: true });
+      removeTree(home);
     },
   };
+}
+
+// Windows refuses to delete a file some handle still has open, where POSIX is
+// happy to. A fault test reaches that state legitimately: `openLocalDatabase`
+// never closes its `DatabaseSync` when it throws partway through — on a corrupt
+// or locked store it fails after construction and the handle is unreachable —
+// so nothing can close it before the rm.
+//
+// Retry through the case where a handle is merely on its way out, then, on
+// Windows only, give the tree to the OS temp sweeper rather than fail a test
+// whose assertions already passed. POSIX keeps throwing: there the same codes
+// mean a cleanup did not run — a forgotten mode restore, say — and that is a
+// defect in the test, not the platform.
+const STILL_HELD = new Set(['EPERM', 'EBUSY', 'EACCES', 'ENOTEMPTY']);
+
+function removeTree(home: string): void {
+  try {
+    rmSync(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (process.platform !== 'win32' || code === undefined || !STILL_HELD.has(code)) throw err;
+  }
 }
 
 /** True for anything with a callable `then` — a promise, or a promise-alike. */

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -13,16 +13,17 @@
  * independent connection on the one file — which is what makes two live
  * writers, and the contention between them, reachable from a test.
  */
-import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, beforeEach } from 'vitest';
 
 import type { LocalDatabase } from '../../src/database.ts';
 import { openLocalDatabase } from '../../src/database.ts';
 import { dataDir, dbPath, settingsDir } from '../../src/local-layout.ts';
-import { DATA_DIR_MODE } from '../../src/paths.ts';
+import { ensureDataDirSync } from '../../src/paths.ts';
 
 export interface TempStore {
   /** The mkdtemp root, standing in for `~/.aka`. */
@@ -39,11 +40,23 @@ export interface TempStore {
    */
   readonly open: () => LocalDatabase;
   /**
+   * A raw `DatabaseSync` on the same file, closed for you at teardown. A test
+   * that opens one by hand has to close it on every path, including the one
+   * where an assertion just failed — which is where it is most often forgotten,
+   * and where Windows then refuses to delete the tree.
+   */
+  readonly openRaw: () => DatabaseSync;
+  /**
+   * How many handles handed out by `open`/`openRaw` are still open. Injectors
+   * whose precondition is "no live connection" check this rather than trust the
+   * caller to have read the doc.
+   */
+  readonly openHandleCount: () => number;
+  /**
    * Run `fn` before the temp tree is removed, most recent first. Fault
    * injectors take this as their `onCleanup` option — a read-only tree cannot
    * be deleted and a held lock cannot be, either on Windows, so both have to
-   * be undone before the rm. Declared as a property, not a method, so it can
-   * be handed to an injector without binding.
+   * be undone before the rm.
    */
   readonly onCleanup: (fn: () => void) => void;
 }
@@ -58,30 +71,69 @@ export interface OwnedTempStore extends TempStore {
  * A temp store the caller destroys by hand. Prefer `withTempStore` (scoped) or
  * `useTempStore` (hook-driven); reach for this only when neither shape fits.
  */
+/** A handle the store handed out, and the two things it needs to track it. */
+interface TrackedHandle {
+  close: () => void;
+  isOpen: () => boolean;
+}
+
 export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
   const home = mkdtempSync(join(tmpdir(), prefix));
-  // `data/` is created by openLocalDatabase, but nothing creates `settings/`
-  // until a settings writer runs — so a test that writes settings.json by hand
-  // would meet an absent directory. Both subdirs exist from the start instead.
-  mkdirSync(settingsDir(home), { recursive: true, mode: DATA_DIR_MODE });
-  const handles: LocalDatabase[] = [];
+  // Both subdirs up front, through the same helper the product uses: a bare
+  // `mkdirSync` mode is umask-masked and is not applied to a directory that
+  // already exists, so `ensureDataDirSync`'s follow-up chmod is what makes 0700
+  // a guarantee rather than a request. `data/` would otherwise appear only on
+  // the first `open()`, and a test seeding the store by hand — a
+  // policy-cache.json, a read-only directory — would meet an absent path.
+  ensureDataDirSync(settingsDir(home));
+  ensureDataDirSync(dataDir(home));
+
+  const handles: TrackedHandle[] = [];
   const cleanups: (() => void)[] = [];
   let destroyed = false;
 
+  // Arrow properties, not method shorthand: these get handed to injectors
+  // unbound (`{ onCleanup: store.onCleanup }`), so binding must not matter.
   return {
     home,
     settingsDir: settingsDir(home),
     dataDir: dataDir(home),
     dbFile: dbPath(home),
-    open(): LocalDatabase {
+    open: (): LocalDatabase => {
       const db = openLocalDatabase(dataDir(home));
-      handles.push(db);
+      // LocalDatabase has no `isOpen`, so the close is wrapped to record it —
+      // otherwise a handle a test closed itself still counts as live.
+      let closed = false;
+      const tracked: LocalDatabase = {
+        ...db,
+        close: () => {
+          closed = true;
+          db.close();
+        },
+      };
+      handles.push({
+        close: () => {
+          tracked.close();
+        },
+        isOpen: () => !closed,
+      });
+      return tracked;
+    },
+    openRaw: (): DatabaseSync => {
+      const db = new DatabaseSync(dbPath(home));
+      handles.push({
+        close: () => {
+          db.close();
+        },
+        isOpen: () => db.isOpen,
+      });
       return db;
     },
-    onCleanup(fn: () => void): void {
+    openHandleCount: (): number => handles.filter((handle) => handle.isOpen()).length,
+    onCleanup: (fn: () => void): void => {
       cleanups.push(fn);
     },
-    destroy(): void {
+    destroy: (): void => {
       if (destroyed) return;
       destroyed = true;
       // Restores run before the handles close: a cleanup may need to widen a
@@ -93,9 +145,9 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
           // A cleanup that cannot run must not strand the temp tree.
         }
       }
-      for (const db of handles) {
+      for (const handle of handles) {
         try {
-          db.close();
+          handle.close();
         } catch {
           // node:sqlite throws on a second close, and a test is free to close a
           // handle itself — an already-closed handle is the expected case here.
@@ -153,7 +205,7 @@ export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): 
   try {
     result = fn(store);
   } catch (err) {
-    store.destroy();
+    destroyAfterFailure(store, err);
     throw err;
   }
   if (!isThenable(result)) {
@@ -166,11 +218,29 @@ export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): 
       return value;
     },
     (err: unknown) => {
-      store.destroy();
+      destroyAfterFailure(store, err);
       throw err;
     },
   );
   return settled as T;
+}
+
+/**
+ * Tear down after the body has already failed, without letting the teardown
+ * speak over it.
+ *
+ * `destroy()` ends in `removeTree`, which rethrows on POSIX by design — a mode
+ * a test tightened and never restored surfaces there. Left unguarded, a test
+ * that both forgot a restore and failed an assertion reports `EACCES … rmdir`
+ * and nothing about the assertion, in the one case where the diagnostic matters
+ * most. The teardown failure still travels, as `cause`.
+ */
+function destroyAfterFailure(store: OwnedTempStore, err: unknown): void {
+  try {
+    store.destroy();
+  } catch (teardownErr) {
+    if (err instanceof Error && err.cause === undefined) err.cause = teardownErr;
+  }
 }
 
 /**
@@ -219,6 +289,8 @@ export function useTempStore(prefix?: string): TempStore {
       return active().dbFile;
     },
     open: () => active().open(),
+    openRaw: () => active().openRaw(),
+    openHandleCount: () => active().openHandleCount(),
     onCleanup: (fn: () => void) => {
       active().onCleanup(fn);
     },

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -63,20 +63,27 @@ export interface TempStore {
 
 /** A `TempStore` whose lifetime the caller owns. */
 export interface OwnedTempStore extends TempStore {
-  /** Run the cleanups, close every handle, remove the tree. Idempotent. */
+  /**
+   * Run the cleanups, close every handle, remove the tree. Idempotent.
+   *
+   * Throws an `AggregateError` if a cleanup or the removal failed — after the
+   * tree is gone, so a failure reports rather than strands. On the
+   * body-already-failed path `withTempStore` demotes it to that error's
+   * `cause`, since the body's failure is the one worth reading.
+   */
   readonly destroy: () => void;
 }
 
-/**
- * A temp store the caller destroys by hand. Prefer `withTempStore` (scoped) or
- * `useTempStore` (hook-driven); reach for this only when neither shape fits.
- */
 /** A handle the store handed out, and the two things it needs to track it. */
 interface TrackedHandle {
   close: () => void;
   isOpen: () => boolean;
 }
 
+/**
+ * A temp store the caller destroys by hand. Prefer `withTempStore` (scoped) or
+ * `useTempStore` (hook-driven); reach for this only when neither shape fits.
+ */
 export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
   const home = mkdtempSync(join(tmpdir(), prefix));
   // Both subdirs up front, through the same helper the product uses: a bare
@@ -144,11 +151,16 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
       destroyed = true;
       // Restores run before the handles close: a cleanup may need to widen a
       // mode the test tightened, and it must run whether or not the test threw.
+      // A failure here is collected rather than swallowed — discarding it is
+      // how an injector's own loud failure (a lock that would not let go, a
+      // mode that would not go back) went silent, since `onCleanup` is the
+      // wiring those injectors recommend.
+      const problems: unknown[] = [];
       for (const fn of cleanups.reverse()) {
         try {
           fn();
-        } catch {
-          // A cleanup that cannot run must not strand the temp tree.
+        } catch (err) {
+          problems.push(err);
         }
       }
       for (const handle of handles) {
@@ -159,7 +171,16 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
           // handle itself — an already-closed handle is the expected case here.
         }
       }
-      removeTree(home);
+      // The tree goes first either way: a cleanup that cannot run must not
+      // strand it. Only once it is gone is there anything to report.
+      try {
+        removeTree(home);
+      } catch (err) {
+        problems.push(err);
+      }
+      if (problems.length > 0) {
+        throw new AggregateError(problems, 'temp store teardown failed');
+      }
     },
   };
 }

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -103,6 +103,12 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
       const db = openLocalDatabase(dataDir(home));
       // LocalDatabase has no `isOpen`, so the close is wrapped to record it —
       // otherwise a handle a test closed itself still counts as live.
+      //
+      // The spread below is load-bearing and only safe because
+      // `openLocalDatabase` returns a plain object literal of closures: no
+      // accessors, nothing `this`-bound, nothing lazily got. Turn that into a
+      // class instance or add a getter and every handle handed out here goes
+      // quietly wrong instead of failing.
       let closed = false;
       const tracked: LocalDatabase = {
         ...db,

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -13,7 +13,7 @@
  * independent connection on the one file — which is what makes two live
  * writers, and the contention between them, reachable from a test.
  */
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -22,6 +22,7 @@ import { afterEach, beforeEach } from 'vitest';
 import type { LocalDatabase } from '../../src/database.ts';
 import { openLocalDatabase } from '../../src/database.ts';
 import { dataDir, dbPath, settingsDir } from '../../src/local-layout.ts';
+import { DATA_DIR_MODE } from '../../src/paths.ts';
 
 export interface TempStore {
   /** The mkdtemp root, standing in for `~/.aka`. */
@@ -36,19 +37,21 @@ export interface TempStore {
    * A fresh `LocalDatabase` on this store, closed for you at teardown. Call it
    * more than once for independent handles on the same file.
    */
-  open(): LocalDatabase;
+  readonly open: () => LocalDatabase;
   /**
    * Run `fn` before the temp tree is removed, most recent first. Fault
-   * injectors register their mode restores here — a 0444/0555 tree cannot be
-   * deleted, so the restore has to run before the rm.
+   * injectors take this as their `onCleanup` option — a read-only tree cannot
+   * be deleted and a held lock cannot be, either on Windows, so both have to
+   * be undone before the rm. Declared as a property, not a method, so it can
+   * be handed to an injector without binding.
    */
-  onCleanup(fn: () => void): void;
+  readonly onCleanup: (fn: () => void) => void;
 }
 
 /** A `TempStore` whose lifetime the caller owns. */
 export interface OwnedTempStore extends TempStore {
   /** Run the cleanups, close every handle, remove the tree. Idempotent. */
-  destroy(): void;
+  readonly destroy: () => void;
 }
 
 /**
@@ -57,6 +60,10 @@ export interface OwnedTempStore extends TempStore {
  */
 export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
   const home = mkdtempSync(join(tmpdir(), prefix));
+  // `data/` is created by openLocalDatabase, but nothing creates `settings/`
+  // until a settings writer runs — so a test that writes settings.json by hand
+  // would meet an absent directory. Both subdirs exist from the start instead.
+  mkdirSync(settingsDir(home), { recursive: true, mode: DATA_DIR_MODE });
   const handles: LocalDatabase[] = [];
   const cleanups: (() => void)[] = [];
   let destroyed = false;
@@ -99,18 +106,49 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
   };
 }
 
+/** True for anything with a callable `then` — a promise, or a promise-alike. */
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
 /**
  * Run `fn` against a temp store, then tear it down — including when `fn`
  * throws. The scoped shape: use it where the store's lifetime is one test body
  * or one block, and `useTempStore` where a suite shares setup across hooks.
+ *
+ * An async `fn` is awaited before teardown. A plain `try/finally` would destroy
+ * the store the moment the body returned its pending promise, and the rest of
+ * the body would then run against closed handles and a deleted tree — green,
+ * and asserting nothing.
  */
 export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): T {
   const store = createTempStore(prefix);
+  let result: T;
   try {
-    return fn(store);
-  } finally {
+    result = fn(store);
+  } catch (err) {
     store.destroy();
+    throw err;
   }
+  if (!isThenable(result)) {
+    store.destroy();
+    return result;
+  }
+  const settled = result.then(
+    (value) => {
+      store.destroy();
+      return value;
+    },
+    (err: unknown) => {
+      store.destroy();
+      throw err;
+    },
+  );
+  return settled as T;
 }
 
 /**
@@ -118,6 +156,11 @@ export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): 
  * describe) scope and read the returned store inside tests and hooks. The
  * store's `beforeEach` is registered where this is called, so it runs before
  * any hook the suite declares afterwards, and its teardown runs after theirs.
+ *
+ * That ordering is `sequence.hooks: 'stack'`, which vitest.config.ts pins
+ * rather than inherit: under `'list'` or `'parallel'` the store would be
+ * destroyed before a suite's own `afterEach`, and a suite that reads the store
+ * in teardown would break with no compile-time signal.
  */
 export function useTempStore(prefix?: string): TempStore {
   let current: OwnedTempStore | undefined;

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -1,0 +1,161 @@
+/**
+ * A disposable `~/.aka` for one test: the mkdtemp + openLocalDatabase + cleanup
+ * sequence that store tests across the workspace repeat, in one place.
+ *
+ * The temp tree mirrors the real home — `settings/` and `data/` under a base,
+ * with the paths resolved through local-layout.ts rather than re-joined here —
+ * so a test that touches settings.json or the fingerprint key sees the same
+ * shape the product does, and a layout change moves the helper with it.
+ *
+ * Handles opened through `open()` are closed at teardown, so a test never has
+ * to pair an open with a close. `openLocalDatabase` has no memoization: every
+ * call re-runs migrations and reseeds default policies, so each `open()` is an
+ * independent connection on the one file — which is what makes two live
+ * writers, and the contention between them, reachable from a test.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach } from 'vitest';
+
+import type { LocalDatabase } from '../../src/database.ts';
+import { openLocalDatabase } from '../../src/database.ts';
+import { dataDir, dbPath, settingsDir } from '../../src/local-layout.ts';
+
+export interface TempStore {
+  /** The mkdtemp root, standing in for `~/.aka`. */
+  readonly home: string;
+  /** `<home>/settings` — where settings.json lives. */
+  readonly settingsDir: string;
+  /** `<home>/data` — where aka.db and its -wal/-shm sidecars live. */
+  readonly dataDir: string;
+  /** `<home>/data/aka.db`. */
+  readonly dbFile: string;
+  /**
+   * A fresh `LocalDatabase` on this store, closed for you at teardown. Call it
+   * more than once for independent handles on the same file.
+   */
+  open(): LocalDatabase;
+  /**
+   * Run `fn` before the temp tree is removed, most recent first. Fault
+   * injectors register their mode restores here — a 0444/0555 tree cannot be
+   * deleted, so the restore has to run before the rm.
+   */
+  onCleanup(fn: () => void): void;
+}
+
+/** A `TempStore` whose lifetime the caller owns. */
+export interface OwnedTempStore extends TempStore {
+  /** Run the cleanups, close every handle, remove the tree. Idempotent. */
+  destroy(): void;
+}
+
+/**
+ * A temp store the caller destroys by hand. Prefer `withTempStore` (scoped) or
+ * `useTempStore` (hook-driven); reach for this only when neither shape fits.
+ */
+export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  const handles: LocalDatabase[] = [];
+  const cleanups: (() => void)[] = [];
+  let destroyed = false;
+
+  return {
+    home,
+    settingsDir: settingsDir(home),
+    dataDir: dataDir(home),
+    dbFile: dbPath(home),
+    open(): LocalDatabase {
+      const db = openLocalDatabase(dataDir(home));
+      handles.push(db);
+      return db;
+    },
+    onCleanup(fn: () => void): void {
+      cleanups.push(fn);
+    },
+    destroy(): void {
+      if (destroyed) return;
+      destroyed = true;
+      // Restores run before the handles close: a cleanup may need to widen a
+      // mode the test tightened, and it must run whether or not the test threw.
+      for (const fn of cleanups.reverse()) {
+        try {
+          fn();
+        } catch {
+          // A cleanup that cannot run must not strand the temp tree.
+        }
+      }
+      for (const db of handles) {
+        try {
+          db.close();
+        } catch {
+          // node:sqlite throws on a second close, and a test is free to close a
+          // handle itself — an already-closed handle is the expected case here.
+        }
+      }
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+/**
+ * Run `fn` against a temp store, then tear it down — including when `fn`
+ * throws. The scoped shape: use it where the store's lifetime is one test body
+ * or one block, and `useTempStore` where a suite shares setup across hooks.
+ */
+export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): T {
+  const store = createTempStore(prefix);
+  try {
+    return fn(store);
+  } finally {
+    store.destroy();
+  }
+}
+
+/**
+ * A per-test temp store wired to the suite's own hooks: call it at module (or
+ * describe) scope and read the returned store inside tests and hooks. The
+ * store's `beforeEach` is registered where this is called, so it runs before
+ * any hook the suite declares afterwards, and its teardown runs after theirs.
+ */
+export function useTempStore(prefix?: string): TempStore {
+  let current: OwnedTempStore | undefined;
+
+  beforeEach(() => {
+    current = createTempStore(prefix);
+  });
+
+  afterEach(() => {
+    current?.destroy();
+    current = undefined;
+  });
+
+  const active = (): OwnedTempStore => {
+    if (!current) {
+      throw new Error(
+        'useTempStore(): no store for the current test — call useTempStore() at module or describe scope, not inside a test.',
+      );
+    }
+    return current;
+  };
+
+  return {
+    get home(): string {
+      return active().home;
+    },
+    get settingsDir(): string {
+      return active().settingsDir;
+    },
+    get dataDir(): string {
+      return active().dataDir;
+    },
+    get dbFile(): string {
+      return active().dbFile;
+    },
+    open: () => active().open(),
+    onCleanup: (fn: () => void) => {
+      active().onCleanup(fn);
+    },
+  };
+}

--- a/packages/persistence/test/helpers/transactions.test.ts
+++ b/packages/persistence/test/helpers/transactions.test.ts
@@ -1,49 +1,32 @@
-import { DatabaseSync } from 'node:sqlite';
-
 import { describe, expect, it } from 'vitest';
 
-import type { TempStore } from './temp-store.ts';
 import { withTempStore } from './temp-store.ts';
 import { assertNoOpenTransaction } from './transactions.ts';
 
-// Two lines that read like a no-op, and every "the failure was contained" claim
-// in the fault suite rests on them. Gut the helper and those claims keep
-// reporting success, so the helper needs a gate of its own: it has to fail on an
-// open transaction, and it has to leave a clean handle exactly as it found it.
-
-/**
- * A raw handle on a store that exists. `data/` is created by
- * `openLocalDatabase`, so a raw handle taken before any `open()` has no
- * directory to create its file in.
- */
-function rawHandle(store: TempStore): DatabaseSync {
-  store.open().close();
-  return new DatabaseSync(store.dbFile);
-}
+// One line, and every "the failure was contained" claim in the fault suite
+// rests on it. Gut it and those claims keep reporting success, so it needs a
+// gate of its own: it has to fail on an open transaction, it has to leave the
+// handle exactly as it found it, and it must not answer for a handle it cannot
+// ask.
 
 describe('assertNoOpenTransaction', () => {
   it('throws when the handle is inside a transaction', () => {
     withTempStore((store) => {
-      const db = rawHandle(store);
-      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      const db = store.openRaw();
       db.exec('BEGIN');
-      try {
-        // The helper's own BEGIN is what fails, so its ROLLBACK never runs and
-        // the caller's transaction is still open afterwards — this test owns
-        // closing it, not the helper.
-        expect(() => {
-          assertNoOpenTransaction(db);
-        }).toThrow();
-      } finally {
-        db.exec('ROLLBACK');
-        db.close();
-      }
+      expect(() => {
+        assertNoOpenTransaction(db);
+      }).toThrow(/transaction is still open/);
+      // The check does not touch the transaction it reports on, so the caller's
+      // is still open here and still the caller's to end.
+      expect(db.isTransaction).toBe(true);
+      db.exec('ROLLBACK');
     });
   });
 
   it('passes on a handle that is not, and hands it back the way it found it', () => {
     withTempStore((store) => {
-      const db = rawHandle(store);
+      const db = store.openRaw();
       db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
       db.prepare('INSERT INTO t (v) VALUES (?)').run('before');
 
@@ -51,28 +34,27 @@ describe('assertNoOpenTransaction', () => {
         assertNoOpenTransaction(db);
       }).not.toThrow();
 
-      // It works by opening and rolling back a transaction of its own, so the
-      // handle must come back usable, outside a transaction, with nothing the
-      // rollback swept up on the way.
+      // Reading `isTransaction` cannot disturb the handle the way a BEGIN and
+      // ROLLBACK of its own would: the row survives, the handle stays usable,
+      // and asking twice is the same as asking once.
       expect(() => {
         assertNoOpenTransaction(db);
       }).not.toThrow();
+      expect(db.isTransaction).toBe(false);
       db.prepare('INSERT INTO t (v) VALUES (?)').run('after');
       expect(db.prepare('SELECT count(*) AS n FROM t').get()).toEqual({ n: 2 });
-
-      db.close();
     });
   });
 
   it('throws on a handle the caller already closed', () => {
     withTempStore((store) => {
-      const db = rawHandle(store);
+      const db = store.openRaw();
       db.close();
       // Not a transaction fault, but the helper must not report "no transaction
       // open" for a handle it could not ask.
       expect(() => {
         assertNoOpenTransaction(db);
-      }).toThrow();
+      }).toThrow(/not open/);
     });
   });
 });

--- a/packages/persistence/test/helpers/transactions.test.ts
+++ b/packages/persistence/test/helpers/transactions.test.ts
@@ -1,0 +1,78 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, expect, it } from 'vitest';
+
+import type { TempStore } from './temp-store.ts';
+import { withTempStore } from './temp-store.ts';
+import { assertNoOpenTransaction } from './transactions.ts';
+
+// Two lines that read like a no-op, and every "the failure was contained" claim
+// in the fault suite rests on them. Gut the helper and those claims keep
+// reporting success, so the helper needs a gate of its own: it has to fail on an
+// open transaction, and it has to leave a clean handle exactly as it found it.
+
+/**
+ * A raw handle on a store that exists. `data/` is created by
+ * `openLocalDatabase`, so a raw handle taken before any `open()` has no
+ * directory to create its file in.
+ */
+function rawHandle(store: TempStore): DatabaseSync {
+  store.open().close();
+  return new DatabaseSync(store.dbFile);
+}
+
+describe('assertNoOpenTransaction', () => {
+  it('throws when the handle is inside a transaction', () => {
+    withTempStore((store) => {
+      const db = rawHandle(store);
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY)');
+      db.exec('BEGIN');
+      try {
+        // The helper's own BEGIN is what fails, so its ROLLBACK never runs and
+        // the caller's transaction is still open afterwards — this test owns
+        // closing it, not the helper.
+        expect(() => {
+          assertNoOpenTransaction(db);
+        }).toThrow();
+      } finally {
+        db.exec('ROLLBACK');
+        db.close();
+      }
+    });
+  });
+
+  it('passes on a handle that is not, and hands it back the way it found it', () => {
+    withTempStore((store) => {
+      const db = rawHandle(store);
+      db.exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+      db.prepare('INSERT INTO t (v) VALUES (?)').run('before');
+
+      expect(() => {
+        assertNoOpenTransaction(db);
+      }).not.toThrow();
+
+      // It works by opening and rolling back a transaction of its own, so the
+      // handle must come back usable, outside a transaction, with nothing the
+      // rollback swept up on the way.
+      expect(() => {
+        assertNoOpenTransaction(db);
+      }).not.toThrow();
+      db.prepare('INSERT INTO t (v) VALUES (?)').run('after');
+      expect(db.prepare('SELECT count(*) AS n FROM t').get()).toEqual({ n: 2 });
+
+      db.close();
+    });
+  });
+
+  it('throws on a handle the caller already closed', () => {
+    withTempStore((store) => {
+      const db = rawHandle(store);
+      db.close();
+      // Not a transaction fault, but the helper must not report "no transaction
+      // open" for a handle it could not ask.
+      expect(() => {
+        assertNoOpenTransaction(db);
+      }).toThrow();
+    });
+  });
+});

--- a/packages/persistence/test/helpers/transactions.ts
+++ b/packages/persistence/test/helpers/transactions.ts
@@ -3,14 +3,21 @@
  *
  * A fault that leaves one open is worse than the fault: the connection holds
  * its locks, every later write on it joins a transaction nobody meant to
- * start, and the store looks healthy from outside. SQLite makes the check
- * free — `BEGIN` throws inside an open transaction — so a fault test can pin
- * "the failure was contained" rather than only "the failure happened".
+ * start, and the store looks healthy from outside. So a fault test pins "the
+ * failure was contained" rather than only "the failure happened".
+ *
+ * The check reads `db.isTransaction`, the same property the package's own
+ * transaction envelopes branch on. Asking with a BEGIN/ROLLBACK pair would
+ * mutate the handle it is inspecting — and if that ROLLBACK threw, on a locked
+ * or corrupt store, it would leave open the very transaction it exists to
+ * disprove. A closed handle throws here rather than reporting "no transaction
+ * open" for a handle it could not ask.
  */
 import type { DatabaseSync } from 'node:sqlite';
 
-/** Throws if `db` is inside a transaction. */
+/** Throws if `db` is inside a transaction, or is not open. */
 export function assertNoOpenTransaction(db: DatabaseSync): void {
-  db.exec('BEGIN');
-  db.exec('ROLLBACK');
+  if (db.isTransaction) {
+    throw new Error('assertNoOpenTransaction(): a transaction is still open on this handle');
+  }
 }

--- a/packages/persistence/test/helpers/transactions.ts
+++ b/packages/persistence/test/helpers/transactions.ts
@@ -1,0 +1,16 @@
+/**
+ * Proof that a handle is not sitting inside a transaction.
+ *
+ * A fault that leaves one open is worse than the fault: the connection holds
+ * its locks, every later write on it joins a transaction nobody meant to
+ * start, and the store looks healthy from outside. SQLite makes the check
+ * free — `BEGIN` throws inside an open transaction — so a fault test can pin
+ * "the failure was contained" rather than only "the failure happened".
+ */
+import type { DatabaseSync } from 'node:sqlite';
+
+/** Throws if `db` is inside a transaction. */
+export function assertNoOpenTransaction(db: DatabaseSync): void {
+  db.exec('BEGIN');
+  db.exec('ROLLBACK');
+}

--- a/packages/persistence/test/helpers/with-two-writers.test.ts
+++ b/packages/persistence/test/helpers/with-two-writers.test.ts
@@ -91,4 +91,24 @@ describe('withWriters', () => {
     }).toThrow('boom');
     expect(existsSync(home)).toBe(false);
   });
+
+  it('holds the writers open until an async body finishes', async () => {
+    let home = '';
+    await withWriters(3, async (writers, store) => {
+      home = store.home;
+      await Promise.resolve();
+      // Every handle is still live after the await, not closed out from under
+      // the body by an eager teardown.
+      writers.forEach((db, i) => {
+        db.ruleProbeCache.setVerdict(`async-${String(i)}`, 'safe', i);
+      });
+      writers.forEach((_db, i) => {
+        expect(writers[0]?.ruleProbeCache.getVerdict(`async-${String(i)}`)).toEqual({
+          verdict: 'safe',
+          worstProbeMs: i,
+        });
+      });
+    });
+    expect(existsSync(home)).toBe(false);
+  });
 });

--- a/packages/persistence/test/helpers/with-two-writers.test.ts
+++ b/packages/persistence/test/helpers/with-two-writers.test.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { withTwoWriters, withWriters } from './with-two-writers.ts';
+
+// Two live handles on one file is the shape the product runs in and the shape
+// no store test could take before these helpers existed.
+
+describe('withTwoWriters', () => {
+  it('yields two distinct handles on one store', () => {
+    withTwoWriters((a, b, store) => {
+      expect(a).not.toBe(b);
+      expect(existsSync(store.dbFile)).toBe(true);
+    });
+  });
+
+  it('lets each handle read what the other committed', () => {
+    withTwoWriters((a, b) => {
+      a.ruleProbeCache.setVerdict('from-a', 'safe', 1.1);
+      b.ruleProbeCache.setVerdict('from-b', 'quarantined', 300);
+
+      expect(b.ruleProbeCache.getVerdict('from-a')).toEqual({ verdict: 'safe', worstProbeMs: 1.1 });
+      expect(a.ruleProbeCache.getVerdict('from-b')).toEqual({
+        verdict: 'quarantined',
+        worstProbeMs: 300,
+      });
+    });
+  });
+
+  it('loses nothing when writes alternate between the handles', () => {
+    withTwoWriters((a, b) => {
+      for (let i = 0; i < 50; i += 1) {
+        (i % 2 === 0 ? a : b).ruleProbeCache.setVerdict(`rule-${String(i)}`, 'safe', i);
+      }
+      for (let i = 0; i < 50; i += 1) {
+        expect(a.ruleProbeCache.getVerdict(`rule-${String(i)}`)).toEqual({
+          verdict: 'safe',
+          worstProbeMs: i,
+        });
+      }
+    });
+  });
+
+  it('closes both handles and removes the tree afterwards', () => {
+    let home = '';
+    withTwoWriters((_a, _b, store) => {
+      home = store.home;
+    });
+    expect(existsSync(home)).toBe(false);
+  });
+});
+
+describe('withWriters', () => {
+  it('opens the requested number of handles, all on one store', () => {
+    withWriters(5, (writers, store) => {
+      expect(writers).toHaveLength(5);
+      expect(new Set(writers).size).toBe(5);
+
+      writers.forEach((db, i) => {
+        db.ruleProbeCache.setVerdict(`writer-${String(i)}`, 'safe', i);
+      });
+      // Every writer's row is visible from a further, independent handle: one
+      // file underneath, not five.
+      const reader = store.open();
+      writers.forEach((_db, i) => {
+        expect(reader.ruleProbeCache.getVerdict(`writer-${String(i)}`)).toEqual({
+          verdict: 'safe',
+          worstProbeMs: i,
+        });
+      });
+      expect(existsSync(store.dbFile)).toBe(true);
+    });
+  });
+
+  it('rejects a count that cannot describe a set of handles', () => {
+    for (const count of [0, -1, 1.5]) {
+      expect(() => {
+        withWriters(count, () => undefined);
+      }).toThrow(/positive integer/);
+    }
+  });
+
+  it('removes the tree when the body throws', () => {
+    let home = '';
+    expect(() => {
+      withWriters(3, (_writers, store) => {
+        home = store.home;
+        throw new Error('boom');
+      });
+    }).toThrow('boom');
+    expect(existsSync(home)).toBe(false);
+  });
+});

--- a/packages/persistence/test/helpers/with-two-writers.ts
+++ b/packages/persistence/test/helpers/with-two-writers.ts
@@ -19,6 +19,8 @@ import { withTempStore } from './temp-store.ts';
 /**
  * Run `fn` with two independent handles on one temp store. `store` is there
  * too, for a test that needs the paths or a third handle.
+ *
+ * An async `fn` is awaited before teardown, as in `withTempStore`.
  */
 export function withTwoWriters<T>(
   fn: (a: LocalDatabase, b: LocalDatabase, store: TempStore) => T,
@@ -44,6 +46,10 @@ export function withTwoWriters<T>(
  * by the time `fn` runs. A test that needs two connections racing to create a
  * store from scratch — concurrent migrations, a first-mint fingerprint — wants
  * `withTempStore` and its `open()` instead.
+ *
+ * Opening up front also matters when the body reaches for `lockStore`: opening
+ * a handle while the write lock is held fails, because `openLocalDatabase`
+ * writes on the way in. Take the handles first, then lock.
  */
 export function withWriters<T>(
   count: number,

--- a/packages/persistence/test/helpers/with-two-writers.ts
+++ b/packages/persistence/test/helpers/with-two-writers.ts
@@ -1,0 +1,60 @@
+/**
+ * Independent write handles on one store — the shape the product runs in.
+ *
+ * Plugin hooks, the CLI and the dashboard each open their own `LocalDatabase`
+ * on the same `aka.db` with nothing between them; WAL and
+ * `PRAGMA busy_timeout` are the only things that keep them apart. These
+ * helpers put a test in that position: N connections, one file, no
+ * coordination.
+ *
+ * `node:sqlite` is synchronous, so two handles in one thread interleave rather
+ * than collide on their own. Handles alone prove the write paths coexist; pair
+ * them with `lockStore` from fault-injection.ts to hold the write lock from
+ * outside the thread and drive real contention.
+ */
+import type { LocalDatabase } from '../../src/database.ts';
+import type { TempStore } from './temp-store.ts';
+import { withTempStore } from './temp-store.ts';
+
+/**
+ * Run `fn` with two independent handles on one temp store. `store` is there
+ * too, for a test that needs the paths or a third handle.
+ */
+export function withTwoWriters<T>(
+  fn: (a: LocalDatabase, b: LocalDatabase, store: TempStore) => T,
+): T {
+  return withWriters(
+    2,
+    (writers, store) => {
+      const [a, b] = writers;
+      if (!a || !b) {
+        throw new Error('withTwoWriters(): expected two handles');
+      }
+      return fn(a, b, store);
+    },
+    'aka-two-writers-',
+  );
+}
+
+/**
+ * Run `fn` with `count` independent handles on one temp store — the N-writer
+ * generalisation of `withTwoWriters`.
+ *
+ * The handles are opened one after another, so the store is already migrated
+ * by the time `fn` runs. A test that needs two connections racing to create a
+ * store from scratch — concurrent migrations, a first-mint fingerprint — wants
+ * `withTempStore` and its `open()` instead.
+ */
+export function withWriters<T>(
+  count: number,
+  fn: (writers: LocalDatabase[], store: TempStore) => T,
+  prefix = 'aka-writers-',
+): T {
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error(`withWriters(): count must be a positive integer, got ${String(count)}`);
+  }
+  return withTempStore((store) => {
+    const writers = Array.from({ length: count }, () => store.open());
+    return fn(writers, store);
+  }, prefix);
+}

--- a/packages/persistence/test/internal/transactions.test.ts
+++ b/packages/persistence/test/internal/transactions.test.ts
@@ -3,6 +3,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { failOpenTransaction, withTransaction } from '../../src/internal/transactions.ts';
+import { assertNoOpenTransaction as assertNoOpenTransactionOn } from '../helpers/transactions.ts';
 
 let db: DatabaseSync;
 
@@ -19,10 +20,10 @@ function rowCount(): number {
   return (db.prepare('SELECT count(*) AS n FROM t').get() as { n: number }).n;
 }
 
-// Proves no transaction is left open: BEGIN throws inside an open transaction.
+// Bound to this suite's handle; the check itself lives in test/helpers so the
+// fault tests can assert the same thing about a store they just broke.
 function assertNoOpenTransaction(): void {
-  db.exec('BEGIN');
-  db.exec('ROLLBACK');
+  assertNoOpenTransactionOn(db);
 }
 
 describe('withTransaction', () => {

--- a/packages/persistence/test/internal/transactions.test.ts
+++ b/packages/persistence/test/internal/transactions.test.ts
@@ -3,7 +3,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { failOpenTransaction, withTransaction } from '../../src/internal/transactions.ts';
-import { assertNoOpenTransaction as assertNoOpenTransactionOn } from '../helpers/transactions.ts';
+import { assertNoOpenTransaction } from '../helpers/transactions.ts';
 
 let db: DatabaseSync;
 
@@ -20,12 +20,6 @@ function rowCount(): number {
   return (db.prepare('SELECT count(*) AS n FROM t').get() as { n: number }).n;
 }
 
-// Bound to this suite's handle; the check itself lives in test/helpers so the
-// fault tests can assert the same thing about a store they just broke.
-function assertNoOpenTransaction(): void {
-  assertNoOpenTransactionOn(db);
-}
-
 describe('withTransaction', () => {
   it('commits: rows written inside fn persist', () => {
     withTransaction(db, () => {
@@ -33,7 +27,7 @@ describe('withTransaction', () => {
       db.prepare('INSERT INTO t (v) VALUES (?)').run('b');
     });
     expect(rowCount()).toBe(2);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('rolls back and rethrows the original error when fn throws', () => {
@@ -49,7 +43,7 @@ describe('withTransaction', () => {
     }
     expect(caught).toBe(boom);
     expect(rowCount()).toBe(0);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('rethrows the original error even when ROLLBACK itself fails', () => {
@@ -66,7 +60,7 @@ describe('withTransaction', () => {
       caught = error;
     }
     expect(caught).toBe(boom);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('runs IMMEDIATE mode end-to-end', () => {
@@ -78,7 +72,7 @@ describe('withTransaction', () => {
       'IMMEDIATE',
     );
     expect(rowCount()).toBe(1);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('joins a caller-owned transaction rather than committing on its own', () => {
@@ -94,7 +88,7 @@ describe('withTransaction', () => {
     // which it could not do had the envelope committed independently.
     db.exec('ROLLBACK');
     expect(rowCount()).toBe(0);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('unwinds only its own work when fn throws while nested, leaving the caller to continue', () => {
@@ -117,7 +111,7 @@ describe('withTransaction', () => {
     expect(rowCount()).toBe(1);
     db.exec('COMMIT');
     expect(rowCount()).toBe(1);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('rethrows while nested even when the statement forced a full rollback', () => {
@@ -137,7 +131,7 @@ describe('withTransaction', () => {
     // included: the outer row is gone and no transaction is left open.
     expect(db.isTransaction).toBe(false);
     expect(rowCount()).toBe(1);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('nests re-entrantly: each envelope unwinds to its own savepoint', () => {
@@ -158,7 +152,7 @@ describe('withTransaction', () => {
     expect((db.prepare('SELECT group_concat(v) AS v FROM t').get() as { v: string }).v).toBe('a,c');
     db.exec('ROLLBACK');
     expect(rowCount()).toBe(0);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 });
 
@@ -178,7 +172,7 @@ describe('failOpenTransaction', () => {
     });
     expect(ok).toBe(false);
     expect(rowCount()).toBe(0);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('supports IMMEDIATE mode', () => {
@@ -204,7 +198,7 @@ describe('failOpenTransaction', () => {
     expect(rowCount()).toBe(2);
     db.exec('ROLLBACK');
     expect(rowCount()).toBe(0);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('returns false while nested and keeps its partial write out of the caller’s transaction', () => {
@@ -222,7 +216,7 @@ describe('failOpenTransaction', () => {
     expect(rowCount()).toBe(1);
     db.exec('COMMIT');
     expect(rowCount()).toBe(1);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 
   it('rethrows while nested when the failure destroyed the caller’s transaction', () => {
@@ -238,6 +232,6 @@ describe('failOpenTransaction', () => {
     // statements it believes are still inside its own transaction.
     expect(db.isTransaction).toBe(false);
     expect(rowCount()).toBe(1);
-    assertNoOpenTransaction();
+    assertNoOpenTransaction(db);
   });
 });

--- a/packages/persistence/test/internal/transactions.test.ts
+++ b/packages/persistence/test/internal/transactions.test.ts
@@ -129,9 +129,15 @@ describe('withTransaction', () => {
     expect(caught).toBeInstanceOf(Error);
     // OR ROLLBACK unwound the caller's whole transaction itself, savepoint
     // included: the outer row is gone and no transaction is left open.
-    expect(db.isTransaction).toBe(false);
     expect(rowCount()).toBe(1);
     assertNoOpenTransaction(db);
+    // Asked of the engine, not of the flag: `failOpenTransaction` and
+    // `withTransaction` both branch on `isTransaction`, so a suite that only
+    // reads it would agree with the code under test even if the flag were wrong.
+    expect(() => {
+      db.exec('BEGIN');
+      db.exec('ROLLBACK');
+    }).not.toThrow();
   });
 
   it('nests re-entrantly: each envelope unwinds to its own savepoint', () => {
@@ -230,8 +236,12 @@ describe('failOpenTransaction', () => {
     ).toThrow();
     // Swallowing here would leave the caller issuing durable autocommit
     // statements it believes are still inside its own transaction.
-    expect(db.isTransaction).toBe(false);
     expect(rowCount()).toBe(1);
     assertNoOpenTransaction(db);
+    // The engine's own answer, for the same reason as above.
+    expect(() => {
+      db.exec('BEGIN');
+      db.exec('ROLLBACK');
+    }).not.toThrow();
   });
 });

--- a/packages/persistence/test/repositories/project-files.test.ts
+++ b/packages/persistence/test/repositories/project-files.test.ts
@@ -1,33 +1,23 @@
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-
 import type { ProjectFileInput, ProjectFilesScan } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { LocalDatabase } from '../../src/database.ts';
-import { openLocalDatabase } from '../../src/database.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
 
 // The real project-file scan write path (recordProjectFiles) read back through
 // the SAME views the Inventory page uses (listProjects access counts +
 // getProjectTree folders/files) — the write is only correct if the page renders.
 
-let dir: string;
+const store = useTempStore('aka-projfiles-db-');
 let db: LocalDatabase;
 let projectId: string;
 
 beforeEach(() => {
-  dir = mkdtempSync(join(tmpdir(), 'aka-projfiles-db-'));
-  db = openLocalDatabase(dir);
+  db = store.open();
   projectId = db.sourceProject.upsert(
     { url: 'https://github.com/org/payments-api.git', name: 'payments-api', attributes: {} },
     Date.now(),
   );
-});
-
-afterEach(() => {
-  db.close();
-  rmSync(dir, { recursive: true, force: true });
 });
 
 function file(path: string, overrides?: Partial<ProjectFileInput>): ProjectFileInput {

--- a/packages/persistence/test/repositories/rule-probe-cache.test.ts
+++ b/packages/persistence/test/repositories/rule-probe-cache.test.ts
@@ -1,60 +1,42 @@
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useTempStore } from '../helpers/temp-store.ts';
 
-import { openLocalDatabase } from '../../src/database.ts';
-
-let dir: string;
-
-beforeEach(() => {
-  dir = mkdtempSync(join(tmpdir(), 'aka-rule-probe-'));
-});
-
-afterEach(() => {
-  rmSync(dir, { recursive: true, force: true });
-});
+const store = useTempStore('aka-rule-probe-');
 
 describe('SqliteRuleProbeCacheRepository (via LocalDatabase.ruleProbeCache)', () => {
   it('returns undefined for an unseen rule key', () => {
-    const db = openLocalDatabase(dir);
-    expect(db.ruleProbeCache.getVerdict('unseen')).toBeUndefined();
-    db.close();
+    expect(store.open().ruleProbeCache.getVerdict('unseen')).toBeUndefined();
   });
 
   it('round-trips a safe verdict', () => {
-    const db = openLocalDatabase(dir);
+    const db = store.open();
     db.ruleProbeCache.setVerdict('rule-a', 'safe', 1.8);
     expect(db.ruleProbeCache.getVerdict('rule-a')).toEqual({ verdict: 'safe', worstProbeMs: 1.8 });
-    db.close();
   });
 
   it('round-trips a quarantined verdict', () => {
-    const db = openLocalDatabase(dir);
+    const db = store.open();
     db.ruleProbeCache.setVerdict('rule-b', 'quarantined', 250);
     expect(db.ruleProbeCache.getVerdict('rule-b')).toEqual({
       verdict: 'quarantined',
       worstProbeMs: 250,
     });
-    db.close();
   });
 
   it('upserts on rule_key: a re-check overwrites the verdict', () => {
-    const db = openLocalDatabase(dir);
+    const db = store.open();
     db.ruleProbeCache.setVerdict('rule-a', 'quarantined', 500);
     db.ruleProbeCache.setVerdict('rule-a', 'safe', 2.1);
     expect(db.ruleProbeCache.getVerdict('rule-a')).toEqual({ verdict: 'safe', worstProbeMs: 2.1 });
-    db.close();
   });
 
   it('persists across reopen', () => {
-    const db1 = openLocalDatabase(dir);
+    const db1 = store.open();
     db1.ruleProbeCache.setVerdict('rule-a', 'safe', 1.2);
     db1.close();
 
-    const db2 = openLocalDatabase(dir);
+    const db2 = store.open();
     expect(db2.ruleProbeCache.getVerdict('rule-a')).toEqual({ verdict: 'safe', worstProbeMs: 1.2 });
-    db2.close();
   });
 });

--- a/packages/persistence/vitest.config.ts
+++ b/packages/persistence/vitest.config.ts
@@ -4,10 +4,16 @@ import { defineConfig } from 'vitest/config';
 // well over a second each on the Windows CI runner, so raise the per-test AND
 // per-hook timeouts above vitest's 5s/10s defaults to leave headroom under
 // parallel load (setup hooks open the DB + load fixtures and are just as slow).
+// `sequence.hooks` is pinned rather than inherited: useTempStore registers its
+// own beforeEach/afterEach around a suite's, and only 'stack' runs its teardown
+// after the suite's own. Under 'list' or 'parallel' the store would be
+// destroyed first, and a suite reading it in teardown would break with no
+// compile-time signal.
 export default defineConfig({
   test: {
     environment: 'node',
     testTimeout: 20000,
     hookTimeout: 20000,
+    sequence: { hooks: 'stack' },
   },
 });


### PR DESCRIPTION
Foundation for the store concurrency and fault-injection test tiers.

The store is shared by three processes with no server between them, and
`busy_timeout = 2000` is the entire contention mitigation. `sqlite-errors.ts`
inspects exactly one extended result code, so contention, a corrupt file, a
full disk and a caller bug all reach the fail-open paths as the same
indistinguishable `Error`. None of that was reachable from a test — every
fail-open `catch` in the package was dead code as far as the suite was
concerned. This adds the harness that makes it reachable. Fail-open behaviour
is unchanged; the point is to make silent drops observable, not loud.

Test-only: nothing under `src/` changes, so no shipped artifact changes and no
version bump is needed.

## What's here

`packages/persistence/test/helpers/`

- **`temp-store.ts`** — `withTempStore(fn)` / `useTempStore(prefix)`: a
  disposable `~/.aka` (`settings/` + `data/`, both created up front, paths
  resolved through `local-layout.ts`) whose handles are closed and tree removed
  for you. An async body is awaited before teardown. Guards double-close
  itself, since `LocalDatabase.close()` is a bare passthrough. `useTempStore`
  is the hook-driven form — most of the 22 in-package files that repeat the
  mkdtemp + open + cleanup dance use `beforeEach`/`afterEach`, which a scoping
  helper alone cannot replace.
- **`with-two-writers.ts`** — `withTwoWriters(fn)` and the N-arity
  `withWriters(n, fn)`: independent `LocalDatabase` handles on one file.
- **`fault-injection.ts`** — `corruptStore`, `readOnlyStore`, `lockStore`,
  `fillStore`, the `SQLITE_*` result codes, `sqliteErrcode()` and
  `primaryCode()`.
- **`transactions.ts`** — `assertNoOpenTransaction(db)`, promoted out of
  `test/internal/transactions.test.ts` so a fault test can pin that the failure
  was contained, not just that it happened.
- **`lock-worker.ts`** — holds `BEGIN IMMEDIATE` on a worker thread.

Each injector produces a real code from the real engine (nothing mocks
`node:sqlite` or the filesystem) and each either takes effect or says so:
`corruptStore` verifies the damage landed, and `readOnlyStore` reports whether
the chmod actually denies writes — `chmod` is a no-op for directories on
Windows and root bypasses modes everywhere, so without that signal a read-only
test passes against a store it can still write. Where that signal comes back
false the test calls `ctx.skip(reason)`, so the run says *skipped* rather than
quietly saying *passed*.

`lockStore` is deterministic by construction: the worker signals "lock held"
through a `SharedArrayBuffer` and the calling thread blocks on `Atomics.wait`
until it does, so the victim can never start early. No sleeps, no polling. It
pins both sides of the boundary — a hold that outlasts `busy_timeout` gives
`SQLITE_BUSY`, one that ends inside it lets the writer wait and succeed.

`fillStore` uses `PRAGMA max_page_count` for a genuine `SQLITE_FULL` from the
engine — no mount, no sudo, no stand-in for `node:sqlite`. The cap is
connection-scoped, which is documented on the function.

Errcode constants are test-local on purpose; widening
`src/internal/sqlite-errors.ts` is a production change and belongs with the
fault-injection tests themselves, not with the harness.

## What the injectors do to the package, not just to node:sqlite

Measured and pinned, because the concurrency and fault-injection suites will
both walk into them:

- **`openLocalDatabase` cannot open under a held lock.** Opening is itself a
  write — the WAL pragma, then the migration and `ensure*` passes — so it does
  not block, it fails with `SQLITE_BUSY` after `busy_timeout`. Take the handles
  first, then lock. `withWriters` opens up front for exactly this reason.
- **A `LocalDatabase` write under the lock is dropped in silence.**
  `failOpenTransaction` swallows the `SQLITE_BUSY`, so `setVerdict` returns
  normally after stalling 2 s and the row simply is not there. That is the
  fail-open contract working as designed; the test pins it so changing it is a
  decision. The handle survives — no transaction left open, and the next write
  after release lands.
- **Each contended write costs the full 2 s `busy_timeout`.** A concurrency suite that
  contends often will outrun the 20 s per-test timeout long before it runs out
  of assertions.

## Migration proof

`rule-probe-cache.test.ts` (DB opened per test) and `project-files.test.ts`
(DB in hooks) move onto the harness — one of each shape, same assertions, same
test counts (5 and 12). The other ~20 in-package files are follow-up, not
silently dropped. The helper lives under `packages/persistence/test/`, so it is
not reachable across a package wall: store tests in `cli`, `local-ops`,
`plugin-runtime` and `plugins/claude-code` still roll their own, and CLAUDE.md
now says so rather than implying otherwise.

## Verification

- Workspace `pnpm lint` 14/14, `pnpm typecheck` 14/14, `pnpm test` 27/27,
  `pnpm format:check` clean.
- Persistence suite 46 files / 599 tests, up from 42 / 543 — 56 new self-tests.
- Green on CI, Windows included: 594 passed / 5 skipped there, every skip
  carrying a reason.
- Helper self-tests run repeatedly back to back: zero failures, and zero leaked
  temp dirs **on POSIX**, including after the read-only, corrupt and locked
  cases. That last figure cannot hold on Windows and was not measured there:
  `removeTree` swallows `EPERM`/`EBUSY`/`EACCES`/`ENOTEMPTY` on win32 by
  design, so a tree a stuck holder keeps open is left to the OS temp sweeper
  rather than failing a test whose assertions already passed.
- Helper self-tests take ~5.8s, of which ~4.2s is the two product-path tests
  waiting out `busy_timeout` by construction. Inside the resilience tier's
  budget.
- Assertions are on result codes, never on elapsed time — Windows CI runs
  several times slower. No vitest `retry` added.

## Cross-platform notes

- `readOnlyStore` tightens to **0400/0500**, not 0444/0555: the store holds
  prompt and file content and the package writes it 0600 everywhere else, so
  denying a write should not widen it to every account on the machine.
- The file-mode read-only test now runs **on Windows**, where Node maps the
  write bit to the read-only attribute — only directory modes are the no-op
  there, and Windows is the platform with no other at-rest control. It asserts
  the refusal and the absent write bits there, and the exact `SQLITE_READONLY`
  only where that has been verified.
- The teardown-failure case is **skipped on Windows**, and on any host that
  writes through the mode. It forces the failure by leaving the store's home at
  0500 so `removeTree` cannot delete through it, and a directory's mode is a
  no-op there — the rm succeeds and there is no teardown failure left to
  assert. The `cause` assertion could not hold on Windows either: `removeTree`
  swallows removal errors on win32 by design, so `destroy()` never throws and
  nothing is ever attached. It reports as skipped with a reason rather than
  passing against a tree it could freely delete. Past that skip `removeTree`
  always rethrows, so a surviving tree is an exact signal that teardown failed
  rather than a proxy for it, which also covers a root process on POSIX.
- `lockStore` and `readOnlyStore` take the store's `onCleanup`, so a body that
  throws strands neither a held lock nor a tightened tree. Both block `rmdir`
  on Windows, where an open file cannot be unlinked.
- `primaryCode()` compares the class of failure: `errcode` carries the
  **extended** code, so `SQLITE_READONLY` also arrives as
  `SQLITE_READONLY_DIRECTORY` (1544). `sqliteErrcode()` stays for the one test
  where the refinement is the point.

## Notes for whoever writes the tests on top of this

- `openLocalDatabase` chmods a locked-down data dir back to 0700 via
  `ensureDataDirSync` before SQLite opens the file, so a directory-permission
  fault never reaches the engine on that path. Pinned in a test — the
  permission-denied fault case needs to plan around it.
- **`fillStore` cannot yet be aimed at any product write path.** It takes a raw
  `DatabaseSync` and `LocalDatabase` exposes none, so the disk-full injector
  reaches `node:sqlite`, not the package built on it. The disk-full case's
  "fail-open, no corruption, no partial rows" needs either a raw-handle seam or
  repositories driven over a raw handle, as `activity.test.ts` already does.
  Documented on the function rather than left in a PR description.
- Node's type-stripping cannot load `packages/persistence/src/*.ts` (parameter
  properties), so any future worker or child-process helper must stay on
  `node:` builtins. Noted in the worker's header.
- `findings.test.ts` quietly raises `busy_timeout` to 5000 for its concurrent
  seeder — worth pinning or removing once the concurrency tests land.
- The two file-level races (the `applyOnboarding` lost update and the
  fingerprint mint TOCTOU) still have no harness; in-process handles cannot
  reliably interleave a `readFileSync` -> `renameSync` pair.
- `packages/persistence/vitest.config.ts` now pins `sequence.hooks: 'stack'`.
  `useTempStore`'s teardown ordering silently depended on that default; under
  `'list'` or `'parallel'` the store is destroyed before a suite's own
  `afterEach`.



