### PR TITLE
test(persistence): use the shared store harness in the vault suites

### DIFF
--- a/packages/persistence/test/repositories/secret-vault.test.ts
+++ b/packages/persistence/test/repositories/secret-vault.test.ts
@@ -1,36 +1,26 @@
 import { randomUUID } from 'node:crypto';
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync } from 'node:sqlite';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { openLocalDatabase } from '../../src/database.ts';
-import { DB_FILENAME } from '../../src/paths.ts';
 import type { VaultRowInsert } from '../../src/repositories/secret-vault.ts';
 import { SqliteSecretVaultRepository } from '../../src/repositories/secret-vault.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
 
 const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
-let dir: string;
-let db: ReturnType<typeof openLocalDatabase>;
+// The package's shared store harness owns the temp tree and closes every handle
+// it hands out at teardown.
+const store = useTempStore('aka-vault-');
 let raw: DatabaseSync;
 let vault: SqliteSecretVaultRepository;
 
 beforeEach(() => {
-  dir = mkdtempSync(join(tmpdir(), 'aka-vault-'));
-  // openLocalDatabase applies the migrations; the repository under test runs on
-  // a second connection to the same migrated file.
-  db = openLocalDatabase(dir);
-  raw = new DatabaseSync(join(dir, DB_FILENAME));
+  // Applies the migrations; the repository under test runs on a second
+  // connection to the same migrated file.
+  store.open();
+  raw = store.openRaw();
   vault = new SqliteSecretVaultRepository(raw);
-});
-
-afterEach(() => {
-  raw.close();
-  db.close();
-  rmSync(dir, { recursive: true, force: true });
 });
 
 const FINGERPRINT_A = 'a'.repeat(64);

--- a/packages/persistence/test/vault/vault.test.ts
+++ b/packages/persistence/test/vault/vault.test.ts
@@ -1,17 +1,14 @@
-import { mkdtempSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync } from 'node:sqlite';
 
 import { PointerToken } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
-import { openLocalDatabase } from '../../src/database.ts';
 import { loadOrCreateFingerprintKey, rotateFingerprintKey } from '../../src/fingerprint.ts';
-import { DB_FILENAME } from '../../src/paths.ts';
 import { SqliteSecretVaultRepository } from '../../src/repositories/secret-vault.ts';
 import { FileKeyProvider } from '../../src/vault/key-provider.ts';
 import { CONSENT_ABSENT, SecretVault, UNAVAILABLE } from '../../src/vault/vault.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
 
 // Narrowing helper: the lint config forbids non-null assertions, and these
 // lookups are all "the row we just wrote must be there" assertions anyway.
@@ -24,8 +21,11 @@ const SECRET = 'AKIAIOSFODNN7EXAMPLE';
 const OTHER = 'AKIAI44QH8DHBEXAMPLE';
 
 describe('SecretVault', () => {
+  // The package's shared store harness owns the temp tree and every handle it
+  // hands out. Re-rolling this by hand is what leaked a migration handle here
+  // and broke the suite's teardown on Windows.
+  const store = useTempStore('aka-vault-');
   let dir: string;
-  let migrated: ReturnType<typeof openLocalDatabase>;
   let db: DatabaseSync;
   let repo: SqliteSecretVaultRepository;
   let vault: SecretVault;
@@ -40,22 +40,15 @@ describe('SecretVault', () => {
     });
 
   beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), 'aka-vault-'));
+    dir = store.dataDir;
     // Applies the migrations; the repository under test runs on a second
-    // connection to the same file. BOTH handles must be closed before the temp
-    // dir is removed — Windows refuses to delete a directory that still has an
-    // open handle inside it (EPERM), where POSIX unlinks it happily.
-    migrated = openLocalDatabase(dir);
-    db = new DatabaseSync(join(dir, DB_FILENAME));
+    // connection to the same file. The harness closes both at teardown, so
+    // neither can be left open to block removal of the tree on Windows.
+    store.open();
+    db = store.openRaw();
     repo = new SqliteSecretVaultRepository(db);
     consented = true;
     vault = build();
-  });
-
-  afterEach(() => {
-    db.close();
-    migrated.close();
-    rmSync(dir, { recursive: true, force: true });
   });
 
   const tokenize = async (raw: string, category = 'secret'): Promise<string> => {


### PR DESCRIPTION
Follow-up to the Windows failure on #133, addressing the convention point raised there after #133 had already merged.

## Why

`vault.test.ts` and `repositories/secret-vault.test.ts` re-rolled the `mkdtempSync` + `openLocalDatabase` + cleanup dance that CLAUDE.md (line 286) asks tests **in this package** to take from `test/helpers/temp-store.ts`.

That is not a style nit here — it is what caused the bug. `vault.test.ts` called `openLocalDatabase(dir)` in statement position and closed only the second handle. POSIX unlinks an open file happily; Windows returns `EPERM`, so `rmSync` threw and all 27 tests reported a teardown error while their assertions passed.

#133 fixed the leak by hand (capture and close). This removes the class of bug instead: `store.open()` / `store.openRaw()` hand out handles the harness closes at teardown, and its `removeTree` already knows the Windows retry-then-tolerate rules.

## Not converted, deliberately

`vault/key-provider.test.ts` keeps its own temp dir. It opens no store at all (its `openLocalDatabase` count is zero — it exercises key files), and it mocks `node:fs`, which the harness would fight. The CLAUDE.md rule targets the store dance, and there is no store here.

`exception-policy.test.ts` gets the same treatment in the still-open stack (vault/07-reveal-grants), where that file lives.

## Verification

Full workspace green: 44/44 turbo tasks, format clean. The two suites pass unchanged (37 tests) — this is a teardown refactor, no assertion moved.