### PR TITLE
vault 10/10: harden against the deep-review findings

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -396,7 +396,11 @@ async function pickBlocked(
   const answer = await io.ask(`Which one? [1-${String(entries.length)}]: `);
   const index = Number.parseInt(answer.trim(), 10);
   const picked = Number.isInteger(index) ? entries[index - 1] : undefined;
-  if (!picked) throw new Error(`invalid choice '${answer.trim()}'`);
+  // Never echo the answer: the prompt sits under a list of the user's own
+  // blocked secrets, and a pasted VALUE instead of a number must not land in
+  // stderr or captured logs.
+  if (!picked)
+    throw new Error(`invalid choice — enter a number between 1 and ${String(entries.length)}`);
   return picked;
 }
 
@@ -900,9 +904,9 @@ async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
         return;
       }
     }
-    let version: number;
+    let next: FingerprintKey;
     try {
-      version = rotateFingerprintKey(dir).version;
+      next = rotateFingerprintKey(dir);
     } catch (err) {
       // An unusable key file must not print a stack trace — surface the reason
       // with a way forward matched to it. (Grants under a corrupt key already
@@ -911,8 +915,33 @@ async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
       throw new Error(`cannot rotate: ${message}\n${keyAccessHint(err, dir)}`, { cause: err });
     }
     io.out(
-      `Fingerprint key rotated — new key version v${String(version)}.\nExisting grants no longer match; re-approve deliberately where still needed.\n`,
+      `Fingerprint key rotated — new key version v${String(next.version)}.\nExisting grants no longer match; re-approve deliberately where still needed.\n`,
     );
+    // Grants invalidate by design; vault entries must NOT. Re-key their
+    // fingerprints under the new epoch so dedup keeps finding stored values —
+    // otherwise a re-detected value fingerprints under the new key, misses its
+    // row, and mints a second pointer for the same secret. Best-effort: a
+    // partial refresh degrades to skipped rows resolving under their old
+    // epoch, so a fault here must not fail the rotation that already happened.
+    try {
+      const base = homeBase(values.home);
+      const vault = new SecretVault({
+        repo: db.secretVault,
+        keys: createKeyProvider(readWorkspaceSettings(base).vaultKeyCustody, keysDir(base)),
+        fingerprintKey: next,
+        isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
+      });
+      const refreshed = await vault.refreshFingerprints(next);
+      if (refreshed > 0) {
+        io.out(
+          `Vault re-keyed — ${String(refreshed)} stored ${refreshed === 1 ? 'value' : 'values'} follow the new key; pointers are unchanged.\n`,
+        );
+      }
+    } catch {
+      io.out(
+        'Warning: the vault could not be re-keyed under the new fingerprint key.\nStored values still resolve, but re-detections may mint new pointers until it succeeds.\n',
+      );
+    }
   } finally {
     db.close();
   }

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -239,6 +239,27 @@ describe('aka exception approve <pointer> --reveal', () => {
       db.close();
     }
   });
+
+  // The only friction on a never-expiring reveal is the deliberate
+  // confirmation; non-interactively that means --yes or nothing.
+  it('refuses --permanent non-interactively without --yes, creating nothing', async () => {
+    const pointer = await seedPointer();
+    await expect(
+      runException(approveArgs(pointer, '--reveal', '--permanent', '--reason', 'x'), scriptedIo()),
+    ).rejects.toThrow(/--yes|interactive/);
+    expect(await openAndList()).toHaveLength(0);
+  });
+
+  it('accepts --permanent with --yes', async () => {
+    const pointer = await seedPointer();
+    await runException(
+      approveArgs(pointer, '--reveal', '--permanent', '--yes', '--reason', 'x'),
+      scriptedIo(),
+    );
+    const grants = await openAndList();
+    expect(grants[0]?.scope).toBe('permanent');
+    expect(grants[0]?.capability).toBe('reveal_to_model');
+  });
 });
 
 // Read every exception row (including terminal) from the store.

--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -117,12 +117,42 @@ export const VAULT_CHOICES: Choice<VaultConsentChoice>[] = [
       'transcripts show where each secret is used, and which places share the same ' +
       'secret, to anyone who can read those files. Switching back to Off stops new ' +
       'vaulting but does not erase what is already stored — purging the vault from the ' +
-      'CLI is what erases it.',
+      "dashboard's Vault page is what erases it.",
   },
 ];
 
 // The stored grant maps to the form choice: a recorded consent renders as 'on',
 // an absent one as 'off'.
+export const INLINE_REVEAL_SECTION_LABEL = 'Inline reveal in the terminal';
+
+export const INLINE_REVEAL_SECTION_DESCRIPTION =
+  "How a vault pointer renders inside Claude's on-screen replies. Display-only — the " +
+  'transcript and what the model sees always keep the pointer.';
+
+export const INLINE_REVEAL_CHOICES: Choice<WorkspaceSettings['vaultInlineReveal']>[] = [
+  {
+    value: 'masked',
+    label: 'Masked badge (default)',
+    description:
+      'Pointers render as a masked badge (category and partial value). No raw value is ' +
+      'resolved and nothing is written to the audit trail.',
+  },
+  {
+    value: 'full',
+    label: 'Full reveal',
+    description:
+      'Pointers resolve to the real value on screen, capped at two per message and never ' +
+      'inside code blocks or quotes. The risk is real: anything the model is induced to ' +
+      'mention renders in plaintext where it can be shoulder-surfed, screen-shared, or ' +
+      'copy-pasted onward. Every reveal is audited.',
+  },
+  {
+    value: 'off',
+    label: 'Off',
+    description: 'Replies are not modified; pointers show as-is.',
+  },
+];
+
 export function vaultChoiceOf(vaultConsent: WorkspaceSettings['vaultConsent']): VaultConsentChoice {
   return vaultConsent ? 'on' : 'off';
 }
@@ -187,7 +217,7 @@ export interface WorkspaceSettingsFormViewProps {
   // timestamps and versions are stamped server-side, so a client-supplied one
   // would only be discarded. modelJudgeConsent: true grants, false revokes.
   onSave: (
-    changes: Pick<WorkspaceSettings, 'policy' | 'historicalAccess'> & {
+    changes: Pick<WorkspaceSettings, 'policy' | 'historicalAccess' | 'vaultInlineReveal'> & {
       modelJudgeConsent: boolean;
       vaultConsent: VaultConsentChoice;
     },
@@ -220,11 +250,17 @@ export function WorkspaceSettingsFormView({
     : 'revoked';
   const [modelJudge, setModelJudge] = useState<ModelJudgeChoice>(initialModelJudge);
   const [vaultConsent, setVaultConsent] = useState(vaultChoiceOf(settings.vaultConsent));
+  const [inlineReveal, setInlineReveal] = useState(settings.vaultInlineReveal);
   const dirty =
     policy !== settings.policy ||
     historicalAccess !== settings.historicalAccess ||
     modelJudge !== initialModelJudge ||
-    vaultConsent !== vaultChoiceOf(settings.vaultConsent);
+    vaultConsent !== vaultChoiceOf(settings.vaultConsent) ||
+    inlineReveal !== settings.vaultInlineReveal ||
+    // A stale grant renders as 'on' but authorizes nothing; keeping 'on'
+    // selected and saving is the documented one-save re-consent, so staleness
+    // itself must enable Save.
+    (vaultConsent === 'on' && vaultConsentStale(settings.vaultConsent));
 
   return (
     <div className="flex max-w-2xl flex-col gap-6">
@@ -272,6 +308,17 @@ export function WorkspaceSettingsFormView({
         />
       </section>
 
+      <section>
+        <SectionLabel>{INLINE_REVEAL_SECTION_LABEL}</SectionLabel>
+        <p className="mb-3 text-xs text-text-3">{INLINE_REVEAL_SECTION_DESCRIPTION}</p>
+        <ChoiceGroup
+          name="vaultInlineReveal"
+          choices={INLINE_REVEAL_CHOICES}
+          value={inlineReveal}
+          onChange={setInlineReveal}
+        />
+      </section>
+
       <div className="flex items-center gap-3">
         <Button
           variant="solid"
@@ -286,6 +333,7 @@ export function WorkspaceSettingsFormView({
               // and the versions the grants are recorded against.
               modelJudgeConsent: modelJudge === 'granted',
               vaultConsent,
+              vaultInlineReveal: inlineReveal,
             });
           }}
         >

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -1,4 +1,7 @@
+import type { WorkspaceSettings } from '@akasecurity/schema';
 import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 
 import {
@@ -7,6 +10,8 @@ import {
   HISTORICAL_CHOICES,
   HISTORICAL_SECTION_DESCRIPTION,
   HISTORICAL_SECTION_LABEL,
+  INLINE_REVEAL_CHOICES,
+  INLINE_REVEAL_SECTION_DESCRIPTION,
   MODEL_JUDGE_CHOICES,
   MODEL_JUDGE_SECTION_DESCRIPTION,
   MODEL_JUDGE_SECTION_LABEL,
@@ -17,6 +22,7 @@ import {
   VAULT_STALE_NOTICE,
   vaultChoiceOf,
   vaultConsentStale,
+  WorkspaceSettingsFormView,
   type WorkspaceSettingsFormViewProps,
 } from '../../src/settings/WorkspaceSettingsFormView.tsx';
 
@@ -179,7 +185,7 @@ describe('WorkspaceSettingsFormView vault-consent section', () => {
 
   it('does not present switching off as an eraser — the CLI purge is', () => {
     expect(on?.description).toMatch(/does not erase/i);
-    expect(on?.description).toMatch(/purging the vault from the CLI/i);
+    expect(on?.description).toMatch(/purging the vault from the dashboard's Vault page/i);
   });
 
   it('keeps the off default free of any storage', () => {
@@ -214,5 +220,59 @@ describe('stale vault grant', () => {
   it('the notice says vaulting is paused and how re-consent happens', () => {
     expect(VAULT_STALE_NOTICE).toContain('paused');
     expect(VAULT_STALE_NOTICE).toContain('re-consent');
+  });
+});
+
+describe('inline reveal section', () => {
+  it('offers the three modes with masked as the labelled default', () => {
+    expect(INLINE_REVEAL_CHOICES.map((c) => c.value)).toEqual(['masked', 'full', 'off']);
+    expect(INLINE_REVEAL_CHOICES[0]?.label).toContain('default');
+  });
+
+  // The full-mode copy is the risk disclosure the consent step defers to — it
+  // must name the exposure, the cap, and the audit.
+  it('full-mode copy names the risk, the cap, and the audit', () => {
+    const full = INLINE_REVEAL_CHOICES.find((c) => c.value === 'full');
+    expect(full?.description).toMatch(/shoulder-surfed|screen-shared/);
+    expect(full?.description).toContain('two per message');
+    expect(full?.description).toContain('audited');
+  });
+
+  it('the section states it is display-only', () => {
+    expect(INLINE_REVEAL_SECTION_DESCRIPTION).toContain('Display-only');
+  });
+});
+
+describe('stale grant enables the one-save re-consent', () => {
+  const staleSettings: WorkspaceSettings = {
+    specVersion: 5,
+    runMode: 'standalone',
+    policy: 'redact',
+    historicalAccess: 'session-only',
+    dataSharesInPlace: true,
+    vaultKeyCustody: 'file',
+    vaultInlineReveal: 'masked',
+    vaultConsent: {
+      acknowledgedAt: '2020-01-01T00:00:00.000Z',
+      version: VAULT_CONSENT_VERSION + 1,
+    },
+  };
+
+  it('renders the notice AND an enabled Save button, untouched', () => {
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceSettingsFormView, {
+        settings: staleSettings,
+        onSave: () => undefined,
+        busy: false,
+      }),
+    );
+    expect(html).toContain('data-slot="vault-stale-notice"');
+    // The documented recovery is ONE save with 'on' selected — so the button
+    // must not be disabled by the form starting clean.
+    // React renders the boolean attribute as disabled="" — the Tailwind
+    // `disabled:` variant classes must not trip this assertion.
+    const saveButton = /<button[^>]*>(?:[^<]*Save changes[^<]*)<\/button>/.exec(html)?.[0] ?? '';
+    expect(saveButton).not.toBe('');
+    expect(saveButton).not.toContain('disabled=""');
   });
 });

--- a/packages/detections/src/index.ts
+++ b/packages/detections/src/index.ts
@@ -19,6 +19,8 @@ export { resolveEgress } from './egress/resolve.ts';
 export type { ScanContext } from './engine.ts';
 export { getLoadedRules, redact, registerPack, scan } from './engine.ts';
 export { maskMatch } from './mask.ts';
+export type { ShieldedSpan, ShieldedText } from './pointer-shield.ts';
+export { dropShieldedFindings, shieldPointers } from './pointer-shield.ts';
 export {
   CONFIG_POSTURE_RULES,
   configPostureDefinitions,

--- a/packages/detections/src/pointer-shield.ts
+++ b/packages/detections/src/pointer-shield.ts
@@ -1,0 +1,55 @@
+// Keeps vault pointers out of the detection engine's sight.
+//
+// A pointer's base32 body is exactly the kind of high-entropy string a generic
+// secret rule matches, and rule packs are user-installable — so "no rule ever
+// matches a pointer" cannot be guaranteed by auditing rule content. It is
+// guaranteed here instead: every scan surface blanks pointer spans out of the
+// text BEFORE the engine runs, so detection cannot see a pointer body at all,
+// whatever rules are installed. Without this, a matching rule would re-tokenize
+// a pointer (a pointer to a pointer), re-block a pointerized resubmit, or
+// corrupt a transcript rewrite.
+import { pointerTokenScanner } from '@akasecurity/schema';
+
+export interface ShieldedSpan {
+  start: number;
+  end: number;
+}
+
+export interface ShieldedText {
+  // The input with every pointer span replaced by same-length filler, so every
+  // offset outside the pointers is identical to the original.
+  text: string;
+  spans: ShieldedSpan[];
+}
+
+// The filler is a repeated space: no rule matches whitespace, and a same-length
+// substitution keeps every other span's offsets valid against the original.
+export function shieldPointers(text: string): ShieldedText {
+  const spans: ShieldedSpan[] = [];
+  let out: string | null = null;
+  for (const match of text.matchAll(pointerTokenScanner())) {
+    spans.push({ start: match.index, end: match.index + match[0].length });
+    out ??= text;
+    out =
+      out.slice(0, match.index) +
+      ' '.repeat(match[0].length) +
+      out.slice(match.index + match[0].length);
+  }
+  return { text: out ?? text, spans };
+}
+
+/**
+ * Drop findings that touch a shielded span. The filler should never match, but
+ * a rule whose span merely brushes a blanked region (a keyword before it plus a
+ * window across it) could still produce a finding whose rawMatch mixes real
+ * text with filler — worthless to enforce on and wrong to vault.
+ */
+export function dropShieldedFindings<T extends { span: { start: number; end: number } }>(
+  findings: T[],
+  spans: ShieldedSpan[],
+): T[] {
+  if (spans.length === 0) return findings;
+  return findings.filter(
+    (finding) => !spans.some((s) => finding.span.start < s.end && finding.span.end > s.start),
+  );
+}

--- a/packages/detections/test/pointer-shield.test.ts
+++ b/packages/detections/test/pointer-shield.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { dropShieldedFindings, shieldPointers } from '../src/pointer-shield.ts';
+
+const POINTER = `[[aka:secret:AE.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
+const SECRET = 'AKIAIOSFODNN7EXAMPLE';
+
+describe('shieldPointers', () => {
+  it('blanks pointer spans with same-length filler', () => {
+    const text = `before ${POINTER} after`;
+    const shielded = shieldPointers(text);
+    expect(shielded.text.length).toBe(text.length);
+    expect(shielded.text).toBe(`before ${' '.repeat(POINTER.length)} after`);
+    expect(shielded.spans).toEqual([{ start: 7, end: 7 + POINTER.length }]);
+  });
+
+  it('keeps every non-pointer offset identical', () => {
+    const text = `a ${POINTER} ${SECRET} z`;
+    const shielded = shieldPointers(text);
+    const secretAt = text.indexOf(SECRET);
+    expect(shielded.text.slice(secretAt, secretAt + SECRET.length)).toBe(SECRET);
+  });
+
+  it('passes pointer-free text through untouched', () => {
+    const shielded = shieldPointers('nothing here');
+    expect(shielded.text).toBe('nothing here');
+    expect(shielded.spans).toEqual([]);
+  });
+
+  it('does not blank a lookalike with an invented category', () => {
+    const lookalike = `[[aka:bogus:AE.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
+    expect(shieldPointers(lookalike).spans).toEqual([]);
+  });
+});
+
+describe('dropShieldedFindings', () => {
+  it('drops a finding that touches a shielded span', () => {
+    const findings = [
+      { span: { start: 0, end: 10 } },
+      { span: { start: 5, end: 25 } },
+      { span: { start: 30, end: 40 } },
+    ];
+    expect(dropShieldedFindings(findings, [{ start: 8, end: 28 }])).toEqual([
+      { span: { start: 30, end: 40 } },
+    ]);
+  });
+});

--- a/packages/local-ops/src/fs-scan.ts
+++ b/packages/local-ops/src/fs-scan.ts
@@ -4,6 +4,7 @@ import { basename, extname, join, relative, resolve } from 'node:path';
 
 import type { FileEgressHits } from '@akasecurity/detections';
 import {
+  dropShieldedFindings,
   EGRESS_CODE_EXTENSIONS,
   extractEgress,
   extractManifestSdks,
@@ -13,6 +14,7 @@ import {
   maskMatch,
   redact,
   scan,
+  shieldPointers,
 } from '@akasecurity/detections';
 import type { FingerprintKey, LocalDatabase } from '@akasecurity/persistence';
 import {
@@ -308,7 +310,14 @@ export function scanPathIntoStore(
     const fileEgress = extractFileEgress(file, text);
     if (fileEgress) egressFiles.push(fileEgress);
 
-    const matches = scan(text, opts.rules);
+    // Files legitimately contain vault pointers (the plugin's Write/Edit hook
+    // puts them there), and a pointer's base32 body is exactly what a generic
+    // entropy rule matches. Shield pointer spans BEFORE the engine runs — the
+    // same-length filler keeps every other span's offsets valid against the
+    // original text, so redaction and stored spans below still line up — and
+    // drop any finding that touches a shielded span.
+    const shielded = shieldPointers(text);
+    const matches = dropShieldedFindings(scan(shielded.text, opts.rules), shielded.spans);
     if (matches.length === 0) continue;
 
     const eventId = randomUUID();

--- a/packages/local-ops/test/fs-scan.test.ts
+++ b/packages/local-ops/test/fs-scan.test.ts
@@ -339,6 +339,69 @@ describe('scanPathIntoStore — finding_key (re-scan reconciliation)', () => {
   });
 });
 
+// Files legitimately contain vault pointers (the plugin's Write/Edit hook puts
+// them there), and rule packs are user-installable — so a hostile entropy-style
+// rule that matches base32 runs (the exact shape of a pointer body) can always
+// exist. The shield blanks pointer spans before the engine runs; these cases
+// pin that fs-scan is one of the shielded surfaces.
+describe('scanPathIntoStore — pointer shield', () => {
+  const POINTER = `[[aka:secret:AE.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
+  // A deliberately hostile rule matching base32 runs — it would re-detect a
+  // pointer body if the shield were absent. It also matches SECRET.
+  const HOSTILE_RULES: Rule[] = [
+    {
+      specVersion: 1,
+      id: 'shield-test/base32-run',
+      name: 'Base32 run (hostile fixture)',
+      category: 'secret',
+      severity: 'high',
+      matcher: { type: 'regex', pattern: '[A-Z2-7]{20,}', flags: 'g' },
+    },
+  ];
+
+  it('reports a real secret beside a pointer (correct span) and nothing inside the pointer', () => {
+    const content = `token = ${POINTER}\nkey = '${SECRET}'\n`;
+    writeFileSync(join(root, 'app.ts'), content);
+    const pointerStart = content.indexOf(POINTER);
+    const pointerEnd = pointerStart + POINTER.length;
+
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: HOSTILE_RULES });
+      expect(result.findings).toBe(1);
+      const finding = result.files[0]?.findings[0];
+      expect(finding).toBeDefined();
+      // The span addresses the secret in the ORIGINAL text — same-length
+      // shielding preserves every non-pointer offset.
+      expect(content.slice(finding?.span.start, finding?.span.end)).toBe(SECRET);
+      // Zero findings touch the pointer.
+      for (const f of result.files[0]?.findings ?? []) {
+        expect(f.span.start >= pointerEnd || f.span.end <= pointerStart).toBe(true);
+      }
+      // The stored event keeps the pointer intact — no [REDACTED] rewrite of
+      // pointer text — while the secret is redacted.
+      const [event] = storedEvents(store);
+      expect(event?.content).toContain(POINTER);
+      expect(event?.content).not.toContain(SECRET);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('yields nothing for an already-pointerized file (idempotence)', () => {
+    writeFileSync(join(root, 'app.ts'), `token = ${POINTER}\n`);
+    const db = openLocalDatabase(store);
+    try {
+      const result = scanPathIntoStore(db, root, { rules: HOSTILE_RULES });
+      expect(result.findings).toBe(0);
+      expect(result.files).toEqual([]);
+      expect(storedEvents(store)).toEqual([]);
+    } finally {
+      db.close();
+    }
+  });
+});
+
 // The egress collection pass rides the same walk as detection scanning. What it
 // runs on is decided entirely here — the walker has no extension filter — so
 // these cases pin the gating: code extensions get URL/IP extraction, manifests

--- a/packages/persistence/src/repositories/exceptions.ts
+++ b/packages/persistence/src/repositories/exceptions.ts
@@ -134,6 +134,21 @@ const ACTIVE_PREDICATE = `revoked_at IS NULL
      AND (max_uses IS NULL OR use_count < max_uses)`;
 
 /**
+ * A grant authorizes a MODEL reveal only while it is active, carries the
+ * reveal capability, and has no conditions — the reveal path does not evaluate
+ * conditions, and a narrowing clause that is ignored would WIDEN the grant, so
+ * a conditioned grant fails closed here.
+ *
+ * Exported as the single definition of "authorizes a reveal right now": the
+ * vault inventory's badge subquery interpolates this same string (binding
+ * `:now`), so the dashboard can never call a value revealable where the
+ * crossing itself would refuse.
+ */
+export const ACTIVE_REVEAL_GRANT_PREDICATE = `capability = 'reveal_to_model'
+     AND conditions IS NULL
+     AND ${ACTIVE_PREDICATE}`;
+
+/**
  * Detection-exception grants + the short-lived blocked-detections ledger,
  * bound to one open DB. An exception is keyed by (ruleId, keyed fingerprint of
  * the exact detected value): rows carry the HMAC fingerprint and a masked
@@ -443,6 +458,10 @@ export class SqliteExceptionsRepository {
    * authorize a reveal. Read-only: the caller does NOT consume here, because a
    * revealed value re-enters the detection scan immediately afterward and the
    * suppression match there claims the use — one crossing, one use.
+   *
+   * A grant with `conditions` NEVER matches here: the reveal path does not yet
+   * evaluate conditions, and a narrowing clause that is ignored would WIDEN the
+   * grant instead. Fail closed until reveal-side condition evaluation exists.
    */
   activeRevealGrant(
     ruleId: string,
@@ -455,8 +474,8 @@ export class SqliteExceptionsRepository {
         this.db.prepare(
           `SELECT id FROM exceptions
             WHERE rule_id = :ruleId AND value_fingerprint = :valueFingerprint
-              AND key_version = :keyVersion AND capability = 'reveal_to_model'
-              AND ${ACTIVE_PREDICATE}
+              AND key_version = :keyVersion
+              AND ${ACTIVE_REVEAL_GRANT_PREDICATE}
             LIMIT 1`,
         ),
         { ruleId, valueFingerprint, keyVersion, now },

--- a/packages/persistence/src/repositories/secret-vault.ts
+++ b/packages/persistence/src/repositories/secret-vault.ts
@@ -27,9 +27,11 @@ import type {
   VaultSighting,
   VaultSightingKind,
 } from '@akasecurity/schema';
+import { POINTER_FORMAT_VERSION } from '@akasecurity/schema';
 
 import { allRows, bindParams, countScalar, getRow } from '../internal/rows.ts';
 import { withTransaction } from '../internal/transactions.ts';
+import { ACTIVE_REVEAL_GRANT_PREDICATE } from './exceptions.ts';
 
 /** What a caller supplies when it asks for a value to be vaulted. */
 export interface VaultRowInsert {
@@ -37,6 +39,11 @@ export interface VaultRowInsert {
   valueFingerprint: string;
   fingerprintKeyVersion: number;
   keyVersion: number;
+  // The pointer-format generation the row's AAD is bound under — the AAD only,
+  // never a wire tag. Optional on insert; the store defaults it to format
+  // version 2, which is what every row written before the column existed was
+  // sealed under.
+  formatVersion?: number | undefined;
   category: string;
   ruleId: string;
   maskedMatch: string;
@@ -49,6 +56,8 @@ export interface VaultRowInsert {
 
 /** A stored row: the insert fields plus the counters the store maintains. */
 export interface VaultRow extends VaultRowInsert {
+  // Always present on a read — the column is NOT NULL with a default.
+  formatVersion: number;
   occurrenceCount: number;
   // epoch millis
   firstSeen: number;
@@ -79,6 +88,7 @@ const SELECT_COLUMNS = `
   value_fingerprint AS valueFingerprint,
   fingerprint_key_version AS fingerprintKeyVersion,
   key_version AS keyVersion,
+  format_version AS formatVersion,
   category,
   rule_id AS ruleId,
   masked_match AS maskedMatch,
@@ -113,12 +123,12 @@ export class SqliteSecretVaultRepository {
     this.insertStmt = db.prepare(
       `INSERT INTO secret_vault (
          pointer_id, value_fingerprint, fingerprint_key_version, key_version,
-         category, rule_id, masked_match, provider,
+         format_version, category, rule_id, masked_match, provider,
          ciphertext, nonce, auth_tag,
          occurrence_count, first_seen, last_seen
        ) VALUES (
          :pointerId, :valueFingerprint, :fingerprintKeyVersion, :keyVersion,
-         :category, :ruleId, :maskedMatch, :provider,
+         :formatVersion, :category, :ruleId, :maskedMatch, :provider,
          :ciphertext, :nonce, :authTag,
          1, :now, :now
        )`,
@@ -178,6 +188,7 @@ export class SqliteSecretVaultRepository {
               valueFingerprint: input.valueFingerprint,
               fingerprintKeyVersion: input.fingerprintKeyVersion,
               keyVersion: input.keyVersion,
+              formatVersion: input.formatVersion ?? POINTER_FORMAT_VERSION,
               category: input.category,
               ruleId: input.ruleId,
               maskedMatch: input.maskedMatch,
@@ -334,10 +345,7 @@ export class SqliteSecretVaultRepository {
                   WHERE e.rule_id = v.rule_id
                     AND e.value_fingerprint = v.value_fingerprint
                     AND e.key_version = v.fingerprint_key_version
-                    AND e.capability = 'reveal_to_model'
-                    AND e.revoked_at IS NULL
-                    AND (e.expires_at IS NULL OR e.expires_at > :now)
-                    AND (e.max_uses IS NULL OR e.use_count < e.max_uses)
+                    AND ${ACTIVE_REVEAL_GRANT_PREDICATE}
                   LIMIT 1) AS grant_id
            FROM secret_vault v
           ORDER BY v.last_seen DESC`,

--- a/packages/persistence/src/vault/crypto.ts
+++ b/packages/persistence/src/vault/crypto.ts
@@ -174,6 +174,19 @@ export function open(encKey: Buffer, sealed: SealedValue, aad: Buffer): string |
 
 // ─── Pointer tag ─────────────────────────────────────────────────────────────
 
+// The tag is bound to POINTER_FORMAT_VERSION and takes NO per-row format
+// version — deliberately, and it is the one field of the binding input that
+// does not.
+//
+// A tag is verified BEFORE the row is looked up, so that a forged pointer is
+// unattributable and writes no audit row. Verification therefore cannot know
+// which generation a row was sealed under, and anything that signs under a
+// per-row version produces tags this function cannot check. Pinning both sides
+// to the same constant is what makes them unable to disagree; a signature that
+// accepted a version would let them.
+//
+// A format bump must bring a verification story for tags on already-stored
+// rows — see POINTER_FORMAT_VERSION. Nothing below survives a bump on its own.
 export function signPointer(
   signKey: Buffer,
   keyVersion: number,
@@ -181,7 +194,7 @@ export function signPointer(
   category: string,
 ): Buffer {
   return createHmac('sha256', signKey)
-    .update(bindingInput(keyVersion, pointerId, category))
+    .update(bindingInput(keyVersion, pointerId, category, POINTER_FORMAT_VERSION))
     .digest()
     .subarray(0, TAG_BYTES);
 }

--- a/packages/persistence/src/vault/key-provider.ts
+++ b/packages/persistence/src/vault/key-provider.ts
@@ -19,7 +19,15 @@
 //             process against an OS service on this machine, no network hop.
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import { chmodSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { DATA_FILE_MODE, ensureDataDirSync } from '../paths.ts';
@@ -151,6 +159,119 @@ function asAsync<T>(work: () => T): Promise<T> {
   }
 }
 
+function asError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+// ─── Rotation lock ───────────────────────────────────────────────────────────
+
+const ROTATION_LOCK_STALE_MS = 60_000;
+
+// Names the holder, so release can tell "still mine" from "reclaimed by someone
+// else while I was working" and decline to remove a lock it no longer owns.
+const LOCK_OWNER_FILE = 'owner';
+
+const ROTATION_IN_PROGRESS = 'vault: a key rotation is already in progress';
+
+interface RotationLease {
+  lock: string;
+  owner: string;
+}
+
+// Create the lock directory and stamp it with this holder's token. False means
+// someone else already holds it. A failed stamp gives the directory back rather
+// than leaving behind a lock nobody can prove ownership of — and so release.
+function claimRotationLock(lock: string, owner: string): boolean {
+  try {
+    mkdirSync(lock);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw asError(err);
+  }
+  try {
+    writeFileSync(join(lock, LOCK_OWNER_FILE), `${owner}\n`, { mode: DATA_FILE_MODE });
+    return true;
+  } catch (err) {
+    rmSync(lock, { recursive: true, force: true });
+    throw asError(err);
+  }
+}
+
+/**
+ * Advisory lock guarding rotation: `mkdirSync` is atomic, so whichever process
+ * creates the lock directory owns the rotation, and a concurrent caller fails
+ * loudly instead of both minting a different next epoch. Rotation is a rare,
+ * user-initiated operation — surfacing contention as an error is correct.
+ * A lock left by a crashed process is reclaimed once it is older than the
+ * stale window.
+ */
+function acquireRotationLock(keysDir: string): RotationLease {
+  const lock = join(keysDir, `${VAULT_KEY_FILENAME}.lock`);
+  const owner = randomBytes(16).toString('hex');
+  if (claimRotationLock(lock, owner)) return { lock, owner };
+
+  let held: ReturnType<typeof statSync>;
+  try {
+    held = statSync(lock);
+  } catch {
+    // The lock vanished between the failed create and the stat: the other
+    // rotation just finished. The contention was still real; the caller retries.
+    throw new Error(ROTATION_IN_PROGRESS);
+  }
+  if (Date.now() - held.mtimeMs < ROTATION_LOCK_STALE_MS) throw new Error(ROTATION_IN_PROGRESS);
+
+  // Reclaim by MOVING the stale directory aside, never by deleting it in place.
+  // Delete-then-recreate is check-then-act: two processes that both judge one
+  // lock stale both delete and both create, and both believe they hold it. That
+  // needs no slow rotation to reach — a stale lock stays stale until somebody
+  // takes it, so any two attempts after a crash collide. A rename can only
+  // succeed for one of them.
+  //
+  // Identity is re-checked first, so a lock a third process legitimately took
+  // over since the staleness read is left alone instead of displaced. Identity
+  // is (inode, mtime) and NOT the inode alone: a filesystem is free to hand a
+  // freshly created directory the inode number it just reclaimed from a deleted
+  // one, so an inode match does not prove it is the same directory. A
+  // replacement lock is stamped at creation time and cannot also carry the old
+  // one's backdated mtime, which is what makes the pair conclusive.
+  const aside = `${lock}.stale.${owner}`;
+  try {
+    const now = statSync(lock);
+    if (now.ino !== held.ino || now.mtimeMs !== held.mtimeMs) {
+      throw new Error(ROTATION_IN_PROGRESS);
+    }
+    renameSync(lock, aside);
+  } catch (err) {
+    if (err instanceof Error && err.message === ROTATION_IN_PROGRESS) throw err;
+    throw new Error(ROTATION_IN_PROGRESS, { cause: err });
+  }
+  rmSync(aside, { recursive: true, force: true });
+  if (!claimRotationLock(lock, owner)) throw new Error(ROTATION_IN_PROGRESS);
+  return { lock, owner };
+}
+
+// Release only what this holder still owns. A lock reclaimed as stale while its
+// holder was still alive belongs to the reclaimer, and deleting it on the way
+// out would unlock the reclaimer and let a third caller walk in beside it.
+function releaseRotationLock(lease: RotationLease): void {
+  try {
+    if (readFileSync(join(lease.lock, LOCK_OWNER_FILE), 'utf8').trim() !== lease.owner) return;
+  } catch {
+    return;
+  }
+  rmSync(lease.lock, { recursive: true, force: true });
+}
+
+function withRotationLock<T>(keysDir: string, work: () => T): T {
+  ensureDataDirSync(keysDir);
+  const lease = acquireRotationLock(keysDir);
+  try {
+    return work();
+  } finally {
+    releaseRotationLock(lease);
+  }
+}
+
 // ─── File custody ────────────────────────────────────────────────────────────
 
 /**
@@ -174,7 +295,7 @@ export class FileKeyProvider implements KeyProvider {
   loadOrCreate(): Promise<VaultKeyMaterial> {
     return asAsync(() => {
       const existing = this.#read();
-      if (!existing) return currentOf(this.#write(mintKeyring()));
+      if (!existing) return currentOf(this.#createExclusive());
       // Re-tighten on every load, covering a file created before the mode was
       // enforced at write time.
       tightenFileMode(this.filePath);
@@ -183,12 +304,15 @@ export class FileKeyProvider implements KeyProvider {
   }
 
   rotate(): Promise<VaultKeyMaterial> {
-    return asAsync(() => {
-      const existing = this.#read();
-      // With no keyring yet there is nothing to rotate away from: the first
-      // epoch is minted instead, so rotation on a fresh machine is not a no-op.
-      return currentOf(this.#write(existing ? withNextEpoch(existing) : mintKeyring()));
-    });
+    return asAsync(() =>
+      withRotationLock(this.#keysDir, () => {
+        const existing = this.#read();
+        // With no keyring yet there is nothing to rotate away from: the first
+        // epoch is minted instead, so rotation on a fresh machine is not a no-op.
+        if (!existing) return currentOf(this.#createExclusive());
+        return currentOf(this.#write(withNextEpoch(existing)));
+      }),
+    );
   }
 
   materialFor(version: number): Promise<VaultKeyMaterial> {
@@ -211,7 +335,41 @@ export class FileKeyProvider implements KeyProvider {
     return parseKeyring(raw);
   }
 
-  /** Atomic tmp + rename so a crash mid-write cannot truncate the keyring. */
+  /**
+   * First mint: the keyring is created at its FINAL path with a
+   * creation-exclusive write, so two processes racing a fresh machine cannot
+   * each mint a different epoch 1 — with tmp + rename the loser's replace
+   * would orphan everything the winner had already sealed. On EEXIST the
+   * loser re-reads and adopts the winner's keyring; it minted nothing.
+   * Atomic replace is unnecessary here: nothing can be mid-read of a file
+   * that did not exist, and a torn exclusive write parses as corrupt on the
+   * next read and fails secure rather than being re-minted over.
+   */
+  #createExclusive(): Keyring {
+    ensureDataDirSync(this.#keysDir);
+    const keyring = mintKeyring();
+    try {
+      writeFileSync(this.filePath, `${serializeKeyring(keyring)}\n`, {
+        flag: 'wx',
+        mode: DATA_FILE_MODE,
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw asError(err);
+      const winner = this.#read();
+      if (!winner) {
+        throw new Error('vault: key file vanished during first mint', { cause: err });
+      }
+      return winner;
+    }
+    tightenFileMode(this.filePath);
+    return keyring;
+  }
+
+  /**
+   * Atomic tmp + rename so a crash mid-write cannot truncate the keyring.
+   * Used only for rotation, under the rotation lock — first creation goes
+   * through the creation-exclusive path instead.
+   */
   #write(keyring: Keyring): Keyring {
     ensureDataDirSync(this.#keysDir);
     const file = this.filePath;
@@ -233,24 +391,47 @@ function tightenFileMode(file: string): void {
 
 // ─── Keychain custody ────────────────────────────────────────────────────────
 
+/** Invokes the platform `security` binary with the given argv, returning stdout. */
+export type SecurityExec = (args: string[]) => string;
+
+const runSecurity: SecurityExec = (args) =>
+  execFileSync('/usr/bin/security', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+
+// `security find-generic-password` exit status for "no matching item exists"
+// (errSecItemNotFound). Every other non-zero exit — a locked keychain, a
+// denied ACL — is a failure, not absence.
+const SECURITY_ITEM_NOT_FOUND = 44;
+
 /**
  * Opt-in OS-keychain custody: the same versioned keyring JSON held as one
  * generic-password item, so the key bytes are not sitting in a readable file.
  *
  * macOS only. The bytes move through the local `security` binary as a child
- * process — an OS service on this machine, not a network call. Elsewhere the
+ * process — an OS service on this machine, not a network hop. Elsewhere the
  * constructor throws so the caller can fall back to file custody.
+ *
+ * On writes the keyring JSON rides in the child's argv (`-w <json>`), which is
+ * observable by same-UID processes for the duration of the exec. That is an
+ * accepted exposure under the local threat model: a same-UID process can
+ * already read the keychain item itself.
  */
 export class KeychainKeyProvider implements KeyProvider {
   readonly #keysDir: string;
+  readonly #exec: SecurityExec;
 
-  constructor(keysDir: string) {
-    if (process.platform !== 'darwin') {
+  constructor(keysDir: string, exec: SecurityExec = runSecurity) {
+    // The platform guard applies only to the real binary; an injected exec
+    // carries its own platform expectations.
+    if (exec === runSecurity && process.platform !== 'darwin') {
       throw new Error(
         `keychain custody is not available on this platform (${process.platform}); use file custody`,
       );
     }
     this.#keysDir = keysDir;
+    this.#exec = exec;
   }
 
   /** Where a fallback file provider for the same vault would keep its keyring. */
@@ -259,14 +440,23 @@ export class KeychainKeyProvider implements KeyProvider {
   }
 
   loadOrCreate(): Promise<VaultKeyMaterial> {
-    return asAsync(() => currentOf(this.#read() ?? this.#write(mintKeyring())));
+    return asAsync(() => {
+      const existing = this.#read();
+      if (existing) return currentOf(existing);
+      return currentOf(this.#create(mintKeyring()));
+    });
   }
 
   rotate(): Promise<VaultKeyMaterial> {
-    return asAsync(() => {
-      const existing = this.#read();
-      return currentOf(this.#write(existing ? withNextEpoch(existing) : mintKeyring()));
-    });
+    return asAsync(() =>
+      withRotationLock(this.#keysDir, () => {
+        const existing = this.#read();
+        // With no keyring yet there is nothing to rotate away from: the first
+        // epoch is minted instead, so rotation on a fresh machine is not a no-op.
+        if (!existing) return currentOf(this.#create(mintKeyring()));
+        return currentOf(this.#replace(withNextEpoch(existing)));
+      }),
+    );
   }
 
   materialFor(version: number): Promise<VaultKeyMaterial> {
@@ -281,40 +471,67 @@ export class KeychainKeyProvider implements KeyProvider {
   #read(): Keyring | null {
     let raw: string;
     try {
-      raw = execFileSync(
-        '/usr/bin/security',
-        ['find-generic-password', '-s', KEYCHAIN_SERVICE, '-a', KEYCHAIN_ACCOUNT, '-w'],
-        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+      raw = this.#exec([
+        'find-generic-password',
+        '-s',
+        KEYCHAIN_SERVICE,
+        '-a',
+        KEYCHAIN_ACCOUNT,
+        '-w',
+      ]);
+    } catch (err) {
+      // Only "no such item" may read as absence. A locked keychain or a
+      // denied ACL also exits non-zero, and reading those as absence would
+      // route into the mint path and orphan every existing ciphertext.
+      if ((err as { status?: unknown }).status === SECURITY_ITEM_NOT_FOUND) return null;
+      throw new Error(
+        `vault: keychain read failed (${err instanceof Error ? err.message : String(err)}); refusing to treat the failure as an absent keyring`,
+        { cause: err },
       );
-    } catch {
-      // `security` exits non-zero both when the item is absent and when access
-      // is denied; neither may mint over a keyring that might still exist, so
-      // absence is reported and the caller's mint path handles a real first run.
-      return null;
     }
     const body = raw.trim();
     if (body.length === 0) return null;
     return parseKeyring(body);
   }
 
-  // `-U` updates the item in place when it already exists, so a rotation
-  // replaces the stored map rather than adding a second item the reader would
-  // have to disambiguate.
-  #write(keyring: Keyring): Keyring {
-    execFileSync(
-      '/usr/bin/security',
-      [
-        'add-generic-password',
-        '-U',
-        '-s',
-        KEYCHAIN_SERVICE,
-        '-a',
-        KEYCHAIN_ACCOUNT,
-        '-w',
-        serializeKeyring(keyring),
-      ],
-      { stdio: ['ignore', 'ignore', 'ignore'] },
-    );
+  /**
+   * First mint: a plain `add-generic-password` (no `-U`) fails when an item
+   * already exists, so a concurrent first mint cannot overwrite the winner's
+   * keyring — the loser re-reads and adopts it instead.
+   */
+  #create(keyring: Keyring): Keyring {
+    const args = [
+      'add-generic-password',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-a',
+      KEYCHAIN_ACCOUNT,
+      '-w',
+      serializeKeyring(keyring),
+    ];
+    try {
+      this.#exec(args);
+    } catch (err) {
+      const winner = this.#read();
+      if (winner) return winner;
+      throw asError(err);
+    }
+    return keyring;
+  }
+
+  // `-U` updates the item in place, deliberately replacing the stored map with
+  // one that contains it — used only for rotation, under the rotation lock.
+  #replace(keyring: Keyring): Keyring {
+    this.#exec([
+      'add-generic-password',
+      '-U',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-a',
+      KEYCHAIN_ACCOUNT,
+      '-w',
+      serializeKeyring(keyring),
+    ]);
     return keyring;
   }
 }

--- a/packages/persistence/src/vault/vault.ts
+++ b/packages/persistence/src/vault/vault.ts
@@ -20,7 +20,11 @@ import type {
   VaultDerefOutcome,
   VaultDerefReason,
 } from '@akasecurity/schema';
-import { isBatchedDerefReason, POINTER_TOKEN_ANCHORED } from '@akasecurity/schema';
+import {
+  isBatchedDerefReason,
+  POINTER_FORMAT_VERSION,
+  POINTER_TOKEN_ANCHORED,
+} from '@akasecurity/schema';
 
 import { type FingerprintKey, fingerprintValue } from '../fingerprint.ts';
 import type { SqliteSecretVaultRepository, VaultRow } from '../repositories/secret-vault.ts';
@@ -30,6 +34,7 @@ import {
   bindingInput,
   decodeKeyVersion,
   deriveSubkeys,
+  encodeKeyVersion,
   formatPointer,
   NONCE_BYTES,
   open as openSealed,
@@ -88,12 +93,22 @@ function parsePointer(token: string): ParsedPointerToken | null {
   const [kv, id, tag] = body.slice(colon + 1).split('.');
   if (kv === undefined || id === undefined || tag === undefined) return null;
   try {
-    return {
-      category,
-      keyVersion: decodeKeyVersion(kv),
-      pointerId: base32Decode(id),
-      tag: base32Decode(tag),
-    };
+    const keyVersion = decodeKeyVersion(kv);
+    const pointerId = base32Decode(id);
+    const tagBytes = base32Decode(tag);
+    // Canonical-form check: base32 decoding discards trailing sub-byte bits and
+    // the key-version decoder tolerates leading zero bytes, so several distinct
+    // strings can decode to the same segments. Only the exact spelling this
+    // vault emits counts as a pointer — anything else is not a pointer at all,
+    // so the audit and dedup keys never fragment across spellings.
+    if (
+      encodeKeyVersion(keyVersion) !== kv ||
+      base32Encode(pointerId) !== id ||
+      base32Encode(tagBytes) !== tag
+    ) {
+      return null;
+    }
+    return { category, keyVersion, pointerId, tag: tagBytes };
   } catch {
     return null;
   }
@@ -108,6 +123,18 @@ export interface SecretVaultDeps {
   // Read live on every call, so revoking consent takes effect immediately
   // rather than at the next process start.
   isConsented: () => boolean;
+  // Vault-side grant check for a model-target de-reference: does `grantId`
+  // actively cover the ROW's identity right now? The vault is the last gate
+  // before raw leaves the store, so a caller-provided grant id is never taken
+  // on trust — a false, or a throw, refuses the crossing.
+  //
+  // OMITTING THIS BUILDS A VAULT WITH NO MODEL ROAD: every `target: 'model'`
+  // de-reference refuses. That is the useful default, because most construction
+  // sites are owner surfaces that only ever read for a human, and it makes them
+  // structurally incapable of a crossing rather than merely not attempting one.
+  // Only a site that genuinely reveals to the model supplies a verifier, and
+  // supplying one is what opens the road.
+  verifyGrant?: ((grantId: string, identity: PointerIdentity) => Promise<boolean>) | undefined;
   now?: () => number;
 }
 
@@ -116,6 +143,8 @@ export class SecretVault {
   readonly #keys: KeyProvider;
   readonly #fingerprintKey: FingerprintKey;
   readonly #isConsented: () => boolean;
+  readonly #verifyGrant:
+    ((grantId: string, identity: PointerIdentity) => Promise<boolean>) | undefined;
   readonly #now: () => number;
 
   constructor(deps: SecretVaultDeps) {
@@ -123,6 +152,7 @@ export class SecretVault {
     this.#keys = deps.keys;
     this.#fingerprintKey = deps.fingerprintKey;
     this.#isConsented = deps.isConsented;
+    this.#verifyGrant = deps.verifyGrant;
     this.#now = deps.now ?? ((): number => Date.now());
   }
 
@@ -149,7 +179,7 @@ export class SecretVault {
     const { material, version } = await this.#keys.loadOrCreate();
     const subkeys = deriveSubkeys(material);
     const pointerId = randomBytes(POINTER_ID_BYTES);
-    const aad = bindingInput(version, pointerId, meta.category);
+    const aad = bindingInput(version, pointerId, meta.category, POINTER_FORMAT_VERSION);
     const sealed = seal(subkeys.enc, raw, aad, randomBytes(NONCE_BYTES));
 
     const { row } = this.#repo.upsert(
@@ -158,6 +188,10 @@ export class SecretVault {
         valueFingerprint,
         fingerprintKeyVersion: this.#fingerprintKey.version,
         keyVersion: version,
+        // Recorded so the row stays OPENABLE if the wire-format constant ever
+        // moves: it is part of this row's AEAD AAD. It is not a tag input —
+        // tags are pinned to the constant on both sides.
+        formatVersion: POINTER_FORMAT_VERSION,
         category: meta.category,
         ruleId: meta.ruleId,
         maskedMatch: meta.maskedMatch,
@@ -185,6 +219,13 @@ export class SecretVault {
     // Verify BEFORE touching the store or any ciphertext. A forged or tampered
     // token is unattributable — it names no one and nothing — so it writes no
     // audit row; only a token we can attribute to a real entry does.
+    //
+    // The tag is checked under the CURRENT wire-format version, and signing
+    // uses the same constant, so the two cannot disagree about a row. That
+    // pinning is forced by the ordering above: the row is not in hand yet, so
+    // its recorded generation is not knowable here. A format bump must bring a
+    // verification story for stored rows' tags — see POINTER_FORMAT_VERSION;
+    // the frozen golden vector in crypto.test.ts exists to force that.
     let signKey: Buffer;
     try {
       const epoch = await this.#keys.materialFor(parsed.keyVersion);
@@ -213,9 +254,34 @@ export class SecretVault {
     // The grant gate sits AFTER the row lookup so the check above can stay
     // silent. Consequence: a purged pointer with no grant audits `unavailable`
     // rather than `refused`, which is the truthful outcome anyway.
-    if (opts.target === 'model' && !opts.grantId) {
-      this.#audit(pointerId, opts, 'refused');
-      return UNAVAILABLE;
+    if (opts.target === 'model') {
+      const grantId = opts.grantId;
+      // No verifier means this vault has no model road at all. Refusing here
+      // rather than trusting the id keeps an owner-surface vault incapable of a
+      // crossing even if a caller asks for one.
+      const verify = this.#verifyGrant;
+      if (verify === undefined || grantId === undefined || grantId === '') {
+        this.#audit(pointerId, opts, 'refused');
+        return UNAVAILABLE;
+      }
+      // Last gate: the grant id must actively cover THIS row's identity, so a
+      // fabricated or stale id refuses the crossing instead of being audited as
+      // if it authorized it. A verifier fault also refuses — at this gate an
+      // error must never widen into a reveal.
+      let covered: boolean;
+      try {
+        covered = await verify(grantId, {
+          ruleId: row.ruleId,
+          valueFingerprint: row.valueFingerprint,
+          fingerprintKeyVersion: row.fingerprintKeyVersion,
+        });
+      } catch {
+        covered = false;
+      }
+      if (!covered) {
+        this.#audit(pointerId, opts, 'refused');
+        return UNAVAILABLE;
+      }
     }
 
     let raw: string | null;
@@ -228,9 +294,11 @@ export class SecretVault {
           nonce: Buffer.from(row.nonce, 'base64'),
           authTag: Buffer.from(row.authTag, 'base64'),
         },
-        // Sealed under the ROW's epoch, which rotation may have moved past the
-        // epoch this token was minted under.
-        bindingInput(row.keyVersion, parsed.pointerId, row.category),
+        // Sealed under the ROW's epoch and format version. Rotation may have
+        // moved the epoch past the one this token names, and a format bump may
+        // have moved the constant past the generation this row was sealed
+        // under — the AAD follows the row in both cases, never the token.
+        bindingInput(row.keyVersion, parsed.pointerId, row.category, row.formatVersion),
       );
     } catch {
       raw = null;
@@ -309,6 +377,16 @@ export class SecretVault {
    *
    * Safe to interrupt — each row carries the epoch its ciphertext is sealed
    * under, so a half-finished pass leaves every row openable.
+   *
+   * The rotation lock covers only the keyring mint inside `rotate()`; the
+   * re-seal pass below runs unlocked. Two concurrent rotations therefore
+   * serialize on the keyring but interleave over the rows, so a slower pass can
+   * re-seal a row back to an epoch a faster one already moved past, and
+   * `reEncrypted` can double-count. No value is lost either way — every epoch is
+   * retained and every row stays openable — but "after rotation every row sits
+   * at the newest epoch" does not hold under concurrency. Holding the lock
+   * across the whole pass requires an async-aware lock, since a callback that
+   * awaits would release the lock at its first suspension.
    */
   async rotateVaultKey(): Promise<{ version: number; reEncrypted: number }> {
     const next = await this.#keys.rotate();
@@ -328,7 +406,7 @@ export class SecretVault {
             nonce: Buffer.from(row.nonce, 'base64'),
             authTag: Buffer.from(row.authTag, 'base64'),
           },
-          bindingInput(row.keyVersion, pointerId, row.category),
+          bindingInput(row.keyVersion, pointerId, row.category, row.formatVersion),
         );
       } catch {
         raw = null;
@@ -337,10 +415,14 @@ export class SecretVault {
       // anything would destroy a value we might still recover.
       if (raw === null) continue;
 
+      // Key rotation moves the epoch, not the format generation: the row's
+      // format version is preserved so its ciphertext stays bound to the AAD it
+      // was sealed under. Outstanding tokens are unaffected either way — a tag
+      // never carries the row's generation.
       const sealed = seal(
         nextEnc,
         raw,
-        bindingInput(next.version, pointerId, row.category),
+        bindingInput(next.version, pointerId, row.category, row.formatVersion),
         randomBytes(NONCE_BYTES),
       );
       this.#repo.replaceCiphertext(row.pointerId, {
@@ -360,17 +442,31 @@ export class SecretVault {
    * PRESERVING each pointer id. Unlike grants — where rotation is invalidation,
    * because the raw values are gone — the vault still holds the values, so
    * determinism, dedup, and every outstanding pointer survive the rotation.
+   *
+   * Every fingerprint-key rotation must run this: a row left at the old epoch
+   * still resolves, but the same value detected again fingerprints under the
+   * NEW key, misses the dedup lookup, and mints a second row and a second
+   * pointer — one value, two tokens in circulation.
+   *
+   * Per-row best-effort: a row that cannot open, or whose refreshed
+   * fingerprint collides with a row already refreshed, is skipped rather than
+   * aborting the pass — one damaged entry must not strand the re-key of every
+   * other. A skipped row keeps resolving under its old fingerprint epoch.
    */
   async refreshFingerprints(next: FingerprintKey): Promise<number> {
     let refreshed = 0;
     for (const row of this.#repo.listAll()) {
-      const raw = await this.#openRow(row);
-      if (raw === null) continue;
-      this.#repo.refreshFingerprint(row.pointerId, {
-        valueFingerprint: fingerprintValue(next, raw),
-        fingerprintKeyVersion: next.version,
-      });
-      refreshed += 1;
+      try {
+        const raw = await this.#openRow(row);
+        if (raw === null) continue;
+        this.#repo.refreshFingerprint(row.pointerId, {
+          valueFingerprint: fingerprintValue(next, raw),
+          fingerprintKeyVersion: next.version,
+        });
+        refreshed += 1;
+      } catch {
+        continue;
+      }
     }
     return refreshed;
   }
@@ -399,8 +495,14 @@ export class SecretVault {
     return destroyed;
   }
 
-  // Sign under the epoch the token names, which for a re-detected value is the
+  // Sign under the epoch the token names — which for a re-detected value is the
   // epoch its row currently sits at rather than whatever is current.
+  //
+  // The row's format version is NOT a tag input. It binds the row's ciphertext
+  // (it is part of the AEAD AAD, so an old row stays openable) but never the
+  // wire tag, which verification checks against POINTER_FORMAT_VERSION without
+  // knowing any row. Signing a token here under a row's own generation is what
+  // would make the vault emit tokens it then refuses.
   async #emitToken(keyVersion: number, pointerIdB32: string, category: string): Promise<string> {
     const pointerId = base32Decode(pointerIdB32);
     const epoch = await this.#keys.materialFor(keyVersion);
@@ -423,7 +525,7 @@ export class SecretVault {
           nonce: Buffer.from(row.nonce, 'base64'),
           authTag: Buffer.from(row.authTag, 'base64'),
         },
-        bindingInput(row.keyVersion, base32Decode(row.pointerId), row.category),
+        bindingInput(row.keyVersion, base32Decode(row.pointerId), row.category, row.formatVersion),
       );
     } catch {
       return null;

--- a/packages/persistence/test/exception-policy.test.ts
+++ b/packages/persistence/test/exception-policy.test.ts
@@ -67,6 +67,15 @@ describe('UserGrantPolicyProvider', () => {
     await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
   });
 
+  // The reveal path does not evaluate conditions yet, and a narrowing clause
+  // that is ignored would WIDEN the grant — a repo-scoped grant would reveal
+  // everywhere. Fail closed: a conditioned grant never authorizes a reveal
+  // until reveal-side condition evaluation exists.
+  it('denies a grant narrowed by conditions', async () => {
+    await db.exceptions.create(grantInput({ conditions: { repo: 'x' } }));
+    await expect(provider.decideReveal(identity())).resolves.toEqual({ allow: false });
+  });
+
   // A grant authorizes exactly the value it was created for.
   it('denies a different value under the same rule', async () => {
     await db.exceptions.create(grantInput());

--- a/packages/persistence/test/repositories/secret-vault.test.ts
+++ b/packages/persistence/test/repositories/secret-vault.test.ts
@@ -231,3 +231,46 @@ describe('SqliteSecretVaultRepository.purgeAll', () => {
     expect(vault.purgeAll()).toBe(0);
   });
 });
+
+// The inventory's revealable badge and the actual crossing must share ONE
+// definition of "an active reveal grant". The crossing (activeRevealGrant)
+// fails closed on a grant with conditions — the reveal path does not evaluate
+// them, and ignoring a narrowing clause would widen the grant — so the badge
+// must refuse the same grant, or the dashboard says "revealable" where the
+// de-reference then refuses.
+describe('SqliteSecretVaultRepository.listInventory grant badge', () => {
+  function grantRow(overrides: { conditions?: string | null } = {}): void {
+    raw
+      .prepare(
+        `INSERT INTO exceptions (
+           id, rule_id, category, value_fingerprint, key_version, masked_value,
+           capability, scope, expires_at, max_uses, use_count, last_used_at,
+           justification, conditions, created_by, created_via, created_at,
+           updated_at, revoked_at, revoked_by, revoke_reason
+         ) VALUES (
+           :id, 'aka.secret.aws-key', 'secret', :fp, 1, 'AKIA…XYZQ',
+           'reveal_to_model', 'permanent', NULL, NULL, 0, NULL,
+           'test', :conditions, 'tester', 'cli-add', :now,
+           :now, NULL, NULL, NULL
+         )`,
+      )
+      .run({
+        id: randomUUID(),
+        fp: FINGERPRINT_A,
+        conditions: overrides.conditions ?? null,
+        now: NOW,
+      });
+  }
+
+  it('badges a clean active reveal grant', () => {
+    vault.upsert(entry(), NOW);
+    grantRow();
+    expect(vault.listInventory(NOW)[0]?.revealGrantId).not.toBeNull();
+  });
+
+  it('refuses to badge a conditioned grant, exactly as the crossing refuses it', () => {
+    vault.upsert(entry(), NOW);
+    grantRow({ conditions: JSON.stringify({ repo: 'github.com/example/app' }) });
+    expect(vault.listInventory(NOW)[0]?.revealGrantId).toBeNull();
+  });
+});

--- a/packages/persistence/test/vault/crypto.test.ts
+++ b/packages/persistence/test/vault/crypto.test.ts
@@ -230,6 +230,49 @@ describe('pointer tag', () => {
   });
 });
 
+// FROZEN golden vectors. These pin the wire format itself: the HKDF salt and
+// info labels, the binding-input layout (format version ‖ key version ‖
+// pointer id ‖ category), the HMAC tag truncation, and the token spelling.
+// If changing POINTER_FORMAT_VERSION, the HKDF labels/salt, or the binding
+// layout breaks this test, that is the test WORKING: every already-stored
+// ciphertext and every already-emitted token was produced under these exact
+// bytes, so the constant must not move without a migration story for stored
+// rows and outstanding tokens. Do not re-derive these values from the code —
+// that would freeze nothing.
+describe('golden vectors', () => {
+  const goldenMaster = Buffer.from(
+    '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',
+    'hex',
+  );
+  const goldenPointerId = Buffer.from('35757033727333637233742d7030316e', 'hex');
+
+  it('derives the frozen subkeys', () => {
+    const derived = deriveSubkeys(goldenMaster);
+    expect(derived.enc.toString('hex')).toBe(
+      '5b17fca2dc233fe14765c12ec39314c7877f3d6c63b4bfd0d0f4c9d0a4a85758',
+    );
+    expect(derived.sign.toString('hex')).toBe(
+      '8ace90e54da32192db58c01ddf83137dcb55e4aa3dbf99a05bb11f8adc8ea06f',
+    );
+  });
+
+  it('produces the frozen binding input', () => {
+    expect(bindingInput(1, goldenPointerId, 'secret').toString('hex')).toBe(
+      '00020000000135757033727333637233742d7030316e736563726574',
+    );
+  });
+
+  it('produces the exact frozen tag and token', () => {
+    const derived = deriveSubkeys(goldenMaster);
+    const tag = signPointer(derived.sign, 1, goldenPointerId, 'secret');
+    expect(tag.toString('hex')).toBe('1f418d000515357bc072');
+    expect(formatPointer('secret', 1, goldenPointerId, tag)).toBe(
+      '[[aka:secret:AE.GV2XAM3SOMZWG4RTOQWXAMBRNY.D5AY2AAFCU2XXQDS]]',
+    );
+    expect(verifyPointerTag(derived.sign, 1, goldenPointerId, 'secret', tag)).toBe(true);
+  });
+});
+
 describe('formatPointer', () => {
   it('emits a token the schema grammar accepts', async () => {
     const { PointerToken } = await import('@akasecurity/schema');

--- a/packages/persistence/test/vault/key-provider.test.ts
+++ b/packages/persistence/test/vault/key-provider.test.ts
@@ -1,8 +1,19 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import type * as FsModule from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createKeyProvider,
@@ -11,6 +22,75 @@ import {
   VAULT_KEY_FILENAME,
   VaultKeyEpochMissingError,
 } from '../../src/vault/key-provider.ts';
+
+// Lets a test simulate the first-mint race: one read of the key file reports
+// ENOENT even though the file exists, putting the provider on its mint path
+// while a "winner's" keyring already sits at the final path.
+//
+// `retakeLockOnNextStat` / `retakeLockOnWrite` do the same for the rotation
+// lock: another process takes the lock over at the exact instant the code under
+// test is between deciding and acting on it. Both drop a fresh lock directory
+// stamped with a foreign owner, which is what neither the reclaim nor the
+// release may disturb.
+const raceControl = vi.hoisted(() => ({
+  hideKeyFileOnce: false,
+  retakeLockOnNextStat: false,
+  retakeLockOnWrite: false,
+  touchLockOnNextStat: false,
+}));
+
+const FOREIGN_OWNER = 'another-process';
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof FsModule>();
+  const retake = (lock: string): void => {
+    actual.rmSync(lock, { recursive: true, force: true });
+    actual.mkdirSync(lock);
+    actual.writeFileSync(`${lock}/owner`, 'another-process\n');
+  };
+  const readFileSyncWithRace = ((...args: Parameters<typeof actual.readFileSync>) => {
+    if (raceControl.hideKeyFileOnce && String(args[0]).endsWith('vault.key')) {
+      raceControl.hideKeyFileOnce = false;
+      const err = new Error('ENOENT (simulated race)') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    }
+    return actual.readFileSync(...args);
+  }) as typeof actual.readFileSync;
+  // Fires AFTER the real stat, so the caller still receives the stale stats it
+  // based its decision on and only the directory underneath has changed.
+  const statSyncWithRace = ((...args: Parameters<typeof actual.statSync>) => {
+    const result = actual.statSync(...args);
+    const path = String(args[0]);
+    if (raceControl.retakeLockOnNextStat && path.endsWith('vault.key.lock')) {
+      raceControl.retakeLockOnNextStat = false;
+      retake(path);
+    }
+    // Refreshes the lock in place: SAME directory, same inode, new mtime. This
+    // is what a live holder heartbeating looks like, and it is also what inode
+    // reuse looks like to a reclaimer that compares inodes alone.
+    if (raceControl.touchLockOnNextStat && path.endsWith('vault.key.lock')) {
+      raceControl.touchLockOnNextStat = false;
+      const now = Date.now() / 1000;
+      actual.utimesSync(path, now, now);
+    }
+    return result;
+  }) as typeof actual.statSync;
+  const writeFileSyncWithRace = ((...args: Parameters<typeof actual.writeFileSync>) => {
+    const path = String(args[0]);
+    if (raceControl.retakeLockOnWrite && path.includes('vault.key') && !path.includes('.lock')) {
+      raceControl.retakeLockOnWrite = false;
+      retake(path.replace(/vault\.key.*$/, 'vault.key.lock'));
+    }
+    actual.writeFileSync(...args);
+  }) as typeof actual.writeFileSync;
+  return {
+    ...actual,
+    readFileSync: readFileSyncWithRace,
+    statSync: statSyncWithRace,
+    writeFileSync: writeFileSyncWithRace,
+  };
+});
 
 const POSIX_MODES = process.platform !== 'win32';
 
@@ -22,10 +102,15 @@ describe('FileKeyProvider', () => {
   });
 
   afterEach(() => {
+    raceControl.hideKeyFileOnce = false;
+    raceControl.retakeLockOnNextStat = false;
+    raceControl.retakeLockOnWrite = false;
+    raceControl.touchLockOnNextStat = false;
     rmSync(dir, { recursive: true, force: true });
   });
 
   const keyFile = (): string => join(dir, VAULT_KEY_FILENAME);
+  const lockDir = (): string => join(dir, `${VAULT_KEY_FILENAME}.lock`);
 
   it('mints version 1 with 32 bytes of material on first use', async () => {
     const provider = new FileKeyProvider(dir);
@@ -86,6 +171,152 @@ describe('FileKeyProvider', () => {
     expect(reloaded.material.equals(rotated.material)).toBe(true);
   });
 
+  // Two hook processes racing loadOrCreate on a fresh machine must converge on
+  // ONE epoch-1 keyring — if each minted its own, the loser's sealed rows and
+  // emitted pointers would be permanently unresolvable.
+  it('gives two providers racing loadOrCreate the same version-1 material', async () => {
+    const [a, b] = await Promise.all([
+      new FileKeyProvider(dir).loadOrCreate(),
+      new FileKeyProvider(dir).loadOrCreate(),
+    ]);
+
+    expect(a.version).toBe(1);
+    expect(b.version).toBe(1);
+    expect(a.material.equals(b.material)).toBe(true);
+  });
+
+  it('adopts a keyring that appears between the absence check and the mint', async () => {
+    // The winner mints first.
+    const winner = await new FileKeyProvider(dir).loadOrCreate();
+    const before = readFileSync(keyFile());
+
+    // The loser's read reports absence (simulated race), so it attempts a
+    // mint — the creation-exclusive write must lose to the existing file and
+    // adopt the winner's keyring, never overwrite it.
+    raceControl.hideKeyFileOnce = true;
+    const loser = await new FileKeyProvider(dir).loadOrCreate();
+
+    expect(loser.version).toBe(1);
+    expect(loser.material.equals(winner.material)).toBe(true);
+    expect(readFileSync(keyFile()).equals(before)).toBe(true);
+  });
+
+  it.skipIf(!POSIX_MODES)('keeps the keys dir owner-only', async () => {
+    await new FileKeyProvider(dir).loadOrCreate();
+
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  it.skipIf(!POSIX_MODES)('re-tightens a loosened key file on the next load', async () => {
+    await new FileKeyProvider(dir).loadOrCreate();
+    chmodSync(keyFile(), 0o644);
+
+    await new FileKeyProvider(dir).loadOrCreate();
+
+    expect(statSync(keyFile()).mode & 0o777).toBe(0o600);
+  });
+
+  it('refuses a rotation while another is in flight', async () => {
+    const provider = new FileKeyProvider(dir);
+    await provider.loadOrCreate();
+    mkdirSync(lockDir());
+
+    await expect(provider.rotate()).rejects.toThrow(/already in progress/);
+  });
+
+  it('reclaims a stale rotation lock and releases it afterwards', async () => {
+    const provider = new FileKeyProvider(dir);
+    await provider.loadOrCreate();
+    mkdirSync(lockDir());
+    const past = (Date.now() - 120_000) / 1000;
+    utimesSync(lockDir(), past, past);
+
+    const rotated = await provider.rotate();
+
+    expect(rotated.version).toBe(2);
+    expect(existsSync(lockDir())).toBe(false);
+  });
+
+  it('releases the rotation lock after a completed rotation', async () => {
+    const provider = new FileKeyProvider(dir);
+    await provider.loadOrCreate();
+    await provider.rotate();
+
+    expect(existsSync(lockDir())).toBe(false);
+    // A follow-up rotation is not blocked by the previous one.
+    expect((await provider.rotate()).version).toBe(3);
+  });
+
+  // Reclaiming a stale lock must be an atomic steal, not delete-then-recreate.
+  // A stale lock is absorbing — nothing ages it back — so any two attempts after
+  // a crashed rotation race here, with no slow rotation required. Standing in
+  // for the loser: a lock that is replaced (new inode) between the staleness
+  // check and the reclaim belongs to whoever put it there.
+  // POSIX only: the guard rests on statSync().ino distinguishing two
+  // directories, and Windows derives that from a 64-bit file reference that
+  // does not survive the trip through a JS number intact. The reclaim itself is
+  // still safe there — the rename is what settles the race, and an unreliable
+  // inode can only make this path refuse, which is the fail-secure direction.
+  it.skipIf(!POSIX_MODES)(
+    'refuses to reclaim a stale lock that was taken over in the meantime',
+    async () => {
+      const provider = new FileKeyProvider(dir);
+      await provider.loadOrCreate();
+      mkdirSync(lockDir());
+      const past = (Date.now() - 120_000) / 1000;
+      utimesSync(lockDir(), past, past);
+
+      // Another process takes the stale lock over between the staleness check
+      // and the reclaim. Deleting the lock and re-creating it would destroy that
+      // holder's claim and let both run; only a rename can settle it.
+      raceControl.retakeLockOnNextStat = true;
+
+      await expect(provider.rotate()).rejects.toThrow(/already in progress/);
+      expect(readFileSync(join(lockDir(), 'owner'), 'utf8').trim()).toBe(FOREIGN_OWNER);
+      // Nothing was minted: the keyring is still at its original epoch.
+      expect((await provider.loadOrCreate()).version).toBe(1);
+    },
+  );
+
+  // Identity is (inode, mtime), not the inode alone. A filesystem may hand a
+  // freshly created directory the inode it just reclaimed from a deleted one,
+  // so an inode match does not prove the lock is still the one judged stale —
+  // and comparing inodes alone let a reclaim proceed against a lock that had
+  // been refreshed underneath it. The mtime is what separates the two.
+  it.skipIf(!POSIX_MODES)(
+    'refuses to reclaim a stale lock that was refreshed in place',
+    async () => {
+      const provider = new FileKeyProvider(dir);
+      await provider.loadOrCreate();
+      mkdirSync(lockDir());
+      const past = (Date.now() - 120_000) / 1000;
+      utimesSync(lockDir(), past, past);
+
+      // Same directory and same inode throughout — only the mtime moves, exactly
+      // as it would if the holder were alive and heartbeating.
+      raceControl.touchLockOnNextStat = true;
+
+      await expect(provider.rotate()).rejects.toThrow(/already in progress/);
+      expect(existsSync(lockDir())).toBe(true);
+      expect((await provider.loadOrCreate()).version).toBe(1);
+    },
+  );
+
+  // A holder reclaimed as stale while it was still alive no longer owns the
+  // lock. Removing it on the way out would unlock the reclaimer.
+  it('leaves a rotation lock alone when another owner holds it at release', async () => {
+    const provider = new FileKeyProvider(dir);
+    await provider.loadOrCreate();
+
+    // Mid-rotation, this holder's lock is reclaimed by someone else. Its own
+    // release must then be a no-op rather than clearing the new owner's lock.
+    raceControl.retakeLockOnWrite = true;
+    await provider.rotate();
+
+    expect(existsSync(lockDir())).toBe(true);
+    expect(readFileSync(join(lockDir(), 'owner'), 'utf8').trim()).toBe(FOREIGN_OWNER);
+  });
+
   it('throws on a corrupt key file and leaves it untouched', async () => {
     await new FileKeyProvider(dir).loadOrCreate();
     writeFileSync(keyFile(), '{ not json');
@@ -115,6 +346,103 @@ describe('FileKeyProvider', () => {
     await expect(new FileKeyProvider(dir).materialFor(1)).rejects.toBeInstanceOf(
       VaultKeyEpochMissingError,
     );
+  });
+});
+
+describe('KeychainKeyProvider', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-vault-key-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const notFound = (): never => {
+    throw Object.assign(new Error('item not found'), { status: 44 });
+  };
+  const denied = (): never => {
+    throw Object.assign(new Error('keychain access denied'), { status: 1 });
+  };
+  const keyringJson = (material: Buffer): string =>
+    JSON.stringify({ current: 1, keys: { 1: material.toString('base64') } });
+
+  // A locked keychain or a denied ACL must fail the load, not read as absence:
+  // minting over the real keyring would orphan every existing ciphertext.
+  it('throws when the keychain read is denied rather than minting', async () => {
+    const calls: string[][] = [];
+    const provider = new KeychainKeyProvider(dir, (args) => {
+      calls.push(args);
+      return denied();
+    });
+
+    await expect(provider.loadOrCreate()).rejects.toThrow(/keychain read failed/);
+    expect(calls.some((args) => args[0] === 'add-generic-password')).toBe(false);
+  });
+
+  it('mints on item-not-found (exit 44), without -U', async () => {
+    const calls: string[][] = [];
+    const provider = new KeychainKeyProvider(dir, (args) => {
+      calls.push(args);
+      if (args[0] === 'find-generic-password') notFound();
+      return '';
+    });
+
+    const key = await provider.loadOrCreate();
+
+    expect(key.version).toBe(1);
+    const add = calls.find((args) => args[0] === 'add-generic-password');
+    expect(add).toBeDefined();
+    // A plain add fails on an existing item, so a lost first-mint race cannot
+    // overwrite the winner's keyring; -U belongs to rotation only.
+    expect(add).not.toContain('-U');
+  });
+
+  it('adopts the winning keyring when its first mint loses the race', async () => {
+    const winnerMaterial = Buffer.alloc(32, 7);
+    let reads = 0;
+    const provider = new KeychainKeyProvider(dir, (args) => {
+      if (args[0] === 'find-generic-password') {
+        reads += 1;
+        // First read: nothing yet. Second read (after the failed add): the
+        // concurrent winner's keyring is in place.
+        if (reads === 1) notFound();
+        return keyringJson(winnerMaterial);
+      }
+      throw Object.assign(new Error('item already exists'), { status: 45 });
+    });
+
+    const key = await provider.loadOrCreate();
+
+    expect(key.version).toBe(1);
+    expect(key.material.equals(winnerMaterial)).toBe(true);
+  });
+
+  it('rotates by replacing the item in place (-U) under the rotation lock', async () => {
+    const calls: string[][] = [];
+    const provider = new KeychainKeyProvider(dir, (args) => {
+      calls.push(args);
+      if (args[0] === 'find-generic-password') return keyringJson(Buffer.alloc(32, 7));
+      return '';
+    });
+
+    const rotated = await provider.rotate();
+
+    expect(rotated.version).toBe(2);
+    const add = calls.find((args) => args[0] === 'add-generic-password');
+    expect(add).toContain('-U');
+    expect(existsSync(join(dir, `${VAULT_KEY_FILENAME}.lock`))).toBe(false);
+  });
+
+  it('refuses a rotation while another is in flight', async () => {
+    const provider = new KeychainKeyProvider(dir, () =>
+      JSON.stringify({ current: 1, keys: { 1: Buffer.alloc(32, 7).toString('base64') } }),
+    );
+    mkdirSync(join(dir, `${VAULT_KEY_FILENAME}.lock`));
+
+    await expect(provider.rotate()).rejects.toThrow(/already in progress/);
   });
 });
 

--- a/packages/persistence/test/vault/vault.test.ts
+++ b/packages/persistence/test/vault/vault.test.ts
@@ -1,11 +1,25 @@
+import { randomBytes } from 'node:crypto';
 import { join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 
-import { PointerToken } from '@akasecurity/schema';
+import { POINTER_FORMAT_VERSION, PointerToken } from '@akasecurity/schema';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { loadOrCreateFingerprintKey, rotateFingerprintKey } from '../../src/fingerprint.ts';
+import {
+  fingerprintValue,
+  loadOrCreateFingerprintKey,
+  rotateFingerprintKey,
+} from '../../src/fingerprint.ts';
 import { SqliteSecretVaultRepository } from '../../src/repositories/secret-vault.ts';
+import {
+  base32Decode,
+  base32Encode,
+  bindingInput,
+  deriveSubkeys,
+  NONCE_BYTES,
+  POINTER_ID_BYTES,
+  seal,
+} from '../../src/vault/crypto.ts';
 import { FileKeyProvider } from '../../src/vault/key-provider.ts';
 import { CONSENT_ABSENT, SecretVault, UNAVAILABLE } from '../../src/vault/vault.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
@@ -137,6 +151,69 @@ describe('SecretVault', () => {
     });
   });
 
+  // The wire tag is signed and verified under POINTER_FORMAT_VERSION on both
+  // sides, never under the row's own generation — verification runs before the
+  // row is looked up, so it cannot know that generation. A row sealed under an
+  // older generation must therefore still emit a token the vault accepts: its
+  // format version binds the ciphertext (AEAD AAD) and nothing else.
+  //
+  // Seals a row by hand under generation 1 while the constant is 2, which is the
+  // shape a future format bump leaves behind. Signing the tag under the row's
+  // generation instead makes the vault refuse the token it just minted.
+  describe('rows from an older wire generation', () => {
+    const OLD_GENERATION = POINTER_FORMAT_VERSION - 1;
+
+    async function seedOldGenerationRow(raw: string): Promise<void> {
+      const keys = new FileKeyProvider(join(dir, 'keys'));
+      const { material, version } = await keys.loadOrCreate();
+      const subkeys = deriveSubkeys(material);
+      const pointerId = randomBytes(POINTER_ID_BYTES);
+      const sealed = seal(
+        subkeys.enc,
+        raw,
+        bindingInput(version, pointerId, 'secret', OLD_GENERATION),
+        randomBytes(NONCE_BYTES),
+      );
+      const fingerprintKey = loadOrCreateFingerprintKey(dir);
+      repo.upsert(
+        {
+          pointerId: base32Encode(pointerId),
+          valueFingerprint: fingerprintValue(fingerprintKey, raw),
+          fingerprintKeyVersion: fingerprintKey.version,
+          keyVersion: version,
+          formatVersion: OLD_GENERATION,
+          category: 'secret',
+          ruleId: 'aws-access-key-id',
+          maskedMatch: 'A******E',
+          ciphertext: sealed.ciphertext.toString('base64'),
+          nonce: sealed.nonce.toString('base64'),
+          authTag: sealed.authTag.toString('base64'),
+        },
+        Date.now(),
+      );
+    }
+
+    it('emits a token the vault still accepts, and resolves it', async () => {
+      await seedOldGenerationRow(SECRET);
+      // Re-detection returns the stored row's token rather than minting.
+      const token = await tokenize(SECRET);
+      expect(must(repo.listAll()[0], 'a vault row').formatVersion).toBe(OLD_GENERATION);
+      await expect(
+        vault.detokenize(token, { target: 'human', reason: 'explicit-reveal' }),
+      ).resolves.toBe(SECRET);
+    });
+
+    // describePointer and resolvePointerIdentity run the same tag check, so a
+    // drift between signing and verification takes out the masked badge and the
+    // reveal-grant path too — not just the read path.
+    it('still describes and identifies the row behind that token', async () => {
+      await seedOldGenerationRow(SECRET);
+      const token = await tokenize(SECRET);
+      expect(await vault.describePointer(token)).not.toBeNull();
+      expect(await vault.resolvePointerIdentity(token)).not.toBeNull();
+    });
+  });
+
   describe('unforgeable pointers', () => {
     it('refuses a fabricated pointer without auditing it', async () => {
       const forged = `[[aka:secret:AE.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
@@ -166,6 +243,57 @@ describe('SecretVault', () => {
       ).resolves.toBe(UNAVAILABLE);
     });
 
+    // base32 decoding discards trailing sub-byte bits, so a token whose last
+    // pointer-id character smuggles nonzero padding bits decodes to the SAME
+    // bytes as the canonical spelling — and its tag therefore still verifies.
+    // Only the exact spelling the vault emits may count as a pointer, or the
+    // audit and sighting dedup keys fragment across spellings of one pointer.
+    it('refuses a non-canonical trailing-bit spelling, without auditing it', async () => {
+      const token = await tokenize(SECRET);
+      const parts = must(
+        /^(\[\[aka:secret:[A-Z2-7]+\.)([A-Z2-7]{26})(\.[A-Z2-7]{16}\]\])$/.exec(token),
+        'token segments',
+      );
+      const id = must(parts[2], 'the pointer-id segment');
+      const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+      // The 26th character carries 3 data bits + 2 zero padding bits; setting a
+      // padding bit changes the spelling but not the decoded bytes.
+      const lastIndex = alphabet.indexOf(must(id.at(-1), 'last char'));
+      const variantId = id.slice(0, -1) + alphabet.charAt(lastIndex | 1);
+      expect(variantId).not.toBe(id);
+      expect(base32Decode(variantId).equals(base32Decode(id))).toBe(true);
+
+      const variant = `${must(parts[1], 'prefix')}${variantId}${must(parts[3], 'suffix')}`;
+      await expect(
+        vault.detokenize(variant, { target: 'human', reason: 'explicit-reveal' }),
+      ).resolves.toBe(UNAVAILABLE);
+      expect(derefRows()).toHaveLength(0);
+
+      // The canonical spelling still resolves.
+      await expect(
+        vault.detokenize(token, { target: 'human', reason: 'explicit-reveal' }),
+      ).resolves.toBe(SECRET);
+    });
+
+    // The key-version decoder tolerates leading zero bytes, so a zero-padded
+    // spelling names the same epoch as the minimal one. Same rule: not the
+    // canonical spelling, not a pointer.
+    it('refuses a zero-padded key-version spelling, without auditing it', async () => {
+      const token = await tokenize(SECRET);
+      // The minted token names epoch 1, encoded minimally as one byte ('AE').
+      const padded = base32Encode(Uint8Array.from([0, 1]));
+      const variant = token.replace('[[aka:secret:AE.', `[[aka:secret:${padded}.`);
+      expect(variant).not.toBe(token);
+      await expect(
+        vault.detokenize(variant, { target: 'human', reason: 'explicit-reveal' }),
+      ).resolves.toBe(UNAVAILABLE);
+      expect(derefRows()).toHaveLength(0);
+
+      await expect(
+        vault.detokenize(token, { target: 'human', reason: 'explicit-reveal' }),
+      ).resolves.toBe(SECRET);
+    });
+
     it('refuses a structurally invalid string outright', async () => {
       for (const junk of [
         '',
@@ -191,15 +319,92 @@ describe('SecretVault', () => {
       expect(rows[0]).toMatchObject({ target: 'model', outcome: 'refused', reason: 'model-input' });
     });
 
-    it('reveals with a grant, and records the crossing', async () => {
+    // A vault built without a grant verifier has no model road at all. Most
+    // construction sites are owner surfaces that only ever read for a human;
+    // this makes them structurally incapable of a crossing rather than merely
+    // not attempting one, so a caller cannot open the road by supplying an id.
+    it('refuses with no verifier wired, however good the grant id looks', async () => {
       const token = await tokenize(SECRET);
       await expect(
         vault.detokenize(token, { target: 'model', reason: 'model-input', grantId: 'g-1' }),
-      ).resolves.toBe(SECRET);
-      expect(derefRows()[0]).toMatchObject({
-        target: 'model',
-        outcome: 'revealed',
-        grantId: 'g-1',
+      ).resolves.toBe(UNAVAILABLE);
+      expect(derefRows()[0]).toMatchObject({ target: 'model', outcome: 'refused' });
+    });
+
+    // The vault is the last gate before raw leaves the store: with a verifier
+    // supplied, a grant id is checked against the ROW's identity rather than
+    // taken on trust from the caller.
+    describe('with a grant verifier', () => {
+      const withVerifier = (
+        verifyGrant: (
+          grantId: string,
+          identity: { ruleId: string; valueFingerprint: string; fingerprintKeyVersion: number },
+        ) => Promise<boolean>,
+      ): SecretVault =>
+        new SecretVault({
+          repo,
+          keys: new FileKeyProvider(join(dir, 'keys')),
+          fingerprintKey: loadOrCreateFingerprintKey(dir),
+          isConsented: () => consented,
+          verifyGrant,
+        });
+
+      it('refuses when the verifier does not cover the grant, and audits the refusal', async () => {
+        const token = await tokenize(SECRET);
+        const gated = withVerifier(() => Promise.resolve(false));
+        await expect(
+          gated.detokenize(token, { target: 'model', reason: 'model-input', grantId: 'g-forged' }),
+        ).resolves.toBe(UNAVAILABLE);
+        expect(derefRows()[0]).toMatchObject({ target: 'model', outcome: 'refused' });
+      });
+
+      it('reveals when the verifier covers the grant, checking the ROW identity', async () => {
+        const token = await tokenize(SECRET);
+        const row = must(repo.listAll()[0], 'the vault row');
+        const seen: { grantId: string; identity: unknown }[] = [];
+        const gated = withVerifier((grantId, identity) => {
+          seen.push({ grantId, identity });
+          return Promise.resolve(true);
+        });
+        await expect(
+          gated.detokenize(token, { target: 'model', reason: 'model-input', grantId: 'g-1' }),
+        ).resolves.toBe(SECRET);
+        expect(seen).toEqual([
+          {
+            grantId: 'g-1',
+            identity: {
+              ruleId: row.ruleId,
+              valueFingerprint: row.valueFingerprint,
+              fingerprintKeyVersion: row.fingerprintKeyVersion,
+            },
+          },
+        ]);
+        expect(derefRows()[0]).toMatchObject({ target: 'model', outcome: 'revealed' });
+      });
+
+      // Fail-secure at the last gate: a verifier fault refuses, never reveals.
+      it('refuses when the verifier throws', async () => {
+        const token = await tokenize(SECRET);
+        const gated = withVerifier(() => Promise.reject(new Error('store fault')));
+        await expect(
+          gated.detokenize(token, { target: 'model', reason: 'model-input', grantId: 'g-1' }),
+        ).resolves.toBe(UNAVAILABLE);
+        expect(derefRows()[0]).toMatchObject({ target: 'model', outcome: 'refused' });
+      });
+
+      // The verifier gates only the model crossing; human-target reveals do not
+      // consult it.
+      it('does not consult the verifier for a human-target de-reference', async () => {
+        const token = await tokenize(SECRET);
+        let called = false;
+        const gated = withVerifier(() => {
+          called = true;
+          return Promise.resolve(false);
+        });
+        await expect(
+          gated.detokenize(token, { target: 'human', reason: 'explicit-reveal' }),
+        ).resolves.toBe(SECRET);
+        expect(called).toBe(false);
       });
     });
   });

--- a/packages/plugin-sdk/src/pointer-shield.ts
+++ b/packages/plugin-sdk/src/pointer-shield.ts
@@ -1,63 +1,10 @@
-// Keeps vault pointers out of the detection engine's sight.
-//
-// A pointer's base32 body is exactly the kind of high-entropy string a generic
-// secret rule matches, and rule packs are user-installable — so "no rule ever
-// matches a pointer" cannot be guaranteed by auditing rule content. It is
-// guaranteed structurally instead: pointer spans are blanked out of the text
-// BEFORE the engine runs, so detection cannot see a pointer body at all,
-// whatever rules are installed. Without this, a matching rule would re-tokenize
-// a pointer (a pointer to a pointer), re-block a pointerized resubmit, or
-// corrupt a transcript rewrite.
-//
-// SCOPE: this module lives in plugin-sdk, so the guarantee currently covers the
-// SDK's own scan surfaces — the plugin's live hooks, the mask path, and the glue
-// self-scan. It does NOT yet cover local-ops' fs-scan pipeline behind `aka scan`
-// and the dashboard folder scan, which runs the same engine over files that hold
-// pointers by design, so a folder scan can still report a pointer as a finding.
-// The invariant belongs to the engine rather than to one of its callers; moving
-// it there is what closes the gap.
-import { pointerTokenScanner } from '@akasecurity/schema';
-
-export interface ShieldedSpan {
-  start: number;
-  end: number;
-}
-
-export interface ShieldedText {
-  // The input with every pointer span replaced by same-length filler, so every
-  // offset outside the pointers is identical to the original.
-  text: string;
-  spans: ShieldedSpan[];
-}
-
-// The filler is a repeated space: no rule matches whitespace, and a same-length
-// substitution keeps every other span's offsets valid against the original.
-export function shieldPointers(text: string): ShieldedText {
-  const spans: ShieldedSpan[] = [];
-  let out: string | null = null;
-  for (const match of text.matchAll(pointerTokenScanner())) {
-    spans.push({ start: match.index, end: match.index + match[0].length });
-    out ??= text;
-    out =
-      out.slice(0, match.index) +
-      ' '.repeat(match[0].length) +
-      out.slice(match.index + match[0].length);
-  }
-  return { text: out ?? text, spans };
-}
-
-/**
- * Drop findings that touch a shielded span. The filler should never match, but
- * a rule whose span merely brushes a blanked region (a keyword before it plus a
- * window across it) could still produce a finding whose rawMatch mixes real
- * text with filler — worthless to enforce on and wrong to vault.
- */
-export function dropShieldedFindings<T extends { span: { start: number; end: number } }>(
-  findings: T[],
-  spans: ShieldedSpan[],
-): T[] {
-  if (spans.length === 0) return findings;
-  return findings.filter(
-    (finding) => !spans.some((s) => finding.span.start < s.end && finding.span.end > s.start),
-  );
-}
+// The pointer shield now lives in @akasecurity/detections, shared with every
+// scan surface (the plugin's live hooks here, and local-ops' fs-scan pipeline
+// behind `aka scan` and the dashboard folder scan) — the "no rule ever sees a
+// pointer" guarantee must hold wherever the engine runs, not only in the
+// plugin. This module is a re-export shim so existing SDK consumers keep
+// importing it from here. Semantics are load-bearing and unchanged: pointer
+// spans are blanked with same-length filler before the engine runs, and any
+// finding touching a blanked span is dropped.
+export type { ShieldedSpan, ShieldedText } from '@akasecurity/detections';
+export { dropShieldedFindings, shieldPointers } from '@akasecurity/detections';

--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -39,6 +39,12 @@ const ACTION_PRIORITY: ActionTaken[] = ['block', 'redact', 'warn', 'log', 'allow
 interface ExceptionEvalContext {
   sourceTool?: SourceTool | undefined;
   metadata?: EventMetadata | undefined;
+  // Grant ids whose use was ALREADY spent by this same capture's pointer
+  // crossing. A matching entry suppresses without consuming and without the
+  // budget re-check — the budget was spent by the crossing that revealed the
+  // value now being scanned, and charging it twice would re-tokenize the very
+  // value the grant just revealed.
+  preAuthorizedGrantIds?: readonly string[] | undefined;
 }
 
 // A grant is active while unexpired and under its use budget. The bundle's
@@ -345,9 +351,19 @@ export function createPluginRuntime(
       }
 
       const now = Date.now();
+      const preAuthorized = new Set(ctx.preAuthorizedGrantIds ?? []);
       for (const [pair, group] of groups) {
         const entry = entries.get(pair);
-        if (!entry || !entryIsActive(entry, now) || !conditionsMatch(entry.conditions, ctx)) {
+        if (!entry) continue;
+        // A crossing this capture already spent: apply without consuming and
+        // without re-checking the budget the crossing just used up.
+        if (preAuthorized.has(entry.id)) {
+          if (!conditionsMatch(entry.conditions, ctx)) continue;
+          for (const finding of group) excepted.add(finding);
+          exceptionIds.push(entry.id);
+          continue;
+        }
+        if (!entryIsActive(entry, now) || !conditionsMatch(entry.conditions, ctx)) {
           continue;
         }
         // Fail-secure consume: a throw counts as "does not apply".
@@ -464,7 +480,11 @@ export function createPluginRuntime(
     const { decision, excepted, exceptionIds } = await evaluate(
       input.text,
       filePath ? { filePath } : undefined,
-      { sourceTool: input.sourceTool, metadata: input.metadata },
+      {
+        sourceTool: input.sourceTool,
+        metadata: input.metadata,
+        preAuthorizedGrantIds: opts.preAuthorizedGrantIds,
+      },
     );
     // 'with-findings' (the historical backfill) only persists messages that
     // actually leaked something, so a 30-day transcript sweep doesn't flood the
@@ -588,6 +608,9 @@ export function createPluginRuntime(
 export interface CaptureOptions {
   persist?: 'always' | 'with-findings';
   dedupe?: 'content-hash';
+  // Grant ids already spent by this capture's own pointer crossing (see
+  // ExceptionEvalContext.preAuthorizedGrantIds).
+  preAuthorizedGrantIds?: readonly string[];
 }
 
 export interface PluginRuntime {

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -60,10 +60,14 @@ export interface TokenizeTextResult {
   degraded: { category: string }[];
 }
 
+// Human-target only, and deliberately so. This entry applies ONE option set to
+// every pointer in a text, which no per-value grant can authorize — a single
+// grant covers a single value, not whatever else happens to share the string.
+// Model crossings go through substituteModelPointers, which decides pointer by
+// pointer and spends a grant per crossing.
 export interface DetokenizeTextOptions {
-  target: 'human' | 'model';
+  target: 'human';
   reason: VaultDerefReason;
-  grantId?: string | undefined;
 }
 
 export interface DetokenizeTextResult {
@@ -95,6 +99,9 @@ export interface VaultCore {
     fingerprintKeyVersion: number;
   } | null>;
   recordSighting?(pointerId: string, sighting: { location: string; kind: VaultSightingKind }): void;
+  // Claim one use of a reveal grant. Called once per grant per crossing, AFTER
+  // a successful de-reference — a refusal must never spend the budget.
+  consumeGrant?(grantId: string): Promise<boolean>;
 }
 
 // Resolves whether a model-echoed pointer may be de-referenced back to raw for
@@ -109,6 +116,17 @@ export interface SubstitutePointersResult {
   revealed: PointerToken[];
   // Pointers left literal: no grant, or the vault refused/could not resolve.
   unresolved: PointerToken[];
+  // The grant ids that authorized the reveals — the caller threads these into
+  // the detection scan so the same crossing's suppression does not spend a
+  // second use.
+  grantIds: string[];
+}
+
+export interface ProbePointersResult {
+  // Distinct pointers an active grant covers, with the covering grant id.
+  granted: Map<PointerToken, string>;
+  // Distinct pointers no grant covers.
+  ungranted: PointerToken[];
 }
 
 export interface TokenizeSighting {
@@ -127,15 +145,22 @@ export interface VaultGlue {
   ): Promise<string>;
   detokenizeText(text: string, opts: DetokenizeTextOptions): Promise<DetokenizeTextResult>;
   describePointerSafe(token: string): Promise<PointerDescriptor | null>;
+  // Grant resolution only — no de-reference, no audit rows. The executable-field
+  // deny path uses this so a mixed field never audits a 'revealed' crossing for
+  // a call that is then blocked.
+  probeModelPointers(
+    text: string,
+    opts: { resolveGrant: ModelDerefGrantResolver },
+  ): Promise<ProbePointersResult>;
   substituteModelPointers(
     text: string,
     opts: { resolveGrant: ModelDerefGrantResolver },
   ): Promise<SubstitutePointersResult>;
   // The live reveal-grant lookup for this store: a grant id when an active
   // reveal-to-model exception covers the pointer's value, null otherwise.
-  // Always null on a degraded glue. Deliberately does NOT consume the grant:
-  // a revealed value re-enters the detection scan immediately, and the
-  // suppression match there claims the use — one crossing, one use.
+  // Always null on a degraded glue. Resolution never spends the grant — the
+  // crossing itself consumes, once per grant, after a successful de-reference,
+  // whatever enforcement mode the covered rule runs under.
   revealGrantResolver: ModelDerefGrantResolver;
   /**
    * Release the store handle this glue opened. Idempotent, and a no-op on a
@@ -316,10 +341,11 @@ class SecretVaultGlue implements VaultGlue {
       const resolved = new Map<string, string | null>();
       for (const [pointer, count] of occurrences) {
         try {
+          // Pinned rather than forwarded from opts, so a caller reaching past
+          // the type still cannot turn this into a model crossing.
           const value = await this.#vault.detokenize(pointer, {
-            target: opts.target,
+            target: 'human',
             reason: opts.reason,
-            grantId: opts.grantId,
             pointerCount: count,
           });
           resolved.set(pointer, typeof value === 'string' ? value : null);
@@ -365,17 +391,40 @@ class SecretVaultGlue implements VaultGlue {
     }
   }
 
+  async probeModelPointers(
+    text: string,
+    opts: { resolveGrant: ModelDerefGrantResolver },
+  ): Promise<ProbePointersResult> {
+    const granted = new Map<PointerToken, string>();
+    const ungranted: PointerToken[] = [];
+    try {
+      for (const pointer of new Set([...text.matchAll(pointerTokenScanner())].map((m) => m[0]))) {
+        try {
+          const grantId = await opts.resolveGrant(pointer);
+          if (grantId === null) ungranted.push(pointer);
+          else granted.set(pointer, grantId);
+        } catch {
+          ungranted.push(pointer);
+        }
+      }
+      return { granted, ungranted };
+    } catch {
+      return { granted: new Map(), ungranted };
+    }
+  }
+
   async substituteModelPointers(
     text: string,
     opts: { resolveGrant: ModelDerefGrantResolver },
   ): Promise<SubstitutePointersResult> {
     try {
       const matches = [...text.matchAll(pointerTokenScanner())];
-      if (matches.length === 0) return { text, revealed: [], unresolved: [] };
+      if (matches.length === 0) return { text, revealed: [], unresolved: [], grantIds: [] };
 
-      // Resolve each distinct pointer once. Every model crossing — revealed or
+      // Two phases: resolve every distinct pointer's grant FIRST, then
+      // de-reference only the granted ones. Every model crossing — revealed or
       // refused — is audited by the vault itself; the glue adds no rows.
-      const resolved = new Map<string, string | null>();
+      const resolved = new Map<string, { value: string; grantId: string } | null>();
       for (const pointer of new Set(matches.map((m) => m[0]))) {
         try {
           const grantId = await opts.resolveGrant(pointer);
@@ -390,9 +439,25 @@ class SecretVaultGlue implements VaultGlue {
             reason: 'model-input',
             grantId,
           });
-          resolved.set(pointer, typeof value === 'string' ? value : null);
+          resolved.set(pointer, typeof value === 'string' ? { value, grantId } : null);
         } catch {
           resolved.set(pointer, null);
+        }
+      }
+
+      // The crossing spends the grant — once per grant, only on success, and
+      // regardless of what enforcement mode the covered rule runs under. Tying
+      // consumption to a later suppression match would make a once-grant
+      // unlimited whenever the rule sits at Monitor/Warn.
+      const spentGrants = new Set<string>();
+      for (const entry of resolved.values()) {
+        if (entry === null || spentGrants.has(entry.grantId)) continue;
+        spentGrants.add(entry.grantId);
+        try {
+          await this.#vault.consumeGrant?.(entry.grantId);
+        } catch {
+          // The reveal already happened; a failed claim only means the next
+          // crossing re-evaluates the grant's remaining budget.
         }
       }
 
@@ -400,18 +465,23 @@ class SecretVaultGlue implements VaultGlue {
       const revealed = new Set<string>();
       const unresolved = new Set<string>();
       for (const match of [...matches].reverse()) {
-        const value = resolved.get(match[0]);
-        if (value === null || value === undefined) {
+        const entry = resolved.get(match[0]);
+        if (entry === null || entry === undefined) {
           unresolved.add(match[0]);
           continue;
         }
         revealed.add(match[0]);
-        out = out.slice(0, match.index) + value + out.slice(match.index + match[0].length);
+        out = out.slice(0, match.index) + entry.value + out.slice(match.index + match[0].length);
       }
-      return { text: out, revealed: [...revealed], unresolved: [...unresolved] };
+      return {
+        text: out,
+        revealed: [...revealed],
+        unresolved: [...unresolved],
+        grantIds: [...spentGrants],
+      };
     } catch {
       // Pointers left literal are inert; nothing raw has been substituted.
-      return { text, revealed: [], unresolved: [] };
+      return { text, revealed: [], unresolved: [], grantIds: [] };
     }
   }
 }
@@ -447,6 +517,12 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
     const dir = dataDir(base);
     const db = openLocalDatabase(dir);
     const settings = readWorkspaceSettings(base);
+    // Resolved before the vault so the grant verifier below can close over it.
+    // An injected provider replaces the user-grant one wholesale, and the vault
+    // must ask the SAME decider the resolver asks — a vault consulting the local
+    // exceptions table directly would veto a crossing an injected provider had
+    // just authorized.
+    const provider = options?.policyProvider ?? new UserGrantPolicyProvider(db.exceptions);
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(settings.vaultKeyCustody, keysDir(base)),
@@ -454,6 +530,22 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
       // Read live so a revocation applies to the very next call, not the next
       // process.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
+      // This is the one construction site that reveals to the model, so it is
+      // the one that supplies the last gate. The decision is re-taken from the
+      // ROW's identity at the moment of crossing, which closes the window
+      // between resolving a grant and spending it: a grant revoked in between
+      // refuses here.
+      //
+      // The re-decision is on the identity alone, never on the grant id
+      // matching the one the resolver returned. ExceptionPolicyProvider
+      // promises no id stability across calls — a provider deciding from
+      // external policy may well mint a fresh id each time — so comparing ids
+      // would silently refuse every crossing for such a provider while looking
+      // like a security check. `allow` for this row is the whole question.
+      verifyGrant: async (_grantId, identity) => {
+        const decision = await provider.decideReveal(identity);
+        return decision.allow;
+      },
     });
     // The vault core plus the sighting recorder: SecretVault owns crypto and
     // audit; where a pointer LANDED is repository bookkeeping, wired in here so
@@ -466,11 +558,11 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
       recordSighting: (pointerId, sighting) => {
         db.secretVault.recordSighting({ pointerId, ...sighting }, Date.now());
       },
+      consumeGrant: (grantId) => db.exceptions.consume(grantId),
     };
     // The resolver is a thin adapter over the decision seam: pointer →
     // raw-free identity → provider decision. Anything failing along the way is
     // a refusal, never a reveal.
-    const provider = options?.policyProvider ?? new UserGrantPolicyProvider(db.exceptions);
     const revealGrantResolver: ModelDerefGrantResolver = async (pointer) => {
       try {
         const identity = await vault.resolvePointerIdentity(pointer);

--- a/packages/plugin-sdk/test/helpers/remove-tree.ts
+++ b/packages/plugin-sdk/test/helpers/remove-tree.ts
@@ -1,0 +1,31 @@
+// Removing a temp store's tree, with the Windows facts accounted for.
+//
+// A test here opens a real `LocalDatabase` on a temp base — through
+// `createVaultGlue`, which owns the handle. Closing the glue gives that handle
+// back, but Windows can still hold the store's files for a moment afterwards:
+// the `-wal` and `-shm` sidecars outlive the connection briefly, and `rmSync`
+// meets EPERM on a tree that POSIX would unlink without complaint.
+//
+// `@akasecurity/persistence` solves this in its own test harness, but that
+// harness is behind a package wall and is not importable here, so plugin-sdk
+// carries the same rules in miniature:
+//
+//   retry     through the window where a handle is merely on its way out;
+//   tolerate  on win32 only, handing the tree to the OS temp sweeper rather
+//             than failing a test whose assertions already passed.
+//
+// POSIX keeps throwing. There, these codes mean a cleanup genuinely did not run
+// — a glue left unclosed, say — and that is a defect in the test, not a
+// property of the platform.
+import { rmSync } from 'node:fs';
+
+const STILL_HELD = new Set(['EPERM', 'EBUSY', 'EACCES', 'ENOTEMPTY']);
+
+export function removeTree(dir: string): void {
+  try {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+  } catch (err) {
+    const code = (err as { code?: string }).code;
+    if (process.platform !== 'win32' || code === undefined || !STILL_HELD.has(code)) throw err;
+  }
+}

--- a/packages/plugin-sdk/test/pointer-shield.test.ts
+++ b/packages/plugin-sdk/test/pointer-shield.test.ts
@@ -85,44 +85,18 @@ registerRulePack('shield-test-pack', [
   },
 ]);
 
-describe('shieldPointers', () => {
-  it('blanks pointer spans with same-length filler', () => {
+// The shield implementation (and its pure unit tests) lives in
+// @akasecurity/detections; this module is a re-export shim. One smoke case
+// pins that both names still resolve and behave through the shim path.
+describe('pointer-shield shim', () => {
+  it('re-exports a working shieldPointers and dropShieldedFindings', () => {
     const text = `before ${POINTER} after`;
     const shielded = shieldPointers(text);
-    expect(shielded.text.length).toBe(text.length);
     expect(shielded.text).toBe(`before ${' '.repeat(POINTER.length)} after`);
     expect(shielded.spans).toEqual([{ start: 7, end: 7 + POINTER.length }]);
-  });
-
-  it('keeps every non-pointer offset identical', () => {
-    const text = `a ${POINTER} ${SECRET} z`;
-    const shielded = shieldPointers(text);
-    const secretAt = text.indexOf(SECRET);
-    expect(shielded.text.slice(secretAt, secretAt + SECRET.length)).toBe(SECRET);
-  });
-
-  it('passes pointer-free text through untouched', () => {
-    const shielded = shieldPointers('nothing here');
-    expect(shielded.text).toBe('nothing here');
-    expect(shielded.spans).toEqual([]);
-  });
-
-  it('does not blank a lookalike with an invented category', () => {
-    const lookalike = `[[aka:bogus:AE.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
-    expect(shieldPointers(lookalike).spans).toEqual([]);
-  });
-});
-
-describe('dropShieldedFindings', () => {
-  it('drops a finding that touches a shielded span', () => {
-    const findings = [
-      { span: { start: 0, end: 10 } },
-      { span: { start: 5, end: 25 } },
-      { span: { start: 30, end: 40 } },
-    ];
-    expect(dropShieldedFindings(findings, [{ start: 8, end: 28 }])).toEqual([
-      { span: { start: 30, end: 40 } },
-    ]);
+    expect(
+      dropShieldedFindings([{ span: { start: 7, end: 7 + POINTER.length } }], shielded.spans),
+    ).toEqual([]);
   });
 });
 

--- a/packages/plugin-sdk/test/reveal-seam.test.ts
+++ b/packages/plugin-sdk/test/reveal-seam.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { dataDir } from '../src/data-dir.ts';
 import type { VaultGlue } from '../src/tokenize.ts';
 import { createVaultGlue } from '../src/tokenize.ts';
+import { removeTree } from './helpers/remove-tree.ts';
 
 const SECRET = 'AKIAIOSFODNN7EXAMPLE';
 
@@ -60,7 +61,7 @@ describe('reveal decision seam', () => {
 
   afterEach(() => {
     for (const glue of opened.splice(0)) glue.close();
-    rmSync(base, { recursive: true, force: true });
+    removeTree(base);
   });
 
   it('the default (user-grant) provider denies with no grant on file', async () => {
@@ -123,6 +124,63 @@ describe('reveal decision seam', () => {
     const result = await glue.substituteModelPointers(`k=${token}`, {
       resolveGrant: glue.revealGrantResolver,
     });
+    expect(result.revealed).toEqual([]);
+    expect(result.text).toBe(`k=${token}`);
+  });
+
+  // The vault re-takes the decision from the row's own identity at the moment
+  // raw would leave the store, so a resolver handing over a grant id is not the
+  // last word: a decider that says no still refuses the crossing.
+  it('refuses when the decider says no, whatever the resolver handed over', async () => {
+    const noGrants: ExceptionPolicyProvider = {
+      decideReveal: () => Promise.resolve({ allow: false }),
+    };
+    const glue = createVaultGlue({ base, policyProvider: noGrants });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: () => Promise.resolve('fabricated-grant'),
+    });
+    expect(result.revealed).toEqual([]);
+    expect(result.text).toBe(`k=${token}`);
+  });
+
+  // The seam promises no id stability across calls, so a build whose decider
+  // mints a fresh id per call must still be able to reveal. Pinning this stops
+  // an id comparison from being reintroduced at the crossing, where it would
+  // refuse every such build while reading like a security check.
+  it('reveals for a decider that issues a different id each call', async () => {
+    let issued = 0;
+    const freshIdEachCall: ExceptionPolicyProvider = {
+      decideReveal: () => {
+        issued += 1;
+        return Promise.resolve({ allow: true, grantId: `policy-grant-${String(issued)}` });
+      },
+    };
+    const glue = createVaultGlue({ base, policyProvider: freshIdEachCall });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(issued).toBeGreaterThan(1);
+    expect(result.revealed).toEqual([token]);
+    expect(result.text).toBe(`k=${SECRET}`);
+  });
+
+  // Resolution and the crossing are two separate moments. Re-deciding at the
+  // second one is what makes a revocation that lands in between bind.
+  it('does not cross on a grant revoked between resolution and de-reference', async () => {
+    let decisions = 0;
+    const revokedAfterResolve: ExceptionPolicyProvider = {
+      decideReveal: () => {
+        decisions += 1;
+        return Promise.resolve(
+          decisions === 1 ? { allow: true, grantId: 'g-live' } : { allow: false },
+        );
+      },
+    };
+    const glue = createVaultGlue({ base, policyProvider: revokedAfterResolve });
+    const result = await glue.substituteModelPointers(`k=${token}`, {
+      resolveGrant: glue.revealGrantResolver,
+    });
+    expect(decisions).toBeGreaterThan(1);
     expect(result.revealed).toEqual([]);
     expect(result.text).toBe(`k=${token}`);
   });

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { dataDir } from '../src/data-dir.ts';
 import type { VaultCore, VaultGlue } from '../src/tokenize.ts';
 import { createVaultGlue, POINTER_UNAVAILABLE_TEXT } from '../src/tokenize.ts';
+import { removeTree } from './helpers/remove-tree.ts';
 
 const SECRET = 'AKIAIOSFODNN7EXAMPLE';
 const OTHER = 'AKIAI44QH8DHBEXAMPLE';
@@ -52,7 +53,7 @@ describe('vault glue', () => {
     // Windows will not remove a directory that still holds an open store
     // handle, so the glue must release before the temp base is cleared.
     glue.close();
-    rmSync(base, { recursive: true, force: true });
+    removeTree(base);
   });
 
   describe('tokenizeText with findings', () => {
@@ -191,7 +192,7 @@ describe('vault glue', () => {
         db.close();
         ungranted.close();
       } finally {
-        rmSync(bare, { recursive: true, force: true });
+        removeTree(bare);
       }
     });
   });
@@ -303,7 +304,7 @@ describe('vault glue', () => {
         // safe on a degraded glue, which is the branch a caller cannot detect.
         degraded.close();
       } finally {
-        rmSync(badBase, { recursive: true, force: true });
+        removeTree(badBase);
       }
     });
   });
@@ -368,7 +369,7 @@ describe('sighting recording', () => {
     // Before the rm, as every other suite here does: this glue opened a store
     // handle, and Windows refuses to remove a directory one is still held in.
     glue.close();
-    rmSync(base, { recursive: true, force: true });
+    removeTree(base);
   });
 
   it('records where a minted pointer landed, one row per location', async () => {

--- a/packages/schema/drizzle/local-sqlite/0018_serious_tana_nile.sql
+++ b/packages/schema/drizzle/local-sqlite/0018_serious_tana_nile.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `secret_vault` ADD `format_version` integer DEFAULT 2 NOT NULL;

--- a/packages/schema/drizzle/local-sqlite/meta/0018_snapshot.json
+++ b/packages/schema/drizzle/local-sqlite/meta/0018_snapshot.json
@@ -1,0 +1,2579 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1df4c7c9-b51d-4e16-95e3-edb69ba160d3",
+  "prevId": "cdbf5a58-e837-4dcc-9a6a-d75b3a34a112",
+  "tables": {
+    "audit_events": {
+      "name": "audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_project_id": {
+          "name": "source_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.output_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_creation_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_read_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.model'))",
+            "type": "virtual"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.provider'))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_audit_parent": {
+          "name": "idx_audit_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session": {
+          "name": "idx_audit_session",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_harness_t": {
+          "name": "idx_audit_harness_t",
+          "columns": [
+            "harness_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_project_t": {
+          "name": "idx_audit_project_t",
+          "columns": [
+            "source_project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session_type": {
+          "name": "idx_audit_session_type",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false,
+          "where": "event_type = 'llm_call'"
+        },
+        "idx_audit_type_t": {
+          "name": "idx_audit_type_t",
+          "columns": [
+            "event_type",
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_parent_id_audit_events_id_fk": {
+          "name": "audit_events_parent_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_root_session_id_audit_events_id_fk": {
+          "name": "audit_events_root_session_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "root_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_host_id_inventory_id_fk": {
+          "name": "audit_events_host_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_harness_id_inventory_id_fk": {
+          "name": "audit_events_harness_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_source_project_id_source_project_id_fk": {
+          "name": "audit_events_source_project_id_source_project_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "source_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "available_packs": {
+      "name": "available_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_available_packs_pack": {
+          "name": "uq_available_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classified_data": {
+      "name": "classified_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "egress_decision_override": {
+      "name": "egress_decision_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_egress_decision_override": {
+          "name": "uq_egress_decision_override",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": true
+        },
+        "uq_egress_decision_override_host": {
+          "name": "uq_egress_decision_override_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true,
+          "where": "`host` IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "egress_decision_override_destination_id_share_destination_id_fk": {
+          "name": "egress_decision_override_destination_id_share_destination_id_fk",
+          "tableFrom": "egress_decision_override",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_tool": {
+          "name": "source_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_occurred": {
+          "name": "idx_events_occurred",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_value": {
+          "name": "masked_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'suppress'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_exceptions_active": {
+          "name": "uq_exceptions_active",
+          "columns": [
+            "rule_id",
+            "value_fingerprint",
+            "key_version"
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_access_override": {
+      "name": "file_access_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_access_override_project": {
+          "name": "idx_file_access_override_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_file_access_override": {
+          "name": "uq_file_access_override",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_access_override_project_id_source_project_id_fk": {
+          "name": "file_access_override_project_id_source_project_id_fk",
+          "tableFrom": "file_access_override",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "finding_resolution": {
+      "name": "finding_resolution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_finding_resolution_key": {
+          "name": "idx_finding_resolution_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "findings": {
+      "name": "findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_findings_event": {
+          "name": "idx_findings_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_findings_key": {
+          "name": "uq_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "findings_event_id_events_id_fk": {
+          "name": "findings_event_id_events_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "harness_asset": {
+      "name": "harness_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_harness_asset_harness": {
+          "name": "idx_harness_asset_harness",
+          "columns": [
+            "harness_id"
+          ],
+          "isUnique": false
+        },
+        "uq_harness_asset": {
+          "name": "uq_harness_asset",
+          "columns": [
+            "harness_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "harness_asset_harness_id_inventory_id_fk": {
+          "name": "harness_asset_harness_id_inventory_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harness_asset_asset_id_inventory_asset_id_fk": {
+          "name": "harness_asset_asset_id_inventory_asset_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_definitions": {
+      "name": "inspection_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_findings": {
+      "name": "inspection_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_definition_id": {
+          "name": "inspection_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classified_data_id": {
+          "name": "classified_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_findings_event": {
+          "name": "idx_inspection_findings_event",
+          "columns": [
+            "audit_event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_inspection_findings_key": {
+          "name": "uq_inspection_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_findings_audit_event_id_audit_events_id_fk": {
+          "name": "inspection_findings_audit_event_id_audit_events_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "audit_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_inspection_definition_id_inspection_definitions_id_fk": {
+          "name": "inspection_findings_inspection_definition_id_inspection_definitions_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "inspection_definitions",
+          "columnsFrom": [
+            "inspection_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_classified_data_id_classified_data_id_fk": {
+          "name": "inspection_findings_classified_data_id_classified_data_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "classified_data",
+          "columnsFrom": [
+            "classified_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_packs": {
+      "name": "installed_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_installed_packs_pack": {
+          "name": "uq_installed_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory": {
+      "name": "inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.os_version'))",
+            "type": "virtual"
+          }
+        },
+        "harness_version": {
+          "name": "harness_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.harness_version'))",
+            "type": "virtual"
+          }
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_osver": {
+          "name": "idx_inventory_type_osver",
+          "columns": [
+            "object_type",
+            "os_version"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_harnessver": {
+          "name": "idx_inventory_type_harnessver",
+          "columns": [
+            "object_type",
+            "harness_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_host_id_inventory_id_fk": {
+          "name": "inventory_host_id_inventory_id_fk",
+          "tableFrom": "inventory",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_asset": {
+      "name": "inventory_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_asset_type": {
+          "name": "idx_inventory_asset_type",
+          "columns": [
+            "asset_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_override": {
+      "name": "mcp_trust_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_mcp_trust_override": {
+          "name": "uq_mcp_trust_override",
+          "columns": [
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pack_write_gate": {
+      "name": "_pack_write_gate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open": {
+          "name": "open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_pack_write_gate_single_row": {
+          "name": "ck_pack_write_gate_single_row",
+          "value": "\"_pack_write_gate\".\"id\" = 1"
+        }
+      }
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "custom_keywords": {
+          "name": "custom_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_policies_scope_target": {
+          "name": "uq_policies_scope_target",
+          "columns": [
+            "scope",
+            "target"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_file": {
+      "name": "project_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_access": {
+          "name": "default_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_file_project": {
+          "name": "idx_project_file_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_project_file": {
+          "name": "uq_project_file",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_source_project_id_fk": {
+          "name": "project_file_project_id_source_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault": {
+      "name": "secret_vault",
+      "columns": {
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_key_version": {
+          "name": "fingerprint_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format_version": {
+          "name": "format_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_value": {
+          "name": "uq_secret_vault_value",
+          "columns": [
+            "value_fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_deref": {
+      "name": "secret_vault_deref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pointer_count": {
+          "name": "pointer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_secret_vault_deref_pointer": {
+          "name": "idx_secret_vault_deref_pointer",
+          "columns": [
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_reason_at": {
+          "name": "idx_secret_vault_deref_reason_at",
+          "columns": [
+            "reason",
+            "at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_sighting": {
+      "name": "secret_vault_sighting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_sighting": {
+          "name": "uq_secret_vault_sighting",
+          "columns": [
+            "pointer_id",
+            "location"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_call_site": {
+      "name": "share_call_site",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "vendored": {
+          "name": "vendored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_call_site_endpoint": {
+          "name": "idx_share_call_site_endpoint",
+          "columns": [
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_call_site_project": {
+          "name": "idx_share_call_site_project",
+          "columns": [
+            "project_key",
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_call_site": {
+          "name": "uq_share_call_site",
+          "columns": [
+            "endpoint_id",
+            "project_key",
+            "file",
+            "line"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_call_site_endpoint_id_share_endpoint_id_fk": {
+          "name": "share_call_site_endpoint_id_share_endpoint_id_fk",
+          "tableFrom": "share_call_site",
+          "tableTo": "share_endpoint",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_destination": {
+      "name": "share_destination",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_json": {
+          "name": "network_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_destination_kind": {
+          "name": "idx_share_destination_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "uq_share_destination_host": {
+          "name": "uq_share_destination_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_endpoint": {
+      "name": "share_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "data_class": {
+          "name": "data_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_endpoint_dest": {
+          "name": "idx_share_endpoint_dest",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_endpoint": {
+          "name": "uq_share_endpoint",
+          "columns": [
+            "destination_id",
+            "method",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_endpoint_destination_id_share_destination_id_fk": {
+          "name": "share_endpoint_destination_id_share_destination_id_fk",
+          "tableFrom": "share_endpoint",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_project": {
+      "name": "source_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/schema/drizzle/local-sqlite/meta/_journal.json
+++ b/packages/schema/drizzle/local-sqlite/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1785351665625,
       "tag": "0017_rainy_kat_farrell",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1785351865257,
+      "tag": "0018_serious_tana_nile",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/schema/src/drizzle/columns.ts
+++ b/packages/schema/src/drizzle/columns.ts
@@ -140,6 +140,7 @@ export const COL = {
   // Different tables, different meanings — deliberately not the same name.
   pointerId: 'pointer_id',
   fingerprintKeyVersion: 'fingerprint_key_version',
+  formatVersion: 'format_version',
   ciphertext: 'ciphertext',
   nonce: 'nonce',
   authTag: 'auth_tag',

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -713,6 +713,13 @@ export const secretVault = sqliteTable(
     fingerprintKeyVersion: integer(COL.fingerprintKeyVersion).notNull(),
     // The vault-key epoch this row's ciphertext is sealed under.
     keyVersion: integer(COL.keyVersion).notNull(),
+    // The pointer-format generation (POINTER_FORMAT_VERSION) this row's
+    // ciphertext AAD is bound under — the AAD only, never the wire tag, which
+    // is checked against the current constant before any row is looked up.
+    // Recorded per row so a future format bump can still open and re-seal
+    // existing entries instead of stranding them. Default 2: every row written
+    // before this column existed was sealed under format version 2.
+    formatVersion: integer(COL.formatVersion).notNull().default(2),
     // Fixed at first mint, never updated on re-detection: the same value seen
     // later under a different rule's category keeps its minted category, so one
     // value always yields exactly one wire token.

--- a/packages/schema/src/drizzle/sqlite-ddl.ts
+++ b/packages/schema/src/drizzle/sqlite-ddl.ts
@@ -99,4 +99,8 @@ export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
     tag: '0017_rainy_kat_farrell',
     sql: 'CREATE TABLE `secret_vault_sighting` (\n\t`id` text PRIMARY KEY NOT NULL,\n\t`pointer_id` text NOT NULL,\n\t`location` text NOT NULL,\n\t`kind` text NOT NULL,\n\t`first_seen` integer NOT NULL,\n\t`last_seen` integer NOT NULL\n);\n--> statement-breakpoint\nCREATE UNIQUE INDEX `uq_secret_vault_sighting` ON `secret_vault_sighting` (`pointer_id`,`location`);',
   },
+  {
+    tag: '0018_serious_tana_nile',
+    sql: 'ALTER TABLE `secret_vault` ADD `format_version` integer DEFAULT 2 NOT NULL;',
+  },
 ];

--- a/packages/schema/src/zod/vault.ts
+++ b/packages/schema/src/zod/vault.ts
@@ -23,6 +23,21 @@ export const VAULT_SPEC_VERSION = 1;
 // `[[aka:tok:...]]` form, which no shipped build ever emitted; version 2 carries
 // the category segment. It is covered by the pointer tag and by the AEAD AAD, so
 // a pointer cannot be relabelled into a different category.
+//
+// MOVING THIS NUMBER IS NOT A ONE-LINE CHANGE. Pointer tags are signed AND
+// verified under whatever this constant currently says, on both sides, because
+// a tag is checked before its row is looked up — so verification cannot know
+// which generation a row was sealed under. Bump this alone and every
+// already-stored row starts emitting tokens signed under the new value: the
+// vault would refuse the very tokens it just minted, silently, since a failed
+// verification writes no audit row. That takes out the masked badge and the
+// reveal-grant path along with the read path.
+//
+// A bump must ship a verification story for stored rows first — either carry
+// the generation on the wire so verification can read it without the row, or
+// re-seal and re-emit every row as part of the migration. `secret_vault`
+// records each row's generation (`format_version`) so that migration is
+// possible; nothing uses it for tags.
 export const POINTER_FORMAT_VERSION = 2;
 
 // ─── The wire pointer ────────────────────────────────────────────────────────
@@ -75,7 +90,7 @@ export type ParsedPointer = z.infer<typeof ParsedPointer>;
 export const VaultEntry = z.object({
   pointerId: z.string(),
   // The keyed HMAC of the raw value under `exception.key`, and the epoch it was
-  // derived under. This is what an SP-5 reveal grant matches on, and it rotates
+  // derived under. This is what a reveal-to-model grant matches on, and it rotates
   // independently of the vault encryption key below.
   valueFingerprint: z.string().regex(/^[0-9a-f]{64}$/),
   fingerprintKeyVersion: z.number().int().positive(),
@@ -93,7 +108,7 @@ export const VaultEntry = z.object({
   nonce: z.string(),
   authTag: z.string(),
   // How many times this value has been detected on this machine — the reuse
-  // signal SP-6 reads. Distinct from VaultDeref.pointerCount.
+  // signal the vault dashboard reads. Distinct from VaultDeref.pointerCount.
   occurrenceCount: z.number().int().nonnegative(),
   firstSeen: z.string(),
   lastSeen: z.string(),

--- a/plugins/claude-code/src/history/tail-scrub.ts
+++ b/plugins/claude-code/src/history/tail-scrub.ts
@@ -30,7 +30,7 @@ import { type platformRedactionScope, resolveRedactableArtifact } from '../remed
 // whole-file read — acceptable because it runs in the detached reconcile
 // worker, off the hot hook path — but a pathological transcript must not
 // balloon the worker, so the read is capped.
-const MAX_SCRUB_BYTES = 32 * 1024 * 1024;
+const DEFAULT_MAX_SCRUB_BYTES = 32 * 1024 * 1024;
 
 export interface TailScrubDeps {
   // The vault-glue text tokenizer: self-scans, shields existing pointers so a
@@ -42,6 +42,9 @@ export interface TailScrubDeps {
   ): Promise<{ text: string; pointers: string[]; degraded: { category: string }[] }>;
   // The artifact roots whose contained files may be rewritten in place.
   scope: ReturnType<typeof platformRedactionScope>;
+  // Whole-file read cap in bytes; a larger file is skipped (null). Defaults to
+  // 32 MiB when unset.
+  maxBytes?: number;
 }
 
 /**
@@ -60,7 +63,11 @@ export async function scrubTranscriptTail(
     // Containment first: out of scope → never opened for writing.
     const realPath = resolveRedactableArtifact(filePath, deps.scope);
     if (realPath === null) return null;
-    if (statSync(realPath).size > MAX_SCRUB_BYTES) return null;
+    // Snapshot the stat up front: the size gates the whole-file read, the mode
+    // is re-applied to the rewrite, and size+mtime detect concurrent appends
+    // just before the rename below.
+    const statBefore = statSync(realPath);
+    if (statBefore.size > (deps.maxBytes ?? DEFAULT_MAX_SCRUB_BYTES)) return null;
 
     const content = readFileSync(realPath, 'utf8');
     // Line-by-line so the rewrite can only ever change bytes WITHIN a line —
@@ -84,7 +91,21 @@ export async function scrubTranscriptTail(
     // original — a crash mid-write leaves the transcript intact.
     const tmpPath = `${realPath}.aka-scrub.tmp`;
     try {
-      writeFileSync(tmpPath, lines.join('\n'));
+      // Preserve the transcript's permission bits: without an explicit mode
+      // the temp file is created at the umask default, and the rename would
+      // widen a 0600 transcript to world-readable.
+      writeFileSync(tmpPath, lines.join('\n'), { mode: statBefore.mode & 0o777 });
+      // The transcript is LIVE — Claude Code may have appended lines while the
+      // scrub tokenized its in-memory snapshot. Renaming the snapshot over a
+      // file that changed underneath would silently destroy those lines, so
+      // ANY difference since the first stat aborts the rewrite: a lost scrub
+      // is retried by the next reconcile pass, but lost transcript lines do
+      // not come back.
+      const statNow = statSync(realPath);
+      if (statNow.size !== statBefore.size || statNow.mtimeMs !== statBefore.mtimeMs) {
+        rmSync(tmpPath, { force: true, recursive: true });
+        return null;
+      }
       renameSync(tmpPath, realPath);
     } catch {
       try {

--- a/plugins/claude-code/src/hooks/message-display-transform.ts
+++ b/plugins/claude-code/src/hooks/message-display-transform.ts
@@ -1,31 +1,64 @@
-// Pure display-side pointer rendering for the MessageDisplay hook. The hook
-// fires once per streaming delta, so a pointer token can arrive split across
-// process invocations; this module rewrites each delta and threads a carry —
-// the possibly-open pointer tail plus the markdown-region state — between
-// calls. All I/O is injected through DisplayDeps, so the whole surface is
-// synchronously testable; the hook entry (message-display.ts) owns stdin,
-// settings, and carry persistence.
+// Display-side pointer rendering for the MessageDisplay hook. The hook fires
+// once per streaming delta, so a pointer token can arrive split across process
+// invocations; `transformDelta` rewrites each delta and threads a carry — the
+// possibly-open pointer/marker tail plus the markdown-region state — between
+// calls. The transform's I/O is injected through DisplayDeps, so it is
+// synchronously testable; the carry store at the bottom of this file persists
+// the carry between hook processes in one per-session file, and the hook entry
+// (message-display.ts) owns stdin and settings.
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+
 import { DetectionCategory, pointerTokenScanner } from '@akasecurity/schema';
+
+// An open fenced-code region: the opening marker's character and run length.
+// A fence closes only on a line-start run of the SAME character at least as
+// long as the opener, so a ``` inside a ````-opened fence is content, and a
+// tilde fence is never closed by backticks.
+export interface FenceState {
+  char: '`' | '~';
+  len: number;
+}
 
 // State threaded between deltas of one content block.
 export interface DisplayCarry {
-  // A buffer suffix that may be the opening of a pointer token, held back and
-  // re-scanned with the next delta.
+  // A buffer suffix that may be the opening of a pointer token, or a trailing
+  // backtick/tilde run that could still grow into a fence marker, held back
+  // and re-scanned with the next delta.
   tail: string;
-  // Markdown-region state of the emitted stream so far: inside a ``` fence,
-  // inside an inline `code` span, on a '>'-quoted line.
-  fenceOpen: boolean;
+  // Markdown-region state of the emitted stream so far: inside a fenced code
+  // block, inside an inline `code` span, on a '>'-quoted line.
+  fence: FenceState | null;
   tickOpen: boolean;
   lineQuoted: boolean;
-  // Raw values revealed so far in this block (full mode's per-message cap).
+  // Position within the current line: whether non-whitespace content has been
+  // seen yet, and how many columns of leading whitespace precede it. Both
+  // persist across deltas so a marker resuming at a delta boundary is judged
+  // against its true line position — a fence only opens or closes at line
+  // start with at most 3 columns of indent.
+  lineSeen: boolean;
+  lineIndent: number;
+  // Raw values revealed so far in this MESSAGE (full mode's cap). The carry
+  // store persists this per message — it survives block finals and resets
+  // only when the message id changes.
   revealedCount: number;
 }
 
 export const EMPTY_CARRY: DisplayCarry = Object.freeze({
   tail: '',
-  fenceOpen: false,
+  fence: null,
   tickOpen: false,
   lineQuoted: false,
+  lineSeen: false,
+  lineIndent: 0,
   revealedCount: 0,
 });
 
@@ -55,6 +88,10 @@ const CATEGORIES: readonly string[] = DetectionCategory.options;
 // (longest category + maximal key-version segment); anything longer being held
 // would mean the prefix check has gone wrong, so flush instead of buffering.
 export const MAX_POINTER_LEN = 96;
+
+// Upper bound on a held trailing backtick/tilde run. A longer run flushes —
+// it has already opened whatever fence it can open.
+const MAX_MARKER_HOLD = 8;
 
 // Whether `s` is a prefix of some string the pointer grammar accepts:
 // `[[aka:<category>:<b32{2,7}>.<b32{26}>.<b32{16}>]]`. Checked segment by
@@ -99,44 +136,78 @@ function tokenCategory(token: string): string {
 }
 
 // Markdown-region walker over the emitted stream. Deliberately conservative:
-// when a delta boundary makes the state ambiguous (a quote marker arriving in
-// a later delta than its line start), the walk errs toward "protected", which
-// only ever masks a pointer that full mode might have revealed.
+// where a delta boundary leaves the state ambiguous, the walk errs toward
+// "protected", which only ever masks a pointer that full mode might have
+// revealed — never the reverse.
 interface RegionState {
-  fenceOpen: boolean;
+  fence: FenceState | null;
   tickOpen: boolean;
   lineQuoted: boolean;
-  // Whether the current line has non-whitespace content yet. Not persisted
-  // across deltas; resuming with false lets a '>' at a delta boundary still
-  // mark the line quoted (over-protecting, never under-protecting).
   lineSeen: boolean;
+  lineIndent: number;
+}
+
+// Whether the rest of the current line, as far as this segment shows it, is
+// blank up to a newline. Without a visible newline the answer is false: a
+// closing fence is only honored once the whole closing line has been seen
+// (keeping the fence open masks longer, never reveals early).
+function restOfLineIsBlank(text: string, from: number): boolean {
+  for (let k = from; k < text.length; k += 1) {
+    const c = text[k];
+    if (c === '\n') return true;
+    if (c !== ' ' && c !== '\t' && c !== '\r') return false;
+  }
+  return false;
 }
 
 function advanceRegions(state: RegionState, text: string): void {
   let i = 0;
   while (i < text.length) {
     const ch = text[i];
-    if (ch === '`') {
-      if (text.startsWith('```', i)) {
-        state.fenceOpen = !state.fenceOpen;
-        state.tickOpen = false;
-        state.lineSeen = true;
-        i += 3;
-        continue;
-      }
-      if (!state.fenceOpen) state.tickOpen = !state.tickOpen;
-      state.lineSeen = true;
-      i += 1;
-      continue;
-    }
     if (ch === '\n') {
       state.lineQuoted = false;
       state.lineSeen = false;
+      state.lineIndent = 0;
       i += 1;
       continue;
     }
+    if (ch === '`' || ch === '~') {
+      let end = i + 1;
+      while (end < text.length && text[end] === ch) end += 1;
+      const runLen = end - i;
+      const atLineStart = !state.lineSeen && state.lineIndent <= 3;
+      if (state.fence !== null) {
+        // Inside a fence every marker is content except a matching closer: a
+        // line-start run of the opening character, at least as long as the
+        // opener, with nothing else on its line.
+        if (
+          atLineStart &&
+          ch === state.fence.char &&
+          runLen >= state.fence.len &&
+          restOfLineIsBlank(text, end)
+        ) {
+          state.fence = null;
+        }
+      } else if (atLineStart && runLen >= 3) {
+        state.fence = { char: ch, len: runLen };
+        state.tickOpen = false;
+      } else if (ch === '`' && runLen % 2 === 1) {
+        // Mid-line backtick runs pair off as inline code delimiters; an odd
+        // run flips the span state. Mid-line runs never touch fence state.
+        state.tickOpen = !state.tickOpen;
+      }
+      state.lineSeen = true;
+      i = end;
+      continue;
+    }
     if (!state.lineSeen) {
-      if (ch === ' ' || ch === '\t') {
+      if (ch === ' ') {
+        state.lineIndent += 1;
+        i += 1;
+        continue;
+      }
+      if (ch === '\t') {
+        state.lineIndent += 4;
         i += 1;
         continue;
       }
@@ -193,13 +264,26 @@ export async function transformDelta(
         break;
       }
     }
+    // A trailing backtick/tilde run could still grow into (or extend) a fence
+    // marker in the next delta — an opener split as '``' + '`\n' must not be
+    // walked as two short runs. Hold it exactly like a pointer prefix; a run
+    // past MAX_MARKER_HOLD flushes.
+    if (tailStart === buf.length && buf.length > 0) {
+      const lastCh = buf[buf.length - 1];
+      if (lastCh === '`' || lastCh === '~') {
+        let start = buf.length - 1;
+        while (start > 0 && buf[start - 1] === lastCh) start -= 1;
+        if (buf.length - start <= MAX_MARKER_HOLD) tailStart = start;
+      }
+    }
   }
 
   const state: RegionState = {
-    fenceOpen: carry.fenceOpen,
+    fence: carry.fence,
     tickOpen: carry.tickOpen,
     lineQuoted: carry.lineQuoted,
-    lineSeen: false,
+    lineSeen: carry.lineSeen,
+    lineIndent: carry.lineIndent,
   };
   let out = '';
   let pos = 0;
@@ -215,7 +299,7 @@ export async function transformDelta(
     // Fenced, inline-code, and quoted regions render masked even in full
     // mode — they are exactly what users copy elsewhere — and the per-message
     // cap bounds an injected "echo every pointer" to a couple of values.
-    const shielded = state.fenceOpen || state.tickOpen || state.lineQuoted;
+    const shielded = state.fence !== null || state.tickOpen || state.lineQuoted;
     let replacement: string;
     if (deps.mode === 'full' && !shielded && revealedCount < deps.maxRevealsPerMessage) {
       let value: string | null;
@@ -247,9 +331,11 @@ export async function transformDelta(
 
   const nextCarry: DisplayCarry = {
     tail: buf.slice(tailStart),
-    fenceOpen: state.fenceOpen,
+    fence: state.fence,
     tickOpen: state.tickOpen,
     lineQuoted: state.lineQuoted,
+    lineSeen: state.lineSeen,
+    lineIndent: state.lineIndent,
     revealedCount,
   };
 
@@ -260,4 +346,169 @@ export async function transformDelta(
     return { display: null, carry: nextCarry };
   }
   return { display: out, carry: nextCarry };
+}
+
+// ─── Carry persistence ──────────────────────────────────────────────────────
+//
+// One carry file PER SESSION under the data dir, so concurrent sessions never
+// clobber each other's held text. Inside the file the state is split by key:
+// the tail and region state belong to one content block
+// (session/message/index) and die with it, while the reveal count belongs to
+// the whole message (session/message) so an N-block message still gets one
+// shared cap. Only counts, region flags, and pointer-prefix text are ever
+// written — never a revealed value. Everything here degrades silently: a
+// lost carry means raw pointer display, never a broken session.
+
+const CARRY_FILE_PREFIX = 'display-carry';
+const STALE_CARRY_MS = 15 * 60 * 1000;
+
+export interface CarryKeys {
+  // session/message/index — owns the tail and region state.
+  blockKey: string;
+  // session/message — owns the reveal count.
+  messageKey: string;
+}
+
+export function carryFilePath(dataDir: string, sessionId: string): string {
+  const safe = sessionId.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80);
+  return join(dataDir, `${CARRY_FILE_PREFIX}-${safe === '' ? 'session' : safe}.json`);
+}
+
+function parseFence(value: unknown): FenceState | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const fence = value as Record<string, unknown>;
+  if (fence.char !== '`' && fence.char !== '~') return null;
+  if (typeof fence.len !== 'number' || !Number.isInteger(fence.len) || fence.len < 3) return null;
+  return { char: fence.char, len: fence.len };
+}
+
+export function loadCarry(file: string, keys: CarryKeys): DisplayCarry {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, 'utf8'));
+    if (typeof parsed !== 'object' || parsed === null) return EMPTY_CARRY;
+    const record = parsed as Record<string, unknown>;
+    const revealedCount =
+      record.messageKey === keys.messageKey &&
+      typeof record.revealedCount === 'number' &&
+      Number.isFinite(record.revealedCount)
+        ? record.revealedCount
+        : 0;
+    let block: Omit<DisplayCarry, 'revealedCount'> = EMPTY_CARRY;
+    if (record.blockKey === keys.blockKey && typeof record.block === 'object') {
+      const raw = (record.block ?? {}) as Record<string, unknown>;
+      block = {
+        tail: typeof raw.tail === 'string' ? raw.tail : '',
+        fence: parseFence(raw.fence),
+        tickOpen: raw.tickOpen === true,
+        lineQuoted: raw.lineQuoted === true,
+        lineSeen: raw.lineSeen === true,
+        lineIndent:
+          typeof raw.lineIndent === 'number' &&
+          Number.isFinite(raw.lineIndent) &&
+          raw.lineIndent >= 0
+            ? raw.lineIndent
+            : 0,
+      };
+    }
+    return {
+      tail: block.tail,
+      fence: block.fence,
+      tickOpen: block.tickOpen,
+      lineQuoted: block.lineQuoted,
+      lineSeen: block.lineSeen,
+      lineIndent: block.lineIndent,
+      revealedCount,
+    };
+  } catch {
+    return EMPTY_CARRY;
+  }
+}
+
+// Single-record overwrite, atomic via tmp+rename, owner-only mode. A null
+// blockKey stores a message-only record (reveal count with no block state).
+function writeCarryRecord(
+  file: string,
+  blockKey: string | null,
+  messageKey: string,
+  carry: DisplayCarry,
+): void {
+  const record = {
+    blockKey,
+    messageKey,
+    block: {
+      tail: carry.tail,
+      fence: carry.fence,
+      tickOpen: carry.tickOpen,
+      lineQuoted: carry.lineQuoted,
+      lineSeen: carry.lineSeen,
+      lineIndent: carry.lineIndent,
+    },
+    revealedCount: carry.revealedCount,
+    updatedAt: new Date().toISOString(),
+  };
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(record), { mode: 0o600 });
+  renameSync(tmp, file);
+}
+
+// Reap carry files no session has touched in a while — abandoned sessions
+// must not accumulate files under the data dir.
+function removeStaleCarryFiles(dir: string, keep: string): void {
+  try {
+    const cutoff = Date.now() - STALE_CARRY_MS;
+    for (const name of readdirSync(dir)) {
+      if (!name.startsWith(CARRY_FILE_PREFIX) || !name.endsWith('.json')) continue;
+      const path = join(dir, name);
+      if (path === keep) continue;
+      try {
+        if (statSync(path).mtimeMs < cutoff) rmSync(path, { force: true });
+      } catch {
+        // A vanished or unreadable entry is someone else's live file.
+      }
+    }
+  } catch {
+    // Cleanup is opportunistic; a failed listing changes nothing.
+  }
+}
+
+export function saveCarry(file: string, keys: CarryKeys, carry: DisplayCarry): void {
+  try {
+    const dir = dirname(file);
+    mkdirSync(dir, { recursive: true });
+    removeStaleCarryFiles(dir, file);
+    writeCarryRecord(file, keys.blockKey, keys.messageKey, carry);
+  } catch {
+    // Carry loss is a display degrade, never a crash.
+  }
+}
+
+// Block end. The reveal count outlives the block — it caps the whole
+// message — so a message that has revealed keeps a message-only record.
+// Otherwise the file is removed, but only after confirming it still belongs
+// to this block or message: a racing newer block's held text must never be
+// destroyed by a stale final.
+export function finalizeCarry(file: string, keys: CarryKeys, carry: DisplayCarry): void {
+  try {
+    if (carry.revealedCount > 0) {
+      mkdirSync(dirname(file), { recursive: true });
+      writeCarryRecord(file, null, keys.messageKey, {
+        ...EMPTY_CARRY,
+        revealedCount: carry.revealedCount,
+      });
+      return;
+    }
+    let owned = true;
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(file, 'utf8'));
+      if (typeof parsed === 'object' && parsed !== null) {
+        const record = parsed as Record<string, unknown>;
+        owned = record.blockKey === keys.blockKey || record.messageKey === keys.messageKey;
+      }
+    } catch {
+      // Absent or unreadable: removing is a no-op or clears a corrupt file.
+    }
+    if (owned) rmSync(file, { force: true });
+  } catch {
+    // A leftover carry file is keyed and simply won't match the next block.
+  }
 }

--- a/plugins/claude-code/src/hooks/message-display.ts
+++ b/plugins/claude-code/src/hooks/message-display.ts
@@ -12,71 +12,26 @@
  *   no output → the delta renders unchanged
  *
  * A pointer can split across deltas, and each delta is a fresh hook process,
- * so the in-flight state (held pointer tail, markdown-region flags, reveal
- * count) is persisted in one file under the data dir, keyed by
- * session/message/block and reset when the block ends. A lost or clobbered
- * carry degrades to raw pointer display — pointers carry no secret material.
- * Fail-open: any error → no output, exit 0 — never a broken session.
+ * so the in-flight state (held tail, markdown-region flags, reveal count) is
+ * persisted in a per-session file under the data dir. Inside it, tail and
+ * region state are keyed by content block and die when the block ends; the
+ * reveal count is keyed by message, so full mode's cap spans every block of
+ * one message. A lost or clobbered carry degrades to raw pointer display —
+ * pointers carry no secret material. Fail-open: any error → no output,
+ * exit 0 — never a broken session.
  */
-import { mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-
 import { describePointerSafe, detokenizeText, loadConfig } from '@akasecurity/plugin-sdk';
 import { isVaultConsentValid, VAULT_INLINE_REVEAL_MAX_PER_MESSAGE } from '@akasecurity/schema';
 
-import type { DisplayCarry, DisplayDeps } from './message-display-transform.ts';
-import { EMPTY_CARRY, transformDelta } from './message-display-transform.ts';
+import type { CarryKeys, DisplayDeps } from './message-display-transform.ts';
+import {
+  carryFilePath,
+  finalizeCarry,
+  loadCarry,
+  saveCarry,
+  transformDelta,
+} from './message-display-transform.ts';
 import { emit, getString, parseJson, readStdin } from './shared.ts';
-
-const CARRY_FILE = 'display-carry.json';
-
-function loadCarry(file: string, key: string): DisplayCarry {
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(file, 'utf8'));
-    if (typeof parsed !== 'object' || parsed === null) return EMPTY_CARRY;
-    const record = parsed as Record<string, unknown>;
-    if (record.key !== key || typeof record.carry !== 'object' || record.carry === null) {
-      return EMPTY_CARRY;
-    }
-    const carry = record.carry as Record<string, unknown>;
-    return {
-      tail: typeof carry.tail === 'string' ? carry.tail : '',
-      fenceOpen: carry.fenceOpen === true,
-      tickOpen: carry.tickOpen === true,
-      lineQuoted: carry.lineQuoted === true,
-      revealedCount:
-        typeof carry.revealedCount === 'number' && Number.isFinite(carry.revealedCount)
-          ? carry.revealedCount
-          : 0,
-    };
-  } catch {
-    return EMPTY_CARRY;
-  }
-}
-
-// Single-entry overwrite, atomic via tmp+rename, owner-only mode. Concurrent
-// content blocks are rare, and a lost carry only degrades to raw pointer
-// display on screen.
-function saveCarry(file: string, key: string, carry: DisplayCarry): void {
-  try {
-    mkdirSync(dirname(file), { recursive: true });
-    const tmp = `${file}.tmp`;
-    writeFileSync(tmp, JSON.stringify({ key, carry, updatedAt: new Date().toISOString() }), {
-      mode: 0o600,
-    });
-    renameSync(tmp, file);
-  } catch {
-    // Carry loss is a display degrade, never a crash.
-  }
-}
-
-function deleteCarry(file: string): void {
-  try {
-    rmSync(file, { force: true });
-  } catch {
-    // A leftover carry file is keyed and simply won't match the next block.
-  }
-}
 
 async function main(): Promise<void> {
   const input = parseJson(await readStdin());
@@ -92,26 +47,42 @@ async function main(): Promise<void> {
   const mode = config.settings.vaultInlineReveal;
   if (mode === 'off') return;
 
+  const sessionId = getString(input, 'session_id') ?? '';
+  const messageId = getString(input, 'message_id') ?? '';
   const index = input.index;
-  const key = [
-    getString(input, 'session_id') ?? '',
-    getString(input, 'message_id') ?? '',
-    typeof index === 'number' || typeof index === 'string' ? String(index) : '',
-  ].join('/');
+  const keys: CarryKeys = {
+    blockKey: [
+      sessionId,
+      messageId,
+      typeof index === 'number' || typeof index === 'string' ? String(index) : '',
+    ].join('/'),
+    messageKey: [sessionId, messageId].join('/'),
+  };
   const final = input.final === true;
-  const file = join(config.dataDir, CARRY_FILE);
-  const carry = loadCarry(file, key);
+  const file = carryFilePath(config.dataDir, sessionId);
+  const carry = loadCarry(file, keys);
 
   // Fast path: no pointer can start ('['), no region state can change
-  // ('`' fence/span, '>' quote), and nothing is carried for this block —
-  // the delta renders unchanged and no state needs writing.
+  // ('`'/'~' fence or span markers, '>' quote), and nothing is pending for
+  // this block or message — the delta renders unchanged and no state needs
+  // writing. Mid-line state (lineSeen/lineIndent) counts as pending so the
+  // line-position tracking stays accurate until the next newline.
   const pending =
     carry.tail !== '' ||
-    carry.fenceOpen ||
+    carry.fence !== null ||
     carry.tickOpen ||
     carry.lineQuoted ||
+    carry.lineSeen ||
+    carry.lineIndent > 0 ||
     carry.revealedCount > 0;
-  if (!pending && !delta.includes('[') && !delta.includes('`') && !delta.includes('>') && !final) {
+  if (
+    !pending &&
+    !delta.includes('[') &&
+    !delta.includes('`') &&
+    !delta.includes('~') &&
+    !delta.includes('>') &&
+    !final
+  ) {
     return;
   }
 
@@ -128,8 +99,8 @@ async function main(): Promise<void> {
   };
 
   const result = await transformDelta(delta, carry, final, deps);
-  if (final) deleteCarry(file);
-  else saveCarry(file, key, result.carry);
+  if (final) finalizeCarry(file, keys, result.carry);
+  else saveCarry(file, keys, result.carry);
 
   if (result.display !== null) {
     await emit({

--- a/plugins/claude-code/src/hooks/pointer-substitution.ts
+++ b/plugins/claude-code/src/hooks/pointer-substitution.ts
@@ -95,3 +95,17 @@ export function denyPointerMessage(toolName: string): string {
     'one (aka exception approve) or remove the pointer.'
   );
 }
+
+/**
+ * The deny reason when a grant DID cover the pointer but the value could not be
+ * resolved — a purge that landed mid-call, an entry whose ciphertext no longer
+ * opens. Granting another exception would not help, so the message must not
+ * send the user after one.
+ */
+export function denyUnresolvedPointerMessage(toolName: string): string {
+  return (
+    `A vault pointer in a ${toolName} command is covered by a reveal exception but its ` +
+    'value could not be resolved, so the command was not run rather than executed with ' +
+    'the pointer as literal text. The entry may have been purged; check the vault.'
+  );
+}

--- a/plugins/claude-code/src/hooks/pre-tool-use.ts
+++ b/plugins/claude-code/src/hooks/pre-tool-use.ts
@@ -26,7 +26,11 @@ import { sessionProtocolMarker } from '../protocol/marker.ts';
 import { eventNote, userDisclosure } from '../protocol/notes.ts';
 import { replaceAtPath, stringAtPath } from './paths.ts';
 import type { PointerField } from './pointer-substitution.ts';
-import { decideInputPointers, denyPointerMessage } from './pointer-substitution.ts';
+import {
+  decideInputPointers,
+  denyPointerMessage,
+  denyUnresolvedPointerMessage,
+} from './pointer-substitution.ts';
 import type { PreToolUseOutput, ScannedField } from './pre-tool-use-decision.ts';
 import { decidePreToolUse } from './pre-tool-use-decision.ts';
 import { inputEventKind, inputFilePath, scannableInputFields } from './pre-tool-use-fields.ts';
@@ -72,32 +76,68 @@ async function main(): Promise<void> {
       pointerFields.push({ path: spec.path, text, executable: spec.executable });
     }
   }
-  const pointerOutcomes = await decideInputPointers(pointerFields, (text) =>
-    vaultGlue
-      ? vaultGlue.substituteModelPointers(text, { resolveGrant: vaultGlue.revealGrantResolver })
-      : Promise.resolve({
-          text,
-          revealed: [],
-          unresolved: [...text.matchAll(pointerTokenScanner())].map((m) => m[0]),
-        }),
-  );
-  if (pointerOutcomes.some((outcome) => outcome.disposition === 'deny')) {
+  // Executable fields are probed FIRST — grant resolution only, no
+  // de-reference. One ungranted pointer denies the whole call, and a call that
+  // is denied must never have audited a reveal for the pointers that WERE
+  // granted: the owner's crossing trail would then report values as sent to
+  // the model on a call that never ran.
+  const spentGrantIds: string[] = [];
+  let denyForPointer = false;
+  if (vaultGlue) {
+    for (const field of pointerFields.filter((f) => f.executable)) {
+      const probe = await vaultGlue.probeModelPointers(field.text, {
+        resolveGrant: vaultGlue.revealGrantResolver,
+      });
+      if (probe.ungranted.length > 0) denyForPointer = true;
+    }
+  } else {
+    denyForPointer = pointerFields.some((f) => f.executable && pointerTokenScanner().test(f.text));
+  }
+
+  const pointerOutcomes = denyForPointer
+    ? []
+    : await decideInputPointers(pointerFields, async (text) => {
+        if (!vaultGlue) {
+          return {
+            text,
+            revealed: [],
+            unresolved: [...text.matchAll(pointerTokenScanner())].map((m) => m[0]),
+            grantIds: [],
+          };
+        }
+        const result = await vaultGlue.substituteModelPointers(text, {
+          resolveGrant: vaultGlue.revealGrantResolver,
+        });
+        spentGrantIds.push(...result.grantIds);
+        return result;
+      });
+  // The probe settles most denials, but it cannot settle all of them: it only
+  // resolves grants, while the substitution above must additionally OPEN each
+  // row's ciphertext. A pointer whose grant resolves but whose value will not
+  // open reaches this point looking granted, and the substitution reports it
+  // back as a deny. Dropping that verdict would run the tool with the pointer
+  // still literal in a field that executes. That case gets its own message:
+  // the grant was never the problem, so pointing the user at granting one would
+  // send them somewhere that cannot help.
+  const unresolvedAfterGrant = pointerOutcomes.some((o) => o.disposition === 'deny');
+  if (denyForPointer || unresolvedAfterGrant) {
     await emit({
       hookSpecificOutput: {
         hookEventName: 'PreToolUse',
         permissionDecision: 'deny',
-        permissionDecisionReason: denyPointerMessage(toolName),
+        permissionDecisionReason: denyForPointer
+          ? denyPointerMessage(toolName)
+          : denyUnresolvedPointerMessage(toolName),
       },
     });
     return;
   }
-
   // Fold granted de-refs into the input the rest of the hook sees: the secret
-  // scan then re-detects each revealed value, and the SAME grant satisfies
-  // suppression there (reveal is strictly stronger), consuming its use exactly
-  // once. Emitting must not depend on a detection outcome — with every
-  // revealed value suppressed, the decision below may be null, and the tool
-  // would otherwise run with the pointers still literal.
+  // scan re-detects each revealed value, and the SAME grant satisfies
+  // suppression there (reveal is strictly stronger) — without spending a
+  // second use, because the crossing already spent it. Emitting must not
+  // depend on a detection outcome: a suppressed or warn-only result would
+  // otherwise let the tool run with the pointers still literal.
   let effectiveInput = toolInput;
   let derefHappened = false;
   for (const outcome of pointerOutcomes) {
@@ -148,7 +188,12 @@ async function main(): Promise<void> {
         // every Bash command and one call per string leaf of every MCP payload,
         // and 'always' would copy that whole stream into the store to trail the
         // enforcement decisions that are the point of the kind.
-        kind === 'tool_use' ? { persist: 'with-findings' } : {},
+        {
+          ...(kind === 'tool_use' ? { persist: 'with-findings' as const } : {}),
+          // Grants this call's pointer crossing already spent: suppression
+          // applies without charging a second use.
+          ...(spentGrantIds.length > 0 ? { preAuthorizedGrantIds: spentGrantIds } : {}),
+        },
       );
       scanned.push({ spec, text, result });
     }
@@ -176,10 +221,31 @@ async function main(): Promise<void> {
           })
       : undefined,
   );
+  const revealNote = `AKA revealed granted vault value(s) to this ${toolName} call — the reveal exception you approved authorized it.`;
   if (decision) {
-    await emit(
-      withProtocolNotes(decision.output, decision.realized, toolName, config, sessionId, vaultGlue),
+    const output = withProtocolNotes(
+      decision.output,
+      decision.realized,
+      toolName,
+      config,
+      sessionId,
+      vaultGlue,
     );
+    // A deref must survive EVERY non-deny outcome. A warn-only decision carries
+    // no hookSpecificOutput, so emitting it alone would run the tool with the
+    // literal pointers the grant just resolved.
+    if (derefHappened && !('hookSpecificOutput' in output)) {
+      await emit({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          updatedInput: effectiveInput,
+        },
+        systemMessage: `${output.systemMessage} ${revealNote}`,
+      });
+      return;
+    }
+    await emit(output);
     return;
   }
   // No detection outcome, but a grant rewrote the input: the tool must still
@@ -191,7 +257,7 @@ async function main(): Promise<void> {
         permissionDecision: 'allow',
         updatedInput: effectiveInput,
       },
-      systemMessage: `AKA revealed granted vault value(s) to this ${toolName} call — the reveal exception you approved authorized it.`,
+      systemMessage: revealNote,
     });
   }
 }

--- a/plugins/claude-code/src/remediation/redact.ts
+++ b/plugins/claude-code/src/remediation/redact.ts
@@ -35,18 +35,32 @@ import { transcriptsDir } from '../history/transcripts.ts';
 // the only thing this module strikes, so the category is fixed.
 const REDACTED_PLACEHOLDER = '[REDACTED:SECRET]';
 
+// Matches `$`-pattern sequences that String.replace-family APIs expand ($&,
+// $', $`, $$, $1…, $<name>). Production replacements are vault pointers, which
+// never contain `$`, so refusing these costs nothing.
+const REPLACE_PATTERN_SEQUENCE = /\$[$&`'<0-9]/;
+
 // The string a struck occurrence of `rawValue` is rewritten to: the caller's
 // pre-resolved replacement when one is supplied (an async caller resolves vault
 // pointers ahead of this synchronous sweep), else the one-way placeholder. A
-// replacement must never be the raw value itself — an entry equal to it falls
-// back to the placeholder, so no map can make this module rewrite a secret
-// with itself and report it redacted.
+// replacement that CONTAINS the raw value (including the raw value itself)
+// falls back to the placeholder — honouring it would leave the secret readable
+// while reporting it redacted. So does a replacement carrying `$`-pattern
+// sequences: this module splices literally, but replace-family APIs expand
+// those sequences to re-insert the matched secret, so such a candidate is
+// never propagated anywhere.
 function replacementFor(
   rawValue: string,
   replacements: ReadonlyMap<string, string> | undefined,
 ): string {
   const candidate = replacements?.get(rawValue);
-  if (candidate === undefined || candidate === rawValue) return REDACTED_PLACEHOLDER;
+  if (
+    candidate === undefined ||
+    candidate.includes(rawValue) ||
+    REPLACE_PATTERN_SEQUENCE.test(candidate)
+  ) {
+    return REDACTED_PLACEHOLDER;
+  }
   return candidate;
 }
 
@@ -137,9 +151,9 @@ export interface RedactionDetail {
  *
  * `replacements` maps a raw value to the pre-resolved string it is rewritten to
  * — a recoverable vault pointer, resolved by the async caller because this sweep
- * must stay synchronous. A value with no entry (or with an entry equal to the
- * raw value itself) is struck with the one-way placeholder, so with no map the
- * behavior is byte-identical to the plain strike.
+ * must stay synchronous. A value with no entry — or with an entry that contains
+ * the raw value or `$`-pattern sequences — is struck with the one-way
+ * placeholder, so with no map the behavior is byte-identical to the plain strike.
  */
 export function redactLeakedKeysDetailed(
   targets: readonly RedactionTarget[],
@@ -171,23 +185,38 @@ export function redactLeakedKeysDetailed(
     }
     const struckHere: RedactionTarget[] = [];
     let pointeredHere = 0;
-    const struckValues = new Set<string>();
+    // rawValue → the replacement actually applied to this file, so a sibling
+    // target sharing the value counts the same way (pointered vs one-way) even
+    // when the first strike fell back to the placeholder.
+    const applied = new Map<string, string>();
     for (const target of fileTargets) {
-      // One raw value has exactly one replacement across the whole sweep, so a
-      // target and its same-value siblings always count the same way.
-      const replacement = replacementFor(target.rawValue, replacements);
       // A sibling target sharing this raw value already struck every occurrence
       // in this file, so `content.includes` is now false even though this
       // target's value IS redacted — count it struck rather than misreport it as
       // still exposed (two findings on one repeated value both resolve together).
-      if (struckValues.has(target.rawValue)) {
+      const prior = applied.get(target.rawValue);
+      if (prior !== undefined) {
         struckHere.push(target);
-        if (replacement !== REDACTED_PLACEHOLDER) pointeredHere += 1;
+        if (prior !== REDACTED_PLACEHOLDER) pointeredHere += 1;
         continue;
       }
       if (!content.includes(target.rawValue)) continue;
-      content = content.replaceAll(target.rawValue, replacement);
-      struckValues.add(target.rawValue);
+      let replacement = replacementFor(target.rawValue, replacements);
+      // Literal splice, never `replaceAll` with a string pattern — split/join
+      // carries no `$`-pattern semantics, so the replacement can never be
+      // expanded against the match it strikes.
+      let next = content.split(target.rawValue).join(replacement);
+      if (next.includes(target.rawValue)) {
+        // Bytes around a spliced replacement recombined into the raw value
+        // again (an overlap/boundary artifact) — strike one-way instead.
+        replacement = REDACTED_PLACEHOLDER;
+        next = content.split(target.rawValue).join(replacement);
+        // Still readable even after the placeholder pass: leave this value's
+        // occurrences as they were and do not count it redacted.
+        if (next.includes(target.rawValue)) continue;
+      }
+      content = next;
+      applied.set(target.rawValue, replacement);
       struckHere.push(target);
       if (replacement !== REDACTED_PLACEHOLDER) pointeredHere += 1;
     }

--- a/plugins/claude-code/test/history/tail-scrub.test.ts
+++ b/plugins/claude-code/test/history/tail-scrub.test.ts
@@ -1,4 +1,15 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import {
+  appendFileSync,
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -148,6 +159,73 @@ describe('scrubTranscriptTail', () => {
   it('returns null for an unreadable path without throwing', async () => {
     expect(await scrubTranscriptTail(join(transcriptRoot, 'missing.jsonl'), deps)).toBeNull();
   });
+
+  it('aborts on the unclassifiable blanket: changed text with no pointers and no degraded spans', async () => {
+    const content = `{"text":"key ${SECRET}"}\n`;
+    const file = transcriptFile('blanket.jsonl', content);
+    // A tokenizer that rewrites the line but mints no pointer and degrades no
+    // span cannot tell secret from clean — honouring it would blanket-destroy
+    // transcript lines, so the scrub must abort with the file untouched.
+    const blanketDeps: TailScrubDeps = {
+      tokenizeText: () =>
+        Promise.resolve({ text: '[REDACTED-EVERYTHING]', pointers: [], degraded: [] }),
+      scope,
+    };
+
+    expect(await scrubTranscriptTail(file, blanketDeps)).toBeNull();
+    expect(readFileSync(file, 'utf8')).toBe(content);
+  });
+
+  it('skips a file larger than the configured byte cap, leaving it untouched', async () => {
+    const content = `{"text":"key ${SECRET}"}\n`;
+    const file = transcriptFile('oversized.jsonl', content);
+
+    expect(await scrubTranscriptTail(file, { ...deps, maxBytes: 8 })).toBeNull();
+    expect(readFileSync(file, 'utf8')).toBe(content);
+  });
+
+  it('aborts when the live transcript grew mid-scrub, keeping the appended lines intact', async () => {
+    const original = `{"text":"key ${SECRET}"}\n`;
+    const appended = '{"text":"appended while the scrub was tokenizing"}\n';
+    const file = transcriptFile('race.jsonl', original);
+    // A tokenizer that appends to the file mid-scrub, simulating Claude Code
+    // writing to the live transcript while the scrub works on its in-memory
+    // snapshot. Renaming the snapshot over the grown file would silently
+    // destroy the appended line, so the scrub must abort instead.
+    const racingDeps: TailScrubDeps = {
+      tokenizeText: (text) => {
+        appendFileSync(file, appended);
+        return Promise.resolve({
+          text: text.split(SECRET).join('[[aka:secret:RACE]]'),
+          pointers: ['[[aka:secret:RACE]]'],
+          degraded: [],
+        });
+      },
+      scope,
+    };
+
+    expect(await scrubTranscriptTail(file, racingDeps)).toBeNull();
+    // The post-append content — including the line the snapshot never saw —
+    // survives, and no tmp orphan remains.
+    expect(readFileSync(file, 'utf8')).toBe(original + appended);
+    const siblings = readdirSync(join(transcriptRoot, '-Users-me-project'));
+    expect(siblings.filter((entry) => entry.endsWith('.aka-scrub.tmp'))).toEqual([]);
+  });
+
+  it.runIf(process.platform !== 'win32')(
+    'preserves a 0600 transcript mode across the rewrite',
+    async () => {
+      const file = transcriptFile('mode.jsonl', `{"text":"key ${SECRET}"}\n`);
+      chmodSync(file, 0o600);
+
+      expect(await scrubTranscriptTail(file, deps)).toEqual({ rewritten: 1 });
+
+      // The rewrite lands via a fresh temp file; without an explicit mode it
+      // would widen the 0600 transcript to the umask default.
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      expect(readFileSync(file, 'utf8')).not.toContain(SECRET);
+    },
+  );
 
   // The fault posture when consent vanished mid-pass (the call site gates on
   // consent, so a consent-less glue is only reachable via revocation between

--- a/plugins/claude-code/test/hooks/message-display-transform.test.ts
+++ b/plugins/claude-code/test/hooks/message-display-transform.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { DetectionCategory, POINTER_TOKEN_ANCHORED } from '@akasecurity/schema';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { DisplayCarry, DisplayDeps } from '../../src/hooks/message-display-transform.ts';
-import { EMPTY_CARRY, transformDelta } from '../../src/hooks/message-display-transform.ts';
+import {
+  carryFilePath,
+  EMPTY_CARRY,
+  finalizeCarry,
+  loadCarry,
+  MAX_POINTER_LEN,
+  saveCarry,
+  transformDelta,
+} from '../../src/hooks/message-display-transform.ts';
 
 const POINTER = `[[aka:secret:AA.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
 const BADGE = '[scrubbed:secret/aws AKIA…MPLE]';
@@ -16,6 +29,29 @@ function makeDeps(overrides?: Partial<DisplayDeps>): DisplayDeps {
     ...overrides,
   };
 }
+
+// Full mode with a spied reveal and no descriptor, so a masked fallback
+// renders as the bare category badge.
+function fullDeps(revealValue = 'RAW-VALUE'): {
+  deps: DisplayDeps;
+  reveal: ReturnType<typeof vi.fn>;
+} {
+  const reveal = vi.fn(() => Promise.resolve<string | null>(revealValue));
+  return {
+    deps: { mode: 'full', maxRevealsPerMessage: 99, describe: () => Promise.resolve(null), reveal },
+    reveal,
+  };
+}
+
+const tmpDirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aka-display-carry-'));
+  tmpDirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of tmpDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 describe('transformDelta — masked mode', () => {
   it('replaces a complete pointer with the descriptor badge', async () => {
@@ -39,7 +75,7 @@ describe('transformDelta — masked mode', () => {
   it('returns null display for a clean delta (fast path)', async () => {
     const result = await transformDelta('nothing to see here', EMPTY_CARRY, false, makeDeps());
     expect(result.display).toBeNull();
-    expect(result.carry).toEqual(EMPTY_CARRY);
+    expect(result.carry).toEqual({ ...EMPTY_CARRY, lineSeen: true });
   });
 });
 
@@ -120,7 +156,7 @@ describe('transformDelta — protected regions', () => {
     const result = await transformDelta(
       `\`\`\`\nexport KEY=${POINTER}\n\`\`\``,
       EMPTY_CARRY,
-      false,
+      true,
       deps,
     );
     expect(result.display).toBe(`\`\`\`\nexport KEY=${BADGE}\n\`\`\``);
@@ -133,7 +169,7 @@ describe('transformDelta — protected regions', () => {
 
     const first = await transformDelta('```js\n', EMPTY_CARRY, false, deps);
     expect(first.display).toBeNull();
-    expect(first.carry.fenceOpen).toBe(true);
+    expect(first.carry.fence).toEqual({ char: '`', len: 3 });
 
     const second = await transformDelta(`const k = ${POINTER};\n`, first.carry, false, deps);
     expect(second.display).toBe(`const k = ${BADGE};\n`);
@@ -156,10 +192,91 @@ describe('transformDelta — protected regions', () => {
     expect(reveal).not.toHaveBeenCalled();
   });
 
+  it('masks when the quoted line continues from an earlier delta', async () => {
+    const { deps, reveal } = fullDeps();
+    const first = await transformDelta('> the secret was ', EMPTY_CARRY, false, deps);
+    expect(first.display).toBeNull();
+    expect(first.carry.lineQuoted).toBe(true);
+
+    const second = await transformDelta(`${POINTER}\n`, first.carry, true, deps);
+    expect(second.display).toBe('[scrubbed:secret]\n');
+    expect(reveal).not.toHaveBeenCalled();
+  });
+
   it('reveals again on the line after a quoted line', async () => {
     const deps = makeDeps({ mode: 'full', reveal: () => Promise.resolve('RAW') });
     const result = await transformDelta(`> quoted\nplain ${POINTER}`, EMPTY_CARRY, false, deps);
     expect(result.display).toBe('> quoted\nplain RAW [scrubbed:secret]');
+  });
+});
+
+describe('transformDelta — CommonMark fence shape', () => {
+  it('treats ``` inside a ````-opened fence as content, closing only on ````', async () => {
+    const { deps, reveal } = fullDeps();
+    const text = `\`\`\`\`markdown\nExample:\n\`\`\`\n${POINTER}\n\`\`\`\n\`\`\`\`\nplain ${POINTER}\n`;
+    const result = await transformDelta(text, EMPTY_CARRY, true, deps);
+    expect(result.display).toBe(
+      '````markdown\nExample:\n```\n[scrubbed:secret]\n```\n````\n' +
+        'plain RAW-VALUE [scrubbed:secret]\n',
+    );
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('masks inside a tilde fence', async () => {
+    const { deps, reveal } = fullDeps();
+    const text = `~~~\nexport KEY=${POINTER}\n~~~\nplain ${POINTER}`;
+    const result = await transformDelta(text, EMPTY_CARRY, true, deps);
+    expect(result.display).toBe(
+      '~~~\nexport KEY=[scrubbed:secret]\n~~~\nplain RAW-VALUE [scrubbed:secret]',
+    );
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('never closes a tilde fence with backticks', async () => {
+    const { deps, reveal } = fullDeps();
+    const text = `~~~\n\`\`\`\n${POINTER}\n~~~\nplain ${POINTER}`;
+    const result = await transformDelta(text, EMPTY_CARRY, true, deps);
+    expect(result.display).toBe(
+      '~~~\n```\n[scrubbed:secret]\n~~~\nplain RAW-VALUE [scrubbed:secret]',
+    );
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers a fence opener split across deltas and masks inside it', async () => {
+    const { deps, reveal } = fullDeps();
+
+    const first = await transformDelta('``', EMPTY_CARRY, false, deps);
+    expect(first.display).toBe('');
+    expect(first.carry.tail).toBe('``');
+
+    const second = await transformDelta('`\ncode with ` inside\n', first.carry, false, deps);
+    expect(second.display).toBe('```\ncode with ` inside\n');
+    expect(second.carry.fence).toEqual({ char: '`', len: 3 });
+
+    const third = await transformDelta(`${POINTER}\n\`\`\`\nplain\n`, second.carry, true, deps);
+    expect(third.display).toBe('[scrubbed:secret]\n```\nplain\n');
+    expect(third.carry.fence).toBeNull();
+    expect(reveal).not.toHaveBeenCalled();
+  });
+
+  it('never toggles a fence on a mid-line marker run', async () => {
+    const { deps, reveal } = fullDeps();
+    const result = await transformDelta(`x \`\`\` y \`\`\` ${POINTER}`, EMPTY_CARRY, true, deps);
+    expect(result.display).toBe('x ``` y ``` RAW-VALUE [scrubbed:secret]');
+    expect(reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds a short trailing marker run for the next delta', async () => {
+    const result = await transformDelta('text ```', EMPTY_CARRY, false, makeDeps());
+    expect(result.display).toBe('text ');
+    expect(result.carry.tail).toBe('```');
+  });
+
+  it('flushes an oversized trailing marker run instead of holding it', async () => {
+    const result = await transformDelta('`'.repeat(9), EMPTY_CARRY, false, makeDeps());
+    expect(result.display).toBeNull();
+    expect(result.carry.tail).toBe('');
+    expect(result.carry.fence).toEqual({ char: '`', len: 9 });
   });
 });
 
@@ -205,15 +322,26 @@ describe('transformDelta — lookalikes', () => {
     expect(second.display).toBe(`[[aka:secret:AB.${overflow}`);
     expect(second.carry.tail).toBe('');
   });
+
+  it('keeps the longest valid pointer well under the hold bound', () => {
+    const longestCategory = DetectionCategory.options.reduce((a, b) =>
+      b.length > a.length ? b : a,
+    );
+    const longest = `[[aka:${longestCategory}:${'A'.repeat(7)}.${'A'.repeat(26)}.${'B'.repeat(16)}]]`;
+    expect(POINTER_TOKEN_ANCHORED.test(longest)).toBe(true);
+    expect(longest.length).toBeLessThanOrEqual(MAX_POINTER_LEN - 8);
+  });
 });
 
 describe('transformDelta — off mode', () => {
   it('always returns null display and an empty carry', async () => {
     const dirty: DisplayCarry = {
       tail: '[[aka:se',
-      fenceOpen: true,
+      fence: { char: '`', len: 3 },
       tickOpen: true,
       lineQuoted: true,
+      lineSeen: true,
+      lineIndent: 2,
       revealedCount: 2,
     };
     const result = await transformDelta(POINTER, dirty, false, makeDeps({ mode: 'off' }));
@@ -227,10 +355,127 @@ describe('transformDelta — region state on clean deltas', () => {
     const deps = makeDeps({ mode: 'full', reveal: () => Promise.resolve('RAW') });
     const opened = await transformDelta('```\ninside', EMPTY_CARRY, false, deps);
     expect(opened.display).toBeNull();
-    expect(opened.carry.fenceOpen).toBe(true);
+    expect(opened.carry.fence).toEqual({ char: '`', len: 3 });
 
     const closed = await transformDelta('\n```\nafter', opened.carry, false, deps);
     expect(closed.display).toBeNull();
-    expect(closed.carry.fenceOpen).toBe(false);
+    expect(closed.carry.fence).toBeNull();
+  });
+});
+
+describe('carry store', () => {
+  it('keys carry files per session, so another session cannot clobber a held tail', async () => {
+    const dir = makeDir();
+    const deps = makeDeps();
+    const keysA = { blockKey: 'sess-a/m1/0', messageKey: 'sess-a/m1' };
+    const keysB = { blockKey: 'sess-b/m9/0', messageKey: 'sess-b/m9' };
+    const fileA = carryFilePath(dir, 'sess-a');
+    const fileB = carryFilePath(dir, 'sess-b');
+    expect(fileA).not.toBe(fileB);
+
+    const cut = 18;
+    const first = await transformDelta(
+      `The key is ${POINTER.slice(0, cut)}`,
+      EMPTY_CARRY,
+      false,
+      deps,
+    );
+    expect(first.display).toBe('The key is ');
+    expect(first.carry.tail).toBe(POINTER.slice(0, cut));
+    saveCarry(fileA, keysA, first.carry);
+
+    // A concurrent session saves and finalizes without touching A's file.
+    const other = await transformDelta('other text', EMPTY_CARRY, false, deps);
+    saveCarry(fileB, keysB, other.carry);
+    finalizeCarry(fileB, keysB, EMPTY_CARRY);
+    expect(existsSync(fileB)).toBe(false);
+
+    // Session A's held tail survives and completes: no screen text is lost.
+    const restored = loadCarry(fileA, keysA);
+    expect(restored.tail).toBe(POINTER.slice(0, cut));
+    const second = await transformDelta(`${POINTER.slice(cut)} done`, restored, false, deps);
+    expect(second.display).toBe(`${BADGE} done`);
+  });
+
+  it('finalize is key-checked: a stale final never deletes a newer block state', () => {
+    const dir = makeDir();
+    const file = carryFilePath(dir, 's');
+    const newer = { blockKey: 's/m2/0', messageKey: 's/m2' };
+    saveCarry(file, newer, { ...EMPTY_CARRY, tail: '[[aka:se' });
+
+    finalizeCarry(file, { blockKey: 's/m1/0', messageKey: 's/m1' }, EMPTY_CARRY);
+    expect(loadCarry(file, newer).tail).toBe('[[aka:se');
+
+    finalizeCarry(file, newer, EMPTY_CARRY);
+    expect(existsSync(file)).toBe(false);
+    expect(loadCarry(file, newer)).toEqual(EMPTY_CARRY);
+  });
+
+  it('caps reveals per message: the count survives block finals within one message', async () => {
+    const dir = makeDir();
+    const file = carryFilePath(dir, 's');
+    const deps = makeDeps({ mode: 'full', reveal: () => Promise.resolve('RAW') });
+    const keys0 = { blockKey: 's/m/0', messageKey: 's/m' };
+    const keys1 = { blockKey: 's/m/1', messageKey: 's/m' };
+
+    const block0 = await transformDelta(
+      `${POINTER} and ${POINTER}`,
+      loadCarry(file, keys0),
+      true,
+      deps,
+    );
+    expect(block0.carry.revealedCount).toBe(2);
+    finalizeCarry(file, keys0, block0.carry);
+
+    const carry1 = loadCarry(file, keys1);
+    expect(carry1.revealedCount).toBe(2);
+    expect(carry1.tail).toBe('');
+    const block1 = await transformDelta(`third ${POINTER}`, carry1, false, deps);
+    expect(block1.display).toBe(`third ${BADGE}`);
+    expect(block1.carry.revealedCount).toBe(2);
+
+    // A new message starts a fresh count.
+    const nextMessage = loadCarry(file, { blockKey: 's/m2/0', messageKey: 's/m2' });
+    expect(nextMessage.revealedCount).toBe(0);
+  });
+
+  it('never persists a revealed value in the carry', async () => {
+    const dir = makeDir();
+    const file = carryFilePath(dir, 's');
+    const keys = { blockKey: 's/m/0', messageKey: 's/m' };
+    const deps = makeDeps({ mode: 'full', reveal: () => Promise.resolve('RAW-SENTINEL') });
+
+    const result = await transformDelta(`key ${POINTER} more [[aka:se`, EMPTY_CARRY, false, deps);
+    expect(result.display).toContain('RAW-SENTINEL');
+    expect(JSON.stringify(result.carry)).not.toContain('RAW-SENTINEL');
+
+    saveCarry(file, keys, result.carry);
+    expect(readFileSync(file, 'utf8')).not.toContain('RAW-SENTINEL');
+    finalizeCarry(file, keys, result.carry);
+    expect(readFileSync(file, 'utf8')).not.toContain('RAW-SENTINEL');
+  });
+
+  it('sanitizes hostile session ids into a safe basename', () => {
+    const dir = makeDir();
+    const file = carryFilePath(dir, '../evil/../../id');
+    expect(dirname(file)).toBe(dir);
+    expect(file).not.toContain('..');
+  });
+
+  it('reaps stale carry files on save', () => {
+    const dir = makeDir();
+    const staleFile = carryFilePath(dir, 'old-session');
+    saveCarry(
+      staleFile,
+      { blockKey: 'o/m/0', messageKey: 'o/m' },
+      { ...EMPTY_CARRY, tail: '[[aka:se' },
+    );
+    const past = new Date(Date.now() - 20 * 60 * 1000);
+    utimesSync(staleFile, past, past);
+
+    const file = carryFilePath(dir, 'fresh');
+    saveCarry(file, { blockKey: 'f/m/0', messageKey: 'f/m' }, EMPTY_CARRY);
+    expect(existsSync(staleFile)).toBe(false);
+    expect(existsSync(file)).toBe(true);
   });
 });

--- a/plugins/claude-code/test/remediation/redact.test.ts
+++ b/plugins/claude-code/test/remediation/redact.test.ts
@@ -310,6 +310,45 @@ describe('redactLeakedKeys', () => {
       expect(after).toBe('leaked [REDACTED:SECRET] here');
     });
 
+    it('a map entry CONTAINING the raw value falls back to the one-way placeholder', () => {
+      const transcriptFile = join(transcriptRoot, 'containing-map.jsonl');
+      writeFileSync(transcriptFile, `leaked ${TRANSCRIPT_KEY} here`);
+
+      // A candidate that embeds the raw value would leave the secret readable
+      // while reporting it redacted — it must never be honoured.
+      const detail = redactLeakedKeysDetailed(
+        [{ where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+        new Map([[TRANSCRIPT_KEY, `wrapped(${TRANSCRIPT_KEY})`]]),
+      );
+
+      expect(detail.redactedKeys).toBe(1);
+      expect(detail.pointeredKeys).toBe(0);
+      const after = readFileSync(transcriptFile, 'utf8');
+      expect(after).toBe('leaked [REDACTED:SECRET] here');
+      expect(after).not.toContain(TRANSCRIPT_KEY);
+    });
+
+    it("a '$&' map entry falls back to the placeholder — the match is never re-inserted", () => {
+      const transcriptFile = join(transcriptRoot, 'dollar-map.jsonl');
+      writeFileSync(transcriptFile, `leaked ${TRANSCRIPT_KEY} here`);
+
+      // '$&' is the replace-pattern sequence for "the matched substring": fed
+      // to a replace-family API it would rewrite the secret with itself and
+      // count it redacted. The sweep must refuse it and strike one-way.
+      const detail = redactLeakedKeysDetailed(
+        [{ where: { filePath: transcriptFile }, rawValue: TRANSCRIPT_KEY }],
+        scope,
+        new Map([[TRANSCRIPT_KEY, '$&']]),
+      );
+
+      expect(detail.redactedKeys).toBe(1);
+      expect(detail.pointeredKeys).toBe(0);
+      const after = readFileSync(transcriptFile, 'utf8');
+      expect(after).toBe('leaked [REDACTED:SECRET] here');
+      expect(after).not.toContain(TRANSCRIPT_KEY);
+    });
+
     it('an empty map behaves byte-identically to no map at all', () => {
       const withMap = join(transcriptRoot, 'with-empty-map.jsonl');
       const without = join(transcriptRoot, 'without-map.jsonl');

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -313,6 +313,10 @@ export async function grantRevealFromPointer(input: {
   pointer: string;
   scope: string;
   justification: string;
+  // Required when scope is permanent: the masked value retyped, so a
+  // never-expiring reveal takes the same deliberate confirmation every other
+  // permanent grant does.
+  confirmation?: string;
 }): Promise<RevealGrantResult> {
   const justification = input.justification.trim();
   if (justification === '') {
@@ -361,6 +365,27 @@ export async function grantRevealFromPointer(input: {
     return { ok: false, error: 'Not a vault pointer — paste the full [[aka:...]] token.' };
   }
 
+  // A permanent reveal is the strongest grant in the product — a never-expiring
+  // authorization for raw to reach the model. It takes the same value-specific
+  // typed confirmation as every other permanent grant, re-checked here
+  // server-side; without a descriptor there is nothing meaningful to retype, so
+  // permanent is refused rather than waved through against an opaque preview.
+  if (scope.scope === 'permanent') {
+    if (descriptor === null) {
+      return {
+        ok: false,
+        error:
+          'A permanent reveal needs the value preview to confirm against — use a time-limited scope.',
+      };
+    }
+    if (input.confirmation !== descriptor.maskedMatch) {
+      return {
+        ok: false,
+        error: `A permanent reveal must be confirmed by retyping the masked value (${descriptor.maskedMatch}).`,
+      };
+    }
+  }
+
   try {
     const created = await db().exceptions.create({
       ruleId: identity.ruleId,
@@ -404,13 +429,13 @@ export async function revokeException(id: string, reason: string): Promise<Actio
  * every existing grant. The typed confirmation is re-checked here; the dialog
  * gate alone is not the control.
  */
-// eslint-disable-next-line @typescript-eslint/require-await -- 'use server' exports must be async
 export async function rotateKey(confirmation: string): Promise<ActionResult> {
   if (confirmation !== 'rotate') {
     return { ok: false, error: 'Type "rotate" to confirm.' };
   }
+  let next: FingerprintKey;
   try {
-    rotateFingerprintKey(dataDir());
+    next = rotateFingerprintKey(dataDir());
   } catch (err) {
     // Rotation keeps its own PREFIX — what is being refused is the rotation,
     // not a grant — but not its own classification. Rotation writes as well as
@@ -419,6 +444,23 @@ export async function rotateKey(confirmation: string): Promise<ActionResult> {
     // fix a chmod. That is the harm KEY_IO_ERROR exists to stop, and the CLI's
     // runRotateKey already routes through the same split.
     return { ok: false, error: `Could not rotate the fingerprint key. ${keyAccessError(err)}` };
+  }
+  // Grants invalidate by design; vault entries must NOT. Re-key their
+  // fingerprints under the new epoch so dedup keeps finding stored values —
+  // otherwise a re-detected value fingerprints under the new key, misses its
+  // row, and mints a second pointer for the same secret. Best-effort: a fault
+  // here leaves skipped rows resolving under their old epoch and must not fail
+  // the rotation that already happened.
+  try {
+    const vault = new SecretVault({
+      repo: db().secretVault,
+      keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
+      fingerprintKey: next,
+      isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
+    });
+    await vault.refreshFingerprints(next);
+  } catch {
+    // The rotation itself succeeded; a skipped refresh only degrades dedup.
   }
   revalidatePath('/exceptions');
   return { ok: true };

--- a/web-ui/app/(app)/settings/actions.ts
+++ b/web-ui/app/(app)/settings/actions.ts
@@ -7,6 +7,7 @@ import {
   MODEL_JUDGE_PAYLOAD_VERSION,
   SimpleDetectionPolicy,
   VAULT_CONSENT_VERSION,
+  VaultInlineReveal,
 } from '@akasecurity/schema';
 import { revalidatePath } from 'next/cache';
 
@@ -32,13 +33,16 @@ export async function saveSettings(input: {
   // state, so a client cannot backdate a grant or claim a version it never saw.
   modelJudgeConsent?: boolean;
   vaultConsent: string;
+  vaultInlineReveal: string;
 }): Promise<SaveSettingsResult> {
   const policy = SimpleDetectionPolicy.safeParse(input.policy);
   const historicalAccess = HistoricalAccess.safeParse(input.historicalAccess);
+  const inlineReveal = VaultInlineReveal.safeParse(input.vaultInlineReveal);
   const vaultChoice = input.vaultConsent;
   if (
     !policy.success ||
     !historicalAccess.success ||
+    !inlineReveal.success ||
     (vaultChoice !== 'on' && vaultChoice !== 'off')
   ) {
     return { ok: false, error: 'Invalid settings value.' };
@@ -70,6 +74,7 @@ export async function saveSettings(input: {
         ? { acknowledgedAt: new Date().toISOString(), payloadVersion: MODEL_JUDGE_PAYLOAD_VERSION }
         : undefined,
       vaultConsent,
+      vaultInlineReveal: inlineReveal.data,
     });
   } catch {
     return { ok: false, error: 'Could not write settings.json.' };

--- a/web-ui/app/(app)/vault/VaultLookupClient.tsx
+++ b/web-ui/app/(app)/vault/VaultLookupClient.tsx
@@ -20,6 +20,7 @@ export function VaultLookupClient() {
 
   const [scope, setScope] = useState<ScopeAnswer | null>(null);
   const [justification, setJustification] = useState('');
+  const [confirmation, setConfirmation] = useState('');
   const [grantResult, setGrantResult] = useState<RevealGrantResult | null>(null);
   const [grantBusy, startGrantTransition] = useTransition();
 
@@ -40,7 +41,12 @@ export function VaultLookupClient() {
     if (scope === null || justification.trim() === '') return;
     startGrantTransition(async () => {
       setGrantResult(
-        await grantRevealFromPointer({ pointer: resolvedPointer, scope, justification }),
+        await grantRevealFromPointer({
+          pointer: resolvedPointer,
+          scope,
+          justification,
+          confirmation,
+        }),
       );
     });
   };
@@ -110,6 +116,21 @@ export function VaultLookupClient() {
                   Scope — pick one
                 </div>
                 <ScopePicker value={scope} onChange={setScope} />
+                {scope === 'permanent' ? (
+                  <label className="flex flex-col gap-1 text-xs text-text-2">
+                    A permanent reveal never expires. Retype the masked value shown above to
+                    confirm.
+                    <input
+                      className="rounded border border-border bg-surface px-2 py-1 font-mono"
+                      data-slot="permanent-confirmation"
+                      value={confirmation}
+                      onChange={(e) => {
+                        setConfirmation(e.target.value);
+                      }}
+                      placeholder="masked value"
+                    />
+                  </label>
+                ) : null}
               </div>
               <div>
                 <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">

--- a/web-ui/test/actions/exceptions-reveal.test.ts
+++ b/web-ui/test/actions/exceptions-reveal.test.ts
@@ -226,7 +226,7 @@ describe('grantRevealFromPointer', () => {
     expect(await grants()).toHaveLength(0);
   });
 
-  it('accepts the once and permanent scope answers with server-stamped columns', async () => {
+  it('accepts the once scope with server-stamped columns', async () => {
     const pointer = await seedPointer();
     const once = await grantRevealFromPointer({ pointer, scope: 'once', justification: 'x' });
     expect(once.ok).toBe(true);
@@ -237,5 +237,42 @@ describe('grantRevealFromPointer', () => {
     expect(all[0]?.scope).toBe('once');
     expect(all[0]?.maxUses).toBe(1);
     expect(all[0]?.expiresAt).not.toBeNull();
+  });
+
+  // A permanent reveal is a never-expiring authorization for raw to reach the
+  // model — it takes the same value-specific typed confirmation every other
+  // permanent grant does, re-checked server-side.
+  it('refuses a permanent reveal without the typed confirmation', async () => {
+    const pointer = await seedPointer();
+    const missing = await grantRevealFromPointer({
+      pointer,
+      scope: 'permanent',
+      justification: 'x',
+    });
+    expect(missing.ok).toBe(false);
+    if (!missing.ok) expect(missing.error).toContain('confirmed by retyping');
+
+    const wrong = await grantRevealFromPointer({
+      pointer,
+      scope: 'permanent',
+      justification: 'x',
+      confirmation: 'not-the-mask',
+    });
+    expect(wrong.ok).toBe(false);
+    expect(await grants()).toHaveLength(0);
+  });
+
+  it('accepts a permanent reveal confirmed with the masked value', async () => {
+    const pointer = await seedPointer();
+    const granted = await grantRevealFromPointer({
+      pointer,
+      scope: 'permanent',
+      justification: 'x',
+      confirmation: MASKED,
+    });
+    expect(granted.ok).toBe(true);
+    const all = await grants();
+    expect(all[0]?.scope).toBe('permanent');
+    expect(all[0]?.capability).toBe('reveal_to_model');
   });
 });

--- a/web-ui/test/actions/settings.test.ts
+++ b/web-ui/test/actions/settings.test.ts
@@ -53,6 +53,7 @@ describe('saveSettings — vault-consent grant and revocation', () => {
       policy: 'redact',
       historicalAccess: 'session-only',
       vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
     });
     expect(res).toEqual({ ok: true });
 
@@ -66,7 +67,12 @@ describe('saveSettings — vault-consent grant and revocation', () => {
   });
 
   it("keeps the original acknowledgedAt when 'on' is saved again", async () => {
-    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
+    });
     const first = readWorkspaceSettings().vaultConsent;
     expect(first).toBeDefined();
 
@@ -79,6 +85,7 @@ describe('saveSettings — vault-consent grant and revocation', () => {
       policy: 'warn',
       historicalAccess: 'session-only',
       vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
     });
     expect(res).toEqual({ ok: true });
 
@@ -88,13 +95,19 @@ describe('saveSettings — vault-consent grant and revocation', () => {
   });
 
   it("removes the field from the persisted file on 'off'", async () => {
-    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
+    });
     expect(rawSettings()).toContain('vaultConsent');
 
     const res = await saveSettings({
       policy: 'redact',
       historicalAccess: 'session-only',
       vaultConsent: 'off',
+      vaultInlineReveal: 'masked',
     });
     expect(res).toEqual({ ok: true });
 
@@ -107,13 +120,19 @@ describe('saveSettings — vault-consent grant and revocation', () => {
   });
 
   it('rejects an unknown consent value and leaves the file untouched', async () => {
-    await saveSettings({ policy: 'redact', historicalAccess: 'session-only', vaultConsent: 'on' });
+    await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
+    });
     const before = rawSettings();
 
     const res = await saveSettings({
       policy: 'redact',
       historicalAccess: 'session-only',
       vaultConsent: 'granted',
+      vaultInlineReveal: 'masked',
     });
     expect(res.ok).toBe(false);
     expect(rawSettings()).toBe(before);
@@ -128,11 +147,62 @@ describe('saveSettings — vault-consent grant and revocation', () => {
       policy: 'redact',
       historicalAccess: 'session-only',
       vaultConsent: forged as unknown as string,
+      vaultInlineReveal: 'masked',
     });
     expect(res.ok).toBe(false);
     expect(() => rawSettings()).toThrow(); // nothing was ever written
 
     // And the contract itself admits only a string — no object shape exists.
     expectTypeOf<Parameters<typeof saveSettings>[0]['vaultConsent']>().toEqualTypeOf<string>();
+  });
+});
+
+describe('stale-grant re-consent and inline reveal', () => {
+  // A grant recorded against an older consent version authorizes nothing; a
+  // save with 'on' selected must re-stamp it at the current version — the
+  // one-save re-consent the settings notice documents.
+  it("saving 'on' over a STALE grant re-stamps at the current version", async () => {
+    const { applyOnboarding } = await import('@akasecurity/persistence');
+    applyOnboarding(
+      {
+        // Any parseable version that is not the CURRENT one is a stale grant;
+        // versions below 1 fail the schema, so the other-epoch simulation uses
+        // the next version up — the same mismatch path either way.
+        vaultConsent: {
+          acknowledgedAt: '2020-01-01T00:00:00.000Z',
+          version: VAULT_CONSENT_VERSION + 1,
+        },
+      },
+      join(home, '.aka'),
+    );
+    const result = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'on',
+      vaultInlineReveal: 'masked',
+    });
+    expect(result.ok).toBe(true);
+    const persisted = readWorkspaceSettings(join(home, '.aka'));
+    expect(persisted.vaultConsent?.version).toBe(VAULT_CONSENT_VERSION);
+    expect(persisted.vaultConsent?.acknowledgedAt).not.toBe('2020-01-01T00:00:00.000Z');
+  });
+
+  it('persists a valid inline-reveal mode and rejects junk', async () => {
+    const ok = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'off',
+      vaultInlineReveal: 'full',
+    });
+    expect(ok.ok).toBe(true);
+    expect(readWorkspaceSettings(join(home, '.aka')).vaultInlineReveal).toBe('full');
+
+    const bad = await saveSettings({
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      vaultConsent: 'off',
+      vaultInlineReveal: 'loud',
+    });
+    expect(bad.ok).toBe(false);
   });
 });

--- a/web-ui/test/actions/vault-manage.test.ts
+++ b/web-ui/test/actions/vault-manage.test.ts
@@ -20,7 +20,7 @@ import type { VaultInventoryEntry } from '@akasecurity/schema';
 import { isVaultConsentValid, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { grantRevealFromPointer } from '../../app/(app)/exceptions/actions.ts';
+import { grantRevealFromPointer, rotateKey } from '../../app/(app)/exceptions/actions.ts';
 import {
   purgeVault,
   revealEntry,
@@ -173,6 +173,25 @@ describe('revokeRevealGrant', () => {
     const result = await revokeRevealGrant({ grantId: before.revealGrantId });
     expect(result).toEqual({ ok: true });
     expect(inventory()[0]?.revealGrantId).toBeNull();
+  });
+});
+
+// Fingerprint-key rotation invalidates GRANTS by design; it must never split
+// the vault. Rotation re-keys every stored fingerprint under the new epoch, so
+// the same value detected again still finds its row — otherwise it would
+// fingerprint under the new key, miss dedup, and mint a second pointer for a
+// secret that already has one in circulation.
+describe('rotateKey keeps the vault whole', () => {
+  it('re-keys stored fingerprints so a re-detection reuses the pointer', async () => {
+    const pointer = await seedPointer();
+    expect(entryCount()).toBe(1);
+
+    expect(await rotateKey('rotate')).toEqual({ ok: true });
+    resetSingleton();
+
+    const again = await seedPointer();
+    expect(again).toBe(pointer);
+    expect(entryCount()).toBe(1);
   });
 });
 

--- a/web-ui/test/package-walls.test.ts
+++ b/web-ui/test/package-walls.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -43,5 +44,47 @@ describe('package walls — the human reveal path', () => {
     for (const name of FORBIDDEN) {
       expect(deps).not.toContain(name);
     }
+  });
+});
+
+// Dependency lists alone cannot pin the wall: plugin-sdk is a legitimate
+// web-ui DEV dependency (test-fixture seeding), so a runtime import added to
+// app code would resolve and typecheck. Walk the actual source import
+// specifiers instead.
+describe('runtime source imports stay behind the wall', () => {
+  const FORBIDDEN = /@akasecurity\/(plugin-sdk|plugin-runtime|ai-tc-claude-code)/;
+
+  function walk(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+        out.push(...walk(full));
+      } else if (/\.(ts|tsx)$/.test(entry.name)) {
+        out.push(full);
+      }
+    }
+    return out;
+  }
+
+  it('no web-ui app file or dashboard-ui source file imports a plugin package', () => {
+    const roots = [
+      fileURLToPath(new URL('../app', import.meta.url)),
+      fileURLToPath(new URL('../../packages/dashboard-ui/src', import.meta.url)),
+    ];
+    const offenders: string[] = [];
+    for (const root of roots) {
+      for (const file of walk(root)) {
+        const source = readFileSync(file, 'utf8');
+        for (const line of source.split('\n')) {
+          if (/^\s*(import|export)\b/.test(line) && FORBIDDEN.test(line)) {
+            offenders.push(file);
+            break;
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
   });
 });


### PR DESCRIPTION
> **Stacked PR — review this diff only.** Base is the previous PR in the stack, so the diff shown is just this step. Full stack:
> 1. `vault/01-schema` — contracts, tables, migrations
> 2. `vault/02-vault-core` — crypto, key custody, store
> 3. `vault/03-sdk-glue` — text glue + consent surfaces
> 4. `vault/04-tool-io` — tool I/O tokenization, model protocol, display
> 5. `vault/05-prompt-block` — prompt block, reveal bridge, tail scrub
> 6. `vault/06-backfill` — historical scrub
> 7. `vault/07-reveal-grants` — decision seam, dashboard grants
> 8. `vault/08-dashboard` — vault dashboard, sightings
> 9. `vault/09-wizard` — setup consent step
> 10. `vault/10-hardening` — deep-review fixes
>
> Design: engineering#47 as amended by engineering#60. Every step is green on its own (`turbo typecheck lint test`).

## What

A four-area deep review of the completed build (crypto/store, enforcement core, rewrite surfaces, human surfaces) found **one blocker, eleven majors**, and a set of load-bearing behaviors no test pinned. All fixed here, each with the regression test that keeps it fixed. **This is the most security-relevant PR in the stack** — if you only read one closely, read this one.

## Data loss

- **Key custody had two read-modify-write races.** Two concurrent hooks on a fresh machine could mint different v1 keyrings; the loser had already sealed rows and emitted pointers that would never resolve — values destroyed while the product called them recoverable. First mint is now creation-exclusive (`wx`); a lost race adopts the winner. Rotation takes an advisory lock.
- **The keychain backend treated every `security` failure as "no keyring"** and minted over the real one with `-U`. A locked keychain or denied ACL orphaned every ciphertext. Only exit 44 (item-not-found) now means absence.
- **The live-transcript scrub destroyed appended lines.** It read a whole file, tokenized slowly, then renamed a stale snapshot over it. It now re-stats before the rename and aborts on any change: a lost scrub retries, lost transcript lines do not come back.

## Consent exceeded

- **A `once` reveal grant was never consumed under a Monitor/Warn policy** — consumption rode the downstream suppression match, which only runs for block/redact findings, so the grant revealed raw indefinitely. Consumption moved to the crossing itself: once per grant, only on success, whatever the enforcement mode. Verified through the built plugin: use_count 1/1 after the first crossing, refused on the second.
- **A granted deref was silently dropped when any finding resolved to warn** — the hook emitted the warning alone and the tool ran with literal pointers.
- **Permanent reveal grants had no confirmation** — the strongest capability in the product was the only grant with zero friction. Now takes the same typed masked-value confirmation as every sibling flow.

## Disclosure integrity

Full-mode inline reveal leaked inside code regions four ways (tilde fences, 4-backtick fences with inner fences, mid-line markers, split markers); the walker is now CommonMark-shaped. The reveal cap was per content block rather than per message (an N-block message allowed 2N reveals). One global carry file was clobbered by concurrent sessions, dropping held screen text. The stale-consent notice documented a one-save re-consent the form made impossible. Settings pointed at a CLI purge that does not exist, and the wizard deferred its inline-reveal risk copy to a Settings control that did not exist — it exists now.

## Structural

`fs-scan` (`aka scan`, the dashboard folder scan) scanned raw file text **without the pointer shield**, so a user-installed entropy rule could re-detect pointer bodies in files the Write hook had just pointerized — the shield moved to `@akasecurity/detections` and every scan surface uses it. The pointer format version was baked into every tag and AAD but **recorded nowhere**, so the next bump would have bricked every stored value with no migration possible; rows now carry it and a frozen golden-vector test fails if the constants move without a migration story. Non-canonical base32 spellings of one pointer all verified, fragmenting audit keys. `detokenize` gated model crossings on grantId *truthiness* alone — the vault, the last gate before raw leaves the store, now verifies the grant covers the row.