### PR TITLE
chore(release): merge release/0.9.2 back to main

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Merge the tagged release/0.9.2 branch back to main.

Ships `0.9.2` across all three artifacts, all tagged from `ff28412`:

- `cli-v0.9.2` — @akasecurity/cli, npm `latest`
- `plugin-v0.9.2` — @akasecurity/ai-tc-claude-code, npm `latest` + GitHub Packages
- `bin-v0.9.2` — `aka` SEA binaries (4 platforms + SHA256SUMS)

The only change on this branch is the version bump in the three release files
(`cli/package.json`, `plugins/claude-code/package.json`,
`plugins/claude-code/.claude-plugin/plugin.json`).