### PR TITLE
fix(web-ui): refuse approving a ledger row keyed to a rotated-away version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,17 @@ jobs:
   # script — BOTH suites, not just the middleware gate:
   #   - test/middleware.test.ts — the sole DNS-rebinding gate; pure string work
   #     (68 tests in ~40ms here).
-  #   - test/actions/exceptions.test.ts — raw-secret handling in addException,
-  #     driving a REAL node:sqlite store and minting a REAL key file per test.
-  #     This is the OS-sensitive half and the reason it belongs on Windows.
-  # That second suite is slow here: ~44s wall for 20 tests, worst single test
-  # ~3.0s against the 20s per-test timeout in web-ui/vitest.config.ts. Keep an
-  # eye on that margin — the persistence suite needed batching twice to stay
-  # under it. web-ui's `test` also drops the `build`/`^build` edges
+  #   - test/actions/exceptions.test.ts — the three exception-granting Server
+  #     Actions (addException's raw-secret handling, approveBlocked's ledger
+  #     gates, rotateKey's confirmation gate), each driving a REAL node:sqlite
+  #     store and a REAL key file per test, several opening the store more than
+  #     once. This is the OS-sensitive half and the reason it belongs on Windows.
+  # That second suite is the slow one: it was ~44s wall for 20 tests when this
+  # note was written and is now 73 tests, so budget proportionally. The per-test
+  # timeout in web-ui/vitest.config.ts is 20s and the worst single test was ~3.0s
+  # — keep an eye on that margin as the suite grows, the persistence suite needed
+  # batching twice to stay under it. Two cases assert POSIX mode bits and skip
+  # here rather than pass vacuously. web-ui's `test` also drops the `build`/`^build` edges
   # (web-ui/turbo.json), so no `next build` runs here. Scoped to the
   # shipped-surface packages to keep the job fast; the full suite runs on the
   # Linux job above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,13 @@ jobs:
   #     gates, rotateKey's confirmation gate), each driving a REAL node:sqlite
   #     store and a REAL key file per test, several opening the store more than
   #     once. This is the OS-sensitive half and the reason it belongs on Windows.
-  # That second suite is the slow one: it was ~44s wall for 20 tests when this
-  # note was written and is now 73 tests, so budget proportionally. The per-test
-  # timeout in web-ui/vitest.config.ts is 20s and the worst single test was ~3.0s
-  # — keep an eye on that margin as the suite grows, the persistence suite needed
-  # batching twice to stay under it. Two cases assert POSIX mode bits and skip
-  # here rather than pass vacuously. web-ui's `test` also drops the `build`/`^build` edges
+  # That second suite is the slow one: ~122s wall for 73 tests here, against ~12s
+  # for the same suite on the Linux leg (it was ~44s for 20 tests when this note
+  # started). Two of the 73 skip here — they assert POSIX mode bits, which
+  # Windows ACLs do not carry, and skipping beats passing with no assertions. The
+  # per-test timeout in web-ui/vitest.config.ts is 20s; keep an eye on that margin
+  # as the suite grows, the persistence suite needed batching twice to stay under
+  # it. web-ui's `test` also drops the `build`/`^build` edges
   # (web-ui/turbo.json), so no `next build` runs here. Scoped to the
   # shipped-surface packages to keep the job fast; the full suite runs on the
   # Linux job above.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
   #     is cheap; one case needs POSIX modes and skips on Windows, so the same
   #     property is also pinned through an injected reader that runs everywhere.
   #   - test/pages/settings-page-head.test.ts — copy guard; pure (8 tests).
-  # The exceptions suite is the slow one: ~122s wall for 73 tests — the other
+  # The exceptions suite is the slow one: ~2min wall for 74 tests — the other
   # three together are under a second — against the 20s per-test timeout in
   # web-ui/vitest.config.ts. A couple of cases assert POSIX mode bits and skip
   # here rather than pass with no assertions. Keep an eye on that margin: the

--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -271,18 +271,26 @@ function printGranted(io: Prompter, ex: DetectionException): void {
 // approve — grant from the blocked-detections ledger (the primary flow)
 // ---------------------------------------------------------------------------
 
-function blockedLine(entry: BlockedDetection): string {
-  return `${entry.reference}  ${entry.maskedValue}  ${entry.ruleId}  ${formatRelative(entry.blockedAt)}`;
+// One ledger row as the picker lists it. A row the approve step will refuse is
+// marked here rather than left to look selectable — the web strip disables those
+// rows, and a picker that offers one and then refuses it wastes the choice.
+function blockedLine(entry: BlockedDetection, key: FingerprintKey | null): string {
+  const line = `${entry.reference}  ${entry.maskedValue}  ${entry.ruleId}  ${formatRelative(entry.blockedAt)}`;
+  return isCurrentKeyVersion(key, entry.keyVersion)
+    ? line
+    : `${line}  [not approvable: recorded under key v${String(entry.keyVersion)}]`;
 }
 
-// A key file that cannot be read is either corrupt or inaccessible, and only the
-// first may be answered with "delete it". Deleting a healthy key over a
-// permissions error destroys every grant on the machine, because the replacement
-// carries fresh material that no stored fingerprint was written under. A
-// filesystem error carries a `code`; the strict parse throws a plain Error
-// without one.
+// A key resolution can fail three ways, and only one of them may be answered
+// with "delete it": deleting a healthy key over a permissions error destroys
+// every grant on the machine, because the replacement carries fresh material
+// that no stored fingerprint was written under. The floor read is a store
+// problem wearing a key-shaped error, so it is separated out first.
 function keyAccessHint(err: unknown, dir: string): string {
-  const code: unknown = (err as NodeJS.ErrnoException | null)?.code;
+  const code: unknown = (err as { code?: unknown } | null)?.code;
+  if (code === 'floor-unreadable') {
+    return `The local store could not be read, and a key minted without it could reuse a version already in use — fix the store first (${dir}/aka.db).`;
+  }
   return typeof code === 'string'
     ? `Check the permissions on ${dir}/exception.key — do not delete it, that invalidates every existing grant.`
     : `Delete ${dir}/exception.key to start fresh — grants written under it already cannot match.`;
@@ -307,7 +315,7 @@ async function pickBlocked(
   entries: BlockedDetection[],
   selector: string | undefined,
   io: Prompter,
-  dir: string,
+  key: FingerprintKey | null,
 ): Promise<BlockedDetection> {
   if (selector !== undefined) {
     // The selector is the ledger reference (as printed in the block message),
@@ -326,7 +334,6 @@ async function pickBlocked(
         `the selector matches ${String(matches.length)} recent blocks — run 'aka exception approve' bare to pick from the list`,
       );
     }
-    const key = readKeyForApprove(dir);
     if (key === null) {
       throw new Error(
         `no blocked detection matches that reference, and matching by value needs the fingerprint key — none exists on this machine`,
@@ -354,17 +361,17 @@ async function pickBlocked(
   }
   const only = entries[0];
   if (entries.length === 1 && only) {
-    io.out(`Approving the only recent block:\n  ${blockedLine(only)}\n`);
+    io.out(`Approving the only recent block:\n  ${blockedLine(only, key)}\n`);
     return only;
   }
   if (!io.isInteractive) {
     io.err(`Blocked in the last 30 minutes:\n`);
-    for (const entry of entries) io.err(`  ${blockedLine(entry)}\n`);
+    for (const entry of entries) io.err(`  ${blockedLine(entry, key)}\n`);
     throw new Error('pass the reference to approve: aka exception approve <reference>');
   }
   io.out('Blocked in the last 30 minutes:\n');
   entries.forEach((entry, i) => {
-    io.out(`  ${String(i + 1)}) ${blockedLine(entry)}\n`);
+    io.out(`  ${String(i + 1)}) ${blockedLine(entry, key)}\n`);
   });
   const answer = await io.ask(`Which one? [1-${String(entries.length)}]: `);
   const index = Number.parseInt(answer.trim(), 10);
@@ -396,7 +403,12 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
     // Trim paste artifacts (a multi-line paste arrives with embedded
     // newlines); a whitespace-only selector falls back to the bare picker.
     const selector = positionals[0]?.trim();
-    const entry = await pickBlocked(entries, selector === '' ? undefined : selector, io, dir);
+    // Resolved ONCE: the picker fingerprints a by-value selector with it and
+    // marks rows it will refuse, and the guard below checks the chosen row
+    // against it. Reading the file twice duplicated the parse and left a window
+    // for the two reads to disagree.
+    const key = readKeyForApprove(dir);
+    const entry = await pickBlocked(entries, selector === '' ? undefined : selector, io, key);
 
     // The ledger row carries the fingerprint computed when the hook blocked,
     // under whichever key was live then; the ledger is retained far longer than
@@ -405,7 +417,6 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
     // grant built from such a row is inert the moment it is created. Refuse
     // BEFORE prompting for scope and reason — an unusable row stays unusable
     // whatever the user answers.
-    const key = readKeyForApprove(dir);
     if (!isCurrentKeyVersion(key, entry.keyVersion)) {
       throw new Error(
         key === null

--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -5,10 +5,13 @@ import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
 import type { BlockedDetection, LocalDatabase } from '@akasecurity/persistence';
 import type { CreateExceptionInput } from '@akasecurity/persistence';
 import { openLocalDatabase } from '@akasecurity/persistence';
+import type { FingerprintKey } from '@akasecurity/plugin-sdk';
 import {
   dataDir,
   fingerprintValue,
+  isCurrentKeyVersion,
   loadOrCreateFingerprintKey,
+  readFingerprintKey,
   registerBundledPacks,
   rotateFingerprintKey,
 } from '@akasecurity/plugin-sdk';
@@ -272,6 +275,34 @@ function blockedLine(entry: BlockedDetection): string {
   return `${entry.reference}  ${entry.maskedValue}  ${entry.ruleId}  ${formatRelative(entry.blockedAt)}`;
 }
 
+// A key file that cannot be read is either corrupt or inaccessible, and only the
+// first may be answered with "delete it". Deleting a healthy key over a
+// permissions error destroys every grant on the machine, because the replacement
+// carries fresh material that no stored fingerprint was written under. A
+// filesystem error carries a `code`; the strict parse throws a plain Error
+// without one.
+function keyAccessHint(err: unknown, dir: string): string {
+  const code: unknown = (err as NodeJS.ErrnoException | null)?.code;
+  return typeof code === 'string'
+    ? `Check the permissions on ${dir}/exception.key — do not delete it, that invalidates every existing grant.`
+    : `Delete ${dir}/exception.key to start fresh — grants written under it already cannot match.`;
+}
+
+// The key as the approve flow needs it: read-only, never minting. Minting here
+// would change which key is current as a side effect of a LOOKUP, orphaning
+// every existing grant to answer a search — and on a store whose key was
+// deleted it would hand fresh material a version stored rows already claim.
+function readKeyForApprove(dir: string): FingerprintKey | null {
+  try {
+    return readFingerprintKey(dir);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`cannot read the fingerprint key: ${message}\n${keyAccessHint(err, dir)}`, {
+      cause: err,
+    });
+  }
+}
+
 async function pickBlocked(
   entries: BlockedDetection[],
   selector: string | undefined,
@@ -295,10 +326,15 @@ async function pickBlocked(
         `the selector matches ${String(matches.length)} recent blocks — run 'aka exception approve' bare to pick from the list`,
       );
     }
-    const key = loadOrCreateFingerprintKey(dir);
+    const key = readKeyForApprove(dir);
+    if (key === null) {
+      throw new Error(
+        `no blocked detection matches that reference, and matching by value needs the fingerprint key — none exists on this machine`,
+      );
+    }
     const fingerprint = fingerprintValue(key, selector);
     const byValue = entries.filter(
-      (e) => e.keyVersion === key.version && e.valueFingerprint === fingerprint,
+      (e) => isCurrentKeyVersion(key, e.keyVersion) && e.valueFingerprint === fingerprint,
     );
     const newest = byValue[0];
     if (newest) {
@@ -361,6 +397,23 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
     // newlines); a whitespace-only selector falls back to the bare picker.
     const selector = positionals[0]?.trim();
     const entry = await pickBlocked(entries, selector === '' ? undefined : selector, io, dir);
+
+    // The ledger row carries the fingerprint computed when the hook blocked,
+    // under whichever key was live then; the ledger is retained far longer than
+    // a rotation takes, so a row can outlive its key. Enforcement fingerprints
+    // under the CURRENT key and scopes its bundle query to that version, so a
+    // grant built from such a row is inert the moment it is created. Refuse
+    // BEFORE prompting for scope and reason — an unusable row stays unusable
+    // whatever the user answers.
+    const key = readKeyForApprove(dir);
+    if (!isCurrentKeyVersion(key, entry.keyVersion)) {
+      throw new Error(
+        key === null
+          ? `cannot approve ${entry.reference}: the fingerprint key file is missing, so the fingerprint recorded for it can no longer be matched — trigger the detection again`
+          : `cannot approve ${entry.reference}: it was blocked under fingerprint key v${String(entry.keyVersion)} and the key is now v${String(key.version)}, so a grant from it could never match — trigger the detection again`,
+      );
+    }
+
     const { scope, reason } = await resolveScopeAndReason(values, io);
     if (scope.scope === 'permanent') {
       await confirmPermanent(io, entry.maskedValue, values.yes === true);
@@ -722,13 +775,11 @@ async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
     try {
       version = rotateFingerprintKey(dir).version;
     } catch (err) {
-      // A corrupt key file must not print a stack trace — surface the reason
-      // with a way forward. (Grants under a corrupt key already cannot match.)
+      // An unusable key file must not print a stack trace — surface the reason
+      // with a way forward matched to it. (Grants under a corrupt key already
+      // cannot match; a key that is merely unreadable must NOT be deleted.)
       const message = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `cannot rotate: ${message}\nDelete ${dir}/exception.key to start fresh — grants written under it already cannot match.`,
-        { cause: err },
-      );
+      throw new Error(`cannot rotate: ${message}\n${keyAccessHint(err, dir)}`, { cause: err });
     }
     io.out(
       `Fingerprint key rotated — new key version v${String(version)}.\nExisting grants no longer match; re-approve deliberately where still needed.\n`,

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -11,7 +11,9 @@ import {
   dataDir,
   fingerprintValue,
   loadOrCreateFingerprintKey,
+  readFingerprintKey,
   registerBundledPacks,
+  rotateFingerprintKey,
 } from '@akasecurity/plugin-sdk';
 import { defaultWorkspaceSettings } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -323,6 +325,92 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
     } finally {
       db.close();
     }
+  });
+
+  // The ledger is retained for a day, so it outlives a key rotation and keeps
+  // offering rows whose fingerprint was computed under the old material.
+  // Enforcement fingerprints under the CURRENT key and scopes its bundle query
+  // to that version, so a grant built from such a row is inert the moment it is
+  // created — and reporting success for it is worse than the grant simply going
+  // quiet, because the operator just deliberately created this one.
+  describe('a row keyed to a version that is no longer current', () => {
+    async function grants(): Promise<unknown[]> {
+      const db = openLocalDatabase(dir);
+      try {
+        return await db.exceptions.list({ includeTerminal: true });
+      } finally {
+        db.close();
+      }
+    }
+
+    it('refuses a row blocked before a rotation', async () => {
+      await seedBlocked('c0ffee');
+      const rotated = rotateFingerprintKey(dir);
+      expect(rotated.version).toBe(2);
+
+      await expect(
+        runException(
+          ['approve', 'c0ffee', '--home', home, '--once', '--reason', 'stale'],
+          scriptedIo(),
+        ),
+      ).rejects.toThrow(/could never match/);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('refuses a row whose key was deleted and re-minted, not just rotated', async () => {
+      // Version alone is not an identity — minting used to restart the counter,
+      // so a key deleted at v1 and re-minted came back as v1 and made this row
+      // look current. The mint now takes the first version the store has not
+      // already claimed.
+      await seedBlocked('deadbe');
+      rmSync(join(dir, 'exception.key'));
+      const reminted = loadOrCreateFingerprintKey(dir);
+      expect(reminted.version).toBe(2);
+
+      await expect(
+        runException(
+          ['approve', 'deadbe', '--home', home, '--once', '--reason', 'reminted'],
+          scriptedIo(),
+        ),
+      ).rejects.toThrow(/could never match/);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('refuses when the key file is missing, and mints nothing to answer the read', async () => {
+      await seedBlocked('ba5eba');
+      rmSync(join(dir, 'exception.key'));
+
+      await expect(
+        runException(
+          ['approve', 'ba5eba', '--home', home, '--once', '--reason', 'no key'],
+          scriptedIo(),
+        ),
+      ).rejects.toThrow(/key file is missing/);
+      expect(await grants()).toHaveLength(0);
+      // A refusal that minted a key would rotate the machine's whole grant set
+      // to answer a lookup.
+      expect(readFingerprintKey(dir)).toBeNull();
+    });
+
+    it('does not mint a key when a by-value selector finds nothing', async () => {
+      // The by-value path fingerprints the selector to compare it, which used to
+      // load-or-create. On a store with no key that minted one as a side effect
+      // of a failed search.
+      await seedBlocked('fa11ed');
+      rmSync(join(dir, 'exception.key'));
+      const unmatched = 'AKIAZZZZNOTBLOCKEDZZ';
+
+      const err = await runException(
+        ['approve', unmatched, '--home', home, '--once', '--reason', 'nope'],
+        scriptedIo(),
+      ).then(
+        () => undefined,
+        (e: unknown) => e as Error,
+      );
+      expect(err?.message).toMatch(/needs the fingerprint key/);
+      expect(err?.message).not.toContain(unmatched);
+      expect(readFingerprintKey(dir)).toBeNull();
+    });
   });
 });
 

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -392,6 +392,31 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
       expect(readFingerprintKey(dir)).toBeNull();
     });
 
+    it('marks unapprovable rows in the picker instead of offering them', async () => {
+      // The picker is the CLI's twin of the web strip, which disables these
+      // rows. Listing one unmarked spends the user's choice on something the
+      // very next step refuses.
+      await seedBlocked('aa0001');
+      await seedBlocked('bb0002');
+      rotateFingerprintKey(dir);
+
+      const io = scriptedIo();
+      const err = await runException(
+        ['approve', '--home', home, '--once', '--reason', 'listing'],
+        io,
+      ).then(
+        () => undefined,
+        (e: unknown) => e as Error,
+      );
+      // Non-interactive with more than one row lists them and asks for a
+      // reference, which is the branch that prints the annotated lines.
+      expect(err?.message).toMatch(/pass the reference/);
+      const listed = io.output();
+      expect(listed).toContain('aa0001');
+      expect(listed).toContain('bb0002');
+      expect(listed.match(/not approvable: recorded under key v1/g)).toHaveLength(2);
+    });
+
     it('does not mint a key when a by-value selector finds nothing', async () => {
       // The by-value path fingerprints the selector to compare it, which used to
       // load-or-create. On a store with no key that minted one as a side effect

--- a/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
+++ b/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
@@ -6,12 +6,19 @@ import { relativeTime } from '../lib/relativeTime.ts';
 import { BLOCKED_WINDOW_PHRASE, type BlockedWindow } from '../lib/timeRanges.ts';
 import { SlashCircleIcon } from '../shared/icons.tsx';
 import { BlockedWindowSelect } from './BlockedWindowSelect.tsx';
+import { isBlockedRowApprovable } from './meta.ts';
 
 export interface BlockedLedgerViewProps {
   items: BlockedDetection[];
   onApprove: (reference: string) => void;
   blockedWindow: BlockedWindow;
   onBlockedWindowChange: (window: BlockedWindow) => void;
+  /**
+   * The fingerprint key version in use now, or null when there is no key file.
+   * A row recorded under any other version can no longer be matched, so its
+   * Approve is disabled rather than left to fail server-side.
+   */
+  keyVersion: number | null;
 }
 
 /**
@@ -19,12 +26,18 @@ export interface BlockedLedgerViewProps {
  * `aka exception approve` picker, with a lookback window filter the CLI
  * doesn't have. Each row carries the keyed fingerprint and masked preview
  * only (never the raw value); Approve opens the grant dialog for that entry.
+ *
+ * The ledger is retained for a day, so it outlives a key rotation and keeps
+ * listing rows fingerprinted under the old key. Those rows are shown — they are
+ * still an accurate record of what was blocked — but marked unapprovable, since
+ * a grant built from one could never match at enforcement time.
  */
 export function BlockedLedgerView({
   items,
   onApprove,
   blockedWindow,
   onBlockedWindowChange,
+  keyVersion,
 }: BlockedLedgerViewProps) {
   return (
     <div className="mb-3.5 overflow-hidden rounded-xl border border-sev-high-fill bg-sev-high-fill">
@@ -48,34 +61,46 @@ export function BlockedLedgerView({
         <div className="px-3.5 pb-3.5 text-xs text-text-2">Nothing blocked in this window.</div>
       ) : (
         <div className="flex flex-col gap-1.5 px-3 pb-3">
-          {items.map((b) => (
-            <div
-              key={b.reference}
-              className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2.5"
-            >
-              <span className="font-mono text-xs font-semibold text-text-3">{b.reference}</span>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-mono text-xs font-semibold text-text">{b.ruleId}</span>
-                  <span className="font-mono text-xs text-text-2">{b.maskedValue}</span>
-                </div>
-                <div className={cn('mt-1 text-label text-text-3')}>
-                  {relativeTime(b.blockedAt)}
-                  {b.repo ? ` · ${b.repo}` : ''}
-                </div>
-              </div>
-              <Button
-                onClick={() => {
-                  onApprove(b.reference);
-                }}
-                variant="ghost"
-                tone="primary"
-                size="sm"
+          {items.map((b) => {
+            const stale = !isBlockedRowApprovable(b, keyVersion);
+            return (
+              <div
+                key={b.reference}
+                className="flex items-center gap-3 rounded-lg border border-border bg-surface px-3 py-2.5"
               >
-                Approve
-              </Button>
-            </div>
-          ))}
+                <span className="font-mono text-xs font-semibold text-text-3">{b.reference}</span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs font-semibold text-text">{b.ruleId}</span>
+                    <span className="font-mono text-xs text-text-2">{b.maskedValue}</span>
+                  </div>
+                  <div className={cn('mt-1 text-label text-text-3')}>
+                    {relativeTime(b.blockedAt)}
+                    {b.repo ? ` · ${b.repo}` : ''}
+                    {stale
+                      ? ` · recorded under fingerprint key v${String(b.keyVersion)} — no longer approvable`
+                      : ''}
+                  </div>
+                </div>
+                <Button
+                  onClick={() => {
+                    onApprove(b.reference);
+                  }}
+                  disabled={stale}
+                  title={
+                    stale
+                      ? 'The fingerprint key changed after this was blocked, so a grant from it could never match. Trigger the detection again.'
+                      : undefined
+                  }
+                  variant="ghost"
+                  tone="primary"
+                  size="sm"
+                >
+                  Approve
+                </Button>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
+++ b/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
@@ -1,12 +1,12 @@
 'use client';
-import type { BlockedDetection } from '@akasecurity/schema';
+import type { BlockedDetection, FingerprintKeyState } from '@akasecurity/schema';
 import { Button, cn } from '@akasecurity/ui-kit';
 
 import { relativeTime } from '../lib/relativeTime.ts';
 import { BLOCKED_WINDOW_PHRASE, type BlockedWindow } from '../lib/timeRanges.ts';
 import { SlashCircleIcon } from '../shared/icons.tsx';
 import { BlockedWindowSelect } from './BlockedWindowSelect.tsx';
-import { isBlockedRowApprovable } from './meta.ts';
+import { blockedRowBlockReason } from './meta.ts';
 
 export interface BlockedLedgerViewProps {
   items: BlockedDetection[];
@@ -14,11 +14,12 @@ export interface BlockedLedgerViewProps {
   blockedWindow: BlockedWindow;
   onBlockedWindowChange: (window: BlockedWindow) => void;
   /**
-   * The fingerprint key version in use now, or null when there is no key file.
-   * A row recorded under any other version can no longer be matched, so its
-   * Approve is disabled rather than left to fail server-side.
+   * What the fingerprint key file amounts to right now. A row recorded under
+   * anything other than the current version can no longer be matched, so its
+   * Approve is disabled rather than left to fail server-side — and the three
+   * states are kept apart because each is a different problem to the reader.
    */
-  keyVersion: number | null;
+  keyState: FingerprintKeyState;
 }
 
 /**
@@ -37,7 +38,7 @@ export function BlockedLedgerView({
   onApprove,
   blockedWindow,
   onBlockedWindowChange,
-  keyVersion,
+  keyState,
 }: BlockedLedgerViewProps) {
   return (
     <div className="mb-3.5 overflow-hidden rounded-xl border border-sev-high-fill bg-sev-high-fill">
@@ -62,7 +63,7 @@ export function BlockedLedgerView({
       ) : (
         <div className="flex flex-col gap-1.5 px-3 pb-3">
           {items.map((b) => {
-            const stale = !isBlockedRowApprovable(b, keyVersion);
+            const blocked = blockedRowBlockReason(b, keyState);
             return (
               <div
                 key={b.reference}
@@ -77,21 +78,18 @@ export function BlockedLedgerView({
                   <div className={cn('mt-1 text-label text-text-3')}>
                     {relativeTime(b.blockedAt)}
                     {b.repo ? ` · ${b.repo}` : ''}
-                    {stale
-                      ? ` · recorded under fingerprint key v${String(b.keyVersion)} — no longer approvable`
-                      : ''}
+                    {blocked === null ? '' : ' · not approvable'}
                   </div>
+                  {blocked === null ? null : (
+                    <div className="mt-1 text-label text-text-3">{blocked}</div>
+                  )}
                 </div>
                 <Button
                   onClick={() => {
                     onApprove(b.reference);
                   }}
-                  disabled={stale}
-                  title={
-                    stale
-                      ? 'The fingerprint key changed after this was blocked, so a grant from it could never match. Trigger the detection again.'
-                      : undefined
-                  }
+                  disabled={blocked !== null}
+                  title={blocked ?? undefined}
                   variant="ghost"
                   tone="primary"
                   size="sm"

--- a/packages/dashboard-ui/src/exceptions/meta.ts
+++ b/packages/dashboard-ui/src/exceptions/meta.ts
@@ -1,7 +1,7 @@
 // Presentational lookups + pure derivations for the Exceptions views. Lives in
 // @akasecurity/dashboard-ui so every host renders
 // identical state/scope/provenance labelling.
-import type { DetectionException } from '@akasecurity/schema';
+import type { BlockedDetection, DetectionException } from '@akasecurity/schema';
 import type { BadgeProps } from '@akasecurity/ui-kit';
 
 export type Tone = NonNullable<BadgeProps['variant']>;
@@ -16,6 +16,28 @@ export function exceptionState(ex: DetectionException, now = Date.now()): Except
   if (ex.maxUses !== null && ex.useCount >= ex.maxUses) return 'consumed';
   if (ex.expiresAt !== null && Date.parse(ex.expiresAt) <= now) return 'expired';
   return 'active';
+}
+
+/**
+ * Whether a blocked-ledger row can still be turned into a grant.
+ *
+ * The row's fingerprint was computed under whichever key was live when the hook
+ * blocked. Enforcement fingerprints under the CURRENT key and scopes its bundle
+ * query to that version, so a grant built from a row keyed to any other version
+ * could never match. The ledger is retained for a day, which is longer than a
+ * key rotation takes, so the strip keeps listing such rows — they are still an
+ * accurate record of what was blocked, just no longer grant material.
+ *
+ * `currentKeyVersion` is null when there is no key file at all; the material is
+ * gone, so no stored fingerprint can be reproduced and nothing is approvable.
+ * This mirrors the server-side refusal, which is the actual control — this only
+ * keeps the UI from offering a click that cannot succeed.
+ */
+export function isBlockedRowApprovable(
+  row: Pick<BlockedDetection, 'keyVersion'>,
+  currentKeyVersion: number | null,
+): boolean {
+  return currentKeyVersion !== null && row.keyVersion === currentKeyVersion;
 }
 
 export const STATE_TONE: Record<ExceptionState, Tone> = {

--- a/packages/dashboard-ui/src/exceptions/meta.ts
+++ b/packages/dashboard-ui/src/exceptions/meta.ts
@@ -1,7 +1,12 @@
 // Presentational lookups + pure derivations for the Exceptions views. Lives in
 // @akasecurity/dashboard-ui so every host renders
 // identical state/scope/provenance labelling.
-import type { BlockedDetection, DetectionException } from '@akasecurity/schema';
+import type {
+  BlockedDetection,
+  DetectionException,
+  FingerprintKeyState,
+} from '@akasecurity/schema';
+import { isMatchableUnder } from '@akasecurity/schema';
 import type { BadgeProps } from '@akasecurity/ui-kit';
 
 export type Tone = NonNullable<BadgeProps['variant']>;
@@ -21,23 +26,43 @@ export function exceptionState(ex: DetectionException, now = Date.now()): Except
 /**
  * Whether a blocked-ledger row can still be turned into a grant.
  *
- * The row's fingerprint was computed under whichever key was live when the hook
- * blocked. Enforcement fingerprints under the CURRENT key and scopes its bundle
- * query to that version, so a grant built from a row keyed to any other version
- * could never match. The ledger is retained for a day, which is longer than a
- * key rotation takes, so the strip keeps listing such rows — they are still an
- * accurate record of what was blocked, just no longer grant material.
+ * The ledger is retained for a day, which is longer than a key rotation takes,
+ * so the strip keeps listing rows fingerprinted under a key that is no longer
+ * current — still an accurate record of what was blocked, just no longer grant
+ * material. This mirrors the server-side refusal, which is the actual control;
+ * the UI use of it only avoids offering a click that cannot succeed.
  *
- * `currentKeyVersion` is null when there is no key file at all; the material is
- * gone, so no stored fingerprint can be reproduced and nothing is approvable.
- * This mirrors the server-side refusal, which is the actual control — this only
- * keeps the UI from offering a click that cannot succeed.
+ * Delegates to the shared rule rather than restating it, so the strip and the
+ * two approve surfaces cannot drift on which rows are usable.
  */
 export function isBlockedRowApprovable(
   row: Pick<BlockedDetection, 'keyVersion'>,
-  currentKeyVersion: number | null,
+  key: FingerprintKeyState,
 ): boolean {
-  return currentKeyVersion !== null && row.keyVersion === currentKeyVersion;
+  return isMatchableUnder(row.keyVersion, key);
+}
+
+/**
+ * Why a row cannot be approved, as something to show the reader — the three key
+ * states are three different problems, and only one of them is solved by
+ * triggering the detection again.
+ */
+export function blockedRowBlockReason(
+  row: Pick<BlockedDetection, 'keyVersion'>,
+  key: FingerprintKeyState,
+): string | null {
+  if (isBlockedRowApprovable(row, key)) return null;
+  switch (key.status) {
+    case 'unreadable':
+      // Nothing changed and nothing is lost: the key is fine once its
+      // permissions are. Telling this reader to re-trigger would be wrong, and
+      // telling them to delete the key would destroy every grant they have.
+      return 'The fingerprint key file cannot be read, so no recorded detection can be matched right now. Check the permissions on ~/.aka/data — do not delete the key.';
+    case 'absent':
+      return 'The fingerprint key file is missing, so the fingerprint recorded for this detection can no longer be matched. Trigger the detection again.';
+    default:
+      return `Recorded under fingerprint key v${String(row.keyVersion)}; the key is now v${String(key.version)}, so a grant from it could never match. Trigger the detection again.`;
+  }
 }
 
 export const STATE_TONE: Record<ExceptionState, Tone> = {

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -244,6 +244,7 @@ export {
 export {
   type ExceptionState,
   exceptionState,
+  isBlockedRowApprovable,
   SCOPE_ANSWER_LABEL,
   SCOPE_ANSWERS,
   SCOPE_LABEL,

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -242,6 +242,7 @@ export {
   type ExceptionsTableViewProps,
 } from './exceptions/ExceptionsTableView.tsx';
 export {
+  blockedRowBlockReason,
   type ExceptionState,
   exceptionState,
   isBlockedRowApprovable,

--- a/packages/dashboard-ui/test/exceptions/meta.test.ts
+++ b/packages/dashboard-ui/test/exceptions/meta.test.ts
@@ -1,7 +1,7 @@
 import type { DetectionException } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
-import { exceptionState } from '../../src/exceptions/meta.ts';
+import { exceptionState, isBlockedRowApprovable } from '../../src/exceptions/meta.ts';
 
 const NOW = Date.parse('2026-07-03T12:00:00.000Z');
 
@@ -62,5 +62,31 @@ describe('exceptionState', () => {
     expect(
       exceptionState(exception({ expiresAt: '2026-07-03T11:59:59.000Z', scope: 'temporary' }), NOW),
     ).toBe('expired');
+  });
+});
+
+describe('isBlockedRowApprovable', () => {
+  it('is approvable only under the key version in use now', () => {
+    expect(isBlockedRowApprovable({ keyVersion: 3 }, 3)).toBe(true);
+  });
+
+  it('is not approvable after a rotation moved the key on', () => {
+    // The ledger is retained longer than a rotation takes, so the strip keeps
+    // listing rows fingerprinted under the old key. A grant built from one
+    // could never match, so the row is shown but not offered.
+    expect(isBlockedRowApprovable({ keyVersion: 1 }, 2)).toBe(false);
+  });
+
+  it('is not approvable under an OLDER current version either', () => {
+    // Not a `<` comparison: any version other than the current one means the
+    // material differs, whichever way the number moved.
+    expect(isBlockedRowApprovable({ keyVersion: 4 }, 2)).toBe(false);
+  });
+
+  it('is not approvable when there is no key file at all', () => {
+    // The material is gone, so no stored fingerprint can be reproduced —
+    // absence is refused on its own terms rather than treated as version 0.
+    expect(isBlockedRowApprovable({ keyVersion: 1 }, null)).toBe(false);
+    expect(isBlockedRowApprovable({ keyVersion: 0 }, null)).toBe(false);
   });
 });

--- a/packages/dashboard-ui/test/exceptions/meta.test.ts
+++ b/packages/dashboard-ui/test/exceptions/meta.test.ts
@@ -1,7 +1,12 @@
-import type { DetectionException } from '@akasecurity/schema';
+import type { DetectionException, FingerprintKeyState } from '@akasecurity/schema';
+import { isMatchableUnder } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
-import { exceptionState, isBlockedRowApprovable } from '../../src/exceptions/meta.ts';
+import {
+  blockedRowBlockReason,
+  exceptionState,
+  isBlockedRowApprovable,
+} from '../../src/exceptions/meta.ts';
 
 const NOW = Date.parse('2026-07-03T12:00:00.000Z');
 
@@ -66,27 +71,79 @@ describe('exceptionState', () => {
 });
 
 describe('isBlockedRowApprovable', () => {
+  const present = (version: number): FingerprintKeyState => ({ status: 'present', version });
+
   it('is approvable only under the key version in use now', () => {
-    expect(isBlockedRowApprovable({ keyVersion: 3 }, 3)).toBe(true);
+    expect(isBlockedRowApprovable({ keyVersion: 3 }, present(3))).toBe(true);
   });
 
   it('is not approvable after a rotation moved the key on', () => {
     // The ledger is retained longer than a rotation takes, so the strip keeps
     // listing rows fingerprinted under the old key. A grant built from one
     // could never match, so the row is shown but not offered.
-    expect(isBlockedRowApprovable({ keyVersion: 1 }, 2)).toBe(false);
+    expect(isBlockedRowApprovable({ keyVersion: 1 }, present(2))).toBe(false);
   });
 
   it('is not approvable under an OLDER current version either', () => {
     // Not a `<` comparison: any version other than the current one means the
     // material differs, whichever way the number moved.
-    expect(isBlockedRowApprovable({ keyVersion: 4 }, 2)).toBe(false);
+    expect(isBlockedRowApprovable({ keyVersion: 4 }, present(2))).toBe(false);
   });
 
-  it('is not approvable when there is no key file at all', () => {
-    // The material is gone, so no stored fingerprint can be reproduced —
-    // absence is refused on its own terms rather than treated as version 0.
-    expect(isBlockedRowApprovable({ keyVersion: 1 }, null)).toBe(false);
-    expect(isBlockedRowApprovable({ keyVersion: 0 }, null)).toBe(false);
+  it('is not approvable when the key is absent or unreadable', () => {
+    // Absent: the material is gone, so no stored fingerprint can be reproduced.
+    // Unreadable: it may be intact, but nothing can be matched until it can be
+    // read. Neither is treated as version 0.
+    expect(isBlockedRowApprovable({ keyVersion: 1 }, { status: 'absent' })).toBe(false);
+    expect(isBlockedRowApprovable({ keyVersion: 0 }, { status: 'absent' })).toBe(false);
+    expect(isBlockedRowApprovable({ keyVersion: 1 }, { status: 'unreadable' })).toBe(false);
+  });
+
+  it('agrees with the shared rule it delegates to', () => {
+    // The point of routing through @akasecurity/schema is that the strip and the
+    // two approve surfaces cannot drift. Pin the delegation itself, so a future
+    // local reimplementation here fails rather than silently disagrees.
+    const cases: [number, FingerprintKeyState][] = [
+      [1, present(1)],
+      [1, present(2)],
+      [2, present(1)],
+      [1, { status: 'absent' }],
+      [1, { status: 'unreadable' }],
+    ];
+    for (const [keyVersion, key] of cases) {
+      expect(isBlockedRowApprovable({ keyVersion }, key)).toBe(isMatchableUnder(keyVersion, key));
+    }
+  });
+});
+
+describe('blockedRowBlockReason', () => {
+  it('is null when the row is approvable — nothing to explain', () => {
+    expect(blockedRowBlockReason({ keyVersion: 2 }, { status: 'present', version: 2 })).toBeNull();
+  });
+
+  it('names the rotation, with both versions, when the key moved on', () => {
+    const reason = blockedRowBlockReason({ keyVersion: 1 }, { status: 'present', version: 3 });
+    expect(reason).toMatch(/v1/);
+    expect(reason).toMatch(/v3/);
+    expect(reason).toMatch(/trigger the detection again/i);
+  });
+
+  it('tells an UNREADABLE key apart from a missing one — and never says delete it', () => {
+    // The whole reason the state is a discriminated union rather than
+    // `number | null`: for a chmod-broken key nothing changed, re-triggering
+    // fixes nothing, and deleting the key to "fix" it would destroy every grant
+    // on the machine.
+    const reason = blockedRowBlockReason({ keyVersion: 1 }, { status: 'unreadable' });
+    expect(reason).toMatch(/cannot be read/i);
+    expect(reason).toMatch(/permissions/i);
+    expect(reason).toMatch(/do not delete/i);
+    expect(reason).not.toMatch(/trigger the detection again/i);
+    expect(reason).not.toBe(blockedRowBlockReason({ keyVersion: 1 }, { status: 'absent' }));
+  });
+
+  it('tells a missing key to re-trigger, which does fix it', () => {
+    const reason = blockedRowBlockReason({ keyVersion: 1 }, { status: 'absent' });
+    expect(reason).toMatch(/missing/i);
+    expect(reason).toMatch(/trigger the detection again/i);
   });
 });

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -176,14 +176,35 @@ function linkHost(input: InventoryInput, hostId: string | undefined): InventoryI
   return hostId ? { ...input, hostId } : input;
 }
 
+// Closing is cleanup: a failure here (already closed, or the close itself
+// failing) must never replace the error that caused it.
+function closeQuietly(db: DatabaseSync): void {
+  try {
+    db.close();
+  } catch {
+    // nothing to salvage — the caller's original error is what matters
+  }
+}
+
 // Open the store with the shared PRAGMAs: WAL lets the plugin (events/findings)
 // and an optional local reader share the file; busy_timeout absorbs brief
 // contention; foreign keys enforce the event→finding reference.
 function openWithPragmas(file: string): DatabaseSync {
   const db = new DatabaseSync(file);
-  db.exec('PRAGMA journal_mode = WAL');
-  db.exec('PRAGMA busy_timeout = 2000');
-  db.exec('PRAGMA foreign_keys = ON');
+  try {
+    db.exec('PRAGMA journal_mode = WAL');
+    db.exec('PRAGMA busy_timeout = 2000');
+    db.exec('PRAGMA foreign_keys = ON');
+  } catch (err) {
+    // The OS handle exists the moment the constructor returns, but SQLite does
+    // not read the file until a statement runs — so a corrupt store opens fine
+    // and answers SQLITE_NOTADB here. Without this the handle leaks: on Windows
+    // that keeps the file locked for the life of the process, and in the
+    // long-lived dashboard server (which memoizes the handle only on success) a
+    // corrupt store would leak one more on every attempt.
+    closeQuietly(db);
+    throw err;
+  }
   return db;
 }
 
@@ -208,23 +229,32 @@ export function openLocalDatabase(dir: string): LocalDatabase {
   const file = join(dir, DB_FILENAME);
   let db = openWithPragmas(file);
 
-  // A legacy (tenant-bearing) aka.db can't be migrated forward onto the
-  // tenant-free lineage — same user_version space, so the applier would skip it,
-  // then every write would die on NOT NULL tenant_id and be swallowed fail-open
-  // (silent persistence loss). Back the old file up (recoverable) and start fresh
-  // so writes work; the reset is a one-time, loud-on-stderr event.
-  if (isForeignSqliteLineage(db)) {
-    db.close();
-    const backup = backupLegacyStore(file);
-    db = openWithPragmas(file);
-    akaWarn(
-      `Detected an older, incompatible (tenant-bearing) ${DB_FILENAME}; backed it up to ` +
-        `${backup} and created a fresh store.`,
-    );
-  }
+  // Bringing the store to a usable state can fail on a file that opened but is
+  // not a healthy store — an unmigratable schema, a read-only or full disk. The
+  // handle is already ours by then, so close it before the error leaves; see
+  // openWithPragmas for what a leak costs.
+  try {
+    // A legacy (tenant-bearing) aka.db can't be migrated forward onto the
+    // tenant-free lineage — same user_version space, so the applier would skip it,
+    // then every write would die on NOT NULL tenant_id and be swallowed fail-open
+    // (silent persistence loss). Back the old file up (recoverable) and start fresh
+    // so writes work; the reset is a one-time, loud-on-stderr event.
+    if (isForeignSqliteLineage(db)) {
+      db.close();
+      const backup = backupLegacyStore(file);
+      db = openWithPragmas(file);
+      akaWarn(
+        `Detected an older, incompatible (tenant-bearing) ${DB_FILENAME}; backed it up to ` +
+          `${backup} and created a fresh store.`,
+      );
+    }
 
-  applyMigrations(db, file);
-  tightenPerms(file);
+    applyMigrations(db, file);
+    tightenPerms(file);
+  } catch (err) {
+    closeQuietly(db);
+    throw err;
+  }
 
   const events = new SqliteEventsRepository(db);
   const findings = new SqliteFindingsRepository(db);
@@ -248,7 +278,14 @@ export function openLocalDatabase(dir: string): LocalDatabase {
   const inspectionDefinitions = new SqliteInspectionDefinitionsRepository(db);
   const inspectionFindings = new SqliteInspectionFindingsRepository(db);
   const configInventory = new SqliteConfigInventoryRepository(db);
-  policies.seedDefaults();
+  // The first WRITE of the open — a read-only store reaches this having passed
+  // everything above, so it is the last place the handle can escape unclosed.
+  try {
+    policies.seedDefaults();
+  } catch (err) {
+    closeQuietly(db);
+    throw err;
+  }
 
   function recordCapture(event: IngestEvent, detected: DetectedFindingWithKey[]): void {
     // Fail-open: dropping telemetry is acceptable; breaking the host session

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -224,15 +224,22 @@ function backupLegacyStore(file: string): string {
   return backup;
 }
 
-export function openLocalDatabase(dir: string): LocalDatabase {
-  ensureDataDirSync(dir);
-  const file = join(dir, DB_FILENAME);
+/**
+ * Open the store and bring it to a usable state: pragmas, the legacy-lineage
+ * reset, migrations, permissions, every repository, and the default policies.
+ *
+ * ONE try covers all of it, because the handle is ours from the moment the
+ * constructor returns and every step after that can throw — migrations on an
+ * unmigratable schema, `tightenPerms` on a hostile filesystem, a repository
+ * constructor's eager `db.prepare` on a schema this build does not expect (a
+ * store written by a newer binary leaves `user_version` ahead, so the applier
+ * skips and the prepares meet columns that are not there), `seedDefaults` on a
+ * read-only disk. Guarding only some of those leaves the rest leaking the
+ * handle, which is the Windows file lock this exists to prevent — so the guard
+ * is one window over the whole sequence rather than one per known thrower.
+ */
+function openAndInitialize(file: string) {
   let db = openWithPragmas(file);
-
-  // Bringing the store to a usable state can fail on a file that opened but is
-  // not a healthy store — an unmigratable schema, a read-only or full disk. The
-  // handle is already ours by then, so close it before the error leaves; see
-  // openWithPragmas for what a leak costs.
   try {
     // A legacy (tenant-bearing) aka.db can't be migrated forward onto the
     // tenant-free lineage — same user_version space, so the applier would skip it,
@@ -251,41 +258,69 @@ export function openLocalDatabase(dir: string): LocalDatabase {
 
     applyMigrations(db, file);
     tightenPerms(file);
-  } catch (err) {
-    closeQuietly(db);
-    throw err;
-  }
 
-  const events = new SqliteEventsRepository(db);
-  const findings = new SqliteFindingsRepository(db);
-  const policies = new SqlitePoliciesRepository(db);
-  const installedPacks = new SqliteInstalledPacksRepository(db);
-  const scanLedger = new SqliteScanLedgerRepository(db);
-  const exceptions = new SqliteExceptionsRepository(db);
-  const resolutions = new SqliteResolutionsRepository(db);
-  const ruleProbeCache = new SqliteRuleProbeCacheRepository(db);
-  const security = new SqliteSecurityRepository(db);
-  const detections = new SqliteDetectionsRepository(db);
-  const shares = new SqliteSharesRepository(db);
-  const policyCatalog = new SqlitePolicyCatalogRepository(installedPacks);
-  const inventory = new SqliteInventoryRepository(db);
-  const inventoryAssets = new SqliteInventoryAssetsRepository(db);
-  const projectFiles = new SqliteProjectFilesRepository(db);
-  const activity = new SqliteActivityRepository(db);
-  const sourceProject = new SqliteSourceProjectRepository(db);
-  const auditEvents = new SqliteAuditEventsRepository(db);
-  const classifiedData = new SqliteClassifiedDataRepository(db);
-  const inspectionDefinitions = new SqliteInspectionDefinitionsRepository(db);
-  const inspectionFindings = new SqliteInspectionFindingsRepository(db);
-  const configInventory = new SqliteConfigInventoryRepository(db);
-  // The first WRITE of the open — a read-only store reaches this having passed
-  // everything above, so it is the last place the handle can escape unclosed.
-  try {
+    const policies = new SqlitePoliciesRepository(db);
+    const installedPacks = new SqliteInstalledPacksRepository(db);
+    const repositories = {
+      events: new SqliteEventsRepository(db),
+      findings: new SqliteFindingsRepository(db),
+      policies,
+      installedPacks,
+      scanLedger: new SqliteScanLedgerRepository(db),
+      exceptions: new SqliteExceptionsRepository(db),
+      resolutions: new SqliteResolutionsRepository(db),
+      ruleProbeCache: new SqliteRuleProbeCacheRepository(db),
+      security: new SqliteSecurityRepository(db),
+      detections: new SqliteDetectionsRepository(db),
+      shares: new SqliteSharesRepository(db),
+      policyCatalog: new SqlitePolicyCatalogRepository(installedPacks),
+      inventory: new SqliteInventoryRepository(db),
+      inventoryAssets: new SqliteInventoryAssetsRepository(db),
+      projectFiles: new SqliteProjectFilesRepository(db),
+      activity: new SqliteActivityRepository(db),
+      sourceProject: new SqliteSourceProjectRepository(db),
+      auditEvents: new SqliteAuditEventsRepository(db),
+      classifiedData: new SqliteClassifiedDataRepository(db),
+      inspectionDefinitions: new SqliteInspectionDefinitionsRepository(db),
+      inspectionFindings: new SqliteInspectionFindingsRepository(db),
+      configInventory: new SqliteConfigInventoryRepository(db),
+    };
     policies.seedDefaults();
+    return { db, ...repositories };
   } catch (err) {
     closeQuietly(db);
     throw err;
   }
+}
+
+export function openLocalDatabase(dir: string): LocalDatabase {
+  ensureDataDirSync(dir);
+  const file = join(dir, DB_FILENAME);
+  const {
+    db,
+    events,
+    findings,
+    policies,
+    installedPacks,
+    scanLedger,
+    exceptions,
+    resolutions,
+    ruleProbeCache,
+    security,
+    detections,
+    shares,
+    policyCatalog,
+    inventory,
+    inventoryAssets,
+    projectFiles,
+    activity,
+    sourceProject,
+    auditEvents,
+    classifiedData,
+    inspectionDefinitions,
+    inspectionFindings,
+    configInventory,
+  } = openAndInitialize(file);
 
   function recordCapture(event: IngestEvent, detected: DetectedFindingWithKey[]): void {
     // Fail-open: dropping telemetry is acceptable; breaking the host session

--- a/packages/persistence/src/fingerprint.ts
+++ b/packages/persistence/src/fingerprint.ts
@@ -10,10 +10,12 @@
 // full data-dir access has both file and key by construction. The key material
 // must never be logged, surfaced, or shipped anywhere.
 import { createHmac, randomBytes } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
-import { ensureDataDirSync, tightenFile, writeOwnerOnlyFileSync } from './paths.ts';
+import { getRow } from './internal/rows.ts';
+import { DB_FILENAME, ensureDataDirSync, tightenFile, writeOwnerOnlyFileSync } from './paths.ts';
 
 export interface FingerprintKey {
   version: number;
@@ -50,6 +52,58 @@ function parseKeyFile(raw: string): FingerprintKey {
   return { version, material: bytes };
 }
 
+// The tables that record WHICH key material produced a stored fingerprint. The
+// column is the version integer, so the version is the only handle either table
+// has on the key — see storedKeyVersionFloor.
+const KEY_VERSION_TABLES = ['exceptions', 'blocked_detections'];
+
+/**
+ * The highest key version any stored row already references (0 when the store
+ * has none, or cannot be read).
+ *
+ * A minted version must never collide with one already in the store. Deleting
+ * `exception.key` — which the corrupt-key recovery guidance tells users to do —
+ * loses the version, so an unguarded mint restarts at 1 while rows written under
+ * the DELETED material still say 1. Those rows then look current: a grant
+ * approved from one is fingerprinted under material that no longer exists and is
+ * inert the moment it is created, which is exactly what the approve-side version
+ * check exists to prevent. Reading the floor from the store closes that, because
+ * the rows outlive the key file.
+ *
+ * Opened only when the store already exists, so resolving a key never creates
+ * one, and read with a SELECT only. Any failure degrades to 0 — the behaviour
+ * before this floor existed — because an unreadable store must never stop a hook
+ * from minting the key it needs.
+ */
+function storedKeyVersionFloor(dataDir: string): number {
+  const file = join(dataDir, DB_FILENAME);
+  if (!existsSync(file)) return 0;
+  let db: DatabaseSync | undefined;
+  try {
+    db = new DatabaseSync(file);
+    db.exec('PRAGMA busy_timeout = 2000');
+    let floor = 0;
+    for (const table of KEY_VERSION_TABLES) {
+      try {
+        // Queried per table: `blocked_detections` is created lazily on the first
+        // block, so it is legitimately absent on a store that has never blocked.
+        // MAX() over an empty table is NULL, which arrives as a null column.
+        const row = getRow<{ v: number | null }>(
+          db.prepare(`SELECT MAX(key_version) AS v FROM ${table}`),
+        );
+        floor = Math.max(floor, row?.v ?? 0);
+      } catch {
+        // Table absent on this store — nothing here to raise the floor.
+      }
+    }
+    return floor;
+  } catch {
+    return 0;
+  } finally {
+    db?.close();
+  }
+}
+
 // Owner-only atomic write (tmp + rename), so a key file that pre-existed with
 // looser permissions ends 0600 rather than carrying its mode through the rename.
 function writeKeyFile(dataDir: string, key: FingerprintKey): FingerprintKey {
@@ -77,11 +131,15 @@ export function readFingerprintKey(dataDir: string): FingerprintKey | null {
 }
 
 /**
- * Load the fingerprint key, minting version 1 on first use. ONLY absence
- * creates a key: a corrupt/unparseable file throws so callers fail secure —
- * silently re-minting would orphan every grant written under the real key.
- * Loading an existing file re-tightens its mode to 0600 (best-effort), covering
- * files created before the mode was enforced at write time.
+ * Load the fingerprint key, minting one on first use. ONLY absence creates a
+ * key: a corrupt/unparseable file throws so callers fail secure — silently
+ * re-minting would orphan every grant written under the real key. Loading an
+ * existing file re-tightens its mode to 0600 (best-effort), covering files
+ * created before the mode was enforced at write time.
+ *
+ * A mint takes version 1 on a fresh store, and otherwise the first version the
+ * store has not already seen — so material minted after the key file was deleted
+ * is never mistaken for the material the stored rows were written under.
  */
 export function loadOrCreateFingerprintKey(dataDir: string): FingerprintKey {
   const existing = readFingerprintKey(dataDir);
@@ -91,21 +149,28 @@ export function loadOrCreateFingerprintKey(dataDir: string): FingerprintKey {
     tightenFile(keyFilePath(dataDir));
     return existing;
   }
-  return writeKeyFile(dataDir, { version: 1, material: randomBytes(KEY_MATERIAL_BYTES) });
+  return writeKeyFile(dataDir, {
+    version: storedKeyVersionFloor(dataDir) + 1,
+    material: randomBytes(KEY_MATERIAL_BYTES),
+  });
 }
 
 /**
- * Rotate the key: fresh 32 bytes, version bumped past the old one (1 when no
- * key exists yet). Rotation is INVALIDATION — fingerprints cannot be re-keyed
- * without the raw values, which are never stored, so grants written under the
- * old version simply stop matching (they remain, inert, for audit). A corrupt
- * existing file still throws: the old version is unknowable, and silently
- * reusing a version could collide new grants with orphaned ones.
+ * Rotate the key: fresh 32 bytes, version bumped past both the old key file and
+ * anything the store already references. Rotation is INVALIDATION — fingerprints
+ * cannot be re-keyed without the raw values, which are never stored, so grants
+ * written under the old version simply stop matching (they remain, inert, for
+ * audit). A corrupt existing file still throws: the old version is unknowable,
+ * and silently reusing a version could collide new grants with orphaned ones.
+ *
+ * The store floor matters when the key file is ABSENT — rotating after a delete
+ * would otherwise restart at 1 and collide with rows written under the deleted
+ * material.
  */
 export function rotateFingerprintKey(dataDir: string): FingerprintKey {
   const existing = readFingerprintKey(dataDir);
   return writeKeyFile(dataDir, {
-    version: (existing?.version ?? 0) + 1,
+    version: Math.max(existing?.version ?? 0, storedKeyVersionFloor(dataDir)) + 1,
     material: randomBytes(KEY_MATERIAL_BYTES),
   });
 }
@@ -113,4 +178,19 @@ export function rotateFingerprintKey(dataDir: string): FingerprintKey {
 /** The keyed fingerprint of one detected value: HMAC-SHA256 hex under the key. */
 export function fingerprintValue(key: FingerprintKey, raw: string): string {
   return createHmac('sha256', key.material).update(raw, 'utf8').digest('hex');
+}
+
+/**
+ * Whether a stored fingerprint — a grant, or a blocked-ledger row — was written
+ * under the key in use now, and so can still be matched.
+ *
+ * Enforcement fingerprints under the CURRENT key and scopes its bundle query to
+ * that version, so a grant minted from a row that fails this check is inert the
+ * moment it is created. Both approve surfaces (`aka exception approve` and the
+ * dashboard) gate on it; keeping the rule here is what stops them drifting apart
+ * on which rows are still usable. An absent key fails the check on its own
+ * terms: the material is gone, so no stored fingerprint can be reproduced.
+ */
+export function isCurrentKeyVersion(key: FingerprintKey | null, keyVersion: number): boolean {
+  return key !== null && key.version === keyVersion;
 }

--- a/packages/persistence/src/fingerprint.ts
+++ b/packages/persistence/src/fingerprint.ts
@@ -14,6 +14,9 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
+import type { FingerprintKeyState } from '@akasecurity/schema';
+import { isMatchableUnder } from '@akasecurity/schema';
+
 import { getRow } from './internal/rows.ts';
 import { DB_FILENAME, ensureDataDirSync, tightenFile, writeOwnerOnlyFileSync } from './paths.ts';
 
@@ -57,9 +60,34 @@ function parseKeyFile(raw: string): FingerprintKey {
 // has on the key — see storedKeyVersionFloor.
 const KEY_VERSION_TABLES = ['exceptions', 'blocked_detections'];
 
+// SQLITE_ERROR — the generic code a missing table reports. node:sqlite gives
+// every SQLite failure the same `code` ('ERR_SQLITE_ERROR'), so only `errcode`
+// separates "this store has no such table" from "this store is damaged or
+// locked": SQLITE_NOTADB and SQLITE_BUSY both arrive here too, and treating
+// those as an absent table is what would silently under-report the floor.
+const SQLITE_ERROR = 1;
+
+// Long enough to ride out the moment a writer holds an exclusive lock, short
+// enough that the mint path — which the plugin runs while a hook is waiting —
+// fails fast instead of stalling. The whole read is best-effort hardening; the
+// default 2s, taken twice, is a quarter-minute of a user's session.
+const FLOOR_BUSY_TIMEOUT_MS = 250;
+
+/** Raised when the store exists but cannot answer which key versions it holds. */
+class FloorUnreadableError extends Error {
+  readonly code = 'floor-unreadable';
+  constructor(cause: unknown) {
+    super(
+      `cannot read the stored fingerprint key versions: ${cause instanceof Error ? cause.message : String(cause)}`,
+      { cause },
+    );
+    this.name = 'FloorUnreadableError';
+  }
+}
+
 /**
- * The highest key version any stored row already references (0 when the store
- * has none, or cannot be read).
+ * The highest key version any stored row already references — 0 when the store
+ * holds none, or does not exist yet.
  *
  * A minted version must never collide with one already in the store. Deleting
  * `exception.key` — which the corrupt-key recovery guidance tells users to do —
@@ -70,35 +98,44 @@ const KEY_VERSION_TABLES = ['exceptions', 'blocked_detections'];
  * check exists to prevent. Reading the floor from the store closes that, because
  * the rows outlive the key file.
  *
+ * THROWS rather than guessing when the store cannot answer. Returning 0 on a
+ * locked or damaged store would be the one direction that is unsafe: too LOW a
+ * floor is exactly the collision above, so a swallowed failure quietly reopens
+ * the hole this exists to close. Callers already fail secure on a throw — the
+ * plugin degrades to writing no ledger row, which costs an approvable row and
+ * never an enforcement decision.
+ *
  * Opened only when the store already exists, so resolving a key never creates
- * one, and read with a SELECT only. Any failure degrades to 0 — the behaviour
- * before this floor existed — because an unreadable store must never stop a hook
- * from minting the key it needs.
+ * one, read-only, and with a short busy timeout so a contended store fails fast.
  */
 function storedKeyVersionFloor(dataDir: string): number {
   const file = join(dataDir, DB_FILENAME);
   if (!existsSync(file)) return 0;
   let db: DatabaseSync | undefined;
   try {
-    db = new DatabaseSync(file);
-    db.exec('PRAGMA busy_timeout = 2000');
+    db = new DatabaseSync(file, { readOnly: true });
+    db.exec(`PRAGMA busy_timeout = ${String(FLOOR_BUSY_TIMEOUT_MS)}`);
     let floor = 0;
     for (const table of KEY_VERSION_TABLES) {
       try {
-        // Queried per table: `blocked_detections` is created lazily on the first
-        // block, so it is legitimately absent on a store that has never blocked.
         // MAX() over an empty table is NULL, which arrives as a null column.
         const row = getRow<{ v: number | null }>(
           db.prepare(`SELECT MAX(key_version) AS v FROM ${table}`),
         );
         floor = Math.max(floor, row?.v ?? 0);
-      } catch {
-        // Table absent on this store — nothing here to raise the floor.
+      } catch (err) {
+        // A genuinely absent table contributes nothing and is not a failure:
+        // this opens its own handle and runs no migrations, so it can meet a
+        // store written before the table was added. Anything else — damaged,
+        // locked, unreadable — means the floor is unknown, not zero.
+        if ((err as { errcode?: number }).errcode !== SQLITE_ERROR) {
+          throw new FloorUnreadableError(err);
+        }
       }
     }
     return floor;
-  } catch {
-    return 0;
+  } catch (err) {
+    throw err instanceof FloorUnreadableError ? err : new FloorUnreadableError(err);
   } finally {
     db?.close();
   }
@@ -139,7 +176,9 @@ export function readFingerprintKey(dataDir: string): FingerprintKey | null {
  *
  * A mint takes version 1 on a fresh store, and otherwise the first version the
  * store has not already seen — so material minted after the key file was deleted
- * is never mistaken for the material the stored rows were written under.
+ * is never mistaken for the material the stored rows were written under. A store
+ * that cannot report its versions throws instead of minting: a colliding key is
+ * worse than no key, because it produces grants that silently never match.
  */
 export function loadOrCreateFingerprintKey(dataDir: string): FingerprintKey {
   const existing = readFingerprintKey(dataDir);
@@ -184,13 +223,20 @@ export function fingerprintValue(key: FingerprintKey, raw: string): string {
  * Whether a stored fingerprint — a grant, or a blocked-ledger row — was written
  * under the key in use now, and so can still be matched.
  *
- * Enforcement fingerprints under the CURRENT key and scopes its bundle query to
- * that version, so a grant minted from a row that fails this check is inert the
- * moment it is created. Both approve surfaces (`aka exception approve` and the
- * dashboard) gate on it; keeping the rule here is what stops them drifting apart
- * on which rows are still usable. An absent key fails the check on its own
- * terms: the material is gone, so no stored fingerprint can be reproduced.
+ * The rule itself is `isMatchableUnder` in @akasecurity/schema, the one package
+ * the approve surfaces AND the dashboard can all import; this is the adapter for
+ * callers that hold a loaded key rather than a UI-facing state. A second copy of
+ * the rule is how the server and the UI come to disagree about which rows are
+ * usable, so there is deliberately only one.
+ *
+ * An absent key fails on its own terms: the material is gone, so no stored
+ * fingerprint can be reproduced.
  */
 export function isCurrentKeyVersion(key: FingerprintKey | null, keyVersion: number): boolean {
-  return key !== null && key.version === keyVersion;
+  return isMatchableUnder(keyVersion, keyStateOf(key));
+}
+
+/** A loaded key (or its absence) as the shared, UI-facing state. */
+export function keyStateOf(key: FingerprintKey | null): FingerprintKeyState {
+  return key === null ? { status: 'absent' } : { status: 'present', version: key.version };
 }

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -5,6 +5,7 @@ export { computeFindingKey } from './finding-key.ts';
 export type { FingerprintKey } from './fingerprint.ts';
 export {
   fingerprintValue,
+  isCurrentKeyVersion,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
   rotateFingerprintKey,

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -6,6 +6,7 @@ export type { FingerprintKey } from './fingerprint.ts';
 export {
   fingerprintValue,
   isCurrentKeyVersion,
+  keyStateOf,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
   rotateFingerprintKey,

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -415,6 +415,32 @@ describe('a failed open leaves no handle behind', () => {
     }
     // afterEach removes the tree — on Windows that is the assertion.
   });
+
+  it('closes the handle when a REPOSITORY CONSTRUCTOR throws, not just the open', () => {
+    // Several repositories `db.prepare(...)` in their constructor, which runs
+    // after migrations have reported success. A store whose schema does not
+    // match what this build expects — one written by a newer binary leaves
+    // `user_version` ahead, so the applier skips and the prepares meet columns
+    // that are not there — throws from there rather than from the open.
+    //
+    // Dropping tables from a migrated store reproduces that exactly: the
+    // migration ledger still says applied, so the reopen goes straight to the
+    // constructors. This region sat outside the guard until the whole sequence
+    // was brought under one try.
+    openLocalDatabase(dir).close();
+    const raw = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      raw.exec('DROP TABLE installed_packs');
+    } finally {
+      raw.close();
+    }
+
+    for (let i = 0; i < 5; i += 1) {
+      expect(() => openLocalDatabase(dir)).toThrow(/no such table/);
+    }
+    // Measured on macOS while this was unguarded: five attempts leaked twelve
+    // descriptors. afterEach is what catches it on Windows.
+  });
 });
 
 describe('store hygiene', () => {

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -1,5 +1,13 @@
 import { randomUUID } from 'node:crypto';
-import { chmodSync, existsSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -367,6 +375,45 @@ describe('transaction', () => {
     expect(all[0]?.revokedAt).toBeNull();
     expect(all[0]?.useCount).toBe(1);
     db.close();
+  });
+});
+
+describe('a failed open leaves no handle behind', () => {
+  // SQLite does not read the file until a statement runs, so a store that is not
+  // a database opens cleanly and fails on the first PRAGMA — with the OS handle
+  // already ours. Leaking it keeps the file locked for the life of the process
+  // on Windows, and the dashboard server memoizes its handle only on success, so
+  // a corrupt store would leak one more on every attempt.
+  //
+  // The proof is platform-split and deliberately so: on Windows the removal in
+  // `afterEach` FAILS with EPERM while a handle is open, which is what makes
+  // this a real regression guard there. On POSIX an open handle does not block
+  // unlink, so the same test only pins that the open fails loudly rather than
+  // half-succeeding — the CI Windows leg is where the leak itself is caught.
+  function corruptTheStore(): string {
+    const file = join(dir, 'aka.db');
+    openLocalDatabase(dir).close(); // a real store first, so this is damage not absence
+    for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
+      rmSync(join(dir, sidecar), { force: true });
+    }
+    writeFileSync(file, 'this is not a SQLite database at all\n');
+    return file;
+  }
+
+  it('throws rather than returning a half-open store', () => {
+    corruptTheStore();
+    expect(() => openLocalDatabase(dir)).toThrow();
+  });
+
+  it('stays throwing across repeated attempts, without accumulating handles', () => {
+    // The shape the dashboard produces: the caller returns an error to the user,
+    // the user retries, and each retry opens again. Any handle kept here is one
+    // per attempt.
+    corruptTheStore();
+    for (let i = 0; i < 5; i += 1) {
+      expect(() => openLocalDatabase(dir)).toThrow();
+    }
+    // afterEach removes the tree — on Windows that is the assertion.
   });
 });
 

--- a/packages/persistence/test/fingerprint.test.ts
+++ b/packages/persistence/test/fingerprint.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -244,15 +245,53 @@ describe('a minted version never reuses one the store already references', () =>
     });
   });
 
-  it('degrades to the un-floored behaviour when the store cannot be read', () => {
-    // An unreadable store must never stop a hook from minting the key it needs
-    // — the floor is a hardening pass, not a precondition. Fail-open here is
-    // deliberate, so pin it rather than let a future change make it fail-closed.
+  it('refuses to mint when a damaged store cannot report its versions', () => {
+    // Returning 0 here would be the one unsafe direction: too LOW a floor is
+    // the collision this whole mechanism exists to prevent, so a store that
+    // cannot answer must stop the mint rather than let it guess v1.
+    //
+    // The damage has to be reached through a QUERY, not the open: SQLite does
+    // not read the file until a statement runs, so `new DatabaseSync` and the
+    // busy_timeout PRAGMA both succeed on these bytes and it is `prepare` that
+    // reports SQLITE_NOTADB. An earlier version of this test asserted a
+    // fail-open degrade and passed for that reason — it was exercising the
+    // per-table branch, which used to swallow exactly this.
+    //
+    // A CONTENDED store (SQLITE_BUSY, from a holder in `locking_mode =
+    // EXCLUSIVE`) takes this same branch — any errcode that is not the generic
+    // SQLITE_ERROR of a missing table. It is not pinned here because provoking
+    // it needs a second connection holding an exclusive lock, whose failure
+    // mode is a flaky test rather than a caught regression.
     ensureDataDirSync(dir);
     writeFileSync(join(dir, 'aka.db'), 'this is not a SQLite database at all\n');
-    const key = loadOrCreateFingerprintKey(dir);
-    expect(key.version).toBe(1);
-    expect(key.material).toHaveLength(32);
+    expect(() => loadOrCreateFingerprintKey(dir)).toThrow(/key versions/);
+    // Nothing half-written: no key file was left behind by the refusal.
+    expect(existsSync(keyFile())).toBe(false);
+  });
+
+  it('refuses to rotate over a damaged store for the same reason', () => {
+    ensureDataDirSync(dir);
+    const before = loadOrCreateFingerprintKey(dir);
+    writeFileSync(join(dir, 'aka.db'), 'this is not a SQLite database at all\n');
+    expect(() => rotateFingerprintKey(dir)).toThrow(/key versions/);
+    // The existing key is untouched — a refused rotation is inert.
+    expect(readFingerprintKey(dir)?.material.equals(before.material)).toBe(true);
+  });
+
+  it('treats a genuinely absent table as no floor, not as a failure', () => {
+    // This opens its own handle and runs no migrations, so it can meet a store
+    // written before a table existed. That is a real 0, distinguishable from a
+    // damaged store only by the SQLite result code.
+    ensureDataDirSync(dir);
+    const raw = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      raw.exec('CREATE TABLE exceptions (key_version INTEGER)');
+      raw.exec('INSERT INTO exceptions VALUES (4)');
+      // blocked_detections deliberately absent.
+    } finally {
+      raw.close();
+    }
+    expect(loadOrCreateFingerprintKey(dir).version).toBe(5);
   });
 
   it('reads the floor without creating a store', () => {

--- a/packages/persistence/test/fingerprint.test.ts
+++ b/packages/persistence/test/fingerprint.test.ts
@@ -18,6 +18,9 @@ import {
   readFingerprintKey,
   rotateFingerprintKey,
 } from '../src/fingerprint.ts';
+import { ensureDataDirSync } from '../src/paths.ts';
+import type { TempStore } from './helpers/temp-store.ts';
+import { withTempStore } from './helpers/temp-store.ts';
 
 let dir: string;
 
@@ -130,7 +133,7 @@ describe('rotateFingerprintKey', () => {
     }
   });
 
-  it('starts at version 1 when no key exists', () => {
+  it('starts at version 1 when no key exists and the store has none either', () => {
     const key = rotateFingerprintKey(dir);
     expect(key.version).toBe(1);
   });
@@ -138,5 +141,126 @@ describe('rotateFingerprintKey', () => {
   it('throws on a corrupt key file (the old version is unknowable)', () => {
     writeFileSync(keyFile(), 'garbage');
     expect(() => rotateFingerprintKey(dir)).toThrow();
+  });
+});
+
+// A minted version must never collide with one the store already references.
+// Deleting exception.key — what the corrupt-key recovery guidance says to do —
+// takes the version with it, so an unguarded mint restarts at 1 while stored
+// rows written under the DELETED material still say 1. Those rows then look
+// current to every version check in the product, and a grant approved from one
+// is inert the moment it is created. The store keeps the answer because the rows
+// outlive the key file.
+describe('a minted version never reuses one the store already references', () => {
+  // Rows are written through the real repository so the columns the floor reads
+  // are the ones the product actually writes.
+  function seedLedger(store: TempStore, keyVersion: number): Promise<void> {
+    return store.open().exceptions.recordBlocked({
+      reference: `ref-v${String(keyVersion)}`,
+      ruleId: 'aws-access-key-id',
+      category: 'secret',
+      valueFingerprint: keyVersion.toString(16).padStart(64, '0'),
+      keyVersion,
+      maskedValue: 'A*****Q',
+      sessionId: null,
+      repo: null,
+    });
+  }
+
+  function seedGrant(store: TempStore, keyVersion: number): Promise<unknown> {
+    return store.open().exceptions.create({
+      ruleId: 'aws-access-key-id',
+      category: 'secret',
+      valueFingerprint: (keyVersion + 0xf00).toString(16).padStart(64, '0'),
+      keyVersion,
+      maskedValue: 'A*****Q',
+      scope: 'permanent',
+      expiresAt: null,
+      maxUses: null,
+      justification: 'seeded',
+      conditions: null,
+      createdBy: 'tester',
+      createdVia: 'cli-add',
+    });
+  }
+
+  it('mints past a blocked-ledger row after the key file is deleted', async () => {
+    await withTempStore(async (store) => {
+      // The shape the bug needs: a ledger row under v1, then the key deleted.
+      const original = loadOrCreateFingerprintKey(store.dataDir);
+      expect(original.version).toBe(1);
+      await seedLedger(store, original.version);
+      rmSync(join(store.dataDir, 'exception.key'));
+
+      const reminted = loadOrCreateFingerprintKey(store.dataDir);
+      // NOT 1: the row under the deleted material owns that version forever, so
+      // reusing it would make the two indistinguishable.
+      expect(reminted.version).toBe(2);
+      expect(reminted.material.equals(original.material)).toBe(false);
+    });
+  });
+
+  it('mints past a grant row too — both tables pin a version', async () => {
+    await withTempStore(async (store) => {
+      await seedGrant(store, 7);
+      expect(loadOrCreateFingerprintKey(store.dataDir).version).toBe(8);
+    });
+  });
+
+  it('takes the highest version across both tables', async () => {
+    await withTempStore(async (store) => {
+      await seedLedger(store, 2);
+      await seedGrant(store, 5);
+      expect(loadOrCreateFingerprintKey(store.dataDir).version).toBe(6);
+    });
+  });
+
+  it('rotating after a delete clears the stored versions instead of restarting at 1', async () => {
+    await withTempStore(async (store) => {
+      await seedLedger(store, 1);
+      // No key file at all: rotate used to fall back to (undefined ?? 0) + 1.
+      expect(readFingerprintKey(store.dataDir)).toBeNull();
+      expect(rotateFingerprintKey(store.dataDir).version).toBe(2);
+    });
+  });
+
+  it('still mints version 1 on a store that references no key version', () => {
+    withTempStore((store) => {
+      // The floor must not inflate the common case — a first run mints v1.
+      expect(loadOrCreateFingerprintKey(store.dataDir).version).toBe(1);
+    });
+  });
+
+  it('rotates from the key file when it is ahead of the store', async () => {
+    await withTempStore(async (store) => {
+      const v1 = loadOrCreateFingerprintKey(store.dataDir);
+      await seedLedger(store, v1.version);
+      const v2 = rotateFingerprintKey(store.dataDir);
+      const v3 = rotateFingerprintKey(store.dataDir);
+      // Nothing was written under v2, so the store floor stays at 1 — the key
+      // file is the higher of the two and rotation keeps stepping by one.
+      expect(v2.version).toBe(2);
+      expect(v3.version).toBe(3);
+    });
+  });
+
+  it('degrades to the un-floored behaviour when the store cannot be read', () => {
+    // An unreadable store must never stop a hook from minting the key it needs
+    // — the floor is a hardening pass, not a precondition. Fail-open here is
+    // deliberate, so pin it rather than let a future change make it fail-closed.
+    ensureDataDirSync(dir);
+    writeFileSync(join(dir, 'aka.db'), 'this is not a SQLite database at all\n');
+    const key = loadOrCreateFingerprintKey(dir);
+    expect(key.version).toBe(1);
+    expect(key.material).toHaveLength(32);
+  });
+
+  it('reads the floor without creating a store', () => {
+    // Resolving a key must never bring a database into existence as a side
+    // effect — that would leave an empty store on a machine that only ever ran
+    // a scan.
+    expect(existsSync(join(dir, 'aka.db'))).toBe(false);
+    expect(loadOrCreateFingerprintKey(dir).version).toBe(1);
+    expect(existsSync(join(dir, 'aka.db'))).toBe(false);
   });
 });

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -52,6 +52,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'inspectionFindingId',
   'inventoryId',
   'isCurrentKeyVersion',
+  'keyStateOf',
   'llmCallId',
   'loadOrCreateFingerprintKey',
   'migrateLegacyLayout',

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -51,6 +51,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'inspectionDefinitionId',
   'inspectionFindingId',
   'inventoryId',
+  'isCurrentKeyVersion',
   'llmCallId',
   'loadOrCreateFingerprintKey',
   'migrateLegacyLayout',

--- a/packages/plugin-sdk/src/fingerprint.ts
+++ b/packages/plugin-sdk/src/fingerprint.ts
@@ -6,6 +6,7 @@
 export type { FingerprintKey } from '@akasecurity/persistence';
 export {
   fingerprintValue,
+  isCurrentKeyVersion,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
   rotateFingerprintKey,

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -27,6 +27,7 @@ export { computeFindingKey } from './finding-key.ts';
 export type { FingerprintKey } from './fingerprint.ts';
 export {
   fingerprintValue,
+  isCurrentKeyVersion,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
   rotateFingerprintKey,

--- a/packages/schema/src/zod/exception.ts
+++ b/packages/schema/src/zod/exception.ts
@@ -106,3 +106,32 @@ export interface BlockedDetection {
 
 // Insert shape: the persistence repo stamps blocked_at at write time.
 export type BlockedDetectionInput = Omit<BlockedDetection, 'blockedAt'>;
+
+/**
+ * What the machine's fingerprint key file amounts to right now.
+ *
+ * The three states need to stay apart because each one means a different thing
+ * to the person reading the screen: `absent` and `unreadable` both leave every
+ * stored fingerprint unmatchable, but only one of them is fixed by triggering
+ * the detection again — the other is fixed by repairing the file's permissions,
+ * and deleting the key to "fix" it would destroy every grant on the machine.
+ * Collapsing them to `number | null` is what makes a UI say "the key changed"
+ * about a key that did not change.
+ */
+export type FingerprintKeyState =
+  { status: 'present'; version: number } | { status: 'absent' } | { status: 'unreadable' };
+
+/**
+ * Whether a stored fingerprint — an exception grant, or a blocked-ledger row —
+ * can still be matched at enforcement time.
+ *
+ * Enforcement fingerprints under the CURRENT key and scopes its bundle query to
+ * that version, so anything recorded under another version could never match: a
+ * grant minted from it is inert the moment it is created. Both approve surfaces
+ * and the dashboard's blocked strip gate on this, which is why it lives in the
+ * one package all three may import — a second copy is how the server and the UI
+ * come to disagree about which rows are usable.
+ */
+export function isMatchableUnder(keyVersion: number, key: FingerprintKeyState): boolean {
+  return key.status === 'present' && key.version === keyVersion;
+}

--- a/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
+++ b/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
@@ -8,7 +8,11 @@ import {
   PageHead,
   RotateKeyDialog,
 } from '@akasecurity/dashboard-ui';
-import type { BlockedDetection, DetectionException } from '@akasecurity/schema';
+import type {
+  BlockedDetection,
+  DetectionException,
+  FingerprintKeyState,
+} from '@akasecurity/schema';
 import { Button } from '@akasecurity/ui-kit';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -21,14 +25,14 @@ export function ExceptionsClient({
   blocked,
   includeTerminal,
   blockedWindow,
-  keyVersion,
+  keyState,
   activePermanent,
 }: {
   items: DetectionException[];
   blocked: BlockedDetection[];
   includeTerminal: boolean;
   blockedWindow: BlockedWindow;
-  keyVersion: number | null;
+  keyState: FingerprintKeyState;
   activePermanent: DetectionException[];
 }) {
   const router = useRouter();
@@ -36,6 +40,11 @@ export function ExceptionsClient({
   const [rotating, setRotating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [busy, startTransition] = useTransition();
+
+  // The rotate button and dialog only label WHICH version is being replaced, so
+  // "absent" and "unreadable" both correctly read as unknown there. The strip
+  // gets the full state, because for it the two mean different things.
+  const keyVersion = keyState.status === 'present' ? keyState.version : null;
 
   const setBlockedWindow = (next: BlockedWindow) => {
     const sp = new URLSearchParams();
@@ -106,7 +115,7 @@ export function ExceptionsClient({
         }}
         blockedWindow={blockedWindow}
         onBlockedWindowChange={setBlockedWindow}
-        keyVersion={keyVersion}
+        keyState={keyState}
       />
 
       <ExceptionsTableView

--- a/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
+++ b/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
@@ -106,6 +106,7 @@ export function ExceptionsClient({
         }}
         blockedWindow={blockedWindow}
         onBlockedWindowChange={setBlockedWindow}
+        keyVersion={keyVersion}
       />
 
       <ExceptionsTableView

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -10,6 +10,7 @@ import {
   DuplicateActiveExceptionError,
   fingerprintValue,
   loadOrCreateFingerprintKey,
+  readFingerprintKey,
   rotateFingerprintKey,
 } from '@akasecurity/persistence';
 import type { ResolvedScope } from '@akasecurity/schema';
@@ -29,6 +30,11 @@ export interface ActionResult {
   ok: boolean;
   error?: string;
 }
+
+// Recovery guidance for a key file that exists but cannot be parsed. Shared by
+// every path that reads the key so the instruction can never drift between them.
+const CORRUPT_KEY_ERROR =
+  'The exception key file is corrupt. Delete ~/.aka/data/exception.key to mint a new key (this invalidates existing grants).';
 
 // The grant creator's identity — the OS account running the local server,
 // mirroring the CLI's resolveCreatedBy.
@@ -70,7 +76,9 @@ function createGrant(input: CreateExceptionInput): Promise<ActionResult> {
  * Grant an exception from a blocked-ledger entry (`aka exception approve`).
  * The value never travels — the ledger row already carries its keyed
  * fingerprint + masked preview. Permanent scope requires the masked value
- * retyped; re-checked here, not just in the dialog.
+ * retyped; re-checked here, not just in the dialog. A row fingerprinted under
+ * a key version that is no longer current is refused: the grant could never
+ * match.
  */
 export async function approveBlocked(input: {
   reference: string;
@@ -95,6 +103,29 @@ export async function approveBlocked(input: {
       error: 'That blocked detection has expired from the ledger — trigger it again.',
     };
   }
+
+  // The ledger row carries the fingerprint computed when the hook blocked the
+  // value, under whichever key version was live then. Enforcement fingerprints
+  // under the CURRENT key and the bundle query is scoped to it, so a grant
+  // minted from a rotated-away (or deleted) key could never match. Reject
+  // rather than write a grant that is inert the moment it is created — the
+  // ledger outlives a rotation, so this is one click away.
+  let keyVersion: number | null;
+  try {
+    keyVersion = readFingerprintKey(dataDir())?.version ?? null;
+  } catch {
+    return { ok: false, error: CORRUPT_KEY_ERROR };
+  }
+  if (keyVersion !== entry.keyVersion) {
+    return {
+      ok: false,
+      error:
+        keyVersion === null
+          ? 'The exception key file is missing, so the fingerprint recorded for this detection can no longer be matched. Trigger the detection again.'
+          : `That detection was blocked under fingerprint key v${String(entry.keyVersion)}; the key is now v${String(keyVersion)}, so a grant from it could never match. Trigger the detection again.`,
+    };
+  }
+
   if (scope.scope === 'permanent' && input.confirmation !== entry.maskedValue) {
     return {
       ok: false,
@@ -174,11 +205,7 @@ export async function addException(input: {
     };
   } catch {
     // Corrupt key file — fail secure with the CLI's recovery guidance.
-    return {
-      ok: false,
-      error:
-        'The exception key file is corrupt. Delete ~/.aka/data/exception.key to mint a new key (this invalidates existing grants).',
-    };
+    return { ok: false, error: CORRUPT_KEY_ERROR };
   }
 
   return createGrant({

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -14,7 +14,7 @@ import {
   readFingerprintKey,
   rotateFingerprintKey,
 } from '@akasecurity/persistence';
-import type { BlockedDetection, ResolvedScope } from '@akasecurity/schema';
+import type { BlockedDetection, ResolvedScope, Rule } from '@akasecurity/schema';
 import { scopeFromAnswer } from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
@@ -32,10 +32,10 @@ export interface ActionResult {
   error?: string;
 }
 
-// Recovery guidance for a key file that exists but cannot be PARSED. Shared by
-// the two paths that fingerprint (add and approve) so the instruction cannot
-// drift between them; `rotateKey` keeps its own wording because the way forward
-// there is different — the rotation itself is what is refused.
+// Recovery guidance for a key file that exists but cannot be PARSED. Every path
+// that resolves the key routes through keyAccessError below, so this
+// instruction — the only one safe to answer with "delete it" — cannot drift
+// between them.
 const CORRUPT_KEY_ERROR =
   'The exception key file is corrupt. Delete ~/.aka/data/exception.key to mint a new key (this invalidates existing grants).';
 
@@ -52,12 +52,19 @@ const KEY_IO_ERROR =
 // shows a framework error page instead of a way forward.
 const STORE_ERROR = 'Could not read the local store (~/.aka/data/aka.db).';
 
-// Corruption and an I/O failure need different guidance, and only the parse
-// failure is safe to answer with "delete the file". A filesystem error carries a
-// `code`; the strict parse in readFingerprintKey throws a plain Error without
-// one.
+// Minting a key reads the store to find a version no stored row already claims,
+// and refuses rather than guess when it cannot — so a key resolution can fail
+// for a reason that is nothing to do with the key file.
+const KEY_FLOOR_ERROR = `${STORE_ERROR} The fingerprint key cannot be minted until it is readable, because a key that reused a stored version would produce grants that never match.`;
+
+// Three failures, three ways forward, and only the parse failure may be
+// answered with "delete the file":
+//   - the floor read gave up      → a store problem, tagged 'floor-unreadable'
+//   - a filesystem error          → carries an errno `code`
+//   - the strict key-file parse   → a plain Error with no `code`
 function keyAccessError(err: unknown): string {
-  const code: unknown = (err as NodeJS.ErrnoException | null)?.code;
+  const code: unknown = (err as { code?: unknown } | null)?.code;
+  if (code === 'floor-unreadable') return KEY_FLOOR_ERROR;
   return typeof code === 'string' ? KEY_IO_ERROR : CORRUPT_KEY_ERROR;
 }
 
@@ -207,7 +214,10 @@ export async function addException(input: {
   // rules the runtime evaluates, read from the DB, passed explicitly (never the
   // engine's process-global registry, which must stay untouched in this
   // long-lived server).
-  let rules;
+  // Typed with the schema's own Rule rather than left to an evolving `let`:
+  // this is a contract boundary, and the annotation is what makes a change to
+  // installedRuleset()'s shape fail here rather than downstream.
+  let rules: Rule[];
   try {
     ({ rules } = db().installedPacks.installedRuleset());
   } catch {
@@ -234,19 +244,24 @@ export async function addException(input: {
     };
   }
 
-  let grant: { valueFingerprint: string; keyVersion: number; maskedValue: string };
+  // Only the key RESOLUTION is guarded: keyAccessError classifies key-file and
+  // store failures, and a plain Error from anything else — a masking bug in
+  // maskMatch, say — has no `code` and would come back as "your key is corrupt,
+  // delete it". Deriving the fingerprint and preview outside the try keeps that
+  // guidance attached to the failure it actually describes.
+  let key: FingerprintKey;
   try {
-    const key = loadOrCreateFingerprintKey(dataDir());
-    grant = {
-      valueFingerprint: fingerprintValue(key, span),
-      keyVersion: key.version,
-      maskedValue: maskMatch(span),
-    };
+    key = loadOrCreateFingerprintKey(dataDir());
   } catch (err) {
     // Unusable key file — fail secure with recovery guidance matched to the
     // reason (a corrupt file may be deleted; a permissions failure must not).
     return { ok: false, error: keyAccessError(err) };
   }
+  const grant = {
+    valueFingerprint: fingerprintValue(key, span),
+    keyVersion: key.version,
+    maskedValue: maskMatch(span),
+  };
 
   return createGrant({
     ruleId: rule.id,
@@ -283,12 +298,14 @@ export async function rotateKey(confirmation: string): Promise<ActionResult> {
   }
   try {
     rotateFingerprintKey(dataDir());
-  } catch {
-    return {
-      ok: false,
-      error:
-        'The exception key file is corrupt and cannot be rotated. Delete ~/.aka/data/exception.key to mint a new key.',
-    };
+  } catch (err) {
+    // Rotation keeps its own PREFIX — what is being refused is the rotation,
+    // not a grant — but not its own classification. Rotation writes as well as
+    // reads, so this catch sees permission and I/O failures too, and answering
+    // one of those with "delete the key" destroys every grant on the machine to
+    // fix a chmod. That is the harm KEY_IO_ERROR exists to stop, and the CLI's
+    // runRotateKey already routes through the same split.
+    return { ok: false, error: `Could not rotate the fingerprint key. ${keyAccessError(err)}` };
   }
   revalidatePath('/exceptions');
   return { ok: true };

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -3,17 +3,18 @@
 import { userInfo } from 'node:os';
 
 import { maskMatch, scan } from '@akasecurity/detections';
-import type { CreateExceptionInput } from '@akasecurity/persistence';
+import type { CreateExceptionInput, FingerprintKey } from '@akasecurity/persistence';
 import {
   BLOCKED_DETECTIONS_RETENTION_MS,
   dataDir,
   DuplicateActiveExceptionError,
   fingerprintValue,
+  isCurrentKeyVersion,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
   rotateFingerprintKey,
 } from '@akasecurity/persistence';
-import type { ResolvedScope } from '@akasecurity/schema';
+import type { BlockedDetection, ResolvedScope } from '@akasecurity/schema';
 import { scopeFromAnswer } from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
@@ -31,10 +32,34 @@ export interface ActionResult {
   error?: string;
 }
 
-// Recovery guidance for a key file that exists but cannot be parsed. Shared by
-// every path that reads the key so the instruction can never drift between them.
+// Recovery guidance for a key file that exists but cannot be PARSED. Shared by
+// the two paths that fingerprint (add and approve) so the instruction cannot
+// drift between them; `rotateKey` keeps its own wording because the way forward
+// there is different — the rotation itself is what is refused.
 const CORRUPT_KEY_ERROR =
   'The exception key file is corrupt. Delete ~/.aka/data/exception.key to mint a new key (this invalidates existing grants).';
+
+// A key file that is present and well-formed but cannot be read or written —
+// wrong owner, lost permissions, a failing disk. Deliberately NOT the corrupt
+// message: telling someone to delete a perfectly good key over a permissions
+// error destroys every grant on the machine, because the replacement carries
+// fresh material that no stored fingerprint was written under.
+const KEY_IO_ERROR =
+  'Could not access the exception key file — check the permissions on ~/.aka/data. Do not delete exception.key to work around this; that invalidates every existing grant.';
+
+// The local store is the only data source; a read that fails has to surface as a
+// message rather than an exception, or a Server Action rejects and the dialog
+// shows a framework error page instead of a way forward.
+const STORE_ERROR = 'Could not read the local store (~/.aka/data/aka.db).';
+
+// Corruption and an I/O failure need different guidance, and only the parse
+// failure is safe to answer with "delete the file". A filesystem error carries a
+// `code`; the strict parse in readFingerprintKey throws a plain Error without
+// one.
+function keyAccessError(err: unknown): string {
+  const code: unknown = (err as NodeJS.ErrnoException | null)?.code;
+  return typeof code === 'string' ? KEY_IO_ERROR : CORRUPT_KEY_ERROR;
+}
 
 // The grant creator's identity — the OS account running the local server,
 // mirroring the CLI's resolveCreatedBy.
@@ -94,9 +119,14 @@ export async function approveBlocked(input: {
   // Looked up against the full retention window, not just the UI's currently
   // selected lookback — approving a row the user can see must not depend on
   // which filter chip happens to be active.
-  const entry = (await db().exceptions.recentBlocked(BLOCKED_DETECTIONS_RETENTION_MS)).find(
-    (b) => b.reference === input.reference,
-  );
+  let entry: BlockedDetection | undefined;
+  try {
+    entry = (await db().exceptions.recentBlocked(BLOCKED_DETECTIONS_RETENTION_MS)).find(
+      (b) => b.reference === input.reference,
+    );
+  } catch {
+    return { ok: false, error: STORE_ERROR };
+  }
   if (!entry) {
     return {
       ok: false,
@@ -110,19 +140,23 @@ export async function approveBlocked(input: {
   // minted from a rotated-away (or deleted) key could never match. Reject
   // rather than write a grant that is inert the moment it is created — the
   // ledger outlives a rotation, so this is one click away.
-  let keyVersion: number | null;
+  //
+  // Checked BEFORE the confirmation gate on purpose: an unusable row is
+  // unusable whatever the user types, and asking someone to retype a masked
+  // value only to then refuse the grant is worse than refusing it up front.
+  let key: FingerprintKey | null;
   try {
-    keyVersion = readFingerprintKey(dataDir())?.version ?? null;
-  } catch {
-    return { ok: false, error: CORRUPT_KEY_ERROR };
+    key = readFingerprintKey(dataDir());
+  } catch (err) {
+    return { ok: false, error: keyAccessError(err) };
   }
-  if (keyVersion !== entry.keyVersion) {
+  if (!isCurrentKeyVersion(key, entry.keyVersion)) {
     return {
       ok: false,
       error:
-        keyVersion === null
+        key === null
           ? 'The exception key file is missing, so the fingerprint recorded for this detection can no longer be matched. Trigger the detection again.'
-          : `That detection was blocked under fingerprint key v${String(entry.keyVersion)}; the key is now v${String(keyVersion)}, so a grant from it could never match. Trigger the detection again.`,
+          : `That detection was blocked under fingerprint key v${String(entry.keyVersion)}; the key is now v${String(key.version)}, so a grant from it could never match. Trigger the detection again.`,
     };
   }
 
@@ -173,7 +207,12 @@ export async function addException(input: {
   // rules the runtime evaluates, read from the DB, passed explicitly (never the
   // engine's process-global registry, which must stay untouched in this
   // long-lived server).
-  const { rules } = db().installedPacks.installedRuleset();
+  let rules;
+  try {
+    ({ rules } = db().installedPacks.installedRuleset());
+  } catch {
+    return { ok: false, error: STORE_ERROR };
+  }
   const rule = rules.find((r) => r.id === input.ruleId);
   if (!rule) return { ok: false, error: `Unknown or disabled rule '${input.ruleId}'.` };
 
@@ -203,9 +242,10 @@ export async function addException(input: {
       keyVersion: key.version,
       maskedValue: maskMatch(span),
     };
-  } catch {
-    // Corrupt key file — fail secure with the CLI's recovery guidance.
-    return { ok: false, error: CORRUPT_KEY_ERROR };
+  } catch (err) {
+    // Unusable key file — fail secure with recovery guidance matched to the
+    // reason (a corrupt file may be deleted; a permissions failure must not).
+    return { ok: false, error: keyAccessError(err) };
   }
 
   return createGrant({

--- a/web-ui/app/(app)/exceptions/page.tsx
+++ b/web-ui/app/(app)/exceptions/page.tsx
@@ -1,5 +1,6 @@
 import { BLOCKED_WINDOW_MS, resolveBlockedWindow } from '@akasecurity/dashboard-ui';
-import { dataDir, readFingerprintKey } from '@akasecurity/persistence';
+import { dataDir, keyStateOf, readFingerprintKey } from '@akasecurity/persistence';
+import type { FingerprintKeyState } from '@akasecurity/schema';
 
 import { db } from '../../lib/db';
 import { ExceptionsClient } from './ExceptionsClient';
@@ -24,13 +25,17 @@ export default async function ExceptionsPage({
     db().exceptions.recentBlocked(BLOCKED_WINDOW_MS[blockedWindow]),
   ]);
 
-  // Key version for the rotate dialog; a corrupt key file must not take the
-  // page down (the rotate action surfaces the recovery guidance).
-  const keyVersion = ((): number | null => {
+  // The key as three distinct states, not `number | null`: an unreadable key
+  // file is not a missing one, and collapsing them is what would have the strip
+  // tell someone with a permissions problem that their key "changed" and to
+  // trigger the detection again — neither of which is true, and the obvious
+  // next step from it (delete the key) destroys every grant on the machine.
+  // A corrupt or unreadable file must still not take the page down.
+  const keyState = ((): FingerprintKeyState => {
     try {
-      return readFingerprintKey(dataDir())?.version ?? null;
+      return keyStateOf(readFingerprintKey(dataDir()));
     } catch {
-      return null;
+      return { status: 'unreadable' };
     }
   })();
 
@@ -47,7 +52,7 @@ export default async function ExceptionsPage({
       blocked={blocked}
       includeTerminal={includeTerminal}
       blockedWindow={blockedWindow}
-      keyVersion={keyVersion}
+      keyState={keyState}
       activePermanent={activePermanent}
     />
   );

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -1,31 +1,52 @@
 import { createHash, createHmac } from 'node:crypto';
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { BLOCKED_WINDOW_MS, BLOCKED_WINDOWS, ROTATE_CONFIRMATION } from '@akasecurity/dashboard-ui';
+import { maskMatch } from '@akasecurity/detections';
 import {
+  BLOCKED_DETECTIONS_RETENTION_MS,
   dataDir,
+  fingerprintValue,
   loadOrCreateFingerprintKey,
   type LocalDatabase,
   openLocalDatabase,
+  readFingerprintKey,
 } from '@akasecurity/persistence';
 import { bundledDetections } from '@akasecurity/plugin-sdk';
-import type { DetectionException } from '@akasecurity/schema';
+import type { BlockedDetectionInput, DetectionException } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type ActionResult, addException } from '../../app/(app)/exceptions/actions.ts';
+import {
+  type ActionResult,
+  addException,
+  approveBlocked,
+  rotateKey,
+} from '../../app/(app)/exceptions/actions.ts';
 
-// `addException` is the ONLY web-ui code that handles a raw secret value. It
-// must verify the ruleId exists in the installed snapshot, verify the value
-// scan-matches that rule, require exactly one distinct span, reduce it to a
-// masked preview + keyed-HMAC fingerprint, and discard the raw — never
-// persisting it, never echoing it in an error. A bug here either creates a
-// dangling grant or leaks the secret, so this suite pins BOTH properties on
-// every branch. It mirrors cli/test/commands/exception.test.ts: a real
-// node:sqlite store, a real fingerprint key file, no mocking of the store.
+// The three exception-granting Server Actions, each covered against a real
+// node:sqlite store and a real fingerprint key file — no mocking of either
+// (the repository's house style; mirrors cli/test/commands/exception.test.ts):
 //
-// The action resolves its store and key location from `homedir()` (never
+//   addException   — the ONLY web-ui code that handles a raw secret value. It
+//                    must verify the ruleId exists in the installed snapshot,
+//                    verify the value scan-matches that rule, require exactly
+//                    one distinct span, reduce it to a masked preview +
+//                    keyed-HMAC fingerprint, and discard the raw — never
+//                    persisting it, never echoing it in an error. A bug here
+//                    either creates a dangling grant or leaks the secret, so
+//                    that suite pins BOTH properties on every branch.
+//   approveBlocked — grants from a ledger row, so no raw value is in play; the
+//                    gates are the server-side permanent-scope confirmation
+//                    and the lookup window.
+//   rotateKey      — INVALIDATES every existing grant, behind a single string
+//                    compare. The dialog gate is a convenience; this compare is
+//                    the control, so the suite pins both what it accepts and
+//                    that everything else leaves the key untouched.
+//
+// The actions resolve their store and key location from `homedir()` (never
 // process.env), so the whole test is redirected into a temp home by mocking
 // `node:os`; `next/cache` is stubbed because revalidatePath needs a Next render
 // context that does not exist under vitest.
@@ -52,6 +73,11 @@ const VALUE: string = example;
 // the pattern's alternation). It is NOT any rule's example, so its absence from
 // the store on disk proves the raw was discarded, not merely never present.
 const SECOND = `ASIA${VALUE.slice(4)}`;
+// A THIRD value whose MASKED preview differs from the other two. maskMatch
+// keeps only the first and last character of a generic secret, so SECOND — which
+// changes only the prefix — previews identically to VALUE; a test that needs two
+// distinguishable previews has to change an end.
+const THIRD = `ASIA${VALUE.slice(4, -1)}${VALUE.endsWith('Z') ? 'Y' : 'Z'}`;
 
 let home: string;
 let dir: string;
@@ -94,6 +120,89 @@ function storeBytes(): string {
   }
   return Buffer.concat(parts).toString('latin1');
 }
+
+function keyFile(): string {
+  return join(dir, 'exception.key');
+}
+
+// The key file verbatim. Rejection paths assert the BYTES, not just the
+// version: a rotation that minted fresh material while keeping the version
+// would orphan every grant just as thoroughly, and read as unchanged.
+function keyBytes(): string {
+  return readFileSync(keyFile(), 'utf8');
+}
+
+// One blocked-ledger row shaped exactly as the hook writes it: the keyed
+// fingerprint and masked preview of the detected value under the CURRENT key,
+// and never the value itself.
+const REFERENCE = 'blk-0001';
+
+function ledgerEntry(overrides: Partial<BlockedDetectionInput> = {}): BlockedDetectionInput {
+  const key = loadOrCreateFingerprintKey(dir);
+  return {
+    reference: REFERENCE,
+    ruleId: RULE_ID,
+    category: 'secret',
+    valueFingerprint: fingerprintValue(key, VALUE),
+    keyVersion: key.version,
+    maskedValue: maskMatch(VALUE),
+    sessionId: null,
+    repo: null,
+    ...overrides,
+  };
+}
+
+// Write a ledger row through the real repository, optionally back-dated.
+// `blocked_at` is stamped inside the write from `Date.now()` and
+// exceptions.ts takes no injectable clock, so moving the clock across that one
+// call is the only seam — which keeps the row shape in step with
+// `recordBlocked` instead of hand-rolling its SQL. The handle is opened BEFORE
+// the clock moves so migrations and default seeding still stamp real times.
+async function seedBlocked(entry: BlockedDetectionInput, agedMs = 0): Promise<void> {
+  const at = Date.now() - agedMs;
+  const store = openLocalDatabase(dir);
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(at);
+  try {
+    await store.exceptions.recordBlocked(entry);
+  } finally {
+    clock.mockRestore();
+    store.close();
+  }
+}
+
+// The ledger as the page's "Recently blocked" banner queries it.
+async function blockedWithin(windowMs: number): Promise<string[]> {
+  const store = openLocalDatabase(dir);
+  try {
+    return (await store.exceptions.recentBlocked(windowMs)).map((b) => b.reference);
+  } finally {
+    store.close();
+  }
+}
+
+// The grants a live detection would actually be matched against: the
+// evaluation bundle under one key version (what plugin-runtime ships to the
+// hook). "No longer matches" means absent from here, not deleted.
+async function bundleIds(keyVersion: number): Promise<string[]> {
+  const store = openLocalDatabase(dir);
+  try {
+    return (await store.exceptions.activeBundleEntries(keyVersion)).map((e) => e.id);
+  } finally {
+    store.close();
+  }
+}
+
+// Server Action arguments arrive as untrusted JSON over an HTTP POST — the
+// `string` in each signature is a compile-time claim the runtime never checks.
+// Call through widened aliases so the tests can drive the boundary as it
+// actually exists.
+const rotateKeyRaw = rotateKey as unknown as (confirmation: unknown) => Promise<ActionResult>;
+const approveBlockedRaw = approveBlocked as unknown as (input: {
+  reference: string;
+  scope: string;
+  reason: string;
+  confirmation?: unknown;
+}) => Promise<ActionResult>;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-ex-'));
@@ -456,6 +565,457 @@ describe('addException — the only web code touching a raw secret', () => {
         expect(err).not.toContain(VALUE);
         expect(err).not.toContain(SECOND);
       }
+    });
+  });
+});
+
+describe('rotateKey — one string compare from invalidating every grant', () => {
+  // A grant under the current key, created through the real add path, so the
+  // "stops matching" assertions run against a grant a live detection would
+  // genuinely have matched a moment earlier.
+  async function grantUnderCurrentKey(): Promise<{ id: string; keyVersion: number }> {
+    const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: '1h', reason: 'x' });
+    expect(res).toEqual({ ok: true });
+    const grant = (await grants())[0];
+    expect(grant).toBeDefined();
+    return { id: grant?.id ?? '', keyVersion: grant?.keyVersion ?? 0 };
+  }
+
+  describe('the gate rejects everything that is not the exact token', () => {
+    // The compare is a strict `!==` against the literal — no trim, no
+    // case-fold, no coercion. Each of these routes to loopback of the intent
+    // ("the user meant rotate") but is NOT the token, and pinning them stops a
+    // future "helpful" normalisation from widening a one-click destructive gate.
+    const NEAR_MISSES = ['', 'Rotate', 'ROTATE', ' rotate', 'rotate ', 'rotate\n', 'rotate-key'];
+
+    it.each(NEAR_MISSES)('rejects %j and leaves the key byte-identical', async (confirmation) => {
+      const { id, keyVersion } = await grantUnderCurrentKey();
+      const before = keyBytes();
+
+      const res = await rotateKey(confirmation);
+      expect(res.ok).toBe(false);
+      expect(res.error).toBe('Type "rotate" to confirm.');
+
+      expect(keyBytes()).toBe(before);
+      expect(readFingerprintKey(dir)?.version).toBe(keyVersion);
+      // The grant is untouched — still the one enforcement would match.
+      expect(await bundleIds(keyVersion)).toContain(id);
+    });
+
+    // Server Actions are an RPC boundary: the argument is whatever JSON the
+    // caller posted. A `!==` against a string rejects every non-string,
+    // including an object whose `toString()` would produce the token — pin
+    // that, because a switch to `==` or `String(x) ===` would accept them.
+    const NON_STRINGS: [string, unknown][] = [
+      ['undefined', undefined],
+      ['null', null],
+      ['an array', ['rotate']],
+      ['an object', {}],
+      ['a stringifiable object', { toString: () => 'rotate' }],
+      ['a number', 1],
+      ['true', true],
+    ];
+
+    it.each(NON_STRINGS)('rejects %s arriving over the wire', async (_label, confirmation) => {
+      loadOrCreateFingerprintKey(dir); // a key to leave unchanged
+      const before = keyBytes();
+      const res = await rotateKeyRaw(confirmation);
+      expect(res.ok).toBe(false);
+      expect(keyBytes()).toBe(before);
+    });
+
+    it('mints nothing when there is no key file yet', async () => {
+      // A rejected rotation must be totally inert. Minting here would be worse
+      // than a no-op: enforcement would start fingerprinting under a key that
+      // the ledger's pending rows were never written against.
+      expect(readFingerprintKey(dir)).toBeNull();
+      expect((await rotateKey('nope')).ok).toBe(false);
+      expect(readFingerprintKey(dir)).toBeNull();
+    });
+
+    it('accepts exactly the token the dialog makes the user type', async () => {
+      // The action hard-codes the literal and the dialog exports its own
+      // constant. If either moves, rotation silently stops working (fail
+      // closed, but broken) — so pin the two together, through the action.
+      expect(ROTATE_CONFIRMATION).toBe('rotate');
+      loadOrCreateFingerprintKey(dir);
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+    });
+  });
+
+  describe('rotation is invalidation, not deletion', () => {
+    it('bumps the version and mints fresh material', async () => {
+      const before = readFingerprintKey(dir);
+      expect(before).toBeNull(); // no key until something needs one
+      const v1 = loadOrCreateFingerprintKey(dir);
+
+      const res = await rotateKey(ROTATE_CONFIRMATION);
+      expect(res).toEqual({ ok: true });
+
+      const v2 = readFingerprintKey(dir);
+      expect(v2?.version).toBe(v1.version + 1);
+      expect(v2?.material.equals(v1.material)).toBe(false);
+    });
+
+    it('leaves old grants listed and unrevoked — they are audit evidence', async () => {
+      const { id, keyVersion } = await grantUnderCurrentKey();
+
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      const all = await grants();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.id).toBe(id);
+      // NOT revoked and NOT expired: nothing about the row changed. It went
+      // inert purely because the key it was written under is no longer the one
+      // enforcement uses.
+      expect(all[0]?.revokedAt).toBeNull();
+      expect(all[0]?.keyVersion).toBe(keyVersion);
+    });
+
+    it('drops old grants out of the bundle enforcement actually reads', async () => {
+      const { id, keyVersion } = await grantUnderCurrentKey();
+      expect(await bundleIds(keyVersion)).toContain(id);
+
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      const rotated = readFingerprintKey(dir)?.version;
+      expect(rotated).toBe(keyVersion + 1);
+      // The bundle is queried under the current version, and the grant is not
+      // in it — a live detection of VALUE would now be enforced, not excepted.
+      expect(await bundleIds(rotated ?? 0)).not.toContain(id);
+      // Still reachable under the old version: partitioned by key, not deleted.
+      expect(await bundleIds(keyVersion)).toContain(id);
+    });
+
+    it('makes the same value grantable again — the documented recovery path', async () => {
+      await grantUnderCurrentKey();
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      // Re-granting the SAME value must not collide with the orphaned grant:
+      // the fingerprint changed with the key, so the one-active-grant-per
+      // (rule, fingerprint, keyVersion) index sees a different slot. This is
+      // what "re-approve deliberately where still needed" depends on.
+      const again = await addException({
+        ruleId: RULE_ID,
+        value: VALUE,
+        scope: '1h',
+        reason: 'still needed',
+      });
+      expect(again).toEqual({ ok: true });
+
+      const key = loadOrCreateFingerprintKey(dir);
+      const wanted = createHmac('sha256', key.material).update(VALUE, 'utf8').digest('hex');
+      const store = openLocalDatabase(dir);
+      try {
+        const bundle = await store.exceptions.activeBundleEntries(key.version);
+        expect(bundle.some((e) => e.valueFingerprint === wanted)).toBe(true);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  describe('failure is secure', () => {
+    it('refuses to rotate over a corrupt key and leaves the file alone', async () => {
+      // The old version is unknowable, so minting a replacement could reuse a
+      // version and collide new grants with orphaned ones. Rotation must fail
+      // rather than guess — and must not consume the evidence on the way out.
+      writeFileSync(keyFile(), 'this is not a valid key file\n');
+      const before = keyBytes();
+
+      const res = await rotateKey(ROTATE_CONFIRMATION);
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('exception.key'); // recovery guidance, not a stack trace
+      expect(keyBytes()).toBe(before);
+    });
+
+    it('checks the confirmation before it ever touches the key file', async () => {
+      writeFileSync(keyFile(), 'corrupt\n');
+      const res = await rotateKey('nope');
+      // The cheap, total gate runs first: a wrong confirmation reports the
+      // confirmation problem, never the store's state.
+      expect(res.error).toBe('Type "rotate" to confirm.');
+    });
+  });
+});
+
+describe('approveBlocked — granting from the ledger, no value in play', () => {
+  beforeEach(async () => {
+    await seedBlocked(ledgerEntry());
+    resetSingleton();
+  });
+
+  // The preview the dialog shows and the confirmation box asks for.
+  const MASKED = maskMatch(VALUE);
+
+  describe('input validation rejects before any grant is written', () => {
+    it('rejects an empty reason — the reason is the audit trail', async () => {
+      const res = await approveBlocked({ reference: REFERENCE, scope: 'once', reason: '   ' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects an unresolvable scope', async () => {
+      const res = await approveBlocked({ reference: REFERENCE, scope: 'forever', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects an unknown reference with the ledger message, not a crash', async () => {
+      const res = await approveBlocked({ reference: 'blk-nope', scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/expired from the ledger/i);
+      expect(await grants()).toHaveLength(0);
+    });
+  });
+
+  describe('permanent scope re-checks the confirmation server-side', () => {
+    it('rejects permanent scope when the confirmation is missing', async () => {
+      const res = await approveBlocked({ reference: REFERENCE, scope: 'permanent', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects permanent scope when the confirmation is wrong', async () => {
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation: `${MASKED}x`,
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects the RAW value as the confirmation — the masked preview is what is asked for', async () => {
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation: VALUE,
+      });
+      expect(res.ok).toBe(false);
+      expect(res.error).not.toContain(VALUE);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('rejects another entry’s masked value — the compare uses the looked-up row', async () => {
+      // The caller controls `reference` and `confirmation` independently. The
+      // masked value on the RIGHT of the compare is read from the store, so a
+      // payload cannot bring its own matching pair.
+      const key = loadOrCreateFingerprintKey(dir);
+      const other = maskMatch(THIRD);
+      expect(other).not.toBe(MASKED); // the case is only meaningful if they differ
+      await seedBlocked({
+        ...ledgerEntry(),
+        reference: 'blk-0002',
+        valueFingerprint: fingerprintValue(key, THIRD),
+        maskedValue: other,
+      });
+      resetSingleton();
+
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation: other,
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('is a deliberateness gate, not proof of knowledge', () => {
+      // The dialog displays the masked preview immediately above the box that
+      // asks for it, and maskMatch reveals only the first and last character —
+      // so distinct values routinely share a preview. The control makes a
+      // permanent grant a deliberate act; it is not, and cannot be, evidence
+      // that the operator knows the value. Pin the collision so the gate is not
+      // mistaken for the stronger property.
+      expect(SECOND).not.toBe(VALUE);
+      expect(maskMatch(SECOND)).toBe(maskMatch(VALUE));
+    });
+
+    const NON_STRINGS: [string, unknown][] = [
+      ['null', null],
+      ['an object', {}],
+      ['a stringifiable object', { toString: () => 'x' }],
+    ];
+
+    it.each(NON_STRINGS)('rejects %s arriving over the wire', async (_label, confirmation) => {
+      const res = await approveBlockedRaw({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation,
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('accepts permanent scope when the confirmation matches exactly', async () => {
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'deliberate',
+        confirmation: MASKED,
+      });
+      expect(res).toEqual({ ok: true });
+
+      const all = await grants();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.scope).toBe('permanent');
+      expect(all[0]?.expiresAt).toBeNull();
+    });
+
+    it('gates ONLY permanent scope — a temporary grant ignores the confirmation', async () => {
+      // Pin the exact boundary in both directions: widening the gate to every
+      // scope would be a UX regression, narrowing it away from permanent would
+      // be a security one.
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: '1h',
+        reason: 'x',
+        confirmation: 'not the masked value',
+      });
+      expect(res).toEqual({ ok: true });
+      expect((await grants())[0]?.scope).toBe('temporary');
+    });
+  });
+
+  describe('the lookup window is the retention window, not the UI filter', () => {
+    it('approves a row no blocked-window chip except the widest can show', async () => {
+      // 12h: past the page's default chip and every narrower one, well inside
+      // the 24h retention the ledger actually keeps. If the action reused the
+      // chip the user happens to be on — or `recentBlocked`'s 30-minute default
+      // — a row visible on the page would be unapprovable.
+      const AGED_MS = 12 * 60 * 60 * 1000;
+      await seedBlocked({ ...ledgerEntry(), reference: 'blk-aged' }, AGED_MS);
+      resetSingleton();
+
+      for (const chip of BLOCKED_WINDOWS) {
+        const span = BLOCKED_WINDOW_MS[chip.value];
+        expect(await blockedWithin(span), `chip ${chip.value}`).toSatisfy((refs: string[]) =>
+          span > AGED_MS ? refs.includes('blk-aged') : !refs.includes('blk-aged'),
+        );
+      }
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: 'blk-aged', scope: '1h', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+      expect(await grants()).toHaveLength(1);
+    });
+
+    it('refuses a row past retention — the ledger is short-lived by design', async () => {
+      await seedBlocked(
+        { ...ledgerEntry(), reference: 'blk-old' },
+        BLOCKED_DETECTIONS_RETENTION_MS + 60_000,
+      );
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: 'blk-old', scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/expired from the ledger/i);
+      expect(await grants()).toHaveLength(0);
+    });
+  });
+
+  describe('a rotated key makes a ledger row unapprovable', () => {
+    it('refuses a row fingerprinted under the previous key version', async () => {
+      // The ledger (24h) outlives a rotation, so the page keeps offering
+      // "Approve" on rows whose fingerprint was computed under the old key.
+      // Granting from one would write a row that is inert the moment it is
+      // created: enforcement fingerprints under the current key and queries the
+      // bundle by that version. Reject instead of reporting success.
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/could never match/i);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('refuses when the key file is missing entirely', async () => {
+      // A deleted key is version-indistinguishable from the one the row was
+      // written under, but the material is gone, so the fingerprint can never
+      // be reproduced. Absence is rejected on its own terms.
+      unlinkSync(keyFile());
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/missing/i);
+      expect(await grants()).toHaveLength(0);
+      // Rejecting must not mint a replacement key as a side effect — that would
+      // orphan every existing grant to answer a read.
+      expect(readFingerprintKey(dir)).toBeNull();
+    });
+
+    it('surfaces recovery guidance for a corrupt key instead of crashing', async () => {
+      writeFileSync(keyFile(), 'this is not a valid key file\n');
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toContain('exception.key');
+      expect(await grants()).toHaveLength(0);
+    });
+  });
+
+  describe('a successful grant copies the ledger row and nothing else', () => {
+    it('binds to the stored fingerprint — the value never enters this action', async () => {
+      const entry = ledgerEntry();
+      const res = await approveBlocked({
+        reference: REFERENCE,
+        scope: '1h',
+        reason: '  rotating tomorrow  ',
+      });
+      expect(res).toEqual({ ok: true });
+
+      const grant = (await grants())[0];
+      expect(grant?.ruleId).toBe(entry.ruleId);
+      expect(grant?.category).toBe(entry.category);
+      expect(grant?.valueFingerprint).toBe(entry.valueFingerprint);
+      expect(grant?.keyVersion).toBe(entry.keyVersion);
+      expect(grant?.maskedValue).toBe(entry.maskedValue);
+      expect(grant?.createdVia).toBe('web-approve');
+      expect(grant?.justification).toBe('rotating tomorrow');
+      expect(JSON.stringify(grant)).not.toContain(VALUE);
+    });
+
+    it('lands in the active evaluation bundle — a real detection would match it', async () => {
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+
+      const key = loadOrCreateFingerprintKey(dir);
+      const wanted = fingerprintValue(key, VALUE);
+      const store = openLocalDatabase(dir);
+      try {
+        const bundle = await store.exceptions.activeBundleEntries(key.version);
+        expect(bundle.some((e) => e.ruleId === RULE_ID && e.valueFingerprint === wanted)).toBe(
+          true,
+        );
+      } finally {
+        store.close();
+      }
+    });
+
+    it('rejects a second approve of the same row with a friendly message, keeping one grant', async () => {
+      // Double-submit, or approving the same value from two ledger rows: the
+      // repository throws DuplicateActiveExceptionError, and the action must
+      // turn that into guidance rather than let it reach the client as a crash.
+      expect(await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'a' })).toEqual({
+        ok: true,
+      });
+
+      const second = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'b' });
+      expect(second.ok).toBe(false);
+      expect(second.error).toMatch(/already exists/i);
+      expect(second.error).not.toMatch(/duplicate-active-exception/);
+      expect(await grants()).toHaveLength(1);
     });
   });
 });

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -822,6 +822,33 @@ describe('rotateKey — one string compare from invalidating every grant', () =>
       expect(keyBytes()).toBe(before);
     });
 
+    it('does not answer an UNREADABLE key with "delete it" — rotation writes too', async (ctx) => {
+      // rotateKey both reads and writes the key, so this catch sees permission
+      // and I/O failures, not only a corrupt parse. Answering one of those with
+      // the corrupt-key guidance destroys every grant on the machine to fix a
+      // chmod — the same harm the add and approve paths were split to avoid,
+      // and the one place that classification was still missing.
+      if (process.platform === 'win32') {
+        ctx.skip('POSIX mode bits do not gate reads under Windows ACLs');
+      }
+      if (process.getuid?.() === 0) {
+        ctx.skip('root bypasses the mode bits this case depends on');
+      }
+      loadOrCreateFingerprintKey(dir);
+      const before = keyBytes();
+      chmodSync(keyFile(), 0o000);
+      try {
+        const res = await rotateKey(ROTATE_CONFIRMATION);
+        expect(res.ok).toBe(false);
+        expect(res.error).toMatch(/permission/i);
+        expect(res.error).not.toMatch(/delete .*exception\.key to mint/i);
+        expect(res.error).toMatch(/do not delete/i);
+      } finally {
+        chmodSync(keyFile(), 0o600);
+      }
+      expect(keyBytes()).toBe(before);
+    });
+
     it('checks the confirmation before it ever touches the key file', async () => {
       writeFileSync(keyFile(), 'corrupt\n');
       const res = await rotateKey('nope');

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -1,5 +1,13 @@
 import { createHash, createHmac } from 'node:crypto';
-import { mkdtempSync, readFileSync, rmSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import type * as NodeOs from 'node:os';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -487,15 +495,18 @@ describe('addException — the only web code touching a raw secret', () => {
       expect(storeBytes()).not.toContain(SECOND);
     });
 
-    it('locks the minted exception.key to 0600 — it is what keeps the fingerprints non-reversible', async () => {
-      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
-      expect(res).toEqual({ ok: true });
+    it('locks the minted exception.key to 0600 — it is what keeps the fingerprints non-reversible', async (ctx) => {
       // The add path mints the fingerprint key on first use. A looser mode would
       // let another local account read the key and reverse the stored HMACs, so
-      // pin 0600 (POSIX only — Windows ACLs do not carry these mode bits).
-      if (process.platform !== 'win32') {
-        expect(statSync(join(dir, 'exception.key')).mode & 0o777).toBe(0o600);
+      // pin 0600. Skipped rather than silently passed on Windows, where ACLs
+      // carry the permission and these mode bits mean nothing — a test that
+      // asserts nothing must not report as covered.
+      if (process.platform === 'win32') {
+        ctx.skip('Windows ACLs do not carry POSIX mode bits');
       }
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+      expect(statSync(join(dir, 'exception.key')).mode & 0o777).toBe(0o600);
     });
   });
 
@@ -838,13 +849,40 @@ describe('approveBlocked — granting from the ledger, no value in play', () => 
       expect(maskMatch(SECOND)).toBe(maskMatch(VALUE));
     });
 
-    const NON_STRINGS: [string, unknown][] = [
-      ['null', null],
-      ['an object', {}],
-      ['a stringifiable object', { toString: () => 'x' }],
+    // Each payload COERCES to the masked value the gate asks for, so each one
+    // survives a switch from `!==` to `String(x) !==` — the mutation these exist
+    // to catch. A payload that coerces to anything else is rejected either way
+    // and would prove nothing, so the coercion is asserted before the call.
+    const COERCING: [string, (masked: string) => unknown][] = [
+      ['a single-element array', (masked) => [masked]],
+      ['a stringifiable object', (masked) => ({ toString: () => masked })],
+      ['a boxed String', (masked) => new String(masked)],
     ];
 
-    it.each(NON_STRINGS)('rejects %s arriving over the wire', async (_label, confirmation) => {
+    it.each(COERCING)('rejects %s that coerces to the masked value', async (_label, build) => {
+      const confirmation = build(MASKED);
+      expect(String(confirmation)).toBe(MASKED); // the case is only meaningful if it coerces
+      const res = await approveBlockedRaw({
+        reference: REFERENCE,
+        scope: 'permanent',
+        reason: 'x',
+        confirmation,
+      });
+      expect(res.ok).toBe(false);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    // The empty-ish payloads a client can post in place of the field. `undefined`
+    // is the missing-field case above; these cannot coerce to a masked value, so
+    // they pin the boundary rather than the coercion.
+    const EMPTYISH: [string, unknown][] = [
+      ['null', null],
+      ['an empty object', {}],
+      ['false', false],
+      ['zero', 0],
+    ];
+
+    it.each(EMPTYISH)('rejects %s arriving over the wire', async (_label, confirmation) => {
       const res = await approveBlockedRaw({
         reference: REFERENCE,
         scope: 'permanent',
@@ -962,6 +1000,121 @@ describe('approveBlocked — granting from the ledger, no value in play', () => 
       expect(res.ok).toBe(false);
       expect(res.error).toContain('exception.key');
       expect(await grants()).toHaveLength(0);
+    });
+
+    it('refuses a row whose key was DELETED and re-minted, not just rotated away', async () => {
+      // The version alone is not an identity: minting restarts the counter, so
+      // a key deleted at v1 and re-minted would come back as v1 and make this
+      // row look current again — a grant from it would be inert the moment it
+      // was created, which is the whole failure this guard exists to stop. The
+      // corrupt-key guidance tells users to delete the key file, so this is the
+      // path the product actively points at. The mint now takes the first
+      // version the store has not already claimed, which keeps them distinct.
+      const original = readFingerprintKey(dir);
+      expect(original?.version).toBe(1);
+
+      unlinkSync(keyFile());
+      const reminted = loadOrCreateFingerprintKey(dir);
+      expect(reminted.material.equals(original?.material ?? Buffer.alloc(0))).toBe(false);
+      expect(reminted.version).not.toBe(original?.version);
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/could never match/i);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('refuses a row after the key was deleted and then ROTATED', async () => {
+      // Rotation used to fall back to (missing ?? 0) + 1 — also v1 — so "delete
+      // the key, then rotate" was a second route to the same collision.
+      unlinkSync(keyFile());
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/could never match/i);
+      expect(await grants()).toHaveLength(0);
+    });
+
+    it('distinguishes an unreadable key from a corrupt one — never says "delete it"', async (ctx) => {
+      // Answering a permissions failure with the corrupt-key guidance would
+      // destroy every grant on the machine to fix a chmod, and the replacement
+      // key is exactly what makes a stale ledger row look current again.
+      if (process.platform === 'win32') {
+        ctx.skip('POSIX mode bits do not gate reads under Windows ACLs');
+      }
+      if (process.getuid?.() === 0) {
+        ctx.skip('root bypasses the mode bits this case depends on');
+      }
+      chmodSync(keyFile(), 0o000);
+      resetSingleton();
+      try {
+        const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+        expect(res.ok).toBe(false);
+        expect(res.error).toMatch(/permission/i);
+        // Not the corrupt-key guidance, and it says so explicitly.
+        expect(res.error).not.toMatch(/delete .*exception\.key to mint/i);
+        expect(res.error).toMatch(/do not delete/i);
+        expect(await grants()).toHaveLength(0);
+      } finally {
+        chmodSync(keyFile(), 0o600); // so the tree can be removed
+      }
+    });
+  });
+
+  describe('a store that cannot be read fails closed with a message, not a crash', () => {
+    it('returns an error instead of rejecting when the ledger read throws', async () => {
+      // A Server Action that throws reaches the client as a framework error
+      // page, not the recovery guidance every other branch here returns. The
+      // store is replaced with bytes SQLite will refuse, which is the shape a
+      // truncated or byte-flipped store arrives in.
+      resetSingleton(); // close the handle before overwriting the file
+      writeFileSync(join(dir, 'aka.db'), 'not a database\n');
+      for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
+        rmSync(join(dir, sidecar), { force: true });
+      }
+
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/local store/i);
+    });
+
+    it('returns an error instead of rejecting when the ruleset read throws', async () => {
+      resetSingleton();
+      writeFileSync(join(dir, 'aka.db'), 'not a database\n');
+      for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
+        rmSync(join(dir, sidecar), { force: true });
+      }
+
+      const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
+      expect(res.ok).toBe(false);
+      expect(res.error).toMatch(/local store/i);
+      expect(res.error).not.toContain(VALUE);
+    });
+  });
+
+  describe('the guard is checked before the write, not with it', () => {
+    it('a rotation landing between the check and the write still writes a grant', async () => {
+      // An honest limitation pinned as a test rather than left implied. The
+      // version is read, then the grant is written; a rotation from another
+      // process (the CLI, another tab) in between lands a grant under the old
+      // version. The window is one store write wide on a single-operator local
+      // tool, and closing it needs the key read and the insert in one
+      // transaction — a seam the repository does not offer. If that seam
+      // arrives, this test is what should change.
+      const before = readFingerprintKey(dir)?.version ?? 0;
+      const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
+      expect(res).toEqual({ ok: true });
+
+      expect(await rotateKey(ROTATE_CONFIRMATION)).toEqual({ ok: true });
+      resetSingleton();
+
+      const grant = (await grants())[0];
+      expect(grant?.keyVersion).toBe(before);
+      // The grant is real but inert — exactly what a mid-flight rotation costs.
+      expect(await bundleIds(readFingerprintKey(dir)?.version ?? 0)).not.toContain(grant?.id);
     });
   });
 


### PR DESCRIPTION
Covers the two exception Server Actions that had no tests — `rotateKey` and `approveBlocked` — and fixes a defect that surfaced from testing them together.

## The fix

The blocked-detections ledger is retained for **24 hours**, so it outlives a fingerprint-key rotation — but `approveBlocked` copied the ledger row's `keyVersion` straight into the grant, while enforcement fingerprints under the *current* key and queries `activeBundleEntries(currentVersion)`.

So approving a pre-rotation row reported success and wrote a grant that was **inert the moment it was created**. One click away from the page, and strictly worse than an old grant going quietly inert, because the user had just deliberately created this one and the UI told them it worked.

`approveBlocked` now refuses a row whose key version is not current. It reads the version with `readFingerprintKey` rather than `loadOrCreateFingerprintKey`, so rejecting can't mint a key as a side effect — that would orphan every existing grant to answer a read. A missing or corrupt key file gets the same recovery guidance `addException` already used, now a shared constant rather than a duplicated string.

## Tests

`web-ui/test/actions/exceptions.test.ts`, **+43 tests (96 → 139)**, against a real `node:sqlite` store and a real key file — no mocking of either.

**`rotateKey` — one string compare from invalidating every grant**
- 7 near-miss tokens (`''`, `Rotate`, `ROTATE`, `␣rotate`, `rotate␣`, `rotate\n`, `rotate-key`) and 7 non-string payloads (`undefined`/`null`/array/object/`{toString:()=>'rotate'}`/number/`true`) — Server Actions are an RPC boundary, so the `string` in the signature is a compile-time claim the runtime never checks
- every rejection asserts the key file is **byte-identical** (not just the version — fresh material under an unchanged version would orphan grants just as thoroughly) and the existing grant is still in the evaluation bundle
- a rejected rotate on a keyless store mints nothing; the confirmation is checked before the key file is ever read
- rotation semantics: version bumps with fresh material · old grants stay listed and `revokedAt === null` for audit · absent from the current-version bundle but **still present under the old version**, so they went inert by key partitioning rather than deletion · the same value is grantable again afterwards (the documented recovery path)
- corrupt key → refuses to rotate and leaves the file intact
- the token the dialog makes the user type is pinned against the action through `ROTATE_CONFIRMATION`, so the two can't drift into a silently broken button

**`approveBlocked` — granting from the ledger, no value in play**
- permanent-scope confirmation rejected when missing, wrong, **the raw value**, another entry's masked value, or a non-string payload; accepted only on an exact match; a non-permanent scope ignores it entirely (pins the gate in both directions)
- the lookup window is the **retention** window, not the UI's filter chip: a 12-hour-old row is asserted invisible under every `BLOCKED_WINDOWS` chip except the widest — iterated from the product's own chip table so a future chip keeps the test honest — then approved successfully; paired with the far edge, a row past `BLOCKED_DETECTIONS_RETENTION_MS`
- `DuplicateActiveExceptionError` → the friendly message, with the raw `duplicate-active-exception` code asserted *not* to leak, and exactly one grant left
- the new key-version guard: rotated-away version, missing key file (and no replacement minted as a side effect), corrupt key file
- an honest note pinned as a test: `maskMatch` reveals only the first and last character, so distinct values routinely share a preview and the dialog displays it right above the box asking for it. The confirmation is a **deliberateness** gate, not proof of knowledge

## Verification

- `pnpm turbo run lint typecheck test` — 44/44 tasks green
- **Mutation-checked**: loosening the rotate compare to `String(x).trim().toLowerCase()`, swapping `recentBlocked(BLOCKED_DETECTIONS_RETENTION_MS)` back to the default window, and removing the key-version guard each produced failures (10 in total) — no new test is vacuous

## Notes for review

- **This bundles a behaviour fix with the tests that found it.** Splitting them would mean a first PR whose tests pin the dangling-grant behaviour as intended, then a second that reverses it and rewrites those same tests. Happy to split anyway if you'd rather keep the two apart.
- **Aging ledger rows needs a seam that doesn't exist yet.** `blocked_at` is stamped inside `recordBlocked` from an inline `Date.now()`, and `exceptions.ts` takes no injectable clock, so rows are aged with a `vi.spyOn(Date, 'now')` scoped to that single call — the DB handle opens *before* the spy, so migrations still stamp real times. It writes through the real repository rather than hand-rolled SQL, so the row shape can't drift. An injectable `now` on the repository (the pattern `activity.ts`/`detections.ts`/`resolutions.ts`/`security.ts` already use) would retire the workaround.

## Known gaps, deliberately not in this PR

1. **`aka exception approve` has the same defect.** `runApprove` in `cli/src/commands/exception.ts` copies `entry.keyVersion` with no check. Four of its five selection paths are unguarded; the by-raw-value fallback is protected only incidentally, because fingerprint matching requires the current key. Narrower window than the web surface — it calls `recentBlocked()` bare, so the default 30-minute TTL applies rather than the 24-hour retention window. Tracked separately.
2. **`RotateKeyDialog` doesn't warn about the ledger** — it lists the permanent grants rotation will orphan, but not that pending blocked rows become unapprovable. Cosmetic now that the action gives a clear error at the point of attempt.
3. **`revokeException` is still untested** — the remaining mutating action in this file.

---

## Follow-up commit — review fixes

A review of the first commit found the key-version guard was **not sound**: the version is not an identity for the key material, so the defect it was written to close was still reachable. Fixed here, along with the rest of the review.

### The version was not an identity (the important one)

`loadOrCreateFingerprintKey` minted **v1** whenever the key file was absent, and `rotateFingerprintKey` fell back to `(missing ?? 0) + 1` — also v1. So:

1. hook blocks a value → ledger row at `keyVersion: 1` (retained 24h)
2. `exception.key` is deleted — **which is what this PR's own corrupt-key guidance tells users to do**
3. the next mint (any hook, `addException`, or a rotate) comes back as v1 with *fresh* material
4. `1 === 1`, the guard passes, and the grant is inert the moment it is created

Confirmed by driving `approveBlocked` through it before the fix: `{ok: true}`, with `grant.valueFingerprint !== fingerprintValue(currentKey, VALUE)`.

**Fix:** a mint or rotate now takes the first version the store has not already claimed — `MAX(key_version)` across `exceptions` + `blocked_detections`. The store can answer because its rows outlive the key file. Read-only, only when the store already exists (resolving a key never creates one), and every failure degrades to the previous behaviour, because an unreadable store must not stop a hook minting the key it needs. That restores the version as a sound identity, which every existing version check — including bundle partitioning — was already assuming.

`isCurrentKeyVersion` now holds the "can this row still be matched" rule in one place, so the two approve surfaces cannot drift on it.

### `aka exception approve` no longer diverges

The CLI had the same defect and, worse, its by-value selector called `loadOrCreateFingerprintKey` — **minting a key as a side effect of a failed lookup**, the exact side effect the web action was written to avoid. Both fixed; the guard refuses before prompting for scope and reason.

The CLI's 30-minute picker window is **deliberately** left alone — it is documented on `BLOCKED_DETECTIONS_TTL_MS` and matches the command's own "Blocked in the last 30 minutes" copy. That is product behaviour, not the bug.

### Smaller fixes

- **"Delete the key file" was given for permissions errors too.** `readFingerprintKey` rethrows any non-`ENOENT` failure, so `EACCES`/`EIO` got the corrupt-key guidance — which destroys every grant on the machine to fix a chmod. Both surfaces now classify on `err.code`.
- **The ledger read and the installed-ruleset read were unguarded**, so a corrupt or locked store rejected the Server Action and reached the client as a framework error page rather than the guidance every other branch returns.
- **The blocked strip still offered Approve on rows the action always refuses.** Now disabled and annotated, via a pure `isBlockedRowApprovable` in `dashboard-ui/exceptions/meta.ts` (testable without a DOM, matching how `exceptionState` is handled).
- **Three of the `approveBlocked` non-string cases were vacuous** — `null`, `{}`, `{toString: () => 'x'}` all survive a `String(x) !==` mutation, so they could not catch the regression they named. Rebuilt so each payload *coerces to the masked value*, with the coercion asserted before the call.
- **The 0600 assertion passed vacuously on Windows.** Now `ctx.skip`.
- **The Windows CI comment was stale** — it pinned "20 tests" covering `addException` only.

### Also added

- A pinned test for the **check-then-write window**: the key version is read, then the grant is written, so a rotation landing in between still lands a grant under the old version. Narrow, single-operator, and closing it needs a key-read-plus-insert transaction the repository does not expose — recorded as a test rather than left implied.
- Store-fault coverage for both actions.

### Verification

- `pnpm turbo run lint typecheck test` — **44/44 green**
- **Mutation-checked, 6 mutations, all caught:** disabling the version floor (2 web + 3 CLI failures), coercing the confirmation compare (3), removing the store guards (2), collapsing the key-error classification (1), removing the CLI approve guard (3), restoring the minting by-value lookup (1)
- web-ui 149 tests · cli 51 · persistence fingerprint 21

### Not done

**No version bumps.** This touches `persistence`, `plugin-sdk` and `dashboard-ui`, which are bundled into both the CLI and the plugin — so per the release rules both need bumping *when you want to publish*, and that starts with you choosing the release type. Say the word and I'll do it.

---

## Third commit — a handle leak the Windows leg caught

The store-fault tests above passed their assertions on Windows and then **teardown** failed with `EPERM`: the temp tree still held an open handle on the store.

`openLocalDatabase` calls `new DatabaseSync(file)`, which succeeds even on a file that is not a database — SQLite does not read it until a statement runs — and then throws on the first `PRAGMA`, with the OS handle already ours and no reference left to close it. Measured on macOS with `lsof`: **five failed opens leave five descriptors** on the file; with the fix, zero.

This is pre-existing, but **this branch makes it easier to reach**: the dashboard memoizes its handle only on success, and `approveBlocked` now returns a message where it used to reject — so a user facing a corrupt store retries, and leaks another handle each time. On Windows each one keeps the file locked for the life of the process.

The fix closes the handle when a PRAGMA, the legacy-lineage reset, migrations, `tightenPerms`, or the default-policy seed throws; a cleanup failure never replaces the original error.

The regression test is **honest about being platform-split**, and says so in the file: on Windows the `afterEach` removal fails while a handle is open, which is what makes it a real guard there; on POSIX an open handle does not block `unlink`, so it only pins that the open fails loudly and repeatedly. A portable fd assertion would need `lsof` (macOS `/dev/fd` entries are not readable symlinks), which is too fragile to commit — the measurement above is the verification.
