### PR TITLE
fix(ci): run CI when a pull request's base branch is retargeted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` is on top of the three default types (opened, synchronize,
+    # reopened) because retargeting a PR's BASE fires only `edited`. Without it
+    # a stacked PR moved onto main after its parent merged never runs this
+    # workflow at all: the branch filter above now matches, but no event does,
+    # so the required checks stay absent and the merge is blocked forever with
+    # nothing to re-run. The cost is a run on title/body edits too — GitHub
+    # gives one `edited` type for all three — which the concurrency group below
+    # bounds, since it cancels a superseded run per PR ref.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## The problem

`ci.yml` filters on `pull_request: branches: [main]` with no `types:`, so it gets the three defaults — `opened`, `synchronize`, `reopened`. Retargeting a PR's **base** fires none of those; it fires `edited`.

That makes a stacked PR unmergeable in a way that has no manual escape. Move a PR onto `main` after its parent merges and the branch filter starts matching, but no event does — so `Lint · Typecheck · Test · Build` and `Windows · Unit tests (shipped surface)` never appear at all. The base-branch policy then blocks the merge waiting for checks that were never queued, and there is no run to re-trigger because none was ever created.

Hit while merging the `vault/01` → `vault/10` stack (#132–#141): #132 merged cleanly, then #133 retargeted to `main` and sat at `BLOCKED` with only the binary-build checks from its old base.

## The fix

Add `edited` to the type list.

The trade, stated plainly: GitHub reports title, body, and base changes under one `edited` type, so this also runs CI on description edits. There is no way to filter by payload in `on:`, and gating the job on `github.event.changes.base` would make the required check report *skipped* rather than *success*, which does not satisfy the policy. The existing `concurrency` group bounds the waste — `cancel-in-progress` per PR ref means repeated edits cancel each other rather than piling up.

## Why it matters beyond this stack

Every future chained PR series hits this. Without it the only ways through are closing and reopening each PR to fake a `reopened`, or an admin bypass that merges with the required checks unrun — and that second one is exactly what the gate exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNrAfWaNGUkLo5QWyUdUfm