### PR TITLE
fix(ci): give gh repo context in the Dependabot major guard

### DIFF
--- a/.github/workflows/dependabot-major-guard.yml
+++ b/.github/workflows/dependabot-major-guard.yml
@@ -34,6 +34,11 @@ jobs:
         if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This job never checks out, so there is no git remote for `gh` to
+          # infer the repository from. The `gh pr` calls below pass a full URL
+          # and are fine, but `gh label create` has no such context and would
+          # shell out to git and fail. GH_REPO supplies it without a checkout.
+          GH_REPO: ${{ github.repository }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           DEP: ${{ steps.meta.outputs.dependency-names }}
           FROM: ${{ steps.meta.outputs.previous-version }}


### PR DESCRIPTION
## Problem

`dependabot-major-guard.yml` has failed on every major bump and has never once flagged one. PRs #113 (`next` 15→16) and #114 (`eslint` 9→10) both hit it.

The `flag-major` job deliberately has no `actions/checkout` step — the header comment explains it never checks out PR code, which is the right call for `pull_request_target`. But that leaves `gh` with no git remote to infer the repository from:

- `gh pr edit "$PR_URL"` and `gh pr comment "$PR_URL"` are fine — a full URL carries the repo.
- `gh label create "dependencies:major"` has nothing to infer from, so it shells out to git and fails:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

It is the **first** command in the `run:` block under `bash -e`, so it takes the whole step down 0.2s in — before the label or the comment is ever applied.

## Fix

Set `GH_REPO: ${{ github.repository }}` in the step's existing `env:` block. This is the documented way to give `gh` repo context without a checkout, and it fixes `gh label create` without touching the URL-based calls.

Adding an `actions/checkout` would also work but is worse — it reintroduces exactly the risk the header comment says this workflow avoids.

## Verification

Reproduced the runner's condition in a non-git directory:

| Check | Result |
|---|---|
| `gh label …` without `GH_REPO` | fails with the **exact** CI error, byte for byte |
| `gh label …` with `GH_REPO` | resolves and returns the repo's labels |
| `gh pr view "$PR_URL"` with `GH_REPO` set | still resolves to #114 — URL calls are unaffected |
| Full `run:` block, extracted from this file, under `bash -e` | **exit 0**, all four commands reached in order |
| Idempotency: marker already present | `gh pr comment` **not** called — comment posts exactly once |
| Negative control | label still absent, so the control made no writes |

The block's comment body renders correctly too (backticks, the `→`, the embedded newline after the marker).

## Note on live confirmation

`pull_request_target` resolves the workflow file from the **base branch**, so this cannot run live until it is on `main` — and re-running the old failed jobs replays the original run's workflow file, so a re-run alone won't pick it up either. After merge, #113/#114 need a fresh event; `@dependabot rebase` fires `synchronize` and will confirm the label plus a single comment.