### PR TITLE
vault 05/10: prompt block with pointerized resubmit, reveal grants, tail scrub

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -4,7 +4,13 @@ import { parseArgs } from 'node:util';
 import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
 import type { BlockedDetection, LocalDatabase } from '@akasecurity/persistence';
 import type { CreateExceptionInput } from '@akasecurity/persistence';
-import { openLocalDatabase } from '@akasecurity/persistence';
+import {
+  createKeyProvider,
+  keysDir,
+  openLocalDatabase,
+  readWorkspaceSettings,
+  SecretVault,
+} from '@akasecurity/persistence';
 import type { FingerprintKey } from '@akasecurity/plugin-sdk';
 import {
   dataDir,
@@ -16,7 +22,13 @@ import {
   rotateFingerprintKey,
 } from '@akasecurity/plugin-sdk';
 import type { DetectionException, ResolvedScope } from '@akasecurity/schema';
-import { resolveScopeFlags, scopeFromAnswer } from '@akasecurity/schema';
+import {
+  DetectionCategory,
+  isVaultConsentValid,
+  PointerToken,
+  resolveScopeFlags,
+  scopeFromAnswer,
+} from '@akasecurity/schema';
 
 import { HOME_OPTION, homeBase } from '../lib/args.ts';
 import { formatRelative, formatTimestamp } from '../lib/duration.ts';
@@ -44,7 +56,7 @@ const SCOPE_REQUIRED = `a scope is required — pick exactly one (there is no de
   --permanent       until revoked (typed confirmation required)`;
 
 const VERB_HELP: Record<string, string> = {
-  approve: `Usage: aka exception approve [reference|value] [flags]
+  approve: `Usage: aka exception approve [reference|value|pointer] [flags]
 
 Grant an exception from a detection blocked in the last 30 minutes. Select the
 block by the reference from the block message, the masked value shown there,
@@ -52,13 +64,20 @@ or by pasting the blocked value itself. A pasted value is matched by its keyed
 fingerprint and never stored or echoed — but it does land in your shell
 history, so prefer the reference where that matters.
 
+A vault pointer ([[aka:...]] — quote it in the shell) selects the vaulted
+value behind it and requires --reveal: the grant lets the model receive that
+value's RAW form at tool boundaries while it is active, with every crossing
+audited. Revoke any time with 'aka exception revoke <id>'.
+
 Flags:
+  --reveal            required with a pointer: grant reveal-to-model, not suppression
   --once | --for <30m|1h|24h> | --permanent   scope (required, pick one)
   --reason "<why>"    required; prompted on a terminal if omitted
   --yes               skip confirmations (non-interactive use)
   --home <dir>        alternate AKA home (default: ~/.aka)
 
 Example: aka exception approve 3f2a --for 1h --reason "temp deploy creds"
+Example: aka exception approve '[[aka:secret:...]]' --reveal --for 1h --reason "agent needs the live key"
 `,
   add: `Usage: aka exception add --rule <ruleId> [--stdin] [flags]
 
@@ -380,17 +399,98 @@ async function pickBlocked(
   return picked;
 }
 
+// The category segment of a pointer token. Safe on any parsed PointerToken:
+// the token grammar pins the segment to the DetectionCategory members.
+function pointerCategory(pointer: string): DetectionCategory {
+  const body = pointer.slice('[[aka:'.length);
+  return DetectionCategory.parse(body.slice(0, body.indexOf(':')));
+}
+
+// Mint a reveal-to-model grant for the vaulted value behind a pointer. The
+// grant identity (rule, fingerprint, key version) comes from the vault row —
+// the raw value never enters this process, and only masked/descriptor data is
+// ever printed.
+async function runApproveReveal(
+  pointer: string,
+  values: ScopeReasonFlags & { yes?: boolean | undefined },
+  io: Prompter,
+  base: string,
+): Promise<void> {
+  const dir = dataDir(base);
+  const db = openLocalDatabase(dir);
+  try {
+    const vault = new SecretVault({
+      repo: db.secretVault,
+      keys: createKeyProvider(readWorkspaceSettings(base).vaultKeyCustody, keysDir(base)),
+      fingerprintKey: loadOrCreateFingerprintKey(dir),
+      // Read live so a consent revocation applies to the very next call.
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
+    });
+    const identity = await vault.resolvePointerIdentity(pointer);
+    if (identity === null) {
+      throw new Error(
+        'the pointer is unknown here — not one this machine issued (forged or tampered), its vault entry was purged, or the key material is unavailable; nothing was granted',
+      );
+    }
+    // Badge data only. A vanished descriptor still never shows raw anything.
+    const descriptor = await vault.describePointer(pointer);
+    const maskedValue = descriptor?.maskedMatch ?? '···';
+    const { scope, reason } = await resolveScopeAndReason(values, io);
+    if (scope.scope === 'permanent') {
+      await confirmPermanent(io, maskedValue, values.yes === true);
+    }
+    const granted = await createGrant(db, {
+      ruleId: identity.ruleId,
+      category: descriptor?.category ?? pointerCategory(pointer),
+      valueFingerprint: identity.valueFingerprint,
+      keyVersion: identity.fingerprintKeyVersion,
+      maskedValue,
+      capability: 'reveal_to_model',
+      ...scope,
+      justification: reason,
+      conditions: null,
+      createdBy: resolveCreatedBy(),
+      createdVia: 'cli-approve',
+    });
+    io.out(
+      `Reveal grant ${shortId(granted.id)}: ${granted.ruleId}  ${granted.maskedValue}  ${scopeSummary(granted)}\n` +
+        `While this grant is active the model can receive this value's RAW form at\n` +
+        `tool boundaries. Every crossing is audited. Revoke with: aka exception revoke ${shortId(granted.id)}\n`,
+    );
+  } finally {
+    db.close();
+  }
+}
+
 async function runApprove(argv: string[], io: Prompter): Promise<void> {
   const { values, positionals } = parseArgs({
     args: argv,
-    options: { ...HOME_OPTION, ...SCOPE_OPTIONS },
+    options: { ...HOME_OPTION, ...SCOPE_OPTIONS, reveal: { type: 'boolean' } },
     allowPositionals: true,
   });
   if (values.help) {
     io.out(VERB_HELP.approve ?? '');
     return;
   }
-  const dir = dataDir(homeBase(values.home));
+  const base = homeBase(values.home);
+  // A pointer selector routes to the vault, not the blocked-detections ledger.
+  const candidate = positionals[0]?.trim();
+  const pointer = candidate === undefined ? undefined : PointerToken.safeParse(candidate);
+  if (pointer?.success === true) {
+    if (values.reveal !== true) {
+      throw new Error(
+        'that selector is a vault pointer — approving one mints a reveal-to-model grant, which must be asked for explicitly: add --reveal',
+      );
+    }
+    await runApproveReveal(pointer.data, values, io, base);
+    return;
+  }
+  if (values.reveal === true) {
+    throw new Error(
+      'a reveal grant is minted from a vault pointer — pass the full [[aka:...]] token (quote it in the shell); the pointer is the proof the value is vaulted',
+    );
+  }
+  const dir = dataDir(base);
   const db = openLocalDatabase(dir);
   try {
     const entries = await db.exceptions.recentBlocked();
@@ -400,15 +500,15 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
       );
       return;
     }
-    // Trim paste artifacts (a multi-line paste arrives with embedded
-    // newlines); a whitespace-only selector falls back to the bare picker.
-    const selector = positionals[0]?.trim();
+    // `candidate` already trimmed paste artifacts (a multi-line paste arrives
+    // with embedded newlines); a whitespace-only selector falls back to the
+    // bare picker.
     // Resolved ONCE: the picker fingerprints a by-value selector with it and
     // marks rows it will refuse, and the guard below checks the chosen row
     // against it. Reading the file twice duplicated the parse and left a window
     // for the two reads to disagree.
     const key = readKeyForApprove(dir);
-    const entry = await pickBlocked(entries, selector === '' ? undefined : selector, io, key);
+    const entry = await pickBlocked(entries, candidate === '' ? undefined : candidate, io, key);
 
     // The ledger row carries the fingerprint computed when the hook blocked,
     // under whichever key was live then; the ledger is retained far longer than

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -1,0 +1,219 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  applyOnboarding,
+  createKeyProvider,
+  dataDir,
+  fingerprintValue,
+  keysDir,
+  loadOrCreateFingerprintKey,
+  openLocalDatabase,
+  readWorkspaceSettings,
+  SecretVault,
+} from '@akasecurity/persistence';
+import type { DetectionException } from '@akasecurity/schema';
+import { isVaultConsentValid, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { runException } from '../../src/commands/exception.ts';
+import type { Prompter } from '../../src/lib/prompter.ts';
+
+// `aka exception approve <pointer> --reveal` is the sanctioned door for "the
+// agent legitimately needs this raw value": it mints a reveal_to_model grant
+// keyed to the vault row's identity, which the plugin resolver later finds via
+// activeRevealGrant. The suite runs against the REAL node:sqlite store and
+// REAL key files (no vault mocking), mirroring vault.test.ts.
+
+// Not secret-shaped on purpose: tokenize never scans, and a plain string keeps
+// secret-looking literals out of this public file.
+const RAW = 'vaulted-value-for-reveal-grant-test';
+const RULE_ID = 'secrets/test-rule';
+const MASKED = 'vau…est';
+
+// Scripted, non-interactive Prompter with captured output.
+function scriptedIo(): Prompter & { output: () => string } {
+  const chunks: string[] = [];
+  return {
+    output: () => chunks.join(''),
+    out: (text) => {
+      chunks.push(text);
+    },
+    err: (text) => {
+      chunks.push(text);
+    },
+    isInteractive: false,
+    ask: () => Promise.reject(new Error('non-interactive test io')),
+    askHidden: () => Promise.reject(new Error('non-interactive test io')),
+    readAllStdin: () => Promise.resolve(''),
+  };
+}
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-cli-exc-reveal-'));
+  // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
+  applyOnboarding(
+    {
+      vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },
+    },
+    home,
+  );
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+// Seed one vaulted value through the real persistence SecretVault — the same
+// construction the command performs — and return its pointer.
+async function seedPointer(): Promise<string> {
+  const dir = dataDir(home);
+  const db = openLocalDatabase(dir);
+  try {
+    const vault = new SecretVault({
+      repo: db.secretVault,
+      keys: createKeyProvider(readWorkspaceSettings(home).vaultKeyCustody, keysDir(home)),
+      fingerprintKey: loadOrCreateFingerprintKey(dir),
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings(home).vaultConsent),
+    });
+    const pointer = await vault.tokenize(RAW, {
+      ruleId: RULE_ID,
+      category: 'secret',
+      maskedMatch: MASKED,
+    });
+    if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
+    return pointer;
+  } finally {
+    db.close();
+  }
+}
+
+// Flip one tag character so the token stays pointer-shaped but can no longer
+// verify — the vault must treat it exactly like a forgery.
+function forge(pointer: string): string {
+  const tagStart = pointer.length - ']]'.length - 16;
+  const original = pointer[tagStart];
+  const flipped = original === 'A' ? 'B' : 'A';
+  return pointer.slice(0, tagStart) + flipped + pointer.slice(tagStart + 1);
+}
+
+function approveArgs(selector: string, ...extra: string[]): string[] {
+  return ['approve', selector, ...extra, '--home', home];
+}
+
+describe('aka exception approve <pointer> --reveal', () => {
+  it('mints a reveal_to_model grant from the vault identity and states the consequence', async () => {
+    const pointer = await seedPointer();
+    const io = scriptedIo();
+    await runException(
+      approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'agent needs the live key'),
+      io,
+    );
+
+    const rows = await openAndList();
+    expect(rows).toHaveLength(1);
+    const grant = rows[0];
+    if (!grant) throw new Error('grant row missing');
+
+    const dir = dataDir(home);
+    const key = loadOrCreateFingerprintKey(dir);
+    expect(grant.capability).toBe('reveal_to_model');
+    expect(grant.ruleId).toBe(RULE_ID);
+    expect(grant.valueFingerprint).toBe(fingerprintValue(key, RAW));
+    expect(grant.keyVersion).toBe(key.version);
+    expect(grant.maskedValue).toBe(MASKED);
+    expect(grant.category).toBe('secret');
+    expect(grant.scope).toBe('temporary');
+    expect(grant.justification).toBe('agent needs the live key');
+    expect(grant.createdVia).toBe('cli-approve');
+
+    // The confirmation names the consequence, the audit, and the way back.
+    const out = io.output();
+    expect(out).toContain(`Reveal grant ${grant.id.slice(0, 6)}`);
+    expect(out).toContain('RAW form');
+    expect(out).toContain('audited');
+    expect(out).toContain(`aka exception revoke ${grant.id.slice(0, 6)}`);
+    // The raw value itself never reaches the output.
+    expect(out).not.toContain(RAW);
+  });
+
+  it('rejects a pointer without --reveal and creates nothing', async () => {
+    const pointer = await seedPointer();
+    await expect(
+      runException(approveArgs(pointer, '--once', '--reason', 'x'), scriptedIo()),
+    ).rejects.toThrow(/--reveal/);
+    expect(await openAndList()).toHaveLength(0);
+  });
+
+  it('rejects --reveal with a non-pointer selector and creates nothing', async () => {
+    await seedPointer();
+    await expect(
+      runException(approveArgs('3f2a', '--reveal', '--once', '--reason', 'x'), scriptedIo()),
+    ).rejects.toThrow(/vault pointer/);
+    expect(await openAndList()).toHaveLength(0);
+  });
+
+  it('rejects a forged pointer with --reveal and creates nothing', async () => {
+    const pointer = await seedPointer();
+    await expect(
+      runException(
+        approveArgs(forge(pointer), '--reveal', '--once', '--reason', 'x'),
+        scriptedIo(),
+      ),
+    ).rejects.toThrow(/unknown here/);
+    expect(await openAndList()).toHaveLength(0);
+  });
+
+  it('rejects a duplicate active reveal grant, keeping exactly one row', async () => {
+    const pointer = await seedPointer();
+    await runException(
+      approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'first'),
+      scriptedIo(),
+    );
+    await expect(
+      runException(
+        approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'second'),
+        scriptedIo(),
+      ),
+    ).rejects.toThrow(/active exception already exists/);
+    expect(await openAndList()).toHaveLength(1);
+  });
+
+  it('is found by activeRevealGrant — the exact lookup the plugin resolver uses', async () => {
+    const pointer = await seedPointer();
+    await runException(
+      approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'bridge contract'),
+      scriptedIo(),
+    );
+
+    const dir = dataDir(home);
+    const key = loadOrCreateFingerprintKey(dir);
+    const db = openLocalDatabase(dir);
+    try {
+      const rows = await db.exceptions.list({ includeTerminal: true });
+      const granted = rows[0];
+      if (!granted) throw new Error('grant row missing');
+      const hit = await db.exceptions.activeRevealGrant(
+        RULE_ID,
+        fingerprintValue(key, RAW),
+        key.version,
+      );
+      expect(hit).toEqual({ id: granted.id });
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// Read every exception row (including terminal) from the store.
+async function openAndList(): Promise<DetectionException[]> {
+  const db = openLocalDatabase(dataDir(home));
+  try {
+    return await db.exceptions.list({ includeTerminal: true });
+  } finally {
+    db.close();
+  }
+}

--- a/packages/dashboard-ui/test/exceptions/meta.test.ts
+++ b/packages/dashboard-ui/test/exceptions/meta.test.ts
@@ -18,6 +18,7 @@ function exception(overrides: Partial<DetectionException>): DetectionException {
     valueFingerprint: 'a'.repeat(64),
     keyVersion: 1,
     maskedValue: 'A****Z',
+    capability: 'suppress',
     scope: 'permanent',
     expiresAt: null,
     maxUses: null,

--- a/packages/persistence/src/repositories/exceptions.ts
+++ b/packages/persistence/src/repositories/exceptions.ts
@@ -36,7 +36,11 @@ export type CreateExceptionInput = Pick<
   | 'conditions'
   | 'createdBy'
   | 'createdVia'
->;
+> & {
+  // Absent means 'suppress' — the pre-capability semantics, so no existing
+  // caller silently starts minting reveal grants.
+  capability?: DetectionExceptionType['capability'] | undefined;
+};
 
 // The ledger-entry shapes live in @akasecurity/schema (zod/exception.ts), shared with
 // the web-ui's approve flow; re-exported so persistence consumers keep importing
@@ -91,6 +95,7 @@ interface ExceptionRow {
   value_fingerprint: string;
   key_version: number;
   masked_value: string;
+  capability: string;
   scope: string;
   expires_at: number | null;
   max_uses: number | null;
@@ -250,11 +255,11 @@ export class SqliteExceptionsRepository {
       .prepare(
         `INSERT INTO exceptions (
              id, rule_id, category, value_fingerprint, key_version, masked_value,
-             scope, expires_at, max_uses, use_count, last_used_at, justification,
-             conditions, created_by, created_via, created_at, updated_at
+             capability, scope, expires_at, max_uses, use_count, last_used_at,
+             justification, conditions, created_by, created_via, created_at, updated_at
            ) VALUES (
              :id, :ruleId, :category, :valueFingerprint, :keyVersion, :maskedValue,
-             :scope, :expiresAt, :maxUses, 0, NULL, :justification,
+             :capability, :scope, :expiresAt, :maxUses, 0, NULL, :justification,
              :conditions, :createdBy, :createdVia, :now, :now
            )`,
       )
@@ -265,6 +270,7 @@ export class SqliteExceptionsRepository {
         valueFingerprint: input.valueFingerprint,
         keyVersion: input.keyVersion,
         maskedValue: input.maskedValue,
+        capability: input.capability ?? 'suppress',
         scope: input.scope,
         expiresAt: input.expiresAt === null ? null : isoToEpochMillis(input.expiresAt),
         maxUses: input.maxUses,
@@ -372,6 +378,7 @@ export class SqliteExceptionsRepository {
         ruleId: row.rule_id,
         valueFingerprint: row.value_fingerprint,
         keyVersion: row.key_version,
+        capability: row.capability,
         expiresAt: row.expires_at === null ? null : epochMillisToIso(row.expires_at),
         maxUses: row.max_uses,
         useCount: row.use_count,
@@ -430,6 +437,37 @@ export class SqliteExceptionsRepository {
   }
 
   /**
+   * The active reveal-to-model grant for a vaulted value's identity, or null.
+   * Matching is exact on (ruleId, valueFingerprint, keyVersion) — the same key
+   * suppression uses — plus the capability: a suppression grant must never
+   * authorize a reveal. Read-only: the caller does NOT consume here, because a
+   * revealed value re-enters the detection scan immediately afterward and the
+   * suppression match there claims the use — one crossing, one use.
+   */
+  activeRevealGrant(
+    ruleId: string,
+    valueFingerprint: string,
+    keyVersion: number,
+    now = Date.now(),
+  ): Promise<{ id: string } | null> {
+    try {
+      const row = getRow<{ id: string }>(
+        this.db.prepare(
+          `SELECT id FROM exceptions
+            WHERE rule_id = :ruleId AND value_fingerprint = :valueFingerprint
+              AND key_version = :keyVersion AND capability = 'reveal_to_model'
+              AND ${ACTIVE_PREDICATE}
+            LIMIT 1`,
+        ),
+        { ruleId, valueFingerprint, keyVersion, now },
+      );
+      return Promise.resolve(row ?? null);
+    } catch (err) {
+      return Promise.reject(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  /**
    * Retention sweep: delete TERMINAL rows (revoked, expired, or use-budget
    * exhausted) whose last transition is older than the retention window.
    * Active grants are never touched — evaluation ignores terminal rows by
@@ -461,6 +499,7 @@ function parseExceptionRow(row: ExceptionRow): DetectionExceptionType {
     valueFingerprint: row.value_fingerprint,
     keyVersion: row.key_version,
     maskedValue: row.masked_value,
+    capability: row.capability,
     scope: row.scope,
     expiresAt: row.expires_at === null ? null : epochMillisToIso(row.expires_at),
     maxUses: row.max_uses,

--- a/packages/persistence/test/migrations.test.ts
+++ b/packages/persistence/test/migrations.test.ts
@@ -83,16 +83,20 @@ describe('applyMigrations tag ledger', () => {
       // stamped user_version accordingly. The count says "all but one applied" but
       // no longer says WHICH — positionally slicing replays 0003 ("table
       // egress_decision_override already exists") and never applies 0002.
+      // 0016 ALTERs the exceptions table 0002 creates, so a store that never
+      // ran 0002 cannot have run 0016 either — both are the missing set here,
+      // and reconciliation must apply them in tag order.
       for (const migration of SQLITE_MIGRATIONS) {
         if (migration.tag === '0002_groovy_big_bertha') continue;
+        if (migration.tag === '0016_breezy_zodiak') continue;
         if (migration.tag === LEGACY_DROP_MIGRATION_TAG) continue;
         db.exec(migration.sql);
       }
-      db.exec(`PRAGMA user_version = ${String(SQLITE_MIGRATIONS.length - 1)}`);
+      db.exec(`PRAGMA user_version = ${String(SQLITE_MIGRATIONS.length - 2)}`);
 
       applyMigrations(db);
 
-      // The genuinely missing migration ran; everything already present was
+      // The genuinely missing migrations ran; everything already present was
       // adopted into the ledger rather than replayed (a replay would throw).
       expect(schemaObjectExists(db, 'table', 'exceptions')).toBe(true);
       expect(appliedTags(db)).toEqual(SQLITE_MIGRATIONS.map((m) => m.tag).sort());

--- a/packages/persistence/test/repositories/exceptions.test.ts
+++ b/packages/persistence/test/repositories/exceptions.test.ts
@@ -367,6 +367,7 @@ describe('SqliteExceptionsRepository', () => {
           ruleId: active.ruleId,
           valueFingerprint: active.valueFingerprint,
           keyVersion: 1,
+          capability: 'suppress',
           expiresAt: active.expiresAt,
           maxUses: 3,
           useCount: 0,

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -86,6 +86,11 @@ export interface VaultCore {
     },
   ): Promise<string | symbol>;
   describePointer(token: string): Promise<PointerDescriptor | null>;
+  resolvePointerIdentity(token: string): Promise<{
+    ruleId: string;
+    valueFingerprint: string;
+    fingerprintKeyVersion: number;
+  } | null>;
 }
 
 // Resolves whether a model-echoed pointer may be de-referenced back to raw for
@@ -114,6 +119,12 @@ export interface VaultGlue {
     text: string,
     opts: { resolveGrant: ModelDerefGrantResolver },
   ): Promise<SubstitutePointersResult>;
+  // The live reveal-grant lookup for this store: a grant id when an active
+  // reveal-to-model exception covers the pointer's value, null otherwise.
+  // Always null on a degraded glue. Deliberately does NOT consume the grant:
+  // a revealed value re-enters the detection scan immediately, and the
+  // suppression match there claims the use — one crossing, one use.
+  revealGrantResolver: ModelDerefGrantResolver;
   /**
    * Release the store handle this glue opened. Idempotent, and a no-op on a
    * glue that opened nothing — a degraded one, or one built over an injected
@@ -174,14 +185,22 @@ function groupSpans(text: string, findings: MatchResult[]): SpanGroup[] {
   return groups;
 }
 
+const NULL_RESOLVER: ModelDerefGrantResolver = () => Promise.resolve(null);
+
 class SecretVaultGlue implements VaultGlue {
   readonly #vault: VaultCore;
+  readonly revealGrantResolver: ModelDerefGrantResolver;
   // Set only when THIS glue opened the store, so a glue over an injected vault
   // never closes a handle it does not own.
   #release: (() => void) | undefined;
 
-  constructor(vault: VaultCore, release?: () => void) {
+  constructor(
+    vault: VaultCore,
+    revealGrantResolver: ModelDerefGrantResolver = NULL_RESOLVER,
+    release?: () => void,
+  ) {
     this.#vault = vault;
+    this.revealGrantResolver = revealGrantResolver;
     this.#release = release;
   }
 
@@ -382,6 +401,8 @@ export interface CreateVaultGlueOptions {
   base?: string;
   // Test seam: a vault core to use instead of opening the real store.
   vault?: VaultCore;
+  // Test seam: a reveal-grant resolver to pair with an injected vault.
+  revealResolver?: ModelDerefGrantResolver;
 }
 
 /**
@@ -391,7 +412,7 @@ export interface CreateVaultGlueOptions {
  * resolves nothing — the two fail postures above, decided once at construction.
  */
 export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
-  if (options?.vault) return new SecretVaultGlue(options.vault);
+  if (options?.vault) return new SecretVaultGlue(options.vault, options.revealResolver);
   const base = options?.base ?? defaultDataDir();
   try {
     const dir = dataDir(base);
@@ -405,7 +426,23 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
       // process.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
     });
-    return new SecretVaultGlue(vault, () => {
+    // Grant matching is exact on the identity a grant is keyed by; anything
+    // failing along the way is a refusal, never a reveal.
+    const revealGrantResolver: ModelDerefGrantResolver = async (pointer) => {
+      try {
+        const identity = await vault.resolvePointerIdentity(pointer);
+        if (identity === null) return null;
+        const grant = await db.exceptions.activeRevealGrant(
+          identity.ruleId,
+          identity.valueFingerprint,
+          identity.fingerprintKeyVersion,
+        );
+        return grant?.id ?? null;
+      } catch {
+        return null;
+      }
+    };
+    return new SecretVaultGlue(vault, revealGrantResolver, () => {
       db.close();
     });
   } catch {
@@ -419,6 +456,7 @@ const UNOPENABLE_VAULT: VaultCore = {
   tokenize: () => Promise.resolve(Symbol('aka.vault.unopenable')),
   detokenize: () => Promise.resolve(Symbol('aka.vault.unopenable')),
   describePointer: () => Promise.resolve(null),
+  resolvePointerIdentity: () => Promise.resolve(null),
 };
 
 // The default glue the hooks use, built once per process against the shared

--- a/packages/plugin-sdk/test/runtime-exceptions.test.ts
+++ b/packages/plugin-sdk/test/runtime-exceptions.test.ts
@@ -71,6 +71,7 @@ function entry(overrides: Partial<ExceptionBundleEntry> & { valueFingerprint: st
     id: randomUUID(),
     ruleId: 'ex/secret-marker',
     keyVersion: 1,
+    capability: 'suppress' as const,
     expiresAt: null,
     maxUses: null,
     useCount: 0,

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -237,6 +237,7 @@ describe('vault glue', () => {
           tokenize: () => Promise.resolve(Symbol('unused')),
           detokenize: () => Promise.resolve(Symbol('unused')),
           describePointer: () => Promise.resolve(null),
+          resolvePointerIdentity: () => Promise.resolve(null),
         },
       });
       expect(() => {
@@ -250,6 +251,7 @@ describe('vault glue', () => {
       tokenize: () => Promise.reject(new Error('store locked')),
       detokenize: () => Promise.reject(new Error('store locked')),
       describePointer: () => Promise.reject(new Error('store locked')),
+      resolvePointerIdentity: () => Promise.reject(new Error('store locked')),
     };
 
     it('a tokenize fault destroys the value one-way', async () => {

--- a/packages/schema/drizzle/local-sqlite/0016_breezy_zodiak.sql
+++ b/packages/schema/drizzle/local-sqlite/0016_breezy_zodiak.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `exceptions` ADD `capability` text DEFAULT 'suppress' NOT NULL;

--- a/packages/schema/drizzle/local-sqlite/meta/0016_snapshot.json
+++ b/packages/schema/drizzle/local-sqlite/meta/0016_snapshot.json
@@ -1,0 +1,2510 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "453a3e67-340c-48e9-bd86-c076fd347cbd",
+  "prevId": "4ebbb623-1c77-4fe3-be30-b0404c8810c5",
+  "tables": {
+    "audit_events": {
+      "name": "audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_project_id": {
+          "name": "source_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.output_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_creation_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_read_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.model'))",
+            "type": "virtual"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.provider'))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_audit_parent": {
+          "name": "idx_audit_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session": {
+          "name": "idx_audit_session",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_harness_t": {
+          "name": "idx_audit_harness_t",
+          "columns": [
+            "harness_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_project_t": {
+          "name": "idx_audit_project_t",
+          "columns": [
+            "source_project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session_type": {
+          "name": "idx_audit_session_type",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false,
+          "where": "event_type = 'llm_call'"
+        },
+        "idx_audit_type_t": {
+          "name": "idx_audit_type_t",
+          "columns": [
+            "event_type",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_parent_id_audit_events_id_fk": {
+          "name": "audit_events_parent_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_root_session_id_audit_events_id_fk": {
+          "name": "audit_events_root_session_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "root_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_host_id_inventory_id_fk": {
+          "name": "audit_events_host_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_harness_id_inventory_id_fk": {
+          "name": "audit_events_harness_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_source_project_id_source_project_id_fk": {
+          "name": "audit_events_source_project_id_source_project_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "source_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "available_packs": {
+      "name": "available_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_available_packs_pack": {
+          "name": "uq_available_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classified_data": {
+      "name": "classified_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "egress_decision_override": {
+      "name": "egress_decision_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_egress_decision_override": {
+          "name": "uq_egress_decision_override",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": true
+        },
+        "uq_egress_decision_override_host": {
+          "name": "uq_egress_decision_override_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true,
+          "where": "`host` IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "egress_decision_override_destination_id_share_destination_id_fk": {
+          "name": "egress_decision_override_destination_id_share_destination_id_fk",
+          "tableFrom": "egress_decision_override",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_tool": {
+          "name": "source_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_occurred": {
+          "name": "idx_events_occurred",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_value": {
+          "name": "masked_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'suppress'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_exceptions_active": {
+          "name": "uq_exceptions_active",
+          "columns": [
+            "rule_id",
+            "value_fingerprint",
+            "key_version"
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_access_override": {
+      "name": "file_access_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_access_override_project": {
+          "name": "idx_file_access_override_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_file_access_override": {
+          "name": "uq_file_access_override",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_access_override_project_id_source_project_id_fk": {
+          "name": "file_access_override_project_id_source_project_id_fk",
+          "tableFrom": "file_access_override",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "finding_resolution": {
+      "name": "finding_resolution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_finding_resolution_key": {
+          "name": "idx_finding_resolution_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "findings": {
+      "name": "findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_findings_event": {
+          "name": "idx_findings_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_findings_key": {
+          "name": "uq_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "findings_event_id_events_id_fk": {
+          "name": "findings_event_id_events_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "harness_asset": {
+      "name": "harness_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_harness_asset_harness": {
+          "name": "idx_harness_asset_harness",
+          "columns": [
+            "harness_id"
+          ],
+          "isUnique": false
+        },
+        "uq_harness_asset": {
+          "name": "uq_harness_asset",
+          "columns": [
+            "harness_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "harness_asset_harness_id_inventory_id_fk": {
+          "name": "harness_asset_harness_id_inventory_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harness_asset_asset_id_inventory_asset_id_fk": {
+          "name": "harness_asset_asset_id_inventory_asset_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_definitions": {
+      "name": "inspection_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_findings": {
+      "name": "inspection_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_definition_id": {
+          "name": "inspection_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classified_data_id": {
+          "name": "classified_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_findings_event": {
+          "name": "idx_inspection_findings_event",
+          "columns": [
+            "audit_event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_inspection_findings_key": {
+          "name": "uq_inspection_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_findings_audit_event_id_audit_events_id_fk": {
+          "name": "inspection_findings_audit_event_id_audit_events_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "audit_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_inspection_definition_id_inspection_definitions_id_fk": {
+          "name": "inspection_findings_inspection_definition_id_inspection_definitions_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "inspection_definitions",
+          "columnsFrom": [
+            "inspection_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_classified_data_id_classified_data_id_fk": {
+          "name": "inspection_findings_classified_data_id_classified_data_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "classified_data",
+          "columnsFrom": [
+            "classified_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_packs": {
+      "name": "installed_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_installed_packs_pack": {
+          "name": "uq_installed_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory": {
+      "name": "inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.os_version'))",
+            "type": "virtual"
+          }
+        },
+        "harness_version": {
+          "name": "harness_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.harness_version'))",
+            "type": "virtual"
+          }
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_osver": {
+          "name": "idx_inventory_type_osver",
+          "columns": [
+            "object_type",
+            "os_version"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_harnessver": {
+          "name": "idx_inventory_type_harnessver",
+          "columns": [
+            "object_type",
+            "harness_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_host_id_inventory_id_fk": {
+          "name": "inventory_host_id_inventory_id_fk",
+          "tableFrom": "inventory",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_asset": {
+      "name": "inventory_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_asset_type": {
+          "name": "idx_inventory_asset_type",
+          "columns": [
+            "asset_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_override": {
+      "name": "mcp_trust_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_mcp_trust_override": {
+          "name": "uq_mcp_trust_override",
+          "columns": [
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pack_write_gate": {
+      "name": "_pack_write_gate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open": {
+          "name": "open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_pack_write_gate_single_row": {
+          "name": "ck_pack_write_gate_single_row",
+          "value": "\"_pack_write_gate\".\"id\" = 1"
+        }
+      }
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "custom_keywords": {
+          "name": "custom_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_policies_scope_target": {
+          "name": "uq_policies_scope_target",
+          "columns": [
+            "scope",
+            "target"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_file": {
+      "name": "project_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_access": {
+          "name": "default_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_file_project": {
+          "name": "idx_project_file_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_project_file": {
+          "name": "uq_project_file",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_source_project_id_fk": {
+          "name": "project_file_project_id_source_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault": {
+      "name": "secret_vault",
+      "columns": {
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_key_version": {
+          "name": "fingerprint_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_value": {
+          "name": "uq_secret_vault_value",
+          "columns": [
+            "value_fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_deref": {
+      "name": "secret_vault_deref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pointer_count": {
+          "name": "pointer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_secret_vault_deref_pointer": {
+          "name": "idx_secret_vault_deref_pointer",
+          "columns": [
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_reason_at": {
+          "name": "idx_secret_vault_deref_reason_at",
+          "columns": [
+            "reason",
+            "at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_call_site": {
+      "name": "share_call_site",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "vendored": {
+          "name": "vendored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_call_site_endpoint": {
+          "name": "idx_share_call_site_endpoint",
+          "columns": [
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_call_site_project": {
+          "name": "idx_share_call_site_project",
+          "columns": [
+            "project_key",
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_call_site": {
+          "name": "uq_share_call_site",
+          "columns": [
+            "endpoint_id",
+            "project_key",
+            "file",
+            "line"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_call_site_endpoint_id_share_endpoint_id_fk": {
+          "name": "share_call_site_endpoint_id_share_endpoint_id_fk",
+          "tableFrom": "share_call_site",
+          "tableTo": "share_endpoint",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_destination": {
+      "name": "share_destination",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_json": {
+          "name": "network_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_destination_kind": {
+          "name": "idx_share_destination_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "uq_share_destination_host": {
+          "name": "uq_share_destination_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_endpoint": {
+      "name": "share_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "data_class": {
+          "name": "data_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_endpoint_dest": {
+          "name": "idx_share_endpoint_dest",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_endpoint": {
+          "name": "uq_share_endpoint",
+          "columns": [
+            "destination_id",
+            "method",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_endpoint_destination_id_share_destination_id_fk": {
+          "name": "share_endpoint_destination_id_share_destination_id_fk",
+          "tableFrom": "share_endpoint",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_project": {
+      "name": "source_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/schema/drizzle/local-sqlite/meta/_journal.json
+++ b/packages/schema/drizzle/local-sqlite/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1785351271070,
       "tag": "0015_busy_vengeance",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1785351462433,
+      "tag": "0016_breezy_zodiak",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/schema/src/drizzle/columns.ts
+++ b/packages/schema/src/drizzle/columns.ts
@@ -45,6 +45,7 @@ export const COL = {
   valueFingerprint: 'value_fingerprint',
   keyVersion: 'key_version',
   maskedValue: 'masked_value',
+  capability: 'capability',
   maxUses: 'max_uses',
   useCount: 'use_count',
   justification: 'justification',

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -219,6 +219,11 @@ export const exceptions = sqliteTable(
     valueFingerprint: text(COL.valueFingerprint).notNull(),
     keyVersion: integer(COL.keyVersion).notNull(),
     maskedValue: text(COL.maskedValue).notNull(),
+    // What the grant authorizes; 'reveal_to_model' also satisfies suppression
+    // (strictly stronger), while 'suppress' never reveals.
+    capability: text(COL.capability, { enum: ['suppress', 'reveal_to_model'] })
+      .notNull()
+      .default('suppress'),
     scope: text(COL.scope, { enum: ['once', 'temporary', 'permanent'] }).notNull(),
     expiresAt: integer(COL.expiresAt),
     maxUses: integer(COL.maxUses),

--- a/packages/schema/src/drizzle/sqlite-ddl.ts
+++ b/packages/schema/src/drizzle/sqlite-ddl.ts
@@ -91,4 +91,8 @@ export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
     tag: '0015_busy_vengeance',
     sql: 'CREATE TABLE `secret_vault` (\n\t`pointer_id` text PRIMARY KEY NOT NULL,\n\t`value_fingerprint` text NOT NULL,\n\t`fingerprint_key_version` integer NOT NULL,\n\t`key_version` integer NOT NULL,\n\t`category` text NOT NULL,\n\t`rule_id` text NOT NULL,\n\t`masked_match` text NOT NULL,\n\t`provider` text,\n\t`ciphertext` text NOT NULL,\n\t`nonce` text NOT NULL,\n\t`auth_tag` text NOT NULL,\n\t`occurrence_count` integer DEFAULT 1 NOT NULL,\n\t`first_seen` integer NOT NULL,\n\t`last_seen` integer NOT NULL\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX `uq_secret_vault_value` ON `secret_vault` (`value_fingerprint`);--> statement-breakpoint\nCREATE TABLE `secret_vault_deref` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`pointer_id` text NOT NULL,\n\t`at` integer NOT NULL,\n\t`target` text NOT NULL,\n\t`reason` text NOT NULL,\n\t`outcome` text NOT NULL,\n\t`grant_id` text,\n\t`pointer_count` integer DEFAULT 1 NOT NULL\n);\n--> statement-breakpoint\nCREATE INDEX `idx_secret_vault_deref_pointer` ON `secret_vault_deref` (`pointer_id`);--> statement-breakpoint\nCREATE INDEX `idx_secret_vault_deref_reason_at` ON `secret_vault_deref` (`reason`,`at`);',
   },
+  {
+    tag: '0016_breezy_zodiak',
+    sql: "ALTER TABLE `exceptions` ADD `capability` text DEFAULT 'suppress' NOT NULL;",
+  },
 ];

--- a/packages/schema/src/zod/exception.ts
+++ b/packages/schema/src/zod/exception.ts
@@ -36,6 +36,16 @@ export type ExceptionConditions = z.infer<typeof ExceptionConditions>;
 // Tenant-free base (local store + wire bundle). NO `.meta({ id })`: an id
 // would register it in Zod's global registry and leak it into the
 // generated OpenAPI client.
+// What a grant authorizes. 'suppress' is today's semantics: the detection is
+// not hard-enforced (block/redact downgrades). 'reveal_to_model' is strictly
+// stronger: the vault may de-reference the value's pointer back to raw FOR THE
+// MODEL at an interception point — and, being stronger, it also satisfies
+// suppression (a revealed value is necessarily not blocked). A suppression
+// grant never reveals: the two are distinct so no existing grant silently
+// widens.
+export const ExceptionCapability = z.enum(['suppress', 'reveal_to_model']);
+export type ExceptionCapability = z.infer<typeof ExceptionCapability>;
+
 export const DetectionException = z.object({
   id: z.guid(),
   ruleId: z.string(),
@@ -52,6 +62,7 @@ export const DetectionException = z.object({
   keyVersion: z.number().int().positive(),
   // maskMatch() preview of the approved value — never the raw value.
   maskedValue: z.string(),
+  capability: ExceptionCapability.default('suppress'),
   scope: ExceptionScope,
   expiresAt: z.iso.datetime().nullable(),
   maxUses: z.number().int().positive().nullable(),
@@ -79,6 +90,7 @@ export const ExceptionBundleEntry = DetectionException.pick({
   ruleId: true,
   valueFingerprint: true,
   keyVersion: true,
+  capability: true,
   expiresAt: true,
   maxUses: true,
   useCount: true,

--- a/packages/schema/test/zod/exception.test.ts
+++ b/packages/schema/test/zod/exception.test.ts
@@ -94,6 +94,7 @@ describe('ExceptionBundleEntry', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(Object.keys(result.data).sort()).toEqual([
+        'capability',
         'conditions',
         'expiresAt',
         'id',

--- a/plugins/claude-code/src/history/tail-scrub.ts
+++ b/plugins/claude-code/src/history/tail-scrub.ts
@@ -1,0 +1,103 @@
+/**
+ * At-rest scrub of a live session's transcript file. Claude Code appends every
+ * prompt to `~/.claude/projects/*.jsonl` even when a hook blocked it, so a raw
+ * secret the tail scan just found is also sitting in plaintext on disk. This
+ * module rewrites those secret spans IN PLACE to vault pointers (via the
+ * injected vault-glue tokenizer), line by line, so the file stays valid
+ * newline-delimited JSON and untouched lines stay byte-identical.
+ *
+ * SCOPE LIMIT: the target must resolve (symlink-safe, real-path containment)
+ * inside the redaction scope's artifact roots. An out-of-scope path is never
+ * opened for writing — the same structural containment the remediation
+ * redactor enforces, reused from `remediation/redact.ts` rather than
+ * re-implemented.
+ *
+ * FAULT POSTURE: any error returns null and leaves the file as it was — the
+ * reconcile pass continues. The injected tokenizer is itself fail-secure: a
+ * span it cannot vault degrades to the one-way `[REDACTED:CATEGORY]`
+ * placeholder, so a fault destroys residue rather than leaking it. The one
+ * tokenizer outcome treated as a fault HERE is the unclassifiable blanket
+ * (a changed line with no pointers and no degraded spans — the tokenizer could
+ * not tell secret from clean): rewriting whole transcript lines to a blanket
+ * placeholder would destroy the user's transcript, so the scrub aborts with
+ * the file untouched instead.
+ */
+import { readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
+
+import { type platformRedactionScope, resolveRedactableArtifact } from '../remediation/redact.ts';
+
+// Files larger than this are skipped whole (return null): this scrub does a
+// whole-file read — acceptable because it runs in the detached reconcile
+// worker, off the hot hook path — but a pathological transcript must not
+// balloon the worker, so the read is capped.
+const MAX_SCRUB_BYTES = 32 * 1024 * 1024;
+
+export interface TailScrubDeps {
+  // The vault-glue text tokenizer: self-scans, shields existing pointers so a
+  // re-run never re-tokenizes them, and replaces each secret span with a
+  // pointer (or a one-way placeholder on degrade).
+  tokenizeText(
+    text: string,
+    opts?: { findings?: unknown[] },
+  ): Promise<{ text: string; pointers: string[]; degraded: { category: string }[] }>;
+  // The artifact roots whose contained files may be rewritten in place.
+  scope: ReturnType<typeof platformRedactionScope>;
+}
+
+/**
+ * Scrub one transcript file: replace every detected secret span with a vault
+ * pointer, in place, preserving line structure and the trailing newline
+ * exactly as found. Returns the count of rewritten lines, `{ rewritten: 0 }`
+ * without writing when nothing matched, and null when the path is out of
+ * scope, oversized, unreadable, or anything failed (the file is then left
+ * byte-identical).
+ */
+export async function scrubTranscriptTail(
+  filePath: string,
+  deps: TailScrubDeps,
+): Promise<{ rewritten: number } | null> {
+  try {
+    // Containment first: out of scope → never opened for writing.
+    const realPath = resolveRedactableArtifact(filePath, deps.scope);
+    if (realPath === null) return null;
+    if (statSync(realPath).size > MAX_SCRUB_BYTES) return null;
+
+    const content = readFileSync(realPath, 'utf8');
+    // Line-by-line so the rewrite can only ever change bytes WITHIN a line —
+    // the newline structure (including a trailing newline, which survives the
+    // split/join round-trip as a final empty element) is preserved exactly.
+    const lines = content.split('\n');
+    let rewritten = 0;
+    for (const [i, line] of lines.entries()) {
+      if (line === '') continue;
+      const result = await deps.tokenizeText(line);
+      if (result.text === line) continue;
+      // A changed line that minted no pointer and degraded no span is the
+      // tokenizer's unclassifiable blanket — abort rather than destroy lines.
+      if (result.pointers.length === 0 && result.degraded.length === 0) return null;
+      lines[i] = result.text;
+      rewritten += 1;
+    }
+    if (rewritten === 0) return { rewritten: 0 };
+
+    // Atomic rewrite: full write to a sibling temp file, then rename over the
+    // original — a crash mid-write leaves the transcript intact.
+    const tmpPath = `${realPath}.aka-scrub.tmp`;
+    try {
+      writeFileSync(tmpPath, lines.join('\n'));
+      renameSync(tmpPath, realPath);
+    } catch {
+      try {
+        // `recursive: true` also clears a tmpPath that turned out to be a
+        // directory, not just a partially written file.
+        rmSync(tmpPath, { force: true, recursive: true });
+      } catch {
+        // temp file may not exist — nothing to clean up
+      }
+      return null;
+    }
+    return { rewritten };
+  } catch {
+    return null;
+  }
+}

--- a/plugins/claude-code/src/history/usage.ts
+++ b/plugins/claude-code/src/history/usage.ts
@@ -20,6 +20,7 @@
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
 import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
 import {
+  createVaultGlue,
   providerFromModelId,
   resolveInventoryContext,
   resolveRepoNwo,
@@ -35,9 +36,11 @@ import type {
   ToolCallInput,
   ToolCallInspection,
 } from '@akasecurity/schema';
-import { harnessFromTool } from '@akasecurity/schema';
+import { harnessFromTool, isVaultConsentValid } from '@akasecurity/schema';
 
+import { platformRedactionScope } from '../remediation/redact.ts';
 import { readOffset, readTail, writeOffset } from './tail.ts';
+import { scrubTranscriptTail } from './tail-scrub.ts';
 import {
   type AssistantUsageRecord,
   iterateUsageAndToolCalls,
@@ -427,6 +430,35 @@ export async function reconcileSessionTail(
       offset: nextOffset,
       lastPromptId: result.lastPromptId,
     });
+    // The store now reflects this tail; scrub the transcript FILE itself so a raw
+    // secret in the new lines (Claude Code logs a prompt even when a hook blocked
+    // it) does not stay at rest in plaintext. Gated on VAULT CONSENT ALONE —
+    // deliberately not on historicalAccess, which governs reading pre-install
+    // history: this tail is the live session's own data, and gating the scrub on
+    // historical access would leave session-only users' residue permanently
+    // unscrubbed. Without consent nothing here runs and no vault is constructed.
+    // Every failure is swallowed — the reconcile pass never fails because
+    // scrubbing did.
+    if (isVaultConsentValid(config.settings.vaultConsent)) {
+      try {
+        const glue = createVaultGlue();
+        const scrubbed = await scrubTranscriptTail(transcriptPath, {
+          tokenizeText: (text) => glue.tokenizeText(text),
+          scope: platformRedactionScope(),
+        });
+        // A rewrite changes the file's byte layout, so the just-persisted offset
+        // no longer marks a line boundary. Reset it: the next pass re-reads the
+        // whole (now pointer-bearing) file, which the idempotent writes absorb.
+        if (scrubbed !== null && scrubbed.rewritten > 0) {
+          writeOffset(config.dataDir, sessionId, {
+            offset: 0,
+            lastPromptId: result.lastPromptId,
+          });
+        }
+      } catch {
+        // Best-effort at-rest scrub — never break the reconcile pass.
+      }
+    }
     return { llmCalls: result.llmCalls, skipped: result.skipped, toolCalls };
   } finally {
     await gateway.close();

--- a/plugins/claude-code/src/hooks/clipboard.ts
+++ b/plugins/claude-code/src/hooks/clipboard.ts
@@ -1,0 +1,71 @@
+/**
+ * Best-effort clipboard write for the prompt-block resubmit flow. The text
+ * handed here is already pointerized — never a raw secret — and the return
+ * value only flips a sentence in the resubmit message, so every failure mode
+ * (no platform utility, spawn error, non-zero exit) is a plain `false`, never
+ * a throw.
+ *
+ * The text travels on the child's stdin with every stdio stream piped —
+ * nothing is ever inherited, so the written text cannot land in the hook's own
+ * output streams or argv (argv is visible in the process table).
+ */
+import { spawnSync } from 'node:child_process';
+
+// One clipboard utility invocation: the command, its argv, and the text to
+// deliver on stdin. Injectable so tests observe exactly what would be spawned
+// (and with what text) without touching a real clipboard.
+export type ClipboardSpawner = (cmd: string, args: string[], input: string) => { ok: boolean };
+
+const defaultSpawner: ClipboardSpawner = (cmd, args, input) => {
+  try {
+    const result = spawnSync(cmd, args, {
+      input,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: 3_000,
+    });
+    return { ok: result.error === undefined && result.status === 0 };
+  } catch {
+    return { ok: false };
+  }
+};
+
+interface ClipboardCommand {
+  readonly cmd: string;
+  readonly args: readonly string[];
+}
+
+// Wayland first, then the two X11 utilities. A missing utility surfaces as a
+// failed spawn, which simply moves on to the next candidate.
+const LINUX_COMMANDS: readonly ClipboardCommand[] = [
+  { cmd: 'wl-copy', args: [] },
+  { cmd: 'xclip', args: ['-selection', 'clipboard'] },
+  { cmd: 'xsel', args: ['--clipboard', '--input'] },
+];
+
+function commandsFor(platform: NodeJS.Platform): readonly ClipboardCommand[] {
+  if (platform === 'darwin') return [{ cmd: 'pbcopy', args: [] }];
+  if (platform === 'win32') return [{ cmd: 'clip', args: [] }];
+  if (platform === 'linux') return LINUX_COMMANDS;
+  return [];
+}
+
+/**
+ * Write `text` to the system clipboard. Returns whether a clipboard utility
+ * accepted the write; on an unrecognized platform, a missing utility, or any
+ * spawn failure it returns `false` without throwing.
+ */
+export function writeClipboard(
+  text: string,
+  opts?: { platform?: NodeJS.Platform; spawn?: ClipboardSpawner },
+): boolean {
+  try {
+    const platform = opts?.platform ?? process.platform;
+    const spawn = opts?.spawn ?? defaultSpawner;
+    for (const command of commandsFor(platform)) {
+      if (spawn(command.cmd, [...command.args], text).ok) return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}

--- a/plugins/claude-code/src/hooks/pre-tool-use.ts
+++ b/plugins/claude-code/src/hooks/pre-tool-use.ts
@@ -24,7 +24,7 @@ import { isVaultConsentValid, pointerTokenScanner } from '@akasecurity/schema';
 
 import { sessionProtocolMarker } from '../protocol/marker.ts';
 import { eventNote, userDisclosure } from '../protocol/notes.ts';
-import { stringAtPath } from './paths.ts';
+import { replaceAtPath, stringAtPath } from './paths.ts';
 import type { PointerField } from './pointer-substitution.ts';
 import { decideInputPointers, denyPointerMessage } from './pointer-substitution.ts';
 import type { PreToolUseOutput, ScannedField } from './pre-tool-use-decision.ts';
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
   }
   const pointerOutcomes = await decideInputPointers(pointerFields, (text) =>
     vaultGlue
-      ? vaultGlue.substituteModelPointers(text, { resolveGrant: () => Promise.resolve(null) })
+      ? vaultGlue.substituteModelPointers(text, { resolveGrant: vaultGlue.revealGrantResolver })
       : Promise.resolve({
           text,
           revealed: [],
@@ -90,6 +90,23 @@ async function main(): Promise<void> {
       },
     });
     return;
+  }
+
+  // Fold granted de-refs into the input the rest of the hook sees: the secret
+  // scan then re-detects each revealed value, and the SAME grant satisfies
+  // suppression there (reveal is strictly stronger), consuming its use exactly
+  // once. Emitting must not depend on a detection outcome — with every
+  // revealed value suppressed, the decision below may be null, and the tool
+  // would otherwise run with the pointers still literal.
+  let effectiveInput = toolInput;
+  let derefHappened = false;
+  for (const outcome of pointerOutcomes) {
+    if (outcome.disposition !== 'deref' || outcome.text === undefined) continue;
+    effectiveInput = replaceAtPath(effectiveInput, outcome.path, outcome.text) as Record<
+      string,
+      unknown
+    >;
+    derefHappened = true;
   }
 
   // A store that cannot open means NOTHING is scanned or enforced for this
@@ -120,7 +137,7 @@ async function main(): Promise<void> {
   const scanned: ScannedField[] = [];
   try {
     for (const spec of fields) {
-      const text = stringAtPath(toolInput, spec.path);
+      const text = stringAtPath(effectiveInput, spec.path);
       if (text === undefined || text === '') continue;
 
       const result = await runtime.capture(
@@ -147,7 +164,7 @@ async function main(): Promise<void> {
   // 7eb59e55) applies here too.
   const decision = await decidePreToolUse(
     toolName,
-    toolInput,
+    effectiveInput,
     scanned,
     vaultGlue ? (text, findings) => vaultGlue.tokenizeText(text, { findings }) : undefined,
   );
@@ -155,6 +172,19 @@ async function main(): Promise<void> {
     await emit(
       withProtocolNotes(decision.output, decision.realized, toolName, config, sessionId, vaultGlue),
     );
+    return;
+  }
+  // No detection outcome, but a grant rewrote the input: the tool must still
+  // receive the revealed values rather than the literal pointers.
+  if (derefHappened) {
+    await emit({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+        updatedInput: effectiveInput,
+      },
+      systemMessage: `AKA revealed granted vault value(s) to this ${toolName} call — the reveal exception you approved authorized it.`,
+    });
   }
 }
 

--- a/plugins/claude-code/src/hooks/resubmit-message.ts
+++ b/plugins/claude-code/src/hooks/resubmit-message.ts
@@ -1,0 +1,42 @@
+/**
+ * The block reason shown when a prompt was blocked AND the vault produced a
+ * pointerized rewrite of it: instead of only "remove the flagged content", the
+ * user gets their own prompt back with each secret replaced by a vault
+ * pointer, ready to paste and resubmit. The rewrite in the message is the
+ * source of truth — the clipboard copy is best-effort and only changes one
+ * sentence.
+ *
+ * Pure string building (no I/O) so it unit-tests without a hook process, same
+ * split as exception-guidance.ts: hook entry files run main() on import and
+ * must never be imported by tests.
+ */
+import type { BlockedDetectionRef } from '@akasecurity/plugin-sdk';
+
+import { exceptionPointer } from '../exception-guidance.ts';
+
+const REWRITE_OPEN = '----- safe prompt (copy everything between these lines) -----';
+const REWRITE_CLOSE = '----- end safe prompt -----';
+
+export function resubmitMessage(opts: {
+  // Comma-joined unique rule ids (uniqueRuleIds output).
+  ruleIds: string;
+  // The pointerized rewrite of the user's own prompt.
+  rewrite: string;
+  // Whether the rewrite also landed on the system clipboard.
+  clipboardWrote: boolean;
+  // First ledger ref recorded for this capture; adds the approve guidance.
+  blockedRef?: BlockedDetectionRef | undefined;
+}): string {
+  const paste = opts.clipboardWrote
+    ? 'It is already on your clipboard — paste and resubmit.'
+    : 'Copy it, then paste and resubmit.';
+  return [
+    `AKA blocked this prompt — flagged ${opts.ruleIds}. The flagged value never reached the model.`,
+    `Here is your prompt with each detected secret replaced by a vault pointer. ${paste}`,
+    REWRITE_OPEN,
+    opts.rewrite,
+    REWRITE_CLOSE,
+    'The model works with the pointers; the real values stay in your local vault.' +
+      exceptionPointer(opts.blockedRef ? [opts.blockedRef] : undefined),
+  ].join('\n');
+}

--- a/plugins/claude-code/src/hooks/user-prompt-submit.ts
+++ b/plugins/claude-code/src/hooks/user-prompt-submit.ts
@@ -8,8 +8,13 @@
  *   {"systemMessage":"..."}              → warning shown, prompt continues
  *   no output                            → allow
  *
- * Claude Code cannot rewrite prompt text, so a `redact` decision degrades to a
- * warning here; true redaction happens in pre-tool-use via updatedInput.
+ * Claude Code cannot rewrite prompt text, so a `redact` decision BLOCKS here —
+ * warning and passing the prompt through would send the raw secret to the
+ * model. With a valid vault-consent grant the block reason carries a
+ * pointerized rewrite of the prompt (each secret replaced by a vault pointer)
+ * for the user to paste and resubmit, copied to the clipboard best-effort;
+ * without consent the reason is the plain removal-based block message. True
+ * in-place redaction happens in pre-tool-use via updatedInput.
  *
  * This is also the first-run nudge point: on a clean prompt from a machine that
  * hasn't completed `/aka:setup`, surface a one-line pointer to it (fail-open
@@ -23,12 +28,16 @@ import type { CaptureResult } from '@akasecurity/plugin-sdk';
 import {
   claimOnboardingNudge,
   createPluginRuntime,
+  createVaultGlue,
   loadConfig,
   uniqueRuleIds,
 } from '@akasecurity/plugin-sdk';
+import { isVaultConsentValid } from '@akasecurity/schema';
 
 import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
+import { writeClipboard } from './clipboard.ts';
 import { ONBOARDING_NUDGE } from './onboarding-nudge.ts';
+import { resubmitMessage } from './resubmit-message.ts';
 import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
 import {
   claimStoreUnavailableWarning,
@@ -71,24 +80,34 @@ async function main(): Promise<void> {
     await runtime.close();
   }
 
-  if (result.action === 'block') {
-    // Removal first; then the copy-paste-complete exception command built from
-    // the ledger reference the runtime just recorded (see exception-guidance).
-    await emit({
-      decision: 'block',
-      reason: blockMessage({
-        subject: 'prompt',
-        ruleIds: uniqueRuleIds(result.findings),
-        blockedRef: result.blockedReferences?.[0],
-      }),
-    });
+  if (result.action === 'block' || result.action === 'redact') {
+    // A redact policy blocks here too: this surface has no prompt-rewrite
+    // channel, so the only way to honor "the raw value must not reach the
+    // model" is to stop the prompt. Removal-based guidance first; with a valid
+    // vault-consent grant the reason upgrades to the resubmit message carrying
+    // a pointerized rewrite of the prompt (and the clipboard gets the same
+    // rewrite, best-effort). Consent absent → the vault is never touched.
+    const ruleIds = uniqueRuleIds(result.findings);
+    const blockedRef = result.blockedReferences?.[0];
+    let reason = blockMessage({ subject: 'prompt', ruleIds, blockedRef });
+    if (isVaultConsentValid(config.settings.vaultConsent)) {
+      const rewrite = await pointerizedRewrite(prompt, result.findings);
+      if (rewrite !== null) {
+        // Only the pointerized text ever reaches the clipboard — never the raw
+        // prompt.
+        const clipboardWrote = writeClipboard(rewrite);
+        reason = resubmitMessage({ ruleIds, rewrite, clipboardWrote, blockedRef });
+      }
+    }
+    await emit({ decision: 'block', reason });
     return;
   }
-  if (result.action === 'redact' || result.action === 'warn') {
-    // A redacted value is ledgered like a blocked one, so when a reference
-    // exists the message points at the same out-of-band approve flow.
+  if (result.action === 'warn') {
+    // A warn never escalates: the prompt continues, flagged. A warned value is
+    // ledgered like a blocked one, so when a reference exists the message
+    // points at the same out-of-band approve flow.
     await emit({
-      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}). Prompts cannot be redacted in place — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
+      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}) — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
     });
     return;
   }
@@ -100,6 +119,28 @@ async function main(): Promise<void> {
   // pre-onboarding session isn't spammed every prompt.
   if (!config.onboarded && claimOnboardingNudge(config.dataDir, sessionId)) {
     await emit({ systemMessage: ONBOARDING_NUDGE });
+  }
+}
+
+// The pointerized rewrite offered in the block reason, or null when it cannot
+// be offered safely. Every DETECTED span is pointerized (not only the enforced
+// ones) — the whole prompt is blocked regardless, so vaulting more never leaks
+// more. Null on any fault, on a rewrite that minted no pointer, or — the
+// never-leak gate — when any finding's raw match still appears in the
+// rewritten text; the caller then falls back to the removal-based message.
+async function pointerizedRewrite(
+  prompt: string,
+  findings: CaptureResult['findings'],
+): Promise<string | null> {
+  try {
+    const tokenized = await createVaultGlue().tokenizeText(prompt, { findings });
+    if (tokenized.pointers.length === 0) return null;
+    for (const finding of findings) {
+      if (finding.rawMatch !== '' && tokenized.text.includes(finding.rawMatch)) return null;
+    }
+    return tokenized.text;
+  } catch {
+    return null;
   }
 }
 

--- a/plugins/claude-code/test/history/tail-scrub.test.ts
+++ b/plugins/claude-code/test/history/tail-scrub.test.ts
@@ -1,0 +1,172 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { applyOnboarding } from '@akasecurity/persistence';
+import { createVaultGlue, type VaultGlue } from '@akasecurity/plugin-sdk';
+import { pointerTokenScanner, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { scrubTranscriptTail, type TailScrubDeps } from '../../src/history/tail-scrub.ts';
+import type { RedactionScope } from '../../src/remediation/redact.ts';
+
+// Canonical test AWS access-key id, composed at runtime so the repo's own secret
+// scan does not flag this test file (mirrors remediation/redact.test.ts).
+const SECRET = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+
+const pointersIn = (text: string): string[] =>
+  [...text.matchAll(pointerTokenScanner())].map((m) => m[0]);
+
+describe('scrubTranscriptTail', () => {
+  // A fake transcripts root (the scope's one artifact root), an out-of-scope
+  // sibling, and a throwaway ~/.aka base holding the real vault.
+  let transcriptRoot: string;
+  let outsideRoot: string;
+  let base: string;
+  let scope: RedactionScope;
+  let glue: VaultGlue;
+  let deps: TailScrubDeps;
+
+  const depsFor = (g: VaultGlue): TailScrubDeps => ({
+    tokenizeText: (text) => g.tokenizeText(text),
+    scope,
+  });
+
+  beforeEach(() => {
+    transcriptRoot = mkdtempSync(join(tmpdir(), 'aka-tail-scrub-transcripts-'));
+    outsideRoot = mkdtempSync(join(tmpdir(), 'aka-tail-scrub-outside-'));
+    base = mkdtempSync(join(tmpdir(), 'aka-tail-scrub-home-'));
+    scope = { artifactRoots: [transcriptRoot] };
+    applyOnboarding(
+      {
+        vaultConsent: {
+          acknowledgedAt: new Date().toISOString(),
+          version: VAULT_CONSENT_VERSION,
+        },
+      },
+      base,
+    );
+    glue = createVaultGlue({ base });
+    deps = depsFor(glue);
+  });
+
+  afterEach(() => {
+    rmSync(transcriptRoot, { recursive: true, force: true });
+    rmSync(outsideRoot, { recursive: true, force: true });
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  const transcriptFile = (name: string, content: string): string => {
+    const dir = join(transcriptRoot, '-Users-me-project');
+    mkdirSync(dir, { recursive: true });
+    const file = join(dir, name);
+    writeFileSync(file, content);
+    return file;
+  };
+
+  it('rewrites the secret line to a vault pointer and leaves the clean line byte-identical', async () => {
+    const secretLine = `{"type":"user","text":"key ${SECRET} end"}`;
+    const cleanLine = '{"type":"assistant","text":"all clear"}';
+    const file = transcriptFile('session.jsonl', `${secretLine}\n${cleanLine}\n`);
+
+    const result = await scrubTranscriptTail(file, deps);
+    expect(result).toEqual({ rewritten: 1 });
+
+    const after = readFileSync(file, 'utf8');
+    expect(after).not.toContain(SECRET);
+    expect(after.endsWith('\n')).toBe(true);
+
+    const lines = after.split('\n');
+    expect(lines).toHaveLength(3); // two records + trailing-newline terminator
+    expect(lines[1]).toBe(cleanLine);
+    expect(lines[2]).toBe('');
+
+    // The secret span became a pointer, embedded in still-valid NDJSON.
+    expect(pointersIn(lines[0] ?? '')).toHaveLength(1);
+    for (const line of lines.slice(0, 2)) {
+      expect(() => {
+        JSON.parse(line);
+      }).not.toThrow();
+    }
+    const parsed = JSON.parse(lines[0] ?? '') as { text: string };
+    expect(parsed.text).toContain('[[aka:');
+  });
+
+  it('mints the SAME pointer for the same value across two lines', async () => {
+    const file = transcriptFile(
+      'repeat.jsonl',
+      `{"text":"first ${SECRET}"}\n{"text":"again ${SECRET}"}\n`,
+    );
+
+    const result = await scrubTranscriptTail(file, deps);
+    expect(result).toEqual({ rewritten: 2 });
+
+    const [a, b] = readFileSync(file, 'utf8').split('\n');
+    const pa = pointersIn(a ?? '');
+    const pb = pointersIn(b ?? '');
+    expect(pa).toHaveLength(1);
+    expect(pb).toHaveLength(1);
+    expect(pa[0]).toBe(pb[0]);
+  });
+
+  it('is idempotent: a second run rewrites nothing and leaves the file byte-identical', async () => {
+    const file = transcriptFile('idem.jsonl', `{"text":"key ${SECRET}"}\n`);
+    expect(await scrubTranscriptTail(file, deps)).toEqual({ rewritten: 1 });
+
+    const afterFirst = readFileSync(file, 'utf8');
+    expect(await scrubTranscriptTail(file, deps)).toEqual({ rewritten: 0 });
+    expect(readFileSync(file, 'utf8')).toBe(afterFirst);
+  });
+
+  it('returns { rewritten: 0 } without writing when the file holds no secret', async () => {
+    const content = '{"text":"nothing sensitive here"}\n';
+    const file = transcriptFile('clean.jsonl', content);
+    expect(await scrubTranscriptTail(file, deps)).toEqual({ rewritten: 0 });
+    expect(readFileSync(file, 'utf8')).toBe(content);
+  });
+
+  it('refuses an out-of-scope path and leaves it byte-identical', async () => {
+    const content = `{"text":"key ${SECRET}"}\n`;
+    const outside = join(outsideRoot, 'not-a-transcript.jsonl');
+    writeFileSync(outside, content);
+
+    expect(await scrubTranscriptTail(outside, deps)).toBeNull();
+    expect(readFileSync(outside, 'utf8')).toBe(content);
+  });
+
+  it('refuses a symlink inside the root that points outside it', async () => {
+    const content = `{"text":"key ${SECRET}"}\n`;
+    const target = join(outsideRoot, 'target.jsonl');
+    writeFileSync(target, content);
+    const link = join(transcriptRoot, 'link.jsonl');
+    symlinkSync(target, link);
+
+    expect(await scrubTranscriptTail(link, deps)).toBeNull();
+    expect(readFileSync(target, 'utf8')).toBe(content);
+  });
+
+  it('returns null for an unreadable path without throwing', async () => {
+    expect(await scrubTranscriptTail(join(transcriptRoot, 'missing.jsonl'), deps)).toBeNull();
+  });
+
+  // The fault posture when consent vanished mid-pass (the call site gates on
+  // consent, so a consent-less glue is only reachable via revocation between
+  // the gate and the scrub): the residue is destroyed one-way — rewritten, but
+  // to the un-recoverable placeholder, never left raw and never vaulted.
+  it('degrades one-way under a consent-less glue: redacted placeholder, no pointer', async () => {
+    const noConsentBase = mkdtempSync(join(tmpdir(), 'aka-tail-scrub-noconsent-'));
+    try {
+      const degradedGlue = createVaultGlue({ base: noConsentBase });
+      const file = transcriptFile('degraded.jsonl', `{"text":"key ${SECRET}"}\n`);
+
+      expect(await scrubTranscriptTail(file, depsFor(degradedGlue))).toEqual({ rewritten: 1 });
+
+      const after = readFileSync(file, 'utf8');
+      expect(after).not.toContain(SECRET);
+      expect(after).toContain('[REDACTED');
+      expect(after).not.toContain('[[aka:');
+    } finally {
+      rmSync(noConsentBase, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/claude-code/test/hooks/clipboard.test.ts
+++ b/plugins/claude-code/test/hooks/clipboard.test.ts
@@ -1,0 +1,83 @@
+// Platform selection + fallback chain for the best-effort clipboard write.
+// Every test injects a spawner, so no real clipboard is ever touched.
+import { describe, expect, it } from 'vitest';
+
+import { writeClipboard } from '../../src/hooks/clipboard.ts';
+
+const POINTERIZED = 'deploy with [[aka:secret:0123456789abcdef0123456789abcdef]] please';
+
+interface SpawnCall {
+  cmd: string;
+  args: string[];
+  input: string;
+}
+
+function recordingSpawner(okFor: (cmd: string) => boolean): {
+  calls: SpawnCall[];
+  spawn: (cmd: string, args: string[], input: string) => { ok: boolean };
+} {
+  const calls: SpawnCall[] = [];
+  return {
+    calls,
+    spawn: (cmd, args, input) => {
+      calls.push({ cmd, args, input });
+      return { ok: okFor(cmd) };
+    },
+  };
+}
+
+describe('writeClipboard', () => {
+  it('darwin uses pbcopy', () => {
+    const { calls, spawn } = recordingSpawner(() => true);
+    expect(writeClipboard(POINTERIZED, { platform: 'darwin', spawn })).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ cmd: 'pbcopy', args: [], input: POINTERIZED });
+  });
+
+  it('win32 uses clip', () => {
+    const { calls, spawn } = recordingSpawner(() => true);
+    expect(writeClipboard(POINTERIZED, { platform: 'win32', spawn })).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe('clip');
+  });
+
+  it('linux walks wl-copy → xclip → xsel, stopping at the first success', () => {
+    const { calls, spawn } = recordingSpawner((cmd) => cmd === 'xclip');
+    expect(writeClipboard(POINTERIZED, { platform: 'linux', spawn })).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(['wl-copy', 'xclip']);
+    expect(calls[1]?.args).toEqual(['-selection', 'clipboard']);
+  });
+
+  it('linux falls through to xsel with the documented selection args', () => {
+    const { calls, spawn } = recordingSpawner((cmd) => cmd === 'xsel');
+    expect(writeClipboard(POINTERIZED, { platform: 'linux', spawn })).toBe(true);
+    expect(calls.map((c) => c.cmd)).toEqual(['wl-copy', 'xclip', 'xsel']);
+    expect(calls[2]?.args).toEqual(['--clipboard', '--input']);
+  });
+
+  it('every utility missing → false, never a throw', () => {
+    const { calls, spawn } = recordingSpawner(() => false);
+    expect(writeClipboard(POINTERIZED, { platform: 'linux', spawn })).toBe(false);
+    expect(calls).toHaveLength(3);
+  });
+
+  it('a spawner that throws → false, never a throw', () => {
+    const spawn = (): { ok: boolean } => {
+      throw new Error('spawn exploded');
+    };
+    expect(writeClipboard(POINTERIZED, { platform: 'darwin', spawn })).toBe(false);
+  });
+
+  it('an unrecognized platform → false without spawning anything', () => {
+    const { calls, spawn } = recordingSpawner(() => true);
+    expect(writeClipboard(POINTERIZED, { platform: 'freebsd', spawn })).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('the spawner receives exactly the given text on every attempt', () => {
+    const { calls, spawn } = recordingSpawner(() => false);
+    writeClipboard(POINTERIZED, { platform: 'linux', spawn });
+    expect(calls.length).toBeGreaterThan(0);
+    for (const call of calls) expect(call.input).toBe(POINTERIZED);
+  });
+});

--- a/plugins/claude-code/test/hooks/resubmit-message.test.ts
+++ b/plugins/claude-code/test/hooks/resubmit-message.test.ts
@@ -1,0 +1,72 @@
+// The resubmit block reason: the user's own prompt, pointerized, presented
+// copyably. Pure builder — importable directly, no hook process needed.
+import type { BlockedDetectionRef } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { resubmitMessage } from '../../src/hooks/resubmit-message.ts';
+
+// Composed at runtime so the repo's own secret scan never flags this file.
+const RAW_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+const POINTERIZED = `deploy with [[aka:secret:0123456789abcdef0123456789abcdef]] please`;
+
+const REF: BlockedDetectionRef = {
+  reference: 'BLK-1234',
+  ruleId: 'aws-access-key',
+  maskedValue: 'A**************E',
+};
+
+describe('resubmitMessage', () => {
+  it('embeds the rewrite verbatim, delimited on its own lines', () => {
+    const message = resubmitMessage({
+      ruleIds: 'aws-access-key',
+      rewrite: POINTERIZED,
+      clipboardWrote: false,
+    });
+    const lines = message.split('\n');
+    const open = lines.findIndex((l) => l.includes('safe prompt') && l.startsWith('-----'));
+    expect(open).toBeGreaterThan(-1);
+    // The rewrite is its own line, exactly as given, inside the delimiters.
+    expect(lines[open + 1]).toBe(POINTERIZED);
+    expect(lines[open + 2]).toContain('end safe prompt');
+  });
+
+  it('states what was caught and that the secret never reached the model', () => {
+    const message = resubmitMessage({
+      ruleIds: 'aws-access-key, stripe-secret-key',
+      rewrite: POINTERIZED,
+      clipboardWrote: false,
+    });
+    expect(message).toContain('aws-access-key, stripe-secret-key');
+    expect(message).toContain('never reached the model');
+    expect(message).toContain('paste and resubmit');
+    expect(message).toContain('local vault');
+  });
+
+  it('carries no raw value when given a pointerized rewrite', () => {
+    const message = resubmitMessage({
+      ruleIds: 'aws-access-key',
+      rewrite: POINTERIZED,
+      clipboardWrote: true,
+      blockedRef: REF,
+    });
+    expect(message).not.toContain(RAW_KEY);
+  });
+
+  it('mentions the clipboard only when the write succeeded', () => {
+    const opts = { ruleIds: 'aws-access-key', rewrite: POINTERIZED };
+    const wrote = resubmitMessage({ ...opts, clipboardWrote: true });
+    const failed = resubmitMessage({ ...opts, clipboardWrote: false });
+    expect(wrote).toContain('clipboard');
+    expect(wrote).toContain('paste and resubmit');
+    expect(failed).not.toContain('clipboard');
+    expect(failed).toContain('paste and resubmit');
+  });
+
+  it('includes the exception-approve guidance only with a ledger ref', () => {
+    const opts = { ruleIds: 'aws-access-key', rewrite: POINTERIZED, clipboardWrote: false };
+    const withRef = resubmitMessage({ ...opts, blockedRef: REF });
+    const withoutRef = resubmitMessage(opts);
+    expect(withRef).toContain('aka exception approve BLK-1234');
+    expect(withoutRef).not.toContain('aka exception approve');
+  });
+});

--- a/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
@@ -4,6 +4,10 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId } from '@akasecurity/schema';
+import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { ONBOARDING_NUDGE } from '../../src/hooks/onboarding-nudge.ts';
@@ -83,6 +87,22 @@ describe('user-prompt-submit hook — driven end-to-end', () => {
     }
   });
 
+  it('emits no block on a clean prompt', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-clean-'));
+    try {
+      const run = runHook(home, {
+        prompt: 'rename this variable across the module',
+        session_id: 'sess-clean',
+        cwd: '/tmp',
+        hook_event_name: 'UserPromptSubmit',
+      });
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('falls back to allow and never throws when a store fault is injected (fail-open)', () => {
     const home = mkdtempSync(join(tmpdir(), 'aka-ups-failopen-'));
     try {
@@ -102,6 +122,148 @@ describe('user-prompt-submit hook — driven end-to-end', () => {
       expect(run.status).toBe(0);
       expect(run.stderr).toBe('');
       expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+// The enforcement matrix, driven through the REAL built hook against a seeded
+// throwaway store. The secret value comes from the bundled rule's own
+// `examples` fixture so no secret-shaped literal lives in this file, and the
+// runHook env carries no PATH — the hook's best-effort clipboard spawn cannot
+// find a utility, so no real clipboard is ever written by this suite. The rule
+// is one whose example matches NO other bundled rule: a value two rules match
+// on overlapping spans degrades one-way by design (no pointer to assert on).
+const RULE_ID = 'secrets/twilio-key';
+function secretFixture(): { pack: ReturnType<typeof bundledDetections>[number]; example: string } {
+  const pack = bundledDetections().find((p) => p.rules.some((r) => r.id === RULE_ID));
+  const example = pack?.rules.find((r) => r.id === RULE_ID)?.examples?.[0];
+  if (pack === undefined || example === undefined) {
+    throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+  }
+  return { pack, example };
+}
+const { pack: SECRET_PACK, example: SECRET_EXAMPLE } = secretFixture();
+const SECRET_PROMPT = `please deploy using this key: ${SECRET_EXAMPLE}`;
+
+// Install the bundled packs the way the gateway does on open, then assign the
+// secrets pack the policy under test — per-rule pack policies are what the
+// runtime's action resolution prefers.
+function seedSecretPolicy(home: string, policyId: BuiltinPolicyId): void {
+  const db = openLocalDatabase(join(home, '.aka', 'data'));
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+    db.installedPacks.setPolicy(SECRET_PACK.namespace, SECRET_PACK.packId, policyId);
+  } finally {
+    db.close();
+  }
+}
+
+function grantVaultConsent(home: string): void {
+  const dir = join(home, '.aka', 'settings');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'settings.json'),
+    JSON.stringify({
+      vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },
+    }),
+  );
+}
+
+function submitSecretPrompt(home: string): HookRun {
+  return runHook(home, {
+    prompt: SECRET_PROMPT,
+    session_id: 'sess-enforce',
+    cwd: '/tmp',
+    hook_event_name: 'UserPromptSubmit',
+  });
+}
+
+describe('user-prompt-submit enforcement — redact blocks in every consent state', () => {
+  it('redact policy, no vault consent → block with the plain removal message, raw never on stdout', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-redact-off-'));
+    try {
+      seedSecretPolicy(home, 'redact');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toContain('twilio-key');
+      expect(payload.reason).toContain('Remove the flagged content and resubmit');
+      // Consent-off surfaces never touch the vault: no pointer, no vault talk.
+      expect(run.stdout).not.toContain('[[aka:');
+      // The never-leak assertion: the raw value appears nowhere on stdout.
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('redact policy, valid vault consent → block whose reason carries a pointerized rewrite', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-redact-on-'));
+    try {
+      seedSecretPolicy(home, 'redact');
+      grantVaultConsent(home);
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toContain('never reached the model');
+      expect(payload.reason).toContain('[[aka:');
+      expect(payload.reason).toContain('paste and resubmit');
+      // The raw value appears nowhere in the pointerized output.
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('block policy, no vault consent → the plain removal-based block, unchanged', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-block-off-'));
+    try {
+      seedSecretPolicy(home, 'block');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toMatch(/^AKA blocked this prompt — flagged /);
+      expect(payload.reason).toContain('Remove the flagged content and resubmit');
+      expect(run.stdout).not.toContain('[[aka:');
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('block policy, valid vault consent → block whose reason carries the resubmit rewrite', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-block-on-'));
+    try {
+      seedSecretPolicy(home, 'block');
+      grantVaultConsent(home);
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toContain('[[aka:');
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('warn policy → the prompt continues with a warning, never a block', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-ups-warn-'));
+    try {
+      seedSecretPolicy(home, 'warn');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('"decision":"block"');
+      const payload = JSON.parse(run.stdout) as { systemMessage?: string };
+      expect(payload.systemMessage).toContain('twilio-key');
+      expect(payload.systemMessage).toContain('sent unchanged');
+      // The stale claim that prompts cannot be redacted is gone.
+      expect(payload.systemMessage).not.toContain('cannot be redacted');
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -88,6 +88,7 @@ function exception(overrides: Partial<DetectionException> = {}): DetectionExcept
     valueFingerprint: 'f'.repeat(64),
     keyVersion: 1,
     maskedValue: 'AKIA…MPLE',
+    capability: 'suppress',
     scope: 'temporary',
     expiresAt: '2026-07-06T13:00:00.000Z',
     maxUses: null,


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

Closes the last raw-egress path and opens the one sanctioned door back.

## The behavior change worth arguing about

A `redact`-classified prompt was previously **sent to the model unchanged** with a warning — this surface has no rewrite channel, and that degrade was a live leak. It now **blocks in every consent state**.

That is deliberate: blocking needs no vault, so gating the leak fix on storage consent would mean declining encrypted storage buys you continued raw egress. Declining storage must never mean accepting egress. With consent the block reason additionally carries a pointerized rewrite of the user's own prompt (clipboard best-effort, delimited copyably in the message as the source of truth) so resubmission is one paste. A never-leak gate verifies no finding's raw match survives into the rewrite before offering it; any doubt falls back to the plain removal-based message. A `warn` never escalates.

## Reveal grants

Exceptions gain a **capability** (`suppress` default, `reveal_to_model` strictly stronger — it also satisfies suppression, while no existing grant silently widens). `aka exception approve <pointer> --reveal` mints one from a vault pointer — the pointer is the proof the value is vaulted, and a reveal must be asked for explicitly.

The plugin's resolver matches the grant by the exact identity suppression uses. Ungranted pointers keep the previous posture: inert as data, denied as executables, refused crossings audited.

## Tail scrub

Claude Code logs a prompt to `~/.claude/projects/*.jsonl` **even when a hook blocked it**, so the reconcile tail now rewrites raw secrets found in new transcript lines to pointers in place. Gated on vault consent **alone**, deliberately not on `historicalAccess`: the tail is the live session's own data, and gating it on historical access would leave session-only users' residue permanently unscrubbed. Reuses the remediation rewriter's symlink-safe scope guard and atomic write; line-by-line so the NDJSON stays valid; idempotent because pointers are shielded from re-detection.

Migration 0016 (additive capability column).