### PR TITLE
vault 06/10: historical transcript backfill scrub and remediation pointers

### DIFF
--- a/plugins/claude-code/src/backfill.ts
+++ b/plugins/claude-code/src/backfill.ts
@@ -17,18 +17,21 @@
 import { fileURLToPath } from 'node:url';
 
 import {
+  createVaultGlue,
   type FingerprintKey,
   fingerprintValue,
   loadConfig,
   loadOrCreateFingerprintKey,
   type PluginConfig,
 } from '@akasecurity/plugin-sdk';
-import { TriageHit } from '@akasecurity/schema';
+import { isVaultConsentValid, TriageHit } from '@akasecurity/schema';
 
 import { scanHistory, type ScanSummary } from './history/scan.ts';
+import { scrubTranscriptTail } from './history/tail-scrub.ts';
 import { type HistoryWalkOptions } from './history/transcripts.ts';
 import { reconcileHistory } from './history/usage.ts';
 import { fenced, indent } from './present.ts';
+import { platformRedactionScope } from './remediation/redact.ts';
 
 // The trailing sentinel that terminates a --triage stream. Its presence (and
 // only its presence) tells the consumer the stream was not truncated:
@@ -77,6 +80,9 @@ export interface BackfillDeps {
   // so runBackfill stays pure + testable; the CLI wiring below computes beforeMs and
   // the host session id.
   guard?: Pick<HistoryWalkOptions, 'excludeSessionId' | 'beforeMs' | 'dir'>;
+  // At-rest scrub of one visited transcript file (test seam). Defaults to the
+  // real tokenizing rewriter over a vault glue built once per run.
+  scrubFile?: (filePath: string) => Promise<{ rewritten: number } | null>;
 }
 
 export async function runBackfill(deps: BackfillDeps): Promise<void> {
@@ -162,6 +168,29 @@ export async function runBackfill(deps: BackfillDeps): Promise<void> {
       // Token backfill is best-effort; the live Stop-hook pass recovers it.
     }
 
+    // At-rest scrub of the history just walked: every visited transcript is
+    // rewritten so detected secrets become recoverable vault pointers. Runs
+    // only when BOTH grants hold — historical access got us here, and vault
+    // consent authorizes keeping recoverable copies. Pointer spans are
+    // invisible to detection, so a re-run finds nothing to rewrite. Entirely
+    // best-effort: a scrub fault never fails the backfill.
+    let scrubbedFiles = 0;
+    if (isVaultConsentValid(cfg.settings.vaultConsent) && summary.visitedFiles.length > 0) {
+      try {
+        const scrubFile = deps.scrubFile ?? buildTranscriptScrubber();
+        for (const file of summary.visitedFiles) {
+          try {
+            const result = await scrubFile(file);
+            if (result !== null && result.rewritten > 0) scrubbedFiles += 1;
+          } catch {
+            // One bad file must not stop the rest.
+          }
+        }
+      } catch {
+        // Glue construction failed — history stays as scanned.
+      }
+    }
+
     if (triage) {
       // A completed scan that touched zero messages is a no-history run (a fresh
       // machine with nothing to calibrate from), distinct from a scan that examined
@@ -178,7 +207,16 @@ export async function runBackfill(deps: BackfillDeps): Promise<void> {
         summary.findings > 0
           ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with /findings.`
           : 'No new pre-install secrets found in your history.';
-      io.stdout(`${fenced([heading, '', indent(scope), '', indent(result)].join('\n'))}\n`);
+      const lines = [heading, '', indent(scope), '', indent(result)];
+      if (scrubbedFiles > 0) {
+        lines.push(
+          '',
+          indent(
+            `Rewrote secrets in ${String(scrubbedFiles)} transcript file${scrubbedFiles === 1 ? '' : 's'} to recoverable vault pointers (aka vault show).`,
+          ),
+        );
+      }
+      io.stdout(`${fenced(lines.join('\n'))}\n`);
     }
   } catch (err) {
     if (triage) {
@@ -194,6 +232,19 @@ export async function runBackfill(deps: BackfillDeps): Promise<void> {
       );
     }
   }
+}
+
+// The production scrub dependency: one vault glue for the whole pass, the
+// remediation scope guard for containment. Built lazily so an unconsented run
+// never constructs the vault.
+function buildTranscriptScrubber(): (filePath: string) => Promise<{ rewritten: number } | null> {
+  const glue = createVaultGlue();
+  const scope = platformRedactionScope();
+  return (filePath) =>
+    scrubTranscriptTail(filePath, {
+      tokenizeText: (text) => glue.tokenizeText(text),
+      scope,
+    });
 }
 
 // Guard so importing the exported helpers in tests never runs the CLI.

--- a/plugins/claude-code/src/history/scan.ts
+++ b/plugins/claude-code/src/history/scan.ts
@@ -24,6 +24,13 @@ export interface ScanSummary {
   findings: number; // findings recorded this run
   bySeverity: Record<string, number>;
   windowDays: number;
+  // Every distinct transcript file the walk visited — INCLUDING files whose
+  // messages were all deduped. The at-rest scrub keys off this list, and a
+  // re-run (where dedup skips every message) must still be able to scrub
+  // history it scanned before; collecting only finding-bearing files would
+  // make the scrub unreachable exactly when the user grants vault consent
+  // after the first sweep.
+  visitedFiles: string[];
 }
 
 // ±chars of surrounding text captured around a match span for the triage sink.
@@ -120,7 +127,15 @@ export async function scanHistory(
 ): Promise<ScanSummary> {
   const windowDays = opts.windowDays ?? 30;
   if (config.settings.historicalAccess !== 'full') {
-    return { consented: false, scanned: 0, skipped: 0, findings: 0, bySeverity: {}, windowDays };
+    return {
+      consented: false,
+      scanned: 0,
+      skipped: 0,
+      findings: 0,
+      bySeverity: {},
+      windowDays,
+      visitedFiles: [],
+    };
   }
 
   const gateway = resolveDataGateway(config);
@@ -129,11 +144,13 @@ export async function scanHistory(
   let scanned = 0;
   let skipped = 0;
   let findings = 0;
+  const visited = new Set<string>();
   try {
     // Hashes already in the store (and we add each one we record, so duplicate
     // messages within this same run dedup too).
     const seen = await gateway.knownContentHashes();
     for (const message of iterateHistory(opts)) {
+      visited.add(message.filePath);
       const hash = contentHashOf(message.text);
       if (seen.has(hash)) {
         skipped++;
@@ -175,5 +192,13 @@ export async function scanHistory(
   } finally {
     await runtime.close();
   }
-  return { consented: true, scanned, skipped, findings, bySeverity, windowDays };
+  return {
+    consented: true,
+    scanned,
+    skipped,
+    findings,
+    bySeverity,
+    windowDays,
+    visitedFiles: [...visited],
+  };
 }

--- a/plugins/claude-code/src/remediation/deliverable.ts
+++ b/plugins/claude-code/src/remediation/deliverable.ts
@@ -6,11 +6,15 @@ import { buildChecklistEntries, generateRotationChecklist } from './rotation-che
 export function resolveRemediationDeliverable(input: {
   readonly findings: readonly MaskedSecretFinding[];
   readonly redactedKeys: number;
+  // How many of `redactedKeys` were replaced with recoverable vault pointers
+  // rather than struck one-way — defaults to 0 (irreversible-strike wording).
+  readonly pointeredKeys?: number;
   // Which of `findings` the redaction pass did NOT strike — defaults to empty
   // (every finding redacted) for callers that know redaction was complete.
   readonly unredactedFindings?: readonly MaskedSecretFinding[];
   readonly cwd: string;
 }) {
+  const pointeredKeys = input.pointeredKeys ?? 0;
   const unredactedFindings = input.unredactedFindings ?? [];
   const entries = buildChecklistEntries(input.findings);
   const writeResult = generateRotationChecklist({ entries, cwd: input.cwd });
@@ -18,6 +22,7 @@ export function resolveRemediationDeliverable(input: {
     writeResult.status === 'written'
       ? renderResolvedSummary({
           redactedKeys: input.redactedKeys,
+          pointeredKeys,
           findings: input.findings,
           unredactedFindings,
           location: writeResult.locationLabel,
@@ -25,6 +30,7 @@ export function resolveRemediationDeliverable(input: {
         })
       : renderResolvedSummary({
           redactedKeys: input.redactedKeys,
+          pointeredKeys,
           findings: input.findings,
           unredactedFindings,
           degradedNote: writeResult.note,

--- a/plugins/claude-code/src/remediation/entry.ts
+++ b/plugins/claude-code/src/remediation/entry.ts
@@ -209,7 +209,7 @@ async function route(
   // a partial redaction never reports the same "resolved" framing as a complete one.
   const redaction = isRedactRoute
     ? await redactSurfacedSecrets(findings)
-    : { redactedKeys: 0, unredacted: [] as readonly MaskedSecretFinding[] };
+    : { redactedKeys: 0, pointeredKeys: 0, unredacted: [] as readonly MaskedSecretFinding[] };
   const redactedKeys = redaction.redactedKeys;
   const outcome = routeRemediationOption(option, {
     redact: () => redactedKeys,
@@ -228,6 +228,7 @@ async function route(
           show(
             renderRedactionOutcome({
               redactedKeys: outcome.redactedKeys,
+              pointeredKeys: redaction.pointeredKeys,
               findings,
               unredactedFindings: redaction.unredacted,
             }),
@@ -244,6 +245,7 @@ async function route(
         const deliverable = resolveRemediationDeliverable({
           findings,
           redactedKeys: outcome.redactedKeys,
+          pointeredKeys: redaction.pointeredKeys,
           unredactedFindings: redaction.unredacted,
           cwd: process.cwd(),
         });

--- a/plugins/claude-code/src/remediation/redact.ts
+++ b/plugins/claude-code/src/remediation/redact.ts
@@ -35,6 +35,21 @@ import { transcriptsDir } from '../history/transcripts.ts';
 // the only thing this module strikes, so the category is fixed.
 const REDACTED_PLACEHOLDER = '[REDACTED:SECRET]';
 
+// The string a struck occurrence of `rawValue` is rewritten to: the caller's
+// pre-resolved replacement when one is supplied (an async caller resolves vault
+// pointers ahead of this synchronous sweep), else the one-way placeholder. A
+// replacement must never be the raw value itself — an entry equal to it falls
+// back to the placeholder, so no map can make this module rewrite a secret
+// with itself and report it redacted.
+function replacementFor(
+  rawValue: string,
+  replacements: ReadonlyMap<string, string> | undefined,
+): string {
+  const candidate = replacements?.get(rawValue);
+  if (candidate === undefined || candidate === rawValue) return REDACTED_PLACEHOLDER;
+  return candidate;
+}
+
 // One leaked key to strike: the finding's where-found reference (the raw-free
 // MaskedSecretFinding location — the artifact path, plus an optional span) and the
 // raw value to remove. The scope limit is enforced on `where.filePath`.
@@ -103,6 +118,11 @@ export function resolveRedactableArtifact(filePath: string, scope: RedactionScop
 // (rather than only how many) can compare its input targets against `struck`.
 export interface RedactionDetail {
   readonly redactedKeys: number;
+  // How many of `redactedKeys` were rewritten to a caller-supplied replacement
+  // (a recoverable vault pointer) rather than the one-way placeholder — so a
+  // caller's copy can say exactly which strikes are recoverable and which are
+  // irreversible. Always ≤ `redactedKeys`; 0 when no replacements were supplied.
+  readonly pointeredKeys: number;
   readonly struck: readonly RedactionTarget[];
 }
 
@@ -114,10 +134,17 @@ export interface RedactionDetail {
  * Targets against the same file are folded into a single read/rewrite. Each file is
  * handled best-effort: a read or write failure on one artifact is skipped so the
  * rest of the batch is still redacted.
+ *
+ * `replacements` maps a raw value to the pre-resolved string it is rewritten to
+ * — a recoverable vault pointer, resolved by the async caller because this sweep
+ * must stay synchronous. A value with no entry (or with an entry equal to the
+ * raw value itself) is struck with the one-way placeholder, so with no map the
+ * behavior is byte-identical to the plain strike.
  */
 export function redactLeakedKeysDetailed(
   targets: readonly RedactionTarget[],
   scope: RedactionScope = platformRedactionScope(),
+  replacements?: ReadonlyMap<string, string>,
 ): RedactionDetail {
   // Group the in-scope targets (keeping each target's identity, not just its raw
   // value) by the real path of the file they strike, so a file with several leaked
@@ -133,6 +160,7 @@ export function redactLeakedKeysDetailed(
   }
 
   let redactedKeys = 0;
+  let pointeredKeys = 0;
   const struck: RedactionTarget[] = [];
   for (const [filePath, fileTargets] of byFile) {
     let content: string;
@@ -142,20 +170,26 @@ export function redactLeakedKeysDetailed(
       continue; // unreadable or vanished artifact — skip, don't abort the batch
     }
     const struckHere: RedactionTarget[] = [];
+    let pointeredHere = 0;
     const struckValues = new Set<string>();
     for (const target of fileTargets) {
+      // One raw value has exactly one replacement across the whole sweep, so a
+      // target and its same-value siblings always count the same way.
+      const replacement = replacementFor(target.rawValue, replacements);
       // A sibling target sharing this raw value already struck every occurrence
       // in this file, so `content.includes` is now false even though this
       // target's value IS redacted — count it struck rather than misreport it as
       // still exposed (two findings on one repeated value both resolve together).
       if (struckValues.has(target.rawValue)) {
         struckHere.push(target);
+        if (replacement !== REDACTED_PLACEHOLDER) pointeredHere += 1;
         continue;
       }
       if (!content.includes(target.rawValue)) continue;
-      content = content.replaceAll(target.rawValue, REDACTED_PLACEHOLDER);
+      content = content.replaceAll(target.rawValue, replacement);
       struckValues.add(target.rawValue);
       struckHere.push(target);
+      if (replacement !== REDACTED_PLACEHOLDER) pointeredHere += 1;
     }
     if (struckHere.length === 0) continue;
     // Write atomically: a full write to a sibling temp file, then rename over the
@@ -176,13 +210,14 @@ export function redactLeakedKeysDetailed(
       }
       continue; // write failed — don't count keys that were not persisted
     }
-    // Count only after the rewrite is on disk, so the returned count reflects keys
+    // Count only after the rewrite is on disk, so the returned counts reflect keys
     // actually redacted rather than merely matched.
     redactedKeys += struckHere.length;
+    pointeredKeys += pointeredHere;
     struck.push(...struckHere);
   }
 
-  return { redactedKeys, struck };
+  return { redactedKeys, pointeredKeys, struck };
 }
 
 /**

--- a/plugins/claude-code/src/remediation/render.ts
+++ b/plugins/claude-code/src/remediation/render.ts
@@ -68,6 +68,19 @@ export function renderRedactionConfirmation(redactedKeys: number): string {
   return `✓ Redacted ${String(redactedKeys)} ${noun}`;
 }
 
+// The recoverable-pointer sentence, spoken only when at least one struck value
+// was replaced with a vault pointer rather than destroyed: it names exactly how
+// many values are recoverable and where to view them. The one-way strike copy
+// never carries it, so an irreversible strike is never described as recoverable
+// — and a recoverable one is never passed off as gone.
+function renderPointeredNote(pointeredKeys: number): string {
+  const subject = pointeredKeys === 1 ? 'value was' : 'values were';
+  return (
+    `${String(pointeredKeys)} ${subject} replaced with recoverable vault pointers — ` +
+    'view them in the dashboard or with `aka vault show`.'
+  );
+}
+
 // The honest partial-strike line — "Redacted N of M keys; K still need attention
 // in <files>" — shared by the redact-only confirmation and the resolved summary
 // so a partial redaction reads identically wherever it surfaces.
@@ -96,11 +109,28 @@ export function renderRedactionOutcome(input: {
   readonly redactedKeys: number;
   readonly findings: readonly MaskedSecretFinding[];
   readonly unredactedFindings: readonly MaskedSecretFinding[];
+  // How many of `redactedKeys` were replaced with recoverable vault pointers
+  // rather than struck one-way. Drives the recoverability sentence; omitted or
+  // 0 keeps the irreversible-strike wording exactly as it always was.
+  readonly pointeredKeys?: number;
 }): string {
+  const pointeredKeys = input.pointeredKeys ?? 0;
   const totalKeys = input.findings.length;
   const isComplete = input.redactedKeys === totalKeys && input.unredactedFindings.length === 0;
-  if (isComplete) return `${renderRedactionConfirmation(input.redactedKeys)}.`;
-  return renderPartialRedactionLine(input.redactedKeys, totalKeys, input.unredactedFindings);
+  if (isComplete) {
+    const confirmation = `${renderRedactionConfirmation(input.redactedKeys)}.`;
+    return pointeredKeys === 0
+      ? confirmation
+      : `${confirmation} ${renderPointeredNote(pointeredKeys)}`;
+  }
+  const partialLine = renderPartialRedactionLine(
+    input.redactedKeys,
+    totalKeys,
+    input.unredactedFindings,
+  );
+  return pointeredKeys === 0
+    ? partialLine
+    : `${partialLine}. ${renderPointeredNote(pointeredKeys)}`;
 }
 
 // The "resolved" framing is only ever honest when every leaked key was struck.
@@ -117,22 +147,28 @@ export function renderResolvedSummary(
     // every finding was redacted. Required (not inferred from the count alone) so
     // the file(s) still holding a live key can be named in the partial message.
     readonly unredactedFindings: readonly MaskedSecretFinding[];
+    // How many of `redactedKeys` were replaced with recoverable vault pointers
+    // rather than struck one-way — see `renderRedactionOutcome`.
+    readonly pointeredKeys?: number;
     readonly entries: readonly RotationChecklistEntry[];
   } & (
     | { readonly location: string; readonly degradedNote?: never }
     | { readonly location?: never; readonly degradedNote: string }
   ),
 ): string {
+  const pointeredKeys = input.pointeredKeys ?? 0;
   const totalKeys = input.findings.length;
   const isComplete = input.redactedKeys === totalKeys && input.unredactedFindings.length === 0;
   const preview = renderChecklistMarkdown(input.entries).trimEnd();
   const checklistLine = input.degradedNote ?? renderRotationChecklistResolvedLine(input.location);
+  // Appended to the redaction line only when some struck values are actually
+  // recoverable; the irreversible wording stays untouched otherwise.
+  const withPointeredNote = (line: string): string =>
+    pointeredKeys === 0 ? line : `${line}. ${renderPointeredNote(pointeredKeys)}`;
 
   if (!isComplete) {
-    const redactionLine = renderPartialRedactionLine(
-      input.redactedKeys,
-      totalKeys,
-      input.unredactedFindings,
+    const redactionLine = withPointeredNote(
+      renderPartialRedactionLine(input.redactedKeys, totalKeys, input.unredactedFindings),
     );
 
     return ['Leaked secrets — partially redacted', redactionLine, checklistLine, '', preview].join(
@@ -142,7 +178,9 @@ export function renderResolvedSummary(
 
   const transcriptCount = new Set(input.findings.map((finding) => finding.where.filePath)).size;
   const transcriptNoun = transcriptCount === 1 ? 'transcript' : 'transcripts';
-  const redactionLine = `${renderRedactionConfirmation(input.redactedKeys)} across ${String(transcriptCount)} ${transcriptNoun}`;
+  const redactionLine = withPointeredNote(
+    `${renderRedactionConfirmation(input.redactedKeys)} across ${String(transcriptCount)} ${transcriptNoun}`,
+  );
 
   return ['Leaked secrets — resolved', redactionLine, checklistLine, '', preview].join('\n');
 }

--- a/plugins/claude-code/src/remediation/surfaced-redact.ts
+++ b/plugins/claude-code/src/remediation/surfaced-redact.ts
@@ -35,11 +35,14 @@ import { readFileSync } from 'node:fs';
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
 import {
   createPluginRuntime,
+  createVaultGlue,
   loadConfig,
+  maskMatch,
   resolveRepo,
   safeMaskedMatch,
 } from '@akasecurity/plugin-sdk';
-import type { MaskedSecretFinding } from '@akasecurity/schema';
+import type { DetectionCategory, MaskedSecretFinding } from '@akasecurity/schema';
+import { isVaultConsentValid } from '@akasecurity/schema';
 
 import { transcriptsDir } from '../history/transcripts.ts';
 import { deriveProvider } from '../triage/surfaced-secrets.ts';
@@ -85,19 +88,78 @@ function enforcedScope(overrides: RedactSurfacedSecretsOverrides): RedactionScop
   return { artifactRoots: roots };
 }
 
-// One recovered (finding, rawValue) redaction target, or undefined when no
-// on-disk occurrence matching this finding's (provider, maskedToken) pair was
-// found in the scanned content.
+// One recovered redaction target plus the detection identity of the on-disk
+// occurrence it came from — the identity the vault needs to mint a pointer for
+// the value. Undefined when no occurrence matching this finding's
+// (provider, maskedToken) pair was found in the scanned content.
+interface RecoveredTarget {
+  target: RedactionTarget;
+  ruleId: string;
+  category: DetectionCategory;
+}
+
 function recoverTarget(
   finding: MaskedSecretFinding,
-  matches: readonly { ruleId: string; rawMatch: string }[],
-): RedactionTarget | undefined {
+  matches: readonly { ruleId: string; rawMatch: string; category: DetectionCategory }[],
+): RecoveredTarget | undefined {
   const hit = matches.find(
     (m) =>
       deriveProvider(m.ruleId) === finding.provider &&
       safeMaskedMatch(m.rawMatch) === finding.maskedToken,
   );
-  return hit === undefined ? undefined : { where: finding.where, rawValue: hit.rawMatch };
+  return hit === undefined
+    ? undefined
+    : {
+        target: { where: finding.where, rawValue: hit.rawMatch },
+        ruleId: hit.ruleId,
+        category: hit.category,
+      };
+}
+
+// Whether the settings on record carry a currently valid vault consent.
+// Fail-closed: a settings load fault reads as no consent, so the strike stays
+// the plain one-way redaction rather than attempting to vault.
+function hasValidVaultConsent(base: string | undefined): boolean {
+  try {
+    return isVaultConsentValid(loadConfig(base).settings.vaultConsent);
+  } catch {
+    return false;
+  }
+}
+
+// The pre-resolved replacement map for the synchronous strike: each DISTINCT
+// raw value among the recovered targets is tokenized ONCE, so the same key
+// leaked into several artifacts resolves to one pointer everywhere. Only a
+// well-formed pointer return lands in the map — a degraded `[REDACTED:…]`
+// return is dropped, because the synchronous default already strikes one-way.
+// Any fault yields an empty map (plain strike), never a throw: the glue is
+// built to never surface raw or throw, and this guard is belt-and-braces on
+// top of that.
+async function buildPointerReplacements(
+  recovered: readonly RecoveredTarget[],
+  base: string | undefined,
+): Promise<ReadonlyMap<string, string>> {
+  const replacements = new Map<string, string>();
+  try {
+    const glue = createVaultGlue(base === undefined ? undefined : { base });
+    const distinct = new Map<string, RecoveredTarget>();
+    for (const entry of recovered) {
+      if (!distinct.has(entry.target.rawValue)) distinct.set(entry.target.rawValue, entry);
+    }
+    for (const [rawValue, entry] of distinct) {
+      const replacement = await glue.tokenizeValue(rawValue, {
+        ruleId: entry.ruleId,
+        category: entry.category,
+        maskedMatch: maskMatch(rawValue),
+      });
+      if (replacement.startsWith('[[aka:') && replacement !== rawValue) {
+        replacements.set(rawValue, replacement);
+      }
+    }
+  } catch {
+    return new Map();
+  }
+  return replacements;
 }
 
 // The real outcome of a redaction pass: the count of keys actually struck, plus
@@ -109,6 +171,11 @@ function recoverTarget(
 // all-clear this shape exists to prevent.
 export interface SurfacedRedactionResult {
   readonly redactedKeys: number;
+  // How many of `redactedKeys` were replaced with recoverable vault pointers
+  // rather than the irreversible placeholder — set only when a valid vault
+  // consent is on record, 0 otherwise. The caller's copy must distinguish the
+  // two: a pointered value is viewable again, a struck value is gone.
+  readonly pointeredKeys: number;
   readonly unredacted: readonly MaskedSecretFinding[];
 }
 
@@ -122,12 +189,19 @@ export interface SurfacedRedactionResult {
  * because a best-effort recovery pass failed. The actual in-place striking is
  * delegated entirely to `redactLeakedKeysDetailed`, so its binding-scope,
  * atomic-write, and per-file fail-open guarantees apply unchanged.
+ *
+ * With a valid vault consent on record the strike is RECOVERABLE: each distinct
+ * recovered value is tokenized into the local secret vault and its occurrences
+ * are rewritten to the resulting pointer instead of the one-way placeholder
+ * (`pointeredKeys` reports how many keys landed that way). Without consent — or
+ * on any vault fault — nothing is vaulted and the strike is byte-identical to
+ * the plain one-way redaction.
  */
 export async function redactSurfacedSecrets(
   findings: readonly MaskedSecretFinding[],
   overrides: RedactSurfacedSecretsOverrides = {},
 ): Promise<SurfacedRedactionResult> {
-  if (findings.length === 0) return { redactedKeys: 0, unredacted: [] };
+  if (findings.length === 0) return { redactedKeys: 0, pointeredKeys: 0, unredacted: [] };
   const scope = enforcedScope(overrides);
 
   // Group by file, and set aside any finding whose artifact does not resolve
@@ -145,15 +219,20 @@ export async function redactSurfacedSecrets(
     if (existing) existing.push(finding);
     else byFile.set(finding.where.filePath, [finding]);
   }
-  if (byFile.size === 0) return { redactedKeys: 0, unredacted: findings };
+  if (byFile.size === 0) return { redactedKeys: 0, pointeredKeys: 0, unredacted: findings };
 
   // Every finding whose raw value could not be recovered — because its file
   // vanished/is unreadable, the re-scan found no matching occurrence, or it was
   // out-of-scope above — accumulates here. `recovered` pairs a finding with the
   // redaction target derived from it, so a struck/unstruck target can be traced
   // back to the finding it came from.
+  // Whether a valid vault consent is on record. Without it no vault is ever
+  // constructed and the strike below is byte-identical to the plain one-way
+  // redaction. An unreadable settings file counts as no consent.
+  const vaultConsented = hasValidVaultConsent(overrides.dataDirBase);
+
   const unrecovered: MaskedSecretFinding[] = [...outOfScope];
-  const recovered: { finding: MaskedSecretFinding; target: RedactionTarget }[] = [];
+  const recovered: { finding: MaskedSecretFinding; recovery: RecoveredTarget }[] = [];
   try {
     const config = loadConfig(overrides.dataDirBase);
     const gateway = resolveDataGateway(config);
@@ -167,7 +246,7 @@ export async function redactSurfacedSecrets(
           unrecovered.push(...fileFindings); // vanished/unreadable artifact — best-effort, skip it
           continue;
         }
-        let matches: { ruleId: string; rawMatch: string }[];
+        let matches: { ruleId: string; rawMatch: string; category: DetectionCategory }[];
         try {
           matches = (await runtime.processText(content)).findings;
         } catch {
@@ -175,9 +254,9 @@ export async function redactSurfacedSecrets(
           continue;
         }
         for (const finding of fileFindings) {
-          const target = recoverTarget(finding, matches);
-          if (target === undefined) unrecovered.push(finding);
-          else recovered.push({ finding, target });
+          const recovery = recoverTarget(finding, matches);
+          if (recovery === undefined) unrecovered.push(finding);
+          else recovered.push({ finding, recovery });
         }
       }
     } finally {
@@ -191,17 +270,29 @@ export async function redactSurfacedSecrets(
     }
   } catch {
     // Config/store unavailable — recover nothing rather than break the session.
-    return { redactedKeys: 0, unredacted: findings };
+    return { redactedKeys: 0, pointeredKeys: 0, unredacted: findings };
   }
 
-  const { redactedKeys, struck } = redactLeakedKeysDetailed(
-    recovered.map((r) => r.target),
+  // With a valid consent the strike becomes recoverable: each distinct raw
+  // value is pre-resolved to a vault pointer, and the synchronous sweep below
+  // substitutes those pointers instead of the one-way placeholder. Without
+  // consent no map is built at all, so the sweep is the plain legacy strike.
+  const replacements = vaultConsented
+    ? await buildPointerReplacements(
+        recovered.map((r) => r.recovery),
+        overrides.dataDirBase,
+      )
+    : undefined;
+
+  const { redactedKeys, pointeredKeys, struck } = redactLeakedKeysDetailed(
+    recovered.map((r) => r.recovery.target),
     scope,
+    replacements,
   );
   const struckTargets = new Set(struck);
   const unredacted = [
     ...unrecovered,
-    ...recovered.filter((r) => !struckTargets.has(r.target)).map((r) => r.finding),
+    ...recovered.filter((r) => !struckTargets.has(r.recovery.target)).map((r) => r.finding),
   ];
-  return { redactedKeys, unredacted };
+  return { redactedKeys, pointeredKeys, unredacted };
 }

--- a/plugins/claude-code/test/backfill.test.ts
+++ b/plugins/claude-code/test/backfill.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import type { PluginConfig } from '@akasecurity/plugin-sdk';
 import type { TriageHit } from '@akasecurity/schema';
+import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { BackfillDeps, BackfillIo } from '../src/backfill.ts';
@@ -42,7 +43,15 @@ function fakeIo(): { io: BackfillIo; stdout: string[]; stderr: string[]; failed:
 }
 
 function zeroSummary(): ScanSummary {
-  return { consented: true, scanned: 0, skipped: 0, findings: 0, bySeverity: {}, windowDays: 30 };
+  return {
+    consented: true,
+    scanned: 0,
+    skipped: 0,
+    findings: 0,
+    bySeverity: {},
+    windowDays: 30,
+    visitedFiles: [],
+  };
 }
 
 function baseDeps(overrides: Partial<BackfillDeps> = {}): BackfillDeps {
@@ -286,5 +295,95 @@ describe('runBackfill — human mode (unchanged)', () => {
       'AKA could not scan your history right now. It will still protect everything from here on.\n',
     ]);
     expect(failed()).toBe(false);
+  });
+});
+
+describe('runBackfill — at-rest scrub of visited transcripts', () => {
+  const consent = { acknowledgedAt: '2026-07-30T00:00:00.000Z', version: VAULT_CONSENT_VERSION };
+
+  function summaryWithFiles(files: string[]): ScanSummary {
+    return { ...zeroSummary(), scanned: files.length, visitedFiles: files };
+  }
+
+  function depsWithConsent(
+    overrides: Partial<BackfillDeps>,
+    consented: boolean,
+  ): { deps: BackfillDeps; out: () => string } {
+    const { io, stdout } = fakeIo();
+    const base = baseDeps({ io, ...overrides });
+    const config = base.loadConfig();
+    if (consented) config.settings.vaultConsent = consent;
+    return { deps: { ...base, loadConfig: () => config }, out: () => stdout.join('') };
+  }
+
+  it('scrubs every visited file when vault consent is granted, and says so', async () => {
+    const scrubFile = vi.fn().mockResolvedValue({ rewritten: 2 });
+    const { deps, out } = depsWithConsent(
+      {
+        scanHistory: () => Promise.resolve(summaryWithFiles(['/h/a.jsonl', '/h/b.jsonl'])),
+        scrubFile,
+      },
+      true,
+    );
+    await runBackfill(deps);
+    expect(scrubFile.mock.calls.map((c): unknown => c[0])).toEqual(['/h/a.jsonl', '/h/b.jsonl']);
+    expect(out()).toContain('Rewrote secrets in 2 transcript files to recoverable vault pointers');
+  });
+
+  // Reading history was consented; KEEPING recoverable copies was not — the
+  // scrub must not run on the historical grant alone.
+  it('never scrubs without vault consent', async () => {
+    const scrubFile = vi.fn();
+    const { deps, out } = depsWithConsent(
+      { scanHistory: () => Promise.resolve(summaryWithFiles(['/h/a.jsonl'])), scrubFile },
+      false,
+    );
+    await runBackfill(deps);
+    expect(scrubFile).not.toHaveBeenCalled();
+    expect(out()).not.toContain('Rewrote');
+  });
+
+  it('a scrub fault fails nothing and claims nothing', async () => {
+    const scrubFile = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('locked'))
+      .mockResolvedValueOnce(null);
+    const { deps, out } = depsWithConsent(
+      {
+        scanHistory: () => Promise.resolve(summaryWithFiles(['/h/a.jsonl', '/h/b.jsonl'])),
+        scrubFile,
+      },
+      true,
+    );
+    await runBackfill(deps);
+    expect(out()).toContain('Historical scan complete');
+    expect(out()).not.toContain('Rewrote');
+  });
+
+  it('clean files (rewritten: 0) are not counted as scrubbed', async () => {
+    const scrubFile = vi.fn().mockResolvedValue({ rewritten: 0 });
+    const { deps, out } = depsWithConsent(
+      { scanHistory: () => Promise.resolve(summaryWithFiles(['/h/a.jsonl'])), scrubFile },
+      true,
+    );
+    await runBackfill(deps);
+    expect(out()).not.toContain('Rewrote');
+  });
+
+  // The --triage stdout stream is a machine protocol (hits + sentinel); the
+  // scrub still runs under both grants but must add nothing to that stream.
+  it('triage mode scrubs silently', async () => {
+    const scrubFile = vi.fn().mockResolvedValue({ rewritten: 1 });
+    const { deps, out } = depsWithConsent(
+      {
+        triage: true,
+        scanHistory: () => Promise.resolve(summaryWithFiles(['/h/a.jsonl'])),
+        scrubFile,
+      },
+      true,
+    );
+    await runBackfill(deps);
+    expect(scrubFile).toHaveBeenCalledTimes(1);
+    expect(out()).toBe(triageSentinel(0, 'complete'));
   });
 });

--- a/plugins/claude-code/test/remediation/deliverable.test.ts
+++ b/plugins/claude-code/test/remediation/deliverable.test.ts
@@ -125,6 +125,31 @@ describe('resolveRemediationDeliverable', () => {
     expect(result.summary).toContain('Redacted 2 of 3 keys');
   });
 
+  it('threads pointeredKeys through to the recoverable-pointer sentence — and omits it by default', () => {
+    const repositoryRoot = mkdtempSync(join(tmpdir(), 'aka-deliverable-pointered-repo-'));
+    temporaryDirectories.push(repositoryRoot);
+    mkdirSync(join(repositoryRoot, '.git'));
+
+    const pointered = resolveRemediationDeliverable({
+      findings,
+      redactedKeys: 3,
+      pointeredKeys: 3,
+      cwd: repositoryRoot,
+    });
+    expect(pointered.summary).toContain('Leaked secrets — resolved');
+    expect(pointered.summary).toContain(
+      '3 values were replaced with recoverable vault pointers — ' +
+        'view them in the dashboard or with `aka vault show`.',
+    );
+
+    const struckOnly = resolveRemediationDeliverable({
+      findings,
+      redactedKeys: 3,
+      cwd: repositoryRoot,
+    });
+    expect(struckOnly.summary).not.toContain('recoverable');
+  });
+
   it('defaults unredactedFindings to empty — a caller that redacted every finding still gets the "resolved" framing', () => {
     const repositoryRoot = mkdtempSync(join(tmpdir(), 'aka-deliverable-default-repo-'));
     temporaryDirectories.push(repositoryRoot);

--- a/plugins/claude-code/test/remediation/production-redact.scenario.test.ts
+++ b/plugins/claude-code/test/remediation/production-redact.scenario.test.ts
@@ -2,9 +2,11 @@ import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSyn
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { applyOnboarding } from '@akasecurity/persistence';
 import type { PluginRuntime } from '@akasecurity/plugin-sdk';
-import { safeMaskedMatch } from '@akasecurity/plugin-sdk';
+import { createVaultGlue, safeMaskedMatch } from '@akasecurity/plugin-sdk';
 import type { MaskedSecretFinding } from '@akasecurity/schema';
+import { pointerTokenScanner, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // A toggle a single test flips to make the adapter's runtime `close()` throw —
@@ -64,6 +66,15 @@ function findingFor(filePath: string, rawValue: string): MaskedSecretFinding {
     where: { filePath },
     state: 'unknown',
   };
+}
+
+// Record a valid vault consent in the throwaway ~/.aka the adapter reads —
+// what flips the strike from the one-way placeholder to recoverable pointers.
+function grantVaultConsent(base: string): void {
+  applyOnboarding(
+    { vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION } },
+    base,
+  );
 }
 
 describe('redactSurfacedSecrets — the production redaction adapter', () => {
@@ -161,7 +172,68 @@ describe('redactSurfacedSecrets — the production redaction adapter', () => {
 
   it('returns 0 and touches nothing for an empty findings set', async () => {
     const result = await redactSurfacedSecrets([], { home, dataDirBase });
-    expect(result).toEqual({ redactedKeys: 0, unredacted: [] });
+    expect(result).toEqual({ redactedKeys: 0, pointeredKeys: 0, unredacted: [] });
+  });
+
+  it('with vault consent, the strike becomes recoverable pointers — one pointer per distinct value, detokenizable back to the key', async () => {
+    grantVaultConsent(dataDirBase);
+    const projectDir = join(home, '.claude', 'projects', '-Users-me-project');
+    mkdirSync(projectDir, { recursive: true });
+    const fileA = join(projectDir, 'a.jsonl');
+    const fileB = join(projectDir, 'b.jsonl');
+    // The SAME key leaked into two transcripts — it must resolve to ONE
+    // pointer, substituted in both files.
+    writeFileSync(fileA, `{"content":"a key ${TRANSCRIPT_KEY} in a prompt"}`);
+    writeFileSync(fileB, `{"content":"same key ${TRANSCRIPT_KEY} again"}`);
+
+    const result = await redactSurfacedSecrets(
+      [findingFor(fileA, TRANSCRIPT_KEY), findingFor(fileB, TRANSCRIPT_KEY)],
+      { home, dataDirBase },
+    );
+
+    expect(result.redactedKeys).toBe(2);
+    expect(result.pointeredKeys).toBe(2);
+    expect(result.unredacted).toEqual([]);
+
+    const afterA = readFileSync(fileA, 'utf8');
+    const afterB = readFileSync(fileB, 'utf8');
+    for (const after of [afterA, afterB]) {
+      expect(after).not.toContain(TRANSCRIPT_KEY);
+      expect(after).not.toContain('[REDACTED:SECRET]');
+    }
+    const pointersA = afterA.match(pointerTokenScanner());
+    const pointersB = afterB.match(pointerTokenScanner());
+    expect(pointersA).toHaveLength(1);
+    // One distinct value → one pointer, identical across both artifacts.
+    expect(pointersB).toEqual(pointersA);
+
+    // The pointer is genuinely recoverable: the same store detokenizes it back
+    // to the original key.
+    const glue = createVaultGlue({ base: dataDirBase });
+    const back = await glue.detokenizeText(afterA, { target: 'human', reason: 'display' });
+    expect(back.revealed).toBe(1);
+    expect(back.text).toBe(`{"content":"a key ${TRANSCRIPT_KEY} in a prompt"}`);
+  });
+
+  it('without vault consent the strike is byte-identical to the legacy one-way redaction', async () => {
+    // No consent is ever granted in this test — the default state of the
+    // throwaway store.
+    const projectDir = join(home, '.claude', 'projects', '-Users-me-project');
+    mkdirSync(projectDir, { recursive: true });
+    const transcriptFile = join(projectDir, 'session.jsonl');
+    writeFileSync(transcriptFile, `{"content":"a key ${TRANSCRIPT_KEY} in a prompt"}`);
+
+    const result = await redactSurfacedSecrets([findingFor(transcriptFile, TRANSCRIPT_KEY)], {
+      home,
+      dataDirBase,
+    });
+
+    expect(result.redactedKeys).toBe(1);
+    expect(result.pointeredKeys).toBe(0);
+    expect(result.unredacted).toEqual([]);
+    expect(readFileSync(transcriptFile, 'utf8')).toBe(
+      '{"content":"a key [REDACTED:SECRET] in a prompt"}',
+    );
   });
 
   it('reports a vanished/unreadable artifact as unredacted rather than silently dropping it', async () => {

--- a/plugins/claude-code/test/remediation/redact.test.ts
+++ b/plugins/claude-code/test/remediation/redact.test.ts
@@ -246,6 +246,113 @@ describe('redactLeakedKeys', () => {
     expect(readFileSync(present, 'utf8')).toContain('[REDACTED:SECRET]');
   });
 
+  describe('pre-resolved replacements (recoverable vault pointers)', () => {
+    // A well-formed pointer-shaped replacement, as the async vault caller would
+    // pre-resolve. Its exact shape is irrelevant to this module — any non-raw
+    // string a caller maps is substituted verbatim.
+    const POINTER = `[[aka:secret:AE.${'A'.repeat(26)}.${'2'.repeat(16)}]]`;
+
+    it('substitutes the mapped replacement, removes the raw value, and leaves every other byte identical', () => {
+      const transcriptFile = join(transcriptRoot, 'session.jsonl');
+      const before = `line one untouched\n{"content":"key ${TRANSCRIPT_KEY} here"}\nline three untouched\n`;
+      writeFileSync(transcriptFile, before);
+
+      const detail = redactLeakedKeysDetailed(
+        [{ where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+        new Map([[TRANSCRIPT_KEY, POINTER]]),
+      );
+
+      expect(detail.redactedKeys).toBe(1);
+      expect(detail.pointeredKeys).toBe(1);
+      const after = readFileSync(transcriptFile, 'utf8');
+      // The rewrite is exactly the raw value's occurrences swapped for the
+      // pointer — no placeholder, no other byte touched.
+      expect(after).toBe(before.replaceAll(TRANSCRIPT_KEY, POINTER));
+      expect(after).not.toContain(TRANSCRIPT_KEY);
+      expect(after).not.toContain('[REDACTED:SECRET]');
+    });
+
+    it('a value without a map entry still strikes one-way, and the counts separate the two', () => {
+      const transcriptFile = join(transcriptRoot, 'mixed.jsonl');
+      writeFileSync(transcriptFile, `pointered ${TRANSCRIPT_KEY} struck ${TEMP_KEY} end`);
+
+      const detail = redactLeakedKeysDetailed(
+        [
+          { where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY },
+          { where: { filePath: transcriptFile }, rawValue: TEMP_KEY },
+        ],
+        scope,
+        new Map([[TRANSCRIPT_KEY, POINTER]]),
+      );
+
+      expect(detail.redactedKeys).toBe(2);
+      expect(detail.pointeredKeys).toBe(1);
+      const after = readFileSync(transcriptFile, 'utf8');
+      expect(after).toBe(`pointered ${POINTER} struck [REDACTED:SECRET] end`);
+    });
+
+    it('a map entry equal to the raw value itself falls back to the one-way placeholder', () => {
+      const transcriptFile = join(transcriptRoot, 'self-map.jsonl');
+      writeFileSync(transcriptFile, `leaked ${TRANSCRIPT_KEY} here`);
+
+      const detail = redactLeakedKeysDetailed(
+        [{ where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+        new Map([[TRANSCRIPT_KEY, TRANSCRIPT_KEY]]),
+      );
+
+      // The self-mapping entry is never honoured: the value is struck one-way
+      // and not counted as pointered.
+      expect(detail.redactedKeys).toBe(1);
+      expect(detail.pointeredKeys).toBe(0);
+      const after = readFileSync(transcriptFile, 'utf8');
+      expect(after).toBe('leaked [REDACTED:SECRET] here');
+    });
+
+    it('an empty map behaves byte-identically to no map at all', () => {
+      const withMap = join(transcriptRoot, 'with-empty-map.jsonl');
+      const without = join(transcriptRoot, 'without-map.jsonl');
+      const content = `leaked ${TRANSCRIPT_KEY} twice ${TRANSCRIPT_KEY}`;
+      writeFileSync(withMap, content);
+      writeFileSync(without, content);
+
+      const mapDetail = redactLeakedKeysDetailed(
+        [{ where: { filePath: withMap }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+        new Map(),
+      );
+      const plainDetail = redactLeakedKeysDetailed(
+        [{ where: { filePath: without }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+      );
+
+      expect(mapDetail.redactedKeys).toBe(plainDetail.redactedKeys);
+      expect(mapDetail.pointeredKeys).toBe(0);
+      expect(plainDetail.pointeredKeys).toBe(0);
+      expect(readFileSync(withMap)).toEqual(readFileSync(without));
+    });
+
+    it('counts every finding on a repeated pointered value, same as the one-way sibling rule', () => {
+      const transcriptFile = join(transcriptRoot, 'repeated-pointered.jsonl');
+      writeFileSync(transcriptFile, `one ${TRANSCRIPT_KEY} two ${TRANSCRIPT_KEY} done`);
+
+      const targets = [
+        { where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY },
+        { where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY },
+      ];
+      const detail = redactLeakedKeysDetailed(targets, scope, new Map([[TRANSCRIPT_KEY, POINTER]]));
+
+      // Both findings resolve on the single rewrite and both count pointered —
+      // one raw value has exactly one replacement across the sweep.
+      expect(detail.redactedKeys).toBe(2);
+      expect(detail.pointeredKeys).toBe(2);
+      expect(detail.struck).toEqual(targets);
+      const after = readFileSync(transcriptFile, 'utf8');
+      expect(after).toBe(`one ${POINTER} two ${POINTER} done`);
+    });
+  });
+
   describe('.aka-redact.tmp cleanup', () => {
     // Entries left behind matching the atomic-write sibling-temp-file naming.
     function orphanedTmpEntries(dir: string): string[] {

--- a/plugins/claude-code/test/remediation/render.test.ts
+++ b/plugins/claude-code/test/remediation/render.test.ts
@@ -338,3 +338,97 @@ describe('renderRedactionOutcome — redact-only confirmation', () => {
     expect(outcome).toContain(awsFinding().where.filePath);
   });
 });
+
+describe('pointered-strike copy — recoverable vault pointers', () => {
+  const entries: readonly RotationChecklistEntry[] = [
+    {
+      provider: 'stripe',
+      maskedToken: MASKED_STRIPE,
+      consolePath: 'dashboard.stripe.com → Developers → API keys',
+      occurrenceSpread: 1,
+    },
+  ];
+
+  it('the clean confirmation says the values are recoverable when every struck value was pointered', () => {
+    const findings = [stripeFinding(), awsFinding()];
+    expect(
+      renderRedactionOutcome({
+        redactedKeys: 2,
+        pointeredKeys: 2,
+        findings,
+        unredactedFindings: [],
+      }),
+    ).toBe(
+      '✓ Redacted 2 keys. 2 values were replaced with recoverable vault pointers — ' +
+        'view them in the dashboard or with `aka vault show`.',
+    );
+  });
+
+  it('a mixed outcome names only the pointered share as recoverable', () => {
+    const findings = [stripeFinding(), awsFinding()];
+    const outcome = renderRedactionOutcome({
+      redactedKeys: 2,
+      pointeredKeys: 1,
+      findings,
+      unredactedFindings: [],
+    });
+    expect(outcome).toContain('✓ Redacted 2 keys.');
+    expect(outcome).toContain('1 value was replaced with recoverable vault pointers');
+  });
+
+  it('pointeredKeys 0 (or omitted) keeps the irreversible wording byte-identical — a one-way strike is never described as recoverable', () => {
+    const findings = [stripeFinding()];
+    const plain = renderRedactionOutcome({ redactedKeys: 1, findings, unredactedFindings: [] });
+    const zeroed = renderRedactionOutcome({
+      redactedKeys: 1,
+      pointeredKeys: 0,
+      findings,
+      unredactedFindings: [],
+    });
+    expect(plain).toBe('✓ Redacted 1 key.');
+    expect(zeroed).toBe(plain);
+    expect(plain).not.toContain('recoverable');
+  });
+
+  it('the partial outcome still names the values that WERE pointered as recoverable', () => {
+    const secondAwsFinding = { ...awsFinding(), where: { filePath: '/tmp/second-agent-dump.txt' } };
+    const findings = [stripeFinding(), awsFinding(), secondAwsFinding];
+    const outcome = renderRedactionOutcome({
+      redactedKeys: 2,
+      pointeredKeys: 2,
+      findings,
+      unredactedFindings: [secondAwsFinding],
+    });
+    expect(outcome).toContain(
+      'Redacted 2 of 3 keys; 1 key still needs attention in /tmp/second-agent-dump.txt',
+    );
+    expect(outcome).toContain('2 values were replaced with recoverable vault pointers');
+  });
+
+  it('the resolved summary carries the recoverable sentence on its redaction line — and drops it when nothing was pointered', () => {
+    const findings = [stripeFinding(), awsFinding()];
+    const pointered = renderResolvedSummary({
+      redactedKeys: 2,
+      pointeredKeys: 2,
+      findings,
+      unredactedFindings: [],
+      location: 'repo root',
+      entries,
+    });
+    expect(pointered).toContain('Leaked secrets — resolved');
+    expect(pointered).toContain(
+      '✓ Redacted 2 keys across 2 transcripts. 2 values were replaced with recoverable vault pointers — ' +
+        'view them in the dashboard or with `aka vault show`.',
+    );
+
+    const struckOnly = renderResolvedSummary({
+      redactedKeys: 2,
+      findings,
+      unredactedFindings: [],
+      location: 'repo root',
+      entries,
+    });
+    expect(struckOnly).toContain('✓ Redacted 2 keys across 2 transcripts');
+    expect(struckOnly).not.toContain('recoverable');
+  });
+});


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

The at-rest half completes: history already scanned for findings gets its raw secrets rewritten in place to recoverable pointers, and the setup remediation's irreversible strike becomes a pointer under consent.

## The design point

The scan now reports **every visited file**, not only finding-bearing ones. On a re-run every message dedups away — collecting only finding files would make the scrub unreachable exactly when it matters most: the user who grants vault consent **after** the first sweep and re-runs the backfill to bring their history under the vault. (This also de-fangs the wizard-ordering question in PR 09.)

Both grants are required — historical access authorizes *reading* the history, vault consent authorizes *keeping recoverable copies* of what it contains. Scrubbing is wholly best-effort (one bad file skips, a glue fault leaves history as scanned), adds one truthful line to the human summary, and adds **nothing** to the `--triage` machine stream.

## Remediation

`redactLeakedKeysDetailed` stays synchronous and gains a pre-resolved replacements map; the async surfaced flow builds it — one vault glue, one `tokenizeValue` per distinct raw value — only under consent, and only genuine pointers enter the map (a degraded return falls back to the strike, so the sync rewriter remains the single strike authority). The consent read is fail-closed and separate from recovery, so a fault can only degrade to the plain strike, never to leaving values exposed. Result shapes count pointered vs struck so the wizard's confirmation never claims recoverability the vault does not hold.

Verified over real transcript fixtures: no consent → files untouched; consent + fully-deduped re-run → both files scrubbed, valid NDJSON, clean lines byte-identical, one pointer for the same value across two sessions, third run byte-identical, and `aka vault show` returns the original.