### PR TITLE
test(persistence): bound the fillStore commit budget on Windows

### DIFF
--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -477,14 +477,30 @@ describe('fillStore', () => {
       const db = store.openRaw();
       db.exec('PRAGMA journal_mode = WAL');
       db.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
-      const filled = fillStore(db);
+      // Autocommit is required here, unlike the sibling test below: this asserts
+      // that the rows committed BEFORE the cap was reached survive it, and one
+      // wrapping transaction would roll every one of them back. So the cost has
+      // to be bounded by the number of commits instead.
+      //
+      // Each row is sized to consume a whole page, so the cap is reached in
+      // `headroomPages` writes rather than the ~40 that 200-byte rows took —
+      // and, more to the point, the loop can never run away. Every iteration is
+      // its own WAL commit, which the sibling below measured at tens of seconds
+      // for 500 of them on the Windows runner; the old 20_000 bound was three
+      // orders of magnitude past that, so any platform where SQLITE_FULL
+      // arrived later than it does here blew the 20s budget and reported a
+      // timeout instead of the assertion that would have explained it.
+      const filled = fillStore(db, { headroomPages: 8 });
+      const pageSize = (db.prepare('PRAGMA page_size').get() as { page_size: number }).page_size;
 
       const insert = db.prepare('INSERT INTO bulk (v) VALUES (?)');
-      const payload = 'x'.repeat(200);
+      const payload = 'x'.repeat(pageSize);
       let written = 0;
       let err: unknown;
       try {
-        for (let i = 0; i < 20_000; i += 1) {
+        // Comfortably above the 8 writes the headroom allows, so a platform that
+        // fills later still fails on the result code below rather than the clock.
+        for (let i = 0; i < 64; i += 1) {
           insert.run(payload);
           written += 1;
         }


### PR DESCRIPTION
## The flake

`fault-injection.test.ts > fillStore > raises SQLITE_FULL from the engine, leaving the store intact` times out at 20s on the Windows leg. It failed twice today on unrelated PRs — including one whose entire diff was nine lines of YAML in `ci.yml`, which rules out any code cause.

## The mechanism

The sibling test in the same block already carries the finding:

> One transaction, not one per row: in autocommit each row is its own WAL commit, and **500 of those runs for tens of seconds on the Windows runner**.

This case allowed `20_000`. Locally the cap is reached after ~38 writes so the bound never mattered; on a platform that fills later, the loop keeps going and the 20s budget goes to WAL commits. The visible result is a timeout rather than the assertion that would have named the problem — the worst of both, because the diagnostic is destroyed along with the run.

Measured locally to check the theory rather than assume it: 38 writes, 3.3ms, errcode 13. The loop is not the cost here, which is exactly why the bound went unnoticed.

This is the third time this suite has needed it — `ci.yml` already notes "the persistence suite needed batching twice to stay under it."

## The fix

Autocommit cannot be batched away here the way the sibling batches it: this case asserts that rows committed *before* the cap survive it, and one wrapping transaction would roll every one of them back. So the commit count is bounded instead.

- Each row is sized to a full page (read from `PRAGMA page_size`, not hardcoded), so the cap is reached in exactly `headroomPages` writes.
- `headroomPages: 8` is passed explicitly rather than relying on the helper's default of 2, so the count a reader expects is stated.
- The loop bound drops from `20_000` to `64` — comfortably above the 8 writes the headroom allows, so a platform that fills later still fails on the **result code** rather than the clock.

Every existing assertion is unchanged: real engine `SQLITE_FULL`, committed rows intact, `integrity_check` ok, no open transaction, and the write that succeeds after `restore()`.

## Verification

Suite green: 639 passed (47 files).

Mutation-tested, since a test that passes proves nothing about whether it still bites — with `fillStore` altered to never apply the cap:

```
FAIL  fillStore > raises SQLITE_FULL from the engine, leaving the store intact
AssertionError: expected undefined to be 13
      Tests  1 failed | 638 passed (639)
real 8.23
```

It fails on the result code, in seconds. Under the old bound that same mutation would have driven 20,000 autocommit inserts and timed out instead.

No vitest `retry` and no timing assertion added — `CLAUDE.md` rules both out, and neither is what this needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FNrAfWaNGUkLo5QWyUdUfm