### PR TITLE
test(persistence): stop the fillStore SQLITE_FULL test flaking on Windows

### DIFF
--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -471,11 +471,25 @@ describe('lockStore against the product write path', () => {
 });
 
 describe('fillStore', () => {
-  it('raises SQLITE_FULL from the engine, leaving the store intact', () => {
+  // The synchronous=OFF handle below takes the fill loop's fsyncs away, but the
+  // migrated store this test seeds first still opens at the product's own
+  // durability settings, on a runner whose disk speed the suite does not
+  // control. Headroom over the config-wide 20s rather than a slow Windows disk
+  // flaking a passing test.
+  it('raises SQLITE_FULL from the engine, leaving the store intact', { timeout: 60_000 }, () => {
     withTempStore((store) => {
       seedStore(store);
       const db = store.openRaw();
       db.exec('PRAGMA journal_mode = WAL');
+      // Autocommit is load-bearing below: each row is its own commit, so
+      // `written` counts rows that really committed and can be compared against
+      // count(*). At the default synchronous level that means one WAL fsync per
+      // row, and on the Windows runner's disks under parallel load those syncs
+      // are what pushed this test past the timeout. SQLITE_FULL comes out of
+      // page allocation rather than the sync path — the run reaches it after
+      // the same number of rows either way — and every assertion here reads the
+      // live handle, so crash durability is not part of what is being proved.
+      db.exec('PRAGMA synchronous = OFF');
       db.exec('CREATE TABLE bulk (id INTEGER PRIMARY KEY, v TEXT)');
       const filled = fillStore(db);
 
@@ -484,6 +498,12 @@ describe('fillStore', () => {
       let written = 0;
       let err: unknown;
       try {
+        // A safety bound, not the expected count: the cap is two pages of
+        // headroom plus whatever the freelist holds, so the engine runs out
+        // after a couple of hundred rows. The bound stays generous because a
+        // page size or freelist this test does not control decides the real
+        // number, and a bound that ran out first would report as a failure to
+        // raise SQLITE_FULL.
         for (let i = 0; i < 20_000; i += 1) {
           insert.run(payload);
           written += 1;


### PR DESCRIPTION
## Summary

Fixes a Windows CI flake in `fillStore > raises SQLITE_FULL from the engine, leaving the store intact`. It timed out at 22.2s against the 20s limit in the "Windows · Unit tests (shipped surface)" job on #132, and passed on re-run.

**The cost was fsyncs, not iterations.** The loop is bounded at `20_000`, but that bound is never reached — instrumenting the real path (migrated store, WAL, `fillStore` cap) shows the engine runs out after **190 rows**:

```
default-sync: written=190 code=13 pages=108 freelist=8 ms=6.6
sync-off    : written=190 code=13 pages=108 freelist=8 ms=1.4
```

The cap is `page_count + 2`, so what's actually available is 2 headroom pages plus the 8 freelist pages the migrations leave behind. The real cost is 190 autocommit WAL commits, each paying an fsync, on a runner disk that is slow under parallel load.

This also rules out lowering the cap as a fix: `headroomPages` is already at its floor of 2, and the freelist — not the cap — supplies most of those pages.

## What changed

**`PRAGMA synchronous = OFF`** on the test's own raw handle, removing all 190 fsyncs. Same technique `legacy-compat-views.test.ts:73` already uses for the identical Windows-NTFS problem.

Autocommit is deliberately kept rather than batching into one transaction: `written` has to count rows that *really committed* for the `count(*) === written` assertion to mean anything, and one transaction would make it count attempted rows instead. (The sibling test below can batch safely — it asserts no error at all.)

Nothing the test proves changes. `written=190` and `code=13` are identical with and without the pragma: `SQLITE_FULL` comes out of page allocation, not the sync path, and every intactness assertion reads the live handle, so crash durability was never part of the claim.

**A 60s timeout on this one test**, as insurance — the migrated store `seedStore` builds first still opens at the product's own durability settings, which the test does not control.

Plus a comment documenting `20_000` as the safety bound it is, so the "20k inserts" misreading doesn't recur. It stays generous on purpose: page size and freelist depth are decided elsewhere, and a bound that ran out first would report as a failure to raise `SQLITE_FULL`.

## Reviewer notes

- No product code touched — one test file.
- Test-only change, so no version bump under the release rules.
- `synchronous = OFF` applies solely to the raw `DatabaseSync` handle this test opens; `openLocalDatabase` keeps its own pragmas.
- Verified locally on macOS, where the fsync cost never reproduced (30ms before and after) — the fix is directed at the measured cause rather than at a locally reproduced failure, with the timeout as the backstop.

## Checklist

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (persistence: 639 tests / 47 files; workspace: 28 tasks green)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
