### PR TITLE
vault 03/10: plugin-sdk glue and the vault-consent surfaces

### DIFF
--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -89,6 +89,44 @@ export const MODEL_JUDGE_CHOICES: Choice<ModelJudgeChoice>[] = [
   },
 ];
 
+// This is a custody change from one-way redaction: with the grant, a detected
+// value survives as recoverable ciphertext instead of being destroyed. The form
+// only ever emits the choice string — the grant object itself (acknowledgedAt,
+// version) is stamped by the server action, never built client-side.
+export const VAULT_SECTION_LABEL = 'Reversible secret vault';
+
+export const VAULT_SECTION_DESCRIPTION =
+  'Whether redaction keeps a recoverable copy of what it removes. Off destroys detected ' +
+  'values as it redacts them; Vault & redact keeps an encrypted copy on this machine.';
+
+export type VaultConsentChoice = 'off' | 'on';
+
+export const VAULT_CHOICES: Choice<VaultConsentChoice>[] = [
+  {
+    value: 'off',
+    label: 'Off (default)',
+    description: 'Detected values keep being redacted irreversibly; nothing recoverable is stored.',
+  },
+  {
+    value: 'on',
+    label: 'Vault & redact',
+    description:
+      'A detected value is replaced by a pointer, and an encrypted, recoverable copy is ' +
+      'kept in the local vault under ~/.aka — this machine holds recoverable copies of ' +
+      'detected secrets, encrypted at rest. The pointers written into files and ' +
+      'transcripts show where each secret is used, and which places share the same ' +
+      'secret, to anyone who can read those files. Switching back to Off stops new ' +
+      'vaulting but does not erase what is already stored — purging the vault from the ' +
+      'CLI is what erases it.',
+  },
+];
+
+// The stored grant maps to the form choice: a recorded consent renders as 'on',
+// an absent one as 'off'.
+export function vaultChoiceOf(vaultConsent: WorkspaceSettings['vaultConsent']): VaultConsentChoice {
+  return vaultConsent ? 'on' : 'off';
+}
+
 function ChoiceGroup<T extends string>({
   name,
   choices,
@@ -133,12 +171,13 @@ function ChoiceGroup<T extends string>({
 
 export interface WorkspaceSettingsFormViewProps {
   settings: WorkspaceSettings;
-  // modelJudgeConsent is a plain boolean signal, not the stored record: the
-  // acknowledgement timestamp and payload version are stamped server-side, so a
-  // client-supplied one would only be discarded. true grants, false revokes.
+  // Both consents are plain answers, not the stored records: acknowledgement
+  // timestamps and versions are stamped server-side, so a client-supplied one
+  // would only be discarded. modelJudgeConsent: true grants, false revokes.
   onSave: (
     changes: Pick<WorkspaceSettings, 'policy' | 'historicalAccess'> & {
       modelJudgeConsent: boolean;
+      vaultConsent: VaultConsentChoice;
     },
   ) => void;
   busy?: boolean;
@@ -148,7 +187,7 @@ export interface WorkspaceSettingsFormViewProps {
 
 /**
  * The workspace settings editor — the web twin of the `/aka:setup` wizard's
- * policy + historical-access questions.
+ * policy, historical-access, and vault-consent questions.
  */
 export function WorkspaceSettingsFormView({
   settings,
@@ -168,10 +207,12 @@ export function WorkspaceSettingsFormView({
     ? 'granted'
     : 'revoked';
   const [modelJudge, setModelJudge] = useState<ModelJudgeChoice>(initialModelJudge);
+  const [vaultConsent, setVaultConsent] = useState(vaultChoiceOf(settings.vaultConsent));
   const dirty =
     policy !== settings.policy ||
     historicalAccess !== settings.historicalAccess ||
-    modelJudge !== initialModelJudge;
+    modelJudge !== initialModelJudge ||
+    vaultConsent !== vaultChoiceOf(settings.vaultConsent);
 
   return (
     <div className="flex max-w-2xl flex-col gap-6">
@@ -203,6 +244,17 @@ export function WorkspaceSettingsFormView({
         />
       </section>
 
+      <section className="rounded-xl border border-border bg-surface p-5">
+        <SectionLabel>{VAULT_SECTION_LABEL}</SectionLabel>
+        <p className="mb-3 text-xs text-text-3">{VAULT_SECTION_DESCRIPTION}</p>
+        <ChoiceGroup
+          name="vaultConsent"
+          choices={VAULT_CHOICES}
+          value={vaultConsent}
+          onChange={setVaultConsent}
+        />
+      </section>
+
       <div className="flex items-center gap-3">
         <Button
           variant="solid"
@@ -213,9 +265,10 @@ export function WorkspaceSettingsFormView({
             onSave({
               policy,
               historicalAccess,
-              // Just the answer — the server stamps the acknowledgement time and
-              // the payload version the grant is recorded against.
+              // Just the answers — the server stamps the acknowledgement times
+              // and the versions the grants are recorded against.
               modelJudgeConsent: modelJudge === 'granted',
+              vaultConsent,
             });
           }}
         >

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
   HANDLING_SECTION_DESCRIPTION,
@@ -10,6 +11,11 @@ import {
   MODEL_JUDGE_SECTION_DESCRIPTION,
   MODEL_JUDGE_SECTION_LABEL,
   POLICY_CHOICES,
+  VAULT_CHOICES,
+  VAULT_SECTION_DESCRIPTION,
+  VAULT_SECTION_LABEL,
+  vaultChoiceOf,
+  type WorkspaceSettingsFormViewProps,
 } from '../../src/settings/WorkspaceSettingsFormView.tsx';
 
 // Nothing on this page happens on a hook, and nothing happens the moment it is
@@ -27,13 +33,15 @@ import {
 // test-only constants in the published binary.
 const ALWAYS_FALSE = [/next hook/i, /nothing is altered/i, /immediately/i, /right away/i];
 
-// Every string the form renders: both section headings, both section
-// descriptions, and each choice's label and description.
+// Every string the form renders: each section's heading and description, and
+// each choice's label and description.
 const FORM_COPY: Record<string, string> = {
   HANDLING_SECTION_LABEL,
   HANDLING_SECTION_DESCRIPTION,
   HISTORICAL_SECTION_LABEL,
   HISTORICAL_SECTION_DESCRIPTION,
+  VAULT_SECTION_LABEL,
+  VAULT_SECTION_DESCRIPTION,
   ...Object.fromEntries(
     POLICY_CHOICES.flatMap((c) => [
       [`POLICY_CHOICES.${c.value}.label`, c.label],
@@ -44,6 +52,12 @@ const FORM_COPY: Record<string, string> = {
     HISTORICAL_CHOICES.flatMap((c) => [
       [`HISTORICAL_CHOICES.${c.value}.label`, c.label],
       [`HISTORICAL_CHOICES.${c.value}.description`, c.description],
+    ]),
+  ),
+  ...Object.fromEntries(
+    VAULT_CHOICES.flatMap((c) => [
+      [`VAULT_CHOICES.${c.value}.label`, c.label],
+      [`VAULT_CHOICES.${c.value}.description`, c.description],
     ]),
   ),
 };
@@ -122,5 +136,58 @@ describe('WorkspaceSettingsFormView model-judge consent control', () => {
   it('defaults to revoked wording never assuming the grant', () => {
     const revoked = MODEL_JUDGE_CHOICES.find((c) => c.value === 'revoked');
     expect(revoked?.description).toMatch(/never assumed/i);
+  });
+});
+
+// The vault grant is a custody change: 'on' means detected values survive as
+// recoverable ciphertext instead of being destroyed, and the pointers that
+// replace them are legible to anyone who can read the files they land in. The
+// copy must disclose both, and must not present switching off as an eraser.
+describe('WorkspaceSettingsFormView vault-consent section', () => {
+  const off = VAULT_CHOICES.find((c) => c.value === 'off');
+  const on = VAULT_CHOICES.find((c) => c.value === 'on');
+
+  it('offers exactly the off/on pair, with off marked as the default', () => {
+    expect(VAULT_CHOICES.map((c) => c.value)).toEqual(['off', 'on']);
+    expect(off?.label).toMatch(/default/i);
+  });
+
+  it('derives the current choice from the stored grant: present → on, absent → off', () => {
+    expect(vaultChoiceOf(undefined)).toBe('off');
+    expect(
+      vaultChoiceOf({
+        acknowledgedAt: '2026-01-01T00:00:00.000Z',
+        version: VAULT_CONSENT_VERSION,
+      }),
+    ).toBe('on');
+  });
+
+  it("discloses what 'on' stores: recoverable copies of secrets, encrypted, on this machine", () => {
+    expect(on?.description).toMatch(/recoverable/i);
+    expect(on?.description).toMatch(/encrypted/i);
+    expect(on?.description).toMatch(/this machine/i);
+    expect(on?.description).toMatch(/secrets/i);
+  });
+
+  it('discloses what the pointers reveal, and to whom', () => {
+    expect(on?.description).toMatch(/where each secret is used/i);
+    expect(on?.description).toMatch(/share the same secret/i);
+    expect(on?.description).toMatch(/anyone who can read/i);
+  });
+
+  it('does not present switching off as an eraser — the CLI purge is', () => {
+    expect(on?.description).toMatch(/does not erase/i);
+    expect(on?.description).toMatch(/purging the vault from the CLI/i);
+  });
+
+  it('keeps the off default free of any storage', () => {
+    expect(off?.description).toMatch(/nothing recoverable is stored/i);
+  });
+
+  it('emits only the choice string — no acknowledgedAt/version leaves the form', () => {
+    // The grant object is stamped by the server action; the form's save payload
+    // carries the bare 'off' | 'on' string and nothing a client could forge.
+    type Emitted = Parameters<WorkspaceSettingsFormViewProps['onSave']>[0]['vaultConsent'];
+    expectTypeOf<Emitted>().toEqualTypeOf<'off' | 'on'>();
   });
 });

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -68,6 +68,21 @@ export type { ExceptionWriter, SuppressionEntry } from './suppressions.ts';
 export { applySetupTriageSuppressions, THIRTY_DAYS_MS } from './suppressions.ts';
 export { throttled } from './throttle.ts';
 export type {
+  CreateVaultGlueOptions,
+  DetokenizeTextOptions,
+  DetokenizeTextResult,
+  TokenizeTextResult,
+  VaultCore,
+  VaultGlue,
+} from './tokenize.ts';
+export {
+  createVaultGlue,
+  detokenizeText,
+  POINTER_UNAVAILABLE_TEXT,
+  tokenizeText,
+  tokenizeValue,
+} from './tokenize.ts';
+export type {
   AkaPluginAdapter,
   BlockedDetectionRef,
   CaptureHooks,

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -1,0 +1,356 @@
+// Text-level glue between the hooks and the reversible vault: replace detected
+// secret spans with pointers, and resolve pointers back for whoever is allowed
+// to see them.
+//
+// Everything here sits on a hook path, so the whole surface is built around two
+// rules the vault core shares:
+//
+//   never throw   a caller on the fail-open boundary must not be broken by a
+//                 vault fault. Every public function catches everything.
+//   never leak    a fault while masking must destroy the value, not pass it.
+//                 A span we cannot tokenize is rewritten to the same one-way
+//                 `[REDACTED:CATEGORY]` placeholder the engine emits, and a
+//                 pointer we cannot resolve renders as `[unavailable]`.
+//
+// The two rules compose to: on any failure the session continues and the model
+// sees LESS, never more.
+import type { MatchResult } from '@akasecurity/detections';
+import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
+import {
+  createKeyProvider,
+  defaultDataDir,
+  keysDir,
+  loadOrCreateFingerprintKey,
+  openLocalDatabase,
+  readWorkspaceSettings,
+  SecretVault,
+} from '@akasecurity/persistence';
+import type { DetectionCategory, PointerToken, VaultDerefReason } from '@akasecurity/schema';
+import { isVaultConsentValid, pointerTokenScanner } from '@akasecurity/schema';
+
+import { dataDir } from './data-dir.ts';
+import { registerBundledPacks } from './rule-packs.ts';
+
+// The one-way placeholder for a span that could not (or must not) be vaulted —
+// identical to the engine's redact() form so a degraded field is
+// indistinguishable from a pre-vault one.
+function redactedPlaceholder(category: string): string {
+  return `[REDACTED:${category.toUpperCase()}]`;
+}
+
+// What an unresolvable pointer renders as on a human surface.
+export const POINTER_UNAVAILABLE_TEXT = '[unavailable]';
+
+export interface TokenizeTextResult {
+  text: string;
+  // The pointers now present in `text` that this call minted or re-emitted.
+  pointers: PointerToken[];
+}
+
+export interface DetokenizeTextOptions {
+  target: 'human' | 'model';
+  reason: VaultDerefReason;
+  grantId?: string | undefined;
+}
+
+export interface DetokenizeTextResult {
+  text: string;
+  // Pointer occurrences replaced with their raw value.
+  revealed: number;
+}
+
+// The slice of the vault core the glue calls. Narrow on purpose: tests inject a
+// stub here to exercise the degrade branches without a real store.
+export interface VaultCore {
+  tokenize(
+    raw: string,
+    meta: { ruleId: string; category: DetectionCategory; maskedMatch: string },
+  ): Promise<string | symbol>;
+  detokenize(
+    token: string,
+    opts: {
+      target: 'human' | 'model';
+      reason: VaultDerefReason;
+      grantId?: string | undefined;
+      pointerCount?: number | undefined;
+    },
+  ): Promise<string | symbol>;
+}
+
+export interface VaultGlue {
+  tokenizeText(text: string, opts?: { findings?: MatchResult[] }): Promise<TokenizeTextResult>;
+  tokenizeValue(
+    raw: string,
+    meta: { ruleId: string; category: DetectionCategory; maskedMatch: string },
+  ): Promise<string>;
+  detokenizeText(text: string, opts: DetokenizeTextOptions): Promise<DetokenizeTextResult>;
+  /**
+   * Release the store handle this glue opened. Idempotent, and a no-op on a
+   * glue that opened nothing — a degraded one, or one built over an injected
+   * vault.
+   *
+   * Hook processes need not call it: they exit, and exiting releases the
+   * handle. Anything that OUTLIVES its glue must — a long-lived process leaks a
+   * connection otherwise, and on Windows an open handle blocks removal of the
+   * directory holding the store.
+   */
+  close(): void;
+}
+
+const SEVERITY_RANK: Record<string, number> = { critical: 3, high: 2, medium: 1, low: 0 };
+
+// Disjoint replacement units over the findings of one text. Overlapping spans
+// cannot each map to one vaulted value — the shared characters belong to both —
+// so an overlapping group degrades to the one-way placeholder of its
+// highest-severity member. Only truly disjoint spans tokenize.
+interface SpanGroup {
+  start: number;
+  end: number;
+  // Present when the group is a single finding whose span text matches its
+  // rawMatch exactly; absent means one-way redaction.
+  finding?: MatchResult;
+  // The category of the group's highest-severity member — what the one-way
+  // placeholder names when per-finding identity is lost.
+  category: string;
+  severity: string;
+}
+
+function groupSpans(text: string, findings: MatchResult[]): SpanGroup[] {
+  const sorted = [...findings]
+    .filter((f) => f.span.start >= 0 && f.span.end <= text.length && f.span.start < f.span.end)
+    .sort((a, b) => a.span.start - b.span.start || b.span.end - a.span.end);
+
+  const groups: SpanGroup[] = [];
+  for (const finding of sorted) {
+    const last = groups[groups.length - 1];
+    if (last && finding.span.start < last.end) {
+      // Overlap: widen the group and drop per-finding identity.
+      last.end = Math.max(last.end, finding.span.end);
+      if ((SEVERITY_RANK[finding.severity] ?? 0) > (SEVERITY_RANK[last.severity] ?? 0)) {
+        last.category = finding.category;
+        last.severity = finding.severity;
+      }
+      delete last.finding;
+      continue;
+    }
+    groups.push({
+      start: finding.span.start,
+      end: finding.span.end,
+      finding,
+      category: finding.category,
+      severity: finding.severity,
+    });
+  }
+  return groups;
+}
+
+class SecretVaultGlue implements VaultGlue {
+  readonly #vault: VaultCore;
+  // Set only when THIS glue opened the store, so a glue over an injected vault
+  // never closes a handle it does not own.
+  #release: (() => void) | undefined;
+
+  constructor(vault: VaultCore, release?: () => void) {
+    this.#vault = vault;
+    this.#release = release;
+  }
+
+  close(): void {
+    const release = this.#release;
+    // Cleared before the call so a second close is a no-op even if the first
+    // throws — and a throw here is swallowed: releasing a handle is cleanup,
+    // never a reason to fail the caller.
+    this.#release = undefined;
+    try {
+      release?.();
+    } catch {
+      // Already unusable; nothing left to do.
+    }
+  }
+
+  async tokenizeValue(
+    raw: string,
+    meta: { ruleId: string; category: DetectionCategory; maskedMatch: string },
+  ): Promise<string> {
+    try {
+      const result = await this.#vault.tokenize(raw, meta);
+      // Any sentinel (consent absent, or a future one) degrades one-way.
+      return typeof result === 'string' ? result : redactedPlaceholder(meta.category);
+    } catch {
+      return redactedPlaceholder(meta.category);
+    }
+  }
+
+  async tokenizeText(
+    text: string,
+    opts?: { findings?: MatchResult[] },
+  ): Promise<TokenizeTextResult> {
+    try {
+      const findings = opts?.findings ?? this.#selfScan(text);
+      // A self-scan that failed outright cannot tell secret from clean; the
+      // only safe output is the blanket the mask path also emits.
+      if (findings === null) return { text: '[REDACTED]', pointers: [] };
+      if (findings.length === 0) return { text, pointers: [] };
+
+      const groups = groupSpans(text, findings);
+      const pointers: PointerToken[] = [];
+      let out = text;
+      // Back to front, so earlier offsets stay valid as later spans change width.
+      for (const group of [...groups].reverse()) {
+        const original = text.slice(group.start, group.end);
+        const finding = group.finding;
+        let replacement: string;
+        if (finding === undefined) {
+          // An overlap group: per-finding identity is gone, destroy the region.
+          replacement = redactedPlaceholder(group.category);
+        } else if (original !== finding.rawMatch) {
+          // A span that no longer slices to its finding's rawMatch is stale;
+          // vaulting the sliced text would store something detection never saw.
+          replacement = redactedPlaceholder(group.category);
+        } else {
+          replacement = await this.tokenizeValue(finding.rawMatch, {
+            ruleId: finding.ruleId,
+            category: finding.category,
+            maskedMatch: maskMatch(finding.rawMatch),
+          });
+          if (replacement.startsWith('[[aka:')) pointers.unshift(replacement);
+        }
+        out = out.slice(0, group.start) + replacement + out.slice(group.end);
+      }
+      return { text: out, pointers };
+    } catch {
+      // The unknown failure could have left raw spans in place; destroy them.
+      return { text: '[REDACTED]', pointers: [] };
+    }
+  }
+
+  async detokenizeText(text: string, opts: DetokenizeTextOptions): Promise<DetokenizeTextResult> {
+    try {
+      const matches = [...text.matchAll(pointerTokenScanner())];
+      if (matches.length === 0) return { text, revealed: 0 };
+
+      // Resolve each DISTINCT pointer once: one audit row per distinct pointer,
+      // carrying how many times it occurs in this text.
+      const occurrences = new Map<string, number>();
+      for (const match of matches) {
+        occurrences.set(match[0], (occurrences.get(match[0]) ?? 0) + 1);
+      }
+      const resolved = new Map<string, string | null>();
+      for (const [pointer, count] of occurrences) {
+        try {
+          const value = await this.#vault.detokenize(pointer, {
+            target: opts.target,
+            reason: opts.reason,
+            grantId: opts.grantId,
+            pointerCount: count,
+          });
+          resolved.set(pointer, typeof value === 'string' ? value : null);
+        } catch {
+          resolved.set(pointer, null);
+        }
+      }
+
+      let out = text;
+      let revealed = 0;
+      for (const match of [...matches].reverse()) {
+        const value = resolved.get(match[0]);
+        const replacement = value ?? POINTER_UNAVAILABLE_TEXT;
+        if (value !== null && value !== undefined) revealed += 1;
+        out = out.slice(0, match.index) + replacement + out.slice(match.index + match[0].length);
+      }
+      return { text: out, revealed };
+    } catch {
+      // Leaving the pointers literal is safe — they carry no secret material.
+      return { text, revealed: 0 };
+    }
+  }
+
+  // Scan with the bundled packs, as the mask path does. Returns null when the
+  // registry or the scan itself failed — the caller must then treat the whole
+  // text as unclassifiable.
+  #selfScan(text: string): MatchResult[] | null {
+    try {
+      registerBundledPacks();
+      return scan(text, getLoadedRules());
+    } catch {
+      return null;
+    }
+  }
+}
+
+export interface CreateVaultGlueOptions {
+  // The ~/.aka base; defaults to the shared layout root.
+  base?: string;
+  // Test seam: a vault core to use instead of opening the real store.
+  vault?: VaultCore;
+}
+
+/**
+ * Build the glue over a live vault. Opening the store, the key provider, or the
+ * fingerprint key can all fail; when anything does, the returned glue is a
+ * degraded one whose tokenize destroys values one-way and whose detokenize
+ * resolves nothing — the two fail postures above, decided once at construction.
+ */
+export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
+  if (options?.vault) return new SecretVaultGlue(options.vault);
+  const base = options?.base ?? defaultDataDir();
+  try {
+    const dir = dataDir(base);
+    const db = openLocalDatabase(dir);
+    const settings = readWorkspaceSettings(base);
+    const vault = new SecretVault({
+      repo: db.secretVault,
+      keys: createKeyProvider(settings.vaultKeyCustody, keysDir(base)),
+      fingerprintKey: loadOrCreateFingerprintKey(dir),
+      // Read live so a revocation applies to the very next call, not the next
+      // process.
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
+    });
+    return new SecretVaultGlue(vault, () => {
+      db.close();
+    });
+  } catch {
+    return new SecretVaultGlue(UNOPENABLE_VAULT);
+  }
+}
+
+// The vault stand-in when the store cannot be opened at all: consent-shaped
+// refusal on write (callers degrade one-way), unavailable on read.
+const UNOPENABLE_VAULT: VaultCore = {
+  tokenize: () => Promise.resolve(Symbol('aka.vault.unopenable')),
+  detokenize: () => Promise.resolve(Symbol('aka.vault.unopenable')),
+};
+
+// The default glue the hooks use, built once per process against the shared
+// ~/.aka. Hook processes are short-lived and hard-exit, so the handle is never
+// explicitly closed.
+let defaultGlue: VaultGlue | null = null;
+
+function glue(): VaultGlue {
+  defaultGlue ??= createVaultGlue();
+  return defaultGlue;
+}
+
+/** {@link VaultGlue.tokenizeText} over the default ~/.aka vault. */
+export function tokenizeText(
+  text: string,
+  opts?: { findings?: MatchResult[] },
+): Promise<TokenizeTextResult> {
+  return glue().tokenizeText(text, opts);
+}
+
+/** {@link VaultGlue.tokenizeValue} over the default ~/.aka vault. */
+export function tokenizeValue(
+  raw: string,
+  meta: { ruleId: string; category: DetectionCategory; maskedMatch: string },
+): Promise<string> {
+  return glue().tokenizeValue(raw, meta);
+}
+
+/** {@link VaultGlue.detokenizeText} over the default ~/.aka vault. */
+export function detokenizeText(
+  text: string,
+  opts: DetokenizeTextOptions,
+): Promise<DetokenizeTextResult> {
+  return glue().detokenizeText(text, opts);
+}

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -1,0 +1,319 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import type { MatchResult } from '@akasecurity/detections';
+import { applyOnboarding, openLocalDatabase } from '@akasecurity/persistence';
+import { PointerToken, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dataDir } from '../src/data-dir.ts';
+import type { VaultCore, VaultGlue } from '../src/tokenize.ts';
+import { createVaultGlue, POINTER_UNAVAILABLE_TEXT } from '../src/tokenize.ts';
+
+const SECRET = 'AKIAIOSFODNN7EXAMPLE';
+const OTHER = 'AKIAI44QH8DHBEXAMPLE';
+
+function finding(overrides: Partial<MatchResult> & { span: MatchResult['span'] }): MatchResult {
+  return {
+    ruleId: 'aws-access-key',
+    category: 'secret',
+    severity: 'critical',
+    rawMatch: SECRET,
+    confidence: 0.9,
+    ...overrides,
+  };
+}
+
+describe('vault glue', () => {
+  let base: string;
+  let glue: VaultGlue;
+
+  const grantConsent = (): void => {
+    applyOnboarding(
+      {
+        vaultConsent: {
+          acknowledgedAt: new Date().toISOString(),
+          version: VAULT_CONSENT_VERSION,
+        },
+      },
+      base,
+    );
+  };
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'aka-glue-'));
+    grantConsent();
+    glue = createVaultGlue({ base });
+  });
+
+  afterEach(() => {
+    // Windows will not remove a directory that still holds an open store
+    // handle, so the glue must release before the temp base is cleared.
+    glue.close();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  describe('tokenizeText with findings', () => {
+    it('replaces exactly the enforced spans and preserves everything else', async () => {
+      const text = `key=${SECRET} and other=${OTHER} end`;
+      const result = await glue.tokenizeText(text, {
+        findings: [
+          finding({ span: { start: 4, end: 4 + SECRET.length } }),
+          finding({
+            span: { start: 4 + SECRET.length + 11, end: 4 + SECRET.length + 11 + OTHER.length },
+            rawMatch: OTHER,
+          }),
+        ],
+      });
+      expect(result.pointers).toHaveLength(2);
+      for (const pointer of result.pointers) {
+        expect(PointerToken.safeParse(pointer).success).toBe(true);
+      }
+      const [first, second] = result.pointers;
+      if (first === undefined || second === undefined) throw new Error('expected two pointers');
+      expect(result.text).toBe(`key=${first} and other=${second} end`);
+      expect(result.text).not.toContain(SECRET);
+      expect(result.text).not.toContain(OTHER);
+    });
+
+    it('round-trips through detokenizeText for a human', async () => {
+      const text = `deploy with ${SECRET} now`;
+      const tokenized = await glue.tokenizeText(text, {
+        findings: [finding({ span: { start: 12, end: 12 + SECRET.length } })],
+      });
+      const back = await glue.detokenizeText(tokenized.text, {
+        target: 'human',
+        reason: 'explicit-reveal',
+      });
+      expect(back.text).toBe(text);
+      expect(back.revealed).toBe(1);
+    });
+
+    it('emits the same pointer for the same value across texts', async () => {
+      const a = await glue.tokenizeText(SECRET, {
+        findings: [finding({ span: { start: 0, end: SECRET.length } })],
+      });
+      const b = await glue.tokenizeText(`x ${SECRET}`, {
+        findings: [finding({ span: { start: 2, end: 2 + SECRET.length } })],
+      });
+      expect(a.pointers[0]).toBe(b.pointers[0]);
+    });
+
+    // Overlapping spans cannot each map to one vaulted value — the shared
+    // characters belong to both findings — so the merged region is destroyed
+    // one-way rather than vaulted ambiguously.
+    it('degrades an overlapping span group to one-way redaction', async () => {
+      const text = `${SECRET}TRAILER`;
+      const result = await glue.tokenizeText(text, {
+        findings: [
+          finding({ span: { start: 0, end: SECRET.length } }),
+          finding({
+            span: { start: 10, end: SECRET.length + 7 },
+            rawMatch: text.slice(10),
+            category: 'pii',
+            severity: 'low',
+          }),
+        ],
+      });
+      expect(result.pointers).toHaveLength(0);
+      expect(result.text).toBe('[REDACTED:SECRET]');
+      const db = openLocalDatabase(dataDir(base));
+      expect(db.secretVault.countEntries()).toBe(0);
+      db.close();
+    });
+
+    // A span that no longer slices to its finding's rawMatch is stale; vaulting
+    // the sliced text would store something detection never saw.
+    it('degrades a stale span one-way instead of vaulting it', async () => {
+      const result = await glue.tokenizeText('short', {
+        findings: [finding({ span: { start: 0, end: 5 }, rawMatch: SECRET })],
+      });
+      expect(result.text).toBe('[REDACTED:SECRET]');
+      expect(result.pointers).toHaveLength(0);
+    });
+
+    it('returns clean text untouched', async () => {
+      const result = await glue.tokenizeText('nothing sensitive here', { findings: [] });
+      expect(result).toEqual({ text: 'nothing sensitive here', pointers: [] });
+    });
+  });
+
+  describe('tokenizeText self-scan', () => {
+    it('finds and tokenizes a value the bundled packs detect', async () => {
+      const result = await glue.tokenizeText(`aws_access_key_id = ${SECRET}`);
+      expect(result.text).not.toContain(SECRET);
+      expect(result.pointers.length).toBeGreaterThan(0);
+      const back = await glue.detokenizeText(result.text, {
+        target: 'human',
+        reason: 'explicit-reveal',
+      });
+      expect(back.text).toContain(SECRET);
+    });
+  });
+
+  describe('consent gate', () => {
+    it('degrades one-way without a grant, storing nothing', async () => {
+      const bare = mkdtempSync(join(tmpdir(), 'aka-glue-nc-'));
+      try {
+        const ungranted = createVaultGlue({ base: bare });
+        const result = await ungranted.tokenizeText(SECRET, {
+          findings: [finding({ span: { start: 0, end: SECRET.length } })],
+        });
+        expect(result.text).toBe('[REDACTED:SECRET]');
+        expect(result.pointers).toHaveLength(0);
+        await expect(
+          ungranted.tokenizeValue(SECRET, {
+            ruleId: 'aws-access-key',
+            category: 'secret',
+            maskedMatch: 'A******E',
+          }),
+        ).resolves.toBe('[REDACTED:SECRET]');
+        const db = openLocalDatabase(dataDir(bare));
+        expect(db.secretVault.countEntries()).toBe(0);
+        db.close();
+        ungranted.close();
+      } finally {
+        rmSync(bare, { recursive: true, force: true });
+      }
+    });
+  });
+
+  // The glue opens a store handle; whoever outlives it has to be able to give
+  // that handle back. Nothing in a hook needs this (the process exits), but a
+  // test does — and on Windows an unreleased handle blocks removal of the very
+  // temp directory the test is cleaning up, which fails the run somewhere far
+  // from the cause.
+  describe('close', () => {
+    it('releases the store handle it opened', async () => {
+      const owned = createVaultGlue({ base });
+      await owned.tokenizeValue(SECRET, {
+        ruleId: 'aws-access-key',
+        category: 'secret',
+        maskedMatch: 'A******E',
+      });
+      owned.close();
+
+      // The handle is really gone: a write through the closed connection can no
+      // longer reach the store, so the glue degrades one-way instead of
+      // vaulting. Never raw, whatever happens to the handle.
+      await expect(
+        owned.tokenizeValue(OTHER, {
+          ruleId: 'aws-access-key',
+          category: 'secret',
+          maskedMatch: 'A******E',
+        }),
+      ).resolves.toBe('[REDACTED:SECRET]');
+    });
+
+    it('is idempotent, and a no-op on a glue that opened nothing', () => {
+      const owned = createVaultGlue({ base });
+      owned.close();
+      expect(() => {
+        owned.close();
+      }).not.toThrow();
+
+      // A glue over an injected vault owns no handle — closing must not reach
+      // for one it never took.
+      const injected = createVaultGlue({
+        vault: {
+          tokenize: () => Promise.resolve(Symbol('unused')),
+          detokenize: () => Promise.resolve(Symbol('unused')),
+        },
+      });
+      expect(() => {
+        injected.close();
+      }).not.toThrow();
+    });
+  });
+
+  describe('fail-secure degrade', () => {
+    const failingVault: VaultCore = {
+      tokenize: () => Promise.reject(new Error('store locked')),
+      detokenize: () => Promise.reject(new Error('store locked')),
+    };
+
+    it('a tokenize fault destroys the value one-way', async () => {
+      const faulty = createVaultGlue({ vault: failingVault });
+      await expect(
+        faulty.tokenizeValue(SECRET, {
+          ruleId: 'r',
+          category: 'secret',
+          maskedMatch: 'A******E',
+        }),
+      ).resolves.toBe('[REDACTED:SECRET]');
+      const result = await faulty.tokenizeText(`k=${SECRET}`, {
+        findings: [finding({ span: { start: 2, end: 2 + SECRET.length } })],
+      });
+      expect(result.text).toBe('k=[REDACTED:SECRET]');
+      expect(result.pointers).toHaveLength(0);
+    });
+
+    it('a detokenize fault renders the pointer unavailable, never raw', async () => {
+      const token = (
+        await glue.tokenizeText(SECRET, {
+          findings: [finding({ span: { start: 0, end: SECRET.length } })],
+        })
+      ).pointers[0];
+      if (token === undefined) throw new Error('expected a pointer');
+      const faulty = createVaultGlue({ vault: failingVault });
+      const result = await faulty.detokenizeText(`v=${token}`, {
+        target: 'human',
+        reason: 'explicit-reveal',
+      });
+      expect(result.text).toBe(`v=${POINTER_UNAVAILABLE_TEXT}`);
+      expect(result.revealed).toBe(0);
+    });
+
+    it('an unopenable store degrades construction, not the session', async () => {
+      const fileAsBase = join(mkdtempSync(join(tmpdir(), 'aka-glue-bad-')), 'not-a-dir');
+      writeFileSync(fileAsBase, 'occupied');
+      const degraded = createVaultGlue({ base: fileAsBase });
+      await expect(
+        degraded.tokenizeValue(SECRET, {
+          ruleId: 'r',
+          category: 'pii',
+          maskedMatch: 'A******E',
+        }),
+      ).resolves.toBe('[REDACTED:PII]');
+    });
+  });
+
+  describe('detokenizeText audit shape', () => {
+    it('resolves a repeated pointer once, counting its occurrences', async () => {
+      const token = (
+        await glue.tokenizeText(SECRET, {
+          findings: [finding({ span: { start: 0, end: SECRET.length } })],
+        })
+      ).pointers[0];
+      if (token === undefined) throw new Error('expected a pointer');
+
+      const result = await glue.detokenizeText(`a=${token} b=${token}`, {
+        target: 'human',
+        reason: 'view-render',
+      });
+      expect(result.text).toBe(`a=${SECRET} b=${SECRET}`);
+      expect(result.revealed).toBe(2);
+
+      // One audit row for the distinct pointer, carrying both occurrences.
+      const db = new DatabaseSync(join(dataDir(base), 'aka.db'));
+      const rows = db
+        .prepare(
+          `SELECT reason, pointer_count AS pointerCount
+           FROM secret_vault_deref WHERE reason = 'view-render'`,
+        )
+        .all() as { reason: string; pointerCount: number }[];
+      db.close();
+      expect(rows).toEqual([{ reason: 'view-render', pointerCount: 2 }]);
+    });
+
+    it('passes pointer-free text through untouched', async () => {
+      const result = await glue.detokenizeText('no pointers here', {
+        target: 'human',
+        reason: 'view-render',
+      });
+      expect(result).toEqual({ text: 'no pointers here', revealed: 0 });
+    });
+  });
+});

--- a/plugins/claude-code/src/onboard.ts
+++ b/plugins/claude-code/src/onboard.ts
@@ -4,7 +4,7 @@
  * collects the answers conversationally, then runs:
  *
  *   node scripts/onboard.js --policy <redact|warn> --historical <full|session-only> \
- *     --posture <json> --floor
+ *     --vault-consent <grant|revoke> --posture <json> --floor
  *
  * Each flag is optional and additive: omit one and its current value (or the
  * default) is kept, so a later wizard step is one more flag with no rewrite.
@@ -33,6 +33,7 @@ import {
   HistoricalAccess,
   MODEL_JUDGE_PAYLOAD_VERSION,
   SimpleDetectionPolicy,
+  VAULT_CONSENT_VERSION,
 } from '@akasecurity/schema';
 
 import { parsePosture } from './onboard-posture.ts';
@@ -93,6 +94,29 @@ if (process.argv.includes('--model-judge-consent')) {
   };
 }
 
+// The vault-consent answer. `grant` stamps the acknowledgment HERE — the flag
+// carries no timestamp or version, so a caller can never supply either; `revoke`
+// clears the stored grant (an explicit undefined overrides the merged value and
+// the key is dropped on write). Revoking stops future vaulting only — entries
+// already stored stay until the vault is purged.
+const rawVaultConsent = flags.get('vault-consent');
+let vaultConsentAction: 'grant' | 'revoke' | undefined;
+if (rawVaultConsent !== undefined) {
+  if (rawVaultConsent === 'grant' || rawVaultConsent === 'revoke') {
+    vaultConsentAction = rawVaultConsent;
+  } else {
+    fail(`invalid --vault-consent "${rawVaultConsent}" (expected grant or revoke)`);
+  }
+}
+if (vaultConsentAction === 'grant') {
+  answers.vaultConsent = {
+    acknowledgedAt: new Date().toISOString(),
+    version: VAULT_CONSENT_VERSION,
+  };
+} else if (vaultConsentAction === 'revoke') {
+  answers.vaultConsent = undefined;
+}
+
 const rawPosture = flags.get('posture');
 const useFloor = process.argv.includes('--floor');
 const recalibrate = process.argv.includes('--recalibrate');
@@ -103,7 +127,7 @@ const recalibrate = process.argv.includes('--recalibrate');
 if (useFloor && rawPosture !== undefined) fail('--floor and --posture are mutually exclusive');
 
 if (Object.keys(answers).length === 0 && rawPosture === undefined && !useFloor) {
-  fail('nothing to save — pass --policy, --historical, --posture and/or --floor');
+  fail('nothing to save — pass --policy, --historical, --vault-consent, --posture and/or --floor');
 }
 
 // Recording the model-judge consent is not an onboarding-posture answer: it
@@ -123,6 +147,17 @@ if (Object.keys(answers).length > 0) {
     if (wroteConsent) {
       process.stdout.write(
         show("Noted — I'll send findings to the model to rate them. You can revoke that anytime."),
+      );
+    }
+    if (vaultConsentAction === 'grant') {
+      process.stdout.write(
+        show('Okay — detected secrets will be kept recoverable in your local encrypted vault.'),
+      );
+    } else if (vaultConsentAction === 'revoke') {
+      process.stdout.write(
+        show(
+          'Okay — new detections will no longer be vaulted. Anything already stored stays until you purge the vault.',
+        ),
       );
     }
     // Caps any existing block/redact category rows to warn once when this

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -262,6 +262,14 @@ export class SetupJourney {
     return this.run('onboard.js', ['--model-judge-consent']);
   }
 
+  // Consent side effect — record or clear the reversible-vault grant. `grant`
+  // stamps the acknowledgment inside onboard.js itself; `revoke` removes the
+  // stored grant (future vaulting stops, already-vaulted entries remain until
+  // purged).
+  onboardVaultConsent(action: 'grant' | 'revoke'): StepResult {
+    return this.run('onboard.js', ['--vault-consent', action]);
+  }
+
   // Out-of-band posture write, e.g. a pack the user hardened before running the
   // wizard — used to prove the confirm write never downgrades it.
   onboardPosture(posture: Record<string, string>): StepResult {

--- a/plugins/claude-code/test/onboard-vault-consent.test.ts
+++ b/plugins/claude-code/test/onboard-vault-consent.test.ts
@@ -1,0 +1,217 @@
+/**
+ * The vault-consent grant/revoke contract on the onboarding writer, proven
+ * end-to-end against the REAL shipped script (onboard.js) in a throwaway ~/.aka
+ * home.
+ *
+ * Grant: `onboard.js --vault-consent grant` records a VaultConsent stamped by
+ * the writer itself — the flag carries no timestamp or version, so a caller can
+ * never supply either. Revoke: the vaultConsent key is removed from the
+ * persisted file entirely, so future vaulting stops; entries already stored are
+ * untouched (purging the vault is the eraser).
+ *
+ * Hermetic: every write lands under a temp home; no developer store is touched.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { isVaultConsentValid, VAULT_CONSENT_VERSION, WorkspaceSettings } from '@akasecurity/schema';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { PLUGIN_ROOT, SetupJourney } from './journey/harness.ts';
+
+function readRawSettings(journey: SetupJourney): Record<string, unknown> {
+  return JSON.parse(readFileSync(journey.settingsPath, 'utf8')) as Record<string, unknown>;
+}
+
+describe('grant — records a writer-stamped VaultConsent', () => {
+  let journey: SetupJourney;
+  let stdout: string;
+  let beforeMs: number;
+  let afterMs: number;
+  let persisted: WorkspaceSettings;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+    beforeMs = Date.now();
+    stdout = journey.onboardVaultConsent('grant').stdout;
+    afterMs = Date.now();
+    persisted = WorkspaceSettings.parse(readRawSettings(journey));
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('persists a vaultConsent the schema validates as a current grant', () => {
+    expect(persisted.vaultConsent?.version).toBe(VAULT_CONSENT_VERSION);
+    expect(isVaultConsentValid(persisted.vaultConsent)).toBe(true);
+  });
+
+  it('stamps a parseable ISO acknowledgedAt inside the run window', () => {
+    const acknowledgedAt = persisted.vaultConsent?.acknowledgedAt;
+    expect(acknowledgedAt).toBeDefined();
+    const stampedMs = Date.parse(acknowledgedAt ?? '');
+    expect(Number.isNaN(stampedMs)).toBe(false);
+    expect(stampedMs).toBeGreaterThanOrEqual(beforeMs);
+    expect(stampedMs).toBeLessThanOrEqual(afterMs);
+  });
+
+  it('confirms on stdout in plain language', () => {
+    expect(stdout).toContain(
+      'Okay — detected secrets will be kept recoverable in your local encrypted vault.',
+    );
+  });
+
+  it('changes neither historicalAccess nor policy — the fields are independent', () => {
+    // The grant answer carries only vaultConsent; the other consent/preference
+    // fields stay at whatever the merge read (here: never-set defaults).
+    const defaults = WorkspaceSettings.parse({});
+    expect(persisted.historicalAccess).toBe(defaults.historicalAccess);
+    expect(persisted.policy).toBe(defaults.policy);
+  });
+
+  it('leaves a previously recorded historical grant untouched', () => {
+    const separate = new SetupJourney();
+    try {
+      separate.onboardHistorical('full');
+      separate.onboardVaultConsent('grant');
+      const after = WorkspaceSettings.parse(readRawSettings(separate));
+      expect(after.historicalAccess).toBe('full');
+      expect(isVaultConsentValid(after.vaultConsent)).toBe(true);
+    } finally {
+      separate.cleanup();
+    }
+  });
+});
+
+describe('grant — the stamp cannot be smuggled in from the caller', () => {
+  let journey: SetupJourney;
+  let beforeMs: number;
+  let afterMs: number;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('ignores extra args carrying an attacker-chosen timestamp or version', () => {
+    // The flag surface has no timestamp/version input at all — these extra args
+    // fall through the parser as unknown flags. Prove it by asserting the
+    // persisted stamp is the writer's own (inside the run window), not 1999.
+    beforeMs = Date.now();
+    execFileSync(
+      process.execPath,
+      [
+        join(PLUGIN_ROOT, 'scripts', 'onboard.js'),
+        '--vault-consent',
+        'grant',
+        '--acknowledgedAt',
+        '1999-01-01T00:00:00.000Z',
+        '--version',
+        '999',
+      ],
+      {
+        env: { HOME: journey.home, USERPROFILE: journey.home },
+        encoding: 'utf8',
+      },
+    );
+    afterMs = Date.now();
+
+    const persisted = WorkspaceSettings.parse(readRawSettings(journey));
+    expect(persisted.vaultConsent?.version).toBe(VAULT_CONSENT_VERSION);
+    const stampedMs = Date.parse(persisted.vaultConsent?.acknowledgedAt ?? '');
+    expect(stampedMs).toBeGreaterThanOrEqual(beforeMs);
+    expect(stampedMs).toBeLessThanOrEqual(afterMs);
+  });
+});
+
+describe('revoke — clears the grant without touching anything else', () => {
+  let journey: SetupJourney;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('after a grant, removes the vaultConsent key from the persisted file', () => {
+    journey.onboardVaultConsent('grant');
+    expect(readRawSettings(journey)).toHaveProperty('vaultConsent');
+
+    const result = journey.onboardVaultConsent('revoke');
+    expect(result.status).toBe(0);
+    const raw = readRawSettings(journey);
+    expect('vaultConsent' in raw).toBe(false);
+    expect(isVaultConsentValid(undefined)).toBe(false);
+    expect(WorkspaceSettings.parse(raw).vaultConsent).toBeUndefined();
+  });
+
+  it('states the revocation boundary on stdout — stored entries stay until purge', () => {
+    const result = journey.onboardVaultConsent('revoke');
+    expect(result.stdout).toContain('new detections will no longer be vaulted');
+    expect(result.stdout).toContain('Anything already stored stays until you purge the vault.');
+  });
+});
+
+describe('revoke — when no grant was ever recorded', () => {
+  let journey: SetupJourney;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('exits 0, persists no vaultConsent key, and changes nothing else', () => {
+    const result = journey.onboardVaultConsent('revoke');
+    expect(result.status).toBe(0);
+    const raw = readRawSettings(journey);
+    expect('vaultConsent' in raw).toBe(false);
+    // Beyond the onboardedAt completion stamp the write is a no-op merge —
+    // every other field still parses to its never-set default.
+    const persisted = WorkspaceSettings.parse(raw);
+    const defaults = WorkspaceSettings.parse({});
+    expect({ ...persisted, onboardedAt: undefined }).toEqual(defaults);
+  });
+});
+
+describe('an invalid --vault-consent value', () => {
+  let journey: SetupJourney;
+
+  beforeAll(() => {
+    journey = new SetupJourney();
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('fails with the expected message and leaves the settings file untouched', () => {
+    journey.onboardVaultConsent('grant');
+    const bytesBefore = readFileSync(journey.settingsPath, 'utf8');
+
+    const result = journey.onboardVaultConsent('maybe' as 'grant');
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain('invalid --vault-consent "maybe" (expected grant or revoke)');
+    expect(readFileSync(journey.settingsPath, 'utf8')).toBe(bytesBefore);
+  });
+
+  it('writes no settings file at all when none existed', () => {
+    const fresh = new SetupJourney();
+    try {
+      const result = fresh.onboardVaultConsent('nonsense' as 'grant');
+      expect(result.status).toBe(1);
+      expect(existsSync(fresh.settingsPath)).toBe(false);
+    } finally {
+      fresh.cleanup();
+    }
+  });
+});

--- a/web-ui/app/(app)/settings/actions.ts
+++ b/web-ui/app/(app)/settings/actions.ts
@@ -1,10 +1,12 @@
 'use server';
 
-import { applyOnboarding } from '@akasecurity/persistence';
+import { applyOnboarding, readWorkspaceSettings } from '@akasecurity/persistence';
 import {
   HistoricalAccess,
+  isVaultConsentValid,
   MODEL_JUDGE_PAYLOAD_VERSION,
   SimpleDetectionPolicy,
+  VAULT_CONSENT_VERSION,
 } from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
@@ -29,16 +31,36 @@ export async function saveSettings(input: {
   // acknowledgement time and payload version are stamped below from server
   // state, so a client cannot backdate a grant or claim a version it never saw.
   modelJudgeConsent?: boolean;
+  vaultConsent: string;
 }): Promise<SaveSettingsResult> {
   const policy = SimpleDetectionPolicy.safeParse(input.policy);
   const historicalAccess = HistoricalAccess.safeParse(input.historicalAccess);
-  if (!policy.success || !historicalAccess.success) {
+  const vaultChoice = input.vaultConsent;
+  if (
+    !policy.success ||
+    !historicalAccess.success ||
+    (vaultChoice !== 'on' && vaultChoice !== 'off')
+  ) {
     return { ok: false, error: 'Invalid settings value.' };
   }
   // policy/historicalAccess are parsed above because their values are persisted
   // verbatim; modelJudgeConsent needs no equivalent parse because only its
   // truthiness survives — the record written below is built entirely here.
   try {
+    // The vault grant is stamped HERE, never accepted from the client — the
+    // input is only the choice string, so a caller-supplied acknowledgedAt or
+    // version has no path in. 'on' records the current time at the current
+    // consent version; if a still-valid grant is already on file it is kept
+    // as-is so its acknowledgedAt survives unrelated edits. 'off' clears the
+    // field entirely: future vaulting stops, but entries already stored remain
+    // until the vault is purged.
+    const current = readWorkspaceSettings();
+    const vaultConsent =
+      vaultChoice === 'off'
+        ? undefined
+        : isVaultConsentValid(current.vaultConsent)
+          ? current.vaultConsent
+          : { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION };
     applyOnboarding({
       policy: policy.data,
       historicalAccess: historicalAccess.data,
@@ -47,6 +69,7 @@ export async function saveSettings(input: {
       modelJudgeConsent: input.modelJudgeConsent
         ? { acknowledgedAt: new Date().toISOString(), payloadVersion: MODEL_JUDGE_PAYLOAD_VERSION }
         : undefined,
+      vaultConsent,
     });
   } catch {
     return { ok: false, error: 'Could not write settings.json.' };

--- a/web-ui/test/actions/settings.test.ts
+++ b/web-ui/test/actions/settings.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { readWorkspaceSettings } from '@akasecurity/persistence';
+import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+
+import { saveSettings } from '../../app/(app)/settings/actions.ts';
+
+// `saveSettings` is the web surface that records and revokes the vault-consent
+// grant. The grant must always be stamped server-side ('on' has no input path
+// for a timestamp or version), a still-valid grant must survive re-saves with
+// its original acknowledgedAt, and 'off' must remove the field from the
+// persisted file entirely — revocation stops future vaulting without touching
+// what the vault already stores.
+//
+// The action resolves settings.json from `homedir()` (never process.env), so
+// the whole test is redirected into a temp home by mocking `node:os`;
+// `next/cache` is stubbed because revalidatePath needs a Next render context
+// that does not exist under vitest.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
+
+let home: string;
+
+function settingsFile(): string {
+  return join(home, '.aka', 'settings', 'settings.json');
+}
+
+function rawSettings(): string {
+  return readFileSync(settingsFile(), 'utf8');
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-settings-'));
+  osHome.dir = home;
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('saveSettings — vault-consent grant and revocation', () => {
+  it("records a server-stamped grant at the current consent version on 'on'", async () => {
+    const before = Date.now();
+    const res = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+    });
+    expect(res).toEqual({ ok: true });
+
+    const consent = readWorkspaceSettings().vaultConsent;
+    expect(consent?.version).toBe(VAULT_CONSENT_VERSION);
+    // The timestamp is minted by the action itself, so it lands inside this
+    // test's own execution window.
+    const acknowledged = Date.parse(consent?.acknowledgedAt ?? '');
+    expect(acknowledged).toBeGreaterThanOrEqual(before);
+    expect(acknowledged).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("keeps the original acknowledgedAt when 'on' is saved again", async () => {
+    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    const first = readWorkspaceSettings().vaultConsent;
+    expect(first).toBeDefined();
+
+    // A later save of unrelated edits with consent still 'on' must not
+    // re-stamp the grant — the recorded acknowledgment time is the consent
+    // record, not a last-touched time. Let the clock tick past the first stamp
+    // so a re-stamp could not coincide with it.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const res = await saveSettings({
+      policy: 'warn',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+    });
+    expect(res).toEqual({ ok: true });
+
+    const again = readWorkspaceSettings();
+    expect(again.policy).toBe('warn');
+    expect(again.vaultConsent).toEqual(first);
+  });
+
+  it("removes the field from the persisted file on 'off'", async () => {
+    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    expect(rawSettings()).toContain('vaultConsent');
+
+    const res = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'off',
+    });
+    expect(res).toEqual({ ok: true });
+
+    // Gone from the raw JSON, not merely parsed away: the absence of the key
+    // is what "not granted" means to every reader of this file.
+    const raw = rawSettings();
+    expect(raw).not.toContain('vaultConsent');
+    expect('vaultConsent' in (JSON.parse(raw) as Record<string, unknown>)).toBe(false);
+    expect(readWorkspaceSettings().vaultConsent).toBeUndefined();
+  });
+
+  it('rejects an unknown consent value and leaves the file untouched', async () => {
+    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    const before = rawSettings();
+
+    const res = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'granted',
+    });
+    expect(res.ok).toBe(false);
+    expect(rawSettings()).toBe(before);
+  });
+
+  it('rejects a client-supplied grant object — there is no input path for a timestamp', async () => {
+    // The input contract is the bare choice string. A caller that smuggles a
+    // pre-built grant (back-dated acknowledgment, forged version) past the
+    // type system must still be rejected at runtime, writing nothing.
+    const forged = { acknowledgedAt: '2001-01-01T00:00:00.000Z', version: VAULT_CONSENT_VERSION };
+    const res = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: forged as unknown as string,
+    });
+    expect(res.ok).toBe(false);
+    expect(() => rawSettings()).toThrow(); // nothing was ever written
+
+    // And the contract itself admits only a string — no object shape exists.
+    expectTypeOf<Parameters<typeof saveSettings>[0]['vaultConsent']>().toEqualTypeOf<string>();
+  });
+});


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

The single door between hook text and the vault, plus the consent that gates all of it.

**Two rules the whole surface is built around:** *never throw* (a caller on the fail-open boundary must not be broken by a vault fault) and *never leak* (a fault while masking destroys the value rather than passing it). They compose to: on failure the model sees **less**, never more.

## Decisions

- **Overlapping spans degrade one-way.** They cannot each map to one vaulted value — the shared characters belong to both findings — so the group becomes the one-way placeholder of its highest-severity member. A span that no longer slices to its finding's `rawMatch` is stale and degrades likewise. Only disjoint, exact spans tokenize.
- **`detokenizeText` resolves each distinct pointer once**, carrying its occurrence count, so a repeated pointer writes one audit row.
- **The fail posture is decided once at construction:** an unopenable store yields a glue whose tokenize destroys one-way and whose detokenize resolves nothing.

## Consent plumbing

Vaulting is opt-in and inert until granted. `onboard.js --vault-consent grant|revoke` and a dashboard control both record it; the grant's timestamp and version are stamped **by the writer**, never accepted from input (a test literally tries to smuggle `--acknowledgedAt 1999…` and asserts it is ignored, and a compile-time test pins that no timestamp can leave the client). Revoking clears the grant and says plainly that existing entries stay until purge.

This ships early — ahead of the wizard — precisely so every later step in the stack is actually enableable and testable.