### PR TITLE
vault 07/10: reveal-grant decision seam, dashboard grant flows, capability surfaces

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -70,14 +70,15 @@ value's RAW form at tool boundaries while it is active, with every crossing
 audited. Revoke any time with 'aka exception revoke <id>'.
 
 Flags:
-  --reveal            required with a pointer: grant reveal-to-model, not suppression
+  --reveal-to-model   grant reveal-to-model instead of suppression (required with a
+                      pointer selector; --reveal is accepted as shorthand)
   --once | --for <30m|1h|24h> | --permanent   scope (required, pick one)
   --reason "<why>"    required; prompted on a terminal if omitted
   --yes               skip confirmations (non-interactive use)
   --home <dir>        alternate AKA home (default: ~/.aka)
 
 Example: aka exception approve 3f2a --for 1h --reason "temp deploy creds"
-Example: aka exception approve '[[aka:secret:...]]' --reveal --for 1h --reason "agent needs the live key"
+Example: aka exception approve '[[aka:secret:...]]' --reveal-to-model --for 1h --reason "agent needs the live key"
 `,
   add: `Usage: aka exception add --rule <ruleId> [--stdin] [flags]
 
@@ -465,7 +466,13 @@ async function runApproveReveal(
 async function runApprove(argv: string[], io: Prompter): Promise<void> {
   const { values, positionals } = parseArgs({
     args: argv,
-    options: { ...HOME_OPTION, ...SCOPE_OPTIONS, reveal: { type: 'boolean' } },
+    options: {
+      ...HOME_OPTION,
+      ...SCOPE_OPTIONS,
+      'reveal-to-model': { type: 'boolean' },
+      // Shorthand for --reveal-to-model.
+      reveal: { type: 'boolean' },
+    },
     allowPositionals: true,
   });
   if (values.help) {
@@ -473,22 +480,18 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
     return;
   }
   const base = homeBase(values.home);
+  const wantsReveal = values['reveal-to-model'] === true || values.reveal === true;
   // A pointer selector routes to the vault, not the blocked-detections ledger.
   const candidate = positionals[0]?.trim();
   const pointer = candidate === undefined ? undefined : PointerToken.safeParse(candidate);
   if (pointer?.success === true) {
-    if (values.reveal !== true) {
+    if (!wantsReveal) {
       throw new Error(
-        'that selector is a vault pointer — approving one mints a reveal-to-model grant, which must be asked for explicitly: add --reveal',
+        'that selector is a vault pointer — approving one mints a reveal-to-model grant, which must be asked for explicitly: add --reveal-to-model',
       );
     }
     await runApproveReveal(pointer.data, values, io, base);
     return;
-  }
-  if (values.reveal === true) {
-    throw new Error(
-      'a reveal grant is minted from a vault pointer — pass the full [[aka:...]] token (quote it in the shell); the pointer is the proof the value is vaulted',
-    );
   }
   const dir = dataDir(base);
   const db = openLocalDatabase(dir);
@@ -531,12 +534,16 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
     }
     // The grant is created FROM THE LEDGER ENTRY — the fingerprint was
     // computed when the hook blocked; the raw value never enters this process.
+    // With the reveal opt-in, the same ledger identity mints the stronger
+    // capability: the value's pointer may then de-reference to raw for the
+    // model, and — being strictly stronger — the grant suppresses too.
     const granted = await createGrant(db, {
       ruleId: entry.ruleId,
       category: entry.category,
       valueFingerprint: entry.valueFingerprint,
       keyVersion: entry.keyVersion,
       maskedValue: entry.maskedValue,
+      ...(wantsReveal ? { capability: 'reveal_to_model' as const } : {}),
       ...scope,
       justification: reason,
       conditions: null,
@@ -544,6 +551,11 @@ async function runApprove(argv: string[], io: Prompter): Promise<void> {
       createdVia: 'cli-approve',
     });
     printGranted(io, granted);
+    if (wantsReveal) {
+      io.out(
+        'While this grant is active the model can receive this value in RAW form at tool boundaries; every crossing is audited.\n',
+      );
+    }
     io.out('Resubmit the blocked prompt — it will now pass.\n');
   } finally {
     db.close();
@@ -717,7 +729,13 @@ async function runList(argv: string[], io: Prompter): Promise<void> {
       const row = [
         shortId(ex.id),
         ex.ruleId,
-        ex.maskedValue,
+        // A reveal grant is strictly stronger than a plain suppression: while
+        // it is active the model can receive this value's RAW form at tool
+        // boundaries. Tag the row so it reads differently from a suppress-only
+        // grant. The value stays masked — the list never shows raw values.
+        ex.capability === 'reveal_to_model'
+          ? `${ex.maskedValue} · REVEALS-TO-MODEL`
+          : ex.maskedValue,
         ex.scope,
         // An expiry countdown is meaningless once the budget/revocation ended
         // the grant ("consumed · expires in 24m" reads as a contradiction);

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -148,12 +148,45 @@ describe('aka exception approve <pointer> --reveal', () => {
     expect(await openAndList()).toHaveLength(0);
   });
 
-  it('rejects --reveal with a non-pointer selector and creates nothing', async () => {
-    await seedPointer();
-    await expect(
-      runException(approveArgs('3f2a', '--reveal', '--once', '--reason', 'x'), scriptedIo()),
-    ).rejects.toThrow(/vault pointer/);
-    expect(await openAndList()).toHaveLength(0);
+  // A non-pointer selector with the reveal opt-in routes to the ledger flow:
+  // a value blocked minutes ago can be granted reveal directly from its ref,
+  // no pointer in hand needed.
+  it('mints a reveal grant from a blocked-detections ledger ref', async () => {
+    const key = loadOrCreateFingerprintKey(dataDir(home));
+    const db = openLocalDatabase(dataDir(home));
+    try {
+      await db.exceptions.recordBlocked({
+        reference: '3f2a91',
+        ruleId: 'secrets/aws-access-key',
+        category: 'secret',
+        valueFingerprint: fingerprintValue(key, RAW),
+        keyVersion: key.version,
+        maskedValue: 'A******E',
+        sessionId: 'sess-1',
+        repo: null,
+      });
+    } finally {
+      db.close();
+    }
+    const io = scriptedIo();
+    await runException(
+      approveArgs('3f2a91', '--reveal-to-model', '--once', '--reason', 'ledger reveal'),
+      io,
+    );
+    const grants = await openAndList();
+    expect(grants).toHaveLength(1);
+    expect(grants[0]?.capability).toBe('reveal_to_model');
+    expect(io.output()).toContain('RAW form at tool boundaries');
+  });
+
+  it('the shorthand --reveal still works on a pointer selector', async () => {
+    const pointer = await seedPointer();
+    await runException(
+      approveArgs(pointer, '--reveal', '--once', '--reason', 'shorthand'),
+      scriptedIo(),
+    );
+    const grants = await openAndList();
+    expect(grants[0]?.capability).toBe('reveal_to_model');
   });
 
   it('rejects a forged pointer with --reveal and creates nothing', async () => {

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -482,4 +482,44 @@ describe('aka exception list / revoke', () => {
     await runException(['list', '--home', home], emptyIo);
     expect(emptyIo.output()).toContain("'aka exception list --all'");
   });
+
+  it('tags a reveal-to-model grant so it cannot be read as a plain suppression', async () => {
+    // A suppress grant via the normal add flow...
+    await runException(
+      ['add', '--home', home, '--rule', RULE_ID, '--stdin', '--for', '1h', '--reason', 'window'],
+      scriptedIo(`${VALUE}\n`),
+    );
+    // ...and a reveal-to-model grant seeded the way the mint flow writes it.
+    const key = loadOrCreateFingerprintKey(dir);
+    const db = openLocalDatabase(dir);
+    try {
+      await db.exceptions.create({
+        ruleId: 'secrets/generic-credential',
+        category: 'secret',
+        valueFingerprint: fingerprintValue(key, 'not-the-listed-value'),
+        keyVersion: key.version,
+        maskedValue: 'gh*…ret',
+        capability: 'reveal_to_model',
+        scope: 'temporary',
+        expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+        maxUses: null,
+        justification: 'agent needs the live key',
+        conditions: null,
+        createdBy: 'tester (local)',
+        createdVia: 'cli-approve',
+      });
+    } finally {
+      db.close();
+    }
+
+    const listIo = scriptedIo();
+    await runException(['list', '--home', home], listIo);
+    const out = listIo.output();
+    // Only the reveal row carries the tag; the suppress row is unchanged.
+    expect(out).toContain('gh*…ret · REVEALS-TO-MODEL');
+    expect(out.match(/REVEALS-TO-MODEL/g)).toHaveLength(1);
+    // The list is metadata-only even for reveal grants — masked, never raw.
+    expect(out).not.toContain(VALUE);
+    expect(out).not.toContain('not-the-listed-value');
+  });
 });

--- a/packages/dashboard-ui/src/exceptions/ExceptionDetailView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionDetailView.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 
 import { relativeTime } from '../lib/relativeTime.ts';
 import { MetaItem, SectionLabel } from '../shared/DetailFields.tsx';
-import { StateTagFor } from './atoms.tsx';
+import { CapabilityTagFor, StateTagFor } from './atoms.tsx';
 import { exceptionState, SCOPE_LABEL, VIA_LABEL } from './meta.ts';
 
 export interface ExceptionDetailViewProps {
@@ -34,7 +34,18 @@ export function ExceptionDetailView({
           {exception.id.slice(0, 8)}
         </span>
         <StateTagFor exception={exception} />
+        <CapabilityTagFor exception={exception} />
       </div>
+
+      {exception.capability === 'reveal_to_model' && (
+        <div className="rounded-lg border border-sev-critical-fill bg-sev-critical-fill p-3">
+          <SectionLabel className="text-sev-critical">Reveal to model</SectionLabel>
+          <p className="text-sm text-text-2">
+            While this grant is active, the model can receive this value&apos;s raw form at tool
+            boundaries. Every crossing is audited in the vault&apos;s de-reference trail.
+          </p>
+        </div>
+      )}
 
       <div className="grid grid-cols-2 gap-x-6 gap-y-4 md:grid-cols-3">
         <MetaItem label="Rule">

--- a/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
@@ -3,7 +3,7 @@ import type { DetectionException } from '@akasecurity/schema';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@akasecurity/ui-kit';
 
 import { relativeTime } from '../lib/relativeTime.ts';
-import { StateTagFor } from './atoms.tsx';
+import { CapabilityTagFor, StateTagFor } from './atoms.tsx';
 import { SCOPE_LABEL, VIA_LABEL } from './meta.ts';
 
 export interface ExceptionsTableViewProps {
@@ -60,7 +60,12 @@ export function ExceptionsTableView({
             >
               <TableCell className="font-mono text-xs text-text-3">{ex.id.slice(0, 8)}</TableCell>
               <TableCell className="font-mono text-xs">{ex.ruleId}</TableCell>
-              <TableCell className="font-mono text-xs">{ex.maskedValue}</TableCell>
+              <TableCell className="font-mono text-xs">
+                <span className="inline-flex items-center gap-2">
+                  {ex.maskedValue}
+                  <CapabilityTagFor exception={ex} />
+                </span>
+              </TableCell>
               <TableCell className="text-xs">{SCOPE_LABEL[ex.scope]}</TableCell>
               <TableCell className="text-xs text-text-2">
                 {ex.expiresAt === null ? '—' : relativeTime(ex.expiresAt)}

--- a/packages/dashboard-ui/src/exceptions/atoms.tsx
+++ b/packages/dashboard-ui/src/exceptions/atoms.tsx
@@ -3,7 +3,13 @@ import type { DetectionException } from '@akasecurity/schema';
 import { Badge, SegmentedControl, SegmentedControlItem } from '@akasecurity/ui-kit';
 
 import type { ExceptionState, ScopeAnswer } from './meta.ts';
-import { exceptionState, SCOPE_ANSWER_LABEL, SCOPE_ANSWERS, STATE_TONE } from './meta.ts';
+import {
+  CAPABILITY_LABEL,
+  exceptionState,
+  SCOPE_ANSWER_LABEL,
+  SCOPE_ANSWERS,
+  STATE_TONE,
+} from './meta.ts';
 
 /** Lifecycle state chip (derived, never stored). */
 export function StateTag({ state }: { state: ExceptionState }) {
@@ -12,6 +18,18 @@ export function StateTag({ state }: { state: ExceptionState }) {
 
 export function StateTagFor({ exception, now }: { exception: DetectionException; now?: number }) {
   return <StateTag state={exceptionState(exception, now)} />;
+}
+
+/**
+ * Capability chip. Rendered ONLY for reveal-to-model grants — while such a
+ * grant is active the model can receive the value's raw form at tool
+ * boundaries, so the register flags it on every surface. Suppression (the
+ * default) stays unlabelled: repeating "suppress" on every row would bury the
+ * one capability that matters.
+ */
+export function CapabilityTagFor({ exception }: { exception: DetectionException }) {
+  if (exception.capability !== 'reveal_to_model') return null;
+  return <Badge variant="critical">{CAPABILITY_LABEL.reveal_to_model}</Badge>;
 }
 
 /**

--- a/packages/dashboard-ui/src/exceptions/meta.ts
+++ b/packages/dashboard-ui/src/exceptions/meta.ts
@@ -78,6 +78,14 @@ export const SCOPE_LABEL: Record<DetectionException['scope'], string> = {
   permanent: 'Permanent',
 };
 
+// Capability labels — what a grant authorizes. Suppression is the default and
+// renders unlabelled in the views; reveal-to-model is called out loudly because
+// it lets the value's raw form reach the model at tool boundaries.
+export const CAPABILITY_LABEL: Record<DetectionException['capability'], string> = {
+  suppress: 'Suppress',
+  reveal_to_model: 'Reveal to model',
+};
+
 // Provenance labels — how the grant was created.
 export const VIA_LABEL: Record<DetectionException['createdVia'], string> = {
   'cli-approve': 'CLI approve',

--- a/packages/dashboard-ui/test/exceptions/views.test.tsx
+++ b/packages/dashboard-ui/test/exceptions/views.test.tsx
@@ -1,0 +1,81 @@
+import type { DetectionException } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ExceptionDetailView } from '../../src/exceptions/ExceptionDetailView.tsx';
+import { ExceptionsTableView } from '../../src/exceptions/ExceptionsTableView.tsx';
+
+// The capability presentation is asymmetric on purpose: a reveal-to-model
+// grant is flagged with a badge on every surface (it lets the raw value reach
+// the model), while suppression — the default — stays unlabelled. Rendered
+// with react-dom's static renderer (this package's test environment is node,
+// with no DOM).
+
+const BADGE = 'Reveal to model';
+
+function exception(overrides: Partial<DetectionException>): DetectionException {
+  return {
+    id: '7d9f7a4e-1111-4222-8333-444455556666',
+    ruleId: 'secrets/aws-access-key',
+    category: 'secret',
+    valueFingerprint: 'a'.repeat(64),
+    keyVersion: 1,
+    maskedValue: 'A****Z',
+    capability: 'suppress',
+    scope: 'permanent',
+    expiresAt: null,
+    maxUses: null,
+    useCount: 0,
+    lastUsedAt: null,
+    justification: 'test fixture',
+    conditions: null,
+    createdBy: 'tester',
+    createdVia: 'web-add',
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    revokedAt: null,
+    revokedBy: null,
+    revokeReason: null,
+    ...overrides,
+  };
+}
+
+const noop = (): void => undefined;
+
+describe('ExceptionsTableView capability badge', () => {
+  it('flags a reveal-to-model row with the badge', () => {
+    const html = renderToStaticMarkup(
+      <ExceptionsTableView
+        items={[exception({ capability: 'reveal_to_model' })]}
+        includeTerminal={false}
+        onSelect={noop}
+      />,
+    );
+    expect(html).toContain(BADGE);
+  });
+
+  it('leaves a suppress row unlabelled', () => {
+    const html = renderToStaticMarkup(
+      <ExceptionsTableView items={[exception({})]} includeTerminal={false} onSelect={noop} />,
+    );
+    expect(html).not.toContain(BADGE);
+  });
+});
+
+describe('ExceptionDetailView capability presentation', () => {
+  it('shows the badge and the consequence callout for a reveal grant', () => {
+    const html = renderToStaticMarkup(
+      <ExceptionDetailView exception={exception({ capability: 'reveal_to_model' })} />,
+    );
+    expect(html).toContain(BADGE);
+    // The consequence must be stated, not implied.
+    expect(html).toContain('raw form at tool boundaries');
+    expect(html).toContain('audited');
+  });
+
+  it('renders a suppress grant without any capability labelling', () => {
+    const html = renderToStaticMarkup(<ExceptionDetailView exception={exception({})} />);
+    expect(html).not.toContain(BADGE);
+    expect(html).not.toContain('raw form at tool boundaries');
+  });
+});

--- a/packages/persistence/src/exception-policy.ts
+++ b/packages/persistence/src/exception-policy.ts
@@ -1,0 +1,53 @@
+// The reveal decision seam: whether a vaulted value's pointer may be
+// de-referenced back to raw FOR THE MODEL.
+//
+// One interface, one question. This build answers from the grant the user
+// created (below): a value reveals exactly when an active reveal-to-model
+// exception covers its identity. Any other implementation — one answering from
+// centrally managed policy, say — plugs in through the same interface, same
+// caller, no change at the crossing site. The decision is separated from the
+// vault so no implementation ever holds key material or ciphertext: it sees
+// the raw-free identity a grant is keyed on, nothing else.
+//
+// Every implementation must fail toward the pointer: an error while deciding
+// is a deny, never a reveal and never a throw that escapes the caller's
+// fail-open boundary.
+import type { PointerIdentity } from '@akasecurity/schema';
+
+import type { SqliteExceptionsRepository } from './repositories/exceptions.ts';
+
+export type RevealDecision = { allow: true; grantId: string } | { allow: false };
+
+export interface ExceptionPolicyProvider {
+  decideReveal(identity: PointerIdentity): Promise<RevealDecision>;
+}
+
+/**
+ * The user-driven provider: the grant IS the decision. Matches an active
+ * reveal-to-model exception on the exact identity suppression matches on —
+ * a suppression-capability grant never satisfies it, an expired/revoked/
+ * use-exhausted grant stops matching by predicate, and a grant written under a
+ * rotated-away fingerprint key simply no longer matches the value's current
+ * identity. Reads live grant state on every call, so a revocation applies to
+ * the very next crossing.
+ */
+export class UserGrantPolicyProvider implements ExceptionPolicyProvider {
+  readonly #exceptions: SqliteExceptionsRepository;
+
+  constructor(exceptions: SqliteExceptionsRepository) {
+    this.#exceptions = exceptions;
+  }
+
+  async decideReveal(identity: PointerIdentity): Promise<RevealDecision> {
+    try {
+      const grant = await this.#exceptions.activeRevealGrant(
+        identity.ruleId,
+        identity.valueFingerprint,
+        identity.fingerprintKeyVersion,
+      );
+      return grant === null ? { allow: false } : { allow: true, grantId: grant.id };
+    } catch {
+      return { allow: false };
+    }
+  }
+}

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -1,5 +1,7 @@
 export type { InventoryContext, LocalDatabase, ResolvedInventory } from './database.ts';
 export { openLocalDatabase } from './database.ts';
+export type { ExceptionPolicyProvider, RevealDecision } from './exception-policy.ts';
+export { UserGrantPolicyProvider } from './exception-policy.ts';
 export type { FindingKeyInput } from './finding-key.ts';
 export { computeFindingKey } from './finding-key.ts';
 export type { FingerprintKey } from './fingerprint.ts';

--- a/packages/persistence/test/exception-policy.test.ts
+++ b/packages/persistence/test/exception-policy.test.ts
@@ -1,0 +1,114 @@
+import type { PointerIdentity } from '@akasecurity/schema';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { LocalDatabase } from '../src/database.ts';
+import { UserGrantPolicyProvider } from '../src/exception-policy.ts';
+import type { CreateExceptionInput } from '../src/repositories/exceptions.ts';
+import { useTempStore } from './helpers/temp-store.ts';
+
+const FP = 'a'.repeat(64);
+const OTHER_FP = 'b'.repeat(64);
+
+function grantInput(overrides: Partial<CreateExceptionInput> = {}): CreateExceptionInput {
+  return {
+    ruleId: 'secrets/aws-access-key',
+    category: 'secret',
+    valueFingerprint: FP,
+    keyVersion: 1,
+    maskedValue: 'A******E',
+    capability: 'reveal_to_model',
+    scope: 'permanent',
+    expiresAt: null,
+    maxUses: null,
+    justification: 'test grant',
+    conditions: null,
+    createdBy: 'tester',
+    createdVia: 'cli-approve',
+    ...overrides,
+  };
+}
+
+function identity(overrides: Partial<PointerIdentity> = {}): PointerIdentity {
+  return {
+    ruleId: 'secrets/aws-access-key',
+    valueFingerprint: FP,
+    fingerprintKeyVersion: 1,
+    ...overrides,
+  };
+}
+
+describe('UserGrantPolicyProvider', () => {
+  // The shared harness owns the temp store and closes its handles at teardown,
+  // so no test here can leave the tree undeletable on Windows.
+  const store = useTempStore('aka-policy-');
+  let db: LocalDatabase;
+  let provider: UserGrantPolicyProvider;
+
+  beforeEach(() => {
+    db = store.open();
+    provider = new UserGrantPolicyProvider(db.exceptions);
+  });
+
+  it('allows with the grant id when an active reveal grant covers the identity', async () => {
+    const grant = await db.exceptions.create(grantInput());
+    await expect(provider.decideReveal(identity())).resolves.toEqual({
+      allow: true,
+      grantId: grant.id,
+    });
+  });
+
+  // The two capabilities are distinct: today's grants must not silently widen.
+  it('denies when the only grant is a suppression grant', async () => {
+    await db.exceptions.create(grantInput({ capability: 'suppress' }));
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
+  it('denies with no grant at all', async () => {
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
+  // A grant authorizes exactly the value it was created for.
+  it('denies a different value under the same rule', async () => {
+    await db.exceptions.create(grantInput());
+    await expect(provider.decideReveal(identity({ valueFingerprint: OTHER_FP }))).resolves.toEqual({
+      allow: false,
+    });
+  });
+
+  it('denies after revocation, on the very next decision', async () => {
+    const grant = await db.exceptions.create(grantInput());
+    await expect(provider.decideReveal(identity())).resolves.toMatchObject({ allow: true });
+    await db.exceptions.revoke(grant.id, 'tester');
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
+  it('denies an expired grant at decision time', async () => {
+    await db.exceptions.create(
+      grantInput({ scope: 'temporary', expiresAt: new Date(Date.now() - 1000).toISOString() }),
+    );
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
+  it('denies a use-exhausted grant', async () => {
+    const grant = await db.exceptions.create(grantInput({ scope: 'once', maxUses: 1 }));
+    await expect(db.exceptions.consume(grant.id)).resolves.toBe(true);
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
+  // Rotation is invalidation for grants: a grant written under an old
+  // fingerprint-key epoch no longer matches the value's refreshed identity.
+  it('denies a grant written under a rotated-away key version', async () => {
+    await db.exceptions.create(grantInput({ keyVersion: 1 }));
+    await expect(provider.decideReveal(identity({ fingerprintKeyVersion: 2 }))).resolves.toEqual({
+      allow: false,
+    });
+  });
+
+  it('a repository fault denies rather than throwing', async () => {
+    // Closing under the provider is the fault: the next query hits a dead
+    // handle. The harness tracks whether each handle it handed out is still
+    // open, so it skips this one at teardown rather than double-closing.
+    db.close();
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+});

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -41,6 +41,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'SqliteSharesRepository',
   'SqliteSourceProjectRepository',
   'UNAVAILABLE',
+  'UserGrantPolicyProvider',
   'VaultKeyEpochMissingError',
   'applyOnboarding',
   'base32Decode',

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -16,6 +16,7 @@
 // sees LESS, never more.
 import type { MatchResult } from '@akasecurity/detections';
 import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
+import type { ExceptionPolicyProvider } from '@akasecurity/persistence';
 import {
   createKeyProvider,
   defaultDataDir,
@@ -24,6 +25,7 @@ import {
   openLocalDatabase,
   readWorkspaceSettings,
   SecretVault,
+  UserGrantPolicyProvider,
 } from '@akasecurity/persistence';
 import type {
   DetectionCategory,
@@ -403,6 +405,10 @@ export interface CreateVaultGlueOptions {
   vault?: VaultCore;
   // Test seam: a reveal-grant resolver to pair with an injected vault.
   revealResolver?: ModelDerefGrantResolver;
+  // The reveal decision seam. Defaults to the user-driven provider (the grant
+  // the user created is the decision); a different provider changes WHO
+  // decides without touching any crossing site.
+  policyProvider?: ExceptionPolicyProvider;
 }
 
 /**
@@ -426,18 +432,16 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
       // process.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
     });
-    // Grant matching is exact on the identity a grant is keyed by; anything
-    // failing along the way is a refusal, never a reveal.
+    // The resolver is a thin adapter over the decision seam: pointer →
+    // raw-free identity → provider decision. Anything failing along the way is
+    // a refusal, never a reveal.
+    const provider = options?.policyProvider ?? new UserGrantPolicyProvider(db.exceptions);
     const revealGrantResolver: ModelDerefGrantResolver = async (pointer) => {
       try {
         const identity = await vault.resolvePointerIdentity(pointer);
         if (identity === null) return null;
-        const grant = await db.exceptions.activeRevealGrant(
-          identity.ruleId,
-          identity.valueFingerprint,
-          identity.fingerprintKeyVersion,
-        );
-        return grant?.id ?? null;
+        const decision = await provider.decideReveal(identity);
+        return decision.allow ? decision.grantId : null;
       } catch {
         return null;
       }

--- a/packages/plugin-sdk/test/reveal-seam.test.ts
+++ b/packages/plugin-sdk/test/reveal-seam.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { ExceptionPolicyProvider } from '@akasecurity/persistence';
+import { applyOnboarding, openLocalDatabase } from '@akasecurity/persistence';
+import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { dataDir } from '../src/data-dir.ts';
+import type { VaultGlue } from '../src/tokenize.ts';
+import { createVaultGlue } from '../src/tokenize.ts';
+
+const SECRET = 'AKIAIOSFODNN7EXAMPLE';
+
+// The reveal decision sits behind one injectable seam: swapping WHO decides
+// (the user's grant, or any other policy) must flip a crossing's outcome with
+// zero change at the crossing site. These tests are that contract.
+describe('reveal decision seam', () => {
+  let base: string;
+  let token: string;
+
+  // Every glue opens a store handle. Tracking them here means no test has to
+  // remember to release one — and on Windows an unreleased handle blocks the
+  // afterEach removal of the temp base, failing the run far from the cause.
+  const opened: VaultGlue[] = [];
+  const openGlue = (options: Parameters<typeof createVaultGlue>[0]): VaultGlue => {
+    const glue = createVaultGlue(options);
+    opened.push(glue);
+    return glue;
+  };
+
+  beforeEach(async () => {
+    base = mkdtempSync(join(tmpdir(), 'aka-seam-'));
+    applyOnboarding(
+      {
+        vaultConsent: {
+          acknowledgedAt: new Date().toISOString(),
+          version: VAULT_CONSENT_VERSION,
+        },
+      },
+      base,
+    );
+    const seeded = await openGlue({ base }).tokenizeText(SECRET, {
+      findings: [
+        {
+          ruleId: 'secrets/aws-access-key',
+          category: 'secret',
+          severity: 'critical',
+          span: { start: 0, end: SECRET.length },
+          rawMatch: SECRET,
+          confidence: 0.9,
+        },
+      ],
+    });
+    const first = seeded.pointers[0];
+    if (first === undefined) throw new Error('expected a pointer');
+    token = first;
+  });
+
+  afterEach(() => {
+    for (const glue of opened.splice(0)) glue.close();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('the default (user-grant) provider denies with no grant on file', async () => {
+    const glue = openGlue({ base });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(result.revealed).toEqual([]);
+    expect(result.unresolved).toEqual([token]);
+    expect(result.text).toBe(`k=${token}`);
+  });
+
+  it('the default provider reveals once the user grants', async () => {
+    const db = openLocalDatabase(dataDir(base));
+    const glue = openGlue({ base });
+    // Mint the grant against the exact identity the provider matches on.
+    const row = db.secretVault.listAll()[0];
+    if (row === undefined) throw new Error('expected the vault row');
+    await db.exceptions.create({
+      ruleId: row.ruleId,
+      category: 'secret',
+      valueFingerprint: row.valueFingerprint,
+      keyVersion: row.fingerprintKeyVersion,
+      maskedValue: 'A******E',
+      capability: 'reveal_to_model',
+      scope: 'permanent',
+      expiresAt: null,
+      maxUses: null,
+      justification: 'seam test',
+      conditions: null,
+      createdBy: 'tester',
+      createdVia: 'cli-approve',
+    });
+    db.close();
+
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(result.revealed).toEqual([token]);
+    expect(result.text).toBe(`k=${SECRET}`);
+  });
+
+  it('an injected provider flips the decision with no call-site change', async () => {
+    const allowAll: ExceptionPolicyProvider = {
+      decideReveal: () => Promise.resolve({ allow: true, grantId: 'policy-grant' }),
+    };
+    const glue = openGlue({ base, policyProvider: allowAll });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(result.revealed).toEqual([token]);
+    expect(result.text).toBe(`k=${SECRET}`);
+  });
+
+  it('a throwing provider denies, never throws', async () => {
+    const broken: ExceptionPolicyProvider = {
+      decideReveal: () => Promise.reject(new Error('policy service down')),
+    };
+    const glue = openGlue({ base, policyProvider: broken });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(result.revealed).toEqual([]);
+    expect(result.text).toBe(`k=${token}`);
+  });
+});

--- a/plugins/claude-code/src/render.ts
+++ b/plugins/claude-code/src/render.ts
@@ -976,7 +976,11 @@ export function renderExceptions(exceptions: DetectionException[], nowMs = Date.
 
   const rows = exceptions.map((e) => [
     e.id.slice(0, 8),
-    e.maskedValue,
+    // A reveal grant is strictly stronger than a plain suppression: while it is
+    // active the model can receive this value's RAW form at tool boundaries.
+    // Tag the row so it can never be mistaken for a suppress-only grant. The
+    // value itself stays masked — this list shows metadata, never raw values.
+    e.capability === 'reveal_to_model' ? `${e.maskedValue} · REVEALS-TO-MODEL` : e.maskedValue,
     e.ruleId,
     e.scope,
     relativeExpiry(e.expiresAt, nowMs),

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -221,14 +221,26 @@ describe('pure renderers', () => {
             useCount: 118,
           }),
           exception({ scope: 'once', maxUses: 1, useCount: 0 }),
+          exception({
+            maskedValue: 'ghp_…6789',
+            capability: 'reveal_to_model',
+            expiresAt: new Date(NOW + 55 * 60_000).toISOString(),
+          }),
         ],
         NOW,
       ),
     );
-    expect(out).toContain('Active exceptions (3)');
+    expect(out).toContain('Active exceptions (4)');
     expect(out).toContain('3f2a91ab'); // short id, enough for `aka exception revoke`
     expect(out).toContain('AKIA…MPLE'); // masked preview only — never a raw value
     expect(out).toContain('secrets/aws-access-key');
+    // A reveal-to-model grant is tagged so it can never be mistaken for a
+    // plain suppression — and ONLY that row carries the tag.
+    expect(out).toContain('ghp_…6789 · REVEALS-TO-MODEL');
+    expect(out.match(/REVEALS-TO-MODEL/g)).toHaveLength(1);
+    // The reveal row is still metadata-only: the value stays masked — this
+    // list must never itself become a reveal surface.
+    expect(out).not.toMatch(/ghp_[A-Za-z0-9]{6,}/);
     expect(out).toContain('in 42m'); // relative expiry
     expect(out).toContain('—'); // permanent grant has no expiry
     expect(out).toContain('118');

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -6,16 +6,31 @@ import { maskMatch, scan } from '@akasecurity/detections';
 import type { CreateExceptionInput, FingerprintKey } from '@akasecurity/persistence';
 import {
   BLOCKED_DETECTIONS_RETENTION_MS,
+  createKeyProvider,
   dataDir,
   DuplicateActiveExceptionError,
   fingerprintValue,
   isCurrentKeyVersion,
+  keysDir,
   loadOrCreateFingerprintKey,
   readFingerprintKey,
+  readWorkspaceSettings,
   rotateFingerprintKey,
+  SecretVault,
 } from '@akasecurity/persistence';
-import type { BlockedDetection, ResolvedScope, Rule } from '@akasecurity/schema';
-import { scopeFromAnswer } from '@akasecurity/schema';
+import type {
+  BlockedDetection,
+  PointerDescriptor,
+  PointerIdentity,
+  ResolvedScope,
+  Rule,
+} from '@akasecurity/schema';
+import {
+  DetectionCategory,
+  isVaultConsentValid,
+  PointerToken,
+  scopeFromAnswer,
+} from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
 import { db } from '../../lib/db';
@@ -273,6 +288,104 @@ export async function addException(input: {
     createdBy: resolveCreatedBy(),
     createdVia: 'web-add',
   });
+}
+
+export type RevealGrantResult = { ok: true; grantIdPrefix: string } | { ok: false; error: string };
+
+// The category segment of a shape-valid pointer. The PointerToken pattern pins
+// the segment to the DetectionCategory members, so this only returns null for
+// a string that never passed PointerToken.safeParse.
+function categoryFromToken(token: string): DetectionCategory | null {
+  const segment = token.slice('[[aka:'.length).split(':')[0] ?? '';
+  const parsed = DetectionCategory.safeParse(segment);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Mint a reveal-to-model grant from a resolved vault pointer (the dashboard
+ * twin of `aka exception approve --reveal-to-model`). No raw value is touched:
+ * the pointer resolves to the vault row's raw-free identity (rule + keyed
+ * fingerprint + key version), which is exactly what the grant matches on. The
+ * fingerprint never reaches the browser — only an id prefix comes back. Scope
+ * timestamps and expiry are stamped server-side from the validated choice.
+ */
+export async function grantRevealFromPointer(input: {
+  pointer: string;
+  scope: string;
+  justification: string;
+}): Promise<RevealGrantResult> {
+  const justification = input.justification.trim();
+  if (justification === '') {
+    return { ok: false, error: 'A justification is required — it is the audit trail.' };
+  }
+  const scope = resolveScope(input.scope);
+  if ('error' in scope) return { ok: false, error: scope.error };
+
+  // Reject anything that is not pointer-shaped before it reaches the vault.
+  const parsed = PointerToken.safeParse(input.pointer.trim());
+  if (!parsed.success) {
+    return { ok: false, error: 'Not a vault pointer — paste the full [[aka:...]] token.' };
+  }
+
+  let identity: PointerIdentity | null;
+  let descriptor: PointerDescriptor | null;
+  try {
+    const vault = new SecretVault({
+      repo: db().secretVault,
+      keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
+      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
+      // Read live so a consent revocation applies to the very next call.
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
+    });
+    identity = await vault.resolvePointerIdentity(parsed.data);
+    descriptor = identity === null ? null : await vault.describePointer(parsed.data);
+  } catch {
+    // Corrupt key file or unreadable store — same outward shape as an
+    // unresolvable pointer; the error never carries store internals.
+    identity = null;
+    descriptor = null;
+  }
+  if (identity === null) {
+    return {
+      ok: false,
+      error:
+        'The pointer could not be resolved — it is not one this machine issued, or its entry was purged.',
+    };
+  }
+
+  // The descriptor is presentation data; if it is unavailable the grant still
+  // binds correctly through the identity, with a category recovered from the
+  // token itself and a fully-opaque preview.
+  const category = descriptor?.category ?? categoryFromToken(parsed.data);
+  if (category === null) {
+    return { ok: false, error: 'Not a vault pointer — paste the full [[aka:...]] token.' };
+  }
+
+  try {
+    const created = await db().exceptions.create({
+      ruleId: identity.ruleId,
+      category,
+      valueFingerprint: identity.valueFingerprint,
+      keyVersion: identity.fingerprintKeyVersion,
+      maskedValue: descriptor?.maskedMatch ?? '···',
+      capability: 'reveal_to_model',
+      ...scope,
+      justification,
+      conditions: null,
+      createdBy: 'dashboard',
+      createdVia: 'web-approve',
+    });
+    revalidatePath('/exceptions');
+    return { ok: true, grantIdPrefix: created.id.slice(0, 8) };
+  } catch (err) {
+    if (err instanceof DuplicateActiveExceptionError) {
+      return {
+        ok: false,
+        error: 'An active exception for this value already exists — revoke it first.',
+      };
+    }
+    return { ok: false, error: 'Could not create the reveal grant.' };
+  }
 }
 
 /** Revoke an active grant (`aka exception revoke`) — terminal, audit-retained. */

--- a/web-ui/app/(app)/vault/VaultLookupClient.tsx
+++ b/web-ui/app/(app)/vault/VaultLookupClient.tsx
@@ -1,23 +1,51 @@
 'use client';
 
-import { ScrubbedValue } from '@akasecurity/dashboard-ui';
+import type { ScopeAnswer } from '@akasecurity/dashboard-ui';
+import { ScopePicker, ScrubbedValue } from '@akasecurity/dashboard-ui';
 import { Button, Input } from '@akasecurity/ui-kit';
 import { useState, useTransition } from 'react';
 
+import type { RevealGrantResult } from '../exceptions/actions';
+import { grantRevealFromPointer } from '../exceptions/actions';
 import type { RevealResult } from './actions';
 import { revealPointer } from './actions';
 
 export function VaultLookupClient() {
   const [pointer, setPointer] = useState('');
   const [result, setResult] = useState<RevealResult | null>(null);
+  // The pointer the current result was resolved from — the grant form submits
+  // this, not the editable input, so editing the field cannot desync the two.
+  const [resolvedPointer, setResolvedPointer] = useState('');
   const [busy, startTransition] = useTransition();
 
+  const [scope, setScope] = useState<ScopeAnswer | null>(null);
+  const [justification, setJustification] = useState('');
+  const [grantResult, setGrantResult] = useState<RevealGrantResult | null>(null);
+  const [grantBusy, startGrantTransition] = useTransition();
+
   const submit = () => {
-    if (pointer.trim() === '') return;
+    const candidate = pointer.trim();
+    if (candidate === '') return;
     startTransition(async () => {
-      setResult(await revealPointer({ pointer }));
+      setResult(await revealPointer({ pointer: candidate }));
+      setResolvedPointer(candidate);
+      // A fresh resolution starts a fresh grant form.
+      setScope(null);
+      setJustification('');
+      setGrantResult(null);
     });
   };
+
+  const submitGrant = () => {
+    if (scope === null || justification.trim() === '') return;
+    startGrantTransition(async () => {
+      setGrantResult(
+        await grantRevealFromPointer({ pointer: resolvedPointer, scope, justification }),
+      );
+    });
+  };
+
+  const resolved = result?.ok === true && result.value !== null;
 
   return (
     <div className="flex max-w-xl flex-col gap-4">
@@ -53,6 +81,66 @@ export function VaultLookupClient() {
           </div>
         )}
       </div>
+
+      {resolved && (
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">
+            Grant reveal to model
+          </div>
+          <p className="mb-3 text-xs text-text-3">
+            Authorize the model to receive this value&apos;s raw form at tool boundaries while the
+            grant is active. Strictly stronger than a suppression — grant it deliberately.
+          </p>
+
+          {grantResult?.ok === true ? (
+            <div className="rounded-lg border border-sev-critical-fill bg-sev-critical-fill p-3">
+              <p className="text-sm font-semibold text-sev-critical">
+                Reveal grant {grantResult.grantIdPrefix} created
+              </p>
+              <p className="mt-1 text-xs text-text-2">
+                While it is active, the model can receive this value&apos;s raw form at tool
+                boundaries. Every crossing is audited in the vault&apos;s de-reference trail. Revoke
+                it any time on the Exceptions page.
+              </p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-3">
+              <div>
+                <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">
+                  Scope — pick one
+                </div>
+                <ScopePicker value={scope} onChange={setScope} />
+              </div>
+              <div>
+                <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">
+                  Justification (required — the audit trail)
+                </div>
+                <textarea
+                  value={justification}
+                  onChange={(e) => {
+                    setJustification(e.target.value);
+                  }}
+                  placeholder="Why the model may receive this value raw"
+                  rows={3}
+                  className="w-full rounded-lg border border-border bg-surface-2 px-3 py-2 text-sm text-text placeholder:text-text-3"
+                />
+              </div>
+              {grantResult && <p className="text-xs text-sev-critical">{grantResult.error}</p>}
+              <div>
+                <Button
+                  variant="solid"
+                  tone="danger"
+                  size="sm"
+                  disabled={scope === null || justification.trim() === '' || grantBusy}
+                  onClick={submitGrant}
+                >
+                  {grantBusy ? 'Granting…' : 'Grant reveal to model'}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web-ui/test/actions/exceptions-reveal.test.ts
+++ b/web-ui/test/actions/exceptions-reveal.test.ts
@@ -1,0 +1,241 @@
+import { createHmac } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  applyOnboarding,
+  createKeyProvider,
+  dataDir,
+  dbPath,
+  keysDir,
+  loadOrCreateFingerprintKey,
+  type LocalDatabase,
+  openLocalDatabase,
+  readWorkspaceSettings,
+  SecretVault,
+} from '@akasecurity/persistence';
+import type { DetectionException } from '@akasecurity/schema';
+import { isVaultConsentValid, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { grantRevealFromPointer } from '../../app/(app)/exceptions/actions.ts';
+
+// `grantRevealFromPointer` mints the strictly-stronger capability: while the
+// grant is active the model may receive the value's raw form at tool
+// boundaries. The suite pins that a grant binds to the vault row's raw-free
+// identity (rule + keyed fingerprint + key version) with the descriptor's
+// masked preview, that `activeRevealGrant` — the query the tool-boundary seam
+// reads — finds it, and that every rejection path writes no row. A real
+// node:sqlite store and real key files — no vault mocking (house style).
+//
+// The action resolves the store from `homedir()` (never process.env), so the
+// whole test is redirected into a temp home by mocking `node:os`; `next/cache`
+// is stubbed because revalidatePath needs a Next render context that does not
+// exist under vitest.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
+
+// Not secret-shaped on purpose: tokenize never scans, and a plain string keeps
+// secret-looking literals out of this public file.
+const RAW = 'vaulted-value-for-reveal-grant-test';
+const RULE_ID = 'secrets/test-rule';
+const MASKED = 'vau…est';
+
+let home: string;
+
+// web-ui memoizes the open DB handle on globalThis (app/lib/db.ts). Close and
+// drop it between tests so the next action reopens against the fresh home.
+function resetSingleton(): void {
+  const store = globalThis as unknown as { __akaDb?: LocalDatabase };
+  store.__akaDb?.close();
+  delete store.__akaDb;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-reveal-'));
+  osHome.dir = home;
+  // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
+  applyOnboarding({
+    vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },
+  });
+});
+
+afterEach(() => {
+  resetSingleton();
+  rmSync(home, { recursive: true, force: true });
+});
+
+// Seed one vaulted value through the real persistence SecretVault — the same
+// construction the action performs — and return its pointer.
+async function seedPointer(): Promise<string> {
+  const db = openLocalDatabase(dataDir());
+  try {
+    const vault = new SecretVault({
+      repo: db.secretVault,
+      keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
+      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
+    });
+    const pointer = await vault.tokenize(RAW, {
+      ruleId: RULE_ID,
+      category: 'secret',
+      provider: 'aws',
+      maskedMatch: MASKED,
+    });
+    if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
+    return pointer;
+  } finally {
+    db.close();
+  }
+}
+
+// Every grant ever written, including terminal rows — a rejection that wrongly
+// wrote a row is caught even if that row is already expired.
+async function grants(): Promise<DetectionException[]> {
+  const db = openLocalDatabase(dataDir());
+  try {
+    return await db.exceptions.list({ includeTerminal: true });
+  } finally {
+    db.close();
+  }
+}
+
+function derefRowCount(): number {
+  const raw = new DatabaseSync(dbPath(), { readOnly: true });
+  try {
+    const row = raw.prepare('SELECT COUNT(*) AS n FROM secret_vault_deref').get() as { n: number };
+    return row.n;
+  } finally {
+    raw.close();
+  }
+}
+
+// Flip one tag character so the token stays pointer-shaped but can no longer
+// verify — the vault must treat it exactly like a forgery.
+function forge(pointer: string): string {
+  const tagStart = pointer.length - ']]'.length - 16;
+  const original = pointer[tagStart];
+  const flipped = original === 'A' ? 'B' : 'A';
+  return pointer.slice(0, tagStart) + flipped + pointer.slice(tagStart + 1);
+}
+
+describe('grantRevealFromPointer', () => {
+  it('creates a reveal_to_model grant bound to the vault row identity', async () => {
+    const pointer = await seedPointer();
+    const result = await grantRevealFromPointer({
+      pointer,
+      scope: '1h',
+      justification: 'integration test needs the live key',
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+
+    const all = await grants();
+    expect(all).toHaveLength(1);
+    const grant = all[0];
+    expect(grant?.id.slice(0, 8)).toBe(result.grantIdPrefix);
+    expect(grant?.capability).toBe('reveal_to_model');
+    expect(grant?.ruleId).toBe(RULE_ID);
+    expect(grant?.category).toBe('secret');
+    expect(grant?.maskedValue).toBe(MASKED);
+    expect(grant?.scope).toBe('temporary');
+    expect(grant?.expiresAt).not.toBeNull();
+    expect(grant?.createdBy).toBe('dashboard');
+    expect(grant?.createdVia).toBe('web-approve');
+
+    // The identity the grant matches on is the keyed HMAC of the raw value
+    // under exception.key — the very fingerprint the vault row carries.
+    const key = loadOrCreateFingerprintKey(dataDir());
+    const fingerprint = createHmac('sha256', key.material).update(RAW, 'utf8').digest('hex');
+    expect(grant?.valueFingerprint).toBe(fingerprint);
+    expect(grant?.keyVersion).toBe(key.version);
+
+    // The query the tool-boundary reveal seam reads must find this grant.
+    const db = openLocalDatabase(dataDir());
+    try {
+      const active = await db.exceptions.activeRevealGrant(RULE_ID, fingerprint, key.version);
+      expect(active?.id).toBe(grant?.id);
+    } finally {
+      db.close();
+    }
+
+    // Minting a grant identifies the row without de-referencing the value —
+    // no audit row claims a reveal happened here.
+    expect(derefRowCount()).toBe(0);
+  });
+
+  it('rejects a duplicate active grant with a friendly message, keeping one row', async () => {
+    const pointer = await seedPointer();
+    const first = await grantRevealFromPointer({ pointer, scope: '1h', justification: 'a' });
+    expect(first.ok).toBe(true);
+
+    const second = await grantRevealFromPointer({ pointer, scope: '1h', justification: 'b' });
+    expect(second.ok).toBe(false);
+    if (second.ok) throw new Error('unreachable');
+    expect(second.error).toMatch(/already exists/i);
+    expect(await grants()).toHaveLength(1);
+  });
+
+  it('rejects a malformed pointer before the vault, writing no row', async () => {
+    await seedPointer();
+    const result = await grantRevealFromPointer({
+      pointer: 'not-a-pointer',
+      scope: '1h',
+      justification: 'x',
+    });
+    expect(result.ok).toBe(false);
+    expect(await grants()).toHaveLength(0);
+  });
+
+  it('rejects a shape-valid forged pointer as unresolvable, writing no row', async () => {
+    const pointer = await seedPointer();
+    const result = await grantRevealFromPointer({
+      pointer: forge(pointer),
+      scope: '1h',
+      justification: 'x',
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toMatch(/could not be resolved/i);
+    expect(await grants()).toHaveLength(0);
+  });
+
+  it('rejects an empty justification — it is the audit trail', async () => {
+    const pointer = await seedPointer();
+    const result = await grantRevealFromPointer({ pointer, scope: '1h', justification: '   ' });
+    expect(result.ok).toBe(false);
+    expect(await grants()).toHaveLength(0);
+  });
+
+  it('rejects a temporary duration over the 24h cap, writing no row', async () => {
+    const pointer = await seedPointer();
+    const result = await grantRevealFromPointer({ pointer, scope: '25h', justification: 'x' });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    // parseDuration's own cap message — the scope vocabulary is shared with
+    // the CLI, not re-implemented here.
+    expect(result.error).toMatch(/24h maximum/i);
+    expect(await grants()).toHaveLength(0);
+  });
+
+  it('accepts the once and permanent scope answers with server-stamped columns', async () => {
+    const pointer = await seedPointer();
+    const once = await grantRevealFromPointer({ pointer, scope: 'once', justification: 'x' });
+    expect(once.ok).toBe(true);
+
+    const all = await grants();
+    expect(all).toHaveLength(1);
+    // once → the 30-minute backstop expiry plus a single-use budget.
+    expect(all[0]?.scope).toBe('once');
+    expect(all[0]?.maxUses).toBe(1);
+    expect(all[0]?.expiresAt).not.toBeNull();
+  });
+});


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

Completes the reveal-to-model machinery around the CLI bridge from PR 05.

## The seam

The reveal decision now sits behind one `ExceptionPolicyProvider` interface in `persistence`. The OSS implementation is user-driven — the grant the user created **is** the decision, matched live on the exact identity suppression uses, so revocation and expiry apply on the very next crossing and a grant under a rotated-away key epoch simply stops matching.

The glue takes the provider by injection. The contract test proves an injected provider flips a crossing's outcome with **zero change at the call site**, and a throwing provider denies rather than leaking. That injection point is the whole enterprise story for policy-driven reveals: same interface, same caller, different decider.

Nine provider tests cover the deny matrix: suppression-grant-never-reveals, cross-value isolation, expiry at crossing time, use exhaustion, key rotation, repository faults.

## CLI

`--reveal-to-model` is canonical (`--reveal` stays as shorthand), and the reveal opt-in now works on the blocked-detections **ledger** path too — a user whose prompt was just blocked can mint the reveal straight from the ref in the block message, no pointer handling needed. Bare `approve` still mints suppression; reveal is never a default.

## Dashboard

The vault lookup page grants reveal-to-model from a resolved pointer (scope picker + required justification, everything stamped server-side, the fingerprint never reaching the browser — only an id prefix returns). Exception rows and details carry a distinct badge with the consequence stated; both terminal lists tag reveal rows `REVEALS-TO-MODEL` and stay metadata-only surfaces.