### PR TITLE
fix(audit-gate): lint the package's root config file

### DIFF
--- a/tools/audit-gate/eslint.config.mjs
+++ b/tools/audit-gate/eslint.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { base } from '@akasecurity/eslint-config';
+import { base, rootConfigFiles } from '@akasecurity/eslint-config';
 
 export default [
   ...base,
@@ -11,4 +11,5 @@ export default [
       },
     },
   },
+  ...rootConfigFiles,
 ];

--- a/tools/audit-gate/package.json
+++ b/tools/audit-gate/package.json
@@ -7,7 +7,7 @@
     ".": "./src/lib.ts"
   },
   "scripts": {
-    "lint": "eslint src test",
+    "lint": "eslint src test *.config.*",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },


### PR DESCRIPTION
`main` is red. Two cases in `packages/eslint-config/test/effective-config.test.js` fail:

```
every guarded package has a lint script covering every top-level file it ships
  @akasecurity/audit-gate (tools/audit-gate) → eslint.config.mjs

reports every network form planted in 'tools/audit-gate/eslint.config.mjs'
  tools/audit-gate/eslint.config.mjs did not parse, so no rule ran against it
```

## Why it broke, and why no PR caught it

The guard is not wrong and neither is #143 — the two just never met before landing.

The guard enumerates workspace packages from `git ls-files` at run time, so it covers whatever is in the tree. `tools/audit-gate` arrived on `main` in #130 at `73eec931`, seven hours *after* the last merge of `main` into #143's branch (`b84286f2`, which pulled in `main` as of #132). `git ls-tree b84286f2 tools/` lists only `installer`. GitHub does not recompute a `pull_request` merge commit unless the branch is pushed, so #143's green run was green against a tree where `audit-gate` did not exist.

Then #143's own run on `main` was cancelled by the concurrency group when #125 merged two minutes later, so the first red run to appear on `main` carries #125's SHA. #125 is not implicated — reverting it changes nothing.

## The fix

`tools/audit-gate` needs the two pieces every other package got in #143, and nothing else.

| File | Change |
|------|--------|
| `tools/audit-gate/package.json` | `lint` target gains `*.config.*` |
| `tools/audit-gate/eslint.config.mjs` | spreads `...rootConfigFiles` after the `projectService` block |

Both are load-bearing and neither is sufficient alone: without the target the file is never handed to ESLint, and without the opt-out the type-aware parser rejects it as owned by no tsconfig, which reports a fatal parse error and zero rule violations. That second half is what the "did not parse, so no rule ran against it" assertion is for.

## Verification

- `pnpm --filter @akasecurity/eslint-config test` → **470 passed**, both cases green.
- `pnpm lint` → **15/15**, `Cached: 0`.
- Mutation-tested rather than trusted green. A `fetch()` planted in a root config file of `tools/audit-gate`:

```
$ pnpm exec eslint src test *.config.*      # new target
EXIT=1   error  Unexpected use of 'fetch'  no-restricted-globals

$ pnpm exec eslint src test                 # the old target
EXIT=0
```

That is the gap, reproduced and closed.

## Note for the branch owners

`tools/audit-gate` runs `vitest` with no `vitest.config.ts` of its own, so it has no `setupFiles` seam. #127 wires the no-network guard through exactly that file in all thirteen packages and its structural guard enumerates every package with a `test` script — so audit-gate will need either a config file or a named exemption there. Same root cause as this PR: a workspace package that arrived after the branch was cut. cc @venuverse
