### PR TITLE
vault 08/10: vault dashboard — inventory, reuse insight, deref audit, sightings

### DIFF
--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -260,6 +260,23 @@ export {
   type RotateKeyDialogProps,
 } from './exceptions/RotateKeyDialog.tsx';
 
+// Vault views — props-driven (no data fetching); the raw-free register of
+// vaulted values, the same-machine reuse signal, and the de-reference audit
+// trail. Fed by @akasecurity/persistence Server Components / Server Actions in
+// the OSS web-ui; all domain shapes are @akasecurity/schema vault types.
+export {
+  DEREF_REASON_LABEL,
+  RevealToModelBadge,
+  SIGHTING_KIND_LABEL,
+  SightingKindChip,
+} from './vault/atoms.tsx';
+export {
+  DerefAuditTableView,
+  type DerefAuditTableViewProps,
+} from './vault/DerefAuditTableView.tsx';
+export { VaultInventoryView, type VaultInventoryViewProps } from './vault/VaultInventoryView.tsx';
+export { VaultReuseView, type VaultReuseViewProps } from './vault/VaultReuseView.tsx';
+
 // Updates views — props-driven; the web twin of `aka check-updates` / `aka
 // update` / `aka plugins`. Fed by @akasecurity/local-ops via server actions in the
 // OSS web-ui.

--- a/packages/dashboard-ui/src/vault/DerefAuditTableView.tsx
+++ b/packages/dashboard-ui/src/vault/DerefAuditTableView.tsx
@@ -1,0 +1,154 @@
+'use client';
+import type { VaultDeref, VaultDerefOutcome } from '@akasecurity/schema';
+import { isBatchedDerefReason } from '@akasecurity/schema';
+import {
+  Badge,
+  Button,
+  cn,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@akasecurity/ui-kit';
+
+import { relativeTime } from '../lib/relativeTime.ts';
+import { DEREF_REASON_LABEL } from './atoms.tsx';
+
+export interface DerefAuditTableViewProps {
+  rows: VaultDeref[];
+  // How many display/view-render rows the caller's query hid.
+  hiddenBatched: number;
+  showBatched: boolean;
+  onToggleBatched?: (showBatched: boolean) => void;
+}
+
+// Model-target crossings are the anomaly signal this trail exists for, so both
+// their outcomes render loud: a revealed crossing means the raw value reached
+// the model; a refused one means something tried and was stopped — the row that
+// must never read as noise.
+const MODEL_ROW_CLASS: Partial<Record<VaultDerefOutcome, string>> = {
+  revealed: 'border-l-2 border-l-sev-critical bg-sev-critical-fill font-medium',
+  refused: 'border-l-2 border-l-sev-high bg-sev-high-fill font-medium',
+};
+
+function OutcomeBadge({ row }: { row: VaultDeref }) {
+  if (row.target === 'model' && row.outcome === 'revealed') {
+    return <Badge variant="critical">revealed</Badge>;
+  }
+  if (row.outcome === 'refused') return <Badge variant="high">refused</Badge>;
+  if (row.outcome === 'unavailable') return <Badge variant="outline">unavailable</Badge>;
+  return <Badge variant="default">revealed</Badge>;
+}
+
+/**
+ * The de-reference audit trail — one row per resolution of a vaulted value
+ * (never the value itself). Display/view-render rows are batched one-per-render
+ * and hidden by default so the model crossings stay visible; purge rows record
+ * that entries were destroyed and their pointers made unresolvable.
+ */
+export function DerefAuditTableView({
+  rows,
+  hiddenBatched,
+  showBatched,
+  onToggleBatched,
+}: DerefAuditTableViewProps) {
+  const toggle =
+    onToggleBatched === undefined ? null : (
+      <Button
+        variant="link"
+        tone="neutral"
+        onClick={() => {
+          onToggleBatched(!showBatched);
+        }}
+      >
+        {showBatched ? 'Hide display/render resolutions' : 'Show them'}
+      </Button>
+    );
+  const hiddenLine =
+    !showBatched && hiddenBatched > 0 ? (
+      <p className="mt-3 flex items-center gap-2 text-xs text-text-3">
+        <span>
+          {String(hiddenBatched)} display/render{' '}
+          {hiddenBatched === 1 ? 'resolution' : 'resolutions'} hidden
+        </span>
+        {toggle}
+      </p>
+    ) : showBatched && onToggleBatched !== undefined ? (
+      <p className="mt-3 text-xs text-text-3">{toggle}</p>
+    ) : null;
+
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-surface p-4">
+        <div className="py-10 text-center text-sm text-text-3">
+          No de-references recorded — every resolution of a vaulted value lands here.
+        </div>
+        {hiddenLine}
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border bg-surface p-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>When</TableHead>
+            <TableHead>Reason</TableHead>
+            <TableHead>Target</TableHead>
+            <TableHead>Outcome</TableHead>
+            <TableHead>Grant</TableHead>
+            <TableHead>Pointers</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) =>
+            row.reason === 'purge' ? (
+              // A purge is an event, not a de-reference: render it as one
+              // distinguished line — the record that values were destroyed
+              // outlives the values.
+              <TableRow key={row.id} data-purge="" className="bg-surface-2">
+                <TableCell className="text-xs text-text-2">{relativeTime(row.at)}</TableCell>
+                <TableCell colSpan={5} className="text-xs font-medium text-text-2">
+                  Vault purge —{' '}
+                  {row.pointerCount === 1 ? 'a pointer' : `${String(row.pointerCount)} pointers`}{' '}
+                  made permanently unresolvable
+                </TableCell>
+              </TableRow>
+            ) : (
+              <TableRow
+                key={row.id}
+                data-model-crossing={row.target === 'model' ? row.outcome : undefined}
+                className={cn(
+                  row.target === 'model' && MODEL_ROW_CLASS[row.outcome],
+                  isBatchedDerefReason(row.reason) && 'text-text-3',
+                )}
+              >
+                <TableCell className="text-xs text-text-2">{relativeTime(row.at)}</TableCell>
+                <TableCell className="text-xs">{DEREF_REASON_LABEL[row.reason]}</TableCell>
+                <TableCell className="text-xs">
+                  {row.target === 'model' ? (
+                    <span className="font-semibold text-sev-critical">model</span>
+                  ) : (
+                    <span className="text-text-2">human</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <OutcomeBadge row={row} />
+                </TableCell>
+                <TableCell className="font-mono text-xs text-text-3">
+                  {row.grantId === undefined ? '—' : row.grantId.slice(0, 8)}
+                </TableCell>
+                <TableCell className="text-xs text-text-2">
+                  {row.pointerCount > 1 ? `×${String(row.pointerCount)}` : '—'}
+                </TableCell>
+              </TableRow>
+            ),
+          )}
+        </TableBody>
+      </Table>
+      {hiddenLine}
+    </div>
+  );
+}

--- a/packages/dashboard-ui/src/vault/VaultInventoryView.tsx
+++ b/packages/dashboard-ui/src/vault/VaultInventoryView.tsx
@@ -1,0 +1,151 @@
+'use client';
+import type { VaultInventoryEntry } from '@akasecurity/schema';
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@akasecurity/ui-kit';
+
+import { relativeTime } from '../lib/relativeTime.ts';
+import { ScrubbedValue } from '../shared/ScrubbedValue.tsx';
+import { RevealToModelBadge, SightingKindChip } from './atoms.tsx';
+
+export interface VaultInventoryViewProps {
+  entries: VaultInventoryEntry[];
+  // Owner-surface reveal by row id; omitting it renders the table read-only.
+  onReveal?: (pointerId: string) => void;
+  // Revoke the active reveal-to-model grant covering the row's value.
+  onRevoke?: (grantId: string) => void;
+}
+
+/**
+ * The vault register — every value currently held, raw-free: the masked
+ * preview is the value's identity for humans. Each row also lists the places
+ * the value's POINTER has been written (its sightings): pointers are
+ * deterministic, so anyone who can read those locations sees the correlation.
+ */
+export function VaultInventoryView({ entries, onReveal, onRevoke }: VaultInventoryViewProps) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-surface py-10 text-center text-sm text-text-3">
+        Nothing vaulted yet — values land here when a redact policy fires with vault consent
+        granted.
+      </div>
+    );
+  }
+  const hasActions = onReveal !== undefined || onRevoke !== undefined;
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border bg-surface p-4">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Value</TableHead>
+            <TableHead>Occurrences</TableHead>
+            <TableHead>First seen</TableHead>
+            <TableHead>Last seen</TableHead>
+            <TableHead>Grant</TableHead>
+            {hasActions ? <TableHead>Actions</TableHead> : null}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {entries.map((entry) => (
+            <VaultInventoryRow
+              key={entry.pointerId}
+              entry={entry}
+              hasActions={hasActions}
+              onReveal={onReveal}
+              onRevoke={onRevoke}
+            />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function VaultInventoryRow({
+  entry,
+  hasActions,
+  onReveal,
+  onRevoke,
+}: {
+  entry: VaultInventoryEntry;
+  hasActions: boolean;
+  onReveal?: ((pointerId: string) => void) | undefined;
+  onRevoke?: ((grantId: string) => void) | undefined;
+}) {
+  const grantId = entry.revealGrantId;
+  const columns = hasActions ? 6 : 5;
+  return (
+    <>
+      <TableRow>
+        <TableCell>
+          <ScrubbedValue value={null} descriptor={entry} />
+        </TableCell>
+        <TableCell className="text-xs text-text-2">{String(entry.occurrences)}</TableCell>
+        <TableCell className="text-xs text-text-2">{relativeTime(entry.firstSeen)}</TableCell>
+        <TableCell className="text-xs text-text-2">{relativeTime(entry.lastSeen)}</TableCell>
+        <TableCell>{grantId === null ? null : <RevealToModelBadge />}</TableCell>
+        {hasActions ? (
+          <TableCell>
+            <span className="inline-flex items-center gap-2">
+              {onReveal === undefined ? null : (
+                <Button
+                  variant="outline"
+                  tone="neutral"
+                  size="sm"
+                  onClick={() => {
+                    onReveal(entry.pointerId);
+                  }}
+                >
+                  Reveal
+                </Button>
+              )}
+              {grantId !== null && onRevoke !== undefined ? (
+                <Button
+                  variant="ghost"
+                  tone="danger"
+                  size="sm"
+                  onClick={() => {
+                    onRevoke(grantId);
+                  }}
+                >
+                  Revoke grant
+                </Button>
+              ) : null}
+            </span>
+          </TableCell>
+        ) : null}
+      </TableRow>
+      {entry.sightings.length > 0 ? (
+        <TableRow>
+          <TableCell colSpan={columns} className="py-2">
+            <details>
+              <summary className="cursor-pointer text-xs font-medium text-text-2">
+                Written to {String(entry.sightings.length)}{' '}
+                {entry.sightings.length === 1 ? 'location' : 'locations'} — anyone who can read them
+                sees the correlation
+              </summary>
+              <ul className="mt-2 space-y-1">
+                {entry.sightings.map((sighting) => (
+                  <li
+                    key={`${sighting.kind}:${sighting.location}`}
+                    className="flex flex-wrap items-center gap-2 text-xs text-text-2"
+                  >
+                    <code className="break-all font-mono">{sighting.location}</code>
+                    <SightingKindChip kind={sighting.kind} />
+                    <span className="text-text-3">{relativeTime(sighting.lastSeen)}</span>
+                  </li>
+                ))}
+              </ul>
+            </details>
+          </TableCell>
+        </TableRow>
+      ) : null}
+    </>
+  );
+}

--- a/packages/dashboard-ui/src/vault/VaultReuseView.tsx
+++ b/packages/dashboard-ui/src/vault/VaultReuseView.tsx
@@ -1,0 +1,69 @@
+import type { VaultInventoryEntry } from '@akasecurity/schema';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@akasecurity/ui-kit';
+
+import { ScrubbedValue } from '../shared/ScrubbedValue.tsx';
+
+export interface VaultReuseViewProps {
+  entries: VaultInventoryEntry[];
+}
+
+// A value counts as reused when it was detected more than once or sighted in
+// more than one place. The claim is scoped to this machine's store: the vault
+// only sees what the local plugin captured.
+function isReused(entry: VaultInventoryEntry): boolean {
+  return entry.occurrences > 1 || entry.sightings.length > 1;
+}
+
+/**
+ * The same-machine reuse signal: values detected in more than one place, ranked
+ * by how often they recur. Reuse widens the blast radius of a single leak — one
+ * exposed value unlocks every location listed here.
+ */
+export function VaultReuseView({ entries }: VaultReuseViewProps) {
+  const reused = entries.filter(isReused).sort((a, b) => b.occurrences - a.occurrences);
+  if (reused.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-surface py-10 text-center text-sm text-text-3">
+        No reused values detected on this machine.
+      </div>
+    );
+  }
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border bg-surface p-4">
+      <p className="mb-3 text-xs text-text-3">
+        Values detected more than once on this machine, most-reused first.
+      </p>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Value</TableHead>
+            <TableHead>Occurrences</TableHead>
+            <TableHead>Seen in</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {reused.map((entry) => {
+            const locations = [...new Set(entry.sightings.map((s) => s.location))];
+            return (
+              <TableRow key={entry.pointerId}>
+                <TableCell>
+                  <ScrubbedValue value={null} descriptor={entry} />
+                </TableCell>
+                <TableCell className="text-xs text-text-2">{String(entry.occurrences)}</TableCell>
+                <TableCell>
+                  <ul className="space-y-0.5">
+                    {locations.map((location) => (
+                      <li key={location} className="font-mono text-xs text-text-2">
+                        {location}
+                      </li>
+                    ))}
+                  </ul>
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/packages/dashboard-ui/src/vault/atoms.tsx
+++ b/packages/dashboard-ui/src/vault/atoms.tsx
@@ -1,0 +1,37 @@
+// Shared presentational atoms for the vault views: the sighting-kind and
+// de-reference vocabularies as display labels, plus the reveal-grant badge.
+import type { VaultDerefReason, VaultSightingKind } from '@akasecurity/schema';
+import { Badge } from '@akasecurity/ui-kit';
+
+// Surface-class labels for sighting chips.
+export const SIGHTING_KIND_LABEL: Record<VaultSightingKind, string> = {
+  prompt: 'Prompt',
+  'tool-input': 'Tool input',
+  'tool-output': 'Tool output',
+  file: 'File',
+  transcript: 'Transcript',
+};
+
+// De-reference reason labels for the audit trail.
+export const DEREF_REASON_LABEL: Record<VaultDerefReason, string> = {
+  display: 'Display render',
+  'explicit-reveal': 'Explicit reveal',
+  'view-render': 'View render',
+  'model-input': 'Model input',
+  remediation: 'Remediation',
+  purge: 'Purge',
+};
+
+/**
+ * Reveal-grant chip. Rendered ONLY while an active reveal-to-model grant
+ * covers the value — the model can receive its raw form at tool boundaries,
+ * so every vault surface flags it. Values without a grant stay unlabelled.
+ */
+export function RevealToModelBadge() {
+  return <Badge variant="critical">Reveal to model</Badge>;
+}
+
+/** Surface-class chip for one sighting. */
+export function SightingKindChip({ kind }: { kind: VaultSightingKind }) {
+  return <Badge variant="outline">{SIGHTING_KIND_LABEL[kind]}</Badge>;
+}

--- a/packages/dashboard-ui/test/vault/views.test.tsx
+++ b/packages/dashboard-ui/test/vault/views.test.tsx
@@ -1,0 +1,241 @@
+import type { VaultDeref, VaultInventoryEntry } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { DerefAuditTableView } from '../../src/vault/DerefAuditTableView.tsx';
+import { VaultInventoryView } from '../../src/vault/VaultInventoryView.tsx';
+import { VaultReuseView } from '../../src/vault/VaultReuseView.tsx';
+
+// Static-render coverage for the vault views (this package's test environment
+// is node, with no DOM). Everything a view receives is already raw-free —
+// masked previews, locations, counts — so the assertions here pin the display
+// contract: the reveal-grant badge only on granted rows, the batched-deref
+// hiding, the model-crossing prominence, and that no raw-shaped string ever
+// appears in the output.
+
+const BADGE = 'Reveal to model';
+
+function entry(overrides: Partial<VaultInventoryEntry>): VaultInventoryEntry {
+  return {
+    pointerId: 'ptr-1111',
+    category: 'secret',
+    provider: 'aws',
+    maskedMatch: 'AKIA****MASK',
+    occurrences: 1,
+    firstSeen: '2026-07-01T00:00:00.000Z',
+    lastSeen: '2026-07-02T00:00:00.000Z',
+    revealGrantId: null,
+    sightings: [
+      {
+        location: '~/.claude/projects/demo/transcript.jsonl',
+        kind: 'transcript',
+        firstSeen: '2026-07-01T00:00:00.000Z',
+        lastSeen: '2026-07-02T00:00:00.000Z',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function deref(overrides: Partial<VaultDeref>): VaultDeref {
+  return {
+    id: '7d9f7a4e-1111-4222-8333-444455556666',
+    pointerId: 'ptr-1111',
+    at: '2026-07-02T00:00:00.000Z',
+    target: 'human',
+    reason: 'explicit-reveal',
+    outcome: 'revealed',
+    pointerCount: 1,
+    ...overrides,
+  };
+}
+
+describe('VaultInventoryView', () => {
+  it('flags only rows covered by an active reveal grant', () => {
+    const html = renderToStaticMarkup(
+      <VaultInventoryView
+        entries={[
+          entry({ pointerId: 'ptr-granted', revealGrantId: 'grant-1' }),
+          entry({ pointerId: 'ptr-plain', maskedMatch: 'ghp_****MASK' }),
+        ]}
+      />,
+    );
+    expect(html.split(BADGE).length - 1).toBe(1);
+  });
+
+  it('renders each sighting with its location and kind chip', () => {
+    const html = renderToStaticMarkup(<VaultInventoryView entries={[entry({})]} />);
+    expect(html).toContain('~/.claude/projects/demo/transcript.jsonl');
+    expect(html).toContain('Transcript');
+    // The consequence of a written pointer is stated, not implied.
+    expect(html).toContain('sees the correlation');
+  });
+
+  it('renders row actions only when the callbacks are supplied', () => {
+    const rows = [entry({ revealGrantId: 'grant-1' })];
+    const readOnly = renderToStaticMarkup(<VaultInventoryView entries={rows} />);
+    expect(readOnly).not.toContain('Reveal</button>');
+    expect(readOnly).not.toContain('Revoke grant');
+    const actionable = renderToStaticMarkup(
+      <VaultInventoryView entries={rows} onReveal={() => undefined} onRevoke={() => undefined} />,
+    );
+    expect(actionable).toContain('Reveal</button>');
+    expect(actionable).toContain('Revoke grant');
+    // No revoke affordance without an active grant to revoke.
+    const ungranted = renderToStaticMarkup(
+      <VaultInventoryView
+        entries={[entry({})]}
+        onReveal={() => undefined}
+        onRevoke={() => undefined}
+      />,
+    );
+    expect(ungranted).not.toContain('Revoke grant');
+  });
+
+  it('states the honest empty state', () => {
+    const html = renderToStaticMarkup(<VaultInventoryView entries={[]} />);
+    expect(html).toContain('Nothing vaulted yet');
+  });
+});
+
+describe('VaultReuseView', () => {
+  it('shows only reused entries, ranked by occurrences, scoped to this machine', () => {
+    const html = renderToStaticMarkup(
+      <VaultReuseView
+        entries={[
+          entry({ pointerId: 'ptr-once', maskedMatch: 'once****MASK' }),
+          entry({ pointerId: 'ptr-three', maskedMatch: 'three****MASK', occurrences: 3 }),
+          entry({ pointerId: 'ptr-nine', maskedMatch: 'nine****MASK', occurrences: 9 }),
+        ]}
+      />,
+    );
+    expect(html).not.toContain('once****MASK');
+    expect(html).toContain('on this machine');
+    // Ranked by occurrences, descending.
+    expect(html.indexOf('nine****MASK')).toBeLessThan(html.indexOf('three****MASK'));
+  });
+
+  it('counts multi-sighting single-occurrence values as reused', () => {
+    const html = renderToStaticMarkup(
+      <VaultReuseView
+        entries={[
+          entry({
+            sightings: [
+              {
+                location: 'a.env',
+                kind: 'file',
+                firstSeen: '2026-07-01T00:00:00.000Z',
+                lastSeen: '2026-07-01T00:00:00.000Z',
+              },
+              {
+                location: 'b.env',
+                kind: 'file',
+                firstSeen: '2026-07-01T00:00:00.000Z',
+                lastSeen: '2026-07-01T00:00:00.000Z',
+              },
+            ],
+          }),
+        ]}
+      />,
+    );
+    expect(html).toContain('a.env');
+    expect(html).toContain('b.env');
+  });
+
+  it('scopes the empty-state claim to this machine', () => {
+    const html = renderToStaticMarkup(<VaultReuseView entries={[]} />);
+    expect(html).toContain('No reused values detected on this machine.');
+  });
+});
+
+describe('DerefAuditTableView', () => {
+  it('hides batched rows behind a muted count line by default', () => {
+    const html = renderToStaticMarkup(
+      <DerefAuditTableView
+        rows={[deref({})]}
+        hiddenBatched={4}
+        showBatched={false}
+        onToggleBatched={() => undefined}
+      />,
+    );
+    expect(html).toContain('4 display/render resolutions hidden');
+    expect(html).not.toContain('Display render');
+  });
+
+  it('shows batched rows with their pointerCount under the flag', () => {
+    const html = renderToStaticMarkup(
+      <DerefAuditTableView
+        rows={[deref({ reason: 'display', pointerCount: 12 })]}
+        hiddenBatched={0}
+        showBatched={true}
+      />,
+    );
+    expect(html).toContain('Display render');
+    expect(html).toContain('×12');
+  });
+
+  it('marks a refused model crossing with the prominence hook', () => {
+    const html = renderToStaticMarkup(
+      <DerefAuditTableView
+        rows={[deref({ target: 'model', reason: 'model-input', outcome: 'refused' })]}
+        hiddenBatched={0}
+        showBatched={false}
+      />,
+    );
+    expect(html).toContain('data-model-crossing="refused"');
+    expect(html).toContain('bg-sev-high-fill');
+  });
+
+  it('marks a revealed model crossing and its grant prefix', () => {
+    const html = renderToStaticMarkup(
+      <DerefAuditTableView
+        rows={[
+          deref({
+            target: 'model',
+            reason: 'model-input',
+            outcome: 'revealed',
+            grantId: 'aaaabbbb-cccc-dddd-eeee-ffff00001111',
+          }),
+        ]}
+        hiddenBatched={0}
+        showBatched={false}
+      />,
+    );
+    expect(html).toContain('data-model-crossing="revealed"');
+    expect(html).toContain('aaaabbbb');
+    expect(html).not.toContain('aaaabbbb-cccc');
+  });
+
+  it('renders a purge as a distinguished event line', () => {
+    const html = renderToStaticMarkup(
+      <DerefAuditTableView
+        rows={[deref({ reason: 'purge', outcome: 'unavailable', pointerCount: 7 })]}
+        hiddenBatched={0}
+        showBatched={false}
+      />,
+    );
+    expect(html).toContain('data-purge');
+    expect(html).toContain('Vault purge');
+    expect(html).toContain('7 pointers');
+  });
+});
+
+describe('raw-value hygiene', () => {
+  it('never renders a raw-shaped credential from raw-free props', () => {
+    const html = renderToStaticMarkup(
+      <>
+        <VaultInventoryView entries={[entry({ revealGrantId: 'grant-1' })]} />
+        <VaultReuseView entries={[entry({ occurrences: 2 })]} />
+        <DerefAuditTableView
+          rows={[deref({ target: 'model', reason: 'model-input', outcome: 'revealed' })]}
+          hiddenBatched={2}
+          showBatched={false}
+        />
+      </>,
+    );
+    // The masked preview is the only value-shaped string allowed through:
+    // nothing matching a live AWS key id or a generic long token may appear.
+    expect(html).not.toMatch(/AKIA[0-9A-Z]{16}/);
+    expect(html).not.toMatch(/\b(?:sk|ghp|gho|xoxb)-?_?[A-Za-z0-9]{20,}/);
+  });
+});

--- a/packages/persistence/src/repositories/secret-vault.ts
+++ b/packages/persistence/src/repositories/secret-vault.ts
@@ -15,9 +15,18 @@
 //
 // Timestamps cross this boundary as epoch milliseconds and are stored as SQLite
 // integers.
+import { randomUUID } from 'node:crypto';
 import type { DatabaseSync, StatementSync } from 'node:sqlite';
 
-import type { DetokenizeTarget, VaultDerefOutcome, VaultDerefReason } from '@akasecurity/schema';
+import type {
+  DetokenizeTarget,
+  VaultDeref,
+  VaultDerefOutcome,
+  VaultDerefReason,
+  VaultInventoryEntry,
+  VaultSighting,
+  VaultSightingKind,
+} from '@akasecurity/schema';
 
 import { allRows, bindParams, countScalar, getRow } from '../internal/rows.ts';
 import { withTransaction } from '../internal/transactions.ts';
@@ -257,6 +266,147 @@ export class SqliteSecretVaultRepository {
       'IMMEDIATE',
     );
     return destroyed;
+  }
+
+  /**
+   * Record (or re-stamp) one place a pointer has been written. One row per
+   * (pointer, location); a re-sighting bumps last_seen. Best-effort bookkeeping
+   * on hook paths — a failure must never affect the rewrite that triggered it,
+   * so callers wrap this, not the other way around.
+   */
+  recordSighting(
+    entry: { pointerId: string; location: string; kind: VaultSightingKind },
+    now: number,
+  ): void {
+    this.db
+      .prepare(
+        `INSERT INTO secret_vault_sighting (id, pointer_id, location, kind, first_seen, last_seen)
+         VALUES (:id, :pointerId, :location, :kind, :now, :now)
+         ON CONFLICT (pointer_id, location) DO UPDATE SET last_seen = :now`,
+      )
+      .run({
+        id: randomUUID(),
+        pointerId: entry.pointerId,
+        location: entry.location,
+        kind: entry.kind,
+        now,
+      });
+  }
+
+  listSightings(pointerId: string): VaultSighting[] {
+    const rows = allRows<{ location: string; kind: string; first_seen: number; last_seen: number }>(
+      this.db.prepare(
+        `SELECT location, kind, first_seen, last_seen FROM secret_vault_sighting
+          WHERE pointer_id = :pointerId ORDER BY last_seen DESC`,
+      ),
+      { pointerId },
+    );
+    return rows.map((r) => ({
+      location: r.location,
+      kind: r.kind as VaultSightingKind,
+      firstSeen: new Date(r.first_seen).toISOString(),
+      lastSeen: new Date(r.last_seen).toISOString(),
+    }));
+  }
+
+  /**
+   * The dashboard inventory: every vaulted value's descriptor data joined with
+   * its sightings and the active reveal-to-model grant when one exists.
+   * Raw-free by construction — neither the fingerprint nor the ciphertext
+   * columns are selected.
+   */
+  listInventory(now = Date.now()): VaultInventoryEntry[] {
+    const rows = allRows<{
+      pointer_id: string;
+      category: string;
+      rule_id: string;
+      masked_match: string;
+      provider: string | null;
+      occurrence_count: number;
+      first_seen: number;
+      last_seen: number;
+      grant_id: string | null;
+    }>(
+      this.db.prepare(
+        `SELECT v.pointer_id, v.category, v.rule_id, v.masked_match, v.provider,
+                v.occurrence_count, v.first_seen, v.last_seen,
+                (SELECT e.id FROM exceptions e
+                  WHERE e.rule_id = v.rule_id
+                    AND e.value_fingerprint = v.value_fingerprint
+                    AND e.key_version = v.fingerprint_key_version
+                    AND e.capability = 'reveal_to_model'
+                    AND e.revoked_at IS NULL
+                    AND (e.expires_at IS NULL OR e.expires_at > :now)
+                    AND (e.max_uses IS NULL OR e.use_count < e.max_uses)
+                  LIMIT 1) AS grant_id
+           FROM secret_vault v
+          ORDER BY v.last_seen DESC`,
+      ),
+      { now },
+    );
+    return rows.map((r) => ({
+      pointerId: r.pointer_id,
+      category: r.category as VaultInventoryEntry['category'],
+      ...(r.provider === null ? {} : { provider: r.provider }),
+      maskedMatch: r.masked_match,
+      occurrences: r.occurrence_count,
+      firstSeen: new Date(r.first_seen).toISOString(),
+      lastSeen: new Date(r.last_seen).toISOString(),
+      revealGrantId: r.grant_id,
+      sightings: this.listSightings(r.pointer_id),
+    }));
+  }
+
+  /**
+   * The de-reference trail, newest first. By default the batched, high-volume
+   * reasons (display, view-render) are hidden and counted instead — the rows
+   * that matter as a signal are the model crossings, and burying them under
+   * render noise would defeat the audit's purpose.
+   */
+  listDerefs(opts?: { includeBatched?: boolean; limit?: number }): {
+    rows: VaultDeref[];
+    hiddenBatched: number;
+  } {
+    const limit = opts?.limit ?? 200;
+    const where =
+      opts?.includeBatched === true ? '' : `WHERE reason NOT IN ('display', 'view-render')`;
+    const rows = allRows<{
+      id: string;
+      pointer_id: string;
+      at: number;
+      target: string;
+      reason: string;
+      outcome: string;
+      grant_id: string | null;
+      pointer_count: number;
+    }>(
+      this.db.prepare(
+        `SELECT id, pointer_id, at, target, reason, outcome, grant_id, pointer_count
+           FROM secret_vault_deref ${where}
+          ORDER BY at DESC, rowid DESC LIMIT :limit`,
+      ),
+      { limit },
+    );
+    const hiddenBatched =
+      opts?.includeBatched === true
+        ? 0
+        : countScalar(
+            this.db,
+            `SELECT count(*) AS n FROM secret_vault_deref WHERE reason IN ('display', 'view-render')`,
+          );
+    return {
+      rows: rows.map((r) => ({
+        id: r.id,
+        pointerId: r.pointer_id,
+        at: new Date(r.at).toISOString(),
+        target: r.target as VaultDeref['target'],
+        reason: r.reason as VaultDeref['reason'],
+        outcome: r.outcome as VaultDeref['outcome'],
+        ...(r.grant_id === null ? {} : { grantId: r.grant_id }),
+        pointerCount: r.pointer_count,
+      })),
+      hiddenBatched,
+    };
   }
 
   countEntries(): number {

--- a/packages/persistence/src/vault/vault.ts
+++ b/packages/persistence/src/vault/vault.ts
@@ -245,6 +245,34 @@ export class SecretVault {
     return raw;
   }
 
+  /**
+   * Owner-surface reveal by row id: the dashboard shows a row the owner can
+   * already see and asks for its value. There is no wire token here to verify —
+   * the tag exists to stop FORGED tokens arriving in untrusted text, and a row
+   * id selected server-side from the owner's own store is not that — so this
+   * loads the row directly, opens its ciphertext under the row's epoch, and
+   * audits exactly like a human-target de-reference. Never callable with
+   * target 'model': the wire-token path with its grant gate is the only road
+   * raw travels toward the model.
+   */
+  async revealEntry(
+    pointerId: string,
+    opts: { reason: 'explicit-reveal' | 'view-render' },
+  ): Promise<DetokenizeResult> {
+    const row = this.#repo.byPointerId(pointerId);
+    if (!row) {
+      this.#audit(pointerId, { target: 'human', reason: opts.reason }, 'unavailable');
+      return UNAVAILABLE;
+    }
+    const raw = await this.#openRow(row);
+    if (raw === null) {
+      this.#audit(pointerId, { target: 'human', reason: opts.reason }, 'unavailable');
+      return UNAVAILABLE;
+    }
+    this.#audit(pointerId, { target: 'human', reason: opts.reason }, 'revealed');
+    return raw;
+  }
+
   /** Badge and listing data. No raw value, no fingerprint, and no audit row. */
   async describePointer(token: string): Promise<PointerDescriptor | null> {
     const row = await this.#rowFor(token);

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -32,6 +32,7 @@ import type {
   PointerDescriptor,
   PointerToken,
   VaultDerefReason,
+  VaultSightingKind,
 } from '@akasecurity/schema';
 import { isVaultConsentValid, pointerTokenScanner } from '@akasecurity/schema';
 
@@ -93,6 +94,7 @@ export interface VaultCore {
     valueFingerprint: string;
     fingerprintKeyVersion: number;
   } | null>;
+  recordSighting?(pointerId: string, sighting: { location: string; kind: VaultSightingKind }): void;
 }
 
 // Resolves whether a model-echoed pointer may be de-referenced back to raw for
@@ -109,8 +111,16 @@ export interface SubstitutePointersResult {
   unresolved: PointerToken[];
 }
 
+export interface TokenizeSighting {
+  location: string;
+  kind: VaultSightingKind;
+}
+
 export interface VaultGlue {
-  tokenizeText(text: string, opts?: { findings?: MatchResult[] }): Promise<TokenizeTextResult>;
+  tokenizeText(
+    text: string,
+    opts?: { findings?: MatchResult[]; sighting?: TokenizeSighting },
+  ): Promise<TokenizeTextResult>;
   tokenizeValue(
     raw: string,
     meta: { ruleId: string; category: DetectionCategory; maskedMatch: string },
@@ -234,7 +244,7 @@ class SecretVaultGlue implements VaultGlue {
 
   async tokenizeText(
     text: string,
-    opts?: { findings?: MatchResult[] },
+    opts?: { findings?: MatchResult[]; sighting?: TokenizeSighting },
   ): Promise<TokenizeTextResult> {
     try {
       const findings = opts?.findings ?? this.#selfScan(text);
@@ -271,6 +281,19 @@ class SecretVaultGlue implements VaultGlue {
           else degraded.unshift({ category: finding.category });
         }
         out = out.slice(0, group.start) + replacement + out.slice(group.end);
+      }
+      // Where these pointers just landed — the ledger that makes pointer
+      // correlation visible to the owner. Best-effort: a bookkeeping fault
+      // never affects the rewrite.
+      if (opts?.sighting && pointers.length > 0) {
+        for (const pointer of pointers) {
+          try {
+            const id = pointer.split('.')[1];
+            if (id !== undefined) this.#vault.recordSighting?.(id, opts.sighting);
+          } catch {
+            // best-effort only
+          }
+        }
       }
       return { text: out, pointers, degraded };
     } catch {
@@ -432,6 +455,18 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
       // process.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
     });
+    // The vault core plus the sighting recorder: SecretVault owns crypto and
+    // audit; where a pointer LANDED is repository bookkeeping, wired in here so
+    // the glue's callers never touch the store directly.
+    const vaultWithSightings: VaultCore = {
+      tokenize: (raw, meta) => vault.tokenize(raw, meta),
+      detokenize: (token, opts) => vault.detokenize(token, opts),
+      describePointer: (token) => vault.describePointer(token),
+      resolvePointerIdentity: (token) => vault.resolvePointerIdentity(token),
+      recordSighting: (pointerId, sighting) => {
+        db.secretVault.recordSighting({ pointerId, ...sighting }, Date.now());
+      },
+    };
     // The resolver is a thin adapter over the decision seam: pointer →
     // raw-free identity → provider decision. Anything failing along the way is
     // a refusal, never a reveal.
@@ -446,7 +481,7 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
         return null;
       }
     };
-    return new SecretVaultGlue(vault, revealGrantResolver, () => {
+    return new SecretVaultGlue(vaultWithSightings, revealGrantResolver, () => {
       db.close();
     });
   } catch {

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -337,3 +337,64 @@ describe('vault glue', () => {
     });
   });
 });
+
+describe('sighting recording', () => {
+  let base: string;
+  let glue: VaultGlue;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'aka-glue-sight-'));
+    applyOnboarding(
+      {
+        vaultConsent: {
+          acknowledgedAt: new Date().toISOString(),
+          version: VAULT_CONSENT_VERSION,
+        },
+      },
+      base,
+    );
+    glue = createVaultGlue({ base });
+  });
+
+  afterEach(() => {
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('records where a minted pointer landed, one row per location', async () => {
+    const text = `key=${SECRET}`;
+    const opts = {
+      findings: [finding({ span: { start: 4, end: 4 + SECRET.length } })],
+      sighting: { location: '/repo/.env', kind: 'file' as const },
+    };
+    await glue.tokenizeText(text, opts);
+    // Re-sighting the same location bumps timestamps instead of duplicating.
+    await glue.tokenizeText(text, opts);
+    await glue.tokenizeText(text, {
+      ...opts,
+      sighting: { location: 'Write input', kind: 'tool-input' as const },
+    });
+
+    const db = new DatabaseSync(join(dataDir(base), 'aka.db'));
+    const rows = db
+      .prepare(`SELECT location, kind FROM secret_vault_sighting ORDER BY location`)
+      .all() as { location: string; kind: string }[];
+    db.close();
+    expect(rows).toEqual([
+      { location: '/repo/.env', kind: 'file' },
+      { location: 'Write input', kind: 'tool-input' },
+    ]);
+  });
+
+  it('a clean text records nothing', async () => {
+    await glue.tokenizeText('nothing here', {
+      findings: [],
+      sighting: { location: '/x', kind: 'file' },
+    });
+    const db = new DatabaseSync(join(dataDir(base), 'aka.db'));
+    const count = db.prepare('SELECT count(*) AS n FROM secret_vault_sighting').get() as {
+      n: number;
+    };
+    db.close();
+    expect(count.n).toBe(0);
+  });
+});

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -357,6 +357,9 @@ describe('sighting recording', () => {
   });
 
   afterEach(() => {
+    // Before the rm, as every other suite here does: this glue opened a store
+    // handle, and Windows refuses to remove a directory one is still held in.
+    glue.close();
     rmSync(base, { recursive: true, force: true });
   });
 

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -287,16 +287,24 @@ describe('vault glue', () => {
     });
 
     it('an unopenable store degrades construction, not the session', async () => {
-      const fileAsBase = join(mkdtempSync(join(tmpdir(), 'aka-glue-bad-')), 'not-a-dir');
-      writeFileSync(fileAsBase, 'occupied');
-      const degraded = createVaultGlue({ base: fileAsBase });
-      await expect(
-        degraded.tokenizeValue(SECRET, {
-          ruleId: 'r',
-          category: 'pii',
-          maskedMatch: 'A******E',
-        }),
-      ).resolves.toBe('[REDACTED:PII]');
+      const badBase = mkdtempSync(join(tmpdir(), 'aka-glue-bad-'));
+      try {
+        const fileAsBase = join(badBase, 'not-a-dir');
+        writeFileSync(fileAsBase, 'occupied');
+        const degraded = createVaultGlue({ base: fileAsBase });
+        await expect(
+          degraded.tokenizeValue(SECRET, {
+            ruleId: 'r',
+            category: 'pii',
+            maskedMatch: 'A******E',
+          }),
+        ).resolves.toBe('[REDACTED:PII]');
+        // Opened nothing, so this releases nothing — pinning that close() is
+        // safe on a degraded glue, which is the branch a caller cannot detect.
+        degraded.close();
+      } finally {
+        rmSync(badBase, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/schema/drizzle/local-sqlite/0017_rainy_kat_farrell.sql
+++ b/packages/schema/drizzle/local-sqlite/0017_rainy_kat_farrell.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `secret_vault_sighting` (
+	`id` text PRIMARY KEY NOT NULL,
+	`pointer_id` text NOT NULL,
+	`location` text NOT NULL,
+	`kind` text NOT NULL,
+	`first_seen` integer NOT NULL,
+	`last_seen` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `uq_secret_vault_sighting` ON `secret_vault_sighting` (`pointer_id`,`location`);

--- a/packages/schema/drizzle/local-sqlite/meta/0017_snapshot.json
+++ b/packages/schema/drizzle/local-sqlite/meta/0017_snapshot.json
@@ -1,0 +1,2571 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cdbf5a58-e837-4dcc-9a6a-d75b3a34a112",
+  "prevId": "453a3e67-340c-48e9-bd86-c076fd347cbd",
+  "tables": {
+    "audit_events": {
+      "name": "audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_project_id": {
+          "name": "source_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.output_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_creation_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_read_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.model'))",
+            "type": "virtual"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.provider'))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_audit_parent": {
+          "name": "idx_audit_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session": {
+          "name": "idx_audit_session",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_harness_t": {
+          "name": "idx_audit_harness_t",
+          "columns": [
+            "harness_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_project_t": {
+          "name": "idx_audit_project_t",
+          "columns": [
+            "source_project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session_type": {
+          "name": "idx_audit_session_type",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false,
+          "where": "event_type = 'llm_call'"
+        },
+        "idx_audit_type_t": {
+          "name": "idx_audit_type_t",
+          "columns": [
+            "event_type",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_parent_id_audit_events_id_fk": {
+          "name": "audit_events_parent_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_root_session_id_audit_events_id_fk": {
+          "name": "audit_events_root_session_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "root_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_host_id_inventory_id_fk": {
+          "name": "audit_events_host_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_harness_id_inventory_id_fk": {
+          "name": "audit_events_harness_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_source_project_id_source_project_id_fk": {
+          "name": "audit_events_source_project_id_source_project_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "source_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "available_packs": {
+      "name": "available_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_available_packs_pack": {
+          "name": "uq_available_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classified_data": {
+      "name": "classified_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "egress_decision_override": {
+      "name": "egress_decision_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_egress_decision_override": {
+          "name": "uq_egress_decision_override",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": true
+        },
+        "uq_egress_decision_override_host": {
+          "name": "uq_egress_decision_override_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true,
+          "where": "`host` IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "egress_decision_override_destination_id_share_destination_id_fk": {
+          "name": "egress_decision_override_destination_id_share_destination_id_fk",
+          "tableFrom": "egress_decision_override",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_tool": {
+          "name": "source_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_occurred": {
+          "name": "idx_events_occurred",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_value": {
+          "name": "masked_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'suppress'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_exceptions_active": {
+          "name": "uq_exceptions_active",
+          "columns": [
+            "rule_id",
+            "value_fingerprint",
+            "key_version"
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_access_override": {
+      "name": "file_access_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_access_override_project": {
+          "name": "idx_file_access_override_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_file_access_override": {
+          "name": "uq_file_access_override",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_access_override_project_id_source_project_id_fk": {
+          "name": "file_access_override_project_id_source_project_id_fk",
+          "tableFrom": "file_access_override",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "finding_resolution": {
+      "name": "finding_resolution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_finding_resolution_key": {
+          "name": "idx_finding_resolution_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "findings": {
+      "name": "findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_findings_event": {
+          "name": "idx_findings_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_findings_key": {
+          "name": "uq_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "findings_event_id_events_id_fk": {
+          "name": "findings_event_id_events_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "harness_asset": {
+      "name": "harness_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_harness_asset_harness": {
+          "name": "idx_harness_asset_harness",
+          "columns": [
+            "harness_id"
+          ],
+          "isUnique": false
+        },
+        "uq_harness_asset": {
+          "name": "uq_harness_asset",
+          "columns": [
+            "harness_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "harness_asset_harness_id_inventory_id_fk": {
+          "name": "harness_asset_harness_id_inventory_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harness_asset_asset_id_inventory_asset_id_fk": {
+          "name": "harness_asset_asset_id_inventory_asset_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_definitions": {
+      "name": "inspection_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_findings": {
+      "name": "inspection_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_definition_id": {
+          "name": "inspection_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classified_data_id": {
+          "name": "classified_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_findings_event": {
+          "name": "idx_inspection_findings_event",
+          "columns": [
+            "audit_event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_inspection_findings_key": {
+          "name": "uq_inspection_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_findings_audit_event_id_audit_events_id_fk": {
+          "name": "inspection_findings_audit_event_id_audit_events_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "audit_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_inspection_definition_id_inspection_definitions_id_fk": {
+          "name": "inspection_findings_inspection_definition_id_inspection_definitions_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "inspection_definitions",
+          "columnsFrom": [
+            "inspection_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_classified_data_id_classified_data_id_fk": {
+          "name": "inspection_findings_classified_data_id_classified_data_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "classified_data",
+          "columnsFrom": [
+            "classified_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_packs": {
+      "name": "installed_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_installed_packs_pack": {
+          "name": "uq_installed_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory": {
+      "name": "inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.os_version'))",
+            "type": "virtual"
+          }
+        },
+        "harness_version": {
+          "name": "harness_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.harness_version'))",
+            "type": "virtual"
+          }
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_osver": {
+          "name": "idx_inventory_type_osver",
+          "columns": [
+            "object_type",
+            "os_version"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_harnessver": {
+          "name": "idx_inventory_type_harnessver",
+          "columns": [
+            "object_type",
+            "harness_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_host_id_inventory_id_fk": {
+          "name": "inventory_host_id_inventory_id_fk",
+          "tableFrom": "inventory",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_asset": {
+      "name": "inventory_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_asset_type": {
+          "name": "idx_inventory_asset_type",
+          "columns": [
+            "asset_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_override": {
+      "name": "mcp_trust_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_mcp_trust_override": {
+          "name": "uq_mcp_trust_override",
+          "columns": [
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pack_write_gate": {
+      "name": "_pack_write_gate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open": {
+          "name": "open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_pack_write_gate_single_row": {
+          "name": "ck_pack_write_gate_single_row",
+          "value": "\"_pack_write_gate\".\"id\" = 1"
+        }
+      }
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "custom_keywords": {
+          "name": "custom_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_policies_scope_target": {
+          "name": "uq_policies_scope_target",
+          "columns": [
+            "scope",
+            "target"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_file": {
+      "name": "project_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_access": {
+          "name": "default_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_file_project": {
+          "name": "idx_project_file_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_project_file": {
+          "name": "uq_project_file",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_source_project_id_fk": {
+          "name": "project_file_project_id_source_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault": {
+      "name": "secret_vault",
+      "columns": {
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_key_version": {
+          "name": "fingerprint_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_value": {
+          "name": "uq_secret_vault_value",
+          "columns": [
+            "value_fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_deref": {
+      "name": "secret_vault_deref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pointer_count": {
+          "name": "pointer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_secret_vault_deref_pointer": {
+          "name": "idx_secret_vault_deref_pointer",
+          "columns": [
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_reason_at": {
+          "name": "idx_secret_vault_deref_reason_at",
+          "columns": [
+            "reason",
+            "at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_sighting": {
+      "name": "secret_vault_sighting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_sighting": {
+          "name": "uq_secret_vault_sighting",
+          "columns": [
+            "pointer_id",
+            "location"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_call_site": {
+      "name": "share_call_site",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "vendored": {
+          "name": "vendored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_call_site_endpoint": {
+          "name": "idx_share_call_site_endpoint",
+          "columns": [
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_call_site_project": {
+          "name": "idx_share_call_site_project",
+          "columns": [
+            "project_key",
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_call_site": {
+          "name": "uq_share_call_site",
+          "columns": [
+            "endpoint_id",
+            "project_key",
+            "file",
+            "line"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_call_site_endpoint_id_share_endpoint_id_fk": {
+          "name": "share_call_site_endpoint_id_share_endpoint_id_fk",
+          "tableFrom": "share_call_site",
+          "tableTo": "share_endpoint",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_destination": {
+      "name": "share_destination",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_json": {
+          "name": "network_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_destination_kind": {
+          "name": "idx_share_destination_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "uq_share_destination_host": {
+          "name": "uq_share_destination_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_endpoint": {
+      "name": "share_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "data_class": {
+          "name": "data_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_endpoint_dest": {
+          "name": "idx_share_endpoint_dest",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_endpoint": {
+          "name": "uq_share_endpoint",
+          "columns": [
+            "destination_id",
+            "method",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_endpoint_destination_id_share_destination_id_fk": {
+          "name": "share_endpoint_destination_id_share_destination_id_fk",
+          "tableFrom": "share_endpoint",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_project": {
+      "name": "source_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/schema/drizzle/local-sqlite/meta/_journal.json
+++ b/packages/schema/drizzle/local-sqlite/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785351462433,
       "tag": "0016_breezy_zodiak",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1785351665625,
+      "tag": "0017_rainy_kat_farrell",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -736,6 +736,29 @@ export const secretVault = sqliteTable(
   ],
 );
 
+// SECRET VAULT SIGHTING — where a pointer has been written: one row per
+// (pointer, location), timestamps bumped on re-sighting. Deliberately no FK to
+// secret_vault: the record of where pointers went is itself evidence and must
+// survive a purge, exactly like the deref trail.
+export const secretVaultSighting = sqliteTable(
+  'secret_vault_sighting',
+  {
+    id: text(COL.id).primaryKey(),
+    pointerId: text(COL.pointerId).notNull(),
+    location: text(COL.location).notNull(),
+    kind: text(COL.kind, {
+      enum: ['prompt', 'tool-input', 'tool-output', 'file', 'transcript'],
+    }).notNull(),
+    firstSeen: integer(COL.firstSeen).notNull(),
+    lastSeen: integer(COL.lastSeen).notNull(),
+  },
+  (t) => [
+    // Also serves every by-pointer lookup as its left prefix — no separate
+    // single-column index.
+    uniqueIndex('uq_secret_vault_sighting').on(t.pointerId, t.location),
+  ],
+);
+
 // SECRET VAULT DEREF — the audit trail. Every de-reference writes one, whatever
 // the outcome. Never carries the raw value or the ciphertext.
 export const secretVaultDeref = sqliteTable(

--- a/packages/schema/src/drizzle/sqlite-ddl.ts
+++ b/packages/schema/src/drizzle/sqlite-ddl.ts
@@ -95,4 +95,8 @@ export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
     tag: '0016_breezy_zodiak',
     sql: "ALTER TABLE `exceptions` ADD `capability` text DEFAULT 'suppress' NOT NULL;",
   },
+  {
+    tag: '0017_rainy_kat_farrell',
+    sql: 'CREATE TABLE `secret_vault_sighting` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`pointer_id` text NOT NULL,\n\t`location` text NOT NULL,\n\t`kind` text NOT NULL,\n\t`first_seen` integer NOT NULL,\n\t`last_seen` integer NOT NULL\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX `uq_secret_vault_sighting` ON `secret_vault_sighting` (`pointer_id`,`location`);',
+  },
 ];

--- a/packages/schema/src/zod/vault.ts
+++ b/packages/schema/src/zod/vault.ts
@@ -176,6 +176,49 @@ export const VaultDeref = z.object({
 });
 export type VaultDeref = z.infer<typeof VaultDeref>;
 
+// ─── Sightings — where a pointer has been seen ───────────────────────────────
+
+// The surface class a pointer landed on when it was minted or re-emitted.
+export const VaultSightingKind = z.enum([
+  'prompt',
+  'tool-input',
+  'tool-output',
+  'file',
+  'transcript',
+]);
+export type VaultSightingKind = z.infer<typeof VaultSightingKind>;
+
+// One place a pointer has been written. Deterministic pointers are correlatable
+// by design; this is the ledger that makes the correlation VISIBLE to the
+// owner — which files and surfaces carry a given value's pointer — instead of
+// discoverable only by whoever greps the artifacts. Raw-free: a location is a
+// path or a surface label, never content.
+export const VaultSighting = z.object({
+  location: z.string(),
+  kind: VaultSightingKind,
+  firstSeen: z.string(),
+  lastSeen: z.string(),
+});
+export type VaultSighting = z.infer<typeof VaultSighting>;
+
+// One inventory row for the dashboard: descriptor data plus the grant status
+// and everywhere the pointer has been sighted. Raw-free — no fingerprint, no
+// ciphertext, no value.
+export const VaultInventoryEntry = z.object({
+  pointerId: z.string(),
+  category: DetectionCategory,
+  provider: z.string().optional(),
+  maskedMatch: z.string(),
+  occurrences: z.number().int().nonnegative(),
+  firstSeen: z.string(),
+  lastSeen: z.string(),
+  // The active reveal-to-model grant covering this value, when one exists —
+  // the inventory badges it, the row links to revocation.
+  revealGrantId: z.string().nullable(),
+  sightings: z.array(VaultSighting),
+});
+export type VaultInventoryEntry = z.infer<typeof VaultInventoryEntry>;
+
 // ─── Settings-side vocabulary ────────────────────────────────────────────────
 
 // Where the vault master key lives. An OPEN discriminant: the custody vocabulary

--- a/plugins/claude-code/src/backfill.ts
+++ b/plugins/claude-code/src/backfill.ts
@@ -242,7 +242,8 @@ function buildTranscriptScrubber(): (filePath: string) => Promise<{ rewritten: n
   const scope = platformRedactionScope();
   return (filePath) =>
     scrubTranscriptTail(filePath, {
-      tokenizeText: (text) => glue.tokenizeText(text),
+      tokenizeText: (text) =>
+        glue.tokenizeText(text, { sighting: { location: filePath, kind: 'transcript' } }),
       scope,
     });
 }

--- a/plugins/claude-code/src/history/usage.ts
+++ b/plugins/claude-code/src/history/usage.ts
@@ -443,7 +443,10 @@ export async function reconcileSessionTail(
       try {
         const glue = createVaultGlue();
         const scrubbed = await scrubTranscriptTail(transcriptPath, {
-          tokenizeText: (text) => glue.tokenizeText(text),
+          tokenizeText: (text) =>
+            glue.tokenizeText(text, {
+              sighting: { location: transcriptPath, kind: 'transcript' },
+            }),
           scope: platformRedactionScope(),
         });
         // A rewrite changes the file's byte layout, so the just-persisted offset

--- a/plugins/claude-code/src/hooks/post-tool-use.ts
+++ b/plugins/claude-code/src/hooks/post-tool-use.ts
@@ -86,7 +86,15 @@ async function main(): Promise<void> {
           { kind: 'response', sourceTool: 'claude-code', text, metadata },
           { persist: 'with-findings' },
         ),
-      vaultGlue ? (text, findings) => vaultGlue.tokenizeText(text, { findings }) : undefined,
+      vaultGlue
+        ? (text, findings) =>
+            vaultGlue.tokenizeText(text, {
+              findings,
+              sighting: filePath
+                ? { location: filePath, kind: 'file' }
+                : { location: `${toolName} output`, kind: 'tool-output' },
+            })
+        : undefined,
     );
   } finally {
     await runtime.close();

--- a/plugins/claude-code/src/hooks/pre-tool-use.ts
+++ b/plugins/claude-code/src/hooks/pre-tool-use.ts
@@ -166,7 +166,15 @@ async function main(): Promise<void> {
     toolName,
     effectiveInput,
     scanned,
-    vaultGlue ? (text, findings) => vaultGlue.tokenizeText(text, { findings }) : undefined,
+    vaultGlue
+      ? (text, findings) =>
+          vaultGlue.tokenizeText(text, {
+            findings,
+            sighting: filePath
+              ? { location: filePath, kind: 'file' }
+              : { location: `${toolName} input`, kind: 'tool-input' },
+          })
+      : undefined,
   );
   if (decision) {
     await emit(

--- a/plugins/claude-code/src/hooks/user-prompt-submit.ts
+++ b/plugins/claude-code/src/hooks/user-prompt-submit.ts
@@ -133,7 +133,10 @@ async function pointerizedRewrite(
   findings: CaptureResult['findings'],
 ): Promise<string | null> {
   try {
-    const tokenized = await createVaultGlue().tokenizeText(prompt, { findings });
+    const tokenized = await createVaultGlue().tokenizeText(prompt, {
+      findings,
+      sighting: { location: 'prompt', kind: 'prompt' },
+    });
     if (tokenized.pointers.length === 0) return null;
     for (const finding of findings) {
       if (finding.rawMatch !== '' && tokenized.text.includes(finding.rawMatch)) return null;

--- a/web-ui/app/(app)/vault/VaultDashboardClient.tsx
+++ b/web-ui/app/(app)/vault/VaultDashboardClient.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import {
+  DerefAuditTableView,
+  ScrubbedValue,
+  VaultInventoryView,
+  VaultReuseView,
+} from '@akasecurity/dashboard-ui';
+import type { VaultDeref, VaultInventoryEntry } from '@akasecurity/schema';
+import { Button, Input } from '@akasecurity/ui-kit';
+import { useState, useTransition } from 'react';
+
+import type { PurgeVaultResult, RotateVaultKeyResult } from './actions';
+import { purgeVault, revealEntry, revokeRevealGrant, rotateVaultKey } from './actions';
+
+interface VaultDashboardClientProps {
+  inventory: VaultInventoryEntry[];
+  // The audit trail with the batched render reasons hidden (the default), plus
+  // the unfiltered variant so the toggle needs no round-trip.
+  derefRows: VaultDeref[];
+  hiddenBatched: number;
+  allDerefRows: VaultDeref[];
+}
+
+function SectionHead({ title, sub }: { title: string; sub: string }) {
+  return (
+    <div>
+      <h2 className="text-sm font-semibold text-text">{title}</h2>
+      <p className="mt-0.5 text-xs text-text-3">{sub}</p>
+    </div>
+  );
+}
+
+/**
+ * The interactive half of the vault page: the inventory with its reveal and
+ * revoke actions, the reuse and audit views, and the maintenance panel (key
+ * rotation and the purge). Revealed values live in component state only —
+ * never persisted, gone when the strip is hidden or the page unmounts.
+ */
+export function VaultDashboardClient({
+  inventory,
+  derefRows,
+  hiddenBatched,
+  allDerefRows,
+}: VaultDashboardClientProps) {
+  // pointerId → revealed value; null means the vault could not resolve it.
+  const [revealed, setRevealed] = useState<Record<string, string | null>>({});
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [rowBusy, startRowTransition] = useTransition();
+
+  const [showBatched, setShowBatched] = useState(false);
+
+  const [purgeText, setPurgeText] = useState('');
+  const [purgeResult, setPurgeResult] = useState<PurgeVaultResult | null>(null);
+  const [purgeBusy, startPurgeTransition] = useTransition();
+
+  const [rotateResult, setRotateResult] = useState<RotateVaultKeyResult | null>(null);
+  const [rotateBusy, startRotateTransition] = useTransition();
+
+  const onReveal = (pointerId: string) => {
+    startRowTransition(async () => {
+      const result = await revealEntry({ pointerId });
+      if (result.ok) {
+        setActionError(null);
+        setRevealed((prev) => ({ ...prev, [pointerId]: result.value }));
+      } else {
+        setActionError(result.error);
+      }
+    });
+  };
+
+  const onRevoke = (grantId: string) => {
+    if (
+      !window.confirm(
+        'Revoke this reveal-to-model grant? The model stops receiving the raw value at the next tool boundary.',
+      )
+    ) {
+      return;
+    }
+    startRowTransition(async () => {
+      const result = await revokeRevealGrant({ grantId });
+      setActionError(result.ok ? null : result.error);
+    });
+  };
+
+  const hide = (pointerId: string) => {
+    setRevealed((prev) =>
+      Object.fromEntries(Object.entries(prev).filter(([id]) => id !== pointerId)),
+    );
+  };
+
+  const submitPurge = () => {
+    startPurgeTransition(async () => {
+      const result = await purgeVault({ confirmation: purgeText });
+      setPurgeResult(result);
+      if (result.ok) {
+        setPurgeText('');
+        // The values behind these are gone; drop them from the page too.
+        setRevealed({});
+      }
+    });
+  };
+
+  const submitRotate = () => {
+    startRotateTransition(async () => {
+      setRotateResult(await rotateVaultKey());
+    });
+  };
+
+  // Rows the user revealed, in inventory order. After a purge revalidates the
+  // page the inventory empties, and the strip disappears with it.
+  const revealedEntries = inventory.filter((entry) => entry.pointerId in revealed);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-3">
+        <SectionHead
+          title="Vaulted values"
+          sub="Every value this machine holds, masked, with everywhere its pointer has been written. Each reveal is audited."
+        />
+        {actionError !== null && <p className="text-xs text-sev-critical">{actionError}</p>}
+        <VaultInventoryView entries={inventory} onReveal={onReveal} onRevoke={onRevoke} />
+        {revealedEntries.length > 0 && (
+          <div className="rounded-xl border border-border bg-surface p-4">
+            <div className="mb-2 text-label font-semibold uppercase tracking-wider text-text-3">
+              Revealed on this page only — hidden again on refresh
+            </div>
+            <ul className="space-y-2">
+              {revealedEntries.map((entry) => {
+                const value = revealed[entry.pointerId] ?? null;
+                return (
+                  <li
+                    key={entry.pointerId}
+                    className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-surface-2 px-3 py-2"
+                  >
+                    <ScrubbedValue value={value} descriptor={entry} />
+                    {value === null && (
+                      <span className="text-xs text-text-3">
+                        could not be resolved — purged or key material unavailable
+                      </span>
+                    )}
+                    <Button
+                      variant="ghost"
+                      tone="neutral"
+                      size="sm"
+                      disabled={rowBusy}
+                      onClick={() => {
+                        hide(entry.pointerId);
+                      }}
+                    >
+                      Hide
+                    </Button>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <SectionHead
+          title="Reuse on this machine"
+          sub="Values detected in more than one place. Reuse widens the blast radius of a single leak."
+        />
+        <VaultReuseView entries={inventory} />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <SectionHead
+          title="De-reference audit"
+          sub="Every resolution of a vaulted value — never the value itself. Model crossings render loud."
+        />
+        <DerefAuditTableView
+          rows={showBatched ? allDerefRows : derefRows}
+          hiddenBatched={hiddenBatched}
+          showBatched={showBatched}
+          onToggleBatched={setShowBatched}
+        />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <SectionHead title="Vault maintenance" sub="Key rotation is routine; the purge is not." />
+        <div className="rounded-xl border border-border bg-surface p-5">
+          <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">
+            Rotate vault key
+          </div>
+          <p className="mb-3 text-xs text-text-3">
+            Mints the next key epoch and re-encrypts every stored value under it. Existing pointers
+            keep working — only the ciphertext changes.
+          </p>
+          {rotateResult?.ok === true && (
+            <p className="mb-3 text-xs text-ok">
+              Key rotated to version {rotateResult.version} —{' '}
+              {rotateResult.reEncrypted === 1
+                ? '1 entry re-encrypted'
+                : `${String(rotateResult.reEncrypted)} entries re-encrypted`}{' '}
+              under it.
+            </p>
+          )}
+          {rotateResult?.ok === false && (
+            <p className="mb-3 text-xs text-sev-critical">{rotateResult.error}</p>
+          )}
+          <Button
+            variant="outline"
+            tone="neutral"
+            size="sm"
+            disabled={rotateBusy}
+            onClick={submitRotate}
+          >
+            {rotateBusy ? 'Rotating…' : 'Rotate key'}
+          </Button>
+        </div>
+
+        <div className="rounded-xl border border-sev-critical-fill bg-surface p-5">
+          <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-sev-critical">
+            Purge vault
+          </div>
+          <p className="mb-3 text-xs text-text-3">
+            Destroys every stored value. Every pointer everywhere — in files, transcripts, and
+            prompts — becomes permanently unresolvable. The audit trail survives. This cannot be
+            undone.
+          </p>
+          {purgeResult?.ok === true && (
+            <p className="mb-3 text-xs text-text-2">
+              Vault purged —{' '}
+              {purgeResult.destroyed === 1
+                ? '1 value destroyed'
+                : `${String(purgeResult.destroyed)} values destroyed`}
+              . The audit trail below is retained.
+            </p>
+          )}
+          {purgeResult?.ok === false && (
+            <p className="mb-3 text-xs text-sev-critical">{purgeResult.error}</p>
+          )}
+          <div className="flex items-center gap-2">
+            <Input
+              value={purgeText}
+              onChange={(e) => {
+                setPurgeText(e.target.value);
+              }}
+              placeholder="Type 'purge' to confirm"
+              className="max-w-56 font-mono"
+            />
+            <Button
+              variant="solid"
+              tone="danger"
+              size="sm"
+              disabled={purgeText !== 'purge' || purgeBusy}
+              onClick={submitPurge}
+            >
+              {purgeBusy ? 'Purging…' : 'Purge vault'}
+            </Button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/web-ui/app/(app)/vault/actions.ts
+++ b/web-ui/app/(app)/vault/actions.ts
@@ -10,13 +10,26 @@ import {
 } from '@akasecurity/persistence';
 import type { PointerDescriptor } from '@akasecurity/schema';
 import { isVaultConsentValid, PointerToken } from '@akasecurity/schema';
+import { revalidatePath } from 'next/cache';
 
 import { db } from '../../lib/db';
 
-// The web reveal surface — the browser twin of `aka vault show`. The raw value
-// exists in-process only for the duration of one request: de-referenced from
-// the vault, returned to the caller, never logged and never persisted anywhere
-// but the audit trail the vault itself writes (reason: explicit-reveal).
+// The web vault surface — the browser twin of `aka vault show` and the manage
+// verbs. A raw value exists in-process only for the duration of one request:
+// de-referenced from the vault, returned to the caller, never logged and never
+// persisted anywhere but the audit trail the vault itself writes.
+
+// The same construction the CLI performs: the vault over the local store, the
+// key custody the settings name, and consent read live so a revocation applies
+// to the very next call.
+function buildVault(): SecretVault {
+  return new SecretVault({
+    repo: db().secretVault,
+    keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
+    fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
+    isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
+  });
+}
 
 export type RevealResult =
   | { ok: true; value: string | null; descriptor: PointerDescriptor | null }
@@ -36,13 +49,7 @@ export async function revealPointer(input: { pointer: string }): Promise<RevealR
   }
 
   try {
-    const vault = new SecretVault({
-      repo: db().secretVault,
-      keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
-      // Read live so a consent revocation applies to the very next call.
-      isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
-    });
+    const vault = buildVault();
     const value = await vault.detokenize(parsed.data, {
       target: 'human',
       reason: 'explicit-reveal',
@@ -53,5 +60,79 @@ export async function revealPointer(input: { pointer: string }): Promise<RevealR
     // Corrupt key file or unreadable store — same outward shape as an
     // unresolvable pointer; the error never carries store internals.
     return { ok: true, value: null, descriptor: null };
+  }
+}
+
+export type EntryRevealResult = { ok: true; value: string | null } | { ok: false; error: string };
+
+/**
+ * Owner-surface reveal of one inventory row by its pointer id — the button on
+ * the vault register, audited exactly like a pasted-pointer reveal (target
+ * 'human', reason 'explicit-reveal'). `value: null` means unresolvable: a
+ * purged entry or unavailable key material.
+ */
+export async function revealEntry(input: { pointerId: string }): Promise<EntryRevealResult> {
+  try {
+    const value = await buildVault().revealEntry(input.pointerId, {
+      reason: 'explicit-reveal',
+    });
+    revalidatePath('/vault');
+    return { ok: true, value: typeof value === 'string' ? value : null };
+  } catch {
+    return { ok: false, error: 'The vault could not be read.' };
+  }
+}
+
+export type VaultActionResult = { ok: true } | { ok: false; error: string };
+
+/** Revoke the active reveal-to-model grant covering a vaulted value — terminal, audit-retained. */
+export async function revokeRevealGrant(input: { grantId: string }): Promise<VaultActionResult> {
+  try {
+    const revoked = await db().exceptions.revoke(input.grantId, 'dashboard');
+    if (!revoked) return { ok: false, error: 'No active grant with that id.' };
+    revalidatePath('/vault');
+    return { ok: true };
+  } catch {
+    return { ok: false, error: 'The grant could not be revoked.' };
+  }
+}
+
+export type PurgeVaultResult = { ok: true; destroyed: number } | { ok: false; error: string };
+
+/**
+ * Destroy every vaulted value. Irreversible: every pointer everywhere becomes
+ * permanently unresolvable; the de-reference audit trail survives. Guarded by
+ * a typed confirmation — anything but the literal word is rejected before the
+ * store is touched.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await -- 'use server' exports must be async
+export async function purgeVault(input: { confirmation: string }): Promise<PurgeVaultResult> {
+  if (input.confirmation !== 'purge') {
+    return { ok: false, error: "Type 'purge' to confirm — nothing was destroyed." };
+  }
+  try {
+    const destroyed = buildVault().purgeVault();
+    revalidatePath('/vault');
+    return { ok: true, destroyed };
+  } catch {
+    return { ok: false, error: 'The vault could not be purged.' };
+  }
+}
+
+export type RotateVaultKeyResult =
+  { ok: true; version: number; reEncrypted: number } | { ok: false; error: string };
+
+/**
+ * Mint the next vault key epoch and re-encrypt every entry under it. Existing
+ * pointers keep working — their tags verify against the historical epoch they
+ * name, which the key provider retains.
+ */
+export async function rotateVaultKey(): Promise<RotateVaultKeyResult> {
+  try {
+    const { version, reEncrypted } = await buildVault().rotateVaultKey();
+    revalidatePath('/vault');
+    return { ok: true, version, reEncrypted };
+  } catch {
+    return { ok: false, error: 'The vault key could not be rotated.' };
   }
 }

--- a/web-ui/app/(app)/vault/page.tsx
+++ b/web-ui/app/(app)/vault/page.tsx
@@ -1,9 +1,10 @@
 import { PageHead } from '@akasecurity/dashboard-ui';
 
+import { db } from '../../lib/db';
+import { VaultDashboardClient } from './VaultDashboardClient';
 import { VaultLookupClient } from './VaultLookupClient';
 
-// node:sqlite (via @akasecurity/persistence, reached from the server action)
-// runs only on the Node.js runtime.
+// node:sqlite (via @akasecurity/persistence) runs only on the Node.js runtime.
 export const runtime = 'nodejs';
 // Reads the local store on every request — never statically prerendered.
 export const dynamic = 'force-dynamic';
@@ -11,13 +12,27 @@ export const dynamic = 'force-dynamic';
 export const metadata = { title: 'Vault' };
 
 export default function VaultPage() {
+  const inventory = db().secretVault.listInventory();
+  // Both audit variants up front, so the batched-rows toggle swaps locally
+  // instead of re-querying.
+  const derefs = db().secretVault.listDerefs();
+  const allDerefs = db().secretVault.listDerefs({ includeBatched: true });
+
   return (
     <div className="px-8 pb-10 pt-7">
       <PageHead
         title="Vault"
-        sub="Resolve a pointer to its stored value. Every reveal is audited."
+        sub="Every value this machine holds, where its pointers have been written, and every de-reference. Reveals are audited."
       />
-      <VaultLookupClient />
+      <div className="flex flex-col gap-8">
+        <VaultLookupClient />
+        <VaultDashboardClient
+          inventory={inventory}
+          derefRows={derefs.rows}
+          hiddenBatched={derefs.hiddenBatched}
+          allDerefRows={allDerefs.rows}
+        />
+      </div>
     </div>
   );
 }

--- a/web-ui/test/actions/vault-manage.test.ts
+++ b/web-ui/test/actions/vault-manage.test.ts
@@ -1,0 +1,235 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import {
+  applyOnboarding,
+  createKeyProvider,
+  dataDir,
+  dbPath,
+  keysDir,
+  loadOrCreateFingerprintKey,
+  type LocalDatabase,
+  openLocalDatabase,
+  readWorkspaceSettings,
+  SecretVault,
+} from '@akasecurity/persistence';
+import type { VaultInventoryEntry } from '@akasecurity/schema';
+import { isVaultConsentValid, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { grantRevealFromPointer } from '../../app/(app)/exceptions/actions.ts';
+import {
+  purgeVault,
+  revealEntry,
+  revokeRevealGrant,
+  rotateVaultKey,
+} from '../../app/(app)/vault/actions.ts';
+
+// The vault manage surface: reveal-by-row-id, grant revocation, the purge, and
+// the key rotation. The suite pins the audit and survival properties — one
+// explicit-reveal deref row per reveal, an audit trail that outlives a purge,
+// and pointers that keep resolving across a key rotation. A real node:sqlite
+// store and real key files — no vault mocking (house style).
+//
+// The actions resolve the store from `homedir()` (never process.env), so the
+// whole test is redirected into a temp home by mocking `node:os`; `next/cache`
+// is stubbed because revalidatePath needs a Next render context that does not
+// exist under vitest.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
+
+// Not secret-shaped on purpose: tokenize never scans, and a plain string keeps
+// secret-looking literals out of this public file.
+const RAW = 'vaulted-value-for-web-manage-test';
+
+let home: string;
+
+// web-ui memoizes the open DB handle on globalThis (app/lib/db.ts). Close and
+// drop it between tests so the next action reopens against the fresh home.
+function resetSingleton(): void {
+  const store = globalThis as unknown as { __akaDb?: LocalDatabase };
+  store.__akaDb?.close();
+  delete store.__akaDb;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-vault-manage-'));
+  osHome.dir = home;
+  // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
+  applyOnboarding({
+    vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },
+  });
+});
+
+afterEach(() => {
+  resetSingleton();
+  rmSync(home, { recursive: true, force: true });
+});
+
+// The construction every action performs — the vault over the local store with
+// the settings-named key custody and live consent.
+function buildVault(db: LocalDatabase): SecretVault {
+  return new SecretVault({
+    repo: db.secretVault,
+    keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
+    fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
+    isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
+  });
+}
+
+// Seed one vaulted value through the real persistence SecretVault and return
+// its wire pointer token.
+async function seedPointer(): Promise<string> {
+  const db = openLocalDatabase(dataDir());
+  try {
+    const pointer = await buildVault(db).tokenize(RAW, {
+      ruleId: 'secrets/test-rule',
+      category: 'secret',
+      provider: 'aws',
+      maskedMatch: 'vau…est',
+    });
+    if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
+    return pointer;
+  } finally {
+    db.close();
+  }
+}
+
+function inventory(): VaultInventoryEntry[] {
+  const db = openLocalDatabase(dataDir());
+  try {
+    return db.secretVault.listInventory();
+  } finally {
+    db.close();
+  }
+}
+
+function seededPointerId(): string {
+  const entry = inventory()[0];
+  if (entry === undefined) throw new Error('no vault entry seeded');
+  return entry.pointerId;
+}
+
+interface DerefRow {
+  reason: string;
+  outcome: string;
+  target: string;
+}
+
+function derefRows(): DerefRow[] {
+  const raw = new DatabaseSync(dbPath(), { readOnly: true });
+  try {
+    return raw
+      .prepare('SELECT reason, outcome, target FROM secret_vault_deref ORDER BY rowid')
+      .all() as unknown as DerefRow[];
+  } finally {
+    raw.close();
+  }
+}
+
+function entryCount(): number {
+  const raw = new DatabaseSync(dbPath(), { readOnly: true });
+  try {
+    const row = raw.prepare('SELECT COUNT(*) AS n FROM secret_vault').get() as { n: number };
+    return row.n;
+  } finally {
+    raw.close();
+  }
+}
+
+describe('revealEntry', () => {
+  it('returns the raw value and writes exactly one explicit-reveal deref row', async () => {
+    await seedPointer();
+    const result = await revealEntry({ pointerId: seededPointerId() });
+
+    expect(result).toEqual({ ok: true, value: RAW });
+    expect(derefRows()).toEqual([
+      { reason: 'explicit-reveal', outcome: 'revealed', target: 'human' },
+    ]);
+  });
+});
+
+describe('revokeRevealGrant', () => {
+  it('flips the inventory row activeRevealGrant to null', async () => {
+    const pointer = await seedPointer();
+    const granted = await grantRevealFromPointer({
+      pointer,
+      scope: '1h',
+      justification: 'integration test needs the live key',
+    });
+    expect(granted.ok).toBe(true);
+
+    const before = inventory()[0];
+    expect(before?.revealGrantId).not.toBeNull();
+    if (before?.revealGrantId == null) throw new Error('unreachable');
+
+    const result = await revokeRevealGrant({ grantId: before.revealGrantId });
+    expect(result).toEqual({ ok: true });
+    expect(inventory()[0]?.revealGrantId).toBeNull();
+  });
+});
+
+describe('purgeVault', () => {
+  it('rejects anything but the typed confirmation, touching nothing', async () => {
+    await seedPointer();
+    const result = await purgeVault({ confirmation: 'Purge' });
+
+    expect(result.ok).toBe(false);
+    expect(entryCount()).toBe(1);
+    expect(derefRows()).toEqual([]);
+  });
+
+  it('destroys every entry while the deref audit survives', async () => {
+    await seedPointer();
+    const pointerId = seededPointerId();
+    // A reveal first, so the purge must preserve a pre-existing audit row too.
+    await revealEntry({ pointerId });
+
+    const result = await purgeVault({ confirmation: 'purge' });
+    expect(result).toEqual({ ok: true, destroyed: 1 });
+    expect(entryCount()).toBe(0);
+
+    // The audit outlives the values: the earlier reveal row plus the purge's
+    // own record.
+    expect(derefRows()).toEqual([
+      { reason: 'explicit-reveal', outcome: 'revealed', target: 'human' },
+      { reason: 'purge', outcome: 'unavailable', target: 'human' },
+    ]);
+
+    // Every pointer is now permanently unresolvable.
+    const after = await revealEntry({ pointerId });
+    expect(after).toEqual({ ok: true, value: null });
+  });
+});
+
+describe('rotateVaultKey', () => {
+  it('bumps the epoch, re-encrypts, and pre-rotation pointers still resolve', async () => {
+    const pointer = await seedPointer();
+
+    const result = await rotateVaultKey();
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('unreachable');
+    expect(result.version).toBeGreaterThan(1);
+    expect(result.reEncrypted).toBe(1);
+
+    // The survival property: a pointer minted under the previous epoch keeps
+    // detokenizing — its tag verifies against the historical epoch it names.
+    const db = openLocalDatabase(dataDir());
+    try {
+      const value = await buildVault(db).detokenize(pointer, {
+        target: 'human',
+        reason: 'explicit-reveal',
+      });
+      expect(value).toBe(RAW);
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

The read half of the vault: what is stored, where its pointers have gone, who de-referenced what, and the controls that end it.

## Sightings — the piece this hinged on

The reuse view and pointer-artifacts listing both need to answer *where* a pointer has gone, and nothing recorded that. A new ledger captures every place a pointer lands — file paths from Write/Edit rewrites, tool surfaces, prompts, transcripts — one row per (pointer, location), threaded through every tokenize call site as best-effort bookkeeping.

This is the amended threat model's mitigation made real: **deterministic pointers are correlatable by design**, and the ledger makes that correlation visible to the *owner* instead of discoverable only by whoever greps the artifacts. Like the deref trail, it deliberately survives a purge — where pointers went is evidence that must outlive the values.

## Views

Inventory (descriptor data + sightings + grant badges, raw-free — no fingerprint, no ciphertext), reuse (values in more than one place, ranked, claim scoped honestly to "on this machine"), and the deref audit with the batched high-volume reasons hidden behind a count by default — the rows that matter are the model crossings, **revealed and refused**, and they render prominently.

## Controls

`revealEntry` is a new owner-surface path: there is no wire token to verify, because a server-side row id from the owner's own store is not untrusted text — the tag exists to stop forged tokens arriving in text. It is audited identically to any human deref and structurally never callable toward the model. Plus revoke, rotate (pre-rotation pointers keep resolving — a test), and purge behind a typed confirmation stating the consequence.

Migration 0017. Verified through the built plugin: one value written via the Write hook and blocked in a prompt records one vault row with two sightings.