### PR TITLE
ci(release): guard the release workflows with a concurrency group

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -19,6 +19,25 @@ on:
 permissions:
   contents: read
 
+# One release per tag at a time. A single tag push can start more than one run;
+# left unguarded they fan out in parallel and both reach the release job, where each
+# creates the same GitHub Release and force-moves `bin-latest` — a race on the
+# published assets and on the tag the install one-liners bootstrap from. Interleaving
+# two runs' uploads can pair binaries with a SHA256SUMS that does not describe them,
+# which the installers reject fail-closed.
+#
+# cancel-in-progress is false deliberately: interrupting a run midway through creating
+# the Release or moving `bin-latest` is worse than making it wait. This serializes
+# rather than deduplicates — a queued duplicate still runs once the first finishes and
+# replaces the assets with its own build, which stays self-consistent.
+#
+# The group is per-ref so a duplicate of the same tag queues behind its twin. A
+# workflow-wide group would also queue unrelated versions, and GitHub cancels a pending
+# run when a newer one joins the group — dropping a real release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: ${{ matrix.target }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -20,6 +20,18 @@ on:
         type: boolean
         default: false
 
+# One release per tag at a time. A single tag push can start more than one run.
+# A duplicate is already self-limiting here: npm rejects a re-publish of the same
+# (name, version), so the losing run fails at the publish step and never reaches the
+# `cli-latest` move or the Release. That safety is a consequence of publish running
+# first — this group holds whatever the step order, and stops two runs overlapping.
+# It does not make a duplicate disappear: the queued run still executes afterward and
+# still fails at publish. cancel-in-progress is false so a run is never interrupted
+# midway through publishing or force-moving a tag.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Tag pushes get no run of the main CI workflow (it triggers only on main
   # pushes/PRs), so the release re-verifies the tagged commit itself — nothing

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -22,6 +22,18 @@ on:
         type: boolean
         default: false
 
+# One release per tag at a time. A single tag push can start more than one run.
+# A duplicate is already self-limiting here: npm and GitHub Packages both reject a
+# re-publish of the same (name, version), so the losing run fails at its publish step
+# and never reaches the Release. That safety is a consequence of publish running
+# before the Release step — this group holds whatever the step order, and stops two
+# runs overlapping. It does not make a duplicate disappear: the queued run still
+# executes afterward and still fails at publish. cancel-in-progress is false so a run
+# is never interrupted midway through publishing to either registry.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # Tag pushes get no run of the main CI workflow (it triggers only on main
   # pushes/PRs), so the release re-verifies the tagged commit itself — nothing

--- a/.github/workflows/release-rules.yml
+++ b/.github/workflows/release-rules.yml
@@ -23,6 +23,16 @@ on:
 permissions:
   contents: read
 
+# One release per tag at a time. A single tag push can start more than one run, and
+# each notifies the publisher repo. The registry treats published (pack, version)
+# pairs as immutable, so a duplicate dispatch re-publishes nothing — this group
+# serializes the runs rather than letting two publisher jobs overlap.
+# cancel-in-progress is false so a run is never interrupted between the fixture gate
+# and the dispatch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Validate · Publish


### PR DESCRIPTION
## Summary

None of the four release workflows had a `concurrency:` block, so nothing stopped two
runs of the same workflow existing at once. During the 0.9.2 release a single
`git push origin bin-v0.9.2` started **two identical runs 16 seconds apart** — both
`event=push`, both on the same commit. One had to be cancelled by hand.

This adds a per-ref concurrency group to all four, with `cancel-in-progress: false`.

## Why `release-binaries.yml` is the real fix

Left alone, both runs fan out to four native binary builds each and then both reach
`Gather · Release`, where each one:

- creates the same GitHub Release via `softprops/action-gh-release`, and
- runs `git tag -f bin-latest && git push -f origin bin-latest`

That is a race on the published release assets and on the `bin-latest` tag that the
curl installer one-liners fetch their bootstrap script from. The specific hazard is
interleaved uploads pairing binaries with a `SHA256SUMS` that does not describe them —
the installers verify against it and fail closed, so the install one-liner breaks.

## Why the other three are included anyway

They are **not** racing today, and the PR does not claim otherwise:

| Workflow | Duplicate-run outcome |
| --- | --- |
| `release-cli.yml` | `npm publish` runs *before* the `cli-latest` move and the Release. npm rejects a duplicate `(name, version)` atomically, so the losing run fails at publish and every later step is skipped. |
| `release-plugin.yml` | Same shape; the parallel GitHub Packages job fails the same way. |
| `release-rules.yml` | Dispatches a publisher repo; the registry treats published `(pack, version)` pairs as immutable, so a duplicate dispatch re-publishes nothing. |

The reason to guard them is that **the current safety is a consequence of step ordering,
not of a stated invariant**. Publish happens to come before the Release creation and the
tag move. Reorder those steps — or add a step that writes something before publishing —
and the protection silently disappears with no test to catch it. The group holds either
way.

## What this does and does not do

`cancel-in-progress: false` is deliberate: interrupting a run midway through creating a
Release or force-moving `bin-latest` is worse than making it wait. The consequence is
that this **serializes rather than deduplicates** — a queued duplicate still runs once
the first finishes. For binaries it then replaces the assets with its own build, which
is internally self-consistent (binaries and `SHA256SUMS` replaced together), so the
installer still verifies. For the npm workflows the queued run still fails at publish
with "already published", so it does not remove that red check either.

The group is per-ref rather than workflow-wide on purpose. GitHub cancels a *pending*
run when a newer one joins the same group, so a workflow-wide group would let an
unrelated version's release get silently dropped while queued. Per-ref means only a
duplicate of the same tag ever queues behind its twin, which is exactly the case where
dropping it is correct.

## Side effect worth noting

Cancelling a duplicate run by hand leaves its jobs reporting as **FAILED** against that
commit, which then shows red on the release merge-back PR's check list — noise that has
nothing to do with the release. A concurrency guard avoids creating that noise in the
first place, since there is no run to cancel.

## Verification

- All eight workflow files parse; `on:`, `jobs:` and the new `concurrency:` keys are
  intact (checked with a real YAML parser, not a grep).
- The group expression `${{ github.workflow }}-${{ github.ref }}` matches the existing
  house style in `ci.yml` and `internal-path-guard.yml` byte-for-byte; only
  `cancel-in-progress` differs (`false` here vs `true` there, since release runs must
  not be interrupted).
- `prettier --check` clean on all four files; `pnpm lint` passes.

## Follow-up

The manual "check that the tag started exactly one run, and cancel the duplicate" step
in the release procedure can be dropped once this lands.
