### PR TITLE
vault 09/10: setup-wizard vault consent step and stale-grant notice

### DIFF
--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -1,6 +1,6 @@
 'use client';
 import type { WorkspaceSettings } from '@akasecurity/schema';
-import { isModelJudgeConsentValid } from '@akasecurity/schema';
+import { isModelJudgeConsentValid, isVaultConsentValid } from '@akasecurity/schema';
 import { Button, cn } from '@akasecurity/ui-kit';
 import { useState } from 'react';
 
@@ -127,6 +127,18 @@ export function vaultChoiceOf(vaultConsent: WorkspaceSettings['vaultConsent']): 
   return vaultConsent ? 'on' : 'off';
 }
 
+// A grant recorded against an older consent version no longer authorizes
+// vaulting — the version bump means what the vault does has widened since the
+// user agreed. The form still derives 'on' (a grant exists) but must say the
+// grant is dormant and re-saving re-consents at the current version.
+export function vaultConsentStale(vaultConsent: WorkspaceSettings['vaultConsent']): boolean {
+  return vaultConsent !== undefined && !isVaultConsentValid(vaultConsent);
+}
+
+export const VAULT_STALE_NOTICE =
+  'Your grant was recorded against an older version of the vault — vaulting is paused ' +
+  'until you re-consent. Saving with "Vault & redact" selected re-consents to the current version.';
+
 function ChoiceGroup<T extends string>({
   name,
   choices,
@@ -247,6 +259,11 @@ export function WorkspaceSettingsFormView({
       <section className="rounded-xl border border-border bg-surface p-5">
         <SectionLabel>{VAULT_SECTION_LABEL}</SectionLabel>
         <p className="mb-3 text-xs text-text-3">{VAULT_SECTION_DESCRIPTION}</p>
+        {vaultConsentStale(settings.vaultConsent) ? (
+          <p className="mb-3 text-xs text-sev-high" data-slot="vault-stale-notice">
+            {VAULT_STALE_NOTICE}
+          </p>
+        ) : null}
         <ChoiceGroup
           name="vaultConsent"
           choices={VAULT_CHOICES}

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -14,7 +14,9 @@ import {
   VAULT_CHOICES,
   VAULT_SECTION_DESCRIPTION,
   VAULT_SECTION_LABEL,
+  VAULT_STALE_NOTICE,
   vaultChoiceOf,
+  vaultConsentStale,
   type WorkspaceSettingsFormViewProps,
 } from '../../src/settings/WorkspaceSettingsFormView.tsx';
 
@@ -189,5 +191,28 @@ describe('WorkspaceSettingsFormView vault-consent section', () => {
     // carries the bare 'off' | 'on' string and nothing a client could forge.
     type Emitted = Parameters<WorkspaceSettingsFormViewProps['onSave']>[0]['vaultConsent'];
     expectTypeOf<Emitted>().toEqualTypeOf<'off' | 'on'>();
+  });
+});
+
+describe('stale vault grant', () => {
+  it('is stale only when a grant exists at an older version', () => {
+    expect(vaultConsentStale(undefined)).toBe(false);
+    expect(
+      vaultConsentStale({
+        acknowledgedAt: '2026-07-30T00:00:00.000Z',
+        version: VAULT_CONSENT_VERSION,
+      }),
+    ).toBe(false);
+    expect(
+      vaultConsentStale({
+        acknowledgedAt: '2026-07-30T00:00:00.000Z',
+        version: VAULT_CONSENT_VERSION - 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('the notice says vaulting is paused and how re-consent happens', () => {
+    expect(VAULT_STALE_NOTICE).toContain('paused');
+    expect(VAULT_STALE_NOTICE).toContain('re-consent');
   });
 });

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -163,11 +163,72 @@ broadens nothing about what AKA may access. Those granular scope and revocation 
 stay inspectable on request and in the dashboard, under **Settings → Historical access**,
 whose own copy repeats the model-API disclosure.
 
+## 1b. Offer the reversible vault
+
+Ask this right after the scan question, on **both** answers to it — vaulting
+governs the live session either way, and asking before the backfill means a
+"yes" here lets that same backfill rewrite scanned history into recoverable
+pointers in one pass instead of leaving raw values sitting in transcripts.
+Use **AskUserQuestion**, as always — never a printed option list.
+
+**Disclose what changes before you show the picker — this is a custody change,
+and the user must see it before choosing.** State it plainly, in your own words,
+covering every point below; do not soften or skip any of them:
+
+- **Today, a detected secret is destroyed.** When a redact policy fires, the
+  value is replaced with `[REDACTED:…]` and is gone. With the vault, it is
+  replaced with a pointer like `[[aka:secret:…]]` instead, and an **encrypted,
+  recoverable copy is kept on this machine** — AES-256-GCM ciphertext in
+  `~/.aka/data`, key material in `~/.aka/keys` (keep that directory out of
+  backup and sync tools; an OS-keychain option exists in settings). Nothing is
+  sent anywhere — the vault is entirely local.
+- **The model only ever sees pointers.** It can keep working with them —
+  writing them into files, referring to them — without ever reading the value.
+  You see the real values in the dashboard's **Vault** page or with
+  `aka vault show <pointer>`; in the terminal, pointers in Claude's replies
+  render as masked badges by default (a full inline-reveal mode exists in
+  Settings, with its own risk disclosure there).
+- **Pointers are correlatable, and that is visible.** The same value always
+  gets the same pointer, so pointers written into files, commits, and
+  transcripts reveal **where** a secret is used and **which places share the
+  same secret** to anyone who can read those artifacts. The Vault page shows
+  you that same map (every sighting of every pointer) so the correlation is
+  never something only an outsider can see.
+- **What it unlocks:** a blocked prompt comes back with a paste-ready rewrite
+  (pointers in place of the secret) instead of a dead end; scanned history is
+  rewritten to recoverable pointers instead of staying raw on disk; and when
+  the agent genuinely needs a real value, you can grant it per-value with
+  `aka exception approve … --reveal-to-model` — audited every time.
+- **Revoking stops future vaulting; it erases nothing.** Values already stored
+  stay recoverable to you until you **purge** the vault (Vault page — the purge
+  is the eraser, and it makes every pointer everywhere permanently
+  unresolvable). Both controls live in the dashboard.
+
+**Keep detected secrets recoverable?** — "Replace detected secrets with pointers and keep an encrypted copy on this machine, or keep destroying them?"
+
+Offer exactly two options:
+
+- **Vault them** — "reversible: pointers for the model, real values for me, everything local"
+- **No — keep destroying them** — "irreversible redaction, exactly as before"
+
+Neither answer is nudged; the honest trade is recoverability against holding a
+recoverable copy at all.
+
 ## 2. Save the answer, then branch
 
-Branch on the answer from step 1. On the **Yes, take a look** path the onboarding
-writer runs, and it must run **before** the backfill (step 3), because the
-backfill script reads `historicalAccess` from the saved settings to decide
+**First, record the vault answer from step 1b — on both branches.** A
+**Vault them** answer runs the writer below; a **No** answer records nothing
+(absence IS the un-consented state — there is no "declined" marker to write).
+This must also run **before** the backfill, so a granted vault lets the same
+sweep rewrite scanned history into recoverable pointers:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/onboard.js" --vault-consent grant
+```
+
+Then branch on the answer from step 1. On the **Yes, take a look** path the
+onboarding writer runs, and it must run **before** the backfill (step 3), because
+the backfill script reads `historicalAccess` from the saved settings to decide
 whether it's allowed to run. Omitting `--policy` is deliberate — the old global
 redact/warn toggle no longer drives enforcement (posture is per-category now);
 its field is kept for backward compatibility but this wizard doesn't ask about

--- a/plugins/claude-code/test/setup-vault-consent-copy.test.ts
+++ b/plugins/claude-code/test/setup-vault-consent-copy.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// The wizard's vault-consent step is the disclosure the grant rests on. These
+// assertions pin its SUBSTANCE — a copy edit that drops one of these facts
+// changes what the user consented to, and must fail loudly here rather than
+// ship silently.
+const setupMd = readFileSync(
+  fileURLToPath(new URL('../commands/setup.md', import.meta.url)),
+  'utf8',
+);
+
+describe('setup.md vault-consent step', () => {
+  it('exists as its own step with the picker contract', () => {
+    expect(setupMd).toContain('## 1b. Offer the reversible vault');
+    expect(setupMd).toContain('Keep detected secrets recoverable?');
+    expect(setupMd).toContain('Vault them');
+    expect(setupMd).toContain('No — keep destroying them');
+  });
+
+  it('states the custody change: recoverable, encrypted, local', () => {
+    expect(setupMd).toContain('encrypted,\n  recoverable copy is kept on this machine');
+    expect(setupMd).toContain('AES-256-GCM');
+    expect(setupMd).toContain('the vault is entirely local');
+  });
+
+  it('names the key directory and the backup exclusion', () => {
+    expect(setupMd).toContain('~/.aka/keys');
+    expect(setupMd).toMatch(/out of\s+backup and sync tools/);
+  });
+
+  it('states the pointer-correlation exposure', () => {
+    expect(setupMd).toMatch(/which places share the\s+same secret/);
+    expect(setupMd).toMatch(/anyone who can read those artifacts/);
+  });
+
+  it('states that revocation is not erasure, and names the purge', () => {
+    expect(setupMd).toContain('Revoking stops future vaulting; it erases nothing');
+    expect(setupMd).toMatch(/purge[\s\S]{0,120}permanently\s+unresolvable/);
+  });
+
+  it('records the grant before the backfill, on both branches', () => {
+    expect(setupMd).toContain('--vault-consent grant');
+    const record = setupMd.indexOf('--vault-consent grant');
+    const backfill = setupMd.indexOf('backfill.js" --triage');
+    expect(record).toBeGreaterThan(-1);
+    expect(backfill).toBeGreaterThan(record);
+    expect(setupMd).toMatch(/on both branches/i);
+    // Declining writes nothing — absence is the un-consented state; the wizard
+    // must never mint a "declined" marker.
+    expect(setupMd).toContain('absence IS the un-consented state');
+  });
+
+  it('keeps the reveal-mode risk pointed at its own disclosure surface', () => {
+    expect(setupMd).toMatch(/masked badges by default/);
+    expect(setupMd).toMatch(/full inline-reveal mode exists in\s+Settings/);
+  });
+});


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

The consent the whole vault rests on, asked properly.

The wizard offers the reversible vault right after the historical-scan question and on **both** of its branches, with the disclosure stated **before** the picker:

- the custody change — a detected secret is no longer destroyed; an encrypted, recoverable copy is kept on this machine (AES-256-GCM in `~/.aka/data`, key material in `~/.aka/keys`, keep it out of backup tools)
- the model only ever sees pointers, while the human resolves real values in the dashboard or `aka vault show`
- **deterministic pointers written into files and commits reveal where secrets are used and which places share the same secret** to anyone who can read those artifacts — and the Vault page shows the owner that same map
- what vaulting unlocks (paste-ready resubmit, scrubbed history, per-value reveal grants)
- revoking stops future vaulting but **erases nothing** — the purge is the eraser

Neither answer is nudged. The grant records **before** the backfill runs, so a double-yes rewrites scanned history into recoverable pointers in the same pass; declining writes nothing, because absence *is* the un-consented state.

## The guard

A copy test pins the disclosure's substance: an edit that drops the custody change, the correlation exposure, the revocation-is-not-erasure line, or the record-before-backfill ordering fails the suite instead of silently narrowing what the user consented to.

## Also

A grant recorded against an older consent version now shows a plain notice — vaulting is paused, re-saving re-consents — instead of rendering indistinguishably from an active grant.