### PR TITLE
fix(persistence): point the fault injectors at the renamed dbSidecars

### DIFF
--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { describe, expect, it } from 'vitest';
 
 import { openLocalDatabase } from '../../src/database.ts';
-import { walSidecars } from '../../src/paths.ts';
+import { dbSidecars } from '../../src/paths.ts';
 import {
   corruptStore,
   fillStore,
@@ -167,14 +167,14 @@ describe('corruptStore', () => {
     });
   });
 
-  it('clears the WAL sidecars so they cannot replay over the damage', () => {
+  it('clears the DB sidecars so they cannot replay over the damage', () => {
     withTempStore((store) => {
       seedStore(store);
-      for (const sidecar of walSidecars(store.dbFile)) {
+      for (const sidecar of dbSidecars(store.dbFile)) {
         writeFileSync(sidecar, 'stale');
       }
       corruptStore(store.dbFile, 'truncate', { store });
-      for (const sidecar of walSidecars(store.dbFile)) {
+      for (const sidecar of dbSidecars(store.dbFile)) {
         expect(existsSync(sidecar)).toBe(false);
       }
     });

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -31,7 +31,7 @@ import { dirname } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { Worker } from 'node:worker_threads';
 
-import { walSidecars } from '../../src/paths.ts';
+import { dbSidecars } from '../../src/paths.ts';
 import type { TempStore } from './temp-store.ts';
 
 /**
@@ -145,7 +145,7 @@ export interface CorruptStoreOptions {
 
 /**
  * Damage a real store at a fixed offset — same input, same bytes changed, every
- * run. The store must have no open handle: the WAL sidecars are removed first,
+ * run. The store must have no open handle: the DB sidecars are removed first,
  * and pulling them out from under a live connection makes the resulting damage
  * depend on that connection's cached pages, which costs the determinism above.
  * Pass `store` and that precondition is enforced.
@@ -164,10 +164,10 @@ export function corruptStore(
   const live = opts.store?.openHandleCount() ?? 0;
   if (live > 0) {
     throw new Error(
-      `corruptStore(): ${String(live)} handle(s) still open on ${file} — close them first, or the WAL removed below is pulled out from under a live connection.`,
+      `corruptStore(): ${String(live)} handle(s) still open on ${file} — close them first, or the sidecars removed below are pulled out from under a live connection.`,
     );
   }
-  for (const sidecar of walSidecars(file)) {
+  for (const sidecar of dbSidecars(file)) {
     if (existsSync(sidecar)) rmSync(sidecar);
   }
 
@@ -240,7 +240,7 @@ const READ_ONLY_FILE_MODE = 0o400;
 const READ_ONLY_DIR_MODE = 0o500;
 
 /**
- * Make a store unwritable by mode. The db and any WAL sidecars go to 0400.
+ * Make a store unwritable by mode. The db and any sidecars go to 0400.
  *
  * Read-only for the owner alone, not 0444: `aka.db` holds prompt and file
  * content and the package writes it 0600 everywhere else, so a test has no
@@ -267,7 +267,7 @@ export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): Re
   if (!existsSync(file)) {
     throw new Error(`readOnlyStore(): no store at ${file}`);
   }
-  const targets = [file, ...walSidecars(file)].filter((path) => existsSync(path));
+  const targets = [file, ...dbSidecars(file)].filter((path) => existsSync(path));
   const dir = dirname(file);
   const original = new Map<string, number>();
 


### PR DESCRIPTION
main is red. `walSidecars is not a function` fails 10 fault-injection tests, and eslint reports 13 unresolved-type errors across the two helper files. Both CI jobs fail from this one cause.

## What happened

Two PRs that were each green in isolation:

- **#108** renamed `walSidecars` → `dbSidecars` in `packages/persistence/src/paths.ts`, widening it to include the rollback journal.
- **#111** added `packages/persistence/test/helpers/fault-injection.ts`, which imports the old name.

They touch different files, so git found no textual conflict. They merged **33 seconds apart** (13:03:29 and 13:04:02), so neither branch's CI ever ran against the other's change. The first `main` build after both landed is the first time the two were ever compiled together.

## The fix

`dbSidecars` returns a superset — `[-wal, -shm, -journal]` against the old `[-wal, -shm]` — so this is a rename at the call sites and nothing else. Six references across the two helper files.

The corrupt-store case gets slightly stronger for it: the rollback journal is now cleared and asserted gone alongside the WAL, so it cannot replay over the injected damage either.

Comments and the one test title that described the old WAL-only scope are updated. The ones that genuinely refer to WAL *mode* (`PRAGMA journal_mode = WAL`, the sidecar-creation path) are left alone.

## Verification

Run on the merge commit that is currently failing (`4251d0d`), reproduced before fixing and confirmed after:

- `pnpm lint` — 14/14 (was 13 errors in persistence)
- `pnpm turbo typecheck` — 14/14
- `pnpm test` — 28/28 tasks; persistence 47 files / 626 tests (was 10 failing)
- `pnpm format:check` — clean