### PR TITLE
feat(ci): audit the shipped CLI's npm resolution in the dependency gate

### DIFF
--- a/.github/audit-waivers.json
+++ b/.github/audit-waivers.json
@@ -2,9 +2,31 @@
   "waivers": [
     {
       "advisory": "GHSA-mh99-v99m-4gvg",
+      "scope": "workspace",
       "module": "brace-expansion",
       "reason": "No patched release on the 1.x line — the fix ships only in 5.0.8, and the advisory's <=5.0.7 range sweeps every earlier major. The 1.x copy is reached solely through eslint > minimatch@3 (lint-time dev tooling, not part of any shipped bundle); the fix becomes reachable only via the ESLint 10 major bump tracked separately — drop this waiver when that lands.",
       "expires": "2026-08-26"
+    },
+    {
+      "advisory": "GHSA-6g55-p6wh-862q",
+      "scope": "artifact",
+      "module": "postcss",
+      "reason": "The fix ships in postcss 8.5.12, but next 15.5.x pins postcss at exactly 8.4.31 and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
+      "expires": "2026-08-28"
+    },
+    {
+      "advisory": "GHSA-r28c-9q8g-f849",
+      "scope": "artifact",
+      "module": "postcss",
+      "reason": "The fix ships in postcss 8.5.18, but next 15.5.x pins postcss at exactly 8.4.31 and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
+      "expires": "2026-08-28"
+    },
+    {
+      "advisory": "GHSA-f88m-g3jw-g9cj",
+      "scope": "artifact",
+      "module": "sharp",
+      "reason": "The fix ships in sharp 0.35.0, but next 15.5.x declares sharp ^0.34.x and an end-user install resolves next's own range, so neither a direct dependency nor a workspace override reaches it; the dashboard has no next/image usage, so sharp is never loaded at runtime. Bump next once it allows sharp >=0.35.0.",
+      "expires": "2026-08-28"
     }
   ]
 }

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,11 +1,14 @@
 name: Dependency audit
 
-# Gates every change on `pnpm audit`: a high or critical advisory without an
-# unexpired waiver in .github/audit-waivers.json fails the check. The daily
-# schedule catches advisories published between merges — a scheduled failure
-# opens (or updates) an issue labeled `security-advisory` instead of failing
-# invisibly. The gate lives in tools/audit-gate (a workspace package with its
-# own unit suite); the waiver process is documented in CONTRIBUTING.md.
+# Gates every change on two audits: `pnpm audit` over the workspace lockfile,
+# and `npm audit` over the resolution an end user gets from installing the
+# published CLI (whose runtime ranges — e.g. next's own pins — the workspace
+# lockfile never covers). A high or critical advisory without an unexpired
+# waiver in .github/audit-waivers.json fails the check. The daily schedule
+# catches advisories published between merges — a scheduled failure opens (or
+# updates) an issue labeled `security-advisory` instead of failing invisibly.
+# The gate lives in tools/audit-gate (a workspace package with its own unit
+# suite); the waiver process is documented in CONTRIBUTING.md.
 
 on:
   push:
@@ -40,17 +43,27 @@ jobs:
         with:
           node-version: 24
 
-      # The audit reads the lockfile only — no `pnpm install` needed. Node 24
-      # runs the TypeScript entry directly (type stripping).
-      - name: Audit dependencies (high/critical gate, waiver-aware)
+      # The workspace audit reads the lockfile only — no `pnpm install`
+      # needed. Node 24 runs the TypeScript entry directly (type stripping).
+      - name: Audit workspace dependencies (high/critical gate, waiver-aware)
         run: node tools/audit-gate/src/audit-dependencies.ts
 
-      - name: Publish the report to the run summary
+      # The artifact audit resolves cli/package.json's runtime dependencies
+      # with npm in a temp dir — the tree an end-user install produces. It runs
+      # even when the workspace audit fails, so one run surfaces both signals.
+      - name: Audit shipped-artifact resolution (high/critical gate, waiver-aware)
+        if: ${{ !cancelled() }}
+        run: node tools/audit-gate/src/audit-dependencies.ts --artifact
+
+      - name: Publish the reports to the run summary
         if: always()
         run: |
-          if [ -f audit-report.md ]; then
-            cat audit-report.md >> "$GITHUB_STEP_SUMMARY"
-          fi
+          for report in audit-report.md artifact-audit-report.md; do
+            if [ -f "$report" ]; then
+              cat "$report" >> "$GITHUB_STEP_SUMMARY"
+              printf '\n' >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
 
   # Scheduled runs must not fail silently: surface a failing daily audit as a
   # tracked issue. PR runs skip this — the red check on the PR is the signal.
@@ -74,15 +87,25 @@ jobs:
         with:
           node-version: 24
 
-      # Re-run the audit to regenerate the report — cheaper than artifact
-      # plumbing, and the audit reads only the lockfile. The exit code is
-      # captured so the issue title matches what actually happened: 1 means
-      # real blocking advisories, anything else means the audit itself failed.
-      - name: Regenerate the audit report
+      # Re-run both audits to regenerate the reports — cheaper than artifact
+      # plumbing between jobs. The exit codes are folded into one so the issue
+      # title matches what actually happened: 1 (either audit found blocking
+      # advisories) wins over an incomplete audit, and 0 means both re-runs
+      # came back clean.
+      - name: Regenerate the audit reports
         id: rerun
         run: |
-          code=0
-          node tools/audit-gate/src/audit-dependencies.ts || code=$?
+          code_ws=0
+          node tools/audit-gate/src/audit-dependencies.ts || code_ws=$?
+          code_art=0
+          node tools/audit-gate/src/audit-dependencies.ts --artifact || code_art=$?
+          if [ "$code_ws" = "1" ] || [ "$code_art" = "1" ]; then
+            code=1
+          elif [ "$code_ws" != "0" ]; then
+            code=$code_ws
+          else
+            code=$code_art
+          fi
           echo "code=$code" >> "$GITHUB_OUTPUT"
 
       # Skips when the re-run comes back clean (the earlier failure was a
@@ -102,7 +125,12 @@ jobs:
             title='Dependency audit could not complete'
           fi
           {
-            cat audit-report.md
+            for report in audit-report.md artifact-audit-report.md; do
+              if [ -f "$report" ]; then
+                cat "$report"
+                printf '\n'
+              fi
+            done
             printf '\n_Scheduled audit run: %s_\n' "$run_url"
           } > issue-body.md
 
@@ -124,7 +152,7 @@ jobs:
               --label security-advisory \
               --body-file issue-body.md
           elif [ "$RERUN_CODE" = "1" ]; then
-            new_ids="$(grep -o 'GHSA-[a-z0-9-]*' audit-report.md | sort -u || true)"
+            new_ids="$(cat audit-report.md artifact-audit-report.md 2>/dev/null | grep -o 'GHSA-[a-z0-9-]*' | sort -u || true)"
             seen_ids="$( { gh issue view "$existing" --repo "$GITHUB_REPOSITORY" --json body --jq '.body'; \
                            gh issue view "$existing" --repo "$GITHUB_REPOSITORY" --json comments --jq '.comments[].body'; } \
                          | grep -o 'GHSA-[a-z0-9-]*' | sort -u || true)"

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ plugins/claude-code/scripts/
 
 # written by tools/audit-gate on every run, always at the repo root
 /audit-report.md
+/artifact-audit-report.md
 
 # Per-developer Claude Code settings (plugin enablement etc.) stay local.
 .claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,21 +57,30 @@ The OSS product is **local-only**: it runs on Node + the SQLite store under `~/.
 4. **Git-style external subcommand dispatch** (`cli/src/lib/external-dispatch.ts`). `aka <name>` execs `aka-<name>` from the user's `PATH` when no built-in owns the name, inheriting the caller's environment and stdio. The child is resolved by name at call time — this repo does not bundle, depend on, verify or version-pin it — so its behaviour, including any network access, is outside what this codebase can describe. AKA Security ships one intended occupant, `aka-claude` from `claude-tools`, which launches a Claude Code profile and is network-bound by definition; the dispatch gives it no special status, and any other `aka-*` on `PATH` runs identically. A built-in always wins, so this can never shadow a shipped command, and the path is POSIX-only (disabled on win32). An allowlist or provenance check is a deliberate non-goal: the precondition for abuse is write access to a `PATH` directory, which already permits shadowing `aka` itself. The invariant that is enforced is that a built-in always wins.
 
 These are the **shipped product's** egress paths. Repo CI additionally talks to the npm
-registry: `.github/workflows/audit.yml` runs `pnpm audit` (via `tools/audit-gate`) on every
+registry: `.github/workflows/audit.yml` (via `tools/audit-gate`) runs `pnpm audit` on every
 PR and daily, sending the workspace dependency graph — package names and versions,
-including the `@akasecurity/*` workspace importers — to the registry's audit endpoint.
-That is repository tooling, not a product path; nothing a user installs performs it.
+including the `@akasecurity/*` workspace importers — to the registry's audit endpoint; it
+also resolves and audits the published CLI's runtime dependency ranges with `npm` in a
+temp dir, sending that (public-package) graph the same way. That is repository tooling,
+not a product path; nothing a user installs performs it.
 
 ## Dependency advisories
 
-CI gates every PR (and a daily run) on `pnpm audit` via `tools/audit-gate`: a **high or
-critical** advisory in `pnpm-lock.yaml` fails the check, so a new or bumped dependency
-that carries one will not merge. Fix by upgrading, or by raising a floor in the root
-`pnpm.overrides` (the existing entries there are exactly such floors). Only when an
-advisory has no fixed release reachable from the tree, add an **expiring** waiver to
-`.github/audit-waivers.json` — format and process in CONTRIBUTING.md ("Dependency
-advisories and waivers"). `pnpm.auditConfig.ignoreCves`/`ignoreGhsas` is not an approved
-suppression route: the gate refuses to run while anything is muted there.
+CI gates every PR (and a daily run) on two audits via `tools/audit-gate`: `pnpm audit`
+over `pnpm-lock.yaml`, and `npm audit` over an end-user resolution of the published
+CLI's runtime `dependencies` (`--artifact` mode — coverage the workspace lockfile
+cannot provide, since consumers re-resolve the published ranges and `pnpm.overrides`
+do not reach them). A **high or critical** advisory in either fails the check, so a
+new or bumped dependency that carries one will not merge. Fix a workspace hit by
+upgrading, or by raising a floor in the root `pnpm.overrides` (the existing entries
+there are exactly such floors); fix an artifact hit by raising the range in
+`cli/package.json` — or, when the vulnerable copy is pinned by another package (e.g.
+next's own pins), by bumping that package once upstream moves. Only when an advisory
+has no fixed release reachable from the tree, add an **expiring** waiver to
+`.github/audit-waivers.json`, scoped to the audit it applies to — format and process
+in CONTRIBUTING.md ("Dependency advisories and waivers").
+`pnpm.auditConfig.ignoreCves`/`ignoreGhsas` is not an approved suppression route: the
+gate refuses to run while anything is muted there.
 
 ## Package dependency rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,28 +37,39 @@ comments factual and reader-facing — no internal narration.
 Two security workflows run alongside the main build:
 
 - **Dependency audit** (`.github/workflows/audit.yml`, gate logic in
-  `tools/audit-gate`) — `pnpm audit` on every PR and daily against `main`. Any **high or
-  critical** advisory fails the check; moderate and below are listed in the run summary
-  but do not block. A failing daily run opens (or updates) an issue labeled
-  `security-advisory`, so an advisory published between merges is surfaced without
-  waiting for the next PR — and it only adds a comment when a **new** advisory id
-  appears, so a known long-lived finding does not ping daily.
+  `tools/audit-gate`) — two audits on every PR and daily against `main`. The
+  **workspace audit** runs `pnpm audit` over the workspace lockfile. The **artifact
+  audit** runs `npm audit` over the resolution an end user gets from installing the
+  published `@akasecurity/cli`: it resolves the CLI's runtime `dependencies` with npm
+  in a temp dir, so advisories reachable only through the published ranges (e.g.
+  next's own pins) are caught too. In both, any **high or critical** advisory fails
+  the check; moderate and below are listed in the run summary but do not block. A
+  failing daily run opens (or updates) an issue labeled `security-advisory`, so an
+  advisory published between merges is surfaced without waiting for the next PR — and
+  it only adds a comment when a **new** advisory id appears, so a known long-lived
+  finding does not ping daily.
 - **CodeQL** (`.github/workflows/codeql.yml`) — static analysis of the TypeScript
   workspace and the workflow files on every PR to `main` and weekly; findings appear
   under the repository's **Security** tab.
 
-When the audit fails, fix first: upgrade the dependency, or raise its floor via
-`pnpm.overrides` in the root `package.json` (the existing entries there are exactly such
-floors). Note that overrides — and the audit itself — cover the **workspace lockfile**;
-end-user installs of the published packages resolve the published dependency ranges,
-which overrides do not reach. Only when an advisory has **no fixed release** reachable from our dependency
-tree, add a waiver to `.github/audit-waivers.json`:
+When the workspace audit fails, fix first: upgrade the dependency, or raise its floor
+via `pnpm.overrides` in the root `package.json` (the existing entries there are exactly
+such floors). Note that overrides cover the **workspace lockfile only**; end-user
+installs of the published packages resolve the published dependency ranges, which
+overrides do not reach — that consumer-side exposure is what the artifact audit gates.
+When the **artifact audit** fails, the fix is raising the affected range in
+`cli/package.json` `dependencies` so a fresh `npm install` resolves a patched release;
+a copy nested under another package (npm keeps e.g. next's exact pins under
+`node_modules/next/node_modules/`) can only be fixed by bumping that package once
+upstream raises its own pin. Only when an advisory has **no fixed release** reachable
+from our dependency tree, add a waiver to `.github/audit-waivers.json`:
 
 ```json
 {
   "waivers": [
     {
       "advisory": "GHSA-xxxx-xxxx-xxxx",
+      "scope": "workspace",
       "module": "left-pad",
       "reason": "Why this is unfixable today and why the exposure is acceptable.",
       "expires": "2026-08-31"
@@ -67,7 +78,12 @@ tree, add a waiver to `.github/audit-waivers.json`:
 }
 ```
 
-- `advisory` is the GHSA id (preferred) or a CVE id.
+- `advisory` is the GHSA id (preferred) or a CVE id. The artifact audit (npm's v2
+  report format) exposes only GHSA ids, so an artifact-scoped waiver must use the
+  GHSA id.
+- `scope` is **required**: `"workspace"` or `"artifact"`, naming the audit the waiver
+  applies to. An advisory hitting both audits takes one entry per scope. Scoping keeps
+  stale-waiver detection exact — each run judges only its own waivers.
 - `module` is optional but recommended: it pins the waiver to one package name, so the
   same advisory id resurfacing through a different package is not silently suppressed.
 - `expires` is **required** — keep it short (about 30 days). The date is **inclusive**

--- a/tools/audit-gate/src/audit-dependencies.ts
+++ b/tools/audit-gate/src/audit-dependencies.ts
@@ -1,40 +1,69 @@
 #!/usr/bin/env node
-// CI gate over `pnpm audit`: fails when the lockfile carries a high or
+// CI gate over the dependency audits: fails when an audit carries a high or
 // critical advisory without an unexpired waiver in .github/audit-waivers.json.
-// Lower severities never block; they appear in the report only. The audit
-// works from the lockfile alone, so no `pnpm install` is required first.
+// Lower severities never block; they appear in the report only. Two modes:
 //
-// Always writes audit-report.md at the repository root — the workflow appends
-// it to the run summary, and the scheduled run posts it to the
-// advisory-tracking issue. The waiver format and process are documented in
-// CONTRIBUTING.md ("Dependency advisories and waivers").
+//   (default)    `pnpm audit` over the workspace lockfile. Works from the
+//                lockfile alone, so no `pnpm install` is required first.
+//   --artifact   `npm audit` over the resolution an end user gets from
+//                `npm install @akasecurity/cli`. Consumers re-resolve the
+//                published runtime ranges (e.g. next's own pins), which the
+//                workspace lockfile and `pnpm.overrides` never reach: this
+//                mode writes cli/package.json's runtime "dependencies" to a
+//                temp manifest, resolves it with
+//                `npm install --package-lock-only`, and audits that lockfile.
+//
+// Each mode writes its report at the repository root (audit-report.md /
+// artifact-audit-report.md) — the workflow appends them to the run summary,
+// and the scheduled run posts them to the advisory-tracking issue. The waiver
+// format and process are documented in CONTRIBUTING.md ("Dependency
+// advisories and waivers"); every waiver names the mode it applies to via
+// "scope", so a waiver held for one audit is never flagged stale by the other.
 //
 // Exit codes:
 //   0 — no blocking advisories (clean, or every hit waived)
 //   1 — at least one unwaived high/critical advisory
 //   2 — the audit could not be completed (transient; retried, then fails closed)
-//   3 — invalid gate configuration (waiver file, or pnpm.auditConfig mutes) —
-//       deterministic, not worth retrying
+//   3 — invalid gate configuration (waiver file, pnpm.auditConfig mutes, or an
+//       unauditable cli manifest) — deterministic, not worth retrying
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
   assertNothingMuted,
+  type AuditMode,
   type AuditPayload,
   buildReport,
   classify,
+  normalizeNpmAudit,
   parseAuditPayload,
+  parseNpmAuditPayload,
+  REPORT_STYLES,
   validateWaivers,
   type Waiver,
   WaiverConfigError,
+  waiversFor,
 } from './lib.ts';
 
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const WAIVERS_PATH = join(REPO_ROOT, '.github', 'audit-waivers.json');
-const REPORT_PATH = join(REPO_ROOT, 'audit-report.md');
+const CLI_MANIFEST_PATH = join(REPO_ROOT, 'cli', 'package.json');
+const REPORT_PATHS: Record<AuditMode, string> = {
+  workspace: join(REPO_ROOT, 'audit-report.md'),
+  artifact: join(REPO_ROOT, 'artifact-audit-report.md'),
+};
+
+const SPAWN_OPTIONS = {
+  encoding: 'utf8',
+  maxBuffer: 64 * 1024 * 1024,
+  // On Windows pnpm and npm are .cmd shims, which spawnSync only resolves
+  // through a shell.
+  shell: process.platform === 'win32',
+} as const;
 
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -50,24 +79,15 @@ function sleepMs(ms: number): void {
 
 // The npm audit endpoint is a separate — and historically flakier — service
 // from the tarball CDN, and this runs as a required check: a single transport
-// blip should not block every merge. Three attempts, then fail closed.
-function runAudit(): AuditPayload {
+// blip should not block every merge. Three attempts, then fail closed. A
+// WaiverConfigError is deterministic and rethrown without retrying.
+function withRetries<T>(attemptFn: () => T): T {
   let lastError: unknown;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
-      const result = spawnSync('pnpm', ['audit', '--json'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-        maxBuffer: 64 * 1024 * 1024,
-        // On Windows pnpm is a .cmd shim, which spawnSync only resolves
-        // through a shell.
-        shell: process.platform === 'win32',
-      });
-      if (result.error) {
-        throw new Error(`could not spawn pnpm: ${result.error.message}`);
-      }
-      return parseAuditPayload(result.stdout, result.stderr);
+      return attemptFn();
     } catch (error) {
+      if (error instanceof WaiverConfigError) throw error;
       lastError = error;
       if (attempt < 3) sleepMs(attempt * 2000);
     }
@@ -75,59 +95,127 @@ function runAudit(): AuditPayload {
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
-function failReport(message: string, exitCode: number): void {
+function runWorkspaceAudit(): AuditPayload {
+  return withRetries(() => {
+    const result = spawnSync('pnpm', ['audit', '--json'], { ...SPAWN_OPTIONS, cwd: REPO_ROOT });
+    if (result.error) {
+      throw new Error(`could not spawn pnpm: ${result.error.message}`);
+    }
+    const payload = parseAuditPayload(result.stdout, result.stderr);
+    assertNothingMuted(payload);
+    return payload;
+  });
+}
+
+function loadCliRuntimeDependencies(): Record<string, string> {
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(CLI_MANIFEST_PATH, 'utf8'));
+  } catch (error) {
+    throw new WaiverConfigError(`cannot read cli/package.json: ${errorMessage(error)}`);
+  }
+  const dependencies = (manifest as { dependencies?: unknown } | null)?.dependencies;
+  if (
+    dependencies === null ||
+    typeof dependencies !== 'object' ||
+    Object.keys(dependencies).length === 0
+  ) {
+    throw new WaiverConfigError('cli/package.json has no runtime "dependencies" to audit');
+  }
+  return dependencies as Record<string, string>;
+}
+
+function runArtifactAudit(): AuditPayload {
+  const dependencies = loadCliRuntimeDependencies();
+  return withRetries(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'artifact-audit-'));
+    try {
+      writeFileSync(
+        join(dir, 'package.json'),
+        JSON.stringify(
+          { name: 'artifact-audit', version: '0.0.0', private: true, dependencies },
+          null,
+          2,
+        ) + '\n',
+      );
+      const install = spawnSync(
+        'npm',
+        ['install', '--package-lock-only', '--ignore-scripts', '--no-audit', '--no-fund'],
+        { ...SPAWN_OPTIONS, cwd: dir },
+      );
+      if (install.error) {
+        throw new Error(`could not spawn npm: ${install.error.message}`);
+      }
+      if (install.status !== 0) {
+        const detail = (install.stderr || install.stdout || '').trim().slice(0, 400);
+        throw new Error(`npm could not resolve the artifact dependency tree: ${detail}`);
+      }
+      const result = spawnSync('npm', ['audit', '--json'], { ...SPAWN_OPTIONS, cwd: dir });
+      if (result.error) {
+        throw new Error(`could not spawn npm: ${result.error.message}`);
+      }
+      return normalizeNpmAudit(parseNpmAuditPayload(result.stdout, result.stderr));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+}
+
+function failReport(mode: AuditMode, message: string, exitCode: number): void {
   writeFileSync(
-    REPORT_PATH,
-    `# Dependency audit\n\n**Audit could not be completed.** ${message}\n`,
+    REPORT_PATHS[mode],
+    `# ${REPORT_STYLES[mode].title}\n\n**Audit could not be completed.** ${message}\n`,
   );
-  print(`::error::dependency audit could not be completed: ${message}`);
+  print(`::error::${mode} dependency audit could not be completed: ${message}`);
   process.exitCode = exitCode;
 }
 
 function main(): void {
+  const mode: AuditMode = process.argv.includes('--artifact') ? 'artifact' : 'workspace';
+  const reportPath = REPORT_PATHS[mode];
+
   let waivers: Waiver[];
   try {
     waivers = validateWaivers(JSON.parse(readFileSync(WAIVERS_PATH, 'utf8')));
   } catch (error) {
-    failReport(`invalid waiver config: ${errorMessage(error)}`, 3);
+    failReport(mode, `invalid waiver config: ${errorMessage(error)}`, 3);
     return;
   }
 
   let payload: AuditPayload;
   try {
-    payload = runAudit();
-    assertNothingMuted(payload);
+    payload = mode === 'artifact' ? runArtifactAudit() : runWorkspaceAudit();
   } catch (error) {
-    failReport(errorMessage(error), error instanceof WaiverConfigError ? 3 : 2);
+    failReport(mode, errorMessage(error), error instanceof WaiverConfigError ? 3 : 2);
     return;
   }
 
   const today = new Date().toISOString().slice(0, 10);
-  const classification = classify(payload, waivers, today);
+  const classification = classify(payload, waiversFor(mode, waivers), today);
   const { blocking, waived, nonBlocking, stale } = classification;
 
   const counts = payload.metadata?.vulnerabilities ?? {};
-  writeFileSync(REPORT_PATH, buildReport({ counts, ...classification }) + '\n');
+  writeFileSync(reportPath, buildReport({ mode, counts, ...classification }) + '\n');
 
   for (const advisory of blocking) {
     const id = advisory.github_advisory_id ?? String(advisory.id ?? '');
     print(
-      `::error::${advisory.severity ?? ''} advisory ${id} in ${advisory.module_name ?? ''} — ${advisory.title ?? ''} (${advisory.url ?? ''})`,
+      `::error::[${mode}] ${advisory.severity ?? ''} advisory ${id} in ${advisory.module_name ?? ''} — ${advisory.title ?? ''} (${advisory.url ?? ''})`,
     );
   }
   for (const { waiver, why } of stale) {
-    print(`::notice::stale audit waiver ${waiver.advisory} — ${why}`);
+    print(`::notice::stale ${mode} audit waiver ${waiver.advisory} — ${why}`);
   }
 
   if (blocking.length > 0) {
     print(
-      `Dependency audit failed: ${String(blocking.length)} blocking advisor${blocking.length === 1 ? 'y' : 'ies'} (see audit-report.md).`,
+      `Dependency audit (${mode}) failed: ${String(blocking.length)} blocking advisor${blocking.length === 1 ? 'y' : 'ies'} (see ${basename(reportPath)}).`,
     );
     process.exitCode = 1;
     return;
   }
   print(
-    `Dependency audit passed: ${String(waived.length)} waived, ${String(nonBlocking.length)} below the gate.`,
+    `Dependency audit (${mode}) passed: ${String(waived.length)} waived, ${String(nonBlocking.length)} below the gate.`,
   );
 }
 

--- a/tools/audit-gate/src/lib.ts
+++ b/tools/audit-gate/src/lib.ts
@@ -1,7 +1,14 @@
-// Pure logic for the dependency-audit CI gate: waiver validation, `pnpm audit`
-// payload parsing, advisory classification, and Markdown report generation.
-// The CLI entry (audit-dependencies.ts) owns all I/O; everything here is
-// side-effect-free so the unit suite can drive it with canned payloads.
+// Pure logic for the dependency-audit CI gate: waiver validation, audit
+// payload parsing (pnpm's v1 format and npm's v2 format), advisory
+// classification, and Markdown report generation. The CLI entry
+// (audit-dependencies.ts) owns all I/O; everything here is side-effect-free
+// so the unit suite can drive it with canned payloads.
+
+// The gate runs in one of two modes — `pnpm audit` over the workspace
+// lockfile, or `npm audit` over an end-user resolution of the published CLI's
+// runtime dependencies — and every waiver names the mode it applies to.
+export const AUDIT_MODES = ['workspace', 'artifact'] as const;
+export type AuditMode = (typeof AUDIT_MODES)[number];
 
 export interface AuditAdvisory {
   id?: number;
@@ -22,6 +29,7 @@ export interface AuditPayload {
 
 export interface Waiver {
   advisory: string;
+  scope: AuditMode;
   reason: string;
   expires: string;
   module?: string;
@@ -70,6 +78,11 @@ export function validateWaivers(raw: unknown): Waiver[] {
     const waiver = entry as Partial<Waiver>;
     if (typeof waiver.advisory !== 'string' || waiver.advisory.trim() === '') {
       throw new WaiverConfigError('every waiver needs an "advisory" (a GHSA or CVE id)');
+    }
+    if (waiver.scope !== 'workspace' && waiver.scope !== 'artifact') {
+      throw new WaiverConfigError(
+        `waiver ${waiver.advisory} needs a "scope" ("workspace" or "artifact")`,
+      );
     }
     if (typeof waiver.reason !== 'string' || waiver.reason.trim() === '') {
       throw new WaiverConfigError(`waiver ${waiver.advisory} needs a non-empty "reason"`);
@@ -124,6 +137,87 @@ export function parseAuditPayload(stdout: string, stderr = ''): AuditPayload {
   return parsed as AuditPayload;
 }
 
+// npm emits the v2 audit format instead: a "vulnerabilities" map keyed by
+// package name, each entry's "via" mixing advisory objects with plain
+// package-name strings (transitive links). Only the objects are advisories;
+// they carry no CVE list, so an artifact-scoped waiver must use the GHSA id.
+export interface NpmAuditVia {
+  source?: number;
+  name?: string;
+  title?: string;
+  url?: string;
+  severity?: string;
+  range?: string;
+}
+
+export interface NpmAuditEntry {
+  name?: string;
+  severity?: string;
+  via?: (NpmAuditVia | string)[];
+  nodes?: string[];
+}
+
+export interface NpmAuditPayload {
+  vulnerabilities: Record<string, NpmAuditEntry>;
+  metadata?: { vulnerabilities?: Record<string, number> };
+}
+
+// The same completed-audit test as parseAuditPayload, for npm's v2 output:
+// JSON that carries a "vulnerabilities" object and no top-level "error".
+export function parseNpmAuditPayload(stdout: string, stderr = ''): NpmAuditPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    const detail = (stderr || stdout || '').trim().slice(0, 400);
+    throw new Error(`npm audit did not return JSON (registry unreachable?): ${detail}`);
+  }
+  if (
+    parsed === null ||
+    typeof parsed !== 'object' ||
+    'error' in parsed ||
+    !('vulnerabilities' in parsed)
+  ) {
+    const transport = (parsed as { error?: { code?: string; summary?: string } } | null)?.error;
+    const detail = transport
+      ? `${transport.code ?? ''} ${transport.summary ?? ''}`.trim()
+      : 'output has no "vulnerabilities" field';
+    throw new Error(`npm audit did not complete: ${detail.slice(0, 400)}`);
+  }
+  return parsed as NpmAuditPayload;
+}
+
+const GHSA_URL = /\/advisories\/(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})$/i;
+
+// Reduces an npm v2 payload to the AuditPayload shape pnpm produces, so
+// classification and reporting are shared across both modes. Each advisory
+// object becomes one entry keyed by advisory id and package, and the entry's
+// resolved node paths stand in for pnpm's dependency paths. npm's counts
+// carry a "total" the pnpm format does not; it is dropped so the report's
+// totals line reads the same in both modes.
+export function normalizeNpmAudit(payload: NpmAuditPayload): AuditPayload {
+  const advisories: Record<string, AuditAdvisory> = {};
+  for (const entry of Object.values(payload.vulnerabilities)) {
+    for (const via of entry.via ?? []) {
+      if (typeof via !== 'object') continue;
+      const ghsa = GHSA_URL.exec(via.url ?? '')?.[1];
+      const module = via.name ?? entry.name;
+      const key = `${ghsa ?? String(via.source ?? '')}:${module ?? ''}`;
+      const normalized: AuditAdvisory = { cves: [], findings: [{ paths: entry.nodes ?? [] }] };
+      if (via.source !== undefined) normalized.id = via.source;
+      if (ghsa !== undefined) normalized.github_advisory_id = ghsa;
+      if (module !== undefined) normalized.module_name = module;
+      if (via.severity !== undefined) normalized.severity = via.severity;
+      if (via.title !== undefined) normalized.title = via.title;
+      if (via.url !== undefined) normalized.url = via.url;
+      advisories[key] ??= normalized;
+    }
+  }
+  const counts = { ...(payload.metadata?.vulnerabilities ?? {}) };
+  delete counts.total;
+  return { advisories, metadata: { vulnerabilities: counts } };
+}
+
 // pnpm's own suppression channel (`pnpm.auditConfig.ignoreCves`/`ignoreGhsas`)
 // filters advisories out of the payload and into `muted` — with no expiry, no
 // reason, and no report row. The gate refuses to run while anything is muted
@@ -136,6 +230,12 @@ export function assertNothingMuted(payload: AuditPayload): void {
         'muted advisories carry no expiry or review trail — use .github/audit-waivers.json instead',
     );
   }
+}
+
+// Waivers apply per audit: a run selects only the waivers scoped to it, so
+// classify() never sees — and never marks stale — the other audit's waivers.
+export function waiversFor(mode: AuditMode, waivers: Waiver[]): Waiver[] {
+  return waivers.filter((waiver) => waiver.scope === mode);
 }
 
 export function waiverMatches(waiver: Waiver, advisory: AuditAdvisory): boolean {
@@ -199,19 +299,48 @@ function advisoryRow(advisory: AuditAdvisory): string {
   return `| ${mdEscape(advisory.module_name)} | ${advisory.severity ?? ''} | [${id}](${advisory.url ?? ''}) | ${mdEscape(advisory.title)} | ${via} |`;
 }
 
+export const REPORT_STYLES: Record<
+  AuditMode,
+  { title: string; headline: string; fixHint: string[] }
+> = {
+  workspace: {
+    title: 'Dependency audit — workspace',
+    headline: '`pnpm audit` over the workspace lockfile',
+    fixHint: [
+      'Fix by upgrading the dependency or raising its floor via `pnpm.overrides`; if no fixed',
+      'release exists, add an expiring waiver — see CONTRIBUTING.md ("Dependency advisories and waivers").',
+    ],
+  },
+  artifact: {
+    title: 'Dependency audit — shipped artifact',
+    headline: "`npm audit` over an end-user resolution of the published CLI's runtime dependencies",
+    fixHint: [
+      'Fix by raising the affected range in cli/package.json `dependencies` so a fresh `npm install`',
+      'resolves a patched release — workspace `pnpm.overrides` do not reach end-user installs, and a',
+      'copy nested under another package is pinned by that package, not by this repo. If the fix is',
+      'blocked upstream, add an expiring waiver — see CONTRIBUTING.md ("Dependency advisories and waivers").',
+    ],
+  },
+};
+
 export function buildReport({
+  mode,
   counts,
   blocking,
   waived,
   stale,
   nonBlocking,
-}: Classification & { counts: Record<string, number> }): string {
-  const lines = ['# Dependency audit', ''];
+}: Classification & { mode: AuditMode; counts: Record<string, number> }): string {
+  const style = REPORT_STYLES[mode];
+  const lines = [`# ${style.title}`, ''];
   const totals = Object.entries(counts)
     .filter(([, n]) => n > 0)
     .map(([severity, n]) => `${String(n)} ${severity}`)
     .join(', ');
-  lines.push(`\`pnpm audit\` — gate: **high/critical** — found: ${totals || 'no advisories'}.`, '');
+  lines.push(
+    `${style.headline} — gate: **high/critical** — found: ${totals || 'no advisories'}.`,
+    '',
+  );
 
   if (blocking.length > 0) {
     lines.push(`## Blocking advisories (${String(blocking.length)})`, '');
@@ -221,11 +350,7 @@ export function buildReport({
     );
     for (const advisory of blocking) lines.push(advisoryRow(advisory));
     lines.push('');
-    lines.push(
-      'Fix by upgrading the dependency or raising its floor via `pnpm.overrides`; if no fixed',
-      'release exists, add an expiring waiver — see CONTRIBUTING.md ("Dependency advisories and waivers").',
-      '',
-    );
+    lines.push(...style.fixHint, '');
   } else {
     lines.push('No blocking advisories.', '');
   }

--- a/tools/audit-gate/test/audit-gate.test.ts
+++ b/tools/audit-gate/test/audit-gate.test.ts
@@ -7,10 +7,15 @@ import {
   buildReport,
   classify,
   mdEscape,
+  normalizeNpmAudit,
+  type NpmAuditPayload,
   parseAuditPayload,
+  parseNpmAuditPayload,
   validateWaivers,
+  type Waiver,
   WaiverConfigError,
   waiverMatches,
+  waiversFor,
 } from '../src/lib.ts';
 
 const advisory = (overrides: Partial<AuditAdvisory> = {}): AuditAdvisory => ({
@@ -32,14 +37,48 @@ const payload = (overrides: Partial<AuditPayload> = {}): AuditPayload => ({
   ...overrides,
 });
 
-const waiver = (overrides: Record<string, unknown> = {}) => ({
+const waiver = (overrides: Record<string, unknown> = {}): Waiver => ({
   advisory: 'GHSA-aaaa-bbbb-cccc',
+  scope: 'workspace',
   reason: 'no patched release reachable',
   expires: '2100-01-01',
   ...overrides,
 });
 
 const TODAY = '2026-07-29';
+
+const npmVia = (overrides: Record<string, unknown> = {}) => ({
+  source: 1104664,
+  name: 'postcss',
+  dependency: 'postcss',
+  title: 'PostCSS: something bad',
+  url: 'https://github.com/advisories/GHSA-dddd-eeee-ffff',
+  severity: 'high',
+  range: '<=8.5.17',
+  ...overrides,
+});
+
+// The shape npm v2 emits when a pinned transitive is vulnerable: the advisory
+// object sits on the vulnerable package's entry, while the depending package
+// references it by bare name in its own "via".
+const npmPayload = (overrides: Partial<NpmAuditPayload> = {}): NpmAuditPayload => ({
+  vulnerabilities: {
+    next: {
+      name: 'next',
+      severity: 'high',
+      via: ['postcss'],
+      nodes: ['node_modules/next'],
+    },
+    postcss: {
+      name: 'postcss',
+      severity: 'high',
+      via: [npmVia()],
+      nodes: ['node_modules/postcss'],
+    },
+  },
+  metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 2, critical: 0, total: 2 } },
+  ...overrides,
+});
 
 describe('validateWaivers', () => {
   it('accepts a well-formed file and returns the waivers', () => {
@@ -54,10 +93,17 @@ describe('validateWaivers', () => {
     expect(waivers[0]?.class).toBe('false-positive');
   });
 
+  it('accepts both audit scopes', () => {
+    const waivers = validateWaivers({ waivers: [waiver({ scope: 'artifact' })] });
+    expect(waivers[0]?.scope).toBe('artifact');
+  });
+
   it.each([
     ['not an object root', 'nope'],
     ['missing waivers array', {}],
     ['missing advisory', { waivers: [waiver({ advisory: undefined })] }],
+    ['missing scope', { waivers: [waiver({ scope: undefined })] }],
+    ['unknown scope', { waivers: [waiver({ scope: 'global' })] }],
     ['empty reason', { waivers: [waiver({ reason: ' ' })] }],
     ['missing expires', { waivers: [waiver({ expires: undefined })] }],
     ['non-ISO expires', { waivers: [waiver({ expires: 'someday' })] }],
@@ -87,6 +133,78 @@ describe('parseAuditPayload', () => {
 
   it('rejects JSON without an advisories field', () => {
     expect(() => parseAuditPayload('{"ok":true}')).toThrow(/no "advisories" field/);
+  });
+});
+
+describe('parseNpmAuditPayload', () => {
+  it('returns the payload for a completed audit', () => {
+    const parsed = parseNpmAuditPayload(JSON.stringify(npmPayload()));
+    expect(parsed.vulnerabilities).toHaveProperty('postcss');
+  });
+
+  it('rejects a transport error reported as JSON', () => {
+    const stdout = JSON.stringify({ error: { code: 'ECONNREFUSED', summary: 'request failed' } });
+    expect(() => parseNpmAuditPayload(stdout)).toThrow(/ECONNREFUSED/);
+  });
+
+  it('rejects non-JSON output', () => {
+    expect(() => parseNpmAuditPayload('npm error network', 'stderr detail')).toThrow(
+      /did not return JSON/,
+    );
+  });
+
+  it('rejects JSON without a vulnerabilities field', () => {
+    expect(() => parseNpmAuditPayload('{"ok":true}')).toThrow(/no "vulnerabilities" field/);
+  });
+});
+
+describe('normalizeNpmAudit', () => {
+  it('turns advisory objects into pnpm-shaped advisories and skips bare-name links', () => {
+    const { advisories } = normalizeNpmAudit(npmPayload());
+    const entries = Object.values(advisories);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      github_advisory_id: 'GHSA-dddd-eeee-ffff',
+      module_name: 'postcss',
+      severity: 'high',
+      title: 'PostCSS: something bad',
+      findings: [{ paths: ['node_modules/postcss'] }],
+    });
+  });
+
+  it('falls back to the numeric source id when the url carries no GHSA id', () => {
+    const viaWithoutGhsa = npmVia({ url: 'https://example.invalid/advisory' });
+    const payload = npmPayload({
+      vulnerabilities: {
+        postcss: { name: 'postcss', severity: 'high', via: [viaWithoutGhsa] },
+      },
+    });
+    const { advisories } = normalizeNpmAudit(payload);
+    const entry = Object.values(advisories)[0];
+    expect(entry?.github_advisory_id).toBeUndefined();
+    expect(entry?.id).toBe(1104664);
+  });
+
+  it('drops the "total" from the counts so both modes report alike', () => {
+    const counts = normalizeNpmAudit(npmPayload()).metadata?.vulnerabilities ?? {};
+    expect(counts).not.toHaveProperty('total');
+    expect(counts.high).toBe(2);
+  });
+
+  it('classifies a normalized payload with a module-pinned artifact waiver', () => {
+    const artifactWaiver = waiver({
+      advisory: 'GHSA-dddd-eeee-ffff',
+      scope: 'artifact',
+      module: 'postcss',
+    });
+    const result = classify(
+      normalizeNpmAudit(npmPayload()),
+      validateWaivers({ waivers: [artifactWaiver] }),
+      TODAY,
+    );
+    expect(result.blocking).toHaveLength(0);
+    expect(result.waived).toHaveLength(1);
+    expect(result.stale).toHaveLength(0);
   });
 });
 
@@ -126,6 +244,27 @@ describe('waiverMatches', () => {
   it('narrows by module when the waiver names one', () => {
     expect(waiverMatches(waiver({ module: 'left-pad' }), advisory())).toBe(true);
     expect(waiverMatches(waiver({ module: 'right-pad' }), advisory())).toBe(false);
+  });
+});
+
+describe('waiversFor', () => {
+  it('selects only the waivers scoped to the running audit', () => {
+    const waivers = validateWaivers({
+      waivers: [waiver(), waiver({ advisory: 'GHSA-dddd-eeee-ffff', scope: 'artifact' })],
+    });
+    expect(waiversFor('workspace', waivers).map((w) => w.advisory)).toEqual([
+      'GHSA-aaaa-bbbb-cccc',
+    ]);
+    expect(waiversFor('artifact', waivers).map((w) => w.advisory)).toEqual(['GHSA-dddd-eeee-ffff']);
+  });
+
+  it("keeps one audit's unmatched waiver out of the other audit's stale list", () => {
+    const waivers = validateWaivers({
+      waivers: [waiver(), waiver({ advisory: 'GHSA-dddd-eeee-ffff', scope: 'artifact' })],
+    });
+    const result = classify(payload(), waiversFor('workspace', waivers), TODAY);
+    expect(result.waived).toHaveLength(1);
+    expect(result.stale).toHaveLength(0);
   });
 });
 
@@ -181,6 +320,7 @@ describe('mdEscape and buildReport', () => {
   it('renders every section and neutralizes registry-supplied markup', () => {
     const hostile = advisory({ title: 'bad | `rm -rf` title' });
     const report = buildReport({
+      mode: 'workspace',
       counts: { high: 2, low: 1 },
       blocking: [hostile],
       waived: [{ advisory: advisory(), waiver: waiver() }],
@@ -203,6 +343,7 @@ describe('mdEscape and buildReport', () => {
       ],
     });
     const report = buildReport({
+      mode: 'workspace',
       counts: { high: 1 },
       blocking: [manyPaths],
       waived: [],
@@ -214,6 +355,7 @@ describe('mdEscape and buildReport', () => {
 
   it('reports a clean audit without advisory sections', () => {
     const report = buildReport({
+      mode: 'workspace',
       counts: {},
       blocking: [],
       waived: [],
@@ -223,5 +365,18 @@ describe('mdEscape and buildReport', () => {
     expect(report).toContain('found: no advisories');
     expect(report).toContain('No blocking advisories.');
     expect(report).not.toContain('## Waived');
+  });
+
+  it('titles and hints each mode for its own audit', () => {
+    const base = { counts: { high: 1 }, waived: [], stale: [], nonBlocking: [] };
+    const workspace = buildReport({ mode: 'workspace', blocking: [advisory()], ...base });
+    expect(workspace).toContain('# Dependency audit — workspace');
+    expect(workspace).toContain('`pnpm audit` over the workspace lockfile');
+    expect(workspace).toContain('raising its floor via `pnpm.overrides`');
+
+    const artifact = buildReport({ mode: 'artifact', blocking: [advisory()], ...base });
+    expect(artifact).toContain('# Dependency audit — shipped artifact');
+    expect(artifact).toContain("end-user resolution of the published CLI's runtime dependencies");
+    expect(artifact).toContain('raising the affected range in cli/package.json');
   });
 });


### PR DESCRIPTION
Stacked on #118. Extends the dependency-audit gate with an **artifact mode** that audits the resolution an end user gets from `npm install @akasecurity/cli` — coverage the workspace `pnpm-lock.yaml` audit structurally cannot provide, since consumers re-resolve the published runtime ranges and `pnpm.overrides` do not propagate to their installs.

## What this adds

- **`--artifact` mode in `tools/audit-gate`** — the entry writes `cli/package.json`'s runtime `dependencies` to a temp manifest, resolves it with `npm install --package-lock-only --ignore-scripts`, and audits that lockfile. npm emits the v2 audit format (`vulnerabilities` keyed by package, advisories as objects in `via` chains, no CVE list); `lib.ts` gains `parseNpmAuditPayload` + `normalizeNpmAudit`, which reduce it to the pnpm-shaped payload so classification, waivers, stale detection and reporting stay one code path. The 0/1/2/3 exit contract holds in both modes — transport failures and unresolvable trees exit 2 after the same three-attempt retry, config problems exit 3 — and each mode writes its own repo-root report (`audit-report.md` / `artifact-audit-report.md`).
- **Waivers gain a required `scope`** (`"workspace"` / `"artifact"`) naming the audit they apply to, validated alongside the existing `module`/`class` fields. Each run selects only its own scope (`waiversFor`), so one audit's waivers are never flagged stale by the other. The existing brace-expansion waiver is now workspace-scoped.
- **Three artifact waivers**, module-pinned, for the advisories the mode surfaces today — all with the same root cause: next 15.5.x pins `postcss@8.4.31` exactly and declares `sharp@^0.34.x`, and npm resolves next's own ranges in consumer installs, so nothing on our side (direct deps or overrides) remediates:
  - GHSA-6g55-p6wh-862q — postcss, fixed in 8.5.12
  - GHSA-r28c-9q8g-f849 — postcss, fixed in 8.5.18
  - GHSA-f88m-g3jw-g9cj — sharp, fixed in 0.35.0

  (npm's only `fixAvailable` for all three is a downgrade to next 9.3.3.) Exposure today is low — the dashboard has no `next/image` usage so sharp never loads, and postcss is build-time — but it ships in every end-user install; the waivers expire 2026-08-28 and note the fix is bumping next once upstream moves.
- **Workflow** runs the artifact step after the workspace step (`if: ${{ !cancelled() }}` so one run surfaces both signals), appends both reports to the run summary, folds both exit codes into the scheduled issue's title choice, and dedupes issue comments against the GHSA ids of both reports.
- **Docs**: CONTRIBUTING.md documents the second audit, the required `scope` field, the artifact-fix path (raise the range in `cli/package.json`; a copy nested under another package is that package's pin to fix), and that artifact-scoped waivers must use GHSA ids; CLAUDE.md's CI-egress note and "Dependency advisories" section cover the npm resolution path.

## Verification

- `pnpm --filter @akasecurity/audit-gate test` — 45 tests pass, including new coverage for scope validation, `waiversFor` cross-mode stale isolation, npm-v2 parsing (transport-error JSON, non-JSON, missing field), normalization (bare-name `via` links skipped, GHSA extraction with numeric-source fallback, `total` dropped from counts), and mode-styled reports. Lint, typecheck and Prettier clean.
- Live runs: workspace mode exit 0 (1 waived); artifact mode exit 1 with the three advisories before the waivers, exit 0 after (3 waived, 1 moderate below the gate); unreachable registry exit 2 with the failure written into the report; waiver missing `scope` exit 3.