### PR TITLE
feat(codex): add the Codex CLI plugin with the full setup wizard

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
     "name": "AKA Security",
     "url": "https://github.com/akasecurity/ai-tc"
   },
-  "description": "AI Traffic Control plugins for Claude Code",
+  "description": "AI Traffic Control plugins for Claude Code and Codex CLI",
   "plugins": [
     {
       "name": "aka",
@@ -17,6 +17,18 @@
         "name": "AKA Security"
       },
       "homepage": "https://github.com/akasecurity/ai-tc/tree/main/plugins/claude-code"
+    },
+    {
+      "name": "aka-codex",
+      "source": {
+        "source": "npm",
+        "package": "@akasecurity/ai-tc-codex"
+      },
+      "description": "AI Traffic Control — inspect and govern AI prompts in Codex CLI. Local detection with inline warn/redact/block policies; every event is recorded to a local SQLite store on your machine.",
+      "author": {
+        "name": "AKA Security"
+      },
+      "homepage": "https://github.com/akasecurity/ai-tc/tree/main/plugins/codex"
     }
   ]
 }

--- a/.github/workflows/release-plugin-codex.yml
+++ b/.github/workflows/release-plugin-codex.yml
@@ -98,7 +98,7 @@ jobs:
         run: |
           cd plugins/codex
           for f in session-start user-prompt-submit pre-tool-use post-tool-use stop reconcile \
-                   query dashboard onboard intro firstrun backfill filescan; do
+                   query dashboard onboard apply-suppressions intro firstrun backfill filescan; do
             test -f "scripts/$f.js" || { echo "::error::missing scripts/$f.js"; exit 1; }
           done
           # The hooks run on the user's machine with no node_modules; junk input

--- a/.github/workflows/release-plugin-codex.yml
+++ b/.github/workflows/release-plugin-codex.yml
@@ -1,0 +1,182 @@
+name: Release plugin (Codex)
+
+# Publishes the Claude Code plugin package to the public npm registry AND to the
+# repo's GitHub Packages registry, and attaches the packed tarball to a GitHub
+# Release. The plugin's hook scripts are a build artifact
+# (plugins/codex/scripts/, git-ignored) — they are generated here and shipped
+# inside the package, never committed. End users install via the `ai-tc` marketplace,
+# whose source resolves this package from public npm (GitHub Packages requires auth
+# even for public reads, so it is a secondary artifact, not the marketplace source).
+#
+# Release flow: bump version in package.json + .codex-plugin/plugin.json, then
+# push a tag `plugin-codex-v<version>` (e.g. plugin-codex-v0.9.1).
+
+on:
+  push:
+    tags:
+      - 'plugin-codex-v*'
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish to npm (otherwise build + pack only — a dry run)'
+        type: boolean
+        default: false
+
+jobs:
+  # Tag pushes get no run of the main CI workflow (it triggers only on main
+  # pushes/PRs), so the release re-verifies the tagged commit itself — nothing
+  # publishes from a commit that would fail CI.
+  verify:
+    name: Lint · Typecheck · Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+  release:
+    name: Build · Verify · Publish
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # create the GitHub Release
+      id-token: write # OIDC trusted publishing to npm (provenance attestation)
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin (Turbo)
+        run: pnpm turbo run build --filter=@akasecurity/ai-tc-codex
+
+      - name: Verify tag matches manifest versions
+        if: github.event_name == 'push'
+        run: |
+          tag="${GITHUB_REF_NAME#plugin-codex-v}"
+          pkg=$(node -p "require('./plugins/codex/package.json').version")
+          manifest=$(node -p "require('./plugins/codex/.codex-plugin/plugin.json').version")
+          echo "tag=$tag  package.json=$pkg  plugin.json=$manifest"
+          if [ "$tag" != "$pkg" ] || [ "$tag" != "$manifest" ]; then
+            echo "::error::Version mismatch — tag plugin-codex-v$tag must equal package.json ($pkg) and plugin.json ($manifest)"
+            exit 1
+          fi
+
+      - name: Smoke-test built scripts (self-contained, fail-open)
+        run: |
+          cd plugins/codex
+          for f in session-start user-prompt-submit pre-tool-use post-tool-use stop reconcile \
+                   query dashboard onboard intro firstrun backfill filescan; do
+            test -f "scripts/$f.js" || { echo "::error::missing scripts/$f.js"; exit 1; }
+          done
+          # The hooks run on the user's machine with no node_modules; junk input
+          # must produce no output and exit 0 (the fail-open contract).
+          echo 'not json' | node scripts/user-prompt-submit.js
+          echo "fail-open OK"
+
+      - name: Pack tarball (release asset)
+        run: pnpm --filter @akasecurity/ai-tc-codex pack --pack-destination "$RUNNER_TEMP"
+
+      # OIDC trusted publishing: the id-token: write permission above lets npm
+      # exchange this job's OIDC token for a short-lived publish credential — no
+      # NPM_TOKEN needed. NPM_CONFIG_PROVENANCE has npm attach a Sigstore
+      # attestation binding the published package to this repository and workflow.
+      # Pre-release versions (any `-` suffix) publish under the `rc` dist-tag;
+      # stable versions publish under `latest`.
+      - name: Publish to npm
+        if: github.event_name == 'push' || inputs.publish
+        run: |
+          version=$(node -p "require('./plugins/codex/package.json').version")
+          case "$version" in
+            *-*) dist_tag="rc" ;;
+            *)   dist_tag="latest" ;;
+          esac
+          pnpm --filter @akasecurity/ai-tc-codex publish --no-git-checks --tag "$dist_tag"
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        with:
+          files: ${{ runner.temp }}/*.tgz
+          generate_release_notes: true
+          prerelease: ${{ startsWith(github.ref_name, 'plugin-codex-v0.') }}
+
+  # Publish the same package to the repo's GitHub Packages registry (requirement:
+  # packages land in the org's GitHub registry). Kept a separate job so its GitHub
+  # Packages .npmrc/auth never collides with the public-npm publish above. The
+  # @akasecurity scope must match the akasecurity org that owns this repo.
+  github-packages:
+    name: Publish to GitHub Packages
+    needs: verify
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://npm.pkg.github.com
+          scope: '@akasecurity'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build plugin (Turbo)
+        run: pnpm turbo run build --filter=@akasecurity/ai-tc-codex
+
+      # publishConfig.registry pins public npm, so override the target here. The
+      # built-in GITHUB_TOKEN can publish to this repo's Packages; setup-node wrote
+      # the matching auth token into .npmrc.
+      - name: Publish to GitHub Packages
+        run: |
+          version=$(node -p "require('./plugins/codex/package.json').version")
+          case "$version" in
+            *-*) dist_tag="rc" ;;
+            *)   dist_tag="latest" ;;
+          esac
+          pnpm --filter @akasecurity/ai-tc-codex publish --registry https://npm.pkg.github.com --no-git-checks --tag "$dist_tag"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-plugin-codex.yml
+++ b/.github/workflows/release-plugin-codex.yml
@@ -1,6 +1,6 @@
 name: Release plugin (Codex)
 
-# Publishes the Claude Code plugin package to the public npm registry AND to the
+# Publishes the Codex CLI plugin package to the public npm registry AND to the
 # repo's GitHub Packages registry, and attaches the packed tarball to a GitHub
 # Release. The plugin's hook scripts are a build artifact
 # (plugins/codex/scripts/, git-ignored) — they are generated here and shipped
@@ -21,6 +21,18 @@ on:
         description: 'Publish to npm (otherwise build + pack only — a dry run)'
         type: boolean
         default: false
+
+# One release per tag at a time. A single tag push can start more than one run.
+# A duplicate is already self-limiting here: npm and GitHub Packages both reject a
+# re-publish of the same (name, version), so the losing run fails at its publish step
+# and never reaches the Release. That safety is a consequence of publish running
+# before the Release step — this group holds whatever the step order, and stops two
+# runs overlapping. It does not make a duplicate disappear: the queued run still
+# executes afterward and still fails at publish. cancel-in-progress is false so a run
+# is never interrupted midway through publishing to either registry.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   # Tag pushes get no run of the main CI workflow (it triggers only on main
@@ -98,7 +110,8 @@ jobs:
         run: |
           cd plugins/codex
           for f in session-start user-prompt-submit pre-tool-use post-tool-use stop reconcile \
-                   query dashboard onboard apply-suppressions intro firstrun backfill filescan; do
+                   query dashboard onboard apply-suppressions intro firstrun backfill filescan \
+                   remediate start-light; do
             test -f "scripts/$f.js" || { echo "::error::missing scripts/$f.js"; exit 1; }
           done
           # The hooks run on the user's machine with no node_modules; junk input

--- a/.github/workflows/release-plugin-codex.yml
+++ b/.github/workflows/release-plugin-codex.yml
@@ -111,7 +111,7 @@ jobs:
           cd plugins/codex
           for f in session-start user-prompt-submit pre-tool-use post-tool-use stop reconcile \
                    query dashboard onboard apply-suppressions intro firstrun backfill filescan \
-                   remediate start-light; do
+                   remediate start-light scan-worker; do
             test -f "scripts/$f.js" || { echo "::error::missing scripts/$f.js"; exit 1; }
           done
           # The hooks run on the user's machine with no node_modules; junk input

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ coverage
 
 .DS_Store
 plugins/claude-code/scripts/
+plugins/codex/scripts/
 
 # written by tools/audit-gate on every run, always at the repo root
 /audit-report.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Read this before generating any code in this repository. These conventions are e
 AI Traffic Control (`ai-tc`, by AKA Security — the `aka` CLI and plugin names come from
 the company) is a **local-first** security control plane for AI coding agents. The whole surface
 runs on one machine with **no server, no Docker, and no database engine**: the Claude Code
-plugin and the `aka` CLI capture agent activity into a local SQLite store at
-`~/.aka/data/aka.db`, and the web dashboard reads that same store directly. There is no
+plugin, the Codex CLI plugin, and the `aka` CLI capture agent activity into a local SQLite
+store at `~/.aka/data/aka.db`, and the web dashboard reads that same store directly. There is no
 account and no AKA backend — nothing is sent to a service AKA runs. (A few narrow outbound
 paths do exist — package-manager installs and the opt-in `/aka:setup` calibration, which
 sends raw findings to the model API via the `claude` CLI — enumerated in §4.)
@@ -20,7 +20,7 @@ sends raw findings to the model API via the `claude` CLI — enumerated in §4.)
 - **Validation:** Zod schemas in `@akasecurity/schema` — the single source of truth
 - **Web dashboard:** Next.js 15 + React 19 (Server Components read the store; Server Actions mutate it)
 - **Testing:** Vitest
-- **Packaging:** the `aka` CLI and the Claude Code plugin, published to npm as self-contained bundles
+- **Packaging:** the `aka` CLI and the Claude Code / Codex CLI plugins, published to npm as self-contained bundles
 
 ## Architecture principles
 
@@ -69,16 +69,17 @@ the fault rows prove silence, and only the enforcement rows can prove what the n
 
 ### 3. `process.env` is off by default
 
-ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Four places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
+ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Five places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
 
-| Site                                      | Mechanism                         | Why                                                    |
-| ----------------------------------------- | --------------------------------- | ------------------------------------------------------ |
-| `packages/plugin-sdk/src/provider.ts`     | file-scoped ESLint config         | LLM-provider resolution at SessionStart                |
-| `cli/src/commands/dashboard.ts`           | inline `eslint-disable-next-line` | spawning the dashboard server                          |
-| `plugins/claude-code/src/backfill.ts`     | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips |
-| `plugins/claude-code/src/triage/judge.ts` | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth            |
+| Site                                        | Mechanism                         | Why                                                    |
+| ------------------------------------------- | --------------------------------- | ------------------------------------------------------ |
+| `packages/plugin-sdk/src/provider.ts`       | file-scoped ESLint config         | LLM-provider resolution at SessionStart                |
+| `packages/plugin-sdk/src/provider-codex.ts` | file-scoped ESLint config         | Codex LLM-provider resolution at SessionStart          |
+| `cli/src/commands/dashboard.ts`             | inline `eslint-disable-next-line` | spawning the dashboard server                          |
+| `plugins/claude-code/src/backfill.ts`       | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips |
+| `plugins/claude-code/src/triage/judge.ts`   | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth            |
 
-Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a fifth site means updating this table.
+Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a sixth site means updating this table.
 
 That last sentence is enforced, not merely asked: `packages/eslint-config/test/effective-config.test.js` parses this table and drives each column against the thing it describes — the site against the tracked tree, the mechanism against the resolved config and the file's own text, the count word against the row count, and the row set against every opt-out shipped source actually carries. So a fifth site that never reaches the table fails CI, and so does a row that outlives the exception it describes. The `Why` column is prose about intent and is guarded by nothing.
 
@@ -331,10 +332,13 @@ cli               → @akasecurity/schema, persistence, local-ops, detections (t
 
 # Plugin
 plugins/claude-code → @akasecurity/plugin-runtime, plugin-sdk
+plugins/codex        → @akasecurity/plugin-runtime, plugin-sdk
 @akasecurity/plugin-runtime → @akasecurity/plugin-sdk, persistence, schema
 @akasecurity/plugin-sdk     → @akasecurity/detections, persistence, schema
                      (provider resolution for the session-root snapshot reads the host env
-                     directly at SessionStart), ignore (gitignore semantics for
+                     directly at SessionStart — `provider.ts` for Claude Code,
+                     `provider-codex.ts` for Codex CLI, each its own file-scoped
+                     `n/no-process-env` opt-out), ignore (gitignore semantics for
                      the SessionStart project-file walk), node:worker_threads
                      (the isolated scan — see Architecture principles §5)
                      `src/scan-worker.ts` is the worker's own entry, exported as the
@@ -353,6 +357,13 @@ plugins/claude-code → @akasecurity/plugin-runtime, plugin-sdk
                      those at its own I/O boundary, which is what lets multiple
                      harness plugins share this without forking it.)
 ```
+
+Both plugin packages bundle the SAME `plugin-runtime`/`plugin-sdk` core and differ only in
+their own thin hook-entrypoint layer (stdin/stdout glue matched to each host's hook contract)
+plus the harness-specific bits `plugin-sdk` deliberately keeps file-scoped (provider
+resolution, tool-name → scannable-field tables). See `plugins/codex/skills/setup/SKILL.md`'s
+"Known limitation" note for the one real behavioral gap between the two: Codex does not yet
+fire PreToolUse/PostToolUse for `apply_patch` (file-write) calls, only `Bash`.
 
 **Cross-cutting rules:**
 
@@ -448,6 +459,7 @@ replays frozen SQL from already-shipped binaries, which app-level guards cannot 
 cli/                  the `aka` CLI (self-contained npm bundle; ships the web-ui as a spawned Next server)
 web-ui/               the OSS Next.js dashboard (Server Components read ~/.aka; Server Actions mutate it)
 plugins/claude-code/  the Claude Code plugin (hooks + commands; self-contained npm bundle)
+plugins/codex/        the Codex CLI plugin (hooks + skills; self-contained npm bundle)
 packages/             the workspace libraries (schema · persistence · local-ops · detections ·
                       extract · dashboard-ui · ui-kit · plugin-runtime · plugin-sdk · scanner …)
 rules/                the built-in detection packs (rule JSON + fixtures)
@@ -600,9 +612,9 @@ sets `noExternal: [/^@akasecurity\//]`, so every `@akasecurity/*` package they u
 the published output (the user's machine has no `node_modules`). So a change to a _bundled_ package
 changes the shipped artifact **even when the app's own `src/` is untouched**:
 
-- **`plugins/claude-code`** bundles `@akasecurity/plugin-runtime` + `plugin-sdk` and everything they
-  pull in — `@akasecurity/schema`, `persistence`, `detections`. A change to any of
-  those changes the plugin's `scripts/*.js`.
+- **`plugins/claude-code`** and **`plugins/codex`** each bundle `@akasecurity/plugin-runtime` +
+  `plugin-sdk` and everything they pull in — `@akasecurity/schema`, `persistence`,
+  `detections`. A change to any of those changes BOTH plugins' `scripts/*.js`.
 - **`cli`** bundles the same `@akasecurity/*` packages **and** ships the OSS web-ui
   (`web-ui` is `external` to the CLI JS but copied in by `prepack`'s `bundle:web-ui` and
   spawned as a separate Next server). So a web-ui change — or any bundled-package change — changes the CLI.
@@ -611,14 +623,16 @@ When a change touches the web-ui or any bundled package and the user wants to pu
 
 1. **Bump every affected artifact**:
    - web-ui / `local-ops` / `dashboard-ui` / `ui-kit` change → `cli` (bundled into the CLI JS
-     and/or the web-ui it ships; the plugin bundles none of these).
+     and/or the web-ui it ships; the plugins bundle none of these).
    - `schema` / `persistence` / `plugin-runtime` / `plugin-sdk` / `detections`
-     change → **both** `cli` **and** `plugins/claude-code` (both bundle them).
-   - `setup-wizard` change → `plugins/claude-code` only (the plugin bundles it;
-     the CLI does not).
-   - The CLI and plugin normally move together on one shared version line.
-2. Keep `plugins/claude-code/.claude-plugin/plugin.json` **in sync** with
-   `plugins/claude-code/package.json` (identical version) whenever the plugin is bumped.
+     change → **all three** of `cli`, `plugins/claude-code`, **and** `plugins/codex` (all bundle them).
+   - `setup-wizard` change → `plugins/claude-code` **and** `plugins/codex` (both bundle
+     it; the CLI does not).
+   - The CLI and both plugins normally move together on one shared version line.
+2. Keep `plugins/claude-code/.claude-plugin/plugin.json` in sync with
+   `plugins/claude-code/package.json`, and `plugins/codex/.codex-plugin/plugin.json` in sync
+   with `plugins/codex/package.json` (identical version within each pair) whenever that plugin
+   is bumped.
 
 **The bump is not a decision to surface during feature work, because it is not made there.**
 Pre-1.0.0 the version numbers are chosen **ad hoc**, at the **scheduled release** (twice a week)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -927,7 +927,8 @@ Assert a raw value is absent from an **error** run by run, not whole. `not.toCon
 stays green if a branch echoes a _truncated_ value, which is still a live credential's
 prefix. `expectNoEchoOf` is the **required form for every raw-value absence assertion that is
 newly written or newly touched** in a package carrying the helper — `cli/test/helpers/no-echo.ts`,
-`plugins/claude-code/test/helpers/no-echo.ts` and `web-ui/test/helpers/no-echo.ts`. A plain
+`plugins/claude-code/test/helpers/no-echo.ts`, `plugins/codex/test/helpers/no-echo.ts`,
+`web-ui/test/helpers/no-echo.ts` and `packages/setup-wizard/test/helpers/no-echo.ts`. A plain
 `not.toContain(rawValue)` in a new or edited assertion is a defect, not a style choice, and
 editing a file means its in-class assertions come along rather than being left beside converted
 ones.
@@ -935,15 +936,18 @@ ones.
 **Older assertions are a backlog, not a clean tree.** `plugins/claude-code` still carries around
 twenty whole-value raw-value assertions in files this convention has not reached —
 `history/`, `journey/`, `remediation/`, `render.test.ts`, `triage/plan-file.test.ts`,
-`hooks/pointer-substitution.test.ts` and `backfill.test.ts` among them. Do not read the rule
-above as a claim that the package is clean. Two shapes are genuinely **exempt** and stay
+`hooks/pointer-substitution.test.ts` and `backfill.test.ts` among them. `plugins/codex` carries
+the same backlog in its counterparts of those files — the helper reached its hook and
+remediation-render assertions, not `history/`, `triage/judge.test.ts` or
+`remediation/redact.test.ts`. Do not read the rule above as a claim that either package is
+clean. Two shapes are genuinely **exempt** and stay
 whole-value: an assertion on a masked preview (`writeback.test.ts` on `maskedValue`,
 `triage/surfaced-secrets.test.ts` on `maskedToken`), because that fragment is revealed on
 purpose; and the deliberate **control** assertions inside each `no-echo.test.ts`, which exist
 to show the whole-value form would have passed.
 
 **Share it inside a package, copy it across a wall — and a copy takes the suite with it.**
-All three packages import a `test/helpers/no-echo.ts` with its own tests in `no-echo.test.ts`:
+All five packages import a `test/helpers/no-echo.ts` with its own tests in `no-echo.test.ts`:
 each case drives the helper with an output that leaks a run, and asserts both that the helper
 refuses it **and** that the whole-value form it replaced would have passed. That second half is
 what shows the assertion is _stronger_ rather than merely also-red, and it is why raising the
@@ -951,7 +955,7 @@ run length or emptying the loop cannot go unnoticed — widening `ECHO_RUN` leav
 **caller** green, so the helper's own suite is the only thing that goes red. `web-ui` is the
 worked example of that failure: its copy was inline with no suite, and all 86 of its action
 tests passed with `ECHO_RUN` set to 64. A package wall blocks the import, not the pattern, so a
-fourth package copies **both** files — including the `expect(value).toBeDefined()` guard,
+further package copies **both** files — including the `expect(value).toBeDefined()` guard,
 without which an `undefined` message satisfies the loop vacuously.
 
 **A masked-preview control calls the product's mask, never a hand-rolled one.** A locally built

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,17 +69,18 @@ the fault rows prove silence, and only the enforcement rows can prove what the n
 
 ### 3. `process.env` is off by default
 
-ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Five places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
+ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Six places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
 
-| Site                                        | Mechanism                         | Why                                                    |
-| ------------------------------------------- | --------------------------------- | ------------------------------------------------------ |
-| `packages/plugin-sdk/src/provider.ts`       | file-scoped ESLint config         | LLM-provider resolution at SessionStart                |
-| `packages/plugin-sdk/src/provider-codex.ts` | file-scoped ESLint config         | Codex LLM-provider resolution at SessionStart          |
-| `cli/src/commands/dashboard.ts`             | inline `eslint-disable-next-line` | spawning the dashboard server                          |
-| `plugins/claude-code/src/backfill.ts`       | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips |
-| `plugins/claude-code/src/triage/judge.ts`   | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth            |
+| Site                                        | Mechanism                         | Why                                                       |
+| ------------------------------------------- | --------------------------------- | --------------------------------------------------------- |
+| `packages/plugin-sdk/src/provider.ts`       | file-scoped ESLint config         | LLM-provider resolution at SessionStart                   |
+| `packages/plugin-sdk/src/provider-codex.ts` | file-scoped ESLint config         | Codex LLM-provider resolution at SessionStart             |
+| `cli/src/commands/dashboard.ts`             | inline `eslint-disable-next-line` | spawning the dashboard server                             |
+| `plugins/claude-code/src/backfill.ts`       | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips    |
+| `plugins/claude-code/src/triage/judge.ts`   | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth               |
+| `plugins/codex/src/triage/judge.ts`         | file-scoped ESLint config         | the judge subprocess must inherit PATH + `CODEX_HOME` auth |
 
-Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a sixth site means updating this table.
+Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a seventh site means updating this table.
 
 That last sentence is enforced, not merely asked: `packages/eslint-config/test/effective-config.test.js` parses this table and drives each column against the thing it describes — the site against the tracked tree, the mechanism against the resolved config and the file's own text, the count word against the row count, and the row set against every opt-out shipped source actually carries. So a fifth site that never reaches the table fails CI, and so does a row that outlives the exception it describes. The `Why` column is prose about intent and is guarded by nothing.
 
@@ -156,12 +157,13 @@ the tree really holds rather than what a lint script says.
 
 `DOCUMENTED_OPT_OUTS` is a hand-written mirror of that table, and it is not what keeps the table true — it never opens this file. `packages/eslint-config/test/no-network.test.js` parses the table and asserts it twice: against that mirror, so the two cannot drift apart in either direction, and against the configs themselves, resolving each row's site through ESLint under the config the row names. The second is what covers the **Site** column, which the mirror does not carry and so cannot check — a row may not name a file the config never reaches, nor keep an exception that has been removed. Any entry in the **Allowed specifier** column that is neither a banned module nor a banned global marked `(inline)` fails rather than being skipped, since a token the module audit cannot see is enforced by nothing.
 
-Network access happens **only through child processes**. In the first three, this repo chooses the program and its arguments; in the fourth it chooses neither:
+Network access happens **only through child processes**. In all but the external-dispatch path, this repo chooses the program and its arguments; in that one it chooses neither:
 
 1. `@akasecurity/local-ops` shelling out to package managers (`npm`/`claude`) for update-and-apply.
 2. The Claude Code plugin's own `npm audit signatures` child process — run from inside the plugin's dependency closure (a plugin script or `@akasecurity/plugin-sdk`, since the plugin cannot import `@akasecurity/local-ops`).
 3. The `/aka:setup` wizard's judge subprocess (`plugins/claude-code/src/triage/judge.ts`), which spawns `claude -p` and **sends findings to the model API** so it can rate false positives and severity. `runJudge` serializes a minimized projection (`toJudgePayload`), not the whole `TriageHit`: `rawMatch` (the raw, unmasked secret) crosses, along with `context` (a ±120-character window of the surrounding transcript text — see `plugins/claude-code/src/history/scan.ts` — re-masked with `maskText`, which scans the **bundled** packs rather than the installed set — coverage is still complete because `buildTriageHit` has already redacted every other finding from the full-ruleset scan, and this hit's own value is masked here where it appears in the window; `rawMatch` is therefore the only raw value that crosses), `id` (a sequential counter the rubric requires the model to echo), and the non-sensitive scoring labels `ruleId`, `category`, `severity`, `maskedMatch` and `confidence`. `filePath` (the source transcript's path), `valueFingerprint` (an HMAC of the secret), and `keyVersion` are dropped before egress — a new `TriageHit` field is not disclosed to the model unless `toJudgePayload` and the disclosure copy are updated together. A large history is chunked, so this is several `claude -p` calls, not one. It runs only on the user's explicit opt-in during setup — a consent distinct from the historical-read grant, recorded as `modelJudgeConsent` and re-checked against `MODEL_JUDGE_PAYLOAD_VERSION` on every run, so widening the payload invalidates consents given for the old one. `historicalAccess` gates the READ only — a `full` grant authorizes no egress by itself, and no consent surface may imply that it does. Both grants are revocable under Settings, where **Historical access** and **Model-judge consent** are separate controls; revoking stops future scans but cannot recall what was already sent. The subprocess asks the CLI to suppress its transcript (`CLAUDE_CODE_SKIP_PROMPT_HISTORY=1`), but that is transcript isolation, **not** network isolation — a copy of the raw values leaves the machine, because the whole point is to reach the model. Consent copy must state the payload, the egress, and that limit on revocation plainly; it must never be described as staying "inside an isolated subprocess." Four surfaces carry that copy and move together: `plugins/claude-code/commands/setup.md`, the `[^egress]` footnote in each of the two READMEs, and the Settings copy in `packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx`.
 4. **Git-style external subcommand dispatch** (`cli/src/lib/external-dispatch.ts`). `aka <name>` execs `aka-<name>` from the user's `PATH` when no built-in owns the name, inheriting the caller's environment and stdio. The child is resolved by name at call time — this repo does not bundle, depend on, verify or version-pin it — so its behaviour, including any network access, is outside what this codebase can describe. AKA Security ships one intended occupant, `aka-claude` from `claude-tools`, which launches a Claude Code profile and is network-bound by definition; the dispatch gives it no special status, and any other `aka-*` on `PATH` runs identically. A built-in always wins, so this can never shadow a shipped command, and the path is POSIX-only (disabled on win32). An allowlist or provenance check is a deliberate non-goal: the precondition for abuse is write access to a `PATH` directory, which already permits shadowing `aka` itself. The invariant that is enforced is that a built-in always wins.
+5. The Codex `aka-setup` wizard's judge subprocess (`plugins/codex/src/triage/judge.ts`), which spawns `codex exec` and sends the same minimized `toJudgePayload` projection to the model API as the Claude Code judge — `rawMatch`, the re-masked `context` window, and the sequential `id`; never `filePath`, `valueFingerprint`, or `keyVersion` — chunked into several `codex exec` calls for a large history, under the same distinct `modelJudgeConsent` opt-in, the same `MODEL_JUDGE_PAYLOAD_VERSION` re-check, and the same revocation limit (revoking stops future scans but cannot recall what was already sent). The `--ephemeral` flag stops the judge session from being written under `~/.codex/sessions` (which AKA's own backfill scans — a persisted judge session would re-ingest the raw findings it carries), but that is session-persistence isolation, **not** network isolation. The same consent-copy honesty rules apply (`plugins/codex/skills/setup/SKILL.md`).
 
 These are the **shipped product's** egress paths. Repo CI additionally talks to the npm
 registry: `.github/workflows/audit.yml` (via `tools/audit-gate`) runs `pnpm audit` on every
@@ -607,7 +609,7 @@ Follow Conventional Commits: `feat:`, `fix:`, `chore:`, `test:`, `docs:`, `refac
 
 ## Releasing (CLI / plugin versioning)
 
-Both shippable artifacts are **self-contained bundles of the workspace** — their `tsup.config.ts`
+All three shippable artifacts are **self-contained bundles of the workspace** — their `tsup.config.ts`
 sets `noExternal: [/^@akasecurity\//]`, so every `@akasecurity/*` package they use is inlined into
 the published output (the user's machine has no `node_modules`). So a change to a _bundled_ package
 changes the shipped artifact **even when the app's own `src/` is untouched**:
@@ -642,8 +644,9 @@ summary or PR description. The steps above are what a **release** does: which ar
 derivable from the bundling rules, and how far they move is settled at release time by whoever
 cuts it.
 
-Versions are bumped by hand in a `chore(release):` commit (no changesets). The CLI and the plugin
-currently share the `0.9.x` line.
+Versions are bumped by hand in a `chore(release):` commit (no changesets). Every release is a
+bare `X.Y.Z` on the one shared version line — never a pre-release suffix. The CLI and both
+plugins currently share the `0.9.x` line.
 
 ### Binary (SEA) channel — `bin-v*`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,13 +71,13 @@ the fault rows prove silence, and only the enforcement rows can prove what the n
 
 ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Six places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
 
-| Site                                        | Mechanism                         | Why                                                       |
-| ------------------------------------------- | --------------------------------- | --------------------------------------------------------- |
-| `packages/plugin-sdk/src/provider.ts`       | file-scoped ESLint config         | LLM-provider resolution at SessionStart                   |
-| `packages/plugin-sdk/src/provider-codex.ts` | file-scoped ESLint config         | Codex LLM-provider resolution at SessionStart             |
-| `cli/src/commands/dashboard.ts`             | inline `eslint-disable-next-line` | spawning the dashboard server                             |
-| `plugins/claude-code/src/backfill.ts`       | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips    |
-| `plugins/claude-code/src/triage/judge.ts`   | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth               |
+| Site                                        | Mechanism                         | Why                                                        |
+| ------------------------------------------- | --------------------------------- | ---------------------------------------------------------- |
+| `packages/plugin-sdk/src/provider.ts`       | file-scoped ESLint config         | LLM-provider resolution at SessionStart                    |
+| `packages/plugin-sdk/src/provider-codex.ts` | file-scoped ESLint config         | Codex LLM-provider resolution at SessionStart              |
+| `cli/src/commands/dashboard.ts`             | inline `eslint-disable-next-line` | spawning the dashboard server                              |
+| `plugins/claude-code/src/backfill.ts`       | inline `eslint-disable-next-line` | the host session id the self-contamination guard skips     |
+| `plugins/claude-code/src/triage/judge.ts`   | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth                |
 | `plugins/codex/src/triage/judge.ts`         | file-scoped ESLint config         | the judge subprocess must inherit PATH + `CODEX_HOME` auth |
 
 Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a seventh site means updating this table.

--- a/cli/src/commands/plugins.ts
+++ b/cli/src/commands/plugins.ts
@@ -3,10 +3,10 @@ import { parseArgs } from 'node:util';
 
 import {
   AGENT_PLUGINS,
-  claudeAvailable,
+  createCliPluginManager,
   findAgent,
   installAgentPlugin,
-  installedPluginVersions,
+  installedAgentPluginVersions,
   pluginRef,
 } from '@akasecurity/local-ops';
 import { openLocalDatabase } from '@akasecurity/persistence';
@@ -47,8 +47,10 @@ async function listPlugins(argv: string[]): Promise<void> {
     }
   }
 
-  // Installed versions, keyed by `<plugin>@<marketplace>`, from Claude Code's ledger.
-  const installed = installedPluginVersions();
+  // Installed versions, keyed by `<plugin>@<marketplace>`, merged from every
+  // registered agent's own install ledger/cache (Claude Code's
+  // installed_plugins.json, Codex CLI's plugins/cache directory layout).
+  const installed = installedAgentPluginVersions();
 
   const out = process.stdout;
   out.write('Agent plugins (the CLI is an optional hub — plugins also self-install):\n\n');
@@ -82,41 +84,42 @@ function installPlugin(argv: string[]): void {
     return;
   }
   const ref = pluginRef(agent);
-  if (!ref) {
+  const cliBin = agent.cliBin;
+  if (!ref || !cliBin) {
     process.stdout.write(
       `${agent.name} has no automated install path yet — install it from the AKA ` +
-        `marketplace in Claude Code, then run \`aka init\`.\n`,
+        `marketplace in ${agent.name}, then run \`aka init\`.\n`,
     );
     return;
   }
 
-  // Delegate to the `claude` plugin manager (it owns the plugin cache + lifecycle).
-  // If it isn't on PATH, fall back to the manual in-app path so the command stays
-  // honest and actionable.
-  if (!claudeAvailable()) {
+  // Delegate to the host CLI's own plugin manager (it owns the plugin cache +
+  // lifecycle). If it isn't on PATH, fall back to the manual in-app path so
+  // the command stays honest and actionable.
+  if (!createCliPluginManager(cliBin).available()) {
     process.stdout.write(
       `Installing ${agent.name}…\n\n` +
-        `The \`claude\` CLI isn't on your PATH, so I can't install it automatically.\n` +
-        `Install it from inside Claude Code:\n` +
-        `  /plugin marketplace add ${agent.marketplaceSource ?? ''}\n` +
-        `  /plugin install ${ref}\n\n` +
+        `The \`${cliBin}\` CLI isn't on your PATH, so I can't install it automatically.\n` +
+        `Install it from inside ${agent.name}:\n` +
+        `  ${cliBin} plugin marketplace add ${agent.marketplaceSource ?? ''}\n` +
+        `  ${cliBin} plugin install ${ref}\n\n` +
         `Then run \`aka init\` to set up the local store.\n`,
     );
     return;
   }
 
-  process.stdout.write(`Installing ${agent.name} via Claude Code…\n`);
+  process.stdout.write(`Installing ${agent.name} via ${cliBin}…\n`);
   const { ok } = installAgentPlugin(agent.id, 'inherit');
   if (ok) {
     process.stdout.write(
       `\n✓ Installed ${agent.name}.\n` +
-        `  ↻ Restart Claude Code to load it.\n` +
+        `  ↻ Restart ${agent.name} to load it.\n` +
         `  Run \`aka init\` to scaffold your local store (if you haven't already).\n`,
     );
   } else {
     process.stderr.write(
-      `\n✗ Install failed — see the output above, or add it in Claude Code with ` +
-        `\`/plugin install ${ref}\`.\n`,
+      `\n✗ Install failed — see the output above, or add it in ${agent.name} with ` +
+        `\`${cliBin} plugin install ${ref}\`.\n`,
     );
     process.exitCode = 1;
   }

--- a/cli/src/commands/update.ts
+++ b/cli/src/commands/update.ts
@@ -4,9 +4,9 @@ import { parseArgs } from 'node:util';
 import {
   applyCliUpdate as applyCliUpdateShared,
   applyPluginUpdate as applyPluginUpdateShared,
-  claudeAvailable,
   clearCache,
   CLI_PACKAGE,
+  createCliPluginManager,
   findAgent,
   gatherReportLive,
   outdated,
@@ -118,18 +118,19 @@ function applyCliUpdate(): boolean {
 function applyPluginUpdate(status: ComponentStatus): boolean {
   const agent = findAgent(status.id);
   const ref = agent ? pluginRef(agent) : undefined;
-  if (!agent || !ref) {
+  const cliBin = agent?.cliBin;
+  if (!agent || !ref || !cliBin) {
     process.stderr.write(`✗ ${status.name}: no update coordinates in the registry.\n`);
     return false;
   }
-  if (!claudeAvailable()) {
+  if (!createCliPluginManager(cliBin).available()) {
     process.stderr.write(
-      `✗ ${status.name}: the \`claude\` CLI isn't on your PATH — install Claude Code, ` +
-        `then run \`claude plugin update ${ref}\`.\n`,
+      `✗ ${status.name}: the \`${cliBin}\` CLI isn't on your PATH — install ${agent.name}, ` +
+        `then run \`${cliBin} plugin update ${ref}\`.\n`,
     );
     return false;
   }
-  process.stdout.write(`Updating ${status.name} (claude plugin update ${ref})…\n`);
+  process.stdout.write(`Updating ${status.name} (${cliBin} plugin update ${ref})…\n`);
   const { ok } = applyPluginUpdateShared(status.id, 'inherit');
   process.stdout.write(ok ? `✓ ${status.name} updated.\n` : `✗ ${status.name} update failed.\n`);
   return ok;

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -254,6 +254,7 @@ const WORKSPACE_PACKAGES = discoverWorkspacePackages();
 // drop / rename.
 const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
   '@akasecurity/ai-tc-claude-code',
+  '@akasecurity/ai-tc-codex',
   '@akasecurity/audit-gate',
   '@akasecurity/cli',
   '@akasecurity/dashboard-ui',

--- a/packages/eslint-config/test/inline-disables.test.js
+++ b/packages/eslint-config/test/inline-disables.test.js
@@ -81,9 +81,10 @@ const GUARDED_RULES = [...NETWORK_RULES, ENV_RULE].sort();
  * are not listed.
  */
 const EXPECTED_INLINE_DISABLES = {
-  // CLAUDE.md §3's three inline rows. The fourth site in that table
-  // (packages/plugin-sdk/src/provider.ts) is a file-scoped CONFIG opt-out, so it
-  // carries no directive and correctly does not appear here — effective-config
+  // CLAUDE.md §3's three inline rows. The other three sites in that table
+  // (packages/plugin-sdk/src/provider.ts, packages/plugin-sdk/src/provider-codex.ts
+  // and plugins/codex/src/triage/judge.ts) are file-scoped CONFIG opt-outs, so they
+  // carry no directive and correctly do not appear here — effective-config
   // .test.js is what holds §3's table against the tree, including this split.
   'cli/src/commands/dashboard.ts': [ENV_RULE],
   'plugins/claude-code/src/backfill.ts': [ENV_RULE],
@@ -99,6 +100,7 @@ const EXPECTED_INLINE_DISABLES = {
   'plugins/claude-code/test/journey/harness.ts': [ENV_RULE],
   'plugins/claude-code/test/provenance.test.ts': [ENV_RULE],
   'plugins/claude-code/test/remediation/entry-posture-close-fault.test.ts': [ENV_RULE],
+  'plugins/codex/test/remediation/entry-posture-close-fault.test.ts': [ENV_RULE],
 
   // CLAUDE.md §4's one global opt-out, tabled there as `fetch` (inline): the
   // runtime suite's deliberate fetch(), which the guard must refuse for that

--- a/packages/eslint-config/test/inline-disables.test.js
+++ b/packages/eslint-config/test/inline-disables.test.js
@@ -100,6 +100,7 @@ const EXPECTED_INLINE_DISABLES = {
   'plugins/claude-code/test/journey/harness.ts': [ENV_RULE],
   'plugins/claude-code/test/provenance.test.ts': [ENV_RULE],
   'plugins/claude-code/test/remediation/entry-posture-close-fault.test.ts': [ENV_RULE],
+  'plugins/codex/test/e2e/scan-worker-bundle.e2e.test.ts': [ENV_RULE],
   'plugins/codex/test/remediation/entry-posture-close-fault.test.ts': [ENV_RULE],
 
   // CLAUDE.md §4's one global opt-out, tabled there as `fetch` (inline): the

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -181,6 +181,7 @@ const VITEST_PACKAGES = TEST_PACKAGES.filter((p) => p.runsVitest);
 // argued out of it in review.
 const EXPECTED_VITEST_PACKAGES = [
   '@akasecurity/ai-tc-claude-code',
+  '@akasecurity/ai-tc-codex',
   '@akasecurity/audit-gate',
   '@akasecurity/cli',
   '@akasecurity/dashboard-ui',

--- a/packages/local-ops/src/apply.ts
+++ b/packages/local-ops/src/apply.ts
@@ -1,4 +1,4 @@
-import { claudeAvailable, ensureMarketplace } from './claude-plugin.ts';
+import { createCliPluginManager } from './cli-plugin-manager.ts';
 import { runCapture, runInherit } from './exec.ts';
 import { findAgent, pluginRef } from './registry.ts';
 import { CLI_PACKAGE } from './updates.ts';
@@ -41,38 +41,47 @@ export function applyCliUpdate(mode: ApplyMode = 'capture'): ApplyResult {
   return run('npm', ['install', '-g', `${CLI_PACKAGE}@latest`], mode);
 }
 
-// Resolve an agent id to its `<plugin>@<marketplace>` ref, failing closed on
-// anything the static registry doesn't know or can't automate.
+// Resolve an agent id to its `<plugin>@<marketplace>` ref plus its bound
+// cli-plugin-manager, failing closed on anything the static registry doesn't
+// know or can't automate.
 function resolveRef(
   agentId: string,
-): { ref: string; marketplaceSource?: string | undefined } | ApplyResult {
+): { ref: string; cliBin: string; marketplaceSource?: string | undefined } | ApplyResult {
   const agent = findAgent(agentId);
   if (!agent) return { ok: false, output: `unknown agent '${agentId}'` };
   const ref = pluginRef(agent);
-  if (!ref) return { ok: false, output: `${agent.name} has no automated install path yet.` };
-  if (!claudeAvailable()) {
+  const cliBin = agent.cliBin;
+  if (!ref || !cliBin) {
+    return { ok: false, output: `${agent.name} has no automated install path yet.` };
+  }
+  const manager = createCliPluginManager(cliBin);
+  if (!manager.available()) {
     return {
       ok: false,
       output:
-        `the \`claude\` CLI isn't on your PATH — install Claude Code, then run ` +
-        `\`claude plugin install ${ref}\` (or update with \`claude plugin update ${ref}\`).`,
+        `the \`${cliBin}\` CLI isn't on your PATH — install ${agent.name}, then run ` +
+        `\`${cliBin} plugin install ${ref}\` (or update with \`${cliBin} plugin update ${ref}\`).`,
     };
   }
-  return { ref, marketplaceSource: agent.marketplaceSource };
+  return { ref, cliBin, marketplaceSource: agent.marketplaceSource };
 }
 
-/** Update an installed agent plugin via `claude plugin update <ref>`. */
+/** Update an installed agent plugin via `<cliBin> plugin update <ref>`. */
 export function applyPluginUpdate(agentId: string, mode: ApplyMode = 'capture'): ApplyResult {
   const resolved = resolveRef(agentId);
   if ('ok' in resolved) return resolved;
-  if (resolved.marketplaceSource) ensureMarketplace(resolved.marketplaceSource);
-  return run('claude', ['plugin', 'update', resolved.ref], mode);
+  if (resolved.marketplaceSource) {
+    createCliPluginManager(resolved.cliBin).ensureMarketplace(resolved.marketplaceSource);
+  }
+  return run(resolved.cliBin, ['plugin', 'update', resolved.ref], mode);
 }
 
-/** Install an agent plugin via `claude plugin install <ref>` (marketplace ensured first). */
+/** Install an agent plugin via `<cliBin> plugin install <ref>` (marketplace ensured first). */
 export function installAgentPlugin(agentId: string, mode: ApplyMode = 'capture'): ApplyResult {
   const resolved = resolveRef(agentId);
   if ('ok' in resolved) return resolved;
-  if (resolved.marketplaceSource) ensureMarketplace(resolved.marketplaceSource);
-  return run('claude', ['plugin', 'install', resolved.ref], mode);
+  if (resolved.marketplaceSource) {
+    createCliPluginManager(resolved.cliBin).ensureMarketplace(resolved.marketplaceSource);
+  }
+  return run(resolved.cliBin, ['plugin', 'install', resolved.ref], mode);
 }

--- a/packages/local-ops/src/claude-plugin.ts
+++ b/packages/local-ops/src/claude-plugin.ts
@@ -1,25 +1,12 @@
-import { binExists, runCapture, runInherit } from './exec.ts';
+import { createCliPluginManager } from './cli-plugin-manager.ts';
 
-// Delegators onto the `claude` CLI's plugin manager — the supported way to install
-// and update Claude Code plugins. The AKA CLI is a hub over it, never a
-// reimplementation: Claude Code owns the plugin cache, enable/disable state, and the
-// restart lifecycle.
+// Bound `claude` instance of the generic cli-plugin-manager. Kept as its own
+// module (rather than inlining `createCliPluginManager('claude')` at call
+// sites) so `apply.ts` and the CLI commands keep their existing named imports
+// — see codex-plugin.ts for the sibling `codex` instance.
+const manager = createCliPluginManager('claude');
 
-export function claudeAvailable(): boolean {
-  return binExists('claude');
-}
-
-// Register the marketplace if it isn't already. `claude plugin marketplace add` is
-// idempotent enough for our purposes — a re-add of an existing marketplace just
-// errors, which we capture and ignore; the subsequent install/update is what matters.
-export function ensureMarketplace(source: string): void {
-  runCapture('claude', ['plugin', 'marketplace', 'add', source], 60_000);
-}
-
-export function installClaudePlugin(ref: string): boolean {
-  return runInherit('claude', ['plugin', 'install', ref]);
-}
-
-export function updateClaudePlugin(ref: string): boolean {
-  return runInherit('claude', ['plugin', 'update', ref]);
-}
+export const claudeAvailable = manager.available;
+export const ensureMarketplace = manager.ensureMarketplace;
+export const installClaudePlugin = manager.install;
+export const updateClaudePlugin = manager.update;

--- a/packages/local-ops/src/cli-plugin-manager.ts
+++ b/packages/local-ops/src/cli-plugin-manager.ts
@@ -1,0 +1,34 @@
+import { binExists, runCapture, runInherit } from './exec.ts';
+
+// Generic delegator onto a host CLI's own plugin manager — the supported way
+// to install and update its plugins. The AKA CLI is a hub over these, never a
+// reimplementation: each host CLI owns its own plugin cache, enable/disable
+// state, and restart lifecycle.
+//
+// Parameterized by binary name because Claude Code (`claude`) and Codex CLI
+// (`codex`) expose the SAME `<bin> plugin marketplace add|install|update`
+// subcommand shape — confirmed for Codex against developers.openai.com/codex/
+// plugins and the `codex-marketplace.com` docs. One factory avoids
+// duplicating this thin wrapper per host; see claude-plugin.ts / codex-plugin.ts
+// for the two bound instances the rest of local-ops imports.
+export interface CliPluginManager {
+  available: () => boolean;
+  // Register the marketplace if it isn't already. `<bin> plugin marketplace add`
+  // is idempotent enough for our purposes — a re-add of an existing marketplace
+  // just errors, which we capture and ignore; the subsequent install/update is
+  // what matters.
+  ensureMarketplace: (source: string) => void;
+  install: (ref: string) => boolean;
+  update: (ref: string) => boolean;
+}
+
+export function createCliPluginManager(bin: string): CliPluginManager {
+  return {
+    available: () => binExists(bin),
+    ensureMarketplace: (source: string) => {
+      runCapture(bin, ['plugin', 'marketplace', 'add', source], 60_000);
+    },
+    install: (ref: string) => runInherit(bin, ['plugin', 'install', ref]),
+    update: (ref: string) => runInherit(bin, ['plugin', 'update', ref]),
+  };
+}

--- a/packages/local-ops/src/codex-plugin.ts
+++ b/packages/local-ops/src/codex-plugin.ts
@@ -1,0 +1,12 @@
+import { createCliPluginManager } from './cli-plugin-manager.ts';
+
+// Bound `codex` instance of the generic cli-plugin-manager — the Codex CLI
+// counterpart of claude-plugin.ts. Codex's `codex plugin marketplace add|
+// install|update` subcommands are the same shape as Claude Code's `claude
+// plugin …` ones, so this is a thin binding, not a reimplementation.
+const manager = createCliPluginManager('codex');
+
+export const codexAvailable = manager.available;
+export const ensureCodexMarketplace = manager.ensureMarketplace;
+export const installCodexPlugin = manager.install;
+export const updateCodexPlugin = manager.update;

--- a/packages/local-ops/src/index.ts
+++ b/packages/local-ops/src/index.ts
@@ -6,6 +6,14 @@ export {
   installClaudePlugin,
   updateClaudePlugin,
 } from './claude-plugin.ts';
+export type { CliPluginManager } from './cli-plugin-manager.ts';
+export { createCliPluginManager } from './cli-plugin-manager.ts';
+export {
+  codexAvailable,
+  ensureCodexMarketplace,
+  installCodexPlugin,
+  updateCodexPlugin,
+} from './codex-plugin.ts';
 export type { EgressRecordResult } from './egress-record.ts';
 export { recordProjectEgress } from './egress-record.ts';
 export type { RunResult } from './exec.ts';
@@ -48,6 +56,8 @@ export {
   cliVersion,
   gatherReport,
   gatherReportLive,
+  installedAgentPluginVersions,
+  installedCodexPluginVersions,
   installedPluginVersions,
   npmViewVersion,
 } from './updates.ts';

--- a/packages/local-ops/src/registry.ts
+++ b/packages/local-ops/src/registry.ts
@@ -10,16 +10,21 @@ export interface AgentPlugin {
   name: string;
   sourceTool: SourceTool;
   description: string;
-  // Install/update coordinates — present for agents distributed through the Claude
-  // Code plugin marketplace. `npmPackage` is the registry package the marketplace
-  // resolves (used for `npm view <pkg> version` to learn the latest version);
-  // `pluginName`@`marketplace` is the ref `claude plugin install|update` expects; and
-  // `marketplaceSource` is the GitHub repo to `claude plugin marketplace add` if the
-  // marketplace isn't registered yet. Absent for agents installed by other means.
+  // Install/update coordinates — present for agents distributed through a host
+  // CLI's own plugin marketplace. `npmPackage` is the registry package the
+  // marketplace resolves (used for `npm view <pkg> version` to learn the latest
+  // version); `pluginName`@`marketplace` is the ref `<cliBin> plugin install|
+  // update` expects; and `marketplaceSource` is the GitHub repo to `<cliBin>
+  // plugin marketplace add` if the marketplace isn't registered yet. Absent for
+  // agents installed by other means.
   npmPackage?: string;
   pluginName?: string;
   marketplace?: string;
   marketplaceSource?: string;
+  // Which host CLI binary's plugin manager `apply.ts` should shell out to for
+  // this agent's install/update coordinates. Only meaningful when the
+  // coordinates above are present.
+  cliBin?: 'claude' | 'codex';
 }
 
 export const AGENT_PLUGINS: readonly AgentPlugin[] = [
@@ -33,6 +38,26 @@ export const AGENT_PLUGINS: readonly AgentPlugin[] = [
     pluginName: 'ai-tc',
     marketplace: 'akasecurity',
     marketplaceSource: 'akasecurity/marketplace',
+    cliBin: 'claude',
+  },
+  {
+    id: 'codex',
+    name: 'Codex CLI',
+    sourceTool: 'codex',
+    description:
+      'Hooks Codex CLI sessions to detect + redact sensitive data in prompts, responses, and Bash tool calls.',
+    npmPackage: '@akasecurity/ai-tc-codex',
+    // Distinct from Claude Code's `pluginName: 'ai-tc'` — ids from the two
+    // registry entries flow into ONE ref-keyed `installed` lookup map
+    // (see updates.ts/installedPluginVersions and apply.ts/resolveRef); an
+    // identical ref for both would make either plugin's install ledger
+    // entry satisfy the other's "is it installed" check.
+    pluginName: 'aka-codex',
+    // Codex CLI installs from this repo's own marketplace file; the canonical
+    // akasecurity/marketplace repo currently carries Claude Code only.
+    marketplace: 'ai-tc',
+    marketplaceSource: 'akasecurity/ai-tc',
+    cliBin: 'codex',
   },
 ];
 

--- a/packages/local-ops/src/semver.ts
+++ b/packages/local-ops/src/semver.ts
@@ -25,6 +25,14 @@ function parse(version: string): Parsed | null {
   };
 }
 
+// Does `version` parse as a semver this module can order? Callers that pick a
+// winner out of a set need this: compareSemver returns 0 for anything it cannot
+// parse, so an unparseable candidate is indistinguishable from an equal one and
+// can survive a reduce it should never have entered.
+export function isSemver(version: string): boolean {
+  return parse(version) !== null;
+}
+
 function comparePre(a: string[], b: string[]): -1 | 0 | 1 {
   // A release (no prerelease) outranks a prerelease of the same core.
   if (a.length === 0 && b.length === 0) return 0;

--- a/packages/local-ops/src/updates.ts
+++ b/packages/local-ops/src/updates.ts
@@ -7,7 +7,7 @@ import type { AvailablePlugin, ComponentStatus, UpdateReport } from '@akasecurit
 
 import { runCapture } from './exec.ts';
 import { AGENT_PLUGINS, pluginRef } from './registry.ts';
-import { compareSemver, isNewer } from './semver.ts';
+import { compareSemver, isNewer, isSemver } from './semver.ts';
 
 // Pure update-report gathering: version discovery over npm + the local Claude Code
 // ledger, with no @akasecurity/plugin-sdk dependency (so the report logic stays unit-
@@ -125,7 +125,14 @@ function activeCodexPluginVersion(dir: string): string | null {
   }
   if (entries.length === 0) return null;
   if (entries.includes('local')) return 'local';
-  return entries.reduce((best, candidate) =>
+  // Only orderable names may enter the reduce. compareSemver returns 0 for
+  // input it cannot parse, so a stray sibling (a partial download, an editor
+  // scratch dir) that reaches the accumulator can never be displaced: it would
+  // be reported as the installed version, and isNewer(latest, junk) is 0 too,
+  // so the update silently stops being offered.
+  const versions = entries.filter(isSemver);
+  if (versions.length === 0) return null;
+  return versions.reduce((best, candidate) =>
     compareSemver(candidate, best) > 0 ? candidate : best,
   );
 }

--- a/packages/local-ops/src/updates.ts
+++ b/packages/local-ops/src/updates.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,7 +7,7 @@ import type { AvailablePlugin, ComponentStatus, UpdateReport } from '@akasecurit
 
 import { runCapture } from './exec.ts';
 import { AGENT_PLUGINS, pluginRef } from './registry.ts';
-import { isNewer } from './semver.ts';
+import { compareSemver, isNewer } from './semver.ts';
 
 // Pure update-report gathering: version discovery over npm + the local Claude Code
 // ledger, with no @akasecurity/plugin-sdk dependency (so the report logic stays unit-
@@ -101,6 +101,71 @@ export function installedPluginVersions(
   return out;
 }
 
+// Codex CLI caches an installed plugin's contents under
+// `<codexHome>/plugins/cache/<marketplaceName>/<pluginName>/<version>/`, with
+// possibly more than one version directory present (a stale prior install
+// left behind) — there is no single ledger file to parse the way Claude
+// Code's installed_plugins.json is, so this walks the cache directory instead.
+// Confirmed against openai/codex's own `PluginStore::active_plugin_version`
+// (codex-rs/core-plugins/src/store.rs): the "active" version is the
+// highest-semver subdirectory found, UNLESS a literal `local` version
+// directory exists (a dev-mode install marker), which always wins.
+function codexPluginCacheRoot(codexHome: string): string {
+  return join(codexHome, 'plugins', 'cache');
+}
+
+function activeCodexPluginVersion(dir: string): string | null {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return null;
+  }
+  if (entries.length === 0) return null;
+  if (entries.includes('local')) return 'local';
+  return entries.reduce((best, candidate) =>
+    compareSemver(candidate, best) > 0 ? candidate : best,
+  );
+}
+
+// Walk `<codexHome>/plugins/cache/<marketplace>/<pluginName>/` for every
+// codex-`cliBin` agent in the registry and resolve its active installed
+// version, keyed the same way as installedPluginVersions() (`<plugin>@
+// <marketplace>`) so the two maps merge directly — see
+// installedAgentPluginVersions() below.
+export function installedCodexPluginVersions(
+  codexHome: string = join(homedir(), '.codex'),
+): Map<string, string> {
+  const out = new Map<string, string>();
+  const cacheRoot = codexPluginCacheRoot(codexHome);
+  for (const agent of AGENT_PLUGINS) {
+    if (agent.cliBin !== 'codex') continue;
+    const ref = pluginRef(agent);
+    if (!ref || !agent.pluginName || !agent.marketplace) continue;
+    const pluginDir = join(cacheRoot, agent.marketplace, agent.pluginName);
+    const version = activeCodexPluginVersion(pluginDir);
+    if (version !== null) out.set(ref, version);
+  }
+  return out;
+}
+
+// The merged view `gatherReport`'s `installed` map needs: every registered
+// agent's installed version, regardless of which host CLI's ledger/cache
+// format it comes from. Refs never collide across agents (registry.ts keeps
+// each agent's `pluginName` distinct for exactly this reason), so a plain
+// merge is safe — no agent's entry can shadow another's.
+export function installedAgentPluginVersions(
+  claudeHome?: string,
+  codexHome?: string,
+): Map<string, string> {
+  return new Map([
+    ...installedPluginVersions(claudeHome),
+    ...installedCodexPluginVersions(codexHome),
+  ]);
+}
+
 // `npm view <pkg> version` — the latest published version, or null on any failure.
 export function npmViewVersion(pkg: string): string | null {
   const res = runCapture('npm', ['view', pkg, 'version'], 15_000);
@@ -153,7 +218,7 @@ export function gatherReport(deps: ReportDeps): UpdateReport {
 export function gatherReportLive(): UpdateReport {
   return gatherReport({
     viewVersion: npmViewVersion,
-    installed: installedPluginVersions(),
+    installed: installedAgentPluginVersions(),
     cliInstalled: cliVersion(),
   });
 }

--- a/packages/local-ops/test/updates-codex.test.ts
+++ b/packages/local-ops/test/updates-codex.test.ts
@@ -1,0 +1,79 @@
+// Tests installedCodexPluginVersions() / installedAgentPluginVersions()
+// against a synthetic `~/.codex/plugins/cache/<marketplace>/<plugin>/<version>/`
+// layout — the directory-walk counterpart to installedPluginVersions()'s
+// single-file ledger read. The "active version" selection rule (highest
+// semver, `local` always wins) is confirmed against openai/codex's own
+// `PluginStore::active_plugin_version` (codex-rs/core-plugins/src/store.rs).
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { installedAgentPluginVersions, installedCodexPluginVersions } from '../src/updates.ts';
+
+let codexHome: string;
+
+beforeEach(() => {
+  codexHome = mkdtempSync(join(tmpdir(), 'aka-codex-home-'));
+});
+
+afterEach(() => {
+  rmSync(codexHome, { recursive: true, force: true });
+});
+
+function makeCacheDir(marketplace: string, plugin: string, ...versions: string[]): void {
+  for (const version of versions) {
+    mkdirSync(join(codexHome, 'plugins', 'cache', marketplace, plugin, version), {
+      recursive: true,
+    });
+  }
+}
+
+describe('installedCodexPluginVersions', () => {
+  it('returns empty when the cache root does not exist', () => {
+    expect(installedCodexPluginVersions(codexHome)).toEqual(new Map());
+  });
+
+  it('resolves the single installed version for the codex agent', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '0.1.0');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(
+      new Map([['aka-codex@ai-tc', '0.1.0']]),
+    );
+  });
+
+  it('picks the highest semver when multiple version dirs are present', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '0.1.0', '0.2.0', '0.1.5');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(
+      new Map([['aka-codex@ai-tc', '0.2.0']]),
+    );
+  });
+
+  it('a literal "local" version directory always wins (dev-mode install marker)', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '0.1.0', '0.2.0', 'local');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(
+      new Map([['aka-codex@ai-tc', 'local']]),
+    );
+  });
+
+  it('ignores non-directory entries under the plugin cache dir', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '0.1.0');
+    // A stray file (e.g. a lockfile) alongside the version directories must
+    // never be treated as a version.
+    writeFileSync(join(codexHome, 'plugins', 'cache', 'ai-tc', 'aka-codex', 'installed.lock'), '');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(
+      new Map([['aka-codex@ai-tc', '0.1.0']]),
+    );
+  });
+});
+
+describe('installedAgentPluginVersions', () => {
+  it('merges the Codex cache read with the (missing) Claude Code ledger without colliding', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '0.3.0');
+    // A nonexistent claudeHome — the Claude side contributes nothing, but must
+    // not clobber or omit the Codex entry.
+    const merged = installedAgentPluginVersions(join(codexHome, 'no-such-claude-home'), codexHome);
+    expect(merged.get('aka-codex@ai-tc')).toBe('0.3.0');
+    expect(merged.size).toBe(1);
+  });
+});

--- a/packages/local-ops/test/updates-codex.test.ts
+++ b/packages/local-ops/test/updates-codex.test.ts
@@ -65,6 +65,22 @@ describe('installedCodexPluginVersions', () => {
       new Map([['aka-codex@ai-tc', '0.1.0']]),
     );
   });
+
+  it('ignores a non-semver version directory rather than reporting it', () => {
+    // compareSemver returns 0 for anything it cannot parse, so a stray
+    // directory reaching the reduce's accumulator could never be displaced —
+    // it was reported as the installed version, and because isNewer against it
+    // is also 0, the update stopped being offered at all.
+    makeCacheDir('ai-tc', 'aka-codex', '0.1.0', '0.9.4', '.tmp-download');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(
+      new Map([['aka-codex@ai-tc', '0.9.4']]),
+    );
+  });
+
+  it('reports nothing when every version directory is unparseable', () => {
+    makeCacheDir('ai-tc', 'aka-codex', '.tmp-download', 'backup');
+    expect(installedCodexPluginVersions(codexHome)).toEqual(new Map());
+  });
 });
 
 describe('installedAgentPluginVersions', () => {

--- a/packages/local-ops/test/updates.test.ts
+++ b/packages/local-ops/test/updates.test.ts
@@ -9,6 +9,7 @@ function views(map: Record<string, string | null>): (pkg: string) => string | nu
 
 const CLI = '@akasecurity/cli';
 const PLUGIN = '@akasecurity/ai-tc-claude-code';
+const CODEX_PLUGIN = '@akasecurity/ai-tc-codex';
 const REF = 'ai-tc@akasecurity';
 
 describe('gatherReport', () => {
@@ -29,7 +30,10 @@ describe('gatherReport', () => {
       installed: new Map([[REF, '0.0.2']]),
       cliInstalled: '0.0.2',
     });
-    expect(report.availablePlugins).toHaveLength(0);
+    // Codex CLI is a separate, uninstalled registry entry (a distinct ref —
+    // see registry.ts's pluginName comment) so it still surfaces as available;
+    // only claude-code, which IS in `installed`, must be excluded.
+    expect(report.availablePlugins.map((p) => p.id)).toEqual(['codex']);
     const plugin = report.statuses.find((s) => s.id === 'claude-code');
     expect(plugin?.installed).toBe('0.0.2');
     expect(plugin?.updateAvailable).toBe(true);
@@ -37,13 +41,16 @@ describe('gatherReport', () => {
 
   it('surfaces an available plugin the user has not installed', () => {
     const report = gatherReport({
-      viewVersion: views({ [CLI]: '0.0.2', [PLUGIN]: '0.0.3' }),
+      viewVersion: views({ [CLI]: '0.0.2', [PLUGIN]: '0.0.3', [CODEX_PLUGIN]: '0.1.0' }),
       installed: new Map(), // nothing installed
       cliInstalled: '0.0.2',
     });
     expect(report.statuses.map((s) => s.id)).toEqual(['cli']);
+    // Every registered agent with no installed version surfaces here — both
+    // Claude Code and Codex CLI (see registry.ts's AGENT_PLUGINS).
     expect(report.availablePlugins).toEqual([
       { id: 'claude-code', name: 'Claude Code', latest: '0.0.3' },
+      { id: 'codex', name: 'Codex CLI', latest: '0.1.0' },
     ]);
   });
 

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -41,14 +41,17 @@ const ACTION_TO_KIND: Partial<Record<string, EnforcementActionKind>> = {
 };
 const ENFORCEMENT_KINDS: readonly EnforcementActionKind[] = ['blocked', 'redacted', 'warned'];
 
-// Per-provider scan coverage. Initial release scans Claude Code only — a curated
-// business fact (constant across the range, not a measured per-window metric),
-// following the shared contract so read surfaces render identically. Order
-// is the dashboard display order.
+// Per-provider scan coverage — a curated business fact (constant across the
+// range, not a measured per-window metric), following the shared contract so
+// read surfaces render identically. Order is the dashboard display order.
+// Codex sits below 100 because the Codex CLI does not yet fire PreToolUse/
+// PostToolUse for apply_patch (file-write) calls — prompts, Bash commands,
+// worktree scans, and history backfill are covered; live file-write
+// interception is not (see plugins/codex/skills/setup/SKILL.md).
 const SCAN_COVERAGE: readonly { provider: Provider; coverage: number; supported: boolean }[] = [
   { provider: 'claudecode', coverage: 100, supported: true },
   { provider: 'cursor', coverage: 0, supported: false },
-  { provider: 'codex', coverage: 0, supported: false },
+  { provider: 'codex', coverage: 80, supported: true },
   { provider: 'chatgpt', coverage: 0, supported: false },
   { provider: 'copilot', coverage: 0, supported: false },
   { provider: 'api', coverage: 0, supported: false },

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -45,9 +45,13 @@ const ENFORCEMENT_KINDS: readonly EnforcementActionKind[] = ['blocked', 'redacte
 // range, not a measured per-window metric), following the shared contract so
 // read surfaces render identically. Order is the dashboard display order.
 // Codex sits below 100 because the Codex CLI does not yet fire PreToolUse/
-// PostToolUse for apply_patch (file-write) calls — prompts, Bash commands,
-// worktree scans, and history backfill are covered; live file-write
-// interception is not (see plugins/codex/skills/setup/SKILL.md).
+// PostToolUse for apply_patch (file-write) calls. Covered: prompts, assistant
+// responses, Bash command text, worktree scans. NOT covered: file-write
+// content, in either direction — the history backfill does not close this gap,
+// because it scans conversation messages only and the tool-call reconciler
+// records a write's changed paths and byte sizes, never its bytes (see
+// plugins/codex/skills/setup/SKILL.md and
+// plugins/codex/src/history/transcripts.ts).
 const SCAN_COVERAGE: readonly { provider: Provider; coverage: number; supported: boolean }[] = [
   { provider: 'claudecode', coverage: 100, supported: true },
   { provider: 'cursor', coverage: 0, supported: false },

--- a/packages/persistence/test/repositories/security.test.ts
+++ b/packages/persistence/test/repositories/security.test.ts
@@ -621,4 +621,16 @@ describe('scanCoverage', () => {
       'api',
     ]);
   });
+
+  it('pins the codex row: supported at partial (80) coverage', async () => {
+    // The Codex plugin's live PreToolUse/PostToolUse hooks cover Bash calls but
+    // not yet apply_patch, so the curated fact is partial coverage — never 100,
+    // never unsupported.
+    const res = await security().scanCoverage('30d');
+    expect(res.providers.find((p) => p.provider === 'codex')).toEqual({
+      provider: 'codex',
+      coverage: 80,
+      supported: true,
+    });
+  });
 });

--- a/packages/plugin-runtime/src/handle-session-start.ts
+++ b/packages/plugin-runtime/src/handle-session-start.ts
@@ -242,8 +242,18 @@ function buildSessionRoot(
   const attributes: Record<string, unknown> = {};
   const osVersion = ctx.host?.attributes.os_version;
   const harnessVersion = ctx.harness?.attributes.harness_version;
+  const harnessInterface = ctx.harness?.attributes.interface;
   if (typeof osVersion === 'string') attributes.os_version = osVersion;
   if (typeof harnessVersion === 'string') attributes.harness_version = harnessVersion;
+  // Snapshotted onto the session's OWN attributes for the same reason as
+  // harness_version above: the shared harness inventory row is keyed only on
+  // `tool` (e.g. 'codex'), so a later session's ensureInventory() upsert would
+  // silently overwrite it there — a durable per-session fact needs to live on
+  // the fact itself. Distinguishes e.g. a Codex session run inside the
+  // ChatGPT desktop app ('codex_desktop') from one run in a terminal
+  // ('codex_cli_rs'/'codex-tui'/'codex_exec') without forking the harness/
+  // sourceTool dimension — see plugins/codex/src/hooks/session-start.ts.
+  if (typeof harnessInterface === 'string') attributes.harness_interface = harnessInterface;
   attributes.provider = provider.provider;
   if (provider.gatewayHost !== undefined) attributes.gateway_host = provider.gatewayHost;
 

--- a/packages/plugin-runtime/test/handle-session-start.test.ts
+++ b/packages/plugin-runtime/test/handle-session-start.test.ts
@@ -108,6 +108,48 @@ describe('handleSessionStart (standalone)', () => {
     db.close();
   });
 
+  it('snapshots harnessInterface onto the session root, durably per-session', async () => {
+    // Two sessions of the SAME harness ('codex') but different entry points —
+    // e.g. a terminal invocation vs Codex running inside the ChatGPT desktop
+    // app. Both share ONE harness inventory row (keyed only on `tool`), so if
+    // the interface were read back off THAT shared row instead of snapshotted
+    // per-session, the second session's ensureInventory() upsert would
+    // silently overwrite what the first session's fact should keep showing.
+    await handleSessionStart(
+      start('s-cli', { tool: 'codex', harnessInterface: 'codex_cli_rs' }),
+      config(dir),
+    );
+    await handleSessionStart(
+      start('s-desktop', { tool: 'codex', harnessInterface: 'codex_desktop' }),
+      config(dir),
+    );
+
+    const db = open();
+    const attrsFor = (sessionId: string): Record<string, unknown> => {
+      const row = db
+        .prepare("SELECT attributes FROM audit_events WHERE event_type = 'session' AND id = :id")
+        .get({ id: sessionId }) as { attributes: string };
+      return JSON.parse(row.attributes) as Record<string, unknown>;
+    };
+    expect(attrsFor('s-cli').harness_interface).toBe('codex_cli_rs');
+    // The second session's fact is unaffected by the first — no cross-session
+    // overwrite via the shared harness inventory row.
+    expect(attrsFor('s-desktop').harness_interface).toBe('codex_desktop');
+    db.close();
+  });
+
+  it('omits harness_interface when the harness exposes no discriminator (Claude Code today)', async () => {
+    await handleSessionStart(start('s1'), config(dir));
+
+    const db = open();
+    const session = db
+      .prepare("SELECT * FROM audit_events WHERE event_type = 'session'")
+      .get() as Record<string, unknown>;
+    const attrs = JSON.parse(session.attributes as string) as Record<string, unknown>;
+    expect(attrs).not.toHaveProperty('harness_interface');
+    db.close();
+  });
+
   it('snapshots a gateway provider + host onto the session root', async () => {
     await handleSessionStart(start('sg'), {
       ...config(dir),

--- a/packages/plugin-sdk/eslint.config.mjs
+++ b/packages/plugin-sdk/eslint.config.mjs
@@ -22,4 +22,13 @@ export default [
       'n/no-process-env': 'off',
     },
   },
+  {
+    // provider-codex.ts is the Codex CLI counterpart: resolves the LLM
+    // provider from the host process env at SessionStart (OPENAI_BASE_URL).
+    // Same file-scoped opt-out as provider.ts above.
+    files: ['src/provider-codex.ts'],
+    rules: {
+      'n/no-process-env': 'off',
+    },
+  },
 ];

--- a/packages/plugin-sdk/src/config.ts
+++ b/packages/plugin-sdk/src/config.ts
@@ -13,6 +13,7 @@ import type { WorkspaceSettings } from '@akasecurity/schema';
 import { dataDir, dbPath, ensureDataDirSync, settingsDir } from './data-dir.ts';
 import type { ResolvedProvider } from './provider.ts';
 import { resolveProvider } from './provider.ts';
+import type { ResolvedCodexProvider } from './provider-codex.ts';
 
 // The settings file readers and writer live in @akasecurity/persistence
 // (shared with the CLI and the web-ui); re-exported so the SDK's public
@@ -29,21 +30,33 @@ export interface PluginConfig {
   settingsDir: string;
   // True once /aka:setup has recorded onboardedAt — drives the first-run nudge.
   onboarded: boolean;
-  // The provider backend this session talks to (anthropic | bedrock | vertex |
-  // gateway), resolved from the contemporaneous env via ./provider.ts. Resolved
-  // here so SessionStart can snapshot it onto the
-  // session-root as an immutable per-session fact (it can't reach the reconciler,
-  // which runs detached without the session's env).
-  provider: ResolvedProvider;
+  // The provider backend this session talks to, resolved from the
+  // contemporaneous env via ./provider.ts (Claude Code: anthropic | bedrock |
+  // vertex | gateway) or ./provider-codex.ts (Codex CLI: openai | gateway) —
+  // whichever resolver `loadConfig`'s caller passed. Resolved here so
+  // SessionStart can snapshot it onto the session-root as an immutable
+  // per-session fact (it can't reach the reconciler, which runs detached
+  // without the session's env).
+  provider: ResolvedProvider | ResolvedCodexProvider;
 }
 
 /**
- * Load the plugin config from ~/.aka. Env vars can't reach hooks (Claude Code
+ * Load the plugin config from ~/.aka. Env vars can't reach hooks (the host
  * spawns them as bare processes), so a file is the only channel; read fresh on
  * every call because hook processes are short-lived. Fully fail-open: a missing
  * or corrupt settings.json yields unonboarded defaults rather than throwing.
+ *
+ * `resolveProviderFn` defaults to Claude Code's `resolveProvider` for
+ * backward compatibility with every existing call site — the Codex plugin's
+ * SessionStart hook is the one place that needs to pass `resolveCodexProvider`
+ * explicitly (see plugins/codex/src/hooks/session-start.ts). Every other hook
+ * loads config for its data dir / settings only and never reads `.provider`,
+ * so the default is harmless there even though it's Claude-shaped.
  */
-export function loadConfig(base: string = defaultDataDir()): PluginConfig {
+export function loadConfig(
+  base: string = defaultDataDir(),
+  resolveProviderFn: () => ResolvedProvider | ResolvedCodexProvider = resolveProvider,
+): PluginConfig {
   // Self-heal the store's at-rest modes on the plugin's entry path, so a
   // group/other-readable base or settings.json left by an older release (or the
   // pre-fix leftover-.tmp bug) is repaired on the next hook — the read-path
@@ -69,19 +82,23 @@ export function loadConfig(base: string = defaultDataDir()): PluginConfig {
     dbPath: dbPath(base),
     settingsDir: settingsDir(base),
     onboarded: settings.onboardedAt != null,
-    provider: resolveProviderSafe(),
+    provider: resolveProviderSafe(resolveProviderFn),
   };
 }
 
 /**
- * Resolve the provider from env, fail-safe. `resolveProvider` is already lenient
- * (it parses {} on a bad env), but we wrap it once more so a config load — on the
- * fail-open hook path — can never throw on an unexpected error; default to
- * Anthropic-direct, matching the module's fail-open style.
+ * Run the given resolver fail-safe. Both `resolveProvider` and
+ * `resolveCodexProvider` are already lenient (they parse {} on a bad env),
+ * but we wrap once more so a config load — on the fail-open hook path — can
+ * never throw on an unexpected error; default to Anthropic-direct, matching
+ * the module's original fail-open default (harmless for a Codex caller too,
+ * since this branch is only reached on a genuinely unexpected resolver bug).
  */
-function resolveProviderSafe(): ResolvedProvider {
+function resolveProviderSafe(
+  resolveProviderFn: () => ResolvedProvider | ResolvedCodexProvider,
+): ResolvedProvider | ResolvedCodexProvider {
   try {
-    return resolveProvider();
+    return resolveProviderFn();
   } catch {
     return { provider: 'anthropic' };
   }

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -61,6 +61,12 @@ export { applyCategoryPosture, detectPostureChanges, severityFloorPosture } from
 export { resolveProjectFiles } from './project-files.ts';
 export type { Provider, ProviderOrUnknown, ResolvedProvider } from './provider.ts';
 export { providerFromModelId, resolveProvider } from './provider.ts';
+export type {
+  CodexProvider,
+  CodexProviderOrUnknown,
+  ResolvedCodexProvider,
+} from './provider-codex.ts';
+export { codexProviderFromModelId, resolveCodexProvider } from './provider-codex.ts';
 export type { EgressHit } from './raw-egress.ts';
 export { assertRawFree, maskContextSlice, RawEgressError, safeMaskedMatch } from './raw-egress.ts';
 export {

--- a/packages/plugin-sdk/src/provider-codex.ts
+++ b/packages/plugin-sdk/src/provider-codex.ts
@@ -1,0 +1,115 @@
+/**
+ * Provider resolution for Codex CLI sessions.
+ *
+ * Codex CLI talks to OpenAI-direct by default, or to Azure OpenAI / any
+ * OpenAI-compatible gateway (LiteLLM, OpenRouter, a self-hosted shim, …) when
+ * `OPENAI_BASE_URL` or a named `model_providers` entry in `~/.codex/config.toml`
+ * points elsewhere. The same `model` id costs a different amount per provider,
+ * so token-usage cost attribution needs the provider as a per-session fact —
+ * same rationale as the Claude Code resolver in `provider.ts`.
+ *
+ * Named `model_providers` (Azure and friends) are selected in config.toml, not
+ * a fixed env var, so this resolver — scoped to `process.env` only, like its
+ * Claude Code counterpart — can only distinguish OpenAI-direct from an
+ * `OPENAI_BASE_URL` gateway override. A config.toml read would be needed to
+ * resolve Azure specifically; out of scope here (see module comment on
+ * `provider-env-codex.ts`).
+ *
+ * Two resolvers live here, mirroring provider.ts:
+ *   - `resolveCodexProvider()` — reads the host env once at SessionStart,
+ *     where it is contemporaneous, and snapshots the result onto the session
+ *     root. Never call it from the reconciler.
+ *   - `codexProviderFromModelId()` — a PURE heuristic (no env) used as the
+ *     fallback when env is silent or stale (backfill / pre-SessionStart roots).
+ */
+
+import { CodexProviderEnvSchema, DEFAULT_OPENAI_HOST } from './provider-env-codex.ts';
+
+/** Provider backend a Codex CLI session talks to. */
+export type CodexProvider = 'openai' | 'gateway';
+
+/** `codexProviderFromModelId` adds 'unknown' for ids it cannot classify. */
+export type CodexProviderOrUnknown = CodexProvider | 'unknown';
+
+export interface ResolvedCodexProvider {
+  provider: CodexProvider;
+  /** Host of `OPENAI_BASE_URL` when the provider is a 'gateway'; else absent. */
+  gatewayHost?: string;
+}
+
+/**
+ * Parse the URL's host; tolerate a bare host (no scheme) by retrying with one.
+ * Identical logic to provider.ts's hostOf() — duplicated rather than shared
+ * because the two resolvers are independent, single-purpose modules with no
+ * other overlap.
+ */
+function hostOf(url: string): string | undefined {
+  try {
+    const host = new URL(url).host;
+    if (host !== '') return host;
+  } catch {
+    // fall through to the scheme-prefixed retry
+  }
+  try {
+    const host = new URL(`https://${url}`).host;
+    return host !== '' ? host : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the provider from the host process env (OPENAI_BASE_URL only —
+ * see module comment for why Azure/named providers aren't resolvable here).
+ * Called once at SessionStart, where the env is contemporaneous, to snapshot
+ * the provider onto the session root.
+ *
+ * Priority cascade:
+ *   1. `OPENAI_BASE_URL` set AND its host ≠ api.openai.com → 'gateway' (+ `gatewayHost`)
+ *   2. else → 'openai'
+ */
+export function resolveCodexProvider(): ResolvedCodexProvider {
+  // Lenient parse — the field is optional and total (`.catch(undefined)`), so a
+  // default OpenAI-direct session (unset) yields an all-undefined object and a
+  // malformed value degrades to undefined instead of throwing in a hook path
+  // (n/no-process-env is off for this file). Fall back to a parse of {} on the
+  // unexpected failure rather than throwing.
+  const parsed = CodexProviderEnvSchema.safeParse(process.env);
+  const env = parsed.success ? parsed.data : CodexProviderEnvSchema.parse({});
+
+  const baseUrl = env.OPENAI_BASE_URL;
+  if (baseUrl !== undefined && baseUrl !== '') {
+    const host = hostOf(baseUrl);
+    if (host !== undefined && host !== DEFAULT_OPENAI_HOST) {
+      return { provider: 'gateway', gatewayHost: host };
+    }
+  }
+
+  return { provider: 'openai' };
+}
+
+/**
+ * PURE heuristic mapping a Codex `model` id to a provider — no env access.
+ * Used as the fallback when env is silent/stale (the reconciler resolving a
+ * backfilled or pre-SessionStart root). Best-effort → 'unknown'.
+ *
+ *   - plain OpenAI ids (`gpt-…`, `o1…`/`o3…`/`o4…`, `codex-…`) → openai
+ *   - `<vendor>/…` (e.g. `azure/…`, `openrouter/…`)            → gateway
+ *   - `…:<tag>` (e.g. gateway-routed aliases)                  → gateway
+ *   - anything else                                            → unknown
+ */
+export function codexProviderFromModelId(modelId: string): CodexProviderOrUnknown {
+  const id = modelId.trim();
+  if (id === '') return 'unknown';
+
+  // Gateway/router ids namespace the vendor with a slash, e.g. `azure/gpt-5-codex`.
+  if (id.includes('/')) return 'gateway';
+
+  // Gateway-routed `name:tag` aliases (e.g. LiteLLM/OpenRouter style).
+  if (id.includes(':')) return 'gateway';
+
+  // Plain OpenAI-direct model families.
+  if (/^(gpt-|o[134](-|$)|codex-)/.test(id)) return 'openai';
+
+  return 'unknown';
+}

--- a/packages/plugin-sdk/src/provider-env-codex.ts
+++ b/packages/plugin-sdk/src/provider-env-codex.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+// Default OpenAI-direct API host. OPENAI_BASE_URL pointing anywhere else means a
+// gateway/proxy is in front of the model (Azure OpenAI, LiteLLM, OpenRouter, a
+// self-hosted shim, …). Kept here so resolveCodexProvider() and the schema
+// agree on the baseline.
+export const DEFAULT_OPENAI_HOST = 'api.openai.com';
+
+// Codex CLI provider/backend selection, inherited from the host process env.
+// Unlike Claude Code (CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_USE_VERTEX booleans),
+// Codex has no fixed env-var flags for named providers — Azure OpenAI and other
+// `model_providers` entries are selected via ~/.codex/config.toml, which this
+// resolver deliberately does NOT read (same scope as the Claude Code resolver:
+// host env only, read once at SessionStart where it is contemporaneous). The one
+// fixed env var Codex itself reads is OPENAI_BASE_URL, so that is the only
+// signal available for gateway classification without a config-file read.
+//
+// OPENAI_BASE_URL is parsed leniently as a non-empty string, NOT a strict URL:
+// it is only used to extract a host for gateway classification, and a
+// scheme-less host like `localhost:11434` (a local proxy) is a legitimate
+// value that `hostOf()` normalizes before extracting the host. An empty or
+// whitespace-only string is coerced to undefined ("unset" — no gateway), so a
+// shell that exports OPENAI_BASE_URL="" must not fail the parse. `.catch(undefined)`
+// makes the field total so one malformed value can never poison the whole parse.
+const optionalBaseUrl = z
+  .preprocess((v) => {
+    if (typeof v === 'string' && v.trim() === '') return undefined;
+    return v;
+  }, z.string().optional())
+  .catch(undefined);
+
+export const codexProviderEnvShape = {
+  OPENAI_BASE_URL: optionalBaseUrl,
+};
+
+// Lenient provider-only schema parsed against the host env by resolveCodexProvider().
+// Every field is optional, so it parses cleanly on a default OpenAI-direct
+// session where OPENAI_BASE_URL isn't set.
+export const CodexProviderEnvSchema = z.object(codexProviderEnvShape);
+export type CodexProviderEnv = z.infer<typeof CodexProviderEnvSchema>;

--- a/packages/plugin-sdk/test/provider-codex.test.ts
+++ b/packages/plugin-sdk/test/provider-codex.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for Codex CLI provider resolution.
+ *
+ *   - resolveCodexProvider(): the env cascade (gateway-via-OPENAI_BASE_URL > openai).
+ *       Env is injected with vi.stubEnv so each branch is exercised in isolation.
+ *   - codexProviderFromModelId(): the pure model-id heuristic (no env).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { codexProviderFromModelId, resolveCodexProvider } from '../src/provider-codex.ts';
+
+function clearProviderEnv(): void {
+  vi.stubEnv('OPENAI_BASE_URL', '');
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// resolveCodexProvider — env cascade
+// ---------------------------------------------------------------------------
+
+describe('resolveCodexProvider', () => {
+  it('returns openai when no provider env is set', () => {
+    clearProviderEnv();
+    expect(resolveCodexProvider()).toEqual({ provider: 'openai' });
+  });
+
+  it('returns gateway with host when OPENAI_BASE_URL is a non-default host', () => {
+    clearProviderEnv();
+    vi.stubEnv('OPENAI_BASE_URL', 'https://litellm.internal:4000/v1');
+    expect(resolveCodexProvider()).toEqual({
+      provider: 'gateway',
+      gatewayHost: 'litellm.internal:4000',
+    });
+  });
+
+  it('returns gateway for a scheme-less OPENAI_BASE_URL (bare host)', () => {
+    clearProviderEnv();
+    vi.stubEnv('OPENAI_BASE_URL', 'localhost:11434');
+    expect(resolveCodexProvider()).toEqual({
+      provider: 'gateway',
+      gatewayHost: 'localhost:11434',
+    });
+  });
+
+  it('returns openai when OPENAI_BASE_URL points at the default host', () => {
+    clearProviderEnv();
+    vi.stubEnv('OPENAI_BASE_URL', 'https://api.openai.com');
+    expect(resolveCodexProvider()).toEqual({ provider: 'openai' });
+  });
+
+  it('returns openai when OPENAI_BASE_URL is malformed', () => {
+    // A malformed value must not throw — it degrades to undefined and the
+    // cascade falls through to the default, same as provider.ts's regression.
+    clearProviderEnv();
+    vi.stubEnv('OPENAI_BASE_URL', '::not a url');
+    expect(resolveCodexProvider()).toEqual({ provider: 'openai' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// codexProviderFromModelId — pure heuristic (no env)
+// ---------------------------------------------------------------------------
+
+describe('codexProviderFromModelId', () => {
+  it('classifies plain gpt-* ids as openai', () => {
+    expect(codexProviderFromModelId('gpt-5-codex')).toBe('openai');
+  });
+
+  it('classifies o1/o3/o4 ids as openai', () => {
+    expect(codexProviderFromModelId('o3')).toBe('openai');
+    expect(codexProviderFromModelId('o4-mini')).toBe('openai');
+  });
+
+  it('classifies codex-* ids as openai', () => {
+    expect(codexProviderFromModelId('codex-mini-latest')).toBe('openai');
+  });
+
+  it('classifies vendor-prefixed gateway ids (azure/…)', () => {
+    expect(codexProviderFromModelId('azure/gpt-5-codex')).toBe('gateway');
+  });
+
+  it('classifies name:tag gateway-routed ids', () => {
+    expect(codexProviderFromModelId('openrouter:gpt-5')).toBe('gateway');
+  });
+
+  it('returns unknown for unrecognized ids', () => {
+    expect(codexProviderFromModelId('claude-3-5-sonnet')).toBe('unknown');
+  });
+
+  it('returns unknown for an empty / whitespace id', () => {
+    expect(codexProviderFromModelId('')).toBe('unknown');
+    expect(codexProviderFromModelId('   ')).toBe('unknown');
+  });
+});

--- a/packages/schema/src/zod/event.ts
+++ b/packages/schema/src/zod/event.ts
@@ -19,7 +19,16 @@ export type EventKind = z.infer<typeof EventKind>;
 export const CAPTURE_EVENT_TYPES_SQL = EventKind.options.map((k) => `'${k}'`).join(',');
 
 export const SourceTool = z
-  .enum(['claude-code', 'claude-desktop', 'cursor', 'chatgpt', 'github-copilot', 'cli', 'unknown'])
+  .enum([
+    'claude-code',
+    'claude-desktop',
+    'cursor',
+    'chatgpt',
+    'github-copilot',
+    'codex',
+    'cli',
+    'unknown',
+  ])
   .meta({ id: 'SourceTool' });
 export type SourceTool = z.infer<typeof SourceTool>;
 

--- a/packages/schema/src/zod/finding.ts
+++ b/packages/schema/src/zod/finding.ts
@@ -69,7 +69,7 @@ export type FindingAction = z.infer<typeof FindingAction>;
 // FindingProvider: API-facing provider enum. 'claudedesktop' is a new value
 // (maps from source_tool = 'claude-desktop'). Never merged with 'claudecode'.
 export const FindingProvider = z
-  .enum(['claudecode', 'claudedesktop', 'cursor', 'copilot', 'chatgpt', 'api'])
+  .enum(['claudecode', 'claudedesktop', 'cursor', 'copilot', 'chatgpt', 'codex', 'api'])
   .meta({ id: 'FindingProvider' });
 export type FindingProvider = z.infer<typeof FindingProvider>;
 

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -88,7 +88,8 @@ export function toDbCategory(apiVal: FindingCategory): string {
  * event.sourceTool → API FindingProvider (claude-desktop and claudecode are
  * distinct values and must never be merged).
  *   claude-code → claudecode · claude-desktop → claudedesktop ·
- *   github-copilot → copilot · cursor → cursor · chatgpt → chatgpt · else → api
+ *   github-copilot → copilot · cursor → cursor · chatgpt → chatgpt ·
+ *   codex → codex · else → api
  */
 export function toApiProvider(sourceTool: string): FindingProvider {
   // Shares the single TOOL_TO_HARNESS table (harness-map.ts) with
@@ -109,6 +110,7 @@ export function toDbProviderFilter(apiProvider: FindingProvider): string[] {
     copilot: ['github-copilot'],
     cursor: ['cursor'],
     chatgpt: ['chatgpt'],
+    codex: ['codex'],
     api: [], // 'api' catches unknown tools — applied in-memory (no single DB value)
   };
   return map[apiProvider];

--- a/packages/schema/src/zod/harness-map.ts
+++ b/packages/schema/src/zod/harness-map.ts
@@ -22,6 +22,7 @@ export const TOOL_TO_HARNESS: Record<string, string> = {
   'github-copilot': 'copilot',
   cursor: 'cursor',
   chatgpt: 'chatgpt',
+  codex: 'codex',
 };
 
 // Map a harness inventory *tool* id — the value the plugin hashes its harness

--- a/packages/schema/test/zod/findings-group-build.test.ts
+++ b/packages/schema/test/zod/findings-group-build.test.ts
@@ -60,11 +60,13 @@ describe('provider mappers', () => {
     expect(toApiProvider('github-copilot')).toBe('copilot');
     expect(toApiProvider('cursor')).toBe('cursor');
     expect(toApiProvider('chatgpt')).toBe('chatgpt');
+    expect(toApiProvider('codex')).toBe('codex');
     expect(toApiProvider('mystery-tool')).toBe('api');
   });
   it('maps API provider → DB filter values', () => {
     expect(toDbProviderFilter('claudecode')).toEqual(['claude-code']);
     expect(toDbProviderFilter('claudedesktop')).toEqual(['claude-desktop']);
+    expect(toDbProviderFilter('codex')).toEqual(['codex']);
     expect(toDbProviderFilter('api')).toEqual([]);
   });
 });

--- a/plugins/claude-code/src/hooks/pre-tool-use-decision.ts
+++ b/plugins/claude-code/src/hooks/pre-tool-use-decision.ts
@@ -33,6 +33,12 @@ export type FieldTokenizer = (
 export const EXECUTABLE_REDACT_NOTE =
   'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead.';
 
+// Woven into the deny message when a redact decision carried no redacted text
+// to put in place, so the block explains why the policy's redact could not be
+// applied rather than the call going out unmasked.
+export const UNREDACTABLE_NOTE =
+  'The redacted form of this input was unavailable, so the call is blocked rather than sent unmasked.';
+
 export type PreToolUseOutput =
   | {
       hookSpecificOutput: {
@@ -87,6 +93,9 @@ export async function decidePreToolUse(
   // Whether the deny (if any) includes an escalated redact — that deny
   // carries EXECUTABLE_REDACT_NOTE so it explains itself.
   let escalated = false;
+  // Whether a redact was denied because no redacted text was available to put
+  // in place — that deny carries UNREDACTABLE_NOTE instead.
+  let escalatedUnredactable = false;
   let updatedInput: Record<string, unknown> | null = null;
   const realized: RealizedRewrite = { pointers: [], degraded: [] };
 
@@ -106,9 +115,6 @@ export async function decidePreToolUse(
       for (const finding of result.findings) blockedRules.add(finding.ruleId);
       if (result.blockedReferences) blockedReferences.push(...result.blockedReferences);
     } else if (action === 'redact') {
-      for (const finding of result.findings) redactedRules.add(finding.ruleId);
-      if (result.blockedReferences) redactedReferences.push(...result.blockedReferences);
-
       // The rewrite: reversible (pointers) when a tokenizer is supplied and
       // the enforced spans are known; otherwise the runtime's one-way text.
       // The tokenizer covers exactly the ENFORCED spans — warn-level findings
@@ -129,11 +135,23 @@ export async function decidePreToolUse(
         }
       }
 
-      // Rebuilt through the path so a nested leaf (MultiEdit's
-      // edits[i].new_string) lands in place with its siblings — and its array
-      // spine — intact. Each pass folds into the previous result, so two
-      // flagged fields of one payload both survive into the emitted input.
-      if (rewritten !== null) {
+      // Decided AFTER the rewrite attempt, because a null `result.text` can
+      // still yield redacted text through the tokenizer. With no redacted form
+      // in hand there is nothing to substitute, and emitting the original under
+      // the "AKA redacted" systemMessage would send the raw value and report it
+      // as masked — so this denies, like the executable-field escalation above.
+      if (rewritten === null) {
+        escalatedUnredactable = true;
+        for (const finding of result.findings) blockedRules.add(finding.ruleId);
+        if (result.blockedReferences) blockedReferences.push(...result.blockedReferences);
+      } else {
+        for (const finding of result.findings) redactedRules.add(finding.ruleId);
+        if (result.blockedReferences) redactedReferences.push(...result.blockedReferences);
+
+        // Rebuilt through the path so a nested leaf (MultiEdit's
+        // edits[i].new_string) lands in place with its siblings — and its array
+        // spine — intact. Each pass folds into the previous result, so two
+        // flagged fields of one payload both survive into the emitted input.
         updatedInput = replaceAtPath(updatedInput ?? toolInput, spec.path, rewritten) as Record<
           string,
           unknown
@@ -154,7 +172,11 @@ export async function decidePreToolUse(
             subject: `${toolName} call`,
             ruleIds: [...blockedRules].join(', '),
             blockedRef: blockedReferences[0],
-            note: escalated ? EXECUTABLE_REDACT_NOTE : undefined,
+            note: escalated
+              ? EXECUTABLE_REDACT_NOTE
+              : escalatedUnredactable
+                ? UNREDACTABLE_NOTE
+                : undefined,
           }),
         },
       },

--- a/plugins/claude-code/test/hooks/pre-tool-use-decision.test.ts
+++ b/plugins/claude-code/test/hooks/pre-tool-use-decision.test.ts
@@ -29,7 +29,11 @@ import type { PolicyBundle, WorkspaceSettings } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import type { PreToolUseOutput } from '../../src/hooks/pre-tool-use-decision.ts';
-import { decidePreToolUse, EXECUTABLE_REDACT_NOTE } from '../../src/hooks/pre-tool-use-decision.ts';
+import {
+  decidePreToolUse,
+  EXECUTABLE_REDACT_NOTE,
+  UNREDACTABLE_NOTE,
+} from '../../src/hooks/pre-tool-use-decision.ts';
 import type { ScannableField } from '../../src/hooks/pre-tool-use-fields.ts';
 
 const IP = ['45', '79', '142', '6'].join('.');
@@ -148,6 +152,37 @@ describe('decidePreToolUse — redact on executable text escalates to deny', () 
       await decide('Bash', { command: COMMAND }, [{ spec: BASH_COMMAND, result: blocked }]),
     );
     expect(reason).not.toContain(EXECUTABLE_REDACT_NOTE);
+  });
+});
+
+describe('decidePreToolUse — a redact with no redacted text denies', () => {
+  // CaptureResult.text is `string | null`, so { action: 'redact', text: null }
+  // is protocol-legal. Allowing it emitted the ORIGINAL toolInput under the
+  // "AKA redacted sensitive content" systemMessage — raw value sent, transcript
+  // claiming it was masked. Checked after the tokenizer runs, since a null
+  // `text` can still yield redacted text through it.
+  it('Write content: denies rather than allowing the original through', async () => {
+    const content = `support = ${EMAIL}`;
+    const output = await decide('Write', { content, file_path: '/tmp/a.ts' }, [
+      {
+        spec: WRITE_CONTENT,
+        result: {
+          action: 'redact',
+          text: null,
+          findings: [finding('core-pii/email', EMAIL, content)],
+        },
+        text: content,
+      },
+    ]);
+
+    const reason = denyReason(output);
+    expect(reason).toContain(UNREDACTABLE_NOTE);
+    expect(reason).not.toContain(EXECUTABLE_REDACT_NOTE);
+
+    const emitted = JSON.stringify(output);
+    expect(emitted).not.toContain('updatedInput');
+    expect(emitted).not.toContain('AKA redacted');
+    expect(emitted).not.toContain(EMAIL);
   });
 });
 

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "aka-codex",
+  "version": "0.9.4",
+  "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI. Detection runs locally; events are recorded to a local SQLite store on your machine.",
+  "hooks": "./hooks/hooks.json",
+  "skills": "./skills",
+  "interface": {
+    "displayName": "AKA Security",
+    "shortDescription": "Local secret detection and redaction for Codex CLI.",
+    "developerName": "AKA Security",
+    "websiteUrl": "https://github.com/akasecurity/ai-tc"
+  }
+}

--- a/plugins/codex/eslint.config.mjs
+++ b/plugins/codex/eslint.config.mjs
@@ -11,5 +11,14 @@ export default [
       },
     },
   },
+  {
+    // The ephemeral judge subprocess inherits the host environment untouched:
+    // `codex` must resolve on PATH and its auth (CODEX_HOME / ~/.codex
+    // credentials) must survive the spawn.
+    files: ['src/triage/judge.ts'],
+    rules: {
+      'n/no-process-env': 'off',
+    },
+  },
   ...rootConfigFiles,
 ];

--- a/plugins/codex/eslint.config.mjs
+++ b/plugins/codex/eslint.config.mjs
@@ -1,0 +1,15 @@
+// @ts-check
+import { base, rootConfigFiles } from '@akasecurity/eslint-config';
+
+export default [
+  ...base,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  ...rootConfigFiles,
+];

--- a/plugins/codex/hooks/hooks.json
+++ b/plugins/codex/hooks/hooks.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/session-start.js\" \"${PLUGIN_ROOT}/.codex-plugin/plugin.json\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/user-prompt-submit.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/pre-tool-use.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|apply_patch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/post-tool-use.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${PLUGIN_ROOT}/scripts/stop.js\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@akasecurity/ai-tc-codex",
+  "version": "0.9.4",
+  "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI",
+  "license": "Apache-2.0",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akasecurity/ai-tc.git",
+    "directory": "plugins/codex"
+  },
+  "homepage": "https://github.com/akasecurity/ai-tc/tree/main/plugins/codex",
+  "files": [
+    ".codex-plugin",
+    "hooks",
+    "skills",
+    "scripts"
+  ],
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "lint": "eslint src test *.config.*",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "prepack": "tsup"
+  },
+  "devDependencies": {
+    "@akasecurity/eslint-config": "workspace:*",
+    "@akasecurity/persistence": "workspace:*",
+    "@akasecurity/plugin-runtime": "workspace:*",
+    "@akasecurity/plugin-sdk": "workspace:*",
+    "@akasecurity/scanner": "workspace:*",
+    "@akasecurity/schema": "workspace:*",
+    "@types/node": "^24.13.3",
+    "eslint": "^9.0.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.10"
+  }
+}

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -35,6 +35,7 @@
     "@akasecurity/plugin-sdk": "workspace:*",
     "@akasecurity/scanner": "workspace:*",
     "@akasecurity/schema": "workspace:*",
+    "@akasecurity/setup-wizard": "workspace:*",
     "@types/node": "^24.13.3",
     "eslint": "^9.0.0",
     "tsup": "^8.0.0",

--- a/plugins/codex/skills/audit/SKILL.md
+++ b/plugins/codex/skills/audit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: aka-audit
+description: Show AKA's recent enforcement decisions
+---
+
+# AKA audit
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is a space-aligned monospace table that Markdown would
+otherwise collapse. Do not reformat or re-narrate the rows.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" audit
+```
+
+This is the decision log: the most recent detections from `~/.aka/data/aka.db`
+with the action AKA took (block / redact / warn / allow), the rule, and where it
+fired (source tool + event kind). It is read-only.

--- a/plugins/codex/skills/dashboard/SKILL.md
+++ b/plugins/codex/skills/dashboard/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: aka-dashboard
+description: Launch the AKA web dashboard in your browser (reads your local store)
+---
+
+# AKA dashboard
+
+Launch the AKA web dashboard and relay the short status the script prints **as-is**.
+The command returns immediately: it starts the dashboard server in the background
+and it opens in the browser once ready, so a lack of further output is **not** an
+error — do not wait on it or re-run it. If the script prints install guidance (the
+`aka` CLI isn't installed), relay that verbatim.
+
+If the user asked for a specific port, pass `--port <N>` through unchanged;
+otherwise run it with no arguments.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/dashboard.js" [--port <N>]
+```
+
+This mirrors the `aka dashboard` CLI command: it serves the OSS web-ui against
+your local store at `~/.aka/data` (no backend) and opens
+`http://localhost:4319/security`. The web server is bundled in the
+`@akasecurity/cli` package — the plugin ships no server of its own — so the
+launcher delegates to the `aka` CLI and, if it isn't installed, prints how to get
+it. For the terminal-only read surfaces, use the aka-health, aka-findings,
+aka-recommend, aka-audit, or aka-tokens skills instead.

--- a/plugins/codex/skills/detections/SKILL.md
+++ b/plugins/codex/skills/detections/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: aka-detections
+description: List installed AKA detection packs, versions, and available updates
+---
+
+# AKA detections
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is a space-aligned monospace table that Markdown would
+otherwise collapse. Do not reformat the columns or restate each row.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" detections
+```
+
+This lists the detection packs installed in `~/.aka/data/aka.db` — one row per
+pack with its installed version, the latest version this plugin ships, rule
+count, enabled state, assigned enforcement policy, and whether an update is
+available. These packs are what the plugin actually scans with.
+
+Detection updates are **never applied automatically** — a plugin upgrade only
+records what's newly available; the installed packs keep running unchanged
+until the user updates them. This skill is strictly **read-only**: do not
+apply, enable, disable, or re-policy a detection from here. If the user wants
+to update, tell them to run one of these themselves in a terminal:
+
+- `aka detections update --all` — update every pack
+- `aka detections update <pack-id>` — update one pack
+- `aka dashboard` → Detections → **Update** — review and apply in the dashboard

--- a/plugins/codex/skills/exceptions/SKILL.md
+++ b/plugins/codex/skills/exceptions/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: aka-exceptions
+description: List active AKA detection exceptions (masked) from the local store
+---
+
+# AKA exceptions
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is a space-aligned monospace table that Markdown would
+otherwise collapse. Do not reformat the columns or restate each row.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" exceptions
+```
+
+This lists the **active** detection exceptions from `~/.aka/data/aka.db` — the
+masked value, rule, scope, relative expiry, use count, and who granted it. The
+approved value is never stored, only a keyed fingerprint and a masked preview.
+
+This skill is strictly **read-only**. Do not offer to create, approve, or
+revoke an exception from here — creation and revocation happen only in a
+terminal, out-of-band, via the `aka` CLI (`aka exception approve`,
+`aka exception revoke <id>`; see `aka exception --help`). If the user asks you
+to grant or revoke one, tell them to run those commands themselves in a
+terminal instead.

--- a/plugins/codex/skills/findings/SKILL.md
+++ b/plugins/codex/skills/findings/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: aka-findings
+description: List recent AKA findings (masked) from the local store
+---
+
+# AKA findings
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is a space-aligned monospace table that Markdown would
+otherwise collapse. Do not reformat the columns or restate each row.
+
+If the user asked to filter by severity — e.g. `--critical`, `--high`,
+`--medium`, `--low`, or `--severity <level>` — pass that flag through to the
+script unchanged. Otherwise run it with no flag.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" findings [--severity <critical|high|medium|low>]
+```
+
+This lists the most recent findings from `~/.aka/data/aka.db` with their rule,
+category, severity, action taken, and the **masked** match (raw secrets are
+never stored), narrowed to one severity when a filter is given. It is read-only.

--- a/plugins/codex/skills/health/SKILL.md
+++ b/plugins/codex/skills/health/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: aka-health
+description: Show AKA detection activity and local security posture
+---
+
+# AKA health
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is space-aligned monospace (gauges, bars, a 7-day chart)
+that Markdown would otherwise collapse. Do not reformat or summarize the table;
+you may add at most one short sentence of context after it.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" health
+```
+
+This reads the local store at `~/.aka/data/aka.db` (detection activity, action
+breakdown, category coverage, last 7 days). It is read-only. If the store is
+empty, the script says so — relay that as-is; nothing is wrong.

--- a/plugins/codex/skills/recommend/SKILL.md
+++ b/plugins/codex/skills/recommend/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: aka-recommend
+description: Surface AKA's top recommendations from recent findings
+---
+
+# AKA recommend
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: the output is space-aligned monospace whose lines start
+with characters like `1.` and `●`; shown unfenced, Markdown collapses the
+indentation and turns those into auto-numbered lists and bullets. You may expand
+on the suggested next steps if the user asks, but lead with the output as-is.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" recommend
+```
+
+This groups recent findings by category (ranked by severity, then frequency) and
+prints a plain-language next step for each. It is read-only over
+`~/.aka/data/aka.db`.

--- a/plugins/codex/skills/scan/SKILL.md
+++ b/plugins/codex/skills/scan/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: aka-scan
+description: Scan working-tree source files for code security flaws
+---
+
+# AKA scan
+
+## Single-repo scan (default)
+
+Run the worktree scan script and show the user its output **exactly as printed**.
+The script already prints its content inside a Markdown code fence — reproduce
+that verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is space-aligned monospace that Markdown would otherwise
+collapse.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/filescan.js" --dir "${PWD}"
+```
+
+This scans all source files (`.ts`, `.js`, `.py`, `.java`, `.rb`, `.cs`, `.go`,
+`.rs`, `.php`, and more) under the current project directory for insecure code
+patterns — SQL injection, command injection, XSS, insecure deserialization, weak
+cryptography, hardcoded credentials, dev-mode configuration leaks, and other
+OWASP Top 10 issues.
+
+Results are recorded to the local store (`~/.aka/data/aka.db`) and are visible
+via the aka-findings skill. Re-running this scan is safe — files whose content
+has already been recorded are skipped.
+
+Files excluded by the repo's `.gitignore` are **still scanned** — local scratch
+and generated files are a common place for real secrets to hide — but their
+findings are marked as coming from gitignored content and reported as
+informational in the summary.
+
+To exclude paths from scanning entirely, add a `.akaignore` file (gitignore
+syntax, any directory level). Unlike `.gitignore`, `.akaignore` is a **hard
+skip**: matching files are never read and produce no findings. A negation also
+re-includes a directory the scanner skips by default — e.g. `!vendor/` scans
+first-party code living under `vendor/`.
+
+## Multi-repo scan (opt-in)
+
+To scan **all git repositories** found under the current directory (up to 4
+directory levels deep), use the `--discover` flag:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/filescan.js" --discover
+```
+
+To search from a different directory, pass `--root` (and optionally `--depth`):
+
+```bash
+node "${PLUGIN_ROOT}/scripts/filescan.js" --discover --root ~/projects --depth 3
+```
+
+Discovery walks the filesystem from the search root looking for `.git`
+directories. It skips large system directories (`Library`, `node_modules`, etc.)
+and stops recursing once a repo root is found (submodules are not separately
+enumerated). The output shows a per-repository breakdown in addition to the
+aggregate totals.
+
+**Scope confirmation:** `--discover` never sweeps the home directory implicitly —
+the default root is the current directory. Before passing a `--root` outside the
+current project (especially `--root ~`, the whole-machine sweep), tell the user
+what will be read and ask for explicit confirmation. Do not assume consent from
+a generic "scan everything" phrasing without naming the scope.
+
+Deduplication is global across all repos in a single `--discover` run — a file
+whose content hash is already recorded (from a previous scan or a live hook
+capture) is skipped regardless of which repo it lives in.

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -66,8 +66,8 @@ Invariants:
 
 Run the intro script and relay its AKA_SHOW region per the execution contract:
 paste the content between the markers verbatim, never the marker lines. It
-prints a single space-aligned monospace card — identity and provenance, then
-what AKA does — inside a Markdown code fence that is part of that pasted
+prints a single space-aligned monospace card — name, repository, version, and
+what AKA adds — inside a Markdown code fence that is part of that pasted
 content. Keep the fence as printed and do **not** add another code fence, strip
 the fence, or reformat it (unfenced, Markdown collapses the indentation and
 mangles the `●` lines).

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: aka-setup
+description: Set up the AKA Control Plane plugin — sensitive-data handling and historical access
+---
+
+# AKA setup wizard
+
+You are onboarding the AKA Control Plane plugin for this machine. AKA works
+fully locally with **zero backend and zero Docker**: detection runs in-process
+and findings persist to a local SQLite store at `~/.aka/data/aka.db`. This
+wizard records two preferences. Ask the questions in order, then save once.
+
+## 0. Show the intro card
+
+Run the intro script and show the user its output **exactly as printed** — it is a
+space-aligned monospace card (name, repository, version, what AKA adds). The script
+already prints it inside a Markdown code fence; reproduce that verbatim and do
+**not** add another code fence, strip the fence, or reformat it (unfenced, Markdown
+collapses the indentation and mangles the `●` line). Then continue with the two
+questions below.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/intro.js" "${PLUGIN_ROOT}/.codex-plugin/plugin.json"
+```
+
+## 1. Ask the two questions
+
+Ask both questions as normal conversational turns, with numbered options for
+the user to pick from. This wizard depends on no specific interactive-picker
+tool being available — present each option clearly and wait for the user's
+reply before moving on. If Codex exposes a native multi-choice picker in your
+environment, prefer that over plain text; otherwise the numbered-list form
+below is the fallback.
+
+Ask these two questions, one at a time:
+
+**Sensitive-data handling** — "When AKA detects sensitive data on its way to a model, it should:"
+
+1. **Warn only** (`warn`, recommended) — flag the request and let the user
+   decide; nothing is modified automatically.
+2. **Actively redact** (`redact`) — replace secrets with safe placeholders
+   before the request is sent. Redaction rewrites the real payload, so opt in
+   only when you want that. (Either mode can be changed per-project later.)
+
+**Historical & memory access** — "Secrets often leak before AKA is installed. May I also review your temp files, agent memory & prior conversation transcripts?"
+
+List **Grant full review** as the first (top) option:
+
+1. **Grant full review** (`full`) — scan scratch/temp files, agent memory & prior
+   transcripts for leaked secrets (deepest coverage · one-time consent, revocable
+   under Policies).
+2. **Current session only** (`session-only`) — decline historical access; AKA
+   reviews only what this session already touches. Even if declined, AKA can still
+   review: the **working tree** (all source, config & dotfiles in the repo), **this
+   session** (prompts, tool calls & files Codex reads or writes now), **git
+   history** (commits reachable from HEAD, incl. removed-but-tracked secrets), and
+   **pointed scans** (any path you explicitly hand AKA during a run).
+
+Map the picked options to the flag values shown above (`redact`/`warn`,
+`full`/`session-only`).
+
+## 2. Save the answers
+
+Run the onboarding writer with the chosen values. Omit a flag to keep its
+default. This validates and persists to `~/.aka/settings/settings.json` (created
+`0600`, owner-only) and stamps the machine as onboarded:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/onboard.js" --policy <redact|warn> --historical <full|session-only>
+```
+
+## 2.5 Scan history (only if they granted full review)
+
+**Only when the user picked "Grant full review" (`historical=full`)**, run the
+backfill. It sweeps prior Codex CLI rollout files (last 30 days, all sessions)
+for secrets that leaked before AKA was installed and records them into the local
+store, so they show up in the first-run summary and the aka-findings skill. The
+scan is idempotent — it skips messages already recorded — so re-running this
+wizard is safe and never duplicates findings. Show its output **exactly as
+printed** (it self-fences; do not add another fence or reformat). Skip this
+step entirely when they chose `session-only`.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/backfill.js"
+```
+
+## 3. Show the first-run summary
+
+Run the first-run script and show its output **exactly as printed** (the
+install-complete summary with live findings/recommendation counts and the health
+score). The script already prints it inside a Markdown code fence; reproduce it
+verbatim and do **not** add another code fence, strip the fence, or reformat it (it
+is space-aligned monospace that Markdown would otherwise collapse).
+
+```bash
+node "${PLUGIN_ROOT}/scripts/firstrun.js"
+```
+
+## 3.5 Offer the AKA CLI + local dashboard (opt-in)
+
+Now that the plugin is set up, offer the optional **AKA CLI + local dashboard** —
+a richer, still-fully-local surface over the same `~/.aka` store this plugin
+writes. The plugin works completely on its own; this is additive (and the path to
+future multi-agent support). Ask the user directly:
+
+**Add the AKA CLI + dashboard?** — "Install the `aka` CLI for a local web +
+terminal dashboard and on-demand scans? Everything stays on your machine."
+
+1. **Yes, install it** (recommended) — adds the `aka` binary: `aka stats`,
+   `aka tui` (terminal dashboard), `aka dashboard` (local web UI), `aka scan`.
+2. **Not now** — skip; it can be added anytime with the one-liner below.
+
+If they choose **Yes**, run the bootstrap installer (it ensures Node is available
+and installs the global CLI from the public npm registry). **Ask permission
+before running it**, then run the line for their OS:
+
+```bash
+# macOS / Linux
+curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.sh | sh
+
+# Windows (PowerShell)
+irm https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.ps1 | iex
+```
+
+The one-liner pins to the stable release **tag** (`cli-latest`), never `main` —
+each release points that tag at its published `cli-v*` version, and the bootstrap
+scripts it fetches hold the installer's pinned ref + checksum, so fetching them
+from a mutable branch would defeat the integrity gate. To pin an exact version
+instead, set `AKA_INSTALL_REF=cli-v<version>` before running the line. Until the
+first release is published the one-liner 404s (fail-closed).
+
+After it completes, point them at `aka init` then `aka dashboard`. If they chose
+**Not now**, show the one-liner once so they can add it later, and move on —
+declining keeps the plugin fully functional standalone.
+
+**Fail open.** This install is optional, so it must never derail the session. If
+the installer fails for any reason — Node missing, network/registry error, a
+non-zero exit, or the checksum check rejecting a bad download — briefly report
+what happened, show the one-liner so they can retry later, and continue the
+wizard normally. The plugin is already fully set up and works on its own; a
+failed CLI install changes nothing about that.
+
+## 4. Report the result
+
+- The first-run summary already confirms the saved handling and points at the
+  aka-health skill. Add at most one short sentence: detection runs locally and
+  nothing leaves the machine.
+
+## Known limitation
+
+Live PreToolUse/PostToolUse redaction currently covers `Bash` shell calls only —
+Codex does not yet fire these hooks for `apply_patch` (file-write) calls (see
+`hooks/hooks.json` and `../pre-tool-use-decision.ts` for the tracking issue).
+File-write content is still covered by the prompt/response scan and by the
+historical/backfill scan above, just not redacted before it is written. If the
+user asks why a secret in a file edit wasn't caught live, explain this gap
+honestly rather than implying full coverage.

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -18,17 +18,19 @@ falls back to a conservative severity-derived floor instead of guessing.
 
 The false-positive/severity judgment needs the raw (unmasked) findings to rate
 them accurately, so it **sends them to the model API** through separate `codex`
-CLI subprocesses (a large history is judged in several batches). Three things
-cross for each finding: its **raw value**, about **120 characters of the
-surrounding transcript text** on either side of it, and the **path of the
-rollout file** it came from. Those subprocesses run the `codex` CLI ephemerally
-so the raw values are never written into `~/.codex/sessions` — they do not enter
-this conversation or your scannable history — but ephemeral mode is a
-local-write guard, **not network isolation**: a copy of them **does leave the
+CLI subprocesses (a large history is judged in several batches). Two things
+cross for each finding: its **raw value**, and about **120 characters of the
+surrounding transcript text** on either side of it — re-masked first, so any
+_other_ detectable secret in that window never leaves raw. The rollout file's
+path, the value's fingerprint, and the fingerprint key version are **dropped
+before egress**. Those subprocesses run the `codex` CLI ephemerally so the raw
+values are never written into `~/.codex/sessions` — they do not enter this
+conversation or your scannable history — but ephemeral mode is a local-write
+guard, **not network isolation**: a copy of the value **does leave the
 machine**, sent to the model provider like any other Codex prompt. You act only
-on the raw-free plan the subprocesses print back. The scan that produces those
-values is offered for explicit consent in step 1, and that consent must state
-the model-API egress plainly before it is given.
+on the raw-free plan the subprocesses print back. Reading history is granted in
+step 1; **sending findings to the model is a distinct consent, collected in
+step 3 before the judgment pipe runs** — the judge refuses to run without it.
 
 Follow the steps below **in order**. Nothing is written to the policy store
 until step 5 (or a floor fallback in step 3 if the calibration can't complete).
@@ -144,9 +146,10 @@ the user is consenting to, so it must be visible before they choose.** State it 
 your own words, without softening it: if they say yes, AKA scans the last 30 days
 of Codex history, and to rate what it finds it **sends the raw, unmasked values —
 including any secrets — to the model API through the `codex` CLI**. Name what
-travels with each one: **its raw value, about 120 characters of the surrounding
-transcript text on either side, and the path of the rollout file it came
-from**. That is real network egress to the model provider (the same one your
+travels with each one: **its raw value, and about 120 characters of the
+surrounding transcript text on either side** (any other secrets detected in
+that window are masked; the rollout file's path stays local). That is real
+network egress to the model provider (the same one your
 Codex session already uses), not a purely local review. **A copy of each value
 leaves the machine.** The rollouts those values came from stay on disk
 untouched — nothing here removes them; that is the separate redaction step in
@@ -256,6 +259,43 @@ it.
 
 ## 3. Run the evidence triage — off-transcript judgment, nothing written yet
 
+**Model-judge consent — a distinct opt-in, asked here before the pipe.** The
+false-positive/severity judgment runs by sending each finding to the model API
+through `codex`. That is a separate egress from the historical-read consent
+collected in step 1 (which only let AKA _read_ the local rollouts), so it needs
+its own explicit grant. Before running the pipe, restate plainly what leaves the
+machine (the step-1 disclosure's payload: each raw value plus its masked context
+window; the file path stays local), then ask as a normal conversational turn
+with numbered options — and present both options flat: this grant sends the
+user's data off the machine, so do **not** mark either one recommended.
+
+**Send findings to the model to sort real leaks from noise?** — "I'll send each
+detected value, plus a bit of surrounding context with any secrets in it masked,
+to the model to tell real leaks from routine noise. The file path stays local."
+
+1. **Yes, send them** — "let the model triage what I found"
+2. **No, keep it local** — "skip the model triage and start from the safe defaults"
+
+**Branch on the choice:**
+
+- **If the user chose "Yes, send them"** — record the model-judge consent, then
+  run the pipe below:
+
+  ```bash
+  node "${PLUGIN_ROOT}/scripts/onboard.js" --model-judge-consent
+  ```
+
+- **If the user chose "No, keep it local"** — do **not** run the pipe. The judge
+  refuses to run without consent (it would only print a clean skip line and a
+  zero-count frame), so there is no calibrated plan to confirm. Fall back to the
+  conservative severity floor exactly as step 2's start-light path does — write
+  the floor, tell the user the model triage was skipped, and continue to step 6
+  with **no `--surfaced` flag**:
+
+  ```bash
+  node "${PLUGIN_ROOT}/scripts/onboard.js" --floor
+  ```
+
 Pipe the backfill's triage stream straight into the `apply-suppressions`
 adapter in **PREVIEW** mode (no `--confirmed`):
 
@@ -266,9 +306,9 @@ node "${PLUGIN_ROOT}/scripts/backfill.js" --triage | node "${PLUGIN_ROOT}/script
 The backfill sweeps prior Codex CLI session rollouts (last 30 days, all
 sessions) and streams one masked-plus-raw triage hit per line; masked findings
 are recorded to the local store as a side effect. The adapter runs the
-false-positive/severity **judgment in separate `codex` subprocesses that send the
-raw hits — each one's value, its surrounding transcript text, and its source path
-— to the model API** (a large history is split into several batches; each runs
+false-positive/severity **judgment in separate `codex` subprocesses that send
+each hit's raw value and masked context window — never its source path — to the
+model API** (a large history is split into several batches; each runs
 the CLI ephemerally so nothing lands in `~/.codex/sessions`), then prints back a
 **raw-free plan** you can safely show the user:
 the calibrated-result card (the real-count headline and the recommended posture),

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -271,7 +271,10 @@ user's data off the machine, so do **not** mark either one recommended.
 
 **Send findings to the model to sort real leaks from noise?** — "I'll send each
 detected value, plus a bit of surrounding context with any secrets in it masked,
-to the model to tell real leaks from routine noise. The file path stays local."
+to the model to tell real leaks from routine noise. The file path stays local.
+This consent is saved machine-wide in AKA's settings, so it also covers the
+same triage step in AKA's other harness plugins on this machine — revoke it
+anytime from the dashboard."
 
 1. **Yes, send them** — "let the model triage what I found"
 2. **No, keep it local** — "skip the model triage and start from the safe defaults"
@@ -805,10 +808,21 @@ relayed to the user. If you summarized one instead of pasting it, paste it now.
 ## Known limitation
 
 Live PreToolUse/PostToolUse redaction currently covers `Bash` shell calls only —
-Codex does not yet fire these hooks for `apply_patch` (file-write) calls (see
-`hooks/hooks.json` and `src/hooks/pre-tool-use-decision.ts` for the tracking
-issue). File-write content is still covered by the prompt/response scan and by
+Codex does not yet fire these hooks for `apply_patch` (file-write) calls (an
+upstream Codex hook-coverage gap). File-write content is still covered by the
+prompt/response scan and by
 the consent-gated historical scan this wizard offers in steps 1/3, just not
 redacted before it is written. If the user asks why a secret in a file edit
 wasn't caught live, explain this gap honestly rather than implying full
 coverage.
+
+The reversible secret vault is not yet wired for Codex sessions, so this wizard
+does not offer the vault-consent step: everything AKA redacts here is one-way
+(the safe direction), and nothing this plugin captures is ever vaulted — even
+when vault consent was granted through the Claude Code wizard on the same
+machine. Vault pointers minted elsewhere still render as literal `[[aka:...]]`
+tokens in Codex output (Codex has no display-side hook to badge them), and a
+pointer inside a Bash command is denied rather than executed or substituted.
+If the user asks about recovering a redacted value, point them at the vault
+surfaces that do exist on this machine (`aka vault show`, the dashboard's
+Vault page) rather than implying this plugin can reveal anything.

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -809,12 +809,14 @@ relayed to the user. If you summarized one instead of pasting it, paste it now.
 
 Live PreToolUse/PostToolUse redaction currently covers `Bash` shell calls only —
 Codex does not yet fire these hooks for `apply_patch` (file-write) calls (an
-upstream Codex hook-coverage gap). File-write content is still covered by the
-prompt/response scan and by
-the consent-gated historical scan this wizard offers in steps 1/3, just not
-redacted before it is written. If the user asks why a secret in a file edit
-wasn't caught live, explain this gap honestly rather than implying full
-coverage.
+upstream Codex hook-coverage gap). File-write **content is not scanned at all**
+on Codex — not live, and not after the fact either. The consent-gated historical
+scan this wizard offers in steps 1/3 reads conversation messages only, and the
+tool-call reconciler records a write's changed paths and byte sizes, never the
+bytes themselves. So a secret written into a file through `apply_patch` is
+neither redacted before it lands nor reported afterwards; only the path is
+recorded. If the user asks why a secret in a file edit wasn't caught, say so
+plainly rather than implying it is picked up somewhere else.
 
 The reversible secret vault is not yet wired for Codex sessions, so this wizard
 does not offer the vault-consent step: everything AKA redacts here is one-way

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -1,133 +1,747 @@
 ---
 name: aka-setup
-description: Set up the AKA Control Plane plugin — sensitive-data handling and historical access
+description: Set up AKA Security — calibrate notifications and detection posture from Codex's real activity.
 ---
 
 # AKA setup wizard
 
-You are onboarding the AKA Control Plane plugin for this machine. AKA works
+You are onboarding the AKA Security plugin for this machine. AKA works
 fully locally with **zero backend and zero Docker**: detection runs in-process
-and findings persist to a local SQLite store at `~/.aka/data/aka.db`. This
-wizard records two preferences. Ask the questions in order, then save once.
+and findings persist to a local SQLite store at `~/.aka/data/aka.db`.
+
+This wizard tells a **calibration story**: introduce AKA → show what it does →
+offer one retroactive scan → report the real numbers it found and the posture it
+recommends → apply on confirmation → show the installed summary → hand off to the
+dashboard. Everything the user sees is derived from their _actual_ history — never
+a fabricated or demo number. When there isn't enough history to judge, the wizard
+falls back to a conservative severity-derived floor instead of guessing.
+
+The false-positive/severity judgment needs the raw (unmasked) findings to rate
+them accurately, so it **sends them to the model API** through separate `codex`
+CLI subprocesses (a large history is judged in several batches). Three things
+cross for each finding: its **raw value**, about **120 characters of the
+surrounding transcript text** on either side of it, and the **path of the
+rollout file** it came from. Those subprocesses run the `codex` CLI ephemerally
+so the raw values are never written into `~/.codex/sessions` — they do not enter
+this conversation or your scannable history — but ephemeral mode is a
+local-write guard, **not network isolation**: a copy of them **does leave the
+machine**, sent to the model provider like any other Codex prompt. You act only
+on the raw-free plan the subprocesses print back. The scan that produces those
+values is offered for explicit consent in step 1, and that consent must state
+the model-API egress plainly before it is given.
+
+Follow the steps below **in order**. Nothing is written to the policy store
+until step 5 (or a floor fallback in step 3 if the calibration can't complete).
+
+## Execution contract (read before step 0)
+
+Every script prints output in three region kinds. Your job for each is fixed:
+
+- **`<<<AKA_SHOW … AKA_SHOW>>>`** — relay every AKA_SHOW region verbatim as your
+  next message: paste the content _between_ the markers exactly — a card region
+  carries its own code fence, a plain confirmation line does not, but either way
+  you paste exactly what's between the markers — never the marker lines, never a
+  paraphrase or summary.
+- **`<<<AKA_FRAME_JSON … AKA_FRAME_JSON>>>`** — machine-only. Parse it if a step
+  tells you to read a value from it; never display it.
+- **Anything else on stdout** — status for you (paths like `Plan saved to:`,
+  errors, exit signals). Act on it; never relay it.
+
+**Collecting a decision.** Wherever a step asks the user a question, ask it as a
+normal conversational turn with numbered options for the user to pick from. This
+wizard depends on no specific interactive-picker tool being available — present
+each option clearly and wait for the user's reply before moving on. If Codex
+exposes a native multi-choice picker in your environment, prefer that over plain
+text; otherwise the numbered-list form is the fallback. Never answer a question
+on the user's behalf.
+
+Invariants:
+
+- **Never write a confirmation or acknowledgement the wizard did not emit** — the
+  script's AKA_SHOW line is the confirmation.
+- **Each step's AKA_SHOW regions must be relayed before you advance.**
+- **One question per decision; never re-ask a decision already collected.**
 
 ## 0. Show the intro card
 
-Run the intro script and show the user its output **exactly as printed** — it is a
-space-aligned monospace card (name, repository, version, what AKA adds). The script
-already prints it inside a Markdown code fence; reproduce that verbatim and do
-**not** add another code fence, strip the fence, or reformat it (unfenced, Markdown
-collapses the indentation and mangles the `●` line). Then continue with the two
-questions below.
+Run the intro script and relay its AKA_SHOW region per the execution contract:
+paste the content between the markers verbatim, never the marker lines. It
+prints a single space-aligned monospace card — identity and provenance, then
+what AKA does — inside a Markdown code fence that is part of that pasted
+content. Keep the fence as printed and do **not** add another code fence, strip
+the fence, or reformat it (unfenced, Markdown collapses the indentation and
+mangles the `●` lines).
 
 ```bash
 node "${PLUGIN_ROOT}/scripts/intro.js" "${PLUGIN_ROOT}/.codex-plugin/plugin.json"
 ```
 
-## 1. Ask the two questions
+## 0b. Repo-aware posture check — tighten-only, working-tree only
 
-Ask both questions as normal conversational turns, with numbered options for
-the user to pick from. This wizard depends on no specific interactive-picker
-tool being available — present each option clearly and wait for the user's
-reply before moving on. If Codex exposes a native multi-choice picker in your
-environment, prefer that over plain text; otherwise the numbered-list form
-below is the fallback.
+Before showing any recommended posture — the start-light default table in
+step 2 or the calibrated posture in step 4 — look at the **current project's**
+working tree yourself, with your own file-reading tools. There is no script for
+this: it is your own reasoning over facts you read directly, not the triage
+subprocess's raw-free plan, and it needs no user interaction.
 
-Ask these two questions, one at a time:
+**In scope:** the manifest's declared frameworks/dependencies
+(`package.json` or equivalent), payment or other third-party API SDKs among
+them, CI config (`.github/workflows/`, etc.), and the **presence and names**
+of `.env*`/config files as a signal that secrets live on disk here — never
+their contents; a secret-bearing file's contents are exactly the kind of raw
+value this wizard never reads. **Out of scope:** Codex's own history and the
+local AKA store (that is the separate, consent-gated scan in steps 1/3) — no
+historical read, and no question or other consent interaction of any kind.
 
-**Sensitive-data handling** — "When AKA detects sensitive data on its way to a model, it should:"
+The severity-floor default map (secret/pii/financial/phi/code_flaw/custom at
+`warn`, code_context/config at `monitor` — the table step 2's start-light card
+prints) is both the **floor** this check is measured against and its
+**fallback**. From what you directly observe you may **tighten** individual
+categories above that floor — raise the level, never lower one below it —
+each tightened category carrying a one-line rationale naming the concrete
+evidence you found, e.g.:
 
-1. **Warn only** (`warn`, recommended) — flag the request and let the user
-   decide; nothing is modified automatically.
-2. **Actively redact** (`redact`) — replace secrets with safe placeholders
-   before the request is sent. Redaction rewrites the real payload, so opt in
-   only when you want that. (Either mode can be changed per-project later.)
+> Stripe + a `Customer` model here — financial → redact
 
-**Historical & memory access** — "Secrets often leak before AKA is installed. May I also review your temp files, agent memory & prior conversation transcripts?"
+Present the tightening on whichever recommended posture is about to render, the
+same "recommended base + changed-packs overlay" shape step 4b's adjust fork
+uses: the tightened categories raise, every other category keeps its existing
+recommended level, each carrying its rationale line. Where you compose the view
+yourself (the adjust fork, the calibrated result) this tightened recommendation
+IS that view; where the view is a script's AKA_SHOW card (the step-2
+start-light card, relayed per the execution contract), show the tightened
+recommendation and its rationale lines adjacent to that card rather than
+rewriting the card's own printed levels.
 
-List **Grant full review** as the first (top) option:
+This tightening is a **display-time recommendation**: it shapes the recommended
+posture the user reads, not a separate write. Persisting a tightened level happens
+only where the wizard already writes a per-category override — the adjust fork's
+`onboard.js --posture` write (step 4b), where the user picks each category's level
+explicitly. The keep-defaults path writes the severity floor (`--floor`, step 2)
+and the calibrated accept path applies the triage subprocess's saved plan
+verbatim (`--confirmed --plan`, step 5); neither carries the tightening on its
+own, so a tightened level the user wants persisted is chosen through the adjust
+fork. Do **not** bolt on an extra `onboard.js --posture` overlay to auto-re-persist
+the tightening across the other paths: it would overwrite — and so could silently
+**downgrade** — a category the user had hardened out of band (a tightening is only
+guaranteed to raise above the severity floor, not above the user's stored level),
+with no downgrade-approval gate. So the tightening is not auto-persisted across
+those paths — a tightened level the user wants kept is set through the adjust fork.
 
-1. **Grant full review** (`full`) — scan scratch/temp files, agent memory & prior
-   transcripts for leaked secrets (deepest coverage · one-time consent, revocable
-   under Policies).
-2. **Current session only** (`session-only`) — decline historical access; AKA
-   reviews only what this session already touches. Even if declined, AKA can still
-   review: the **working tree** (all source, config & dotfiles in the repo), **this
-   session** (prompts, tool calls & files Codex reads or writes now), **git
-   history** (commits reachable from HEAD, incl. removed-but-tracked secrets), and
-   **pointed scans** (any path you explicitly hand AKA during a run).
+**When nothing in the working tree is inferable, change nothing.** Render the
+recommended posture exactly as the static frame already gives it — no rationale
+line and no tightened category (fail-open).
 
-Map the picked options to the flag values shown above (`redact`/`warn`,
-`full`/`session-only`).
+## 1. Offer the retroactive scan
 
-## 2. Save the answers
+Ask this **before** anything about detection posture — the posture
+recommendation in step 4 is _derived from_ the answer to this question, so it
+has to come first. Ask it per the execution contract's decision rules: a
+conversational turn with numbered options, waiting for the user's reply.
 
-Run the onboarding writer with the chosen values. Omit a flag to keep its
-default. This validates and persists to `~/.aka/settings/settings.json` (created
-`0600`, owner-only) and stamps the machine as onboarded:
+**Disclose the model-API egress plainly before you show the options — this is what
+the user is consenting to, so it must be visible before they choose.** State it in
+your own words, without softening it: if they say yes, AKA scans the last 30 days
+of Codex history, and to rate what it finds it **sends the raw, unmasked values —
+including any secrets — to the model API through the `codex` CLI**. Name what
+travels with each one: **its raw value, about 120 characters of the surrounding
+transcript text on either side, and the path of the rollout file it came
+from**. That is real network egress to the model provider (the same one your
+Codex session already uses), not a purely local review. **A copy of each value
+leaves the machine.** The rollouts those values came from stay on disk
+untouched — nothing here removes them; that is the separate redaction step in
+step 6. The values are kept out of your local Codex session history — the judge
+subprocesses run ephemerally, so nothing lands in `~/.codex/sessions` — but that
+is a local-write guard only, not network isolation. The findings are also
+recorded, masked, to the local store. The grant is revocable from the
+dashboard's **Settings → Historical access**, which stops future scans — it
+cannot recall anything already sent. Do not present the options until you have
+said this.
+
+**Want me to look over what Codex has been up to?** — "I'll scan Codex's recent work — session rollouts, temp files, agent memory — and send what I find to the model to rate it, so I can tune what I bring you next."
+
+Offer exactly two options:
+
+1. **Yes, take a look** — "scan my real work here; raw findings go to the model to be rated, then tune what you bring me"
+2. **Not now** — "start light and I'll learn as we go"
+
+Choosing **Yes, take a look** records the same historical-review consent the wizard has
+always recorded — the identical scope (which includes the model-API judgment disclosed
+above), the one-time grant, and the same revocation semantics — so the simpler question
+broadens nothing about what AKA may access. Those granular scope and revocation details
+stay inspectable on request and in the dashboard, under **Settings → Historical access**,
+whose own copy repeats the model-API disclosure.
+
+## 2. Save the answer, then branch
+
+Branch on the answer from step 1. On the **Yes, take a look** path the onboarding
+writer runs, and it must run **before** the backfill (step 3), because the
+backfill script reads `historicalAccess` from the saved settings to decide
+whether it's allowed to run. Omitting `--policy` is deliberate — the old global
+redact/warn toggle no longer drives enforcement (posture is per-category now);
+its field is kept for backward compatibility but this wizard doesn't ask about
+it.
+
+**Branch on the choice:**
+
+- **If the user chose "Yes, take a look"** — record the historical-review consent and
+  continue to step 3 (which runs the scan and leads to the calibrated result in
+  step 4). "Yes, take a look" maps to the existing full historical-review path — no
+  access is granted beyond what that path already granted:
+
+  ```bash
+  node "${PLUGIN_ROOT}/scripts/onboard.js" --historical full
+  ```
+
+- **If the user chose "Not now"** — take the **start-light** path.
+  This path takes **zero historical access**: do **not** read any history, do
+  **not** run the backfill, and do **not** record consent — nothing about the
+  machine's past is touched.
+  Instead present the start-light posture card, write the posture the user picks
+  (this write **is** the applying frame — it stands in for step 5, which never
+  runs here because there is no scan plan to apply), and rejoin the spine at the
+  installed summary (step 6). **Skip steps 3, 4, and 5 entirely** — there is no
+  scan to triage, no calibrated result to confirm, and no suppression plan to
+  write. Do the following in order:
+
+  1. **Show the start-light card.** Run the start-light script and relay its
+     AKA_SHOW card per the execution contract — the
+     `● Starting light — your detection categories` heading, the full 8-pack ×
+     4-level default posture table, the per-pack rationale, and the re-tune
+     hint, pasted between the markers exactly as printed, fence included. It
+     reads no history and writes nothing; it only prints the card
+     (the severity-floor default map — secret, pii, financial, phi, code_flaw, custom at
+     `warn`; code_context, config at `monitor`).
+
+     ```bash
+     node "${PLUGIN_ROOT}/scripts/start-light.js"
+     ```
+
+  2. **Confirm or adjust.** Ask — per the execution contract's decision rules —
+     whether to keep the recommended defaults or tune individual packs:
+
+     **Set your detection categories** — "Keep the defaults I'd recommend, or adjust any of them?"
+
+     1. **Keep defaults** _(recommended)_ — "the careful defaults shown above"
+     2. **Adjust** — "change one or more levels, keep the rest as I recommend"
+
+     If they choose **Adjust**, ask again — same decision rules — to collect the
+     new level (monitor/warn/redact/block) for each pack they want to change,
+     then merge those overrides over the severity-floor defaults to form the
+     full 8-pack map.
+
+  3. **Write the chosen posture.** The default map is the severity floor,
+     so when the user keeps the defaults, write the floor directly; when they
+     adjusted packs, write the merged 8-pack map:
+
+     ```bash
+     # Kept the recommended defaults
+     node "${PLUGIN_ROOT}/scripts/onboard.js" --floor
+
+     # Adjusted one or more packs — <json> is the merged 8-pack map
+     node "${PLUGIN_ROOT}/scripts/onboard.js" --posture '<json>'
+     ```
+
+     Either write prints only `✓ Set all K detection categories` (the `--floor`
+     write appends ` — safe defaults`) — which is the honest confirmation here,
+     because nothing was scanned or suppressed. Show that line to the user; do
+     **not** invent a dismissed count or any calibration counts.
+
+  4. **Rejoin the spine at the installed summary (step 6).** Continue to step 6
+     to show the installed summary and hand off to the dashboard, using honest
+     no-scan copy. No scan ran, so there is **no surfaced count** — call
+     `firstrun.js` with **no `--surfaced` flag** (the same floor-fallback rule
+     step 6 already follows when no calibration frame was emitted). Step 7
+     then runs as written.
+
+## 3. Run the evidence triage — off-transcript judgment, nothing written yet
+
+Pipe the backfill's triage stream straight into the `apply-suppressions`
+adapter in **PREVIEW** mode (no `--confirmed`):
 
 ```bash
-node "${PLUGIN_ROOT}/scripts/onboard.js" --policy <redact|warn> --historical <full|session-only>
+node "${PLUGIN_ROOT}/scripts/backfill.js" --triage | node "${PLUGIN_ROOT}/scripts/apply-suppressions.js"
 ```
 
-## 2.5 Scan history (only if they granted full review)
+The backfill sweeps prior Codex CLI session rollouts (last 30 days, all
+sessions) and streams one masked-plus-raw triage hit per line; masked findings
+are recorded to the local store as a side effect. The adapter runs the
+false-positive/severity **judgment in separate `codex` subprocesses that send the
+raw hits — each one's value, its surrounding transcript text, and its source path
+— to the model API** (a large history is split into several batches; each runs
+the CLI ephemerally so nothing lands in `~/.codex/sessions`), then prints back a
+**raw-free plan** you can safely show the user:
+the calibrated-result card (the real-count headline and the recommended posture),
+the per-category reasoning, the masked false positives it would suppress, any
+categories it skipped, and its notes.
 
-**Only when the user picked "Grant full review" (`historical=full`)**, run the
-backfill. It sweeps prior Codex CLI rollout files (last 30 days, all sessions)
-for secrets that leaked before AKA was installed and records them into the local
-store, so they show up in the first-run summary and the aka-findings skill. The
-scan is idempotent — it skips messages already recorded — so re-running this
-wizard is safe and never duplicates findings. Show its output **exactly as
-printed** (it self-fences; do not add another fence or reformat). Skip this
-step entirely when they chose `session-only`.
+The preview also **persists that exact raw-free plan to a temp file and prints
+its path** — a line beginning `Plan saved to: <path>`. Capture that path: step 5
+applies **this saved plan verbatim**, so the confirm step performs no second scan
+and no second judgment. (The plan file carries only masked/fingerprint/enum data;
+it is deleted after a successful apply.)
+
+Alongside the human copy, the preview also emits a **machine-readable calibration
+frame** — a single JSON block delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>`
+carrying the raw-free calibration counts and categories, plus (when the scan
+surfaced any) a `maskedFindings` array of raw-free secret-leak summaries. Do
+**not** show this block to the user (it is additive to the human copy above).
+Capture its `counts.important` value — the **surfaced count** — and pass it to the
+first-run summary in step 6 as `--surfaced <count>` — but **only when the preview
+also printed a `Plan saved to:` path** (a real calibrated plan to confirm in step
+4). The `Plan saved to:` line is the completion signal: a preview that omits it did
+not calibrate a plan you can confirm. The fallback branches below carry no
+surfaced count; the scan-ran-clean empty state (a scan that completed but
+surfaced nothing) emits a zero-count frame but **no plan path**, so it too routes
+to the floor branch below rather than step 4.
+
+Also **retain the block's full text verbatim** (not just the counts you read out
+of it) — step 6's "Review leaked keys" branch feeds this same text to the
+secret-leak remediation entry, which reads its own `maskedFindings` from it,
+and step 4's finding narration and step 6's secret-leak narration (both below)
+read the same `maskedFindings` array off it too. When present, the block's
+`falsePositivePatterns` array is what step 4's fixture/exception offer (below)
+names its pattern and count from — never invent either off-signal.
+
+Everything you show the user in step 4 comes from **this command's output**. You
+never read the raw finding values yourself — do not echo, quote, or reconstruct
+them; the judge subprocesses send them to the model API and return only the
+raw-free plan, so they never enter this conversation.
+
+**Failed or truncated triage — never proceed silently (fallback).** If this
+command exits non-zero, or the adapter reports a truncated / sentinel-less
+stream, the calibration could **not** complete. Do not guess a posture and do
+not leave setup half-applied. Apply the conservative severity floor, **tell the
+user it happened**, and continue to step 6:
 
 ```bash
-node "${PLUGIN_ROOT}/scripts/backfill.js"
+node "${PLUGIN_ROOT}/scripts/onboard.js" --floor
 ```
 
-## 3. Show the first-run summary
+Say plainly: the historical scan couldn't finish, so AKA is starting from the
+conservative severity floor (high-impact categories at `warn`, observe-only at
+`monitor`) instead of a calibrated posture, and it can be re-run any time with
+the aka-setup skill.
 
-Run the first-run script and show its output **exactly as printed** (the
-install-complete summary with live findings/recommendation counts and the health
-score). The script already prints it inside a Markdown code fence; reproduce it
-verbatim and do **not** add another code fence, strip the fence, or reformat it (it
-is space-aligned monospace that Markdown would otherwise collapse).
+**Nothing to calibrate.** A scan that **completes but surfaces nothing** prints
+the honest **scan-ran-clean** card — `I looked over Codex's recent work —
+nothing needs your attention right now. You're starting clean; here's what I'd
+recommend:` over the recommended posture — with a zero-count calibration frame
+(its `counts.important` is `0`) and **no `Plan saved to:` path**. A machine with
+no history to scan instead prints the no-history card (`Nothing to learn from
+yet — Codex hasn't left any work on this machine.` over the start-light table),
+and a scan skipped for lack of consent prints `I didn't review anything —
+historical access wasn't granted.`. In every one of these cases there's no
+evidence to calibrate from and no plan to confirm: show the card the adapter
+printed, take the floor branch (`onboard.js --floor`), tell the user the scan
+found nothing to calibrate from, and skip to step 6 (with **no `--surfaced`**,
+the floor-fallback rule there — nothing was surfaced to carry over). Do **not**
+continue to step 4.
+
+Otherwise (the preview printed a `Plan saved to:` path) continue to step 4.
+
+## 4. Show the calibrated result and get explicit confirmation — before any write
+
+The preview output is raw-free. Lead with the **calibrated-result card** it
+printed and show it in full:
+
+1. **The calibrated headline.** The `I went through Codex's recent work — N
+detections, M results worth a look.` line — every count templated over the
+   real scan (surfaced findings are the `M results` worth a look; the rest are
+   routine noise a plain scanner would have screamed about). Show it verbatim;
+   never substitute a demo number.
+2. **The recommended posture.** The condensed one-row-per-pack recommended view
+   the card printed — the level AKA would set for each category. Show it in full.
+   - **Surface the downgrades the preview flags — this is not optional.** For the
+     recommended posture it is about to write, the preview compares each category
+     against its stored setting and flags any that would be **LOWERED** from a
+     stronger existing one (e.g. an existing `block`/`redact` dropping to
+     `warn`/`monitor`), printing a `WARNING` line summarizing them. Call these out
+     prominently: a user who hardened a category must **explicitly approve weakening
+     it** before applying.
+3. **The false positives to be suppressed (the human gate).** The masked value,
+   rule, and masked context for each detection the writeback would suppress —
+   the routine noise being dismissed. This is the checkpoint that stops a genuine
+   secret being silenced: the user reads the masked evidence and approves it.
+4. **Explain what surfaced, in plain language.** When the frame carries
+   `maskedFindings`, walk through them — what each one is, where it showed up,
+   and why it matters — grounded entirely in that array: every count you speak
+   equals the frame's own count for it (`counts.important`/`counts.total`, or
+   a specific finding kind's count), and every value you reference appears
+   masked, exactly as the frame gives it — never a raw value, never an
+   invented one. This is an actual explanation of the known findings, not a
+   restatement of the headline's counts. When the frame carries no
+   `maskedFindings` (nothing surfaced, or a fallback floor ran), skip this —
+   the calibrated-result card already said so; do not invent narration over a
+   missing signal.
+5. **Offer an exception for a grounded false-positive pattern.** When the
+   frame carries `falsePositivePatterns`, name each group's pattern and count
+   **strictly from that signal** — never invent a pattern name or fabricate a
+   count. For each group, ask — per the execution contract's decision rules —
+   whether to set a pre-filled exception, with a duration choice (the exception
+   scope axis — `once` / `temporary` / `permanent`):
+
+   **Make an exception for `<pattern>` (×N)?** — "This `<pattern>` looks like a
+   test fixture — want me to set an exception so it stops popping up?"
+
+   1. **Once** — just this once — expires in 30 minutes
+   2. **Temporary** — for a set window, then I'll check it again
+   3. **Permanent** — stays until you revoke it
+   4. **Not now** — skip — I won't write anything
+
+   **Temporary needs a concrete window.** `once` and `permanent` fully determine
+   the scope on their own, but `temporary` does not — resolving it into the
+   stored `{scope, expiresAt, maxUses}` triple requires an actual duration, and
+   you must **never** invent or default one. When the user picks **Temporary**,
+   follow up with a second question that offers concrete windows only
+   — `30m` / `1h` / `24h` (the exception scope resolver accepts `<n>m`/`<n>h`,
+   capped at 24h; a longer bypass is a `permanent` grant, not a forgotten timer)
+   — and resolve the exact chosen string through that resolver. **Once** and
+   **Permanent** take no follow-up.
+
+   Accepting surfaces the exact pre-filled exception — one **per distinct value
+   identity** (`ruleId`/`valueFingerprint`/`keyVersion`) at the chosen
+   `{scope, expiresAt, maxUses}` — for review, and the marked pattern is
+   suppressed as part of the calibration plan confirmed below (the same store
+   the aka-exceptions skill reads). A group whose displayed pattern covers more
+   than one distinct value surfaces one exception per distinct value — never a
+   single grant collapsing them — and a value missing its exact identity is not
+   offered for. Declining surfaces nothing; this offer is separate from the
+   calibration plan's suppressions confirmed below, so declining here changes
+   nothing about that confirmation. When the frame carries no
+   `falsePositivePatterns` (nothing was marked a likely false positive, or the
+   scan was declined), skip this entirely — no offer, nothing invented
+   (fail-open).
+
+Then ask — per the execution contract's decision rules, never answering for the
+user — to confirm:
+
+**Want me to apply this?** — "I'll set these levels and suppress the false
+positives above."
+
+1. **Yes, apply** _(recommended)_ — write the posture and suppressions exactly as
+   previewed.
+2. **Adjust a category** — "change one or more first; keep the rest as I
+   recommend"
+
+Do **not** proceed until the user picks one. On **Yes, apply**, continue to
+step 5 and apply the previewed plan verbatim — that is the confirm spine,
+unchanged. On **Adjust a category**, take the **adjust fork** (step 4b), which
+applies within the fork and rejoins the spine at the installed summary (step 6).
+
+## 4b. Adjust a category — the override fork
+
+The **adjust base is the calibrated recommended posture the preview just
+printed** — the condensed one-row-per-pack view from step 4, not the cold-start
+severity floor. The user changes the packs they want and keeps the rest as
+recommended.
+
+1. **Collect the changes.** Ask — per the execution contract's decision rules —
+   which packs to change and to which level (monitor/warn/redact/block), one
+   clear numbered-option question at a time.
+
+2. **Show the adjust-confirm table.** Compose the merged 8-pack map — the
+   recommended base with the user's picks overlaid — and render the adjust-confirm
+   card by passing the calibrated recommended posture as `--recommended` and that
+   merged map as `--posture`. Relay its AKA_SHOW region per the execution
+   contract — the fenced `category │ recommended │ yours` table, pasted between
+   the markers exactly as printed (it is space-aligned monospace; do **not** add
+   another code fence, strip the fence, or reformat it):
+
+   ```bash
+   node "${PLUGIN_ROOT}/scripts/start-light.js" --adjust-confirm --recommended '<recommended-json>' --posture '<merged-json>' --current '<current-json>'
+   ```
+
+   `<recommended-json>` is the calibrated recommended posture the preview printed
+   (the adjust base) — so the `recommended` column shows each pack's calibrated
+   level, and a pack calibration escalated above the floor never renders as a
+   spurious change. `<merged-json>` is the full 8-pack map — that same recommended
+   base with the user's overrides overlaid — so a changed pack reads as a different
+   `yours` value and every untouched pack repeats its recommended level.
+   `<current-json>` is the `current` object from the plan file at the path step 3
+   printed (`Plan saved to: <path>`) — the store's per-category action at preview
+   time, the baseline the downgrade check compares against. Pass it verbatim; do
+   not retype or summarize it.
+
+3. **Surface any downgrade — the card computes this, you do not.** With
+   `--current` passed, the card itself appends the `WARNING: N categories … would
+be LOWERED from a stronger existing setting` footer whenever a pick weakens
+   enforcement — the same rule and the same wording as the confirm gate above,
+   from the same code. Show the card in full, footer included, and when that
+   footer is present get explicit approval before saving. Never let an enforcement
+   downgrade through without the user having seen it.
+
+4. **Save or back out.** Ask — per the execution contract's decision rules —
+   with **N** the number of packs the user changed and **M** the number kept as
+   recommended (`M = 8 − N`), both real — never a placeholder:
+
+   **Save your adjustments?**
+
+   1. **Save adjusted — N changed, M as recommended** — apply with the adjusted
+      posture.
+   2. **Back to recommended** — discard the changes and apply the recommended
+      posture instead.
+
+5. **On "Save adjusted" — produce the applying frame here, carrying the adjusted
+   posture, then rejoin the spine at the installed summary (step 6).** This fork
+   applies within itself and **stands in for step 5**, so step 5 never runs on
+   this path. First apply the previewed plan with the **unchanged confirm spine**,
+   so the reviewed false positives are dismissed and the recommended base is
+   written (the reviewed evidence packs overwrite; the severity floor fill-gaps the
+   rest, so a pack hardened out of band is never downgraded):
+
+   ```bash
+   node "${PLUGIN_ROOT}/scripts/apply-suppressions.js" --confirmed --plan <path>
+   ```
+
+   If that `--confirmed` run exits non-zero (or `--plan` is missing/unreadable),
+   handle it exactly as step 5 does: tell the user the write did not complete, fall
+   back to the floor (`onboard.js --floor`), and continue to step 6. Do **not** run
+   the overlay below on a failed spine — nothing was written, so there is no
+   recommended base to overlay the changes onto.
+
+   Then overwrite **only the packs the user changed** with their chosen levels:
+
+   ```bash
+   node "${PLUGIN_ROOT}/scripts/onboard.js" --posture '<changed-packs-json>'
+   ```
+
+   `<changed-packs-json>` carries **only** the packs the user adjusted (not the
+   full 8-pack map), so the packs kept as recommended keep the fill-gaps-safe
+   values the spine wrote and only the user's explicit, downgrade-approved changes
+   overwrite.
+
+   If that overlay exits non-zero, the spine already wrote the recommended base, so
+   the store holds a valid posture — but **not** the user's overrides. Tell the user
+   their adjustments did not save and the store holds the recommended posture, then
+   continue to step 6. Do **not** report the adjusted posture as saved on a failed
+   overlay.
+
+   On success, present the applying-frame confirmation the **spine** printed —
+   `✓ Set all 8 detection categories · set aside N routine results · Ready: …` —
+   the store now holds the adjusted posture. The overlay's own smaller
+   `✓ Set all N detection categories` line (the count of just the changed packs)
+   is bookkeeping — **do not show it**; the applying frame reports the full
+   8-pack posture. Then continue to step 6.
+
+   **On "Back to recommended"** — take the **Yes, apply** path instead: continue
+   to step 5 and apply the previewed plan verbatim with no override.
+
+Do **not** write anything until the user has explicitly confirmed at step 4
+(Yes, apply) or saved at step 4b (Save adjusted).
+
+## 5. Write the posture and suppressions
+
+On confirmation, run the adapter again with `--confirmed --plan <path>`, passing
+the **plan-file path the preview printed in step 3** (`Plan saved to: <path>`). It
+reads that saved plan back and applies it **exactly as previewed** — establishing
+the **full 8-pack posture** the recommended view showed (the reviewed
+evidence packs overwrite; the conservative severity floor fill-gaps the remaining
+packs, so a pack the user had already hardened out of band is never downgraded) and
+writing one 30-day suppression per confirmed false positive **without re-running the
+backfill or the judge**. There is deliberately **no `backfill.js` pipe here**:
+re-scanning and re-judging would produce a fresh, non-deterministic plan and
+silently defeat the human gate the user just approved.
+
+The posture overwrite and the suppression writes are applied as a **single
+all-or-nothing transaction**: a mid-batch failure rolls back the posture change
+too, so the store is never left half-applied. That is why the floor fallback below
+is safe — a non-zero exit means **nothing** persisted, so re-applying the
+conservative floor cannot collide with a partially-written posture.
 
 ```bash
-node "${PLUGIN_ROOT}/scripts/firstrun.js"
+node "${PLUGIN_ROOT}/scripts/apply-suppressions.js" --confirmed --plan <path>
 ```
 
-## 3.5 Offer the AKA CLI + local dashboard (opt-in)
+The script prints the applying confirmation — `✓ Set all K detection categories
+· set aside N routine results · Ready: …` — with both counts threaded from the
+real write. Show that line to the user.
+
+If `--plan` is missing or the file is unreadable/invalid, the adapter **fails loud
+(non-zero) and writes nothing** — it never falls back to a re-judge. Treat that
+like the `--confirmed` failure below: tell the user the write did not complete,
+fall back to the floor, and continue to step 6.
+
+If the `--confirmed` run exits non-zero, tell the user the write did not
+complete, fall back to the floor (`onboard.js --floor`), and continue to step 6
+so setup still finishes.
+
+## 6. Show the installed summary and hand off to the dashboard
+
+Run the first-run script and relay its **install-complete summary** AKA_SHOW
+region per the execution contract (live findings/recommendation counts, the
+health score, and the per-category posture just written or floored). The
+script wraps that summary in a Markdown code fence; paste it between the
+markers exactly as printed and do **not** add another code fence, strip the
+fence, or reformat it (it is space-aligned monospace that Markdown would
+otherwise collapse).
+
+Pass the **surfaced count** captured from step 3's calibration frame
+(`counts.important`) as `--surfaced <count>` — this is the 'N worth a look' figure
+the script emits in its own machine-readable handoff payload — but only when step 3
+carried a surfaced count forward (it printed a `Plan saved to:` path). If the
+calibration fell back to the floor (no plan path in step 3 — a fallback branch, or
+the scan-ran-clean empty state whose zero-count frame carries nothing to look at),
+**omit `--surfaced` entirely** — the script then withholds that payload rather than
+fabricating a count.
+
+Alongside it, pass the **surfaced live-key count** — the number of surfaced
+live-key secret findings, which is the length of the calibration frame's
+`maskedFindings` array (absent ⇒ 0) — as `--live-keys <count>`. This is the
+narrower secret subset of the surfaced count; it gates the remediation
+chain-entry the handoff offers, so a calibration that surfaced only non-secret
+findings passes `--live-keys 0` and offers no remediation.
+
+When `--surfaced` is passed, the script appends that handoff payload as a single
+JSON block delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>` after the fenced
+card. Like step 3's calibration frame, do **not** show this block to the user — it
+is additive and machine-only; only the fenced install summary above is
+user-facing.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/firstrun.js" --surfaced <count> --live-keys <count>
+```
+
+**Then hand off to the dashboard.** When the payload carries a positive
+`worthALook` count, ask explicitly — per the execution contract's decision rules
+— using that count for `N`:
+
+**N worth a look — want to see them in the browser?**
+
+1. **Review leaked keys** — "let's deal with the exposed keys I found" —
+   _(offer this option first only when the payload's `options` include
+   `enter-remediation`, i.e. `liveKeys > 0`)_; entering it starts the
+   secret-leak remediation chain on the surfaced live keys. This composes with —
+   never replaces — the dashboard handoff below, so both stay reachable.
+2. **Open dashboard** — "open the local dashboard on what I found"
+3. **Not now** — "stay here — you can open it anytime"
+
+Use the payload's `worthALook` value for `N` verbatim — do not invent or round it.
+Offer **Review leaked keys** exactly when the payload's `options` carry the
+`enter-remediation` entry (never otherwise); the **Open dashboard** / **Not now**
+handoff is always present. If the payload was withheld (the floor fallback, or
+nothing surfaced), skip this handoff question rather than inventing a count.
+
+**If they choose "Review leaked keys"** — run the secret-leak remediation entry's
+**present** mode, feeding it the calibration frame block you captured in step 3
+(the same text `maskedFindings` came from) on stdin:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/remediate.js" <<'AKA_FRAME'
+<the <<<AKA_FRAME_JSON … AKA_FRAME_JSON>>> block captured in step 3, verbatim>
+AKA_FRAME
+```
+
+It prints the decision as human-facing text, then a machine-readable block
+delimited by `<<<AKA_FRAME_JSON` … `AKA_FRAME_JSON>>>` carrying the same decision
+structured (do **not** show that block to the user). The human text has three
+parts, all of which you **show to the user verbatim, in order**:
+
+1. the templated count line ("I found N exposed secret keys sitting in old
+   transcripts."),
+2. the fenced finding table (provider, masked token, where, state), and
+3. inside that same fence, a most-exposed-first recommendation line and a
+   secret-scan chaining line.
+
+This entire human-text block is the entry's AKA_SHOW region — relay it per the
+execution contract, pasting it between the markers exactly as printed — do not
+drop the recommendation or chaining lines, and do not paraphrase.
+
+Alongside that fenced block, explain the findings in plain language grounded
+in the same `maskedFindings` array the block came from — what each finding is
+and why it matters, not a bare recital of the count line above it. The same
+grounding discipline as step 4's narration applies here: every count you
+speak matches the frame's own count, and every value you reference stays
+masked. With no `maskedFindings` present there is nothing to narrate beyond
+the count line and table already shown — do not invent an explanation.
+
+Then ask — per the execution contract's decision rules — offering exactly these
+four options, in order (each option's label maps to the `--option` id shown in
+parentheses):
+
+1. **Redact + rotation checklist** (`redact-rotation-checklist`)
+2. **Redact only** (`redact-only`)
+3. **Set 'secret' to redact** (`set-secret-redact`)
+4. **Leave** (`leave`)
+
+**If they chose "Redact + rotation checklist" or "Redact only"** — before running
+the route, ask a second question presenting the standing-posture prompt,
+offering exactly these four options, in order (each option's label maps to the
+`--posture` level in parentheses):
+
+**Set the 'secret' detection level**
+
+1. **Redact** (`redact`)
+2. **Warn** (`warn`)
+3. **Block** (`block`)
+4. **Monitor** (`monitor`)
+
+Then run the entry's **route** mode ONCE with the chosen redact option's id AND
+the chosen posture level, feeding it the SAME calibration frame block again on
+stdin:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/remediate.js" --option <id> --posture <level> <<'AKA_FRAME'
+<the same block>
+AKA_FRAME
+```
+
+Never run the route a second time for this choice — a repeat call would strike
+the already-redacted keys again and corrupt the reported count. Show its printed
+result verbatim, in order. For "Redact only" that is the redaction confirmation
+then the standing-posture confirmation. For "Redact + rotation checklist" it is
+the standing-posture confirmation then the resolved rotation-checklist summary —
+which reports the redaction itself, so the script does not print a separate
+redaction confirmation ahead of it.
+
+**If they chose "Set 'secret' to redact" or "Leave"** — run the entry's **route**
+mode with the chosen option's id (the id in parentheses above, e.g. **Leave** →
+`leave`), feeding it the SAME calibration frame block again on stdin:
+
+```bash
+node "${PLUGIN_ROOT}/scripts/remediate.js" --option <id> <<'AKA_FRAME'
+<the same block>
+AKA_FRAME
+```
+
+Show its printed result verbatim — a standing-posture confirmation, or (choosing
+"Leave") a plain note that nothing changed. This entry reads its findings from the
+calibration frame alone and holds no wizard state of its own, so it works
+identically from any caller.
+
+## 7. Offer the AKA CLI + local dashboard (opt-in)
 
 Now that the plugin is set up, offer the optional **AKA CLI + local dashboard** —
 a richer, still-fully-local surface over the same `~/.aka` store this plugin
 writes. The plugin works completely on its own; this is additive (and the path to
-future multi-agent support). Ask the user directly:
+future multi-agent support). Ask — per the execution contract's decision rules:
 
-**Add the AKA CLI + dashboard?** — "Install the `aka` CLI for a local web +
-terminal dashboard and on-demand scans? Everything stays on your machine."
+**Want the AKA CLI + dashboard too?** — "The `aka` CLI adds a local user
+interface + terminal dashboard and on-demand scans."
 
-1. **Yes, install it** (recommended) — adds the `aka` binary: `aka stats`,
-   `aka tui` (terminal dashboard), `aka dashboard` (local web UI), `aka scan`.
-2. **Not now** — skip; it can be added anytime with the one-liner below.
+1. **Yes, add it** _(recommended)_ — "adds the `aka` command: stats, a terminal
+   dashboard, a local user interface, and on-demand scans"
+2. **Not now** — "skip — you can add it anytime with the one-liner below"
 
-If they choose **Yes**, run the bootstrap installer (it ensures Node is available
-and installs the global CLI from the public npm registry). **Ask permission
-before running it**, then run the line for their OS:
+**Yes, add it** is the install authorization — run the bootstrap installer
+directly, with no second question (it downloads the self-contained `aka` binary for
+their platform — no Node.js or npm required — and links it onto PATH). Run the
+line for their OS:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.sh | sh
 
 # Windows (PowerShell)
-irm https://raw.githubusercontent.com/akasecurity/ai-tc/cli-latest/tools/installer/install.ps1 | iex
+irm https://raw.githubusercontent.com/akasecurity/ai-tc/bin-latest/tools/installer/install.ps1 | iex
 ```
 
-The one-liner pins to the stable release **tag** (`cli-latest`), never `main` —
-each release points that tag at its published `cli-v*` version, and the bootstrap
-scripts it fetches hold the installer's pinned ref + checksum, so fetching them
-from a mutable branch would defeat the integrity gate. To pin an exact version
-instead, set `AKA_INSTALL_REF=cli-v<version>` before running the line. Until the
-first release is published the one-liner 404s (fail-closed).
+The one-liner pins to the latest published binary release **tag** (`bin-latest`),
+never `main` — each binary release (`bin-v*`) moves that tag to its commit, and
+the installer verifies the downloaded binary against the release's `SHA256SUMS`
+(fail-closed), so a corrupted or tampered download is refused. To pin an exact
+version instead, set `AKA_INSTALL_REF=bin-v<version>` before running the line. If
+no `bin-v*` release exists yet the one-liner fails closed rather than guessing.
 
 After it completes, point them at `aka init` then `aka dashboard`. If they chose
 **Not now**, show the one-liner once so they can add it later, and move on —
@@ -140,18 +754,21 @@ what happened, show the one-liner so they can retry later, and continue the
 wizard normally. The plugin is already fully set up and works on its own; a
 failed CLI install changes nothing about that.
 
-## 4. Report the result
+**Close the wizard.** The first-run summary already confirmed the saved posture
+and pointed at the aka-health skill. Whichever way the CLI offer went —
+installed, declined, or a failed install you already reported — end with one
+warm close: "That's it — I'm watching out for Codex going forward."
 
-- The first-run summary already confirms the saved handling and points at the
-  aka-health skill. Add at most one short sentence: detection runs locally and
-  nothing leaves the machine.
+Before you finish, confirm every AKA_SHOW region on the path you took was
+relayed to the user. If you summarized one instead of pasting it, paste it now.
 
 ## Known limitation
 
 Live PreToolUse/PostToolUse redaction currently covers `Bash` shell calls only —
 Codex does not yet fire these hooks for `apply_patch` (file-write) calls (see
-`hooks/hooks.json` and `../pre-tool-use-decision.ts` for the tracking issue).
-File-write content is still covered by the prompt/response scan and by the
-historical/backfill scan above, just not redacted before it is written. If the
-user asks why a secret in a file edit wasn't caught live, explain this gap
-honestly rather than implying full coverage.
+`hooks/hooks.json` and `src/hooks/pre-tool-use-decision.ts` for the tracking
+issue). File-write content is still covered by the prompt/response scan and by
+the consent-gated historical scan this wizard offers in steps 1/3, just not
+redacted before it is written. If the user asks why a secret in a file edit
+wasn't caught live, explain this gap honestly rather than implying full
+coverage.

--- a/plugins/codex/skills/tokens/SKILL.md
+++ b/plugins/codex/skills/tokens/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: aka-tokens
+description: Show token usage and estimated cost per model from your local AKA store
+---
+
+# AKA tokens
+
+Run the read script and show the user its output **exactly as printed**. The
+script already prints its content inside a Markdown code fence — reproduce that
+verbatim and do **not** add another code fence, strip the fence, or reformat it.
+The fence is required: it is space-aligned monospace (a per-model usage table)
+that Markdown would otherwise collapse. Do not reformat or summarize the table;
+you may add at most one short sentence of context after it.
+
+```bash
+node "${PLUGIN_ROOT}/scripts/query.js" tokens
+```
+
+This reads the local store at `~/.aka/data/aka.db` (token counts reconciled from
+your Codex CLI rollout files, grouped by provider/model, with estimated USD cost).
+It is read-only. Token counts are exact; cost is **derived** at read time — a `—`
+means unknown pricing (a local or non-OpenAI model/gateway), so a `≥` total is a
+lower bound, not an understatement. If the store is empty, the script says so —
+relay that as-is; nothing is wrong.

--- a/plugins/codex/src/apply-suppressions.ts
+++ b/plugins/codex/src/apply-suppressions.ts
@@ -1,0 +1,95 @@
+/**
+ * The `apply-suppressions` adapter. Invoked by the `aka:setup`
+ * wizard's FP-writeback flow. This file is UNTESTABLE GLUE only: it wires real IO
+ * (stdin/file read, the ephemeral judge subprocess, the local store, the clock)
+ * into the dependency-injected orchestrator in @akasecurity/setup-wizard, which
+ * holds all the logic (and its tests).
+ *
+ *   Preview:  node scripts/apply-suppressions.js [--stream <path>]
+ *   Confirm:  node scripts/apply-suppressions.js --confirmed --plan <path>
+ *
+ * Preview reads the `backfill.js --triage` stream (stdin unless --stream), runs
+ * the judge, renders the human gate, and PERSISTS the resolved raw-free plan to a
+ * temp file whose path it prints. Confirm reads that persisted plan back and
+ * applies it VERBATIM — no re-scan, no re-judge — so the human gate is binding.
+ * Without --plan the confirm path fails loud rather than re-judging.
+ *
+ * RUBRIC: runJudge's default rubric path (the @akasecurity/setup-wizard
+ * assets/triage-rubric.md source) is NOT in the shipped
+ * plugin `files`, so it would throw at runtime. We inject loadRubric from a
+ * SHIPPED source: scripts/triage-rubric.md, copied from the package asset at build
+ * (tsup onSuccess) and shipped via the package's `files: ["scripts"]`. Falls back
+ * to the workspace package asset when run un-built from src/ (dev only).
+ */
+import { existsSync, readFileSync } from 'node:fs';
+import { userInfo } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import { runApply } from '@akasecurity/setup-wizard';
+
+import { runJudge, spawnCodex } from './triage/judge.ts';
+import { adapterPresenter } from './triage/presenter.ts';
+
+function fail(message: string): never {
+  process.stderr.write(`AKA apply-suppressions failed: ${message}\n`);
+  process.exit(1);
+}
+
+// Who grants the suppression. No machine-local identity in the OSS store, so the
+// OS account name is the honest source — mirrors the CLI's resolveCreatedBy.
+function resolveCreatedBy(): string {
+  try {
+    return userInfo().username;
+  } catch {
+    return 'unknown';
+  }
+}
+
+// The locked triage rubric from a SHIPPED source (see the RUBRIC note above).
+function loadRubric(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const shipped = join(here, 'triage-rubric.md');
+  if (existsSync(shipped)) return readFileSync(shipped, 'utf8');
+  return readFileSync(
+    join(here, '..', '..', '..', 'packages', 'setup-wizard', 'assets', 'triage-rubric.md'),
+    'utf8',
+  );
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+  const code = await runApply({
+    argv,
+    // fd 0 = stdin; the wizard pipes `backfill.js --triage` into this on preview.
+    // Called only on the preview path — the confirm path never reads a stream.
+    readStream: (streamPath) =>
+      streamPath !== undefined ? readFileSync(streamPath, 'utf8') : readFileSync(0, 'utf8'),
+    runJudge: (hits) => runJudge(hits, { spawn: spawnCodex, loadRubric }),
+    openDb: () => {
+      const db = openLocalDatabase(loadConfig().dataDir);
+      return {
+        policies: db.policies,
+        exceptions: db.exceptions,
+        // Makes the confirm write (posture overwrite + suppression inserts)
+        // all-or-nothing; bound so `this` stays the LocalDatabase handle.
+        transaction: (fn) => db.transaction(fn),
+        close: () => {
+          db.close();
+        },
+      };
+    },
+    now: () => Date.now(),
+    createdBy: resolveCreatedBy,
+    stdout: (s) => process.stdout.write(s),
+    present: adapterPresenter,
+    stderr: (s) => process.stderr.write(s),
+  });
+  process.exit(code);
+}
+
+main().catch((err: unknown) => {
+  fail(err instanceof Error ? err.message : 'unexpected failure');
+});

--- a/plugins/codex/src/apply-suppressions.ts
+++ b/plugins/codex/src/apply-suppressions.ts
@@ -30,6 +30,7 @@ import { openLocalDatabase } from '@akasecurity/persistence';
 import { loadConfig } from '@akasecurity/plugin-sdk';
 import { runApply } from '@akasecurity/setup-wizard';
 
+import { isModelJudgeConsentValid } from './triage/consent.ts';
 import { runJudge, spawnCodex } from './triage/judge.ts';
 import { adapterPresenter } from './triage/presenter.ts';
 
@@ -83,6 +84,7 @@ async function main(): Promise<void> {
     },
     now: () => Date.now(),
     createdBy: resolveCreatedBy,
+    modelJudgeConsent: () => isModelJudgeConsentValid(loadConfig().settings.modelJudgeConsent),
     stdout: (s) => process.stdout.write(s),
     present: adapterPresenter,
     stderr: (s) => process.stderr.write(s),

--- a/plugins/codex/src/backfill.ts
+++ b/plugins/codex/src/backfill.ts
@@ -1,0 +1,57 @@
+/**
+ * Historical backfill entry — invoked by the aka-setup skill right after
+ * onboarding when the user chose "Grant full review" (historicalAccess: full).
+ * It sweeps prior Codex CLI rollout files (~/.codex/sessions) for secrets that
+ * leaked BEFORE AKA was installed and records them into the same local store
+ * the read surfaces query:
+ *
+ *   node scripts/backfill.js
+ *
+ * The scan dedups against the local store's content hashes, so re-running on
+ * every setup run is idempotent and never duplicates findings. Fully
+ * fail-open — any error prints a friendly note and exits 0 so onboarding
+ * never breaks.
+ */
+import { loadConfig } from '@akasecurity/plugin-sdk';
+
+import { scanHistory } from './history/scan.ts';
+import { reconcileHistory } from './history/usage.ts';
+import { fenced, indent } from './present.ts';
+
+try {
+  const cfg = loadConfig();
+
+  if (cfg.settings.historicalAccess !== 'full') {
+    // Belt-and-suspenders: setup only runs this when consent is 'full'.
+    process.stdout.write('Historical scan skipped — full review was not granted.\n');
+    process.exit(0);
+  }
+
+  const summary = await scanHistory(cfg);
+
+  // Token-usage backfill: sweep the same
+  // transcript window and reconcile token usage into idempotent `llm_call` rows.
+  // Independent of the secret scan and fully fail-open — a reconcile error must
+  // never break onboarding, so a failure is swallowed and only the scan summary
+  // is reported.
+  try {
+    await reconcileHistory(cfg);
+  } catch {
+    // Token backfill is best-effort; the live Stop-hook pass recovers it.
+  }
+
+  const heading = '✓ Historical scan complete';
+  const scope = `Scanned ${String(summary.scanned)} messages from the last ${String(summary.windowDays)} days of Codex CLI history.`;
+  const result =
+    summary.findings > 0
+      ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with the aka-findings skill.`
+      : 'No new pre-install secrets found in your history.';
+
+  process.stdout.write(`${fenced([heading, '', indent(scope), '', indent(result)].join('\n'))}\n`);
+} catch {
+  process.stdout.write(
+    'AKA could not scan your history right now. It will still protect everything from here on.\n',
+  );
+}
+
+process.exit(0);

--- a/plugins/codex/src/backfill.ts
+++ b/plugins/codex/src/backfill.ts
@@ -3,55 +3,234 @@
  * onboarding when the user chose "Grant full review" (historicalAccess: full).
  * It sweeps prior Codex CLI rollout files (~/.codex/sessions) for secrets that
  * leaked BEFORE AKA was installed and records them into the same local store
- * the read surfaces query:
+ * the read surfaces query.
  *
- *   node scripts/backfill.js
- *
- * The scan dedups against the local store's content hashes, so re-running on
- * every setup run is idempotent and never duplicates findings. Fully
- * fail-open — any error prints a friendly note and exits 0 so onboarding
- * never breaks.
+ * Two output contracts:
+ *   - human (default): fully fail-open — any error prints a friendly note and
+ *     exits 0 so onboarding never breaks.
+ *   - --triage: stdout is a machine-read JSONL data channel and must fail loud.
+ *     A truncated stream (mid-scan crash, EPIPE) is byte-indistinguishable from
+ *     a complete one, so a completed stream ends in a sentinel line and any
+ *     error writes a diagnostic to stderr plus a non-zero exit — never a silent
+ *     exit 0 with a partial stream.
  */
-import { loadConfig } from '@akasecurity/plugin-sdk';
+import { fileURLToPath } from 'node:url';
 
-import { scanHistory } from './history/scan.ts';
+import {
+  type FingerprintKey,
+  fingerprintValue,
+  loadConfig,
+  loadOrCreateFingerprintKey,
+  type PluginConfig,
+} from '@akasecurity/plugin-sdk';
+import { TriageHit } from '@akasecurity/schema';
+import { TRIAGE_STATUSES } from '@akasecurity/setup-wizard';
+
+import { scanHistory, type ScanSummary } from './history/scan.ts';
+import { type HistoryWalkOptions } from './history/transcripts.ts';
 import { reconcileHistory } from './history/usage.ts';
 import { fenced, indent } from './present.ts';
 
-try {
-  const cfg = loadConfig();
+// The trailing sentinel that terminates a --triage stream. Its presence (and
+// only its presence) tells the consumer the stream was not truncated:
+//   complete            — the scan ran to completion over history that was examined;
+//                         count hits precede this.
+//   complete:no-history — the scan ran to completion but the history set was empty
+//                         (no messages examined); still a completed, non-truncated
+//                         scan, distinguished so the empty-state copy can say why.
+//   skipped:no-consent  — consent wasn't 'full'; an empty-but-intentional scan.
+// A truncated stream has no sentinel, so it is never mistaken for a real
+// zero-finding scan (which ends in status:"complete","count":0).
+//
+// The vocabulary itself is owned by @akasecurity/setup-wizard, which holds the
+// CONSUMER (parseTriageStream). This producer re-exports it rather than
+// declaring its own copy, so the two cannot drift.
+export { TRIAGE_STATUSES };
+export type TriageStatus = (typeof TRIAGE_STATUSES)[number];
 
-  if (cfg.settings.historicalAccess !== 'full') {
-    // Belt-and-suspenders: setup only runs this when consent is 'full'.
-    process.stdout.write('Historical scan skipped — full review was not granted.\n');
-    process.exit(0);
-  }
-
-  const summary = await scanHistory(cfg);
-
-  // Token-usage backfill: sweep the same
-  // transcript window and reconcile token usage into idempotent `llm_call` rows.
-  // Independent of the secret scan and fully fail-open — a reconcile error must
-  // never break onboarding, so a failure is swallowed and only the scan summary
-  // is reported.
-  try {
-    await reconcileHistory(cfg);
-  } catch {
-    // Token backfill is best-effort; the live Stop-hook pass recovers it.
-  }
-
-  const heading = '✓ Historical scan complete';
-  const scope = `Scanned ${String(summary.scanned)} messages from the last ${String(summary.windowDays)} days of Codex CLI history.`;
-  const result =
-    summary.findings > 0
-      ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with the aka-findings skill.`
-      : 'No new pre-install secrets found in your history.';
-
-  process.stdout.write(`${fenced([heading, '', indent(scope), '', indent(result)].join('\n'))}\n`);
-} catch {
-  process.stdout.write(
-    'AKA could not scan your history right now. It will still protect everything from here on.\n',
-  );
+export function triageSentinel(count: number, status: TriageStatus): string {
+  return JSON.stringify({ done: true, count, status }) + '\n';
 }
 
-process.exit(0);
+// Injected IO so the framing logic is unit-testable without a subprocess; the
+// bottom of this file wires the real process streams. fail() marks a non-zero
+// exit without writing to stdout — stdout stays the pure data channel.
+export interface BackfillIo {
+  stdout(chunk: string): void;
+  stderr(chunk: string): void;
+  fail(): void;
+}
+
+export interface BackfillDeps {
+  triage: boolean;
+  io: BackfillIo;
+  loadConfig: () => PluginConfig;
+  scanHistory: (
+    config: PluginConfig,
+    opts: HistoryWalkOptions,
+    onHit?: (hit: TriageHit) => void,
+  ) => Promise<ScanSummary>;
+  reconcileHistory: (config: PluginConfig) => Promise<unknown>;
+  // Walk options threaded into the scan. The self-contamination guard: `beforeMs`
+  // drops any rollout message written at/after the backfill started (so a re-run
+  // never re-ingests the wizard's own in-progress session). Codex exposes no
+  // session id to this subprocess (hooks receive session_id on stdin; the setup
+  // skill's shell carries only PLUGIN_ROOT), so the timestamp cutoff is the whole
+  // guard — there is no id-based sibling. `dir` can override the rollout root for
+  // isolated tests; no production or harness call site passes it — the harness
+  // sets HOME so the default transcriptsDir() already resolves under the
+  // throwaway home. Injected (not read from the environment here) so runBackfill
+  // stays pure + testable; the CLI wiring below computes beforeMs.
+  guard?: Pick<HistoryWalkOptions, 'beforeMs' | 'dir'>;
+}
+
+export async function runBackfill(deps: BackfillDeps): Promise<void> {
+  const { triage, io } = deps;
+  try {
+    const cfg = deps.loadConfig();
+
+    if (cfg.settings.historicalAccess !== 'full') {
+      if (triage) {
+        io.stdout(triageSentinel(0, 'skipped:no-consent'));
+      } else {
+        io.stdout('Historical scan skipped — full review was not granted.\n');
+      }
+      return;
+    }
+
+    // Resolve the fingerprint key once for the whole stream: a later
+    // suppression writeback keys on (ruleId, valueFingerprint, keyVersion).
+    // Mints on first use; a corrupt/unwritable key fails secure (fpKey stays
+    // null) — hits then stream without a fingerprint, and a downstream
+    // writeback step skips exactly those. Only under --triage.
+    let fpKey: FingerprintKey | null = null;
+    if (triage) {
+      try {
+        fpKey = loadOrCreateFingerprintKey(cfg.dataDir);
+      } catch {
+        fpKey = null;
+      }
+    }
+
+    // Hits actually streamed, so the sentinel can carry N. Only incremented
+    // after a successful write, so a mid-write EPIPE throws to the catch below
+    // rather than being counted as emitted. Also doubles as the per-hit id
+    // sequence (monotonic, 0-based).
+    let count = 0;
+    // scanHistory isolates each onHit call in its own try/catch (a misbehaving
+    // sink must not abort the rest of the sweep), so a synchronous throw from
+    // this closure — e.g. an EPIPE from io.stdout when the --triage consumer
+    // closes its pipe mid-stream — never reaches this function's own catch.
+    // Capture it here instead and rethrow after the scan settles, so a
+    // truncated stream still fails loud rather than ending in a silently
+    // undercounted 'complete' sentinel.
+    let onHitError: unknown;
+    const summary = await deps.scanHistory(
+      cfg,
+      deps.guard ?? {},
+      triage
+        ? (hit) => {
+            if (onHitError !== undefined) return;
+            try {
+              const enriched: TriageHit = {
+                ...hit,
+                id: String(count),
+                valueFingerprint: fpKey ? fingerprintValue(fpKey, hit.rawMatch) : undefined,
+                keyVersion: fpKey?.version,
+              };
+              // Validate WITHOUT letting a ZodError carry the raw hit value: on a
+              // shape mismatch the error message would echo rawMatch/context, and
+              // it is rethrown to the outer catch which writes it to stderr. Emit
+              // a raw-free error at the source instead. A raw-free io.stdout error
+              // (e.g. EPIPE) still propagates verbatim for diagnostics.
+              const validated = TriageHit.safeParse(enriched);
+              if (!validated.success) {
+                throw new Error('enriched triage hit failed TriageHit validation');
+              }
+              io.stdout(JSON.stringify(validated.data) + '\n');
+              count += 1;
+            } catch (err) {
+              onHitError = err;
+            }
+          }
+        : undefined,
+    );
+    if (onHitError !== undefined) {
+      throw onHitError instanceof Error
+        ? onHitError
+        : new Error(typeof onHitError === 'string' ? onHitError : 'triage stream write failed');
+    }
+
+    try {
+      await deps.reconcileHistory(cfg);
+    } catch {
+      // Token backfill is best-effort; the live Stop-hook pass recovers it.
+    }
+
+    if (triage) {
+      // A completed scan that touched zero messages is a no-history run (a fresh
+      // machine with nothing to calibrate from), distinct from a scan that examined
+      // history and surfaced/kept nothing. A message already recorded on a prior run
+      // counts under skipped (dedup), not scanned, so a fully-deduped rescan of real
+      // history is NOT no-history — both counters must be zero.
+      const status: TriageStatus =
+        summary.scanned === 0 && summary.skipped === 0 ? 'complete:no-history' : 'complete';
+      io.stdout(triageSentinel(count, status));
+    } else {
+      const heading = '✓ Historical scan complete';
+      const scope = `Scanned ${String(summary.scanned)} messages from the last ${String(summary.windowDays)} days of Codex CLI history.`;
+      const result =
+        summary.findings > 0
+          ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with the aka-findings skill.`
+          : 'No new pre-install secrets found in your history.';
+      io.stdout(`${fenced([heading, '', indent(scope), '', indent(result)].join('\n'))}\n`);
+    }
+  } catch (err) {
+    if (triage) {
+      // The raw vector on this path — a ZodError over an enriched (raw-bearing)
+      // hit — is neutralised at its source in the onHit sink above, so every error
+      // reaching here (config/fs faults, an io.stdout EPIPE) is raw-free and its
+      // message is safe (and useful) to surface on the machine channel.
+      io.stderr(`aka backfill --triage: history scan failed: ${String(err)}\n`);
+      io.fail();
+    } else {
+      io.stdout(
+        'AKA could not scan your history right now. It will still protect everything from here on.\n',
+      );
+    }
+  }
+}
+
+// Guard so importing the exported helpers in tests never runs the CLI.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const triage = process.argv.includes('--triage');
+  // Self-contamination guard value (see BackfillDeps.guard). `beforeMs` is this
+  // run's start: every real pre-install message predates it, so it drops only
+  // what is written at/after the scan begins — the wizard's own in-progress
+  // session.
+  const startedAt = Date.now();
+  await runBackfill({
+    triage,
+    io: {
+      stdout: (chunk) => process.stdout.write(chunk),
+      stderr: (chunk) => process.stderr.write(chunk),
+      fail: () => {
+        process.exitCode = 1;
+      },
+    },
+    loadConfig: () => loadConfig(),
+    scanHistory,
+    reconcileHistory: (cfg) => reconcileHistory(cfg),
+    guard: { beforeMs: startedAt },
+  });
+  // process.exit() does not flush a buffered async stdout write on darwin, so a
+  // large --triage stream's trailing sentinel could be dropped; drain first.
+  if (process.stdout.writableLength > 0) {
+    await new Promise<void>((resolve) => {
+      process.stdout.write('', () => {
+        resolve();
+      });
+    });
+  }
+  process.exit(process.exitCode ?? 0);
+}

--- a/plugins/codex/src/calibration.ts
+++ b/plugins/codex/src/calibration.ts
@@ -112,6 +112,20 @@ const NO_HISTORY_HEADLINE =
 // table. Both carry a valid zero-count CalibrationFrame. This is the
 // found-nothing/empty-store copy only; an unreadable store is the separate
 // STORE_UNAVAILABLE_NOTE path, not framed here.
+// The machine-readable half of every "nothing to report" outcome: a frame whose
+// counts are all zero over the given posture. Separated from the copy so a
+// caller that already has its own honest line (the model-judge consent skip)
+// can still emit a parseable frame without borrowing an empty state's wording.
+export function zeroCountFrame(posture: CalibrationFrame['posture']): CalibrationFrame {
+  return {
+    counts: { total: 0, important: 0, routine: 0 },
+    routineCategories: [],
+    surfacedCategories: [],
+    findingKinds: [],
+    posture,
+  };
+}
+
 export function frameEmptyState(
   cause: EmptyCause,
   posture: CalibrationFrame['posture'],

--- a/plugins/codex/src/calibration.ts
+++ b/plugins/codex/src/calibration.ts
@@ -1,0 +1,131 @@
+/**
+ * Pure calibration count-framing for the aka-setup wizard's calibrated-result
+ * screen. frameCalibration turns the backfill + apply-suppressions preview
+ * breakdown into the CalibrationFrame emitted for downstream consumers and the
+ * human-facing copy "I went through Codex's recent work — N detections, M
+ * result(s) worth a look. (KIND)" — every count follows the preview input.
+ * frameEmptyState produces the honest empty-state copy over a zero-count frame
+ * for a scan that found nothing or a machine with no history. Surfaced
+ * (genuine, non-suppressed) findings are 'important'; suppressed findings are
+ * 'routine'; the total is their sum. No IO.
+ */
+import type {
+  CalibrationFrame,
+  CalibrationPreview,
+  CalibrationResult,
+  DetectionCategory,
+  FalsePositivePatternGroup,
+  MaskedSecretFinding,
+} from '@akasecurity/schema';
+
+import { renderPostureGrid, renderRecommendedPosture } from './render.ts';
+
+// Plain-English kind of a surfaced category, for the 'M result(s) worth a
+// look. (…)' parenthetical. Presentation-only — not a persisted contract.
+const SURFACED_KIND_LABEL: Record<DetectionCategory, string> = {
+  secret: 'live keys',
+  pii: 'personal data',
+  financial: 'financial records',
+  phi: 'health records',
+  code_context: 'source context',
+  code_flaw: 'code flaws',
+  custom: 'custom matches',
+  config: 'configuration secrets',
+};
+
+export function frameCalibration(
+  preview: CalibrationPreview,
+  maskedFindings: readonly MaskedSecretFinding[] = [],
+  falsePositivePatterns: readonly FalsePositivePatternGroup[] = [],
+): CalibrationResult {
+  const important = preview.categories.reduce((n, c) => n + c.genuineCount, 0);
+  const routine = preview.categories.reduce((n, c) => n + c.fpCount, 0);
+  const total = important + routine;
+
+  const surfacedCategories = preview.categories
+    .filter((c) => c.genuineCount > 0)
+    .map((c) => c.category);
+  const routineCategories = preview.categories.filter((c) => c.fpCount > 0).map((c) => c.category);
+
+  const findingKinds = preview.categories
+    .filter((c) => c.genuineCount + c.fpCount > 0)
+    .map((c) => ({ category: c.category, count: c.genuineCount + c.fpCount, egress: c.egress }));
+
+  // The masked per-finding summaries ride ALONGSIDE the counts additively: the
+  // optional `maskedFindings` field is populated only when a secret finding
+  // surfaced, so an empty set omits it entirely and a pre-existing frame without
+  // it still validates. The finding table and the narration read these fields.
+  // `falsePositivePatterns` follows the same additive discipline: populated only
+  // when a hit was marked a false positive, so a clean run's frame still omits
+  // it entirely — the fixture/exception offer's grounded pattern×count signal.
+  const frame: CalibrationFrame = {
+    counts: { total, important, routine },
+    routineCategories,
+    surfacedCategories,
+    findingKinds,
+    posture: preview.posture,
+    ...(maskedFindings.length > 0 ? { maskedFindings: [...maskedFindings] } : {}),
+    ...(falsePositivePatterns.length > 0
+      ? { falsePositivePatterns: [...falsePositivePatterns] }
+      : {}),
+  };
+
+  const kind = surfacedCategories.map((c) => SURFACED_KIND_LABEL[c]).join(', ');
+  // Omit the kind parenthetical entirely when nothing surfaced, so an
+  // all-suppressed run reads 'worth a look.' with no dangling ' ()'.
+  const parenthetical = kind ? ` (${kind})` : '';
+  const headline =
+    `I went through Codex's recent work — ${String(total)} detection${total === 1 ? '' : 's'}, ` +
+    `${String(important)} result${important === 1 ? '' : 's'} worth a look.${parenthetical}`;
+
+  // The frame carries the finding kinds (incl. the egress axis) for downstream
+  // consumers; the calibrated headline is the copy. A positive observation over
+  // these findings is an evidence-grounded intelligence-layer output, not a
+  // static line here — it renders only when the evidence honestly supports it.
+  const copy = headline;
+
+  return { frame, copy };
+}
+
+// Which cause left the calibration empty: a scan ran and surfaced nothing
+// ('scan-clean') or there is no history on this machine to scan ('no-history').
+// Selects which honest empty-state copy renders. Presentation-only — not a
+// persisted contract.
+export type EmptyCause = 'scan-clean' | 'no-history';
+
+// The scan-ran-clean headline: a scan looked at recent work and found
+// nothing worth surfacing, so the user starts from the recommended posture.
+const SCAN_CLEAN_HEADLINE =
+  "I looked over Codex's recent work — nothing needs your attention right now. " +
+  "You're starting clean; here's what I'd recommend:";
+
+// The no-history headline: there is nothing on this machine to learn from,
+// so each detection category starts at its careful default (the start-light
+// table).
+const NO_HISTORY_HEADLINE =
+  "Nothing to learn from yet — Codex hasn't left any work on this machine. " +
+  "I'll start each detection category at a careful default:";
+
+// The empty-state framing: two distinct honest copies, one per cause, each
+// stating why it is empty — never '0 detections' theater. A scan-clean state
+// renders the recommended posture; a no-history state renders the start-light
+// table. Both carry a valid zero-count CalibrationFrame. This is the
+// found-nothing/empty-store copy only; an unreadable store is the separate
+// STORE_UNAVAILABLE_NOTE path, not framed here.
+export function frameEmptyState(
+  cause: EmptyCause,
+  posture: CalibrationFrame['posture'],
+): CalibrationResult {
+  const frame: CalibrationFrame = {
+    counts: { total: 0, important: 0, routine: 0 },
+    routineCategories: [],
+    surfacedCategories: [],
+    findingKinds: [],
+    posture,
+  };
+  const copy =
+    cause === 'scan-clean'
+      ? `${SCAN_CLEAN_HEADLINE}\n${renderRecommendedPosture(posture)}`
+      : `${NO_HISTORY_HEADLINE}\n${renderPostureGrid(posture)}`;
+  return { frame, copy };
+}

--- a/plugins/codex/src/dashboard-launch.ts
+++ b/plugins/codex/src/dashboard-launch.ts
@@ -1,0 +1,41 @@
+// Pure helpers for the aka-dashboard launcher (src/dashboard.ts). Kept free of
+// I/O so the arg parsing + user-facing copy unit-test without spawning anything;
+// the entry script owns the child_process spawn + stdout. Identical to
+// plugins/claude-code/src/dashboard-launch.ts — the dashboard is a shared
+// surface, launched the same way regardless of which plugin invoked it.
+
+// The CLI's default dashboard port + landing route — mirrors
+// cli/src/commands/dashboard.ts so the URL we print matches where `aka`
+// actually serves.
+export const DEFAULT_PORT = '4319';
+const ROUTE = '/security';
+
+// The port `aka dashboard` will bind: honour a forwarded `--port <N>` / `--port=N`
+// so the printed URL tracks the CLI; default otherwise.
+export function parsePort(argv: string[]): string {
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? '';
+    if (arg === '--port') return argv[i + 1] ?? DEFAULT_PORT;
+    if (arg.startsWith('--port=')) return arg.slice('--port='.length);
+  }
+  return DEFAULT_PORT;
+}
+
+export function dashboardUrl(port: string): string {
+  return `http://localhost:${port}${ROUTE}`;
+}
+
+export function startMessage(url: string): string {
+  return (
+    `Starting the AKA dashboard at ${url} — it opens in your browser once ready.\n` +
+    `It serves your local store at ~/.aka/data; leave it running (stop it with Ctrl-C in that process).`
+  );
+}
+
+// Shown when the `aka` CLI isn't on PATH: the plugin ships no web server of its
+// own, so the dashboard is launched by @akasecurity/cli.
+export const INSTALL_HINT =
+  'The AKA dashboard is launched by the `aka` CLI, which the plugin does not bundle.\n' +
+  'Install it and run the aka-dashboard skill again:\n' +
+  '  npm i -g @akasecurity/cli      # then it is on your PATH as `aka`\n' +
+  'From a repo checkout instead:  pnpm --filter @akasecurity/cli dev dashboard';

--- a/plugins/codex/src/dashboard.ts
+++ b/plugins/codex/src/dashboard.ts
@@ -1,0 +1,52 @@
+/**
+ * aka-dashboard — launch the AKA web dashboard, mirroring the `aka dashboard`
+ * CLI command.
+ *
+ *   node scripts/dashboard.js [--port N] [--no-open]
+ *
+ * The plugin ships as self-contained bundled scripts (no node_modules on the
+ * user's machine), so it can't host the Next.js web-ui itself — that server is
+ * bundled inside @akasecurity/cli. This launcher therefore delegates to the
+ * `aka` CLI: it spawns `aka dashboard` DETACHED (a long-running server) so the
+ * skill returns immediately, then prints the local URL. Flags are
+ * forwarded untouched.
+ *
+ * Fail-open: if the CLI isn't installed (or anything throws) it prints how to
+ * get it and exits 0 — a skill should never surface a stack trace.
+ */
+import { spawn, spawnSync } from 'node:child_process';
+
+import { dashboardUrl, INSTALL_HINT, parsePort, startMessage } from './dashboard-launch.ts';
+
+const args = process.argv.slice(2);
+
+// Is the `aka` CLI reachable? Probe synchronously so we pick the right message
+// before spawning the long-running server. ENOENT ⇒ it isn't on PATH.
+function akaMissing(): boolean {
+  const probe = spawnSync('aka', ['--help'], { stdio: 'ignore' });
+  return probe.error !== undefined && (probe.error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+try {
+  if (akaMissing()) {
+    process.stdout.write(`${INSTALL_HINT}\n`);
+    process.exit(0);
+  }
+
+  // Detached + unref so the dashboard server outlives this short-lived launcher
+  // (and the skill returns at once). The CLI opens the browser when ready.
+  const child = spawn('aka', ['dashboard', ...args], { detached: true, stdio: 'ignore' });
+  // Swallow a late spawn failure rather than crashing with an unhandled 'error'
+  // after we've already reported the URL — stay fail-open.
+  child.on('error', () => {
+    /* already probed for ENOENT; ignore any late failure */
+  });
+  child.unref();
+
+  process.stdout.write(`${startMessage(dashboardUrl(parsePort(args)))}\n`);
+  // No process.exit here: the unref'd child no longer holds the event loop open,
+  // so this launcher drains and exits 0 on its own without killing the server.
+} catch {
+  process.stdout.write(`${INSTALL_HINT}\n`);
+  process.exit(0);
+}

--- a/plugins/codex/src/exception-guidance.ts
+++ b/plugins/codex/src/exception-guidance.ts
@@ -1,0 +1,155 @@
+// Copy-paste-complete exception guidance for the enforcement messages. When a
+// detection blocks (or redacts), the runtime has already recorded a
+// fingerprint-only row in the short-lived blocked-detections ledger and handed
+// back a rich reference on `CaptureResult.blockedReferences`; these builders
+// turn that into the exact `aka exception approve` command so the user can
+// grant an explicit, audited bypass from a terminal. Removal of the flagged
+// content stays the first recommendation — the exception is the sanctioned
+// escape hatch, offered at the point of failure, never promoted.
+//
+// The preview and the reference both come from the SAME ledger row
+// (BlockedDetectionRef), so the masked value shown can never describe a
+// different value than the one `approve <ref>` resolves — and no raw match
+// text is handled here at all.
+//
+// Identical to plugins/claude-code/src/exception-guidance.ts: the messaging is
+// host-agnostic (references `aka`, the CLI, never Codex-specific wording).
+//
+// Pure string building (no I/O) so it unit-tests without a hook process. Hook
+// entry files run main() on import and must NEVER be imported by tests — that
+// is exactly why this lives in its own module instead of inline in the hooks.
+import type { BlockedDetectionRef } from '@akasecurity/plugin-sdk';
+
+import { SHADE } from './present.ts';
+
+export interface BlockMessageInput {
+  // What was blocked, as it reads mid-sentence: 'prompt' or 'Bash call'.
+  subject: string;
+  // Comma-joined unique rule ids (uniqueRuleIds output / a joined rule set).
+  ruleIds: string;
+  // First ledger ref recorded for this capture. Without one the approve
+  // command degrades to its bare form, which lists recent blocks to pick from.
+  blockedRef?: BlockedDetectionRef | undefined;
+  // Extra sentence woven into the first line, between the flag preview and the
+  // removal advice — e.g. why a redact policy escalated to a block on
+  // executable command text (EXECUTABLE_REDACT_NOTE).
+  note?: string | undefined;
+}
+
+// The block message (transcript-rendered, so it stays ≤ 5 lines): what was
+// flagged (masked preview from the ledger row), removal as the primary fix,
+// then the copy-paste-complete exception command with the ledger reference
+// baked in, and one help pointer. With a reference the pasted-value form is
+// offered as a second, aligned command line — the selector the user already
+// has in their clipboard; it only appears when a ledger row is guaranteed,
+// because approve-by-value resolves against that same row. Without one the
+// command degrades to its bare form, which lists recent blocks to pick from.
+export function blockMessage(input: BlockMessageInput): string {
+  const preview = input.blockedRef ? ` (${input.blockedRef.maskedValue})` : '';
+  const commands = input.blockedRef
+    ? [
+        `  aka exception approve ${input.blockedRef.reference}       (asks for scope + reason, then resubmit)`,
+        '  aka exception approve <value>      (same flow, pasting the blocked value itself)',
+      ]
+    : ['  aka exception approve       (asks for scope + reason, then resubmit)'];
+  const note = input.note ? ` ${input.note}` : '';
+  return [
+    `AKA blocked this ${input.subject} — flagged ${input.ruleIds}${preview}.${note} Remove the flagged content and resubmit.`,
+    'If this is intentional and you accept the risk, grant an exception:',
+    ...commands,
+    'More: aka exception --help',
+  ].join('\n');
+}
+
+// One trailing sentence for the redact/warn systemMessage branches: redacted
+// values land in the same ledger as blocked ones, so the same approve flow
+// applies. Empty when nothing was ledgered — the message is only extended when
+// the command would actually find the block.
+export function exceptionPointer(references: readonly BlockedDetectionRef[] | undefined): string {
+  const ref = references?.[0];
+  if (ref === undefined) return '';
+  return ` To allow this exact value intentionally, run: aka exception approve ${ref.reference}.`;
+}
+
+export interface WithheldBannerInput {
+  toolName: string;
+  // Most-severe aggregate label for the header line.
+  action: 'withheld' | 'redacted';
+  // Comma-joined unique rule ids (uniqueRuleIds output), kept per action so a
+  // mixed outcome renders as separate `Withheld:` / `Redacted:` lines — one
+  // merged list under a single "withheld" label reads as if every rule's
+  // surrounding text was removed, when redacted fields WERE delivered with
+  // only their spans masked.
+  withheldRuleIds?: string | undefined;
+  redactedRuleIds?: string | undefined;
+  // Warn-action rules flagged in OTHER fields of the same response. Without a
+  // line of their own they would vanish: the warn-only systemMessage branch is
+  // unreachable once any field was rewritten.
+  warnedRuleIds?: string | undefined;
+  blockedRef?: BlockedDetectionRef | undefined;
+}
+
+// The PostToolUse systemMessage as a shade-glyph banner. A one-line
+// "PostToolUse:<tool> says: …" is easy to read past; the full-shade gutter
+// makes the intervention unmissable while staying inside the monochrome
+// transcript grammar (present.ts: heavier fill = more severe; ANSI is not
+// interpreted here, so emphasis is carried by glyph texture only). Same
+// 5-line budget as blockMessage in the common single-action case (+1 per
+// extra action present).
+//
+// The masked preview renders on the approve line, not next to the rule list:
+// preview and reference come from the same ledger row, and appending one
+// preview to a multi-rule list implies the value belongs to the last rule.
+export function withheldBanner(input: WithheldBannerInput): string {
+  const header = `${SHADE.full}${SHADE.dark}${SHADE.medium}${SHADE.light} AKA ${SHADE.light}${SHADE.medium}${SHADE.dark}${SHADE.full}`;
+  const subject = input.action === 'withheld' ? 'The flagged value' : 'Redacted spans';
+  const approve = input.blockedRef
+    ? `Allow this exact value (${input.blockedRef.maskedValue}) intentionally: aka exception approve ${input.blockedRef.reference}`
+    : 'Allow intentionally: aka exception approve';
+  return [
+    `${header} ${input.toolName} output ${input.action}`,
+    ...(input.withheldRuleIds ? [`${SHADE.full} Withheld: ${input.withheldRuleIds}`] : []),
+    ...(input.redactedRuleIds ? [`${SHADE.full} Redacted: ${input.redactedRuleIds}`] : []),
+    ...(input.warnedRuleIds ? [`${SHADE.full} Also flagged (warn): ${input.warnedRuleIds}`] : []),
+    `${SHADE.full} ${subject} never reached the model.`,
+    `${SHADE.full} ${approve}`,
+    `${SHADE.full} More: aka exception --help`,
+  ].join('\n');
+}
+
+// The model-visible replacement for a withheld field: states what happened,
+// that the content is genuinely absent from context, and that the user should
+// be told prominently — the model's own reply is the most visible line in the
+// transcript. Deliberately does NOT mention `aka exception approve`: the
+// escape hatch is the user's audited decision, not something to nudge an
+// agent toward running itself (the user-facing banner carries it instead).
+//
+// `field` names which part was replaced (e.g. 'stderr', 'file.content') so an
+// stderr-only withhold doesn't read as "the whole output was blocked" next to
+// perfectly visible stdout.
+//
+// The placeholder sentence is load-bearing: this text sits where real content
+// was, and a read-modify-write flow (Read .env → edit → Write) would otherwise
+// persist it back to disk over the user's real file.
+//
+// The retry sentence is load-bearing too: the no-circumvention directive must
+// not read as "never try again". The user can grant an exception out-of-band,
+// and the ONLY way it takes effect is the same tool call running again — a
+// model that refuses the retry strands the grant unconsumed. Qualified with
+// "if it is safe to repeat" so it never instructs re-executing a
+// side-effectful command (a deploy, a POST) just to re-fetch its output.
+export function withheldToolText(toolName: string, ruleIds: string, field?: string): string {
+  const part = field !== undefined && field !== '' ? field : 'output';
+  return (
+    `[AKA SECURITY] ${toolName} ${part} withheld — flagged ${ruleIds}. ` +
+    'The flagged content was not added to your context. ' +
+    'This notice is a placeholder, not the real content: the underlying file ' +
+    'or command output is unchanged, so never write this notice back to a ' +
+    'file or treat it as data. ' +
+    'Do not attempt to obtain the withheld content through other channels. ' +
+    'Tell the user AKA withheld this output and why. ' +
+    'If the user asks again — for example after granting an AKA exception — ' +
+    're-run this same tool call if it is safe to repeat: AKA re-evaluates ' +
+    'every capture and passes values the user has excepted.'
+  );
+}

--- a/plugins/codex/src/filescan.ts
+++ b/plugins/codex/src/filescan.ts
@@ -1,0 +1,89 @@
+/**
+ * Working-tree scan entry — invoked by the aka-scan skill:
+ *
+ *   node scripts/filescan.js [--dir <path>]
+ *   node scripts/filescan.js --discover [--root <path>] [--depth <n>]
+ *
+ * Without flags: scans the current directory (or --dir path).
+ * With --discover: scans all git repos found under --root (default: the
+ * CURRENT directory — never the home directory implicitly; a machine-wide
+ * sweep requires an explicit `--root ~`, and the aka-scan skill requires user
+ * confirmation first).
+ *
+ * Rendering lives in @akasecurity/scanner (host-neutral); this entry
+ * owns only what is Codex-specific: flag parsing, the findings hint,
+ * and the Markdown code fence.
+ * Fail-open: any error prints a friendly note and exits 0 so the command
+ * never surfaces a stack trace.
+ */
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import {
+  renderMultiRepoSummary,
+  renderWorktreeSummary,
+  scanAllRepos,
+  scanWorktree,
+} from '@akasecurity/scanner';
+
+import { fenced } from './present.ts';
+
+interface Flags {
+  dir: string | undefined;
+  discover: boolean;
+  root: string | undefined;
+  depth: number | undefined;
+}
+
+function valueFlag(argv: string[], flag: string): string | undefined {
+  const idx = argv.indexOf(flag);
+  let value: string | undefined;
+  if (idx !== -1 && argv[idx + 1]) value = argv[idx + 1];
+  const prefixed = argv.find((a) => a.startsWith(`${flag}=`));
+  if (prefixed) value = prefixed.slice(flag.length + 1);
+  return value;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const dir = valueFlag(argv, '--dir');
+  const root = valueFlag(argv, '--root');
+  const depthRaw = valueFlag(argv, '--depth');
+  const depth = depthRaw !== undefined ? Number.parseInt(depthRaw, 10) : undefined;
+  const discover = argv.includes('--discover');
+  return {
+    dir,
+    discover,
+    root,
+    depth: depth !== undefined && Number.isFinite(depth) && depth > 0 ? depth : undefined,
+  };
+}
+
+// The follow-up hint is host-specific (points at the aka-findings skill), so
+// it is injected here rather than baked into the shared renderer.
+const FOLLOW_UP = 'Run the aka-findings skill to review details.';
+
+try {
+  const { dir, discover, root, depth } = parseFlags(process.argv.slice(2));
+  const cfg = loadConfig();
+
+  if (discover) {
+    // Never the home directory implicitly: --discover without --root sweeps
+    // the current directory. `--root ~` is the explicit machine-wide opt-in.
+    const summary = await scanAllRepos(cfg, {
+      sourceTool: 'codex',
+      searchRoots: [root ?? process.cwd()],
+      ...(depth !== undefined ? { maxDepth: depth } : {}),
+    });
+    process.stdout.write(`${fenced(renderMultiRepoSummary(summary, { followUp: FOLLOW_UP }))}\n`);
+  } else {
+    const summary = await scanWorktree(cfg, {
+      sourceTool: 'codex',
+      ...(dir !== undefined ? { rootDir: dir } : {}),
+    });
+    process.stdout.write(`${fenced(renderWorktreeSummary(summary, { followUp: FOLLOW_UP }))}\n`);
+  }
+} catch {
+  process.stdout.write(
+    'AKA could not complete the worktree scan. The live hooks will still protect your session.\n',
+  );
+}
+
+process.exit(0);

--- a/plugins/codex/src/firstrun-core.ts
+++ b/plugins/codex/src/firstrun-core.ts
@@ -1,0 +1,150 @@
+/**
+ * The first-run screen's testable core — the dependency-injected orchestration
+ * behind the thin firstrun.ts entry (the install-complete screen of the
+ * aka-setup wizard).
+ *
+ * Renders the install-complete card AND emits the handoff-offer payload
+ * as a structured JSON block alongside it. All IO (gateway reads, posture read,
+ * stdout) is injected so this is unit-testable with a seeded gateway; firstrun.ts
+ * wires the real implementations.
+ *
+ * The handoff payload's 'M worth a look' count is the surfaced/important count
+ * from the calibration preview (`counts.important`), threaded in via
+ * `--surfaced`. It is NOT the whole-store finding total: a suppressed finding
+ * stays in the store (its FP suppression is a temporary exception, not a
+ * deletion), so the total over-counts the surfaced items. When no count is
+ * supplied (no scan ran), the payload is omitted rather than fabricated.
+ *
+ * The narrower surfaced live-key secret count arrives via `--live-keys` and gates
+ * the remediation chain-entry: it is a subset of `--surfaced`, so a scan that
+ * surfaced only non-secret findings carries a positive `--surfaced` with
+ * `--live-keys` 0 and offers no remediation. Absent flag ⇒ 0.
+ */
+import type { DataGateway } from '@akasecurity/plugin-sdk';
+
+import { fenced, show } from './present.ts';
+import {
+  buildHandoffOffer,
+  buildRecommendations,
+  healthScore,
+  renderFirstRun,
+  STORE_UNAVAILABLE_NOTE,
+  topFindings,
+} from './render.ts';
+import { frameJsonBlock } from './setup-frame-json.ts';
+import { readRegisteredSkills } from './skills-registry.ts';
+
+// The surfaced/important count for the handoff payload, parsed from
+// `--surfaced <n>`. Returns a non-negative integer, or undefined when the flag
+// is absent or malformed — the caller then omits the handoff payload instead of
+// fabricating a count. This is the same value the calibration preview emitted as
+// `counts.important`; the wizard orchestration reads it there and passes it here.
+export function parseSurfacedCount(argv: readonly string[]): number | undefined {
+  return parseNonNegativeFlag(argv, '--surfaced');
+}
+
+// The surfaced live-key secret count for the remediation chain-entry gate, parsed
+// from `--live-keys <n>`. A subset of `--surfaced` — the flag is absent (⇒ 0)
+// whenever no live-key secret surfaced, so the plain dashboard handoff stands.
+export function parseLiveKeyCount(argv: readonly string[]): number {
+  return parseNonNegativeFlag(argv, '--live-keys') ?? 0;
+}
+
+// Read a `<flag> <n>` non-negative integer from argv, or undefined when the flag
+// is absent or its value is malformed.
+function parseNonNegativeFlag(argv: readonly string[], flag: string): number | undefined {
+  const i = argv.indexOf(flag);
+  if (i === -1) return undefined;
+  const raw = argv[i + 1];
+  if (raw === undefined) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : undefined;
+}
+
+export interface FirstRunDeps {
+  argv: readonly string[];
+  gateway: DataGateway;
+  // Per-category posture block for the card. Injected (rather than opening the
+  // store here) so the emission seam is unit-testable; readPostureBlock owns its
+  // own catch and degrades to '' so a policies-read fault only hides the Posture
+  // section rather than collapsing into the outer fail-open note.
+  readPosture: () => Promise<string>;
+  stdout: (s: string) => void;
+}
+
+// Emit the first-run card and, alongside it, the handoff-offer payload.
+// Reads only; never closes the gateway (the caller owns its lifecycle). Throws on
+// a store-read failure so the entry's fail-open catch can substitute its note.
+export async function runFirstRun(deps: FirstRunDeps): Promise<void> {
+  const [summary, findings] = await Promise.all([
+    deps.gateway.healthSummary(),
+    deps.gateway.recentFindings({ limit: 500 }),
+  ]);
+  // "Recommendations" mirrors the aka-recommend skill exactly — the same
+  // builder + cap — so the card's count never disagrees with what that screen
+  // lists.
+  const recommendations = buildRecommendations(findings).length;
+
+  // Per-category posture — the wizard's policy write, read straight from the
+  // local store so the card shows what's actually enforced, not the single
+  // settings.policy string.
+  const postureBlock = await deps.readPosture();
+
+  // The surfaced/important count from the calibration preview (a real preview value) drives
+  // both the visible 'N worth a look' handoff line and the structured offer
+  // payload below; when no scan supplied one, both are omitted, never fabricated.
+  const surfaced = parseSurfacedCount(deps.argv);
+  // The narrower live-key secret count gates the remediation chain-entry below,
+  // independent of the all-category `surfaced` display count.
+  const liveKeys = parseLiveKeyCount(deps.argv);
+
+  // The installed skill registry, resolved at this I/O boundary and threaded
+  // into the pure renderer so the Try line's curated set is validated against the
+  // skills the plugin actually registers.
+  const registry = readRegisteredSkills();
+
+  deps.stdout(
+    show(
+      fenced(
+        renderFirstRun(
+          {
+            // A surfaced count means a scan ran and carried a real preview value
+            // through setup — the same signal that gates the handoff payload
+            // below. Its absence means the floor fallback ran instead.
+            calibration: surfaced !== undefined ? 'scan' : 'floor',
+            posture: postureBlock,
+            health: healthScore(summary),
+            // The card's "Findings N" stat is the whole-store total — correct here.
+            findings: summary.findings,
+            recommendations,
+            // Only threaded when a scan supplied a count — never as an explicit
+            // undefined (exactOptionalPropertyTypes), so the card omits the handoff
+            // line rather than fabricating a zero.
+            ...(surfaced !== undefined ? { worthALook: surfaced } : {}),
+            topFindings: topFindings(findings),
+          },
+          registry,
+        ),
+      ),
+    ),
+  );
+
+  // The handoff-offer payload, emitted ALONGSIDE the card above so a
+  // harness (and the model layer) can read the structured offer without
+  // observing the question the prompt layer asks.
+  if (surfaced !== undefined) {
+    deps.stdout(frameJsonBlock(buildHandoffOffer(surfaced, liveKeys)));
+  }
+}
+
+// Fail-open wrapper around runFirstRun: on a store-read failure it degrades to the
+// honest store-unavailable note instead of throwing, so no error escapes to break
+// the Codex session. The thin firstrun.ts entry delegates its catch here so the
+// degradation is unit-tested rather than living in untestable glue.
+export async function runFirstRunFailOpen(deps: FirstRunDeps): Promise<void> {
+  try {
+    await runFirstRun(deps);
+  } catch {
+    deps.stdout(show(STORE_UNAVAILABLE_NOTE));
+  }
+}

--- a/plugins/codex/src/firstrun.ts
+++ b/plugins/codex/src/firstrun.ts
@@ -1,58 +1,50 @@
 /**
  * First-run screen — the install-complete frame of the aka-setup wizard.
+ * UNTESTABLE GLUE only: it wires real IO (config, data gateway, posture store,
+ * stdout) into the dependency-injected core in ./firstrun-core.ts, which holds
+ * the logic (and its tests).
  *
- *   node scripts/firstrun.js
+ *   node scripts/firstrun.js [--surfaced <n>] [--live-keys <n>]
  *
- * Handling (from settings), findings (real count) and recommendations (same
+ * Posture (per-category policy), findings (real count) and recommendations (same
  * count the aka-recommend skill renders) are read live; the Health score is
  * derived (see render.healthScore — a documented heuristic, not stored data).
  * Resolves the same data gateway the read commands use, so the numbers match
  * what aka-health and aka-findings show. Rendering lives in ./render.
  *
+ * `--surfaced <n>` is the surfaced/important count from the calibration preview,
+ * threaded through by the wizard orchestration into the handoff-offer payload —
+ * see ./firstrun-core.ts. `--live-keys <n>` is the narrower surfaced live-key
+ * secret count that gates the remediation chain-entry offer.
+ *
  * Fail-open: an unreadable store prints a friendly note.
  */
+import { openLocalDatabase } from '@akasecurity/persistence';
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
 import { loadConfig } from '@akasecurity/plugin-sdk';
 
-import { fenced } from './present.ts';
-import { buildRecommendations, healthScore, renderFirstRun, topFindings } from './render.ts';
-
-const HANDLING: Record<string, string> = {
-  redact: 'Active redaction enabled',
-  warn: 'Warn-only enabled',
-};
-// The read surfaces this build registers.
-const COMMANDS = ['aka-health', 'aka-recommend', 'aka-findings', 'aka-audit'];
+import { runFirstRunFailOpen } from './firstrun-core.ts';
+import { readPostureBlock } from './posture.ts';
+import { show } from './present.ts';
+import { STORE_UNAVAILABLE_NOTE } from './render.ts';
 
 try {
   const cfg = loadConfig();
   const gateway = resolveDataGateway(cfg);
   try {
-    const [summary, findings] = await Promise.all([
-      gateway.healthSummary(),
-      gateway.recentFindings({ limit: 500 }),
-    ]);
-    // "Recommendations" mirrors aka-recommend exactly — the same builder + cap
-    // — so the card's count never disagrees with what that screen lists.
-    const recommendations = buildRecommendations(findings).length;
-
-    process.stdout.write(
-      `${fenced(
-        renderFirstRun({
-          commands: COMMANDS,
-          handling: HANDLING[cfg.settings.policy] ?? cfg.settings.policy,
-          health: healthScore(summary),
-          findings: summary.findings,
-          recommendations,
-          topFindings: topFindings(findings),
-        }),
-      )}\n`,
-    );
+    await runFirstRunFailOpen({
+      argv: process.argv.slice(2),
+      gateway,
+      readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
+      stdout: (s) => process.stdout.write(s),
+    });
   } finally {
     await gateway.close();
   }
 } catch {
-  process.stdout.write('AKA could not read your data yet. It populates as you use Codex.\n');
+  // Config/gateway-resolution/close faults land here; the store-read failure inside
+  // runFirstRunFailOpen already degraded to the same note above.
+  process.stdout.write(show(STORE_UNAVAILABLE_NOTE));
 }
 
 process.exit(0);

--- a/plugins/codex/src/firstrun.ts
+++ b/plugins/codex/src/firstrun.ts
@@ -1,0 +1,58 @@
+/**
+ * First-run screen — the install-complete frame of the aka-setup wizard.
+ *
+ *   node scripts/firstrun.js
+ *
+ * Handling (from settings), findings (real count) and recommendations (same
+ * count the aka-recommend skill renders) are read live; the Health score is
+ * derived (see render.healthScore — a documented heuristic, not stored data).
+ * Resolves the same data gateway the read commands use, so the numbers match
+ * what aka-health and aka-findings show. Rendering lives in ./render.
+ *
+ * Fail-open: an unreadable store prints a friendly note.
+ */
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+
+import { fenced } from './present.ts';
+import { buildRecommendations, healthScore, renderFirstRun, topFindings } from './render.ts';
+
+const HANDLING: Record<string, string> = {
+  redact: 'Active redaction enabled',
+  warn: 'Warn-only enabled',
+};
+// The read surfaces this build registers.
+const COMMANDS = ['aka-health', 'aka-recommend', 'aka-findings', 'aka-audit'];
+
+try {
+  const cfg = loadConfig();
+  const gateway = resolveDataGateway(cfg);
+  try {
+    const [summary, findings] = await Promise.all([
+      gateway.healthSummary(),
+      gateway.recentFindings({ limit: 500 }),
+    ]);
+    // "Recommendations" mirrors aka-recommend exactly — the same builder + cap
+    // — so the card's count never disagrees with what that screen lists.
+    const recommendations = buildRecommendations(findings).length;
+
+    process.stdout.write(
+      `${fenced(
+        renderFirstRun({
+          commands: COMMANDS,
+          handling: HANDLING[cfg.settings.policy] ?? cfg.settings.policy,
+          health: healthScore(summary),
+          findings: summary.findings,
+          recommendations,
+          topFindings: topFindings(findings),
+        }),
+      )}\n`,
+    );
+  } finally {
+    await gateway.close();
+  }
+} catch {
+  process.stdout.write('AKA could not read your data yet. It populates as you use Codex.\n');
+}
+
+process.exit(0);

--- a/plugins/codex/src/history/reconcile-trigger.ts
+++ b/plugins/codex/src/history/reconcile-trigger.ts
@@ -1,0 +1,50 @@
+// Throttled, detached spawn of the token-usage reconcile worker. Identical to
+// plugins/claude-code/src/history/reconcile-trigger.ts — no harness-specific
+// logic here.
+//
+// Detached + unref + on-disk min-gap marker so the hook never waits on it. It
+// passes the session id + transcript path through to the worker via argv, so the
+// Stop hook never reconstructs a path — it forwards exactly what the Stop payload
+// handed it.
+//
+// Fully fail-open: the hook NEVER waits on or is broken by the reconcile. The child
+// outlives this process (detached + unref); a spawn failure is swallowed and the
+// next Stop (or the SessionStart catch-up) recovers the tail idempotently.
+import { spawn } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { throttled } from '@akasecurity/plugin-sdk';
+
+import { safeSessionId } from './tail.ts';
+
+// Min gap between reconcile spawns. Stop fires once per turn; batching a few turns
+// into one tail pass is lossless (the offset read is cumulative), so
+// this window is purely a freshness-vs-cost knob, not a correctness one.
+const RECONCILE_THROTTLE_MS = 30_000;
+
+// Marker-file PREFIX for the reconcile throttle, namespaced PER SESSION — see
+// the Claude Code sibling module for the full rationale.
+const RECONCILE_MARKER_PREFIX = 'reconcile-last-attempt';
+
+/**
+ * Trigger a background reconcile of one session's transcript tail. Throttle-checks
+ * first; if not throttled, spawns `reconcile.js` DETACHED + unref, forwarding the
+ * session id and transcript path as argv. Returns immediately — the hook adds no
+ * latency. `reconcile.js` is resolved next to this module so the bundled hook
+ * script finds its compiled sibling in `scripts/`.
+ */
+export function triggerReconcile(dataDir: string, sessionId: string, transcriptPath: string): void {
+  try {
+    const marker = `${RECONCILE_MARKER_PREFIX}-${safeSessionId(sessionId)}`;
+    if (throttled(dataDir, marker, RECONCILE_THROTTLE_MS)) return;
+    const here = dirname(fileURLToPath(import.meta.url));
+    const child = spawn(process.execPath, [join(here, 'reconcile.js'), sessionId, transcriptPath], {
+      detached: true,
+      stdio: 'ignore',
+    });
+    child.unref();
+  } catch {
+    // Fail-open: the next Stop or the SessionStart catch-up recovers the tail.
+  }
+}

--- a/plugins/codex/src/history/scan.ts
+++ b/plugins/codex/src/history/scan.ts
@@ -1,0 +1,74 @@
+// Historical backfill: when the user granted "full" review at onboarding, sweep
+// their prior Codex CLI rollout files for secrets that leaked BEFORE AKA was
+// installed (the live hooks cover everything after). Format-agnostic — the
+// Codex rollout shape lives in ./transcripts; here we just feed each message
+// through the same SDK detect→mask→record path the hooks use, so a backfilled
+// finding is indistinguishable from a live one. Identical to
+// plugins/claude-code/src/history/scan.ts except sourceTool.
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import { contentHashOf, createPluginRuntime } from '@akasecurity/plugin-sdk';
+
+import { type HistoryWalkOptions, iterateHistory } from './transcripts.ts';
+
+export interface ScanSummary {
+  consented: boolean;
+  scanned: number;
+  skipped: number;
+  findings: number;
+  bySeverity: Record<string, number>;
+  windowDays: number;
+}
+
+// Scan the host's rollout history and record any findings into the same local
+// store the read surfaces query. Gated on consent; reuses ONE gateway +
+// runtime for the whole sweep and persists only messages that actually leaked
+// (`with-findings`) so a benign 30-day history doesn't flood the store.
+//
+// Idempotent: messages whose content is already recorded (a prior scan, or a
+// live capture) are skipped, so the setup skill can re-run the scan any number
+// of times without ever duplicating findings. A cleared store re-scans in full.
+export async function scanHistory(
+  config: PluginConfig,
+  opts: HistoryWalkOptions = {},
+): Promise<ScanSummary> {
+  const windowDays = opts.windowDays ?? 30;
+  if (config.settings.historicalAccess !== 'full') {
+    return { consented: false, scanned: 0, skipped: 0, findings: 0, bySeverity: {}, windowDays };
+  }
+
+  const gateway = resolveDataGateway(config);
+  const runtime = createPluginRuntime(gateway, config.settings, { dataDir: config.dataDir });
+  const bySeverity: Record<string, number> = {};
+  let scanned = 0;
+  let skipped = 0;
+  let findings = 0;
+  try {
+    const seen = await gateway.knownContentHashes();
+    for (const message of iterateHistory(opts)) {
+      const hash = contentHashOf(message.text);
+      if (seen.has(hash)) {
+        skipped++;
+        continue;
+      }
+      seen.add(hash);
+      scanned++;
+      const result = await runtime.capture(
+        {
+          kind: message.kind,
+          sourceTool: 'codex',
+          text: message.text,
+          occurredAt: message.occurredAt,
+        },
+        { persist: 'with-findings', dedupe: 'content-hash' },
+      );
+      for (const finding of result.findings) {
+        findings++;
+        bySeverity[finding.severity] = (bySeverity[finding.severity] ?? 0) + 1;
+      }
+    }
+  } finally {
+    await runtime.close();
+  }
+  return { consented: true, scanned, skipped, findings, bySeverity, windowDays };
+}

--- a/plugins/codex/src/history/scan.ts
+++ b/plugins/codex/src/history/scan.ts
@@ -6,18 +6,94 @@
 // finding is indistinguishable from a live one. Identical to
 // plugins/claude-code/src/history/scan.ts except sourceTool.
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
-import type { PluginConfig } from '@akasecurity/plugin-sdk';
-import { contentHashOf, createPluginRuntime } from '@akasecurity/plugin-sdk';
+import type { EgressHit, PluginConfig } from '@akasecurity/plugin-sdk';
+import {
+  contentHashOf,
+  createPluginRuntime,
+  maskContextSlice,
+  safeMaskedMatch,
+} from '@akasecurity/plugin-sdk';
+import type { DetectionCategory, Severity, Span, TriageHit } from '@akasecurity/schema';
 
 import { type HistoryWalkOptions, iterateHistory } from './transcripts.ts';
 
 export interface ScanSummary {
+  // false when historicalAccess !== 'full' — the scan is a no-op without consent.
   consented: boolean;
-  scanned: number;
-  skipped: number;
-  findings: number;
+  scanned: number; // messages examined this run
+  skipped: number; // messages already recorded (deduped) — not re-scanned
+  findings: number; // findings recorded this run
   bySeverity: Record<string, number>;
   windowDays: number;
+}
+
+// ±chars of surrounding text captured around a match span for the triage sink.
+const CONTEXT_RADIUS = 120;
+
+// Redact every OTHER finding's raw value that overlaps this context window.
+// The normal (span-based) path leaves the current finding's own match
+// legible, since it masks only the other findings' precise character ranges.
+// The fallback below is a blunt string-level redaction used only if the
+// guarded mask can't verify full removal — scanning a user's history must
+// never throw on a pathological input — and, unlike the normal path, it
+// cannot tell the current finding's own match apart from an identical raw
+// value belonging to another finding, so it may redact both; that is a safe
+// (over-redaction) failure mode, never a leak.
+function redactOverlapping(
+  rawContext: string,
+  contextStart: number,
+  others: readonly EgressHit[],
+): string {
+  if (others.length === 0) return rawContext;
+  try {
+    return maskContextSlice(rawContext, contextStart, others);
+  } catch {
+    let safe = rawContext;
+    for (const other of others) {
+      if (other.rawMatch.length > 0) safe = safe.split(other.rawMatch).join('[REDACTED]');
+    }
+    return safe;
+  }
+}
+
+// Build the transient triage hit for one finding. f is a structural subset of
+// @akasecurity/detections's MatchResult, so this module never imports
+// @akasecurity/detections directly. The returned TriageHit's `rawMatch` and
+// `context` carry unmasked text by design (see @akasecurity/schema's TriageHit
+// doc) — it is never persisted here, only handed to scanHistory's onHit sink.
+// `otherFindings` are the message's other findings (if any); any of their raw
+// values that fall inside this hit's context window are redacted, so a single
+// hit never exposes a second, unrelated secret through its context. `filePath`
+// is the rollout file this text came from, carried through so a surfaced
+// finding can later be located and struck in place; omitted when the source
+// path is unknown (an empty string means the same as absent).
+export function buildTriageHit(
+  text: string,
+  f: {
+    ruleId: string;
+    category: DetectionCategory;
+    severity: Severity;
+    rawMatch: string;
+    span: Span;
+    confidence: number;
+  },
+  otherFindings: readonly { rawMatch: string; span: Span }[] = [],
+  filePath = '',
+): TriageHit {
+  const start = Math.max(0, f.span.start - CONTEXT_RADIUS);
+  const end = Math.min(text.length, f.span.end + CONTEXT_RADIUS);
+  const rawContext = text.slice(start, end);
+  const overlapping = otherFindings.filter((o) => o.span.start < end && o.span.end > start);
+  return {
+    ruleId: f.ruleId,
+    category: f.category,
+    severity: f.severity,
+    maskedMatch: safeMaskedMatch(f.rawMatch),
+    rawMatch: f.rawMatch,
+    context: redactOverlapping(rawContext, start, overlapping),
+    confidence: f.confidence,
+    ...(filePath !== '' ? { filePath } : {}),
+  };
 }
 
 // Scan the host's rollout history and record any findings into the same local
@@ -28,9 +104,20 @@ export interface ScanSummary {
 // Idempotent: messages whose content is already recorded (a prior scan, or a
 // live capture) are skipped, so the setup skill can re-run the scan any number
 // of times without ever duplicating findings. A cleared store re-scans in full.
+//
+// `onHit`, when given, receives one TriageHit per finding as it is scanned —
+// a transient, in-process stream for a same-process consumer (e.g. a triage
+// judge) to read. Its `rawMatch` and its own match inside `context` are
+// unmasked by design (see @akasecurity/schema's TriageHit); any OTHER
+// finding's raw value that happens to fall inside the same context window is
+// already redacted before the hit is emitted. A consumer must still run
+// `rawMatch`/`context` through the @akasecurity/plugin-sdk raw-egress
+// guardrails (`assertRawFree` / `maskContextSlice`) before either crosses out
+// to a log, a rendered surface, or a persisted row.
 export async function scanHistory(
   config: PluginConfig,
   opts: HistoryWalkOptions = {},
+  onHit?: (hit: TriageHit) => void,
 ): Promise<ScanSummary> {
   const windowDays = opts.windowDays ?? 30;
   if (config.settings.historicalAccess !== 'full') {
@@ -44,6 +131,8 @@ export async function scanHistory(
   let skipped = 0;
   let findings = 0;
   try {
+    // Hashes already in the store (and we add each one we record, so duplicate
+    // messages within this same run dedup too).
     const seen = await gateway.knownContentHashes();
     for (const message of iterateHistory(opts)) {
       const hash = contentHashOf(message.text);
@@ -60,11 +149,28 @@ export async function scanHistory(
           text: message.text,
           occurredAt: message.occurredAt,
         },
+        // 'content-hash': a backfill re-run would otherwise re-record identical
+        // messages under fresh event ids — the gateway uses the hash to drop
+        // what it already recorded.
         { persist: 'with-findings', dedupe: 'content-hash' },
       );
       for (const finding of result.findings) {
         findings++;
         bySeverity[finding.severity] = (bySeverity[finding.severity] ?? 0) + 1;
+        if (onHit) {
+          const otherFindings = result.findings.filter((other) => other !== finding);
+          const hit = buildTriageHit(message.text, finding, otherFindings, message.filePath);
+          try {
+            // onHit is a synchronous void callback (see its parameter type on
+            // scanHistory below) — this try/catch guards a synchronous throw
+            // only. A caller must not pass an async function here; an
+            // unhandled rejection from one would not be caught by this block.
+            onHit(hit);
+          } catch {
+            // A misbehaving onHit sink must not abort the rest of the sweep —
+            // this scan is fail-open like every other plugin surface.
+          }
+        }
       }
     }
   } finally {

--- a/plugins/codex/src/history/tail.ts
+++ b/plugins/codex/src/history/tail.ts
@@ -1,0 +1,167 @@
+// Incremental per-session transcript tail reader for the live Stop-hook reconcile.
+// Identical to plugins/claude-code/src/history/tail.ts — purely a byte-offset
+// fs reader with no knowledge of the transcript's own record format, so it
+// needs no Codex-specific changes.
+//
+// A whole-file re-read on every turn would be wasteful and (more
+// importantly for the partial/final split) re-parse already-consumed records; the
+// tail reader instead consumes ONLY the bytes appended since the last pass, tracked
+// by a per-session byte offset persisted beside the transcript marker.
+//
+// Two correctness rules baked in here:
+//   1. NEVER consume a half-written final line. We read from the stored offset to
+//      EOF but cut at the LAST NEWLINE — the bytes after it are an in-flight record
+//      that Codex is still writing; the rest arrives next pass. The advanced
+//      offset therefore points exactly at the byte after the last complete line.
+//   2. Handle truncation/rotation: if the file is now SMALLER than the stored
+//      offset, the session file was replaced — reset to 0 and re-read from the top.
+//      The UPSERT-take-MAX / INSERT-OR-IGNORE writes make the re-read a safe no-op.
+//
+// The offset marker also carries `lastPromptId` (Codex: the last seen turn_id),
+// the run_key carry-forward across tail boundaries: a tail whose parent
+// context was consumed in a prior pass still attributes its run_key from this seed.
+import { createHash } from 'node:crypto';
+import {
+  closeSync,
+  fstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+import { DATA_DIR_MODE, DATA_FILE_MODE } from '@akasecurity/plugin-sdk';
+
+// Per-session reconcile checkpoint, persisted as JSON at
+// `<dataDir>/usage-offsets/<sessionId>`. `offset` is the byte position one past the
+// last COMPLETE line consumed; `lastPromptId` seeds the next pass's run_key.
+export interface UsageOffset {
+  offset: number;
+  lastPromptId?: string | undefined;
+}
+
+// The directory holding per-session offset markers.
+function offsetsDir(dataDir: string): string {
+  return join(dataDir, 'usage-offsets');
+}
+
+// Filename-safe characters only — no path separators, no expansion room for a
+// hostile id to name anything outside its directory.
+const SAFE_SESSION_ID = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Filesystem-safe form of a hook-supplied session id, for embedding in paths
+ * under the data dir (offset markers, throttle markers). The id arrives on
+ * hook stdin, so treat it as untrusted input even though the harness generates
+ * it: an id that is not a plain filename token (or that names a directory
+ * entry like `.`/`..`) is replaced by its SHA-256 hex — deterministic, so the
+ * same session still converges on one marker, and never escapes the directory
+ * it is joined into.
+ */
+export function safeSessionId(sessionId: string): string {
+  if (SAFE_SESSION_ID.test(sessionId) && sessionId !== '.' && sessionId !== '..') {
+    return sessionId;
+  }
+  return createHash('sha256').update(sessionId).digest('hex');
+}
+
+function offsetPath(dataDir: string, sessionId: string): string {
+  return join(offsetsDir(dataDir), safeSessionId(sessionId));
+}
+
+// Read a session's persisted checkpoint. Fail-open: a missing/corrupt/unreadable
+// marker is treated as a fresh start (offset 0, no seed) so a bad marker can never
+// break reconcile — at worst it re-reads from the top, which the idempotent writes
+// absorb. A non-finite/negative stored offset is also normalized to 0.
+export function readOffset(dataDir: string, sessionId: string): UsageOffset {
+  try {
+    const raw = readFileSync(offsetPath(dataDir, sessionId), 'utf8');
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'object' && parsed !== null) {
+      const rec = parsed as Record<string, unknown>;
+      const offset =
+        typeof rec.offset === 'number' && Number.isFinite(rec.offset) && rec.offset >= 0
+          ? rec.offset
+          : 0;
+      const lastPromptId = typeof rec.lastPromptId === 'string' ? rec.lastPromptId : undefined;
+      return lastPromptId !== undefined ? { offset, lastPromptId } : { offset };
+    }
+  } catch {
+    // No marker yet, or unreadable/corrupt → start from the top.
+  }
+  return { offset: 0 };
+}
+
+// Persist a session's checkpoint (best-effort; a write failure just means the next
+// pass re-reads from the prior offset — idempotent, never lost).
+export function writeOffset(dataDir: string, sessionId: string, value: UsageOffset): void {
+  try {
+    mkdirSync(offsetsDir(dataDir), { recursive: true, mode: DATA_DIR_MODE });
+    const payload: UsageOffset =
+      value.lastPromptId !== undefined
+        ? { offset: value.offset, lastPromptId: value.lastPromptId }
+        : { offset: value.offset };
+    writeFileSync(offsetPath(dataDir, sessionId), JSON.stringify(payload), {
+      mode: DATA_FILE_MODE,
+    });
+  } catch {
+    // Best-effort: an unwritable marker just re-reads the same tail next pass.
+  }
+}
+
+// Result of reading a transcript's new tail.
+export interface TailRead {
+  // The newly-consumed chunk (complete lines only). Empty when nothing new — or only
+  // a half-written final line — is available.
+  chunk: string;
+  // The byte offset one past the last COMPLETE line — persist this as the next start.
+  nextOffset: number;
+}
+
+// Read the new tail of `transcriptPath` starting at `startOffset`, consuming up to
+// (and including) the LAST NEWLINE only. Returns the consumed chunk and the advanced
+// offset. Handles truncation/rotation by resetting to 0 when the file shrank below
+// the stored offset. Fully fail-open: an unreadable/missing file yields an empty
+// chunk and the unchanged offset (nothing consumed), so the next pass retries.
+export function readTail(transcriptPath: string, startOffset: number): TailRead {
+  let fd: number;
+  try {
+    fd = openSync(transcriptPath, 'r');
+  } catch {
+    return { chunk: '', nextOffset: startOffset };
+  }
+  try {
+    const size = fstatSync(fd).size;
+
+    // Truncated/rotated: the file is smaller than where we left off → re-read from 0.
+    const from = size < startOffset ? 0 : startOffset;
+    if (from >= size) return { chunk: '', nextOffset: from }; // nothing new
+
+    const length = size - from;
+    const buf = Buffer.allocUnsafe(length);
+    let filled = 0;
+    while (filled < length) {
+      const bytesRead = readSync(fd, buf, filled, length - filled, from + filled);
+      if (bytesRead === 0) break;
+      filled += bytesRead;
+    }
+
+    const slice = buf.subarray(0, filled);
+    const lastNl = slice.lastIndexOf(0x0a);
+    if (lastNl === -1) return { chunk: '', nextOffset: from };
+
+    const consumedBytes = lastNl + 1; // include the newline
+    const chunk = slice.subarray(0, consumedBytes).toString('utf8');
+    return { chunk, nextOffset: from + consumedBytes };
+  } catch {
+    return { chunk: '', nextOffset: startOffset };
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      // fd already invalid — nothing to release.
+    }
+  }
+}

--- a/plugins/codex/src/history/transcripts.ts
+++ b/plugins/codex/src/history/transcripts.ts
@@ -30,11 +30,14 @@ import type { EventKind } from '@akasecurity/schema';
 
 // One scannable unit pulled from a transcript. `occurredAt` is the record's own
 // ISO timestamp so a recorded finding lands on the timeline when it really
-// leaked, not at scan time.
+// leaked, not at scan time. `filePath` is the rollout file this text came from
+// ('' when parsed from an in-memory string), carried through so a surfaced
+// finding can later be located and struck in place.
 export interface ScannedMessage {
   kind: EventKind; // 'prompt' (a user turn) | 'response' (an assistant reply)
   text: string;
   occurredAt: string;
+  filePath: string;
 }
 
 // Where Codex CLI writes its rollout files. Codex itself honors a CODEX_HOME
@@ -73,10 +76,17 @@ function extractContentText(content: unknown): string {
 }
 
 // Parse one rollout file's contents (newline-delimited JSON) for prompt/response
-// text. `sinceMs` drops records older than the retention window. Malformed
-// lines are skipped, never thrown — a truncated/partial rollout must not abort
-// the scan.
-export function parseTranscript(jsonl: string, sinceMs = 0): ScannedMessage[] {
+// text. `sinceMs` drops records older than the retention window; `beforeMs`
+// (when set) is an UPPER bound that drops records at/after it — the setup-start
+// cutoff, so the wizard's own (masked) output, written during onboarding, is
+// never fed back into the scan. Malformed lines are skipped, never thrown — a
+// truncated/partial rollout must not abort the scan.
+export function parseTranscript(
+  jsonl: string,
+  sinceMs = 0,
+  beforeMs = Infinity,
+  filePath = '',
+): ScannedMessage[] {
   const out: ScannedMessage[] = [];
   for (const line of jsonl.split('\n')) {
     const trimmed = line.trim();
@@ -94,6 +104,10 @@ export function parseTranscript(jsonl: string, sinceMs = 0): ScannedMessage[] {
     const occurredMs = Date.parse(occurredAt);
     if (Number.isNaN(occurredMs)) continue;
     if (sinceMs > 0 && occurredMs < sinceMs) continue;
+    // Setup-start upper bound: drop anything at/after the cutoff so a re-run
+    // backfill never re-scans post-install messages — the wizard's own masked
+    // output among them. Default Infinity keeps normal scans unbounded.
+    if (occurredMs >= beforeMs) continue;
 
     const payload = rec.payload;
     if (!isRecord(payload) || payload.type !== 'message') continue;
@@ -101,7 +115,7 @@ export function parseTranscript(jsonl: string, sinceMs = 0): ScannedMessage[] {
     if (role !== 'user' && role !== 'assistant') continue;
     const text = extractContentText(payload.content);
     if (text.trim() === '') continue;
-    out.push({ kind: role === 'user' ? 'prompt' : 'response', text, occurredAt });
+    out.push({ kind: role === 'user' ? 'prompt' : 'response', text, occurredAt, filePath });
   }
   return out;
 }
@@ -481,6 +495,10 @@ export interface HistoryWalkOptions {
   dir?: string; // override the transcripts root (tests)
   windowDays?: number; // retention window; default 30
   now?: number; // clock injection (tests); default Date.now()
+  // Self-contamination guard (secret-scan path only). OFF by default, so a
+  // normal user's full pre-install history is still scanned; it engages only
+  // for AKA's OWN setup session.
+  beforeMs?: number; // setup-start upper bound: drop messages at/after this ms
 }
 
 // Recursively collect rollout file paths under the year/month/day-sharded
@@ -509,12 +527,12 @@ function* walkJsonlFiles(dir: string, depth = 0): Generator<string> {
   }
 }
 
-function* iterateFileContents(dir: string): Generator<string> {
-  for (const file of walkJsonlFiles(dir)) {
+function* iterateFileContents(dir: string): Generator<{ content: string; filePath: string }> {
+  for (const filePath of walkJsonlFiles(dir)) {
     try {
       // Skip anything the walk can't stat (broken symlink) before the read.
-      statSync(file);
-      yield readFileSync(file, 'utf8');
+      statSync(filePath);
+      yield { content: readFileSync(filePath, 'utf8'), filePath };
     } catch {
       // Unreadable file — skip, same fail-open contract as the rest of the walk.
     }
@@ -528,15 +546,16 @@ function windowStartMs(opts: Pick<HistoryWalkOptions, 'windowDays' | 'now'>): nu
 
 export function* iterateHistory(opts: HistoryWalkOptions = {}): Generator<ScannedMessage> {
   const sinceMs = windowStartMs(opts);
-  for (const content of iterateFileContents(opts.dir ?? transcriptsDir()))
-    yield* parseTranscript(content, sinceMs);
+  const beforeMs = opts.beforeMs ?? Infinity;
+  for (const { content, filePath } of iterateFileContents(opts.dir ?? transcriptsDir()))
+    yield* parseTranscript(content, sinceMs, beforeMs, filePath);
 }
 
 export function* iterateUsage(
   opts: Pick<HistoryWalkOptions, 'dir' | 'windowDays' | 'now'> = {},
 ): Generator<UsageRecord> {
   const sinceMs = windowStartMs(opts);
-  for (const content of iterateFileContents(opts.dir ?? transcriptsDir()))
+  for (const { content } of iterateFileContents(opts.dir ?? transcriptsDir()))
     yield* parseTranscriptUsage(content, sinceMs);
 }
 
@@ -544,7 +563,7 @@ export function* iterateUsageAndToolCalls(
   opts: Pick<HistoryWalkOptions, 'dir' | 'windowDays' | 'now'> = {},
 ): Generator<{ usage: UsageRecord[]; toolCalls: ToolCallRecord[] }> {
   const sinceMs = windowStartMs(opts);
-  for (const content of iterateFileContents(opts.dir ?? transcriptsDir())) {
+  for (const { content } of iterateFileContents(opts.dir ?? transcriptsDir())) {
     yield {
       usage: parseTranscriptUsage(content, sinceMs),
       toolCalls: parseTranscriptToolCalls(content, sinceMs),

--- a/plugins/codex/src/history/transcripts.ts
+++ b/plugins/codex/src/history/transcripts.ts
@@ -1,0 +1,553 @@
+// Codex CLI transcript adapter: turn the host's `~/.codex/sessions/YYYY/MM/DD/
+// rollout-*.jsonl` session logs into the text-bearing messages worth scanning
+// for already-leaked secrets. This is the ONE place that knows the Codex
+// rollout line shape; the scan orchestrator (./scan.ts) stays format-agnostic
+// and reuses the SDK detect→record path — mirrors
+// plugins/claude-code/src/history/transcripts.ts, which plays the same role
+// for `~/.claude/projects/*/*.jsonl`.
+//
+// Field names below are taken from openai/codex's own wire types
+// (codex-rs/protocol/src/protocol.rs — RolloutLine/RolloutItem/EventMsg;
+// codex-rs/protocol/src/models.rs — ResponseItem/ContentItem), read directly
+// from the `openai/codex` repo (main branch) rather than guessed. Still worth
+// spot-checking against a live `codex` session before relying on this in
+// production — Codex's rollout schema is actively evolving (see the repo's own
+// "compatibility-only field" comments).
+//
+// Every rollout line has the shape:
+//   { "timestamp": "<ISO8601>", "ordinal"?: number, "type": "<tag>", "payload": {...} }
+// (`RolloutLine` flattens `RolloutItem`'s internally-tagged
+// `{type, payload}` onto itself.) We only care about three tags:
+//   - "session_meta"  → SessionMetaLine (session id, cwd, cli_version, once per file)
+//   - "response_item" → ResponseItem (message / function_call / tool output / …)
+//   - "event_msg"     → EventMsg (token_count, exec_command_begin/end, patch_apply_begin/end, …)
+import type { Dirent } from 'node:fs';
+import { closeSync, openSync, readdirSync, readFileSync, readSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import type { EventKind } from '@akasecurity/schema';
+
+// One scannable unit pulled from a transcript. `occurredAt` is the record's own
+// ISO timestamp so a recorded finding lands on the timeline when it really
+// leaked, not at scan time.
+export interface ScannedMessage {
+  kind: EventKind; // 'prompt' (a user turn) | 'response' (an assistant reply)
+  text: string;
+  occurredAt: string;
+}
+
+// Where Codex CLI writes its rollout files. Codex itself honors a CODEX_HOME
+// override, but this reader intentionally does not — matches
+// plugins/claude-code/src/history/transcripts.ts's transcriptsDir(), which
+// likewise reads no env override for ~/.claude (n/no-process-env stays on for
+// this package; CODEX_HOME support can be added later behind its own
+// file-scoped opt-out if it turns out to be needed).
+export function transcriptsDir(): string {
+  return join(homedir(), '.codex', 'sessions');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function optString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+// A `message` ResponseItem's `content` is an array of ContentItem: `input_text`
+// / `output_text` (both carry `text`) or `input_image` (carries `image_url`,
+// never text). We keep only the text-bearing kinds — mirrors Claude Code's
+// parser dropping `thinking`/`tool_use`/`image` blocks.
+function extractContentText(content: unknown): string {
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!isRecord(block)) continue;
+    if (block.type === 'input_text' || block.type === 'output_text') {
+      const text = optString(block.text);
+      if (text) parts.push(text);
+    }
+  }
+  return parts.join('\n');
+}
+
+// Parse one rollout file's contents (newline-delimited JSON) for prompt/response
+// text. `sinceMs` drops records older than the retention window. Malformed
+// lines are skipped, never thrown — a truncated/partial rollout must not abort
+// the scan.
+export function parseTranscript(jsonl: string, sinceMs = 0): ScannedMessage[] {
+  const out: ScannedMessage[] = [];
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let rec: unknown;
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!isRecord(rec)) continue;
+    if (rec.type !== 'response_item') continue;
+    const occurredAt = optString(rec.timestamp) ?? '';
+    if (occurredAt === '') continue;
+    const occurredMs = Date.parse(occurredAt);
+    if (Number.isNaN(occurredMs)) continue;
+    if (sinceMs > 0 && occurredMs < sinceMs) continue;
+
+    const payload = rec.payload;
+    if (!isRecord(payload) || payload.type !== 'message') continue;
+    const role = optString(payload.role);
+    if (role !== 'user' && role !== 'assistant') continue;
+    const text = extractContentText(payload.content);
+    if (text.trim() === '') continue;
+    out.push({ kind: role === 'user' ? 'prompt' : 'response', text, occurredAt });
+  }
+  return out;
+}
+
+// ───────────────────────────── usage (token) path ─────────────────────────────
+//
+// A SECOND, independent parse of the same rollout files, for the token-usage
+// reconciler. Codex reports usage per-turn via `event_msg`/`token_count`
+// (EventMsg::TokenCount → TokenCountEvent{ info: TokenUsageInfo, rate_limits }),
+// NOT per-assistant-message like Claude Code — there is no per-record
+// message.usage block to read. `TokenUsageInfo.last_token_usage` is the delta
+// since the PRIOR TokenCountEvent, so one TokenCountEvent already IS one
+// usage-bearing unit — no streaming-partial collapse needed (unlike Claude
+// Code's message.id collapse, which exists because Anthropic streams multiple
+// content-block records per API call).
+//
+// Codex also has no Claude-style linear uuid/parentUuid chain; `turn_id` is
+// the natural run_key equivalent, carried directly on most events.
+
+// The usage bag this parser surfaces, shaped to match the fields
+// `buildAttributes` in usage.ts already knows how to promote (input_tokens /
+// output_tokens / cache_read_input_tokens / …) — Codex's `cached_input_tokens`
+// is the closest analog to Claude's `cache_read_input_tokens` (Codex does not
+// distinguish cache creation from cache read), and `reasoning_output_tokens`
+// rides the bag as an extra field (already included in `output_tokens`
+// per Codex's own TokenUsage — kept here anyway so the raw fact isn't lost).
+export interface TranscriptUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  reasoning_output_tokens?: number;
+  [key: string]: unknown;
+}
+
+// One `event_msg`/`token_count` = one usage-bearing unit. `runKey` is the
+// nearest preceding turn_id (from a `turn_context` line or the event's own
+// `turn_id`, when Codex includes one on this event type — currently it does
+// not, so this is sourced from the most recent `turn_context` line seen in
+// file order, best-effort).
+export interface UsageEventRecord {
+  kind: 'usage';
+  sessionId: string;
+  // Synthetic key: TokenCountEvent carries no id of its own, so the key is
+  // (sessionId, occurredAt, ordinal-among-same-timestamp-records). Keying on
+  // the timestamp — not a per-parse ordinal — is what makes the key stable
+  // across parses that see different windows of the same file: the
+  // incremental tail path re-parses only the newly-appended chunk, and a
+  // per-parse ordinal would restart at 1 there, colliding every later turn's
+  // usage with the first turn's row. See parseTranscriptUsage.
+  eventKey: string;
+  model: string | undefined;
+  runKey: string | undefined;
+  usage: TranscriptUsage;
+  occurredAt: string;
+  cwd: string | undefined;
+  version: string | undefined; // cli_version, from session_meta
+  // Which client wrote this rollout — session_meta.originator, e.g.
+  // 'codex_cli_rs' (terminal), 'codex-tui', 'codex_exec' (non-interactive),
+  // 'codex_desktop' (the Codex mode inside the ChatGPT desktop app), or
+  // 'codex_vscode'. Same engine, same hooks/plugin system regardless of
+  // originator — this rides as a descriptive harnessInterface fact (see
+  // usage.ts's reconcileSession) so the dashboard can tell them apart
+  // without forking the harness/sourceTool dimension. See
+  // codex-rs/otel/src/metrics/tags.rs's KNOWN_ORIGINATOR_TAG_VALUES in
+  // openai/codex for the full known set.
+  originator: string | undefined;
+}
+
+export type UsageRecord = UsageEventRecord;
+
+function isZeroUsage(usage: TranscriptUsage): boolean {
+  const input = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const output = typeof usage.output_tokens === 'number' ? usage.output_tokens : 0;
+  const cacheRead =
+    typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
+  return input + output + cacheRead === 0;
+}
+
+// Parse one rollout file's contents into usage-relevant records. Threads a
+// running "current session/turn context" forward as it walks the file in
+// order (session_meta → sessionId/cwd/cli_version; turn_context → runKey/model),
+// so each token_count event is stamped with the context active at that point —
+// Codex writes these as separate lines rather than duplicating them onto every
+// event the way Claude Code's transcript does. `sinceMs` bounds the window like
+// the sibling parser; a record with a missing/unparseable timestamp is KEPT
+// (matches parseTranscript's "malformed timestamp still recorded" tolerance
+// being the exception, not the rule — here we simply skip it, since without a
+// timestamp there is no way to bound OR display it).
+//
+// `knownSessionId` seeds the running session id (still overridden by an
+// in-chunk `session_meta` line, if one is present). This matters for the
+// INCREMENTAL tail path (reconcileSessionTail): `session_meta` is a one-time
+// header written ONCE per rollout file, so any tail chunk read after the
+// offset has advanced past it contains no session_meta line at all — without
+// a seed, every usage/tool-call record in that chunk would be unattributable
+// and silently dropped. The whole-file backfill path doesn't need the seed
+// (session_meta is always the first line of a fresh parse), but passing it
+// there is harmless.
+export function parseTranscriptUsage(
+  jsonl: string,
+  sinceMs = 0,
+  knownSessionId?: string,
+): UsageRecord[] {
+  const out: UsageRecord[] = [];
+  let sessionId: string | undefined = knownSessionId;
+  let cwd: string | undefined;
+  let version: string | undefined;
+  let originator: string | undefined;
+  let runKey: string | undefined;
+  let model: string | undefined;
+  // Disambiguates multiple token_count records sharing one timestamp. Ticked
+  // for EVERY timestamped token_count line — including ones the sinceMs /
+  // zero-usage / malformed-payload filters drop below — so a record's number
+  // depends only on its position in the file, never on which filters applied
+  // to its neighbours in a given parse.
+  const perTimestamp = new Map<string, number>();
+
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let rec: unknown;
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!isRecord(rec)) continue;
+    const payload = rec.payload;
+    if (!isRecord(payload)) continue;
+
+    if (rec.type === 'session_meta') {
+      sessionId = optString(payload.session_id) ?? optString(payload.id);
+      cwd = optString(payload.cwd);
+      version = optString(payload.cli_version);
+      originator = optString(payload.originator);
+      continue;
+    }
+    if (rec.type === 'turn_context') {
+      // A turn_context line without a turn_id still marks a turn boundary.
+      // Falling back to the line's own timestamp keeps per-turn grouping
+      // stable across re-parses of the same file, and deliberately does NOT
+      // carry the previous turn's key forward (each turn_context resets it).
+      const turnTs = optString(rec.timestamp);
+      runKey = optString(payload.turn_id) ?? (turnTs !== undefined ? `turn-${turnTs}` : undefined);
+      model = optString(payload.model) ?? model;
+      const turnCwd = optString(payload.cwd);
+      if (turnCwd) cwd = turnCwd;
+      continue;
+    }
+    if (rec.type !== 'event_msg' || payload.type !== 'token_count') continue;
+
+    const occurredAt = optString(rec.timestamp);
+    if (occurredAt === undefined) continue;
+    const ordinal = (perTimestamp.get(occurredAt) ?? 0) + 1;
+    perTimestamp.set(occurredAt, ordinal);
+    const occurredMs = Date.parse(occurredAt);
+    if (!Number.isNaN(occurredMs) && sinceMs > 0 && occurredMs < sinceMs) continue;
+    if (sessionId === undefined) continue; // no session_meta seen yet — can't attribute
+
+    const info = payload.info;
+    if (!isRecord(info)) continue;
+    const last = info.last_token_usage;
+    if (!isRecord(last)) continue;
+    const usage: TranscriptUsage = {};
+    if (typeof last.input_tokens === 'number') usage.input_tokens = last.input_tokens;
+    if (typeof last.output_tokens === 'number') usage.output_tokens = last.output_tokens;
+    if (typeof last.cached_input_tokens === 'number') {
+      usage.cache_read_input_tokens = last.cached_input_tokens;
+    }
+    if (typeof last.reasoning_output_tokens === 'number') {
+      usage.reasoning_output_tokens = last.reasoning_output_tokens;
+    }
+    if (isZeroUsage(usage)) continue;
+
+    out.push({
+      kind: 'usage',
+      sessionId,
+      eventKey: `${sessionId}:${occurredAt}:${String(ordinal)}`,
+      model,
+      runKey,
+      usage,
+      occurredAt,
+      cwd,
+      version,
+      originator,
+    });
+  }
+  return out;
+}
+
+// Cheap, best-effort peek at a rollout file's `session_meta.originator` — the
+// live SessionStart hook needs this without paying for a full-file parse (the
+// backfill/tail parsers above already extract it, but they're not meant to be
+// called on a still-growing, possibly-multi-MB file from the hot hook path).
+// Reads only the first ~4KB (session_meta is always the first line and is
+// small) and gives up silently on anything else — a missing/unreadable/
+// oversized-first-line file just means the interface fact is omitted, never a
+// thrown error on the SessionStart path.
+const SESSION_META_PEEK_BYTES = 4096;
+
+export function peekSessionOriginator(transcriptPath: string): string | undefined {
+  let head: string;
+  try {
+    const fd = openSync(transcriptPath, 'r');
+    try {
+      const buf = Buffer.allocUnsafe(SESSION_META_PEEK_BYTES);
+      const bytesRead = readSync(fd, buf, 0, SESSION_META_PEEK_BYTES, 0);
+      head = buf.subarray(0, bytesRead).toString('utf8');
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    return undefined;
+  }
+  const firstLine = head.split('\n')[0]?.trim();
+  if (!firstLine) return undefined;
+  let rec: unknown;
+  try {
+    rec = JSON.parse(firstLine);
+  } catch {
+    return undefined; // the line was cut off mid-JSON by the byte cap — give up
+  }
+  if (!isRecord(rec) || rec.type !== 'session_meta') return undefined;
+  const payload = rec.payload;
+  if (!isRecord(payload)) return undefined;
+  return optString(payload.originator);
+}
+
+// ───────────────────────────── tool-I/O path ─────────────────────────────
+//
+// A THIRD independent parse of the same rollout files, for the tool-call
+// reconciler. Codex's PreToolUse/PostToolUse HOOKS only reliably fire for
+// `Bash`-equivalent (shell) calls today (see plugins/codex/hooks/hooks.json
+// and the upstream issue it cites — apply_patch calls don't fire hooks yet),
+// so this backfill-time parse of `exec_command_begin`/`exec_command_end` and
+// `patch_apply_begin`/`patch_apply_end` event pairs is currently the ONLY way
+// AKA observes a Codex file-write's content at all, live enforcement aside.
+export interface ToolCallRecord {
+  sessionId: string;
+  toolUseId: string; // call_id
+  toolName: string; // 'shell' | 'apply_patch'
+  runKey: string | undefined; // turn_id
+  occurredAt: string;
+  inputSize: number | undefined;
+  isError: boolean | undefined;
+  outputSize: number | undefined;
+  target: string | undefined; // the command line / changed paths, RAW and UNTRUNCATED
+}
+
+function contentSize(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value === 'string') return value.length;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return undefined;
+  }
+}
+
+// `knownSessionId` — see the identical parameter on parseTranscriptUsage
+// above; the same one-time-header problem applies to tool-call attribution
+// on the incremental tail path.
+export function parseTranscriptToolCalls(
+  jsonl: string,
+  sinceMs = 0,
+  knownSessionId?: string,
+): ToolCallRecord[] {
+  const sessionIdBySessionMeta = { current: knownSessionId };
+  // Running turn key from the most recent turn_context line, mirroring the
+  // usage parser: exec/patch events carry no turn_id of their own on current
+  // rollouts, so without this fallback tool calls would never group by turn.
+  let runKey: string | undefined;
+  const begins = new Map<
+    string,
+    { toolName: string; runKey: string | undefined; occurredAt: string; target: string | undefined }
+  >();
+  const out: ToolCallRecord[] = [];
+
+  for (const line of jsonl.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    let rec: unknown;
+    try {
+      rec = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!isRecord(rec)) continue;
+    const payload = rec.payload;
+    if (!isRecord(payload)) continue;
+
+    if (rec.type === 'session_meta') {
+      sessionIdBySessionMeta.current = optString(payload.session_id) ?? optString(payload.id);
+      continue;
+    }
+    if (rec.type === 'turn_context') {
+      // Same reset-per-turn rule (and timestamp fallback) as the usage parser.
+      const turnTs = optString(rec.timestamp);
+      runKey = optString(payload.turn_id) ?? (turnTs !== undefined ? `turn-${turnTs}` : undefined);
+      continue;
+    }
+    if (rec.type !== 'event_msg') continue;
+    const occurredAt = optString(rec.timestamp);
+    if (occurredAt === undefined) continue;
+    const occurredMs = Date.parse(occurredAt);
+    if (!Number.isNaN(occurredMs) && sinceMs > 0 && occurredMs < sinceMs) continue;
+
+    if (payload.type === 'exec_command_begin') {
+      const callId = optString(payload.call_id);
+      if (callId === undefined) continue;
+      const command = Array.isArray(payload.command)
+        ? payload.command.filter((c): c is string => typeof c === 'string').join(' ')
+        : undefined;
+      begins.set(callId, {
+        toolName: 'shell',
+        runKey: optString(payload.turn_id) ?? runKey,
+        occurredAt,
+        target: command,
+      });
+      continue;
+    }
+    if (payload.type === 'exec_command_end') {
+      const callId = optString(payload.call_id);
+      if (callId === undefined || sessionIdBySessionMeta.current === undefined) continue;
+      const begin = begins.get(callId);
+      const exitCode = payload.exit_code;
+      out.push({
+        sessionId: sessionIdBySessionMeta.current,
+        toolUseId: callId,
+        toolName: 'shell',
+        runKey: begin?.runKey ?? optString(payload.turn_id) ?? runKey,
+        occurredAt: begin?.occurredAt ?? occurredAt,
+        inputSize: begin?.target !== undefined ? begin.target.length : undefined,
+        isError: typeof exitCode === 'number' ? exitCode !== 0 : undefined,
+        outputSize: contentSize(payload.aggregated_output ?? payload.formatted_output),
+        target: begin?.target,
+      });
+      continue;
+    }
+    if (payload.type === 'patch_apply_begin') {
+      const callId = optString(payload.call_id);
+      if (callId === undefined) continue;
+      const changes = isRecord(payload.changes) ? Object.keys(payload.changes) : [];
+      begins.set(callId, {
+        toolName: 'apply_patch',
+        runKey: optString(payload.turn_id) ?? runKey,
+        occurredAt,
+        target: changes.length > 0 ? changes.join(', ') : undefined,
+      });
+      continue;
+    }
+    if (payload.type === 'patch_apply_end') {
+      const callId = optString(payload.call_id);
+      if (callId === undefined || sessionIdBySessionMeta.current === undefined) continue;
+      const begin = begins.get(callId);
+      out.push({
+        sessionId: sessionIdBySessionMeta.current,
+        toolUseId: callId,
+        toolName: 'apply_patch',
+        runKey: begin?.runKey ?? optString(payload.turn_id) ?? runKey,
+        occurredAt: begin?.occurredAt ?? occurredAt,
+        inputSize: begin?.target !== undefined ? begin.target.length : undefined,
+        isError: typeof payload.success === 'boolean' ? !payload.success : undefined,
+        outputSize: contentSize(payload.stdout ?? payload.stderr),
+        target: begin?.target,
+      });
+    }
+  }
+  return out;
+}
+
+// ───────────────────────────── directory walk ─────────────────────────────
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface HistoryWalkOptions {
+  dir?: string; // override the transcripts root (tests)
+  windowDays?: number; // retention window; default 30
+  now?: number; // clock injection (tests); default Date.now()
+}
+
+// Recursively collect rollout file paths under the year/month/day-sharded
+// sessions root (`~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`), unlike
+// Claude Code's flat two-level `projects/<project>/*.jsonl` layout. Only
+// plain `.jsonl` files are read — `.jsonl.zst` (Codex's compressed archive
+// format for inactive sessions) is intentionally skipped for now rather than
+// guessed at: decompressing it needs a zstd dependency this self-contained
+// hook bundle doesn't carry. This means the backfill sweep under-covers
+// long-archived sessions; live hook capture is unaffected.
+function* walkJsonlFiles(dir: string, depth = 0): Generator<string> {
+  if (depth > 6) return; // guard against a pathological symlink loop
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkJsonlFiles(full, depth + 1);
+    } else if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      yield full;
+    }
+  }
+}
+
+function* iterateFileContents(dir: string): Generator<string> {
+  for (const file of walkJsonlFiles(dir)) {
+    try {
+      // Skip anything the walk can't stat (broken symlink) before the read.
+      statSync(file);
+      yield readFileSync(file, 'utf8');
+    } catch {
+      // Unreadable file — skip, same fail-open contract as the rest of the walk.
+    }
+  }
+}
+
+function windowStartMs(opts: Pick<HistoryWalkOptions, 'windowDays' | 'now'>): number {
+  const windowDays = opts.windowDays ?? 30;
+  return (opts.now ?? Date.now()) - windowDays * DAY_MS;
+}
+
+export function* iterateHistory(opts: HistoryWalkOptions = {}): Generator<ScannedMessage> {
+  const sinceMs = windowStartMs(opts);
+  for (const content of iterateFileContents(opts.dir ?? transcriptsDir()))
+    yield* parseTranscript(content, sinceMs);
+}
+
+export function* iterateUsage(
+  opts: Pick<HistoryWalkOptions, 'dir' | 'windowDays' | 'now'> = {},
+): Generator<UsageRecord> {
+  const sinceMs = windowStartMs(opts);
+  for (const content of iterateFileContents(opts.dir ?? transcriptsDir()))
+    yield* parseTranscriptUsage(content, sinceMs);
+}
+
+export function* iterateUsageAndToolCalls(
+  opts: Pick<HistoryWalkOptions, 'dir' | 'windowDays' | 'now'> = {},
+): Generator<{ usage: UsageRecord[]; toolCalls: ToolCallRecord[] }> {
+  const sinceMs = windowStartMs(opts);
+  for (const content of iterateFileContents(opts.dir ?? transcriptsDir())) {
+    yield {
+      usage: parseTranscriptUsage(content, sinceMs),
+      toolCalls: parseTranscriptToolCalls(content, sinceMs),
+    };
+  }
+}

--- a/plugins/codex/src/history/transcripts.ts
+++ b/plugins/codex/src/history/transcripts.ts
@@ -45,9 +45,12 @@ export interface ScannedMessage {
 // plugins/claude-code/src/history/transcripts.ts's transcriptsDir(), which
 // likewise reads no env override for ~/.claude (n/no-process-env stays on for
 // this package; CODEX_HOME support can be added later behind its own
-// file-scoped opt-out if it turns out to be needed).
-export function transcriptsDir(): string {
-  return join(homedir(), '.codex', 'sessions');
+// file-scoped opt-out if it turns out to be needed). `home` overrides the OS
+// home root; it is supplied only by tests/harnesses that need a throwaway
+// ~/.codex in isolation — no production call site passes it, so every real run
+// falls back to the OS home.
+export function transcriptsDir(home?: string): string {
+  return join(home ?? homedir(), '.codex', 'sessions');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/plugins/codex/src/history/transcripts.ts
+++ b/plugins/codex/src/history/transcripts.ts
@@ -355,7 +355,10 @@ export function peekSessionOriginator(transcriptPath: string): string | undefine
 // and the upstream issue it cites — apply_patch calls don't fire hooks yet),
 // so this backfill-time parse of `exec_command_begin`/`exec_command_end` and
 // `patch_apply_begin`/`patch_apply_end` event pairs is currently the ONLY way
-// AKA observes a Codex file-write's content at all, live enforcement aside.
+// AKA observes a Codex file write at all, live enforcement aside. It observes
+// the write's changed paths and byte sizes — NOT its content. Nothing on Codex
+// scans file-write content: parseTranscript keeps `message` payloads only, so
+// the backfill scan never sees an apply_patch body either.
 export interface ToolCallRecord {
   sessionId: string;
   toolUseId: string; // call_id

--- a/plugins/codex/src/history/usage.ts
+++ b/plugins/codex/src/history/usage.ts
@@ -1,0 +1,376 @@
+// Token-usage reconciler for Codex CLI. Reads a rollout file's usage records
+// and writes idempotent `llm_call` audit-event leaves under the session root,
+// plus a 30-day backfill that sweeps the transcript window. Structurally
+// mirrors plugins/claude-code/src/history/usage.ts, but simpler: Codex stamps
+// a `turn_id` directly on each event (see ./transcripts.ts), so there is no
+// Claude-Code-style uuid→promptId join pass, and no per-message streaming
+// collapse (one `token_count` event already IS one usage-bearing unit —
+// see the module comment in ./transcripts.ts).
+//
+// This path does WHOLE-FILE reads only for the backfill sweep; the incremental
+// tail read (`reconcileSessionTail`) handles the live per-turn path.
+//
+// FK-safety invariant: `audit_events.parent_id` / `root_session_id` are
+// enforced FKs to the session root, and the root's host/harness/project FK
+// into inventory (`PRAGMA foreign_keys = ON`). SessionStart is fail-open and
+// may never have written the root. So for EVERY session, EVERY pass, the
+// reconciler ensures inventory then the root (idempotent) BEFORE the leaves —
+// it never trusts SessionStart. Provider is then read back off the ensured
+// root, never from live env (which would mislabel backfilled history under
+// today's env).
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
+import {
+  codexProviderFromModelId,
+  resolveInventoryContext,
+  scanText,
+} from '@akasecurity/plugin-sdk';
+import type {
+  AuditEventInput,
+  InventoryContext,
+  LlmCallAttributes,
+  LlmCallInput,
+  ResolvedInventory,
+  ToolCallAttributes,
+  ToolCallInput,
+  ToolCallInspection,
+} from '@akasecurity/schema';
+import { harnessFromTool } from '@akasecurity/schema';
+
+import { readOffset, readTail, writeOffset } from './tail.ts';
+import {
+  iterateUsageAndToolCalls,
+  parseTranscriptToolCalls,
+  parseTranscriptUsage,
+  type ToolCallRecord,
+  type UsageRecord,
+} from './transcripts.ts';
+
+// An absolute path with no `.git` ancestor — used when a transcript record carries
+// no cwd, so `resolveRepoIdentity` resolves no project. Mirrors the Claude Code
+// reconciler's NO_PROJECT_CWD sentinel.
+const NO_PROJECT_CWD = '/nonexistent/aka-reconciler/no-project';
+
+// The longest (masked) tool target we store — see usage.ts (claude-code) for
+// why this is applied AFTER masking.
+const MAX_TARGET_LEN = 500;
+const truncateTarget = (s: string): string =>
+  s.length > MAX_TARGET_LEN ? `${s.slice(0, MAX_TARGET_LEN)}…` : s;
+
+export interface ReconcileSummary {
+  sessions: number;
+  llmCalls: number;
+  skipped: number;
+  toolCalls: number;
+}
+
+export interface SessionReconcileResult {
+  llmCalls: number;
+  skipped: number;
+  lastPromptId: string | undefined; // last runKey (turn_id) seen, carried to the next tail pass
+}
+
+export interface ReconcileSessionOptions {
+  seedPromptId?: string | undefined;
+}
+
+// Reconcile ONE session's usage records into `llm_call` leaves. `records` are
+// the parsed usage records for a single session in file order. Ensures
+// inventory + the session root first (FK-safety), reads the provider back off
+// the root, then writes one `llm_call` per usage record.
+export async function reconcileSession(
+  gateway: DataGateway,
+  sessionId: string,
+  records: readonly UsageRecord[],
+  opts: ReconcileSessionOptions = {},
+): Promise<SessionReconcileResult> {
+  let lastPromptId = opts.seedPromptId;
+  for (const r of records) if (r.runKey !== undefined) lastPromptId = r.runKey;
+
+  if (records.length === 0) return { llmCalls: 0, skipped: 0, lastPromptId };
+
+  // FK-safety: ensure inventory + the session root BEFORE any leaf. Build the
+  // inventory context from the transcript's OWN fields — never live env.
+  const anchor = records[0];
+  if (anchor === undefined) return { llmCalls: 0, skipped: 0, lastPromptId };
+  const ctx = resolveInventoryContext({
+    cwd: anchor.cwd ?? NO_PROJECT_CWD,
+    tool: 'codex',
+    harnessVersion: anchor.version,
+    // Descriptive only (never hashed, never forks the harness dimension) —
+    // distinguishes e.g. 'codex_desktop' (Codex inside the ChatGPT desktop
+    // app) from 'codex_cli_rs'/'codex-tui'/'codex_exec' (terminal entry
+    // points). See transcripts.ts's UsageEventRecord.originator doc comment.
+    harnessInterface: anchor.originator,
+  });
+  const resolved = await gateway.ensureInventory(ctx);
+
+  const heuristicProvider =
+    anchor.model !== undefined ? codexProviderFromModelId(anchor.model) : 'unknown';
+  await gateway.recordAuditEvent(
+    buildSessionRoot(sessionId, ctx, resolved, anchor, heuristicProvider),
+  );
+
+  const provider = (await gateway.readSessionProvider(sessionId)) ?? heuristicProvider;
+
+  const inputs: LlmCallInput[] = records.map((rec) => ({
+    sessionId,
+    // No stable message id in Codex's usage event — key on the record's own
+    // synthetic eventKey (see transcripts.ts), which is stable across re-reads
+    // of the SAME file range and unique per event within a session.
+    messageId: rec.eventKey,
+    parentId: sessionId,
+    rootSessionId: sessionId,
+    startedAt: rec.occurredAt,
+    // A record with no in-chunk turn_context (a tail chunk that starts
+    // mid-turn) falls back to the seeded promptId carried by the offset
+    // checkpoint, so its run_key attribution survives the chunk boundary.
+    attributes: buildAttributes(
+      rec.runKey === undefined && opts.seedPromptId !== undefined
+        ? { ...rec, runKey: opts.seedPromptId }
+        : rec,
+      provider,
+    ),
+  }));
+
+  try {
+    await gateway.recordLlmCalls(inputs);
+    return { llmCalls: inputs.length, skipped: 0, lastPromptId };
+  } catch {
+    return { llmCalls: 0, skipped: inputs.length, lastPromptId };
+  }
+}
+
+// Reconcile ONE session's transcript tool-call records into `tool_call` leaves.
+// Runs AFTER `reconcileSession` (which ensures the root). Fail-open: a
+// contended (SQLITE_BUSY) or FK-violating batch is dropped whole and
+// recovered idempotently on the next pass.
+export async function reconcileSessionToolCalls(
+  gateway: DataGateway,
+  sessionId: string,
+  toolCalls: readonly ToolCallRecord[],
+  opts: { seedPromptId?: string | undefined } = {},
+): Promise<number> {
+  if (toolCalls.length === 0) return 0;
+
+  const inputs: ToolCallInput[] = toolCalls.map((tc) => {
+    const attributes: ToolCallAttributes = { tool_name: tc.toolName, tool_use_id: tc.toolUseId };
+    let inspections: ToolCallInspection[] = [];
+    if (tc.target !== undefined) {
+      // Mask the FULL raw target, THEN size-cap the masked value — see the
+      // Claude Code reconciler's identical comment for why order matters.
+      const { masked, findings } = scanText(tc.target);
+      if (masked !== '') attributes.target = truncateTarget(masked);
+      inspections = findings.map((f) => ({
+        ruleId: f.ruleId,
+        ruleName: f.ruleName,
+        ruleVersion: f.ruleVersion,
+        category: f.category,
+        severity: f.severity,
+        span: f.span,
+        maskedMatch: f.maskedMatch,
+        actionTaken: 'log',
+        confidence: f.confidence,
+      }));
+    }
+    if (tc.isError !== undefined) attributes.is_error = tc.isError;
+    if (tc.inputSize !== undefined) attributes.input_size = tc.inputSize;
+    if (tc.outputSize !== undefined) attributes.output_size = tc.outputSize;
+    // Same chunk-boundary seed fallback as reconcileSession's llm_call pass.
+    const runKey = tc.runKey ?? opts.seedPromptId;
+    if (runKey !== undefined) attributes.run_key = runKey;
+    return {
+      sessionId,
+      toolUseId: tc.toolUseId,
+      parentId: sessionId,
+      rootSessionId: sessionId,
+      startedAt: tc.occurredAt,
+      attributes,
+      inspections,
+    };
+  });
+
+  try {
+    await gateway.recordToolCalls(inputs);
+    return inputs.length;
+  } catch {
+    return 0;
+  }
+}
+
+function groupToolCallsBySession(records: Iterable<ToolCallRecord>): Map<string, ToolCallRecord[]> {
+  const bySession = new Map<string, ToolCallRecord[]>();
+  for (const rec of records) {
+    const bucket = bySession.get(rec.sessionId);
+    if (bucket) bucket.push(rec);
+    else bySession.set(rec.sessionId, [rec]);
+  }
+  return bySession;
+}
+
+function groupBySession(records: Iterable<UsageRecord>): Map<string, UsageRecord[]> {
+  const bySession = new Map<string, UsageRecord[]>();
+  for (const rec of records) {
+    const bucket = bySession.get(rec.sessionId);
+    if (bucket) bucket.push(rec);
+    else bySession.set(rec.sessionId, [rec]);
+  }
+  return bySession;
+}
+
+// Backfill: sweep the transcript window and reconcile every session's usage
+// into `llm_call` leaves. Idempotent — deterministic ids + `INSERT OR IGNORE`
+// make a re-run yield identical row counts.
+export async function reconcileHistory(
+  config: PluginConfig,
+  opts: { dir?: string; windowDays?: number; now?: number } = {},
+): Promise<ReconcileSummary> {
+  const gateway = resolveDataGateway(config);
+  let sessions = 0;
+  let llmCalls = 0;
+  let skipped = 0;
+  let toolCalls = 0;
+  try {
+    const usageRecords: UsageRecord[] = [];
+    const toolCallRecords: ToolCallRecord[] = [];
+    for (const file of iterateUsageAndToolCalls(opts)) {
+      usageRecords.push(...file.usage);
+      toolCallRecords.push(...file.toolCalls);
+    }
+    const toolCallsBySession = groupToolCallsBySession(toolCallRecords);
+    for (const [sessionId, records] of groupBySession(usageRecords)) {
+      sessions++;
+      const result = await reconcileSession(gateway, sessionId, records);
+      llmCalls += result.llmCalls;
+      skipped += result.skipped;
+      toolCalls += await reconcileSessionToolCalls(
+        gateway,
+        sessionId,
+        toolCallsBySession.get(sessionId) ?? [],
+      );
+    }
+  } finally {
+    await gateway.close();
+  }
+  return { sessions, llmCalls, skipped, toolCalls };
+}
+
+// The live per-turn capture path (primary trigger). Reconcile ONLY the new
+// tail of one session's transcript. Invoked by the detached `reconcile.js`
+// worker the Stop hook spawns (and the SessionStart catch-up).
+export async function reconcileSessionTail(
+  config: PluginConfig,
+  sessionId: string,
+  transcriptPath: string,
+): Promise<{ llmCalls: number; skipped: number; toolCalls: number }> {
+  const checkpoint = readOffset(config.dataDir, sessionId);
+  const { chunk, nextOffset } = readTail(transcriptPath, checkpoint.offset);
+  if (chunk === '') {
+    if (nextOffset !== checkpoint.offset) {
+      writeOffset(config.dataDir, sessionId, {
+        offset: nextOffset,
+        lastPromptId: checkpoint.lastPromptId,
+      });
+    }
+    return { llmCalls: 0, skipped: 0, toolCalls: 0 };
+  }
+
+  // Seed both parsers with the CALLER-supplied sessionId (straight from the
+  // Stop hook payload): a tail chunk past the first pass never contains the
+  // rollout file's one-time session_meta header, so without this seed every
+  // usage/tool-call record here would be unattributable — see the parser
+  // functions' own doc comments for the full explanation.
+  const records = parseTranscriptUsage(chunk, 0, sessionId);
+  const toolCallRecords = parseTranscriptToolCalls(chunk, 0, sessionId);
+
+  const gateway = resolveDataGateway(config);
+  try {
+    const result = await reconcileSession(gateway, sessionId, records, {
+      seedPromptId: checkpoint.lastPromptId,
+    });
+    const toolCalls = await reconcileSessionToolCalls(gateway, sessionId, toolCallRecords, {
+      seedPromptId: checkpoint.lastPromptId,
+    });
+    // Advance the offset only when nothing was dropped: a contended
+    // (SQLITE_BUSY) batch reports `skipped` (usage) or writes fewer tool
+    // calls than parsed, and advancing past it would lose those records for
+    // good — the writes are idempotent, so re-reading the same chunk on the
+    // next pass simply absorbs the retry.
+    const toolCallsDropped = toolCallRecords.length > 0 && toolCalls === 0;
+    if (result.skipped === 0 && !toolCallsDropped) {
+      writeOffset(config.dataDir, sessionId, {
+        offset: nextOffset,
+        lastPromptId: result.lastPromptId,
+      });
+    }
+    return { llmCalls: result.llmCalls, skipped: result.skipped, toolCalls };
+  } finally {
+    await gateway.close();
+  }
+}
+
+// The Session root audit event for a root the reconciler may be CREATING.
+// Mirrors `buildSessionRoot` in plugins/claude-code/src/history/usage.ts, but
+// sources cwd/version straight off the Codex usage record (no gitBranch/nwo —
+// Codex's rollout format carries no per-event git branch field; `session_meta`
+// DOES optionally carry `git.branch`, but that would need threading through
+// transcripts.ts's usage parser — left for a follow-up rather than guessed at).
+function buildSessionRoot(
+  sessionId: string,
+  ctx: InventoryContext,
+  resolved: ResolvedInventory,
+  anchor: UsageRecord,
+  provider: string,
+): AuditEventInput {
+  const attributes: Record<string, unknown> = {};
+  const osVersion = ctx.host?.attributes.os_version;
+  if (typeof osVersion === 'string') attributes.os_version = osVersion;
+  if (anchor.version !== undefined) attributes.harness_version = anchor.version;
+  // Snapshotted directly from the transcript's own originator (not read back
+  // off the shared harness inventory row — see the identical comment in
+  // plugin-runtime's handle-session-start.ts for why that row can't hold a
+  // durable per-session fact). Distinguishes a Codex session run inside the
+  // ChatGPT desktop app ('codex_desktop') from a terminal one.
+  if (anchor.originator !== undefined) attributes.harness_interface = anchor.originator;
+  attributes.provider = provider;
+
+  attributes.harness = harnessFromTool('codex');
+  if (anchor.cwd !== undefined) attributes.cwd = anchor.cwd;
+  if (anchor.version !== undefined) attributes.version = anchor.version;
+  const hostName = ctx.host?.attributes.host_name;
+  if (typeof hostName === 'string') attributes.host = hostName;
+  if (ctx.project) attributes.project = ctx.project.name;
+
+  const event: AuditEventInput = {
+    id: sessionId,
+    eventType: 'session',
+    startedAt: anchor.occurredAt,
+  };
+  if (resolved.hostId) event.hostId = resolved.hostId;
+  if (resolved.harnessId) event.harnessId = resolved.harnessId;
+  if (resolved.sourceProjectId) event.sourceProjectId = resolved.sourceProjectId;
+  if (Object.keys(attributes).length > 0) event.attributes = attributes;
+  return event;
+}
+
+function buildAttributes(rec: UsageRecord, provider: string): LlmCallAttributes {
+  const usage = rec.usage;
+  const attrs: LlmCallAttributes = {
+    model: rec.model ?? 'unknown',
+    provider,
+    message_id: rec.eventKey,
+    uuid: rec.eventKey,
+  };
+  if (rec.runKey !== undefined) attrs.run_key = rec.runKey;
+  setNum(attrs, 'input_tokens', usage.input_tokens);
+  setNum(attrs, 'output_tokens', usage.output_tokens);
+  setNum(attrs, 'cache_read_input_tokens', usage.cache_read_input_tokens);
+  if (typeof usage.reasoning_output_tokens === 'number') {
+    attrs.reasoning_output_tokens = usage.reasoning_output_tokens;
+  }
+  return attrs;
+}
+
+function setNum(attrs: LlmCallAttributes, key: string, value: unknown): void {
+  if (typeof value === 'number' && Number.isFinite(value)) attrs[key] = value;
+}

--- a/plugins/codex/src/hooks/post-tool-use.ts
+++ b/plugins/codex/src/hooks/post-tool-use.ts
@@ -1,0 +1,74 @@
+/**
+ * PostToolUse — fires after a tool succeeds. Unlike Claude Code, Codex's
+ * PostToolUse cannot rewrite the tool's output in place (no
+ * `updatedToolOutput` field) — the strongest available action is
+ * `{"decision":"block","reason":"..."}`, which replaces the WHOLE tool
+ * result with `reason` and continues the model from there. See
+ * scan-response.ts's module comment for why a `redact` outcome escalates to
+ * this same whole-result withhold rather than attempting a partial splice.
+ *
+ * Only `Bash` is scanned today — PostToolUse does not fire for `apply_patch`
+ * yet (see pre-tool-use-decision.ts).
+ *
+ * stdin:  { tool_name, tool_input, tool_response, ... }
+ * stdout (exit 0):
+ *   {"decision":"block","reason":"...","systemMessage":"..."} → tool result withheld
+ *   {"systemMessage":"..."} → warning only
+ *   no output → pass through
+ *
+ * Fail-open: any error → no output, exit 0.
+ */
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import { createPluginRuntime, loadConfig } from '@akasecurity/plugin-sdk';
+
+import { responseEmitPayload, scanResponseFields } from './scan-response.ts';
+import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
+import { scannableResponseFields } from './tool-response.ts';
+
+async function main(): Promise<void> {
+  const input = parseJson(await readStdin());
+  if (!input) return;
+
+  const rawToolName = getString(input, 'tool_name');
+  const toolName = rawToolName ?? 'tool';
+  const response = input.tool_response ?? input.tool_output;
+  const fields = scannableResponseFields(toolName, response);
+  if (fields.length === 0) return;
+
+  const metadata = baseMetadata(input) ?? {};
+  // The RAW name only — an absent tool_name must not be recorded as the
+  // literal 'tool' placeholder the display fallback uses.
+  if (rawToolName) metadata.toolName = rawToolName;
+  const rawToolInput = input.tool_input;
+  const filePath =
+    typeof rawToolInput === 'object' && rawToolInput !== null
+      ? getString(rawToolInput as Record<string, unknown>, 'file_path')
+      : undefined;
+  if (filePath) metadata.filePath = filePath;
+
+  const config = loadConfig();
+  const gateway = resolveDataGateway(config);
+  const runtime = createPluginRuntime(gateway, config.settings, { dataDir: config.dataDir });
+
+  let outcome;
+  try {
+    outcome = await scanResponseFields(toolName, fields, (text) =>
+      runtime.capture(
+        { kind: 'response', sourceTool: 'codex', text, metadata },
+        { persist: 'with-findings' },
+      ),
+    );
+  } finally {
+    await runtime.close();
+  }
+
+  const payload = responseEmitPayload(outcome);
+  if (payload !== undefined) await emit(payload);
+}
+
+try {
+  await main();
+} catch {
+  // Fail-open: never break the user's session
+}
+process.exit(0);

--- a/plugins/codex/src/hooks/pre-tool-use-decision.ts
+++ b/plugins/codex/src/hooks/pre-tool-use-decision.ts
@@ -1,0 +1,135 @@
+// The pure decision half of the PreToolUse hook: collapse the per-field
+// runtime results into the hook's stdout payload. Pure object building (no
+// I/O) so it unit-tests without a hook process — hook entry files run main()
+// on import and must NEVER be imported by tests (same split as
+// exception-guidance.ts). The decision logic itself is identical to
+// plugins/claude-code/src/hooks/pre-tool-use-decision.ts — Codex's PreToolUse
+// hook uses the SAME hookSpecificOutput.permissionDecision shape (confirmed
+// against developers.openai.com/codex/hooks). Only SCANNABLE_FIELDS differs,
+// because Codex's built-in tool names/arguments differ from Claude Code's.
+import type { BlockedDetectionRef, CaptureResult } from '@akasecurity/plugin-sdk';
+
+import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
+
+// Which tool_input fields carry user-authored text worth scanning, and whether
+// that text EXECUTES — see the Claude Code sibling module for the full
+// rationale (masking an executable field changes what runs, so it escalates
+// to deny instead of rewriting in place).
+//
+// IMPORTANT — Codex-specific caveat: as of the current `codex` CLI, PreToolUse/
+// PostToolUse hooks only reliably fire for `Bash` calls; `apply_patch` calls do
+// NOT fire them yet (confirmed: github.com/openai/codex/issues/16732 — "Hooks
+// only fire for Bash tool"). The `apply_patch` entry below is registered for
+// forward compatibility (so this table needs no further change once upstream
+// fixes it) but is currently INERT — Codex never invokes this hook for a file
+// write, so live redaction/blocking of file-write content is not yet possible
+// on Codex. Leaked file content is instead caught after the fact by the
+// history backfill scan (../history/scan.ts via the rollout's
+// patch_apply_begin/end events), not before it leaves the sandbox. The exact
+// `apply_patch` tool_input field name below (`input`) is inferred from Codex's
+// own patch-call wire shape (codex-rs/protocol/src/models.rs — CustomToolCall's
+// `input: String`) and should be re-verified once the hook actually fires.
+export interface ScannableField {
+  field: string;
+  executable: boolean;
+}
+
+export const SCANNABLE_FIELDS: Record<string, readonly ScannableField[]> = {
+  Bash: [{ field: 'command', executable: true }],
+  apply_patch: [{ field: 'input', executable: false }],
+};
+
+// One scanned field: its spec plus the runtime's decision for the field text.
+export interface ScannedField {
+  spec: ScannableField;
+  result: CaptureResult;
+}
+
+// Woven into the deny message when a redact decision was escalated off an
+// executable field, so the block explains why the policy's redact didn't
+// rewrite in place.
+export const EXECUTABLE_REDACT_NOTE =
+  'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead.';
+
+export type PreToolUseOutput =
+  | {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse';
+        permissionDecision: 'deny';
+        permissionDecisionReason: string;
+      };
+    }
+  | {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse';
+        permissionDecision: 'allow';
+        updatedInput: Record<string, unknown>;
+      };
+      systemMessage: string;
+    }
+  | { systemMessage: string };
+
+export function decidePreToolUse(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  scanned: readonly ScannedField[],
+): PreToolUseOutput | null {
+  const blockedRules = new Set<string>();
+  const warnedRules = new Set<string>();
+  const redactedRules = new Set<string>();
+  const blockedReferences: BlockedDetectionRef[] = [];
+  const redactedReferences: BlockedDetectionRef[] = [];
+  let escalated = false;
+  let updatedInput: Record<string, unknown> | null = null;
+
+  for (const { spec, result } of scanned) {
+    const escalate = result.action === 'redact' && spec.executable;
+    if (escalate) escalated = true;
+    const action = escalate ? 'block' : result.action;
+
+    if (action === 'block') {
+      for (const finding of result.findings) blockedRules.add(finding.ruleId);
+      if (result.blockedReferences) blockedReferences.push(...result.blockedReferences);
+    } else if (action === 'redact') {
+      for (const finding of result.findings) redactedRules.add(finding.ruleId);
+      if (result.blockedReferences) redactedReferences.push(...result.blockedReferences);
+      updatedInput ??= { ...toolInput };
+      if (result.text !== null) updatedInput[spec.field] = result.text;
+    } else if (action === 'warn') {
+      for (const finding of result.findings) warnedRules.add(finding.ruleId);
+    }
+  }
+
+  if (blockedRules.size > 0) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: blockMessage({
+          subject: `${toolName} call`,
+          ruleIds: [...blockedRules].join(', '),
+          blockedRef: blockedReferences[0],
+          note: escalated ? EXECUTABLE_REDACT_NOTE : undefined,
+        }),
+      },
+    };
+  }
+
+  if (redactedRules.size > 0) {
+    return {
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'allow',
+        updatedInput: updatedInput ?? { ...toolInput },
+      },
+      systemMessage: `AKA redacted sensitive content in ${toolName} input — flagged ${[...redactedRules].join(', ')}.${exceptionPointer(redactedReferences)}`,
+    };
+  }
+
+  if (warnedRules.size > 0) {
+    return {
+      systemMessage: `AKA flagged sensitive content in ${toolName} input (${[...warnedRules].join(', ')}).`,
+    };
+  }
+  return null;
+}

--- a/plugins/codex/src/hooks/pre-tool-use-decision.ts
+++ b/plugins/codex/src/hooks/pre-tool-use-decision.ts
@@ -8,6 +8,7 @@
 // against developers.openai.com/codex/hooks). Only SCANNABLE_FIELDS differs,
 // because Codex's built-in tool names/arguments differ from Claude Code's.
 import type { BlockedDetectionRef, CaptureResult } from '@akasecurity/plugin-sdk';
+import { pointerTokenScanner } from '@akasecurity/schema';
 
 import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
 
@@ -50,6 +51,44 @@ export interface ScannedField {
 // rewrite in place.
 export const EXECUTABLE_REDACT_NOTE =
   'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead.';
+
+// The deny reason when a vault pointer appears in a field that EXECUTES. The
+// Codex plugin has no vault wiring, so it never substitutes a pointer back to
+// its raw value — but pointers minted elsewhere on the same machine (the
+// Claude Code plugin's vault, the wizard's history scrub) can be echoed into a
+// Bash command here, and executing one as literal text is never right. Same
+// posture as Claude Code's un-consented branch: deny, in every consent state.
+export function denyPointerMessage(toolName: string): string {
+  return (
+    `A vault pointer in a ${toolName} command cannot execute as text, and this plugin ` +
+    'never substitutes a pointer back to its raw value. Remove the pointer from the ' +
+    'command, or resolve the value yourself with `aka vault show` or the dashboard ' +
+    'Vault page and retype what you need.'
+  );
+}
+
+// The pointer pre-check the hook runs BEFORE the secret scan (and before the
+// store is opened): a vault pointer in an executable field denies the whole
+// call. Returns null when nothing denies. Pure over its inputs so it
+// unit-tests without a hook process.
+export function decideInputPointerDeny(
+  toolName: string,
+  toolInput: Record<string, unknown>,
+  fields: readonly ScannableField[],
+): Extract<PreToolUseOutput, { hookSpecificOutput: { permissionDecision: 'deny' } }> | null {
+  const denies = fields.some((spec) => {
+    const value = toolInput[spec.field];
+    return spec.executable && typeof value === 'string' && pointerTokenScanner().test(value);
+  });
+  if (!denies) return null;
+  return {
+    hookSpecificOutput: {
+      hookEventName: 'PreToolUse',
+      permissionDecision: 'deny',
+      permissionDecisionReason: denyPointerMessage(toolName),
+    },
+  };
+}
 
 export type PreToolUseOutput =
   | {

--- a/plugins/codex/src/hooks/pre-tool-use-decision.ts
+++ b/plugins/codex/src/hooks/pre-tool-use-decision.ts
@@ -52,6 +52,12 @@ export interface ScannedField {
 export const EXECUTABLE_REDACT_NOTE =
   'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead.';
 
+// Woven into the deny message when a redact decision carried no redacted text
+// to put in place, so the block explains why the policy's redact could not be
+// applied rather than the call going out unmasked.
+export const UNREDACTABLE_NOTE =
+  'The redacted form of this input was unavailable, so the call is blocked rather than sent unmasked.';
+
 // The deny reason when a vault pointer appears in a field that EXECUTES. The
 // Codex plugin has no vault wiring, so it never substitutes a pointer back to
 // its raw value — but pointers minted elsewhere on the same machine (the
@@ -118,12 +124,22 @@ export function decidePreToolUse(
   const redactedRules = new Set<string>();
   const blockedReferences: BlockedDetectionRef[] = [];
   const redactedReferences: BlockedDetectionRef[] = [];
-  let escalated = false;
+  let escalatedExecutable = false;
+  let escalatedUnredactable = false;
   let updatedInput: Record<string, unknown> | null = null;
 
   for (const { spec, result } of scanned) {
-    const escalate = result.action === 'redact' && spec.executable;
-    if (escalate) escalated = true;
+    // A redact this hook cannot carry out denies rather than allowing and
+    // claiming success. Two ways it cannot: masking an executable field would
+    // silently change what runs, and a null `text` leaves no redacted form to
+    // substitute — emitting the untouched input under the "AKA redacted"
+    // systemMessage would send the raw value and report it as masked.
+    const unredactable = result.action === 'redact' && result.text === null;
+    const escalate = result.action === 'redact' && (spec.executable || unredactable);
+    if (escalate) {
+      if (spec.executable) escalatedExecutable = true;
+      else escalatedUnredactable = true;
+    }
     const action = escalate ? 'block' : result.action;
 
     if (action === 'block') {
@@ -133,6 +149,7 @@ export function decidePreToolUse(
       for (const finding of result.findings) redactedRules.add(finding.ruleId);
       if (result.blockedReferences) redactedReferences.push(...result.blockedReferences);
       updatedInput ??= { ...toolInput };
+      // Non-null here: a redact carrying no text escalated to block above.
       if (result.text !== null) updatedInput[spec.field] = result.text;
     } else if (action === 'warn') {
       for (const finding of result.findings) warnedRules.add(finding.ruleId);
@@ -148,7 +165,11 @@ export function decidePreToolUse(
           subject: `${toolName} call`,
           ruleIds: [...blockedRules].join(', '),
           blockedRef: blockedReferences[0],
-          note: escalated ? EXECUTABLE_REDACT_NOTE : undefined,
+          note: escalatedExecutable
+            ? EXECUTABLE_REDACT_NOTE
+            : escalatedUnredactable
+              ? UNREDACTABLE_NOTE
+              : undefined,
         }),
       },
     };

--- a/plugins/codex/src/hooks/pre-tool-use.ts
+++ b/plugins/codex/src/hooks/pre-tool-use.ts
@@ -1,0 +1,90 @@
+/**
+ * PreToolUse — fires before a tool call executes. Same hookSpecificOutput
+ * shape as Claude Code's PreToolUse (confirmed against
+ * developers.openai.com/codex/hooks): `updatedInput` replaces the tool's
+ * arguments for redact-in-place fields; an executable field escalates a
+ * redact to a deny instead (see pre-tool-use-decision.ts).
+ *
+ * CAVEAT (see pre-tool-use-decision.ts's SCANNABLE_FIELDS comment): today
+ * Codex only reliably fires this hook for `Bash` calls, not `apply_patch` —
+ * the `apply_patch` matcher/field entry here is forward-compatible but
+ * currently inert.
+ *
+ * stdin:  { tool_name, tool_input, session_id, ... }
+ * stdout (exit 0):
+ *   {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny",...}}
+ *     → tool call blocked
+ *   {"hookSpecificOutput":{...,"permissionDecision":"allow","updatedInput":{...}}}
+ *     → tool runs with redacted input
+ *   no output → allow unchanged
+ *
+ * Fail-open: any error → no output, exit 0.
+ */
+import { createPluginRuntime, loadConfig } from '@akasecurity/plugin-sdk';
+
+import type { ScannedField } from './pre-tool-use-decision.ts';
+import { decidePreToolUse, SCANNABLE_FIELDS } from './pre-tool-use-decision.ts';
+import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
+import {
+  claimStoreUnavailableWarning,
+  openGatewayOrNull,
+  storeUnavailableMessage,
+} from './store-health.ts';
+
+async function main(): Promise<void> {
+  const input = parseJson(await readStdin());
+  if (!input) return;
+
+  const toolName = getString(input, 'tool_name') ?? '';
+  const fields = SCANNABLE_FIELDS[toolName];
+  const rawToolInput = input.tool_input;
+  if (!fields || typeof rawToolInput !== 'object' || rawToolInput === null) return;
+
+  const config = loadConfig();
+  const gateway = openGatewayOrNull(config);
+  if (gateway === null) {
+    if (claimStoreUnavailableWarning(config.dataDir, getString(input, 'session_id'))) {
+      await emit({ systemMessage: storeUnavailableMessage(config.dbPath) });
+    }
+    return;
+  }
+  const runtime = createPluginRuntime(gateway, config.settings, { dataDir: config.dataDir });
+
+  const toolInput = { ...(rawToolInput as Record<string, unknown>) };
+  // apply_patch's input is durable content the agent authors, recorded as
+  // 'code_change' with the default persist ('always' — the at-rest trail the
+  // re-scan resolver reconciles against). Bash commands are text the host acts
+  // on, recorded as 'tool_use' at persist 'with-findings': this hook sees
+  // every command, and 'always' would copy that whole stream into the store
+  // to trail the enforcement decisions that are the point of the kind. Same
+  // split as Claude Code's Write/Edit vs Bash.
+  const kind = toolName === 'apply_patch' ? 'code_change' : 'tool_use';
+  const metadata = baseMetadata(input) ?? {};
+  if (toolName) metadata.toolName = toolName;
+
+  const scanned: ScannedField[] = [];
+  try {
+    for (const spec of fields) {
+      const value = toolInput[spec.field];
+      if (typeof value !== 'string' || value === '') continue;
+
+      const result = await runtime.capture(
+        { kind, sourceTool: 'codex', text: value, metadata },
+        kind === 'tool_use' ? { persist: 'with-findings' } : {},
+      );
+      scanned.push({ spec, result });
+    }
+  } finally {
+    await runtime.close();
+  }
+
+  const output = decidePreToolUse(toolName, toolInput, scanned);
+  if (output) await emit(output);
+}
+
+try {
+  await main();
+} catch {
+  // Fail-open: never break the user's session
+}
+process.exit(0);

--- a/plugins/codex/src/hooks/pre-tool-use.ts
+++ b/plugins/codex/src/hooks/pre-tool-use.ts
@@ -23,7 +23,11 @@
 import { createPluginRuntime, loadConfig } from '@akasecurity/plugin-sdk';
 
 import type { ScannedField } from './pre-tool-use-decision.ts';
-import { decidePreToolUse, SCANNABLE_FIELDS } from './pre-tool-use-decision.ts';
+import {
+  decideInputPointerDeny,
+  decidePreToolUse,
+  SCANNABLE_FIELDS,
+} from './pre-tool-use-decision.ts';
 import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
 import {
   claimStoreUnavailableWarning,
@@ -39,6 +43,21 @@ async function main(): Promise<void> {
   const fields = SCANNABLE_FIELDS[toolName];
   const rawToolInput = input.tool_input;
   if (!fields || typeof rawToolInput !== 'object' || rawToolInput === null) return;
+
+  // A model-echoed vault pointer in text that EXECUTES is decided before the
+  // secret scan (and before the store is even opened): this plugin never
+  // substitutes pointers, so an ungranted pointer must deny outright rather
+  // than run as literal text. Pointers reach Codex from the same machine's
+  // vault surfaces (the Claude Code plugin, the wizard's history scrub).
+  const pointerDeny = decideInputPointerDeny(
+    toolName,
+    rawToolInput as Record<string, unknown>,
+    fields,
+  );
+  if (pointerDeny) {
+    await emit(pointerDeny);
+    return;
+  }
 
   const config = loadConfig();
   const gateway = openGatewayOrNull(config);

--- a/plugins/codex/src/hooks/scan-response.ts
+++ b/plugins/codex/src/hooks/scan-response.ts
@@ -1,0 +1,109 @@
+// The PostToolUse per-field scan/rewrite loop, extracted from the hook entry
+// so it can be unit-tested (hook entry modules run main() on import and hang
+// vitest collection). `scanResponseFields` is pure orchestration, identical to
+// plugins/claude-code/src/hooks/scan-response.ts.
+//
+// `responseEmitPayload` DIVERGES from the Claude Code sibling in one real,
+// load-bearing way: Codex's PostToolUse has no `updatedToolOutput` field to
+// splice a partially-redacted value back into the tool result (confirmed —
+// Agent Guard's plugin README: Codex "does not expose that Claude field").
+// Codex instead offers a coarser, whole-result mechanism: `{"decision":"block",
+// "reason":"..."}` on PostToolUse replaces the ENTIRE tool result with `reason`
+// and continues the model from there (developers.openai.com/codex/hooks).
+// There is no partial field-level splice, so a `redact` outcome — which on
+// Claude Code masks matched spans IN PLACE while leaving the rest of the
+// output visible — cannot be replicated on Codex without risking the
+// unmasked remainder leaking anyway. Rather than silently under-protect,
+// `redact` here ESCALATES to the same whole-result withhold as `block` (same
+// escalate-on-no-safe-in-place-option pattern PreToolUse already uses for
+// redact-on-an-executable-field — see pre-tool-use-decision.ts). `warn`-only
+// outcomes are unaffected: the output still reaches the model unmodified,
+// same as Claude Code.
+import type { BlockedDetectionRef, CaptureResult } from '@akasecurity/plugin-sdk';
+import { uniqueRuleIds } from '@akasecurity/plugin-sdk';
+
+import { withheldBanner, withheldToolText } from '../exception-guidance.ts';
+import type { ScannableResponseField } from './tool-response.ts';
+
+export interface ResponseScanOutcome {
+  withheldFindings: { ruleId: string }[];
+  // Collected separately from withheldFindings so the banner/reason can name
+  // WHY a redact escalated (`redactedButWithheld`), even though both buckets
+  // are withheld the same way on Codex. See module comment.
+  redactedButWithheldFindings: { ruleId: string }[];
+  warnedFindings: { ruleId: string }[];
+  blockedReferences: BlockedDetectionRef[];
+  redactedReferences: BlockedDetectionRef[];
+  toolName: string;
+}
+
+export async function scanResponseFields(
+  toolName: string,
+  fields: ScannableResponseField[],
+  capture: (text: string) => Promise<CaptureResult>,
+): Promise<ResponseScanOutcome> {
+  const outcome: ResponseScanOutcome = {
+    withheldFindings: [],
+    redactedButWithheldFindings: [],
+    warnedFindings: [],
+    blockedReferences: [],
+    redactedReferences: [],
+    toolName,
+  };
+
+  for (const field of fields) {
+    const result = await capture(field.text);
+    if (result.findings.length === 0) continue;
+
+    if (result.action === 'block') {
+      outcome.withheldFindings.push(...result.findings);
+      if (result.blockedReferences) outcome.blockedReferences.push(...result.blockedReferences);
+    } else if (result.action === 'redact') {
+      outcome.redactedButWithheldFindings.push(...result.findings);
+      if (result.blockedReferences) outcome.redactedReferences.push(...result.blockedReferences);
+    } else if (result.action === 'warn') {
+      outcome.warnedFindings.push(...result.findings);
+    }
+  }
+
+  return outcome;
+}
+
+/**
+ * The single JSON object the hook should emit for a scan outcome, or
+ * undefined for "no opinion" (nothing flagged). A withhold (block OR an
+ * escalated redact) uses PostToolUse's `decision:'block'` + `reason` to
+ * replace the whole tool result — the closest Codex equivalent to Claude
+ * Code's field-level `updatedToolOutput` splice.
+ */
+export function responseEmitPayload(outcome: ResponseScanOutcome): unknown {
+  const { toolName, withheldFindings, redactedButWithheldFindings, warnedFindings } = outcome;
+  const allWithheld = [...withheldFindings, ...redactedButWithheldFindings];
+  if (allWithheld.length > 0) {
+    const withheldRuleIds =
+      withheldFindings.length > 0 ? uniqueRuleIds(withheldFindings) : undefined;
+    const redactedRuleIds =
+      redactedButWithheldFindings.length > 0
+        ? uniqueRuleIds(redactedButWithheldFindings)
+        : undefined;
+    const ref = outcome.blockedReferences[0] ?? outcome.redactedReferences[0];
+    return {
+      decision: 'block',
+      reason: withheldToolText(toolName, uniqueRuleIds(allWithheld)),
+      systemMessage: withheldBanner({
+        toolName,
+        action: 'withheld',
+        withheldRuleIds,
+        redactedRuleIds,
+        warnedRuleIds: warnedFindings.length > 0 ? uniqueRuleIds(warnedFindings) : undefined,
+        blockedRef: ref,
+      }),
+    };
+  }
+  if (warnedFindings.length > 0) {
+    return {
+      systemMessage: `AKA flagged sensitive content in ${toolName} output (${uniqueRuleIds(warnedFindings)}).`,
+    };
+  }
+  return undefined;
+}

--- a/plugins/codex/src/hooks/session-start.ts
+++ b/plugins/codex/src/hooks/session-start.ts
@@ -1,0 +1,92 @@
+/**
+ * SessionStart — fires when a Codex CLI session begins (startup, resume,
+ * clear, or compact). Same event name and payload shape as Claude Code's
+ * SessionStart hook.
+ *
+ * stdin:  { session_id, cwd, hook_event_name, ... }
+ * argv[2] (optional): the plugin manifest path (${PLUGIN_ROOT}/.codex-plugin/
+ *   plugin.json), so the harness build version lands in the inventory bag.
+ *
+ * The once-per-session inventory pass: resolve this machine's host/harness/account
+ * and the project, upsert them, and open the Session audit-event root. All the
+ * logic lives in @akasecurity/plugin-runtime; this script is just Codex CLI stdio glue.
+ *
+ * Emits nothing (SessionStart has no decision to make). Fully fail-open: any error
+ * → no output, exit 0.
+ */
+import { readFileSync } from 'node:fs';
+
+import { handleSessionStart } from '@akasecurity/plugin-runtime';
+import { loadConfig, resolveCodexProvider } from '@akasecurity/plugin-sdk';
+
+import { triggerReconcile } from '../history/reconcile-trigger.ts';
+import { peekSessionOriginator } from '../history/transcripts.ts';
+import { getString, parseJson, readStdin } from './shared.ts';
+
+// The plugin's own version, read from the manifest the hook command passes as
+// argv[2] (same source as the intro card). Best-effort: an unreadable/old
+// manifest just omits the version — the harness dimension still resolves on tool.
+function harnessVersion(): string | undefined {
+  const manifestPath = process.argv[2];
+  if (!manifestPath) return undefined;
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version?: unknown };
+    return typeof manifest.version === 'string' ? manifest.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function main(): Promise<void> {
+  const input = parseJson(await readStdin());
+  const sessionId = input ? getString(input, 'session_id') : undefined;
+  const cwd = (input ? getString(input, 'cwd') : undefined) ?? process.cwd();
+  const transcriptPath = input ? getString(input, 'transcript_path') : undefined;
+  // Best-effort: session_meta.originator distinguishes which client is
+  // hosting this Codex session — 'codex_cli_rs'/'codex-tui'/'codex_exec' for
+  // a terminal invocation, 'codex_desktop' for Codex running inside the
+  // ChatGPT desktop app, 'codex_vscode' for the VS Code extension. Same
+  // engine, same hooks/plugin system in every case; this is purely a
+  // descriptive fact for the dashboard, never a fork of the harness/
+  // sourceTool dimension. A missing/unreadable transcript file just omits it.
+  const harnessInterface =
+    transcriptPath !== undefined ? peekSessionOriginator(transcriptPath) : undefined;
+  // handleSessionStart's config parameter defaults to loadConfig() with NO
+  // resolver override, which resolves Claude Code's provider shape — every
+  // OTHER Codex hook can rely on that default (they never read
+  // config.provider), but SessionStart is the one place that snapshots it
+  // onto the session root, so it must pass the Codex resolver explicitly.
+  const config = loadConfig(undefined, resolveCodexProvider);
+  const result = await handleSessionStart(
+    {
+      sessionId,
+      cwd,
+      tool: 'codex',
+      harnessVersion: harnessVersion(),
+      harnessInterface,
+    },
+    config,
+  );
+  // Stale-session notice (once per session — it rides the SessionStart claim):
+  // a newer binary recorded the mirror, so this session's plugin generation is
+  // outdated and its installed-pack writes are gated. stderr, not a decision.
+  if (result.staleBinaryNotice !== null) {
+    process.stderr.write(`[aka] ${result.staleBinaryNotice}\n`);
+  }
+
+  // Token-usage catch-up (safety net): after the inventory pass, trigger
+  // the SAME throttled, detached reconcile for the just-opened session so a final
+  // usage record that lagged the last Stop is picked up. Behind the shared
+  // reconcile throttle (so it never piles onto a recent Stop spawn) and fully
+  // best-effort — a missing path or any error just skips it, the Stop path covers it.
+  if (sessionId !== undefined && transcriptPath !== undefined) {
+    triggerReconcile(config.dataDir, sessionId, transcriptPath);
+  }
+}
+
+try {
+  await main();
+} catch {
+  // Fail-open: never break the user's session
+}
+process.exit(0);

--- a/plugins/codex/src/hooks/shared.ts
+++ b/plugins/codex/src/hooks/shared.ts
@@ -1,0 +1,94 @@
+// Codex CLI stdio helpers — the only tool-specific glue the adapter keeps.
+// Detection, policy, and persistence live in @akasecurity/plugin-sdk; these
+// just move bytes between Codex and the runtime. Structurally identical to
+// plugins/claude-code/src/hooks/shared.ts — Codex's hook stdin/stdout
+// contract is the same JSON-over-stdio shape.
+
+import { resolveRepo } from '@akasecurity/plugin-sdk';
+import type { EventMetadata } from '@akasecurity/schema';
+
+export async function readStdin(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    let data = '';
+    let settled = false;
+
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      process.stdin.removeListener('data', onData);
+      process.stdin.removeListener('end', finish);
+      resolve(data);
+    };
+    const onData = (chunk: string): void => {
+      data += chunk;
+    };
+    // A stalled or never-closed stdin must not hang the hook past the host's
+    // own timeout: settle with whatever arrived and let the caller fail open.
+    const timer = setTimeout(finish, 5_000);
+
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', onData);
+    process.stdin.on('end', finish);
+    // An unhandled 'error' here would be an uncaughtException, not a
+    // rejection — settle instead so the hook still exits 0.
+    process.stdin.on('error', finish);
+  });
+}
+
+export function parseJson(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+// Hook output protocol: write one JSON object to stdout and exit 0.
+// Writing nothing and exiting 0 means "no opinion" (allow).
+//
+// The flush must be awaited: hook entries call process.exit(0) right after
+// main(), and exit does not wait for pending pipe writes — anything past the
+// ~64KB pipe buffer is dropped, Codex sees invalid JSON, and the original
+// (possibly secret-bearing) payload passes through untouched.
+export function emit(output: unknown): Promise<void> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    // Same hazard as readStdin: an unhandled 'error' on stdout (e.g. EPIPE if
+    // the caller closed its end) is an uncaughtException, not a rejection —
+    // resolve instead so the hook still exits 0 rather than crashing on
+    // write. Deliberately never removed: a hook process exits right after, so
+    // one leftover no-op listener is free.
+    process.stdout.on('error', finish);
+    process.stdout.write(JSON.stringify(output), finish);
+  });
+}
+
+// Base event metadata every Codex hook can derive from its stdin payload: the
+// session id and the repo slug. Repo is resolved from the hook's `cwd` (every
+// Codex hook event carries it), falling back to the hook process's own cwd —
+// hooks run in the project root, so this is the same directory. Returns
+// undefined when nothing could be derived, so callers keep passing the
+// optional metadata through unchanged. Per-hook fields (filePath, toolName, …)
+// are layered on by the caller.
+export function baseMetadata(input: Record<string, unknown>): EventMetadata | undefined {
+  const metadata: EventMetadata = {};
+  const sessionId = getString(input, 'session_id');
+  if (sessionId) metadata.sessionId = sessionId;
+  const repo = resolveRepo(getString(input, 'cwd') ?? process.cwd());
+  if (repo) metadata.repo = repo;
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+}

--- a/plugins/codex/src/hooks/stop-payload.ts
+++ b/plugins/codex/src/hooks/stop-payload.ts
@@ -1,0 +1,23 @@
+// Pure Stop-payload parsing, split out of the `stop.ts` entry script so it can be
+// unit-tested WITHOUT importing the entry (whose top-level `main()` reads stdin and
+// would block test collection forever). Hooks stay thin glue; their logic is tested
+// here. See `stop.ts` for the runtime wiring. Identical to
+// plugins/claude-code/src/hooks/stop-payload.ts — Codex's Stop payload carries
+// the same session_id + transcript_path fields.
+import { getString } from './shared.ts';
+
+export interface StopTrigger {
+  sessionId: string;
+  transcriptPath: string;
+}
+
+// Pull the two fields the reconcile worker needs from a Stop payload. Returns
+// undefined when either is missing/non-string so the caller fails open (no spawn) —
+// a payload without a transcript path or session id can't be reconciled.
+export function parseStopPayload(input: Record<string, unknown> | null): StopTrigger | undefined {
+  if (input === null) return undefined;
+  const sessionId = getString(input, 'session_id');
+  const transcriptPath = getString(input, 'transcript_path');
+  if (sessionId === undefined || transcriptPath === undefined) return undefined;
+  return { sessionId, transcriptPath };
+}

--- a/plugins/codex/src/hooks/stop.ts
+++ b/plugins/codex/src/hooks/stop.ts
@@ -1,0 +1,32 @@
+/**
+ * Stop — fires once when the assistant finishes a turn. The live token-usage
+ * capture trigger. Identical wiring to plugins/claude-code/src/hooks/stop.ts —
+ * Codex's Stop payload carries the same session_id + transcript_path fields.
+ *
+ * stdin: { session_id, transcript_path, cwd, hook_event_name, ... }
+ *
+ * This hook does NOT reconcile inline — it only TRIGGERS the background worker so it
+ * adds zero latency to the turn. It reads `session_id` + `transcript_path` STRAIGHT
+ * from the payload (no path reconstruction), throttle-checks, and if not throttled
+ * spawns `scripts/reconcile.js` detached + unref, forwarding both via argv, then
+ * returns immediately. Fully fail-open: any error → no output, exit 0.
+ */
+import { loadConfig } from '@akasecurity/plugin-sdk';
+
+import { triggerReconcile } from '../history/reconcile-trigger.ts';
+import { parseJson, readStdin } from './shared.ts';
+import { parseStopPayload } from './stop-payload.ts';
+
+async function main(): Promise<void> {
+  const trigger = parseStopPayload(parseJson(await readStdin()));
+  if (trigger === undefined) return; // nothing to reconcile
+  const config = loadConfig();
+  triggerReconcile(config.dataDir, trigger.sessionId, trigger.transcriptPath);
+}
+
+try {
+  await main();
+} catch {
+  // Fail-open: never break the user's session
+}
+process.exit(0);

--- a/plugins/codex/src/hooks/store-health.ts
+++ b/plugins/codex/src/hooks/store-health.ts
@@ -1,0 +1,77 @@
+// Store-health degradation surfacing for the hook adapters.
+//
+// Every hook is fail-open: a store that cannot open must never break the
+// user's session, so enforcement errors collapse to "allow". But silence has a
+// cost of its own — with an unopenable store (corrupt/locked aka.db) NOTHING
+// is scanned, enforced, or recorded, and without a signal the session looks
+// protected while it is not. This module is the middle ground the adapters
+// share: opening the gateway stays fail-open (null instead of a throw), and
+// the user is told ONCE per session that detection is off and how to recover.
+//
+// Identical to plugins/claude-code/src/hooks/store-health.ts — no
+// harness-specific logic here, only @akasecurity/plugin-runtime/plugin-sdk
+// calls and a session-id-keyed fs marker.
+//
+// Pure logic + a tiny fs marker only — no main() side effect, so tests can
+// import it (hook ENTRY files run main() on import and must never be imported
+// by tests).
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
+import { DATA_DIR_MODE, DATA_FILE_MODE } from '@akasecurity/plugin-sdk';
+
+// A single marker holding the last session id warned — one file, overwritten
+// each new session so it never accumulates (same scheme as the onboarding
+// nudge marker).
+const STORE_WARNING_MARKER = 'store-warning-last-session';
+
+/**
+ * Open the data gateway, fail-open: any store-open failure (corrupt aka.db,
+ * bad permissions, a held lock) yields null instead of a throw, so the caller
+ * can both keep the session alive AND know that detection is off — a silent
+ * catch at the hook entry can't tell those apart.
+ */
+export function openGatewayOrNull(config: PluginConfig): DataGateway | null {
+  try {
+    return resolveDataGateway(config);
+  } catch {
+    return null;
+  }
+}
+
+/** The once-per-session degradation warning shown when the store cannot open. */
+export function storeUnavailableMessage(dbPath: string): string {
+  return (
+    `AKA could not open its local store (${dbPath}) — detection, enforcement, and recording are OFF for this session (fails open, so your session keeps working). ` +
+    'To restore protection, check the file and its permissions; a corrupt store can be moved aside and AKA will recreate it.'
+  );
+}
+
+/**
+ * Gate the store-unavailable warning to once per Codex session instead of
+ * once per hook fire. Records the current session id in a single marker file
+ * and returns true only the first time a given session asks. Fail-open toward
+ * WARNING: with no session id (can't dedupe), or on any fs error, it returns
+ * true — repeating the warning is noise; hiding that detection is off is not.
+ */
+export function claimStoreUnavailableWarning(
+  dataDir: string,
+  sessionId: string | undefined,
+): boolean {
+  if (!sessionId) return true; // no session id → can't dedupe, warn anyway
+  const path = join(dataDir, STORE_WARNING_MARKER);
+  try {
+    if (readFileSync(path, 'utf8') === sessionId) return false;
+  } catch {
+    // No marker yet (or unreadable) → this is the first warning for the session.
+  }
+  try {
+    mkdirSync(dataDir, { recursive: true, mode: DATA_DIR_MODE });
+    writeFileSync(path, sessionId, { mode: DATA_FILE_MODE });
+  } catch {
+    // Couldn't record the claim → still warn now (an extra warning beats silence).
+  }
+  return true;
+}

--- a/plugins/codex/src/hooks/tool-response.ts
+++ b/plugins/codex/src/hooks/tool-response.ts
@@ -1,0 +1,77 @@
+// PostToolUse tool_response shapes for Codex CLI. Structurally identical to
+// plugins/claude-code/src/hooks/tool-response.ts (path-based read/rewrite over
+// a structured response object) — only RESPONSE_TEXT_PATHS differs, because
+// Codex's built-in tools differ from Claude Code's.
+//
+// IMPORTANT — Codex-specific caveat, unlike Claude Code: Codex's PostToolUse
+// hook has no `updatedToolOutput` field (confirmed: the Agent Guard plugin's
+// own README states Codex "does not expose that Claude field" and instead
+// injects a warning via `additionalContext`). `replaceResponseField` below is
+// therefore used only to compute what WOULD be redacted for the systemMessage/
+// additionalContext text — never to actually rewrite what the model sees. See
+// post-tool-use.ts for how the emit payload degrades accordingly.
+//
+// Only `Bash` is mapped today: PostToolUse does not fire for `apply_patch`
+// calls yet (see pre-tool-use-decision.ts's module comment), so there is no
+// live tool_response shape for it to verify against.
+//
+// Kept free of I/O and hook wiring so it can be unit-tested (hook entry modules
+// run main() on import and hang vitest collection).
+
+export interface ScannableResponseField {
+  /** Key path into the response object; [] means the response itself. */
+  path: string[];
+  text: string;
+}
+
+// Which fields of each tool's structured response carry text the model will
+// see. `stdout`/`stderr` mirrors Claude Code's own Bash mapping — Codex's
+// rollout `exec_command_end` event carries the same field names
+// (codex-rs/protocol/src/protocol.rs — ExecCommandEndEvent).
+const RESPONSE_TEXT_PATHS: Record<string, string[][]> = {
+  Bash: [['stdout'], ['stderr']],
+};
+
+function stringAt(response: unknown, path: string[]): string | undefined {
+  let current: unknown = response;
+  for (const key of path) {
+    if (typeof current !== 'object' || current === null) return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return typeof current === 'string' ? current : undefined;
+}
+
+/**
+ * The text fields of a tool response worth scanning, with the path needed to
+ * write a redacted replacement back. Empty strings are skipped — nothing to
+ * scan, and rewriting them would be a pointless output replacement.
+ */
+export function scannableResponseFields(
+  toolName: string,
+  response: unknown,
+): ScannableResponseField[] {
+  if (typeof response === 'string') {
+    return response === '' ? [] : [{ path: [], text: response }];
+  }
+  const paths = Object.hasOwn(RESPONSE_TEXT_PATHS, toolName)
+    ? RESPONSE_TEXT_PATHS[toolName]
+    : undefined;
+  const fields: ScannableResponseField[] = [];
+  for (const path of paths ?? []) {
+    const text = stringAt(response, path);
+    if (text !== undefined && text !== '') fields.push({ path, text });
+  }
+  return fields;
+}
+
+/**
+ * Copy of `response` with the string at `path` replaced, leaving the original
+ * untouched. Only the spine along `path` is cloned; sibling values are shared.
+ */
+export function replaceResponseField(response: unknown, path: string[], text: string): unknown {
+  const head = path[0];
+  if (head === undefined) return text;
+  if (typeof response !== 'object' || response === null) return response;
+  const record = response as Record<string, unknown>;
+  return { ...record, [head]: replaceResponseField(record[head], path.slice(1), text) };
+}

--- a/plugins/codex/src/hooks/user-prompt-submit.ts
+++ b/plugins/codex/src/hooks/user-prompt-submit.ts
@@ -15,7 +15,8 @@
  *   no output                            → allow
  *
  * Codex cannot rewrite prompt text on this event either, so a `redact` decision
- * degrades to a warning here, same as Claude Code; true redaction happens in
+ * BLOCKS here, same as Claude Code — warning and passing the prompt through
+ * would send the raw secret to the model. True in-place redaction happens in
  * pre-tool-use via updatedInput.
  *
  * This is also the first-run nudge point: on a clean prompt from a machine that
@@ -70,7 +71,10 @@ async function main(): Promise<void> {
     await runtime.close();
   }
 
-  if (result.action === 'block') {
+  if (result.action === 'block' || result.action === 'redact') {
+    // A redact policy blocks here too: this surface has no prompt-rewrite
+    // channel, so the only way to honor "the raw value must not reach the
+    // model" is to stop the prompt with removal-based guidance.
     await emit({
       decision: 'block',
       reason: blockMessage({
@@ -81,9 +85,12 @@ async function main(): Promise<void> {
     });
     return;
   }
-  if (result.action === 'redact' || result.action === 'warn') {
+  if (result.action === 'warn') {
+    // A warn never escalates: the prompt continues, flagged. A warned value is
+    // ledgered like a blocked one, so when a reference exists the message
+    // points at the same out-of-band approve flow.
     await emit({
-      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}). Prompts cannot be redacted in place — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
+      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}) — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
     });
     return;
   }
@@ -91,7 +98,7 @@ async function main(): Promise<void> {
   if (!config.onboarded && claimOnboardingNudge(config.dataDir, sessionId)) {
     await emit({
       systemMessage:
-        'AKA is active and monitoring your prompts (log-only by default — nothing is blocked or redacted yet). Run the aka:setup skill to choose your installation type and set enforcement (warn/redact/block) per detection.',
+        'AKA is active and monitoring your prompts (log-only by default — nothing is blocked or redacted yet). Run the aka-setup skill to choose your installation type and set enforcement (warn/redact/block) per detection.',
     });
   }
 }

--- a/plugins/codex/src/hooks/user-prompt-submit.ts
+++ b/plugins/codex/src/hooks/user-prompt-submit.ts
@@ -1,0 +1,104 @@
+/**
+ * UserPromptSubmit — fires after the user submits a prompt, before the model
+ * sees it. Same event name and stdin shape as Claude Code's UserPromptSubmit hook.
+ *
+ * stdin:  { prompt, session_id, cwd, hook_event_name, ... }
+ * stdout (exit 0):
+ *   {"decision":"block","reason":"..."}  → this prompt is rejected, reason
+ *     shown, the SESSION continues (the user can resubmit) — confirmed
+ *     against UserPromptSubmitCommandOutputWire in openai/codex's
+ *     codex-rs/hooks/src/schema.rs. `continue:false` (the universal
+ *     HookUniversalOutputWire field every hook output shares) is a DIFFERENT,
+ *     stronger signal that stops the whole turn — using it here would kill
+ *     the session over one flagged prompt instead of just rejecting it.
+ *   {"systemMessage":"..."}              → warning shown, prompt continues
+ *   no output                            → allow
+ *
+ * Codex cannot rewrite prompt text on this event either, so a `redact` decision
+ * degrades to a warning here, same as Claude Code; true redaction happens in
+ * pre-tool-use via updatedInput.
+ *
+ * This is also the first-run nudge point: on a clean prompt from a machine that
+ * hasn't completed setup, surface a one-line pointer to it. And it is the
+ * store-health surface: when the local store cannot open (so nothing is
+ * scanned or recorded), say so once per session instead of silently looking
+ * protected.
+ * Fail-open: any error → no output, exit 0.
+ */
+import type { CaptureResult } from '@akasecurity/plugin-sdk';
+import {
+  claimOnboardingNudge,
+  createPluginRuntime,
+  loadConfig,
+  uniqueRuleIds,
+} from '@akasecurity/plugin-sdk';
+
+import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
+import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
+import {
+  claimStoreUnavailableWarning,
+  openGatewayOrNull,
+  storeUnavailableMessage,
+} from './store-health.ts';
+
+async function main(): Promise<void> {
+  const input = parseJson(await readStdin());
+  const prompt = input ? getString(input, 'prompt') : undefined;
+  if (prompt === undefined || prompt === '') return;
+
+  const config = loadConfig();
+  const sessionId = input ? getString(input, 'session_id') : undefined;
+  const metadata = input ? baseMetadata(input) : undefined;
+
+  const gateway = openGatewayOrNull(config);
+  if (gateway === null) {
+    if (claimStoreUnavailableWarning(config.dataDir, sessionId)) {
+      await emit({ systemMessage: storeUnavailableMessage(config.dbPath) });
+    }
+    return;
+  }
+  const runtime = createPluginRuntime(gateway, config.settings, { dataDir: config.dataDir });
+  let result: CaptureResult;
+  try {
+    result = await runtime.capture({
+      kind: 'prompt',
+      sourceTool: 'codex',
+      text: prompt,
+      metadata,
+    });
+  } finally {
+    await runtime.close();
+  }
+
+  if (result.action === 'block') {
+    await emit({
+      decision: 'block',
+      reason: blockMessage({
+        subject: 'prompt',
+        ruleIds: uniqueRuleIds(result.findings),
+        blockedRef: result.blockedReferences?.[0],
+      }),
+    });
+    return;
+  }
+  if (result.action === 'redact' || result.action === 'warn') {
+    await emit({
+      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}). Prompts cannot be redacted in place — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
+    });
+    return;
+  }
+
+  if (!config.onboarded && claimOnboardingNudge(config.dataDir, sessionId)) {
+    await emit({
+      systemMessage:
+        'AKA is active and monitoring your prompts (log-only by default — nothing is blocked or redacted yet). Run the aka:setup skill to choose your installation type and set enforcement (warn/redact/block) per detection.',
+    });
+  }
+}
+
+try {
+  await main();
+} catch {
+  // Fail-open: never break the user's session
+}
+process.exit(0);

--- a/plugins/codex/src/intro.ts
+++ b/plugins/codex/src/intro.ts
@@ -1,0 +1,72 @@
+/**
+ * Setup-intro card — the first screen of the aka-setup wizard (the onboarding
+ * mock). Invoked by the wizard as:
+ *
+ *   node scripts/intro.js <path-to-.codex-plugin/plugin.json>
+ *
+ * The wizard passes the manifest path (it has ${PLUGIN_ROOT} in the shell).
+ * Factual fields — version, repository, publisher — are read from that
+ * manifest so the card never drifts from the actually-installed plugin; the
+ * descriptive copy (display name, tagline, "what it adds") is product wording
+ * supplied here. Rendering lives in ./render so it unit-tests without touching
+ * the filesystem.
+ *
+ * Fail-open: an unreadable/old manifest still prints the card with the product
+ * copy and blank/placeholder facts — onboarding should never show a stack trace.
+ */
+import { readFileSync } from 'node:fs';
+
+import { fenced } from './present.ts';
+import { renderSetupIntro } from './render.ts';
+
+// Product copy. Not in the manifest because it's marketing wording, not a fact
+// about the installed build — the values below ARE read from the manifest.
+const NAME = 'AKA Security';
+const TAGLINE = 'Agent Harness Security for Codex CLI.';
+const ADDS = 'Secures your local environment to prevent secret leakage and vulnerabilities.';
+
+interface Manifest {
+  version?: string;
+  homepage?: string;
+  author?: { name?: string } | string;
+}
+
+// "https://github.com/org/repo/tree/main/..." → "github.com/org/repo", the
+// compact form the mock shows. Falls back to the raw value if it isn't a URL.
+function repoLabel(homepage: string | undefined): string {
+  if (!homepage) return '';
+  const stripped = homepage.replace(/^https?:\/\//, '');
+  const parts = stripped.split('/');
+  return parts.length >= 3 ? parts.slice(0, 3).join('/') : stripped;
+}
+
+function authorName(author: Manifest['author']): string {
+  if (typeof author === 'string') return author;
+  return author?.name ?? '';
+}
+
+const manifestPath = process.argv[2];
+
+let manifest: Manifest = {};
+try {
+  manifest = JSON.parse(readFileSync(manifestPath ?? '', 'utf8')) as Manifest;
+} catch {
+  // Keep manifest empty; the card renders with product copy + blank facts.
+}
+
+process.stdout.write(
+  `${fenced(
+    renderSetupIntro({
+      name: NAME,
+      tagline: TAGLINE,
+      repository: repoLabel(manifest.homepage),
+      version: manifest.version ?? '',
+      publisher: authorName(manifest.author),
+      adds: ADDS,
+    }),
+  )}\n`,
+);
+
+// Match the other adapter scripts (query.js, onboard.js) which hard-exit on
+// completion so no stray handle can keep the process alive.
+process.exit(0);

--- a/plugins/codex/src/onboard.ts
+++ b/plugins/codex/src/onboard.ts
@@ -29,7 +29,11 @@ import {
   severityFloorPosture,
 } from '@akasecurity/plugin-sdk';
 import type { WorkspaceSettings } from '@akasecurity/schema';
-import { HistoricalAccess, SimpleDetectionPolicy } from '@akasecurity/schema';
+import {
+  HistoricalAccess,
+  MODEL_JUDGE_PAYLOAD_VERSION,
+  SimpleDetectionPolicy,
+} from '@akasecurity/schema';
 import { parsePosture } from '@akasecurity/setup-wizard';
 
 import { show } from './present.ts';
@@ -79,6 +83,16 @@ if (rawHistorical !== undefined) {
   else answers.historicalAccess = parsed.data;
 }
 
+// The distinct consent for sending findings to the model API (separate from
+// --historical, which only governs reading rollouts). A boolean flag: its
+// presence records consent against the current payload-shape version.
+if (process.argv.includes('--model-judge-consent')) {
+  answers.modelJudgeConsent = {
+    acknowledgedAt: new Date().toISOString(),
+    payloadVersion: MODEL_JUDGE_PAYLOAD_VERSION,
+  };
+}
+
 const rawPosture = flags.get('posture');
 const useFloor = process.argv.includes('--floor');
 const recalibrate = process.argv.includes('--recalibrate');
@@ -89,13 +103,30 @@ const recalibrate = process.argv.includes('--recalibrate');
 if (useFloor && rawPosture !== undefined) fail('--floor and --posture are mutually exclusive');
 
 if (Object.keys(answers).length === 0 && rawPosture === undefined && !useFloor) {
-  fail('nothing to save — pass --policy, --historical, --posture and/or --floor');
+  fail(
+    'nothing to save — pass --policy, --historical, --model-judge-consent, --posture and/or --floor',
+  );
 }
+
+// Recording the model-judge consent is not an onboarding-posture answer: it
+// grants an egress, and on the wizard's Yes path this write's confirmation is
+// the only signal the grant registered. So it gets its own line rather than the
+// historical-scan one, and a consent-only write does not run the posture pass
+// below — acknowledging an egress must never be able to change enforcement.
+const wroteConsent = answers.modelJudgeConsent !== undefined;
+const wrotePosture = answers.policy !== undefined || answers.historicalAccess !== undefined;
 
 if (Object.keys(answers).length > 0) {
   try {
     const settings = applyOnboarding(answers);
-    process.stdout.write(show("Got it — I'll look over Codex's recent work to tune things."));
+    if (wrotePosture) {
+      process.stdout.write(show("Got it — I'll look over Codex's recent work to tune things."));
+    }
+    if (wroteConsent) {
+      process.stdout.write(
+        show("Noted — I'll send findings to the model to rate them. You can revoke that anytime."),
+      );
+    }
     // Caps any existing block/redact category rows to warn once when this
     // store's chosen handling is 'warn'. Failure here does not fail the
     // settings write above.

--- a/plugins/codex/src/onboard.ts
+++ b/plugins/codex/src/onboard.ts
@@ -1,27 +1,42 @@
 /**
  * Onboarding writer invoked by the aka-setup skill — the only entry that
- * mutates settings.json. The wizard (skills/setup/SKILL.md) collects the
- * answers conversationally, then runs:
+ * mutates settings.json and the policies store. The wizard (skills/setup/SKILL.md)
+ * collects the answers conversationally, then runs:
  *
- *   node scripts/onboard.js --policy <redact|warn> --historical <full|session-only>
+ *   node scripts/onboard.js --policy <redact|warn> --historical <full|session-only> \
+ *     --posture <json> --floor
  *
  * Each flag is optional and additive: omit one and its current value (or the
  * default) is kept, so a later wizard step is one more flag with no rewrite.
  * Validation lives in @akasecurity/schema (SimpleDetectionPolicy/HistoricalAccess);
  * persistence + the onboardedAt stamp live in the SDK's applyOnboarding. Pure
- * adapter glue — identical to plugins/claude-code/src/onboard.ts.
+ * adapter glue.
+ *
+ * `--posture <json>` writes the wizard's per-category model calibration
+ * (validated by @akasecurity/setup-wizard's parsePosture); `--floor` writes the
+ * severity-floor fallback instead (`severityFloorPosture()`) when the backfill
+ * was too thin to calibrate from. Both go straight to the policies store via
+ * applyCategoryPosture, separate from the settings.json answers above.
+ * `--posture` overwrites existing category rows (confirmed calibration) while
+ * `--floor` only fills gaps; `--recalibrate` forces an overwrite on the floor
+ * write. `--floor` and `--posture` are mutually exclusive.
  */
 import { capWarnEraEnforcementOnce, openLocalDatabase } from '@akasecurity/persistence';
-import { applyCategoryPosture, applyOnboarding, loadConfig } from '@akasecurity/plugin-sdk';
-import type { WorkspaceSettings } from '@akasecurity/schema';
 import {
-  FULL_ENFORCEMENT_POSTURE,
-  HistoricalAccess,
-  SimpleDetectionPolicy,
-} from '@akasecurity/schema';
+  applyCategoryPosture,
+  applyOnboarding,
+  loadConfig,
+  severityFloorPosture,
+} from '@akasecurity/plugin-sdk';
+import type { WorkspaceSettings } from '@akasecurity/schema';
+import { HistoricalAccess, SimpleDetectionPolicy } from '@akasecurity/schema';
+import { parsePosture } from '@akasecurity/setup-wizard';
+
+import { show } from './present.ts';
+import { renderCategoriesTuned } from './render.ts';
 
 // Pull `--flag value` and `--flag=value` pairs out of argv. Unknown flags and
-// positionals are ignored — the wizard only ever passes the two it knows.
+// positionals are ignored — the wizard only ever passes the ones it knows.
 function parseFlags(argv: string[]): Map<string, string> {
   const flags = new Map<string, string>();
   for (let i = 0; i < argv.length; i++) {
@@ -64,54 +79,79 @@ if (rawHistorical !== undefined) {
   else answers.historicalAccess = parsed.data;
 }
 
-if (Object.keys(answers).length === 0) {
-  fail('nothing to save — pass --policy and/or --historical');
+const rawPosture = flags.get('posture');
+const useFloor = process.argv.includes('--floor');
+const recalibrate = process.argv.includes('--recalibrate');
+
+// --floor (the severity-floor fallback) and --posture (a confirmed calibration)
+// are two different writes for the same store — passing both is ambiguous, so
+// reject it before touching anything.
+if (useFloor && rawPosture !== undefined) fail('--floor and --posture are mutually exclusive');
+
+if (Object.keys(answers).length === 0 && rawPosture === undefined && !useFloor) {
+  fail('nothing to save — pass --policy, --historical, --posture and/or --floor');
 }
 
-try {
-  const settings = applyOnboarding(answers);
-  process.stdout.write(
-    `AKA configured: policy=${settings.policy}, ` +
-      `historicalAccess=${settings.historicalAccess}. ` +
-      `Settings saved to ~/.aka/settings/settings.json.\n`,
-  );
-  // Caps any existing block/redact category rows to warn once when this
-  // store's chosen handling is 'warn'. Failure here does not fail the
-  // settings write above.
+if (Object.keys(answers).length > 0) {
   try {
-    const dataDir = loadConfig().dataDir;
-    const db = openLocalDatabase(dataDir);
+    const settings = applyOnboarding(answers);
+    process.stdout.write(show("Got it — I'll look over Codex's recent work to tune things."));
+    // Caps any existing block/redact category rows to warn once when this
+    // store's chosen handling is 'warn'. Failure here does not fail the
+    // settings write above.
     try {
-      const { capped } = capWarnEraEnforcementOnce(db, settings.policy, dataDir);
-      if (capped > 0) {
-        process.stdout.write(
-          `AKA: kept ${String(capped)} existing block/redact categories at warn ` +
-            `(the global "warn only" handling was retired). Confirm per-category ` +
-            `enforcement in this setup.\n`,
-        );
-      }
-    } finally {
-      db.close();
-    }
-  } catch {
-    // Best-effort: see comment above.
-  }
-  // A --policy redact flag writes FULL_ENFORCEMENT_POSTURE as real
-  // per-category policy rows. --policy warn requires no additional write.
-  if (rawPolicy === 'redact') {
-    try {
-      const db = openLocalDatabase(loadConfig().dataDir);
+      const dataDir = loadConfig().dataDir;
+      const db = openLocalDatabase(dataDir);
       try {
-        applyCategoryPosture(FULL_ENFORCEMENT_POSTURE, db.policies, 'overwrite');
+        const { capped } = capWarnEraEnforcementOnce(db, settings.policy, dataDir);
+        if (capped > 0) {
+          process.stdout.write(
+            show(
+              `I eased ${String(capped)} detection level${capped === 1 ? '' : 's'} back to ` +
+                `"warn" to match the new defaults — you can raise any of them again in this setup.`,
+            ),
+          );
+        }
       } finally {
         db.close();
       }
     } catch {
-      // Best-effort: a failed write here leaves the existing posture in place.
+      // Best-effort: see comment above.
     }
+  } catch (err) {
+    fail(err instanceof Error ? err.message : 'could not save your settings');
   }
-} catch (err) {
-  fail(err instanceof Error ? err.message : 'could not write settings.json');
+}
+
+// The wizard's per-category posture (its model calibration, or the
+// severity-floor fallback on a too-thin backfill) — written straight to the
+// policies store, separate from the settings.json answers above.
+if (rawPosture !== undefined || useFloor) {
+  try {
+    let posture;
+    if (useFloor) posture = severityFloorPosture();
+    else if (rawPosture !== undefined) posture = parsePosture(rawPosture);
+    else fail('--posture requires a JSON value');
+    // --posture is a user-confirmed calibration, so it overwrites any existing
+    // category rows; --floor is the fallback and only fills gaps (never
+    // downgrades a calibrated posture) unless --recalibrate forces an overwrite.
+    const mode = rawPosture !== undefined || recalibrate ? 'overwrite' : 'fill-gaps';
+    const db = openLocalDatabase(loadConfig().dataDir);
+    try {
+      applyCategoryPosture(posture, db.policies, mode);
+      // The applying confirmation — the "tuned" segment reports the
+      // categories the applied posture covers (the 8-pack matrix, or the
+      // severity-floor fallback), never a literal.
+      const categoryCount = Object.keys(posture).length;
+      process.stdout.write(
+        show(renderCategoriesTuned(categoryCount) + (useFloor ? ' — safe defaults' : '')),
+      );
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    fail(err instanceof Error ? err.message : 'could not save per-category posture');
+  }
 }
 
 // Explicit success exit, matching the other adapter entry scripts (query.js,

--- a/plugins/codex/src/onboard.ts
+++ b/plugins/codex/src/onboard.ts
@@ -1,0 +1,121 @@
+/**
+ * Onboarding writer invoked by the aka-setup skill — the only entry that
+ * mutates settings.json. The wizard (skills/setup/SKILL.md) collects the
+ * answers conversationally, then runs:
+ *
+ *   node scripts/onboard.js --policy <redact|warn> --historical <full|session-only>
+ *
+ * Each flag is optional and additive: omit one and its current value (or the
+ * default) is kept, so a later wizard step is one more flag with no rewrite.
+ * Validation lives in @akasecurity/schema (SimpleDetectionPolicy/HistoricalAccess);
+ * persistence + the onboardedAt stamp live in the SDK's applyOnboarding. Pure
+ * adapter glue — identical to plugins/claude-code/src/onboard.ts.
+ */
+import { capWarnEraEnforcementOnce, openLocalDatabase } from '@akasecurity/persistence';
+import { applyCategoryPosture, applyOnboarding, loadConfig } from '@akasecurity/plugin-sdk';
+import type { WorkspaceSettings } from '@akasecurity/schema';
+import {
+  FULL_ENFORCEMENT_POSTURE,
+  HistoricalAccess,
+  SimpleDetectionPolicy,
+} from '@akasecurity/schema';
+
+// Pull `--flag value` and `--flag=value` pairs out of argv. Unknown flags and
+// positionals are ignored — the wizard only ever passes the two it knows.
+function parseFlags(argv: string[]): Map<string, string> {
+  const flags = new Map<string, string>();
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg?.startsWith('--')) continue;
+    const eq = arg.indexOf('=');
+    if (eq !== -1) {
+      flags.set(arg.slice(2, eq), arg.slice(eq + 1));
+    } else {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('--')) {
+        flags.set(arg.slice(2), next);
+        i++;
+      }
+    }
+  }
+  return flags;
+}
+
+function fail(message: string): never {
+  process.stdout.write(`AKA setup failed: ${message}\n`);
+  process.exit(1);
+}
+
+const flags = parseFlags(process.argv.slice(2));
+const answers: Partial<WorkspaceSettings> = {};
+
+const rawPolicy = flags.get('policy');
+if (rawPolicy !== undefined) {
+  const parsed = SimpleDetectionPolicy.safeParse(rawPolicy);
+  if (!parsed.success) fail(`invalid --policy "${rawPolicy}" (expected redact or warn)`);
+  else answers.policy = parsed.data;
+}
+
+const rawHistorical = flags.get('historical');
+if (rawHistorical !== undefined) {
+  const parsed = HistoricalAccess.safeParse(rawHistorical);
+  if (!parsed.success)
+    fail(`invalid --historical "${rawHistorical}" (expected full or session-only)`);
+  else answers.historicalAccess = parsed.data;
+}
+
+if (Object.keys(answers).length === 0) {
+  fail('nothing to save — pass --policy and/or --historical');
+}
+
+try {
+  const settings = applyOnboarding(answers);
+  process.stdout.write(
+    `AKA configured: policy=${settings.policy}, ` +
+      `historicalAccess=${settings.historicalAccess}. ` +
+      `Settings saved to ~/.aka/settings/settings.json.\n`,
+  );
+  // Caps any existing block/redact category rows to warn once when this
+  // store's chosen handling is 'warn'. Failure here does not fail the
+  // settings write above.
+  try {
+    const dataDir = loadConfig().dataDir;
+    const db = openLocalDatabase(dataDir);
+    try {
+      const { capped } = capWarnEraEnforcementOnce(db, settings.policy, dataDir);
+      if (capped > 0) {
+        process.stdout.write(
+          `AKA: kept ${String(capped)} existing block/redact categories at warn ` +
+            `(the global "warn only" handling was retired). Confirm per-category ` +
+            `enforcement in this setup.\n`,
+        );
+      }
+    } finally {
+      db.close();
+    }
+  } catch {
+    // Best-effort: see comment above.
+  }
+  // A --policy redact flag writes FULL_ENFORCEMENT_POSTURE as real
+  // per-category policy rows. --policy warn requires no additional write.
+  if (rawPolicy === 'redact') {
+    try {
+      const db = openLocalDatabase(loadConfig().dataDir);
+      try {
+        applyCategoryPosture(FULL_ENFORCEMENT_POSTURE, db.policies, 'overwrite');
+      } finally {
+        db.close();
+      }
+    } catch {
+      // Best-effort: a failed write here leaves the existing posture in place.
+    }
+  }
+} catch (err) {
+  fail(err instanceof Error ? err.message : 'could not write settings.json');
+}
+
+// Explicit success exit, matching the other adapter entry scripts (query.js,
+// the hooks) which hard-exit so node:sqlite handles can't keep the process
+// alive. Reaching here means the write above succeeded — every failure path
+// goes through fail() → exit(1).
+process.exit(0);

--- a/plugins/codex/src/posture.ts
+++ b/plugins/codex/src/posture.ts
@@ -1,0 +1,37 @@
+import type { LocalDatabase } from '@akasecurity/persistence';
+
+import { renderPosture } from './render.ts';
+
+// The install-complete card's per-category posture block, read from the local
+// store (the wizard's policy write) so the card shows what's actually enforced
+// rather than the single settings.policy string.
+//
+// Best-effort by design: this OWNS the catch so a policies fault degrades to ''
+// — renderFirstRun then hides only the Posture section instead of letting the
+// throw propagate to firstrun's outer fail-open handler and collapse the entire
+// card into the store-unavailable note. The store is opened INSIDE the guarded
+// scope via the injected opener, so an open failure degrades identically to a
+// read failure. Always closes the handle when one was opened, on both paths.
+export async function readPostureBlock(
+  open: () => Pick<LocalDatabase, 'policies' | 'close'>,
+): Promise<string> {
+  let db: Pick<LocalDatabase, 'policies' | 'close'> | undefined;
+  try {
+    db = open();
+    const policies = await db.policies.readPolicies();
+    return renderPosture(
+      policies
+        .map((p) => ({
+          category: (p.target as { category?: string }).category ?? '',
+          action: p.action,
+        }))
+        .filter((r) => r.category !== ''),
+    );
+  } catch {
+    // Best-effort: an unreadable or unopenable policies store just omits the
+    // Posture section.
+    return '';
+  } finally {
+    db?.close();
+  }
+}

--- a/plugins/codex/src/present.ts
+++ b/plugins/codex/src/present.ts
@@ -1,3 +1,5 @@
+import { showBlock } from './setup-show.ts';
+
 // Tiny zero-dependency terminal layout kit for the read surfaces. The
 // hook/command scripts ship self-contained (no node_modules on the user's
 // machine), so we can't pull in picocolors/cli-table — plain text and a few
@@ -201,4 +203,11 @@ export function fenced(body: string): string {
   const longestRun = Math.max(0, ...[...body.matchAll(/`+/g)].map((m) => m[0].length));
   const fence = '`'.repeat(Math.max(3, longestRun + 1));
   return [fence, body, fence].join('\n');
+}
+
+// Wrap user-facing output in a SHOW relay region. The wizard's global contract
+// pastes everything between the markers verbatim; the markers are delimiters,
+// never shown. A card is show(fenced(card)); a plain confirmation is show(line).
+export function show(body: string): string {
+  return showBlock(body);
 }

--- a/plugins/codex/src/present.ts
+++ b/plugins/codex/src/present.ts
@@ -1,0 +1,204 @@
+// Tiny zero-dependency terminal layout kit for the read surfaces. The
+// hook/command scripts ship self-contained (no node_modules on the user's
+// machine), so we can't pull in picocolors/cli-table — plain text and a few
+// box-drawing / shade characters give the mockup's look with nothing to bundle.
+//
+// NO COLOR on the read surfaces. They are echoed verbatim into the Codex
+// transcript inside a monospace code block, where ANSI escape codes are NOT
+// interpreted — they'd show as literal `\x1b[…m` garbage. So meaning is carried
+// by glyph texture (shade blocks), spacing and labels, never by hue. All helpers
+// are pure (data → string); the entry scripts do the single process.stdout.write.
+//
+// `paint` (a 24-bit truecolor ANSI palette) is kept for parity with the Claude
+// Code adapter's optional statusline surface, but is unused here unless/until
+// Codex CLI exposes an equivalent ANSI-interpreting status surface — never
+// route a read-surface string through it.
+// visibleLength strips ANSI, so even if a colored span flows through, padding
+// math is unaffected.
+
+// Shade glyphs, lightest → darkest. The whole UI grammar: heavier fill = more
+// severe / more intense. Used for severity cells, the unreviewed tallies and the
+// stacked /health chart, so every surface reads the same way in plain monochrome.
+export const SHADE = {
+  light: '░',
+  medium: '▒',
+  dark: '▓',
+  full: '█',
+} as const;
+
+// Visible width. With no ANSI emitted this is just the length, but we still strip
+// any stray escape so padding/box math can never be thrown off by one.
+// eslint-disable-next-line no-control-regex -- matching the ANSI CSI escape
+const ANSI_RE = /\x1b\[[0-9;]*m/g;
+
+export function visibleLength(text: string): number {
+  return text.replace(ANSI_RE, '').length;
+}
+
+// ANSI palette, kept for parity — see module header. Colours are the exact
+// design tokens from packages/ui-kit/src/styles/theme.css, emitted as 24-bit
+// truecolor. Kept dependency-free — the hooks bundle with no node_modules.
+const fg =
+  (hex: string) =>
+  (text: string): string => {
+    const r = Number.parseInt(hex.slice(1, 3), 16);
+    const g = Number.parseInt(hex.slice(3, 5), 16);
+    const b = Number.parseInt(hex.slice(5, 7), 16);
+    return `\x1b[38;2;${String(r)};${String(g)};${String(b)}m${text}\x1b[0m`;
+  };
+
+export const paint = {
+  brand: fg('#33e6c6'), // --color-brand        · ▸▸ AKA wordmark (accent text)
+  dim: fg('#838995'), // --color-text-3      · separators · "/100" · the "unreviewed" label
+  bold: (text: string): string => `\x1b[1m${text}\x1b[0m`, // the health score number
+  ok: fg('#0db15f'), // --color-ok          · healthy ● dot
+  critical: fg('#e63448'), // --color-sev-critical · ■ and the open-findings flag
+  high: fg('#e97a0a'), // --color-sev-high     · ■ and the mid-health dot
+  medium: fg('#f7bd00'), // --color-sev-medium   · ■
+  low: fg('#0581d4'), // --color-sev-low      · ■ (azure blue, not purple)
+} as const;
+
+export function padEnd(text: string, width: number): string {
+  const pad = width - visibleLength(text);
+  return pad > 0 ? text + ' '.repeat(pad) : text;
+}
+
+export function padStart(text: string, width: number): string {
+  const pad = width - visibleLength(text);
+  return pad > 0 ? ' '.repeat(pad) + text : text;
+}
+
+// A proportional bar of solid blocks, padded to `width` with a faint track — the
+// gauge bars from the mockup. `max` of 0 renders an empty track. Length alone
+// carries the value, so it reads with no color.
+export function bar(value: number, max: number, width = 24): string {
+  const filled = max <= 0 ? 0 : Math.round((value / max) * width);
+  const clamped = Math.max(0, Math.min(width, filled));
+  return SHADE.full.repeat(clamped) + SHADE.light.repeat(width - clamped);
+}
+
+// A horizontal stacked bar: each segment contributes a run of its own shade
+// glyph, sized by its share of `total`; the whole run's length scales `total`
+// against `max`, so a day with fewer requests draws a shorter bar. The remainder
+// to `width` is blank (not a track) so the bar simply ends and the trailing count
+// still aligns. This is the per-day /health chart (passed / redacted / warned /
+// blocked runs), with the shade telling the segments apart in place of color.
+export interface BarSegment {
+  value: number;
+  glyph: string;
+}
+
+export function stackedBar(segments: BarSegment[], total: number, max: number, width = 24): string {
+  const filled = max <= 0 ? 0 : Math.max(0, Math.min(width, Math.round((total / max) * width)));
+  // Largest-remainder allocation. Rounding each segment independently with
+  // Math.round() can make the lengths sum to less than `filled`, leaving blank
+  // holes inside the bar. Instead floor every segment, then hand the leftover
+  // characters to the largest fractional remainders so the segments fill exactly
+  // their share — precisely `filled` characters when the values sum to `total`.
+  const parts = segments.map((seg) => {
+    const exact = total <= 0 ? 0 : (Math.max(0, seg.value) / total) * filled;
+    const len = Math.floor(exact);
+    return { glyph: seg.glyph, len, frac: exact - len };
+  });
+  const floored = parts.reduce((sum, p) => sum + p.len, 0);
+  // Round the segments' exact total to know how many chars they should cover
+  // (== filled when the values sum to total), capped at filled so we never overflow.
+  const target = Math.min(filled, Math.round(parts.reduce((sum, p) => sum + p.len + p.frac, 0)));
+  let remainder = target - floored;
+  for (const p of [...parts].sort((a, b) => b.frac - a.frac)) {
+    if (remainder <= 0) break;
+    p.len += 1;
+    remainder -= 1;
+  }
+  const out = parts.map((p) => p.glyph.repeat(p.len)).join('');
+  const placed = parts.reduce((sum, p) => sum + p.len, 0);
+  return out + ' '.repeat(Math.max(0, width - placed));
+}
+
+// Greedy word-wrap to `width` columns. Always returns at least one (possibly
+// empty) line so callers can index [0] safely.
+export function wrapText(text: string, width: number): string[] {
+  const lines: string[] = [];
+  let current = '';
+  for (const word of text.split(' ')) {
+    if (current === '') current = word;
+    else if (current.length + 1 + word.length <= width) current += ` ${word}`;
+    else {
+      lines.push(current);
+      current = word;
+    }
+  }
+  if (current !== '') lines.push(current);
+  return lines.length > 0 ? lines : [''];
+}
+
+// A definition list: labels in a fixed-width column, values trailing — the
+// "Repository / Version / Adds" block from the setup mock. Labels are padded to
+// the widest so the value column lines up. `gap` is the space between columns.
+export function defList(rows: [string, string][], gap = 4): string {
+  const labelWidth = Math.max(0, ...rows.map(([label]) => visibleLength(label)));
+  return rows
+    .map(([label, value]) => `${padEnd(label, labelWidth)}${' '.repeat(gap)}${value}`)
+    .join('\n');
+}
+
+// Left-pad every line of a (possibly multi-line) block by `spaces`, so a heading
+// can sit at column 0 with its body indented under it.
+export function indent(text: string, spaces = 2): string {
+  const pad = ' '.repeat(spaces);
+  return text
+    .split('\n')
+    .map((line) => pad + line)
+    .join('\n');
+}
+
+// A left-aligned column table with UPPERCASE headers and a configurable column
+// gap — the read-surface table style. `rowSep` draws a full-width rule under the
+// header and between every data row, so each row reads as its own banded entry
+// (the /findings look); without it the header gets the lighter per-column rule
+// and rows sit flush (the /audit look).
+export function table(
+  headers: string[],
+  rows: string[][],
+  opts: { gap?: number; rowSep?: boolean } = {},
+): string {
+  const gap = opts.gap ?? 3;
+  const widths = headers.map((h, i) =>
+    Math.max(visibleLength(h), ...rows.map((r) => visibleLength(r[i] ?? ''))),
+  );
+  const sep = ' '.repeat(gap);
+  const fmt = (cells: string[]): string =>
+    cells.map((cell, i) => padEnd(cell, widths[i] ?? 0)).join(sep);
+  const headerLine = fmt(headers.map((h) => h.toUpperCase()));
+
+  if (opts.rowSep === true) {
+    const fullWidth = widths.reduce((n, w) => n + w, 0) + gap * Math.max(0, widths.length - 1);
+    const rule = '─'.repeat(fullWidth);
+    const body: string[] = [];
+    rows.forEach((row, i) => {
+      if (i > 0) body.push(rule);
+      body.push(fmt(row));
+    });
+    return [headerLine, rule, ...body].join('\n');
+  }
+
+  const ruleLine = widths.map((w) => '─'.repeat(w)).join(sep);
+  return [headerLine, ruleLine, ...rows.map(fmt)].join('\n');
+}
+
+// Wrap a rendered surface in a Markdown code fence. The read surfaces are
+// space-aligned monospace and ONLY render correctly inside a fenced block —
+// outside one, Markdown collapses the indentation and turns line-start `1.`/`●`
+// into lists/bullets. Emitting the fence here (rather than trusting whatever
+// displays the output to add one) makes each surface self-contained: anything
+// that shows the script's stdout verbatim gets correct monospace.
+//
+// The fence is widened to one backtick longer than the longest backtick run in
+// the body: CommonMark closes a fenced block on the first line of >= as many
+// backticks, so a body that ever contains ``` (e.g. a masked match) would
+// otherwise break out of the block and mis-render everything after it.
+export function fenced(body: string): string {
+  const longestRun = Math.max(0, ...[...body.matchAll(/`+/g)].map((m) => m[0].length));
+  const fence = '`'.repeat(Math.max(3, longestRun + 1));
+  return [fence, body, fence].join('\n');
+}

--- a/plugins/codex/src/query.ts
+++ b/plugins/codex/src/query.ts
@@ -1,0 +1,89 @@
+/**
+ * Read surface for the transcript screens. Invoked by the aka-health,
+ * aka-findings, aka-recommend, aka-audit, and aka-exceptions skills as:
+ *
+ *   node scripts/query.js <findings|health|recommend|audit|tokens|exceptions>
+ *
+ * Resolves the data gateway from config (the local SQLite store), renders its
+ * plain data to monochrome terminal text, prints it, and exits.
+ * Adapter-only: the gateway + data shapes live in @akasecurity/plugin-runtime /
+ * @akasecurity/plugin-sdk; rendering lives in ./render. Writes go through
+ * process.stdout.write because no-console is an error in the shared config.
+ *
+ * Fail-open: a missing/locked store prints a friendly note and exits 0 — a
+ * read command should never surface a stack trace.
+ */
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+
+import { fenced } from './present.ts';
+import {
+  renderDetections,
+  renderExceptions,
+  runQuery,
+  SEVERITIES,
+  type Severity,
+} from './render.ts';
+
+const sub = process.argv[2] ?? '';
+const args = process.argv.slice(3);
+
+// findings severity filter: accept `--severity <level>`, `--severity=<level>`,
+// or the bare shorthands `--critical` / `--high` / `--medium` / `--low`. An
+// unknown level is ignored (the command still lists everything).
+function parseSeverity(argv: string[]): Severity | undefined {
+  const valid = (value: string | undefined): Severity | undefined =>
+    SEVERITIES.find((s) => s === value);
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i] ?? '';
+    if (arg === '--severity') return valid(argv[i + 1]);
+    if (arg.startsWith('--severity=')) return valid(arg.slice('--severity='.length));
+    const shorthand = valid(arg.replace(/^--/, ''));
+    if (shorthand !== undefined) return shorthand;
+  }
+  return undefined;
+}
+
+try {
+  const config = loadConfig();
+  if (sub === 'exceptions') {
+    // Detection-exception grants live in the plugin-local store (they are a
+    // machine-local trust decision, not gateway data — the DataGateway port has
+    // no exceptions read), so this view reads @akasecurity/persistence
+    // directly: db.exceptions.list() returns the ACTIVE grants only.
+    const db = openLocalDatabase(config.dataDir);
+    try {
+      process.stdout.write(`${fenced(renderExceptions(await db.exceptions.list()))}\n`);
+    } finally {
+      db.close();
+    }
+  } else if (sub === 'detections') {
+    // The installed detection inventory + update availability are local-store
+    // state (installed_packs vs the available_packs mirror), not gateway data —
+    // read @akasecurity/persistence directly, like `exceptions`.
+    const db = openLocalDatabase(config.dataDir);
+    try {
+      const { items } = await db.detections.listDetections({ filter: 'all' });
+      process.stdout.write(`${fenced(renderDetections(items))}\n`);
+    } finally {
+      db.close();
+    }
+  } else {
+    // Resolve the gateway at the configured data dir / connection (same config
+    // the hooks use), so the read commands stay in step with the active run mode.
+    const gateway = resolveDataGateway(config);
+    try {
+      const severity = parseSeverity(args);
+      process.stdout.write(
+        `${fenced(await runQuery(sub, gateway, severity !== undefined ? { severity } : {}))}\n`,
+      );
+    } finally {
+      await gateway.close();
+    }
+  }
+} catch {
+  process.stdout.write('AKA could not read your data yet. It populates as you use Codex.\n');
+}
+
+process.exit(0);

--- a/plugins/codex/src/reconcile.ts
+++ b/plugins/codex/src/reconcile.ts
@@ -1,0 +1,30 @@
+/**
+ * Detached token-usage reconcile worker.
+ * Spawned DETACHED by the Stop hook (and the SessionStart catch-up) so the live
+ * per-turn capture never adds hook latency — this process outlives the hook and
+ * does the actual read/parse/write off the hot path:
+ *
+ *   node scripts/reconcile.js <sessionId> <transcriptPath>
+ *
+ * It reconciles ONLY the new transcript tail (from the stored per-session byte
+ * offset) into idempotent `llm_call` leaves under the session root, in one
+ * transaction. Both args come straight from the Stop payload — no path
+ * reconstruction. Fully fail-open: any error (a locked store, a missing file, a
+ * malformed arg) drops this pass silently; the next Stop or SessionStart catch-up
+ * recovers the tail idempotently. Always exits 0.
+ */
+import { loadConfig } from '@akasecurity/plugin-sdk';
+
+import { reconcileSessionTail } from './history/usage.ts';
+
+try {
+  const sessionId = process.argv[2];
+  const transcriptPath = process.argv[3];
+  if (sessionId && transcriptPath) {
+    const config = loadConfig();
+    await reconcileSessionTail(config, sessionId, transcriptPath);
+  }
+} catch {
+  // Fail-open: the next pass recovers this tail idempotently.
+}
+process.exit(0);

--- a/plugins/codex/src/remediation/entry.ts
+++ b/plugins/codex/src/remediation/entry.ts
@@ -1,0 +1,287 @@
+/**
+ * The production entry for the secret-leak remediation chain — the shipped
+ * script the aka-setup skill runs when the user chooses "Review leaked keys"
+ * at frame 0.6. Untestable glue only: it composes the existing DI core
+ * (findings loader, batched-decision presenter, decision layout renderer,
+ * option router, standing-posture writer, deliverable resolver) with real IO —
+ * no logic lives here that isn't already tested in its own module.
+ *
+ *   Present:  node scripts/remediate.js
+ *   Route:    node scripts/remediate.js --option <redact-rotation-checklist|redact-only|set-secret-redact|leave>
+ *             [--posture <redact|warn|block|monitor>]  (required for the two redact options)
+ *
+ * Both modes read the SAME calibration frame text from stdin: the frame JSON
+ * block the calibration preview emitted at frame 0.4, carrying the raw-free
+ * `maskedFindings` this flow presents. That text is the only place the surfaced
+ * secret-leak findings exist outside the store, so the wizard threads the SAME
+ * captured text through both invocations unchanged — mirroring how the
+ * calibration preview's own preview/confirm split reads its plan back rather
+ * than re-deriving it.
+ *
+ * The chain is invoked with a findings set plus a RemediationEntryContext and
+ * holds no wizard state, so this entry is one caller among the
+ * entry-point-agnostic chain's callers — nothing here is specific to the
+ * frame-0.6 first-run entry beyond the `entrySource` it supplies.
+ *
+ * Redaction is bound to the hardened production adapter (redactSurfacedSecrets),
+ * which derives its own rollout/temp artifact scope rather than trusting a
+ * caller-supplied root — never the raw `redactLeakedKeys` primitive a caller
+ * could widen. Fail-open throughout: an unreadable frame or a store/redaction
+ * fault degrades to an honest note rather than throwing and breaking the Codex
+ * session; a malformed `--option`, or a redact route missing a valid
+ * `--posture`, fails loud (a wizard wiring bug, not a session fault),
+ * mirroring the calibration preview's malformed `--plan` handling.
+ *
+ * Both redact options carry a follow-up standing-posture step after redacting:
+ * the wizard collects a standing-posture level (Redact/Warn/Block/Monitor) and
+ * threads it straight through as `--posture` — no second script call. This
+ * script only persists the chosen level. `redact-only` prints the redaction
+ * confirmation, then the posture confirmation. `redact-rotation-checklist`
+ * prints the posture confirmation, then the resolved summary — which reports the
+ * redaction (with the transcript count) itself, so the standalone confirmation
+ * is not repeated ahead of it.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import {
+  BuiltinPolicyId,
+  CalibrationFrame,
+  type MaskedSecretFinding,
+  RemediationOption,
+} from '@akasecurity/schema';
+import { presentBatchedRemediation, routeRemediationOption } from '@akasecurity/setup-wizard';
+import { resolveRemediationDeliverable } from '@akasecurity/setup-wizard';
+import { type StandingPostureResult, writeStandingSecretPosture } from '@akasecurity/setup-wizard';
+import { renderRedactionOutcome } from '@akasecurity/setup-wizard';
+
+import { fenced, show } from '../present.ts';
+import { frameJsonBlock, readFrameJsonBlock } from '../setup-frame-json.ts';
+import { readRegisteredSkills } from '../skills-registry.ts';
+import { loadSecretLeakFindings } from './findings.ts';
+import { renderRemediationDecision } from './render.ts';
+import { redactSurfacedSecrets } from './surfaced-redact.ts';
+
+function fail(message: string): never {
+  process.stderr.write(`AKA remediate failed: ${message}\n`);
+  process.exit(1);
+}
+
+// The honest note both modes print when the calibration frame could not be read
+// or parsed. `loadSecretLeakFindings` returns `undefined` on a read/parse fault
+// (distinct from `[]`, a clean read with no secrets), so neither mode fabricates
+// an all-clear ("No exposed keys to deal with — you're clear.") or a false
+// success ("✓ Redacted 0 keys.") off a frame it never actually read.
+const FRAME_READ_NOTE =
+  "I couldn't pull up what I found just now — the details weren't available.\n";
+
+// The batched remediation decision's chaining line "N more worth a look" count: the calibration
+// preview's whole-run surfaced count minus the secret findings this batch
+// already covers — real and non-negative, never fabricated. Best-effort: an
+// unreadable/malformed frame yields 0 (no fabricated figure) rather than
+// throwing — the caller already degraded honestly if the frame itself could
+// not be read.
+//
+// SCOPE: `counts.important` counts distinct VALUES (the judge reasons over one
+// representative per value), while `findings` carries one entry per artifact a
+// value was found in. Subtracting the raw finding count would mix the two and
+// understate the remainder whenever one key sits in several transcripts, so the
+// batch's coverage is converted to its distinct-value count first.
+function moreWorthALook(frameText: string, findings: readonly MaskedSecretFinding[]): number {
+  try {
+    const frame = CalibrationFrame.parse(readFrameJsonBlock(frameText));
+    const distinctValues = new Set(findings.map((f) => f.maskedToken)).size;
+    return Math.max(0, frame.counts.important - distinctValues);
+  } catch {
+    return 0;
+  }
+}
+
+// Present the batched remediation decision over the findings the
+// calibration frame carries: the templated-count prompt, the full layout
+// (finding table, recommendation line, registry-driven chaining line), and the
+// exactly-four options as a machine-readable block for the wizard/harness to
+// read alongside the human copy.
+function present(frameText: string): void {
+  const findings = loadSecretLeakFindings(() => frameText);
+  if (findings === undefined) {
+    process.stdout.write(show(FRAME_READ_NOTE));
+    return;
+  }
+  const decision = presentBatchedRemediation(findings, { entrySource: 'first-run' });
+  if (decision.kind !== 'decision') {
+    process.stdout.write(show("No exposed keys to deal with — you're clear."));
+    return;
+  }
+  const layout = renderRemediationDecision(
+    findings,
+    moreWorthALook(frameText, findings),
+    readRegisteredSkills(),
+  );
+  process.stdout.write(show(`${decision.prompt}\n\n${fenced(layout)}`));
+  process.stdout.write(frameJsonBlock(decision));
+}
+
+// The posture confirmation line both the redact routes' post-redact posture
+// write and the 'set-secret-redact' shortcut print.
+function postureConfirmation(result: StandingPostureResult): string {
+  return result.persisted
+    ? `✓ From now on, I'll treat secrets like these as ${result.level}.\n`
+    : "I couldn't save that detection level just now — my records weren't reachable.\n";
+}
+
+// Persist the chosen standing 'secret' posture to the policies store, opening
+// and closing the local store within this one call — the same fail-open path
+// the 'set-secret-redact' shortcut has always used. A store that can't even be
+// opened reports a non-persisted result rather than throwing. The teardown
+// `close()` is best-effort: a fault there must never override the write result
+// `writeStandingSecretPosture` already computed and returned — a real persisted
+// write is not a false failure just because closing the connection afterward
+// happened to throw.
+export function writeSecretPosture(level: BuiltinPolicyId): StandingPostureResult {
+  let db: ReturnType<typeof openLocalDatabase>;
+  try {
+    db = openLocalDatabase(loadConfig().dataDir);
+  } catch {
+    return { persisted: false };
+  }
+  try {
+    return writeStandingSecretPosture(level, db.policies);
+  } finally {
+    try {
+      db.close();
+    } catch {
+      // best-effort teardown — see comment above
+    }
+  }
+}
+
+// Validate the wizard-supplied `--posture` for a redact route via the
+// schema-sourced `BuiltinPolicyId`. A missing or malformed value fails loud (a
+// wizard-wiring bug, not a session fault) rather than redacting with no posture
+// recorded.
+function requireRedactPosture(rawPosture: string | undefined): BuiltinPolicyId {
+  const parsedPosture = BuiltinPolicyId.safeParse(rawPosture);
+  if (!parsedPosture.success) {
+    fail(`redact route requires a valid --posture (got ${JSON.stringify(rawPosture)})`);
+  }
+  return parsedPosture.data;
+}
+
+// Route the chosen remediation option through the domain router
+// (routeRemediationOption): the two redact options strike the leaked keys via the
+// hardened production adapter, 'set-secret-redact' persists the standing 'secret'
+// posture on its own with no redaction, and 'leave' does nothing. On a redact
+// outcome this entry then persists the standing posture the wizard's
+// follow-up prompt collected (`--posture`) and, for 'redact-rotation-checklist'
+// only, prints the resolved summary. A redact route with a missing or
+// malformed `--posture` fails loud rather than redacting with no posture
+// recorded.
+async function route(
+  frameText: string,
+  rawOption: string,
+  rawPosture: string | undefined,
+): Promise<void> {
+  const parsedOption = RemediationOption.safeParse(rawOption);
+  if (!parsedOption.success) fail(`unknown --option "${rawOption}"`);
+  const option = parsedOption.data;
+
+  // A redact route validates its `--posture` before reading the frame, so a
+  // wizard-wiring bug fails loud regardless of frame readability — mirroring the
+  // malformed `--option` guard above, which also fires before the frame load.
+  // `postureLevel` is set iff this is a redact route (it maps 1:1 to the router's
+  // 'redacted' outcome).
+  const isRedactRoute = option === 'redact-only' || option === 'redact-rotation-checklist';
+  const postureLevel = isRedactRoute ? requireRedactPosture(rawPosture) : undefined;
+
+  const findings = loadSecretLeakFindings(() => frameText);
+  if (findings === undefined) {
+    process.stdout.write(show(FRAME_READ_NOTE));
+    return;
+  }
+
+  // Redact (async, hardened adapter) before dispatch, then hand the router a sync
+  // closure returning the count — the router owns which options redact and
+  // whether a rotation checklist was requested. `unredacted` names exactly which
+  // findings the redaction pass did not strike (out of scope, vanished/unreadable
+  // artifact, or a recovery/write failure) — threaded to the deliverable below so
+  // a partial redaction never reports the same "resolved" framing as a complete one.
+  const redaction = isRedactRoute
+    ? await redactSurfacedSecrets(findings)
+    : { redactedKeys: 0, unredacted: [] as readonly MaskedSecretFinding[] };
+  const redactedKeys = redaction.redactedKeys;
+  const outcome = routeRemediationOption(option, {
+    redact: () => redactedKeys,
+    setStandingRedactPosture: () => writeSecretPosture('redact'),
+  });
+
+  switch (outcome.kind) {
+    case 'redacted':
+      // 'redact-only' has no resolved summary, so it prints its own redaction
+      // confirmation — partial-aware, naming any key left unredacted rather than
+      // claiming a clean strike. 'redact-rotation-checklist' reports the
+      // redaction inside the resolved summary below (with the transcript count),
+      // so it does not print the standalone confirmation here — reported once.
+      if (!outcome.withRotationChecklist) {
+        process.stdout.write(
+          show(
+            renderRedactionOutcome({
+              redactedKeys: outcome.redactedKeys,
+              findings,
+              unredactedFindings: redaction.unredacted,
+            }),
+          ),
+        );
+      }
+      // A 'redacted' outcome comes only from a redact route, where
+      // requireRedactPosture already produced a validated level; persist it after
+      // the strike and before any resolved summary.
+      if (postureLevel !== undefined) {
+        process.stdout.write(show(postureConfirmation(writeSecretPosture(postureLevel))));
+      }
+      if (outcome.withRotationChecklist) {
+        const deliverable = resolveRemediationDeliverable({
+          findings,
+          redactedKeys: outcome.redactedKeys,
+          unredactedFindings: redaction.unredacted,
+          cwd: process.cwd(),
+        });
+        process.stdout.write(show(deliverable.summary));
+      }
+      break;
+    case 'posture-set':
+      process.stdout.write(show(postureConfirmation(outcome.posture)));
+      break;
+    case 'left':
+      process.stdout.write(show('Left them as they are — nothing redacted, nothing changed.'));
+      break;
+  }
+}
+
+// Guard so importing the exported helpers in tests never runs the CLI.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  try {
+    const argv = process.argv.slice(2);
+    const optionIndex = argv.indexOf('--option');
+    const frameText = readFileSync(0, 'utf8');
+    if (optionIndex === -1) {
+      present(frameText);
+    } else {
+      const rawOption = argv[optionIndex + 1];
+      if (rawOption === undefined) fail('--option requires a value');
+      const postureIndex = argv.indexOf('--posture');
+      const rawPosture = postureIndex === -1 ? undefined : argv[postureIndex + 1];
+      await route(frameText, rawOption, rawPosture);
+    }
+  } catch (err) {
+    process.stdout.write(
+      show(
+        `Could not run the remediation chain (${err instanceof Error ? err.message : 'unknown error'}).`,
+      ),
+    );
+  }
+
+  process.exit(0);
+}

--- a/plugins/codex/src/remediation/findings.ts
+++ b/plugins/codex/src/remediation/findings.ts
@@ -1,0 +1,33 @@
+/**
+ * Loads the secret-leak finding set the remediation chain presents in its
+ * decision by reading the persisted calibration frame's optional `maskedFindings` — the
+ * raw-free per-secret summaries (provider, masked token, where, state) the finding
+ * table renders from. The loader consumes only what the frame carries; it never
+ * synthesizes or hardcodes a finding.
+ *
+ * The load is FAIL-OPEN: reading and validating the persisted frame is wrapped, so
+ * a store/read/parse failure returns `undefined` instead of throwing and breaking
+ * the Codex session. `undefined` (the load failed) is kept DISTINCT from `[]`
+ * (the frame read cleanly and carried no secret summary): the caller presents no
+ * remediation decision and fabricates no count on `undefined`, and degrades honestly to
+ * the no-decision outcome on `[]`.
+ */
+import { CalibrationFrame, type MaskedSecretFinding } from '@akasecurity/schema';
+
+import { readFrameJsonBlock } from '../setup-frame-json.ts';
+
+// `readCalibrationFrame` yields the persisted frame's stdout text (the block the
+// apply-suppressions preview emitted, captured by the wizard). Injected so the
+// read boundary — the seam a store/read failure surfaces at — is exercised
+// directly. Returns the surfaced secret summaries, `[]` when the read succeeded
+// but none surfaced, or `undefined` when the read/parse failed (fail-open).
+export function loadSecretLeakFindings(
+  readCalibrationFrame: () => string,
+): MaskedSecretFinding[] | undefined {
+  try {
+    const frame = CalibrationFrame.parse(readFrameJsonBlock(readCalibrationFrame()));
+    return frame.maskedFindings ?? [];
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/codex/src/remediation/redact.ts
+++ b/plugins/codex/src/remediation/redact.ts
@@ -1,0 +1,198 @@
+/**
+ * Redacts leaked keys from the local rollout/temp artifacts the
+ * remediation "Redact" options route through. Given the where-found references the
+ * secret findings carry plus the raw value to strike, it rewrites each in-scope
+ * artifact in place so the leaked key is no longer readable, and reports how many
+ * keys it actually redacted.
+ *
+ * BINDING SCOPE LIMIT: redaction is limited to the artifact roots the scope names —
+ * the platform default is the Codex CLI rollout directory, and a caller that
+ * scans a bounded temp directory supplies that directory explicitly. A target
+ * whose real path falls outside every root is an ordinary project file and is left
+ * byte-identical; the flow never performs in-place redaction of arbitrary project
+ * files. The limit is structural: an out-of-scope path is never opened for writing,
+ * and containment is checked against real paths so a symlink inside a root cannot
+ * redirect a write to a file outside it.
+ *
+ * RAW SAFETY: `rawValue` is raw-bearing and lives in-process only — it is recovered
+ * from the still-on-disk artifact, struck here, and dropped. It is never persisted
+ * or rendered; the persisted projection stays the raw-free MaskedSecretFinding.
+ * This module returns only a count, never a raw value.
+ *
+ * IO is node:fs only — no store access, no network, no detection engine. Reads and
+ * writes are best-effort per file: an unreadable or vanished artifact is skipped so
+ * one bad file cannot abort the sweep of the rest.
+ */
+import { readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { isAbsolute, relative, resolve } from 'node:path';
+
+import type { MaskedFindingLocation } from '@akasecurity/schema';
+
+import { transcriptsDir } from '../history/transcripts.ts';
+
+// The masked/redacted form a struck key is replaced with, matching the
+// `[REDACTED:CATEGORY]` convention the detections redactor uses. Secret keys are
+// the only thing this module strikes, so the category is fixed.
+const REDACTED_PLACEHOLDER = '[REDACTED:SECRET]';
+
+// One leaked key to strike: the finding's where-found reference (the raw-free
+// MaskedSecretFinding location — the artifact path, plus an optional span) and the
+// raw value to remove. The scope limit is enforced on `where.filePath`.
+export interface RedactionTarget {
+  where: MaskedFindingLocation;
+  rawValue: string;
+}
+
+// The rollout/temp artifact roots whose contained files may be redacted in
+// place. A file outside every root is an ordinary project file, left untouched.
+export interface RedactionScope {
+  artifactRoots: readonly string[];
+}
+
+// The platform default scope: prior Codex CLI rollouts under
+// `~/.codex/sessions`. `transcriptsDir()` is the one place that knows the
+// rollout layout, so it is reused rather than re-derived here. The whole OS temp
+// tree is deliberately NOT a default root — a caller scanning a bounded temp
+// directory passes that directory explicitly, so redaction is never granted over
+// arbitrary files that merely happen to live under the OS temp dir. `home`
+// mirrors `transcriptsDir`'s own override — supplied only by tests/harnesses that
+// need a throwaway rollouts root; no production call site passes it.
+export function platformRedactionScope(home?: string): RedactionScope {
+  return { artifactRoots: [transcriptsDir(home)] };
+}
+
+// The real (symlink-resolved) path, or null when the path does not exist or cannot
+// be resolved. Resolving symlinks is what makes the containment check safe against
+// a symlink inside an allowed root that points at an external file. Exported so the
+// production surfaced-secret adapter (surfaced-redact.ts) can apply the same
+// symlink-safe containment check when validating a candidate root, rather than
+// re-implementing it.
+export function realPathOrNull(path: string): string | null {
+  try {
+    return realpathSync(path);
+  } catch {
+    return null;
+  }
+}
+
+// True when `realTarget` (already a resolved real path) sits strictly inside `root`
+// (a nested descendant, never the root itself and never an escaping `..` sibling).
+// The root is resolved too, so both sides are compared as real paths.
+function isWithinRoot(realTarget: string, root: string): boolean {
+  const realRoot = realPathOrNull(root);
+  if (realRoot === null) return false;
+  const rel = relative(realRoot, realTarget);
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+// The real path of `filePath` when it is an in-scope artifact, else null. Returns
+// the resolved real path so the caller reads and writes exactly the canonical
+// in-scope file — never a path that a symlink could redirect out of scope.
+// Exported so the production surfaced-secret adapter can decide which findings'
+// artifacts are even worth reading for raw-value recovery, without re-implementing
+// this containment check.
+export function resolveRedactableArtifact(filePath: string, scope: RedactionScope): string | null {
+  const realTarget = realPathOrNull(resolve(filePath));
+  if (realTarget === null) return null;
+  return scope.artifactRoots.some((root) => isWithinRoot(realTarget, root)) ? realTarget : null;
+}
+
+// The detailed outcome of a redaction sweep: the real count (same figure
+// `redactLeakedKeys` returns) plus exactly which input targets were struck —
+// so a caller that needs to know which specific findings remain unredacted
+// (rather than only how many) can compare its input targets against `struck`.
+export interface RedactionDetail {
+  readonly redactedKeys: number;
+  readonly struck: readonly RedactionTarget[];
+}
+
+/**
+ * Redact every in-scope leaked-key occurrence in place and report the real count of
+ * keys actually redacted (a key counts only when its raw value was present, struck,
+ * and the rewrite persisted) plus exactly which of the input targets were struck.
+ * Targets outside the scope roots are skipped and their files never written.
+ * Targets against the same file are folded into a single read/rewrite. Each file is
+ * handled best-effort: a read or write failure on one artifact is skipped so the
+ * rest of the batch is still redacted.
+ */
+export function redactLeakedKeysDetailed(
+  targets: readonly RedactionTarget[],
+  scope: RedactionScope = platformRedactionScope(),
+): RedactionDetail {
+  // Group the in-scope targets (keeping each target's identity, not just its raw
+  // value) by the real path of the file they strike, so a file with several leaked
+  // keys is read and rewritten once.
+  const byFile = new Map<string, RedactionTarget[]>();
+  for (const target of targets) {
+    if (target.rawValue === '') continue;
+    const artifactPath = resolveRedactableArtifact(target.where.filePath, scope);
+    if (artifactPath === null) continue;
+    const existing = byFile.get(artifactPath);
+    if (existing === undefined) byFile.set(artifactPath, [target]);
+    else existing.push(target);
+  }
+
+  let redactedKeys = 0;
+  const struck: RedactionTarget[] = [];
+  for (const [filePath, fileTargets] of byFile) {
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf8');
+    } catch {
+      continue; // unreadable or vanished artifact — skip, don't abort the batch
+    }
+    const struckHere: RedactionTarget[] = [];
+    const struckValues = new Set<string>();
+    for (const target of fileTargets) {
+      // A sibling target sharing this raw value already struck every occurrence
+      // in this file, so `content.includes` is now false even though this
+      // target's value IS redacted — count it struck rather than misreport it as
+      // still exposed (two findings on one repeated value both resolve together).
+      if (struckValues.has(target.rawValue)) {
+        struckHere.push(target);
+        continue;
+      }
+      if (!content.includes(target.rawValue)) continue;
+      content = content.replaceAll(target.rawValue, REDACTED_PLACEHOLDER);
+      struckValues.add(target.rawValue);
+      struckHere.push(target);
+    }
+    if (struckHere.length === 0) continue;
+    // Write atomically: a full write to a sibling temp file, then rename over the
+    // original (rename is atomic on the same filesystem). A crash mid-write leaves
+    // the original rollout intact rather than truncated.
+    const tmpPath = `${filePath}.aka-redact.tmp`;
+    try {
+      writeFileSync(tmpPath, content);
+      renameSync(tmpPath, filePath);
+    } catch {
+      try {
+        // `recursive: true` also clears a `tmpPath` that turned out to be a
+        // directory (e.g. a stray leftover), not just a partially written file —
+        // a bare `force: true` throws EISDIR on a directory and the entry survives.
+        rmSync(tmpPath, { force: true, recursive: true });
+      } catch {
+        // temp file may not exist — nothing to clean up
+      }
+      continue; // write failed — don't count keys that were not persisted
+    }
+    // Count only after the rewrite is on disk, so the returned count reflects keys
+    // actually redacted rather than merely matched.
+    redactedKeys += struckHere.length;
+    struck.push(...struckHere);
+  }
+
+  return { redactedKeys, struck };
+}
+
+/**
+ * Redact every in-scope leaked-key occurrence in place and return the real count of
+ * keys actually redacted. A thin wrapper over `redactLeakedKeysDetailed` for callers
+ * that only need the count.
+ */
+export function redactLeakedKeys(
+  targets: readonly RedactionTarget[],
+  scope: RedactionScope = platformRedactionScope(),
+): number {
+  return redactLeakedKeysDetailed(targets, scope).redactedKeys;
+}

--- a/plugins/codex/src/remediation/render.ts
+++ b/plugins/codex/src/remediation/render.ts
@@ -1,0 +1,55 @@
+/**
+ * The leaked-key presentation: the full layout the batched remediation
+ * decision is shown over. A provider/token/where/state finding table rendered
+ * from the masked per-finding summaries (masked tokens only — no raw key ever
+ * crosses here), the most-exposed-first recommendation line, and the closing
+ * chaining line naming the single secret-scan continuation the installed plugin
+ * registers. Pure formatter: the count and the registry are threaded in, so it
+ * unit-tests without I/O.
+ *
+ * This module stays in the plugin because it is the one remediation formatter
+ * that names a HOST skill (`aka-secretscan` · `aka-scan`) and so cannot be
+ * shared across harnesses. The harness-agnostic redaction/resolved-summary
+ * formatters live in `@akasecurity/setup-wizard`'s redaction-summary module.
+ */
+import type { MaskedSecretFinding, SecretFindingState } from '@akasecurity/schema';
+
+import { table } from '../present.ts';
+import { selectSecretScanContinuation } from '../skills-registry.ts';
+
+// The verbatim recommendation line: redact, then rotate, most-exposed-first.
+const RECOMMENDATION_LINE = "I'd redact them and get you rotating, most-exposed first";
+
+// The finding state as human-facing text — the table renders each finding's own
+// state, not the enum token. A leaked key's validity is unverifiable offline, so
+// the default 'unknown' reads as 'unknown'; 'still valid' is claimed only for a
+// finding a caller could actually verify.
+const STATE_LABEL: Record<SecretFindingState, string> = {
+  'still-valid': 'still valid',
+  unknown: 'unknown',
+  invalid: 'invalid',
+};
+
+// Render the full decision layout over the masked findings: the finding table, the
+// recommendation line, and the chaining line. `moreCount` templates the chaining
+// line's 'N more worth a look' count; `registry` is the installed skill set
+// (readRegisteredSkills()), resolved at the caller's I/O boundary and threaded
+// in so this stays a pure formatter — the chaining line's secret-scan
+// continuation is selected against it, so it names only a skill the plugin
+// actually registers and throws rather than naming an unregistered one.
+export function renderRemediationDecision(
+  findings: readonly MaskedSecretFinding[],
+  moreCount: number,
+  registry: readonly string[],
+): string {
+  const scanSkill = selectSecretScanContinuation(registry);
+  const rows = findings.map((f) => [
+    f.provider,
+    f.maskedToken,
+    f.where.filePath,
+    STATE_LABEL[f.state],
+  ]);
+  const findingTable = table(['Provider', 'Token', 'Where', 'State'], rows, { rowSep: true });
+  const chainingLine = `${String(moreCount)} more worth a look — run the ${scanSkill} skill when you're ready.`;
+  return [findingTable, '', RECOMMENDATION_LINE, '', chainingLine].join('\n');
+}

--- a/plugins/codex/src/remediation/surfaced-redact.ts
+++ b/plugins/codex/src/remediation/surfaced-redact.ts
@@ -1,0 +1,207 @@
+/**
+ * The PRODUCTION redaction adapter a shipped caller binds: given the raw-free
+ * secret findings the remediation decision presents, it redacts the leaked keys
+ * they reference and returns the real redacted-key count.
+ *
+ * Unlike `redactLeakedKeys` (which trusts whatever `RedactionScope` its caller
+ * builds — fine for tests that construct their own fixture roots), this adapter
+ * DERIVES the artifact scope itself from `platformRedactionScope()` /
+ * `transcriptsDir()`, so a future production caller can never widen redaction by
+ * handing it an arbitrary `artifactRoots` list. In production the enforced scope
+ * is exactly the platform rollouts root — the current shipped caller passes no
+ * temp root. This adapter also supports one additional, EXPLICITLY named bounded
+ * temp directory a caller can say it owns for a given call — validated before it
+ * is trusted: it must not itself resolve to (or sit inside) a git-tracked project
+ * — the same repo-resolution primitive (`resolveRepo`) the codebase already uses
+ * to find a real repo root — so a mislabeled project directory can never be
+ * smuggled in as "temp." That path is exercised only by tests today, via the
+ * `tempRoot` override below. A finding whose artifact resolves outside the
+ * enforced scope is simply never redacted — the same binding-scope guarantee
+ * `redactLeakedKeys` already provides, just enforced against a self-derived
+ * scope rather than a caller-supplied one.
+ *
+ * `MaskedSecretFinding` deliberately omits the raw key value (it is a raw-free
+ * projection persisted in the calibration frame), so the raw value redaction
+ * needs has to be recovered fresh from the on-disk artifact the finding
+ * references. That recovery reuses the SAME secret-detection engine the
+ * historical backfill scans with (`createPluginRuntime(...).processText`, the
+ * shared detect path behind `scanHistory`) — never a hand-rolled matcher — read
+ * ONLY over artifacts already inside the enforced scope, and matched back to a
+ * finding by the same (provider, maskedToken) pair `deriveSurfacedSecretFindings`
+ * used to build the finding in the first place.
+ */
+import { readFileSync } from 'node:fs';
+
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import {
+  createPluginRuntime,
+  loadConfig,
+  resolveRepo,
+  safeMaskedMatch,
+} from '@akasecurity/plugin-sdk';
+import type { MaskedSecretFinding } from '@akasecurity/schema';
+import { deriveProvider } from '@akasecurity/setup-wizard';
+
+import { transcriptsDir } from '../history/transcripts.ts';
+import {
+  realPathOrNull,
+  type RedactionScope,
+  type RedactionTarget,
+  redactLeakedKeysDetailed,
+  resolveRedactableArtifact,
+} from './redact.ts';
+
+// Test-only overrides — no production call site sets any of these; every real
+// invocation derives its scope from the real OS home and reads the real `~/.aka`
+// store. `home` mirrors `transcriptsDir`'s own override (which real HOME's
+// rollouts to scan); `dataDirBase` mirrors `loadConfig`'s own override (which
+// real `~/.aka` to read, so a test never opens the developer's actual local
+// store); `tempRoot` names ONE additional bounded scratch directory this call
+// explicitly owns — validated below, never trusted outright.
+export interface RedactSurfacedSecretsOverrides {
+  home?: string;
+  dataDirBase?: string;
+  tempRoot?: string;
+}
+
+// `tempRoot` is trusted as an additional artifact root ONLY when it exists and
+// does not itself resolve to (or sit inside) a git-tracked project — the same
+// check the codebase already uses to find a real repo root. A caller that hands
+// in a project directory under the guise of "temp" fails this check and the
+// root is simply dropped from the enforced scope, exactly as if it had never
+// been supplied — never widening redaction into a project working tree.
+function isBoundedTempRoot(candidate: string): boolean {
+  return realPathOrNull(candidate) !== null && resolveRepo(candidate) === undefined;
+}
+
+// The scope this adapter will enforce: the platform's rollouts root, plus the
+// caller's named temp root when (and only when) it validates as genuinely
+// bounded. Never widened by anything else a caller supplies.
+function enforcedScope(overrides: RedactSurfacedSecretsOverrides): RedactionScope {
+  const roots = [transcriptsDir(overrides.home)];
+  if (overrides.tempRoot !== undefined && isBoundedTempRoot(overrides.tempRoot)) {
+    roots.push(overrides.tempRoot);
+  }
+  return { artifactRoots: roots };
+}
+
+// One recovered (finding, rawValue) redaction target, or undefined when no
+// on-disk occurrence matching this finding's (provider, maskedToken) pair was
+// found in the scanned content.
+function recoverTarget(
+  finding: MaskedSecretFinding,
+  matches: readonly { ruleId: string; rawMatch: string }[],
+): RedactionTarget | undefined {
+  const hit = matches.find(
+    (m) =>
+      deriveProvider(m.ruleId) === finding.provider &&
+      safeMaskedMatch(m.rawMatch) === finding.maskedToken,
+  );
+  return hit === undefined ? undefined : { where: finding.where, rawValue: hit.rawMatch };
+}
+
+// The real outcome of a redaction pass: the count of keys actually struck, plus
+// exactly which of the input findings are NOT covered by that count — a
+// vanished/unreadable artifact, content that changed between the calibration
+// scan and this redact-time re-scan, an out-of-scope artifact, or a recovery
+// failure all land a finding here. A caller must never present a "resolved"
+// framing while `unredacted` is non-empty — that is exactly the false
+// all-clear this shape exists to prevent.
+export interface SurfacedRedactionResult {
+  readonly redactedKeys: number;
+  readonly unredacted: readonly MaskedSecretFinding[];
+}
+
+/**
+ * Redact every in-scope leaked key the surfaced secret findings reference, and
+ * report the real count of keys actually redacted plus which findings were not
+ * (so a caller can render an honest partial outcome rather than claim complete
+ * redaction). Fully fail-open: any failure recovering raw values (config/store
+ * unavailable, an unreadable artifact) leaves the affected findings in
+ * `unredacted` rather than throwing — the caller's session must never break
+ * because a best-effort recovery pass failed. The actual in-place striking is
+ * delegated entirely to `redactLeakedKeysDetailed`, so its binding-scope,
+ * atomic-write, and per-file fail-open guarantees apply unchanged.
+ */
+export async function redactSurfacedSecrets(
+  findings: readonly MaskedSecretFinding[],
+  overrides: RedactSurfacedSecretsOverrides = {},
+): Promise<SurfacedRedactionResult> {
+  if (findings.length === 0) return { redactedKeys: 0, unredacted: [] };
+  const scope = enforcedScope(overrides);
+
+  // Group by file, and set aside any finding whose artifact does not resolve
+  // inside the enforced scope BEFORE reading it — an out-of-scope (e.g. project)
+  // file is never opened, let alone scanned, by this adapter, and the finding
+  // referencing it is honestly reported as unredacted rather than silently dropped.
+  const byFile = new Map<string, MaskedSecretFinding[]>();
+  const outOfScope: MaskedSecretFinding[] = [];
+  for (const finding of findings) {
+    if (resolveRedactableArtifact(finding.where.filePath, scope) === null) {
+      outOfScope.push(finding);
+      continue;
+    }
+    const existing = byFile.get(finding.where.filePath);
+    if (existing) existing.push(finding);
+    else byFile.set(finding.where.filePath, [finding]);
+  }
+  if (byFile.size === 0) return { redactedKeys: 0, unredacted: findings };
+
+  // Every finding whose raw value could not be recovered — because its file
+  // vanished/is unreadable, the re-scan found no matching occurrence, or it was
+  // out-of-scope above — accumulates here. `recovered` pairs a finding with the
+  // redaction target derived from it, so a struck/unstruck target can be traced
+  // back to the finding it came from.
+  const unrecovered: MaskedSecretFinding[] = [...outOfScope];
+  const recovered: { finding: MaskedSecretFinding; target: RedactionTarget }[] = [];
+  try {
+    const config = loadConfig(overrides.dataDirBase);
+    const gateway = resolveDataGateway(config);
+    const runtime = createPluginRuntime(gateway, config.settings, { dataDir: config.dataDir });
+    try {
+      for (const [filePath, fileFindings] of byFile) {
+        let content: string;
+        try {
+          content = readFileSync(filePath, 'utf8');
+        } catch {
+          unrecovered.push(...fileFindings); // vanished/unreadable artifact — best-effort, skip it
+          continue;
+        }
+        let matches: { ruleId: string; rawMatch: string }[];
+        try {
+          matches = (await runtime.processText(content)).findings;
+        } catch {
+          unrecovered.push(...fileFindings); // a scan failure on one artifact must not abort the others
+          continue;
+        }
+        for (const finding of fileFindings) {
+          const target = recoverTarget(finding, matches);
+          if (target === undefined) unrecovered.push(finding);
+          else recovered.push({ finding, target });
+        }
+      }
+    } finally {
+      try {
+        await runtime.close();
+      } catch {
+        // Best-effort teardown: a close fault here must never rewrite the
+        // outcome already computed above — the targets already recovered stay
+        // recovered, and the redaction below still runs.
+      }
+    }
+  } catch {
+    // Config/store unavailable — recover nothing rather than break the session.
+    return { redactedKeys: 0, unredacted: findings };
+  }
+
+  const { redactedKeys, struck } = redactLeakedKeysDetailed(
+    recovered.map((r) => r.target),
+    scope,
+  );
+  const struckTargets = new Set(struck);
+  const unredacted = [
+    ...unrecovered,
+    ...recovered.filter((r) => !struckTargets.has(r.target)).map((r) => r.finding),
+  ];
+  return { redactedKeys, unredacted };
+}

--- a/plugins/codex/src/render.ts
+++ b/plugins/codex/src/render.ts
@@ -13,7 +13,14 @@ import type {
   SessionTokenReport,
 } from '@akasecurity/plugin-sdk';
 import { aggregateTokenUsage, formatCostTotal, formatUsd } from '@akasecurity/plugin-sdk';
-import type { DetectionException, DetectionListItem } from '@akasecurity/schema';
+import type {
+  ActionTaken,
+  BuiltinPolicyId,
+  DetectionException,
+  DetectionListItem,
+} from '@akasecurity/schema';
+import { BUILTIN_ORDER, DetectionCategory, toApiAction } from '@akasecurity/schema';
+import { downgradeWarning, isDowngrade } from '@akasecurity/setup-wizard';
 
 import {
   bar,
@@ -27,6 +34,16 @@ import {
   table,
   wrapText,
 } from './present.ts';
+import { selectRegisteredSkills } from './skills-registry.ts';
+
+// The fail-open note shown when the local store can't be READ (missing / corrupt
+// / locked db) mid-wizard: the calibration and first-run frames print this instead
+// of throwing, so a store fault never breaks the Codex session. This is the
+// store-UNAVAILABLE (read-failure) path only. The found-nothing / empty-store case
+// (a store that reads fine but holds nothing) is a distinct path with its own
+// honest copy — frameEmptyState in calibration.ts — not this note.
+export const STORE_UNAVAILABLE_NOTE =
+  "I couldn't check my records just now — we can check again soon. Your Codex session keeps going, and I'll fill in as you work.";
 
 const SEVERITY_WEIGHT: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
 
@@ -67,6 +84,226 @@ function shortTime(iso: string): string {
 
 function empty(message: string): string {
   return message;
+}
+
+// ActionTaken (the DB enum: warn|redact|block|allow|log) -> the user-facing
+// palette label the wizard uses (monitor|warn|redact|block|allow). Only 'log'
+// differs (-> 'monitor'); everything else is identity. Kept local to the
+// render surface so the DB vocabulary never leaks into the first-run screen.
+const ACTION_LABEL: Record<string, string> = {
+  log: 'monitor',
+  warn: 'warn',
+  redact: 'redact',
+  block: 'block',
+  allow: 'allow',
+};
+
+// Canonical category order for the posture card, from the schema enum. Rows
+// come out of the store in DB order; rendering in this fixed order keeps the
+// card stable regardless of how the caller read them. An unknown category (a
+// custom rule's) sorts after the known ones, in its incoming order.
+const CATEGORY_ORDER: readonly string[] = DetectionCategory.options;
+function categoryRank(category: string): number {
+  const i = CATEGORY_ORDER.indexOf(category);
+  return i === -1 ? CATEGORY_ORDER.length : i;
+}
+
+// Compact, aligned per-category posture block for the first-run screen: one
+// row per category, its stored action translated to the palette label. Rows
+// are rendered in the canonical category order above so the card is stable.
+// Pure (no I/O) so it unit-tests without a DB; the caller (firstrun.ts)
+// supplies rows read from the policies store.
+export function renderPosture(rows: { category: string; action: string }[]): string {
+  const width = Math.max(0, ...rows.map((r) => r.category.length));
+  return [...rows]
+    .sort((a, b) => categoryRank(a.category) - categoryRank(b.category))
+    .map((r) => `  ${r.category.padEnd(width)}  ${ACTION_LABEL[r.action] ?? r.action}`)
+    .join('\n');
+}
+
+// The condensed recommended-posture view for the calibrated-result frame: one
+// compact row per pack showing the level AKA recommends, in canonical category
+// order. This is the recommend-and-confirm glance — distinct from the start-light
+// branch's full 8×4 level table, which lays every level out per pack. Pure (no
+// I/O); the caller hands in the recommended posture (severityFloorPosture()),
+// whose palette levels (monitor/warn/redact/block) render verbatim.
+export function renderRecommendedPosture(
+  posture: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+): string {
+  const rows = (Object.keys(posture) as DetectionCategory[]).map((category) => ({
+    category,
+    level: posture[category] ?? '',
+  }));
+  const width = Math.max(0, ...rows.map((r) => r.category.length));
+  return rows
+    .sort((a, b) => categoryRank(a.category) - categoryRank(b.category))
+    .map((r) => `  ${r.category.padEnd(width)}  ${r.level}`)
+    .join('\n');
+}
+
+// The full 8×4 posture matrix for the start-light branch: every pack laid out
+// against all four levels (monitor/warn/redact/block), the chosen level marked,
+// in canonical category order. This lays the whole choice space out per pack —
+// distinct from renderRecommendedPosture's condensed one-level-per-pack glance.
+// The level columns come from BUILTIN_ORDER (the schema's palette order), so the
+// DB action vocabulary (log/allow) never appears. Pure (no I/O); the caller
+// hands in the posture map (severityFloorPosture() for the recommended defaults).
+const GRID_MARK = '●';
+export function renderPostureGrid(
+  posture: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+): string {
+  const packs = (Object.keys(posture) as DetectionCategory[]).sort(
+    (a, b) => categoryRank(a) - categoryRank(b),
+  );
+  const rows = packs.map((category) => [
+    category,
+    ...BUILTIN_ORDER.map((level) => (posture[category] === level ? GRID_MARK : '')),
+  ]);
+  return indent(table(['Category', ...BUILTIN_ORDER], rows));
+}
+
+// The re-tune hint that closes the start-light card and the applied frame,
+// pointing at the two surfaces that re-open calibration: the aka-setup wizard
+// and the web-ui settings grid (the deep-tuning surface). Exported so the wizard
+// prose (the setup skill's SKILL.md) and the applied-frame copy single-source it
+// instead of repeating the string and letting the two drift.
+export const RE_TUNE_HINT = 'Re-tune anytime with the aka-setup skill or the dashboard';
+
+// Why each pack sits at its default: calm, plain-language reasons in the product
+// voice — "notifications" not alarms. The warn packs surface sensitive data for
+// the user's call; the monitor packs (code_context, config) watch quietly to keep
+// the noise down. Presentation copy only — not a persisted contract.
+const PACK_RATIONALE: Record<DetectionCategory, string> = {
+  secret: 'keys and credentials are the costliest thing to lose, so I bring those straight to you.',
+  pii: 'personal data carries real obligations, so I surface it before it moves.',
+  financial: 'card and account numbers are sensitive by default, so these come to you.',
+  phi: 'health information is regulated wherever it lands, so I flag it for your call.',
+  code_context:
+    'proprietary code context is common and mostly benign, so I watch quietly and keep the record.',
+  code_flaw: 'an insecure pattern is worth a look before it ships, so I raise it.',
+  custom: 'your own policy matches start surfaced so nothing you care about slips by unseen.',
+  config: 'config values are noisy, so I keep an eye on them without notifying you.',
+};
+
+// The start-light card — the aka-setup Not-now branch, shown when the user
+// declines the retroactive scan so they still leave setup calibrated.
+// Composes the full 8×4 grid (renderPostureGrid) seeded with the conservative
+// defaults, a per-pack rationale line explaining why each pack sits at its
+// default, and the re-tune hint. Pure (no I/O); the caller hands in the posture
+// map (severityFloorPosture() for the severity-floor defaults), whose packs render in
+// canonical category order.
+export function renderStartLight(
+  posture: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+): string {
+  const packs = (Object.keys(posture) as DetectionCategory[]).sort(
+    (a, b) => categoryRank(a) - categoryRank(b),
+  );
+  const rationale = packs.map(
+    (pack) => `  ${pack} — ${posture[pack] ?? ''}: ${PACK_RATIONALE[pack]}`,
+  );
+  return [
+    '● Starting light — your detection categories',
+    '',
+    indent(
+      "For now, each detection category starts at a careful default. Run the aka-setup skill whenever you like and I'll tune these from Codex's recent work.",
+    ),
+    '',
+    renderPostureGrid(posture),
+    '',
+    ...rationale,
+    '',
+    indent(RE_TUNE_HINT),
+  ].join('\n');
+}
+
+// The adjust-confirm card of the aka-setup Yes-path adjust loop: a
+// three-column 'category │ recommended │ yours' table laying each pack's
+// recommended level beside the level the user chose, so a changed pack reads as
+// a different 'yours' value and the untouched packs repeat their recommended
+// level. Closes with the adjust copy and the shared re-tune pointer at the
+// deep-tuning surface. Pure (no I/O); the caller hands in the recommended posture
+// (severityFloorPosture()), the chosen map (that base with the user's overrides
+// overlaid), and `current` — the store's existing action per category
+// (undefined = no row yet) — whose packs render in canonical category order.
+// A chosen level that ranks BELOW the category's existing action is an
+// enforcement downgrade and appends the shared WARNING footer, so the adjust fork
+// can no longer quietly lower a pack hardened out of band.
+export function renderAdjustConfirm(
+  recommended: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+  chosen: Partial<Record<DetectionCategory, BuiltinPolicyId>>,
+  current: Partial<Record<DetectionCategory, ActionTaken>> = {},
+): string {
+  const packs = (Object.keys(recommended) as DetectionCategory[]).sort(
+    (a, b) => categoryRank(a) - categoryRank(b),
+  );
+  const rows = packs.map((category) => [
+    category,
+    recommended[category] ?? '',
+    chosen[category] ?? recommended[category] ?? '',
+  ]);
+  const downgrades = packs.filter((category) => {
+    const planned = chosen[category] ?? recommended[category];
+    return planned !== undefined && isDowngrade(planned, current[category]);
+  });
+  return [
+    '● Adjust — set the detection categories you want, keep the rest',
+    '',
+    indent(table(['category', 'recommended', 'yours'], rows)),
+    '',
+    indent("I'll keep the rest as recommended."),
+    '',
+    indent(RE_TUNE_HINT),
+  ]
+    .join('\n')
+    .concat(downgradeWarning(downgrades));
+}
+
+// The applying-confirmation "Ready" line's curated skill set — the read
+// surfaces to run once calibration is applied (health, findings, recommend), a
+// surface-specific subset (not the whole registry) deliberately distinct from the
+// Try line's, written as the skill names the plugin's SKILL.md files declare
+// (the form the user invokes them by). Validated against the installed skill
+// registry before it renders, so the call-to-action never names a skill the user
+// cannot invoke.
+export const READY_SKILLS = ['aka-health', 'aka-findings', 'aka-recommend'] as const;
+
+// The installed-summary "Try" line's curated skill set — the dashboard and the
+// working-tree scan, a surface-specific subset (not the whole registry), written
+// as the skill names the plugin's SKILL.md files declare (the form the user
+// invokes them by). Validated against the installed skill registry before it
+// renders, so the call-to-action never names a skill the user cannot invoke.
+export const TRY_SKILLS = ['aka-dashboard', 'aka-scan'] as const;
+
+// The "set" segment — the count of detection categories the writer wrote,
+// threaded from the real write (never a literal). Single-sourced here so
+// onboard.ts's posture-write confirmation and the composed applying-confirmation
+// line read identically.
+export function renderCategoriesTuned(categoriesTuned: number): string {
+  return `✓ Set all ${String(categoriesTuned)} detection categories`;
+}
+
+// The aka-setup wizard's applying confirmation, shown once the
+// calibration takes effect: '✓ Set all K detection categories · set aside N
+// routine results · Ready: …'. Both counts are threaded from the real apply
+// result (the posture writer's category count and the apply-suppressions
+// result's written count), never a literal. When nothing routine was set aside
+// (N === 0) the middle segment is honest empty-state copy rather than a
+// fabricated 'set aside 0 routine results'. `registry` is the installed skill
+// registry (readRegisteredSkills()), resolved at the caller's I/O boundary and
+// threaded in so this stays a pure formatter: the Ready line's curated set is
+// validated against it, and an unregistered curated skill throws rather than
+// rendering. Pure (no I/O) so it unit-tests without a DB.
+export function renderApplied(
+  categoriesTuned: number,
+  dismissed: number,
+  registry: readonly string[],
+): string {
+  const routine =
+    dismissed > 0
+      ? `set aside ${String(dismissed)} routine result${dismissed === 1 ? '' : 's'}`
+      : 'nothing routine to set aside';
+  const ready = `Ready: ${selectRegisteredSkills(READY_SKILLS, registry).join(' · ')}`;
+  return `${renderCategoriesTuned(categoriesTuned)} · ${routine} · ${ready}`;
 }
 
 const RULE_WIDTH = 64;
@@ -166,7 +403,7 @@ export function renderFirstRun(s: FirstRunSummary): string {
       `${severityGlyph(f.severity)} ${f.severity}`,
       f.category,
       f.ruleId,
-      f.actionTaken,
+      toApiAction(f.actionTaken),
       f.maskedMatch,
     ]);
     lines.push(
@@ -205,7 +442,7 @@ export function renderFindings(
     `${severityGlyph(f.severity)} ${f.severity}`,
     f.category,
     f.ruleId,
-    f.actionTaken,
+    toApiAction(f.actionTaken),
     f.maskedMatch,
   ]);
   const heading =
@@ -569,7 +806,7 @@ export function renderAudit(findings: FindingView[]): string {
   }
   const rows = findings.map((f) => [
     shortTime(f.occurredAt),
-    f.actionTaken,
+    toApiAction(f.actionTaken),
     f.ruleId,
     f.category,
     // Join only the parts that are present so a finding missing sourceTool/kind

--- a/plugins/codex/src/render.ts
+++ b/plugins/codex/src/render.ts
@@ -1,0 +1,800 @@
+// Pure renderers for the read surfaces: plain data from the data gateway → a
+// formatted, monochrome string. Kept free of I/O so they unit-test without a DB
+// and a future interactive TUI can reuse them; query.ts owns the gateway + stdout.
+//
+// No color anywhere — the surfaces are echoed verbatim into the Codex CLI
+// transcript, which doesn't render ANSI. Severity / intensity is carried by the
+// shade glyphs from present.ts (█ ▓ ▒ ░), so every screen reads in plain text.
+import type {
+  DataGateway,
+  DayActivity,
+  FindingView,
+  HealthSummary,
+  SessionTokenReport,
+} from '@akasecurity/plugin-sdk';
+import { aggregateTokenUsage, formatCostTotal, formatUsd } from '@akasecurity/plugin-sdk';
+import type { DetectionException, DetectionListItem } from '@akasecurity/schema';
+
+import {
+  bar,
+  defList,
+  indent,
+  padEnd,
+  padStart,
+  paint,
+  SHADE,
+  stackedBar,
+  table,
+  wrapText,
+} from './present.ts';
+
+const SEVERITY_WEIGHT: Record<string, number> = { critical: 4, high: 3, medium: 2, low: 1 };
+
+// Severity → shade glyph: heavier fill = more severe (critical solid, low light),
+// so the severity column reads as texture with no color. The same four glyphs
+// carry intensity on the /health chart and the unreviewed tallies.
+const SEVERITY_GLYPH: Record<string, string> = {
+  critical: SHADE.full,
+  high: SHADE.dark,
+  medium: SHADE.medium,
+  low: SHADE.light,
+};
+
+function severityGlyph(severity: string): string {
+  return SEVERITY_GLYPH[severity] ?? SHADE.light;
+}
+
+// Plain-language next step per detection category, shown by `/recommend`.
+const ADVICE: Record<string, string> = {
+  secret:
+    'Rotate the exposed credentials and move them out of prompts (secrets manager / env vars).',
+  pii: 'Remove or mask personal data before it reaches the model.',
+  financial: 'Strip card and account numbers; share only non-sensitive references.',
+  phi: 'Remove protected health information — it should never reach an external model.',
+  code_context: 'Confirm this proprietary code context is safe to share.',
+  code_flaw:
+    'Review the flagged pattern and apply the secure alternative (parameterized queries, safe deserializers, etc.).',
+  custom: 'Review against your organization’s custom policy.',
+};
+
+// "2026-06-19T11:14:53.000Z" → "06-19 11:14" (compact, table-friendly). A
+// finding missing its timestamp renders a placeholder rather than a blank cell
+// so the table doesn't read as broken.
+function shortTime(iso: string): string {
+  if (!iso) return '—';
+  return iso.length >= 16 ? `${iso.slice(5, 10)} ${iso.slice(11, 16)}` : iso;
+}
+
+function empty(message: string): string {
+  return message;
+}
+
+const RULE_WIDTH = 64;
+
+// The setup-intro "card" the /aka:setup wizard shows first.
+// Factual fields (version, repository, publisher) are read from the plugin
+// manifest by the intro script; the descriptive copy (name, tagline, adds) is
+// product wording the script supplies. Pure here so it renders without any I/O.
+export interface PluginMeta {
+  name: string;
+  tagline: string;
+  repository: string;
+  version: string;
+  publisher: string;
+  adds: string;
+}
+
+export function renderSetupIntro(meta: PluginMeta): string {
+  const heading = `● Found ${meta.name} — ${meta.tagline}`;
+
+  const details = defList([
+    ['Repository', meta.repository],
+    ['Version', `${meta.version} · ${meta.publisher}`],
+    ['Adds', meta.adds],
+  ]);
+
+  const ask = "Before installing I'll ask two quick questions to tailor the setup.";
+
+  return [heading, '', indent(details), '', indent(ask)].join('\n');
+}
+
+// Derived posture score (0–100). HEURISTIC — we don't store a posture score, so
+// this blends what we actually have: category coverage (how much sensitive-data
+// is under an enabled policy) and the share of findings that were acted on
+// (block/redact/warn) rather than let through. Centralized so the /health and
+// first-run screens agree, and so it can be swapped for the product's intended
+// scoring model in one place.
+export function healthScore(summary: HealthSummary): number {
+  const handled = summary.byAction.block + summary.byAction.redact + summary.byAction.warn;
+  const handledRatio = summary.findings === 0 ? 1 : handled / summary.findings;
+  return Math.round(100 * (0.6 * summary.coverage + 0.4 * handledRatio));
+}
+
+// The "First run" completion screen. Commands,
+// handling, findings and recommendations are real; `health` is the derived score
+// above. The host's input box and window chrome are not the plugin's to draw.
+export interface FirstRunSummary {
+  commands: string[];
+  handling: string;
+  health: number;
+  findings: number;
+  recommendations: number;
+  // Highest-severity findings from the first scan, ranked + capped by topFindings.
+  // Omitted (or empty) on a clean scan — the section is hidden then.
+  topFindings?: FindingView[];
+}
+
+// Rank findings for the install card's "Top findings" list: most severe first,
+// then most recent within a severity, capped to `limit`. Pure so the first-run
+// script and a future TUI rank identically and it unit-tests without a DB.
+export function topFindings(findings: FindingView[], limit = 10): FindingView[] {
+  return [...findings]
+    .sort((a, b) => {
+      const sev = (SEVERITY_WEIGHT[b.severity] ?? 0) - (SEVERITY_WEIGHT[a.severity] ?? 0);
+      return sev !== 0 ? sev : b.occurredAt.localeCompare(a.occurredAt);
+    })
+    .slice(0, limit);
+}
+
+export function renderFirstRun(s: FirstRunSummary): string {
+  const heading = '✓ AKA Security installed';
+
+  const details = defList([
+    ['Commands', s.commands.join(' · ')],
+    ['Handling', s.handling],
+  ]);
+
+  const stats = `Health ${String(s.health)}/100   Findings ${String(s.findings)}   Recommendations ${String(s.recommendations)}`;
+
+  const lines = [
+    heading,
+    '',
+    indent(details),
+    '',
+    indent('─'.repeat(RULE_WIDTH)),
+    '',
+    indent('First scan complete'),
+    '',
+    indent(stats),
+  ];
+
+  // Top findings — a compact, severity-ranked glance at what the first scan
+  // caught. Hidden on a clean scan so the card stays a tidy success state.
+  const top = s.topFindings ?? [];
+  if (top.length > 0) {
+    const rows = top.map((f) => [
+      `${severityGlyph(f.severity)} ${f.severity}`,
+      f.category,
+      f.ruleId,
+      f.actionTaken,
+      f.maskedMatch,
+    ]);
+    lines.push(
+      '',
+      indent(`Top findings (${String(top.length)})`),
+      '',
+      indent(
+        table(['Severity', 'Category', 'Rule', 'Action', 'Match'], rows, {
+          gap: 4,
+          rowSep: true,
+        }),
+      ),
+    );
+  }
+
+  lines.push('', indent('Opening your health dashboard… use the aka-health skill anytime'));
+  return lines.join('\n');
+}
+
+// `severity`, when set, is the active `--severity` filter — it only tailors the
+// heading and the empty-state copy; the caller has already narrowed `findings`.
+export function renderFindings(
+  findings: FindingView[],
+  status: FindingStatus,
+  severity?: string,
+): string {
+  if (findings.length === 0) {
+    return empty(
+      severity !== undefined
+        ? `No ${severity} findings recorded yet.`
+        : 'No findings recorded yet — AKA scans prompts, file edits, and tool output as you work.',
+    );
+  }
+  const rows = findings.map((f) => [
+    shortTime(f.occurredAt),
+    `${severityGlyph(f.severity)} ${f.severity}`,
+    f.category,
+    f.ruleId,
+    f.actionTaken,
+    f.maskedMatch,
+  ]);
+  const heading =
+    severity !== undefined
+      ? `● Recent ${severity} findings (${String(findings.length)})`
+      : `● Recent findings (${String(findings.length)})`;
+  return [
+    heading,
+    '',
+    indent(
+      table(['Time', 'Severity', 'Category', 'Rule', 'Action', 'Match'], rows, {
+        gap: 4,
+        rowSep: true,
+      }),
+    ),
+    '',
+    indent('Filter by level with --severity <critical|high|medium|low>.'),
+    '',
+    indent(renderStatusBar(status)),
+  ].join('\n');
+}
+
+// The /health screen (the marquee dashboard). A row of score gauges, a summary
+// line, the 7-day detections chart, and a status footer. Pure — the caller builds
+// the report (see buildHealthReport) so this stays I/O-free and testable.
+export interface HealthGauge {
+  label: string;
+  score: number; // 0–100
+  note: string; // trailing detail, e.g. "3/4 acted on"
+  outOf100?: boolean; // Overall renders "/ 100"
+}
+
+export interface HealthDay {
+  label: string; // "Mon"
+  total: number; // findings detected that day
+  redacted: number;
+  warned: number;
+  blocked: number;
+}
+
+export interface HealthReport {
+  title: string;
+  gauges: HealthGauge[];
+  openFindings: number;
+  scanCoverage: number; // 0..1
+  week: HealthDay[];
+  weekFindings: number; // sum of the window's per-day totals
+  recommendCount: number;
+  unreviewed: { critical: number; high: number; medium: number; low: number };
+  score: number; // for the footer "health NN/100"
+}
+
+const GAUGE_LABEL_W = 14;
+const GAUGE_BAR_W = 18;
+const WEEK_LABEL_W = 5;
+const WEEK_BAR_W = 44;
+
+function renderGauge(g: HealthGauge): string {
+  const fill = bar(g.score, 100, GAUGE_BAR_W);
+  const score = padStart(String(g.score), 3);
+  const outOf = g.outOf100 === true ? '/ 100' : '     ';
+  return `${padEnd(g.label, GAUGE_LABEL_W)}  ${fill}  ${score} ${outOf}   ${g.note}`;
+}
+
+// The persistent status line shared by /findings, /health and /recommend.
+export interface FindingStatus {
+  score: number;
+  unreviewed: { critical: number; high: number; medium: number; low: number };
+  openFindings: number;
+}
+
+// `color` is opt-in and honored only by the status line (the one ANSI-capable
+// surface). The transcript footers on /findings, /health and /recommend call
+// this with no options and stay monochrome, since ANSI doesn't render there.
+function renderStatusBar(s: FindingStatus, opts: { color?: boolean } = {}): string {
+  const u = s.unreviewed;
+  if (opts.color !== true) {
+    // Monochrome (transcript footers): severity carried by shade-glyph texture,
+    // never hue, since these surfaces print as plain text in the transcript.
+    const unreviewed =
+      `unreviewed ${SHADE.full}${String(u.critical)} ${SHADE.dark}${String(u.high)} ` +
+      `${SHADE.medium}${String(u.medium)} ${SHADE.light}${String(u.low)}`;
+    return `▸▸ AKA   health ${String(s.score)}/100   ${unreviewed}   ⚑ ${String(s.openFindings)} open findings`;
+  }
+
+  // Status line: ANSI colour. Severity is one square glyph tinted per level, bar
+  // separators divide the sections, the health dot reflects the score, and the
+  // flag goes red when findings are open (plain grey when the slate is clean).
+  const sep = ` ${paint.dim('│')} `;
+  const sq = '■';
+  const dot = s.score >= 80 ? paint.ok('●') : s.score >= 50 ? paint.high('●') : paint.critical('●');
+  const score = `${dot} health ${paint.bold(String(s.score))}${paint.dim('/100')}`;
+  const tally =
+    `${paint.dim('unreviewed')} ` +
+    `${paint.critical(sq)}${String(u.critical)} ${paint.high(sq)}${String(u.high)} ` +
+    `${paint.medium(sq)}${String(u.medium)} ${paint.low(sq)}${String(u.low)}`;
+  const flag = s.openFindings > 0 ? paint.critical('⚑') : paint.dim('⚑');
+  const open = `${flag} ${String(s.openFindings)} open findings`;
+  return `${paint.brand('▸▸ AKA')}${sep}${score}${sep}${tally}${sep}${open}`;
+}
+
+// One line for a statusLine-style persistent footer, if/when Codex CLI exposes
+// an equivalent ANSI-interpreting status surface — same data and look as the
+// read surfaces' status bar, but ANSI is honored here, so open findings show
+// in red. See present.ts's module comment on `paint`.
+export function renderStatusLine(summary: HealthSummary): string {
+  return renderStatusBar(findingStatus(summary), { color: true });
+}
+
+// Shared status powering the bar on /findings, /health and /recommend: the
+// derived score, the unreviewed-by-severity tally, and the open-findings count.
+// All three come from the whole-store health summary — NOT the finding page a
+// given command fetched — so the footer reads identically on every surface
+// regardless of each command's row limit (25 on /findings vs 500 elsewhere).
+// `openFindings` is the real finding total (the store has no resolution state,
+// so every finding is open) and sums `bySeverity`.
+function findingStatus(summary: HealthSummary): FindingStatus {
+  return {
+    score: healthScore(summary),
+    unreviewed: { ...summary.bySeverity },
+    openFindings: summary.findings,
+  };
+}
+
+export function renderHealth(r: HealthReport): string {
+  const lines = [`● ${r.title}`, ''];
+  for (const g of r.gauges) lines.push(indent(renderGauge(g)));
+
+  lines.push('');
+  const pct = Math.round(r.scanCoverage * 100);
+  const stats = `Open findings ${String(r.openFindings)}` + `    Scan coverage ${String(pct)}%`;
+  lines.push(indent(stats), '');
+
+  lines.push(indent('Detections & actions — last 7 days'));
+  const maxDay = Math.max(1, ...r.week.map((d) => d.total));
+  for (const d of r.week) {
+    const allowed = Math.max(0, d.total - d.redacted - d.warned - d.blocked);
+    const segments = [
+      { value: allowed, glyph: SHADE.light },
+      { value: d.redacted, glyph: SHADE.medium },
+      { value: d.warned, glyph: SHADE.dark },
+      { value: d.blocked, glyph: SHADE.full },
+    ];
+    lines.push(
+      indent(
+        `${padEnd(d.label, WEEK_LABEL_W)}${stackedBar(segments, d.total, maxDay, WEEK_BAR_W)}  ${padStart(String(d.total), 3)}`,
+      ),
+    );
+  }
+
+  lines.push('');
+  lines.push(
+    indent(
+      `${SHADE.light} allowed   ${SHADE.medium} redacted   ${SHADE.dark} warned   ${SHADE.full} blocked`,
+    ),
+  );
+  lines.push(indent(`${String(r.weekFindings)} findings in the last 7 days`));
+
+  lines.push('');
+  lines.push(
+    indent(
+      `Use the aka-recommend skill to review ${String(r.recommendCount)} prioritized actions.`,
+    ),
+  );
+
+  lines.push('');
+  lines.push(
+    indent(
+      renderStatusBar({ score: r.score, unreviewed: r.unreviewed, openFindings: r.openFindings }),
+    ),
+  );
+
+  return lines.join('\n');
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'] as const;
+
+// "2026-06-21" (UTC day from activityByDay) → "Sat". Falls back to the raw day
+// string if it can't be parsed, so the chart never breaks on odd input.
+function weekday(isoDay: string): string {
+  const date = new Date(`${isoDay}T00:00:00Z`);
+  return Number.isNaN(date.getTime()) ? isoDay : (WEEKDAYS[date.getUTCDay()] ?? isoDay);
+}
+
+// Assemble the /health report entirely from gateway data — no placeholders. The
+// gauges are the real posture inputs: Overall (the blended score), Coverage (how
+// many detection categories sit under an enabled policy) and Handled (the share
+// of findings actually acted on). The week chart is the real per-day findings
+// breakdown from activityByDay.
+//
+// NOTE: Skills / Hooks / MCP / Configuration gauges and token accounting are
+// intentionally omitted — they need setup-health detectors and a token meter
+// this build doesn't capture yet. We show only what we can actually measure
+// rather than fabricate numbers.
+export function buildHealthReport(
+  summary: HealthSummary,
+  findings: FindingView[],
+  activity: DayActivity[],
+): HealthReport {
+  const status = findingStatus(summary);
+
+  const handled = summary.byAction.block + summary.byAction.redact + summary.byAction.warn;
+  const handledPct = summary.findings === 0 ? 100 : Math.round((handled / summary.findings) * 100);
+  const coveragePct = Math.round(summary.coverage * 100);
+
+  const gauges: HealthGauge[] = [
+    {
+      label: 'Overall',
+      score: status.score,
+      note: `${String(summary.findings)} finding${summary.findings === 1 ? '' : 's'} total`,
+      outOf100: true,
+    },
+    { label: 'Coverage', score: coveragePct, note: 'categories under policy' },
+    {
+      label: 'Handled',
+      score: handledPct,
+      note:
+        summary.findings === 0
+          ? 'no findings yet'
+          : `${String(handled)}/${String(summary.findings)} acted on`,
+    },
+  ];
+
+  const week: HealthDay[] = activity.map((d) => ({
+    label: weekday(d.day),
+    total: d.total,
+    redacted: d.redacted,
+    warned: d.warned,
+    blocked: d.blocked,
+  }));
+
+  return {
+    title: 'Setup health — local Codex CLI deployment',
+    gauges,
+    openFindings: status.openFindings,
+    scanCoverage: summary.coverage,
+    week,
+    weekFindings: week.reduce((n, d) => n + d.total, 0),
+    // Exactly the number of rows /recommend renders (one per category, capped),
+    // so "review N prioritized actions" always matches that screen.
+    recommendCount: buildRecommendations(findings).length,
+    unreviewed: status.unreviewed,
+    score: status.score,
+  };
+}
+
+// One row of the /recommend list. Severity drives ordering + the shade label;
+// `context` is the meta left of the arrow, `action` the verb after.
+export interface Recommendation {
+  severity: string;
+  title: string;
+  description: string;
+  context: string;
+  action: string;
+}
+
+// Per-category copy for findings-derived recommendations (the live source until
+// the setup-health recommender lands). Title + the verb after the → arrow.
+const REC_TEMPLATE: Record<string, { title: string; action: string }> = {
+  secret: { title: 'Exposed secret detected', action: 'Rotate' },
+  pii: { title: 'Personal data in a prompt', action: 'Remove' },
+  financial: { title: 'Financial data detected', action: 'Strip' },
+  phi: { title: 'Health information detected', action: 'Remove' },
+  code_context: { title: 'Proprietary code shared', action: 'Review' },
+  custom: { title: 'Custom policy match', action: 'Review' },
+};
+
+// Cap on the recommendation list. One entry per category, so today it's bounded
+// by the handful of REC_TEMPLATE categories — but custom rules can mint new
+// categories, so cap it explicitly. Entries are severity-ranked, so the cap keeps
+// the most important; the slice only ever drops low-priority overflow.
+const MAX_RECOMMENDATIONS = 10;
+
+// Derive recommendations from real findings: one per category, ranked by
+// severity then frequency, described with the category's advice. (Setup-health
+// items — MCP/hooks/permissions — need detectors we don't have, so
+// the live list speaks to the sensitive-data findings we actually capture.)
+export function buildRecommendations(findings: FindingView[]): Recommendation[] {
+  interface Bucket {
+    category: string;
+    count: number;
+    severity: string;
+    weight: number;
+    ruleId: string;
+  }
+  const buckets = new Map<string, Bucket>();
+  for (const f of findings) {
+    const b = buckets.get(f.category) ?? {
+      category: f.category,
+      count: 0,
+      severity: f.severity,
+      weight: 0,
+      ruleId: f.ruleId,
+    };
+    b.count++;
+    const w = SEVERITY_WEIGHT[f.severity] ?? 0;
+    if (w > b.weight) {
+      b.weight = w;
+      b.severity = f.severity;
+      b.ruleId = f.ruleId;
+    }
+    buckets.set(f.category, b);
+  }
+
+  return [...buckets.values()]
+    .sort((a, b) => b.weight - a.weight || b.count - a.count)
+    .slice(0, MAX_RECOMMENDATIONS)
+    .map((b) => {
+      const t = REC_TEMPLATE[b.category] ?? { title: `${b.category} finding`, action: 'Review' };
+      return {
+        severity: b.severity,
+        title: t.title,
+        description: ADVICE[b.category] ?? 'Review this finding against your policy.',
+        context: `${b.ruleId} · ${String(b.count)} finding${b.count === 1 ? '' : 's'}`,
+        action: t.action,
+      };
+    });
+}
+
+// Description wrap width for a recommendation. The body sits indented under the
+// severity badge; this keeps the block within a comfortable reading measure on a
+// wide terminal while still fitting ~80 columns once indented.
+const REC_DESC_WIDTH = 72;
+// Indent of the body/meta lines, aligning them under the severity badge that
+// follows the "N. " rank prefix.
+const REC_BODY_INDENT = '   ';
+
+export function renderRecommend(recs: Recommendation[], status: FindingStatus): string {
+  if (recs.length === 0) {
+    return empty(
+      'No recommendations yet — nothing to act on. Guidance appears as AKA detects sensitive content.',
+    );
+  }
+
+  const count = `${String(recs.length)} recommendation${recs.length === 1 ? '' : 's'}`;
+  const lines = [`● ${count} for your setup, ordered by severity:`, ''];
+
+  recs.forEach((r, i) => {
+    // Heading: rank · severity badge (two spaces) · what's wrong.
+    const badge = `${severityGlyph(r.severity)} ${r.severity.toUpperCase()}`;
+    lines.push(indent(`${String(i + 1)}. ${badge}  ${r.title}`));
+    // Description, wrapped and indented under the badge.
+    for (const line of wrapText(r.description, REC_DESC_WIDTH)) {
+      lines.push(indent(`${REC_BODY_INDENT}${line}`));
+    }
+    // A blank line, then the finding context and the action verb on one line.
+    lines.push('', indent(`${REC_BODY_INDENT}${r.context}  → ${r.action}`), '');
+  });
+
+  lines.push(
+    indent('Use aka-recommend <n> to act on one, or aka-health for the summary.'),
+    '',
+    indent(renderStatusBar(status)),
+  );
+  return lines.join('\n');
+}
+
+export function renderAudit(findings: FindingView[]): string {
+  if (findings.length === 0) {
+    return empty('No decisions recorded yet — AKA logs each detection here as it acts.');
+  }
+  const rows = findings.map((f) => [
+    shortTime(f.occurredAt),
+    f.actionTaken,
+    f.ruleId,
+    f.category,
+    // Join only the parts that are present so a finding missing sourceTool/kind
+    // renders cleanly instead of a bare "/".
+    [f.sourceTool, f.kind].filter(Boolean).join('/'),
+  ]);
+  return [
+    `Recent decisions (${String(findings.length)})`,
+    '',
+    table(['Time', 'Action', 'Rule', 'Category', 'Source'], rows),
+  ].join('\n');
+}
+
+// Thousands-separated integer for token counts (locale-stable, monochrome).
+function num(value: number): string {
+  return Math.round(value).toLocaleString('en-US');
+}
+
+// /aka:tokens — token usage rolled up across sessions by (provider, model). Token
+// counts are saved truth; cost is DERIVED (— for unknown pricing, e.g. local Ollama
+// or a non-Anthropic gateway). When any call is unpriced the totals are a LOWER
+// bound, rendered with "≥" and a footnote, never silently understated.
+export function renderTokens(reports: SessionTokenReport[]): string {
+  if (reports.length === 0) {
+    return empty('No token usage recorded yet — AKA reconciles your transcripts as you work.');
+  }
+
+  // Collapse every rollup onto its (provider, model) via the shared aggregator —
+  // the SAME roll-up the OSS Activity page, `aka stats`, and the TUI use, so every
+  // surface agrees on the per-model totals and the ≥-lower-bound cost.
+  const summary = aggregateTokenUsage(reports);
+  const rows = summary.models.map((m) => [
+    m.provider,
+    m.model,
+    num(m.inputTokens),
+    num(m.outputTokens),
+    num(m.cacheTokens),
+    num(m.totalTokens),
+    m.estimatedCostUsd !== null ? formatUsd(m.estimatedCostUsd) : '—',
+  ]);
+
+  const totalCost = formatCostTotal(summary.estimatedCostUsd, summary.costIsPartial);
+  const sessions =
+    summary.sessionCount === 1 ? '1 session' : `${String(summary.sessionCount)} sessions`;
+  const lines = [
+    `Token usage — ${sessions}, ${num(summary.totalTokens)} tokens, ${totalCost}`,
+    '',
+    table(['Provider', 'Model', 'Input', 'Output', 'Cache', 'Total', 'Cost'], rows),
+  ];
+  if (summary.costIsPartial) {
+    lines.push('', '— = unknown pricing (local / non-Anthropic model); cost is a lower bound.');
+  }
+  return lines.join('\n');
+}
+
+// "in 42m" / "in 3h" / "in 2d" — relative expiry for the /aka:exceptions table.
+// A permanent grant has no expiry and renders as —; a just-lapsed one as
+// "expired" (list() normally filters those, but the renderer stays honest for
+// any caller). Takes `nowMs` so it is pure and unit-tests deterministically.
+function relativeExpiry(expiresAt: string | null, nowMs: number): string {
+  if (expiresAt === null) return '—';
+  const deltaMs = Date.parse(expiresAt) - nowMs;
+  if (Number.isNaN(deltaMs)) return expiresAt;
+  if (deltaMs <= 0) return 'expired';
+  const minutes = Math.ceil(deltaMs / 60_000);
+  if (minutes < 60) return `in ${String(minutes)}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `in ${String(hours)}h`;
+  return `in ${String(Math.round(hours / 24))}d`;
+}
+
+// /aka:exceptions — the ACTIVE detection-exception grants, read-only. Shows the
+// masked preview (values are never stored — only a keyed fingerprint), the rule,
+// scope, relative expiry, use count, and who granted it. Creation and revocation
+// stay in the terminal (`aka exception …`) on purpose: a slash command is
+// model-invocable, so this surface only displays and points at the CLI.
+export function renderExceptions(exceptions: DetectionException[], nowMs = Date.now()): string {
+  if (exceptions.length === 0) {
+    return [
+      'No active exceptions.',
+      'One is granted when a detection blocks you — follow the instructions in the block message.',
+    ].join('\n');
+  }
+
+  const rows = exceptions.map((e) => [
+    e.id.slice(0, 8),
+    e.maskedValue,
+    e.ruleId,
+    e.scope,
+    relativeExpiry(e.expiresAt, nowMs),
+    e.maxUses === null ? String(e.useCount) : `${String(e.useCount)}/${String(e.maxUses)}`,
+    e.createdBy,
+  ]);
+
+  const howTo = defList([
+    ['Grant from a recent block', 'aka exception approve'],
+    ['Undo a grant', 'aka exception revoke <id>'],
+  ]);
+
+  return [
+    `● Active exceptions (${String(exceptions.length)})`,
+    '',
+    indent(table(['ID', 'Value', 'Rule', 'Scope', 'Expires', 'Uses', 'Created by'], rows)),
+    '',
+    indent(howTo),
+  ].join('\n');
+}
+
+// /aka:detections — the installed detection packs, read-only: installed
+// version, rule count, enabled state, effective policy, and whether the
+// running plugin ships a newer snapshot. Updates are MANUAL by design (nothing
+// auto-updates an installed pack), and applying one stays in the terminal /
+// dashboard on purpose — a slash command is model-invocable, so this surface
+// only displays and points at the CLI (mirrors renderExceptions).
+export function renderDetections(items: DetectionListItem[]): string {
+  if (items.length === 0) {
+    return [
+      'No detection packs installed yet.',
+      'They are recorded on the first plugin hook of a session, or by `aka init`.',
+    ].join('\n');
+  }
+
+  const rows = items.map((i) => [
+    i.id,
+    `v${i.version}`,
+    i.latestVersion ? `v${i.latestVersion}` : `v${i.version}`,
+    String(i.ruleCount),
+    i.enabled ? 'yes' : 'no',
+    i.policyId ?? 'monitor',
+    i.latestVersion ? '⬆ update available' : '✓ up to date',
+  ]);
+
+  const updates = items.filter((i) => i.latestVersion != null);
+  const totalRules = items.reduce((n, i) => n + i.ruleCount, 0);
+  const active = items.filter((i) => i.enabled).length;
+
+  const lines = [
+    `● Installed detections (${String(items.length)} packs · ${String(totalRules)} rules · ${String(active)} enabled)`,
+    '',
+    indent(table(['Pack', 'Installed', 'Latest', 'Rules', 'Enabled', 'Policy', 'Status'], rows)),
+    '',
+  ];
+  if (updates.length > 0) {
+    lines.push(
+      indent(
+        `⬆ ${String(updates.length)} update(s) available. Updates are never applied automatically —`,
+      ),
+      indent('apply them yourself in a terminal or the dashboard:'),
+      '',
+      indent(
+        defList([
+          ['Update every pack', 'aka detections update --all'],
+          ['Update one pack', `aka detections update ${updates[0]?.packId ?? '<pack-id>'}`],
+          ['Review in the dashboard', 'aka dashboard → Detections → Update'],
+        ]),
+      ),
+    );
+  } else {
+    lines.push(indent('✓ All detection packs are up to date with this plugin.'));
+  }
+  return lines.join('\n');
+}
+
+export type QuerySubcommand = 'findings' | 'health' | 'recommend' | 'audit' | 'tokens';
+
+// Severity levels accepted by the `--severity` filter on /findings.
+export const SEVERITIES = ['critical', 'high', 'medium', 'low'] as const;
+export type Severity = (typeof SEVERITIES)[number];
+
+export interface QueryOptions {
+  severity?: Severity;
+}
+
+// `exceptions` is listed for the user-facing usage line but dispatched
+// UPSTREAM in query.ts (it reads the local store directly, not the gateway) —
+// runQuery itself never receives it.
+const USAGE = 'Usage: query <findings|health|recommend|audit|tokens|exceptions|detections>';
+
+// Dispatch a read subcommand against a resolved data gateway and return the text
+// to print. Reads only — nothing is mutated here. Async because the DataGateway
+// contract is async.
+export async function runQuery(
+  sub: string,
+  gateway: DataGateway,
+  opts: QueryOptions = {},
+): Promise<string> {
+  switch (sub) {
+    case 'findings': {
+      // Pull a wider window when filtering so the severity isn't limited to the
+      // 25 most recent overall; otherwise keep the default recent slice.
+      const limit = opts.severity !== undefined ? 500 : 25;
+      // Independent reads — fetch concurrently.
+      const [findings, summary] = await Promise.all([
+        gateway.recentFindings({ limit }),
+        gateway.healthSummary(),
+      ]);
+      // Narrow to the requested level when a `--severity` filter is given; the
+      // status bar still reflects the whole-store summary, so its tally stays put
+      // even though the listed rows are a recent (and possibly filtered) slice.
+      const rows =
+        opts.severity !== undefined
+          ? findings.filter((f) => f.severity === opts.severity)
+          : findings;
+      return renderFindings(rows, findingStatus(summary), opts.severity);
+    }
+    case 'health': {
+      const [summary, findings, activity] = await Promise.all([
+        gateway.healthSummary(),
+        gateway.recentFindings({ limit: 500 }),
+        gateway.activityByDay(7),
+      ]);
+      return renderHealth(buildHealthReport(summary, findings, activity));
+    }
+    case 'recommend': {
+      const [findings, summary] = await Promise.all([
+        gateway.recentFindings({ limit: 500 }),
+        gateway.healthSummary(),
+      ]);
+      return renderRecommend(buildRecommendations(findings), findingStatus(summary));
+    }
+    case 'audit':
+      return renderAudit(await gateway.recentFindings({ limit: 25 }));
+    case 'tokens':
+      return renderTokens(await gateway.tokenReports());
+    default:
+      return USAGE;
+  }
+}

--- a/plugins/codex/src/render.ts
+++ b/plugins/codex/src/render.ts
@@ -18,6 +18,8 @@ import type {
   BuiltinPolicyId,
   DetectionException,
   DetectionListItem,
+  FirstRunCalibration,
+  SetupHandoffOffer,
 } from '@akasecurity/schema';
 import { BUILTIN_ORDER, DetectionCategory, toApiAction } from '@akasecurity/schema';
 import { downgradeWarning, isDowngrade } from '@akasecurity/setup-wizard';
@@ -347,15 +349,28 @@ export function healthScore(summary: HealthSummary): number {
   return Math.round(100 * (0.6 * summary.coverage + 0.4 * handledRatio));
 }
 
-// The "First run" completion screen. Commands,
-// handling, findings and recommendations are real; `health` is the derived score
-// above. The host's input box and window chrome are not the plugin's to draw.
+// The "First run" completion screen. Posture, findings and
+// recommendations are real; `health` is the derived score above. The host's
+// input box and window chrome are not the plugin's to draw.
 export interface FirstRunSummary {
-  commands: string[];
-  handling: string;
+  // Whether the card followed a completed calibration scan or fell back to the
+  // severity floor with no scan run — the same signal that gates the dashboard
+  // handoff (`worthALook`) below. Drives the heading and the post-stats
+  // divider so the card never claims a scan that did not happen.
+  calibration: FirstRunCalibration;
+  // Per-category posture block (renderPosture's output) — the wizard's
+  // per-category policy read, one row per category. Optional/omittable: the
+  // read lives inside firstrun's fail-open try/catch, so a store that can't
+  // be read yet just hides the section rather than breaking the card.
+  posture?: string;
   health: number;
   findings: number;
   recommendations: number;
+  // The surfaced/important count carried over from the calibration
+  // preview — drives the 'N worth a look' dashboard handoff. Rendered only when
+  // it is a positive count; when nothing surfaced (0/undefined) the card omits
+  // the handoff line and its stats degrade to an honest empty-state.
+  worthALook?: number;
   // Highest-severity findings from the first scan, ranked + capped by topFindings.
   // Omitted (or empty) on a clean scan — the section is hidden then.
   topFindings?: FindingView[];
@@ -373,27 +388,82 @@ export function topFindings(findings: FindingView[], limit = 10): FindingView[] 
     .slice(0, limit);
 }
 
-export function renderFirstRun(s: FirstRunSummary): string {
-  const heading = '✓ AKA Security installed';
-
-  const details = defList([
-    ['Commands', s.commands.join(' · ')],
-    ['Handling', s.handling],
-  ]);
-
-  const stats = `Health ${String(s.health)}/100   Findings ${String(s.findings)}   Recommendations ${String(s.recommendations)}`;
-
-  const lines = [
-    heading,
-    '',
-    indent(details),
-    '',
-    indent('─'.repeat(RULE_WIDTH)),
-    '',
-    indent('First scan complete'),
-    '',
-    indent(stats),
+// The handoff-offer payload: the 'M worth a look' count the installed
+// summary hands to its handoff question, plus the offer options.
+// `worthALook` is the surfaced/important count the caller carries over from the
+// calibration preview (the sum across every category); `liveKeys` is the
+// narrower surfaced live-key secret count. Both are real store-derived values —
+// this builder never invents them. The prompt layer (the setup skill) asks the
+// question; this is the structured payload a harness reads to assert the offer.
+//
+// The chain-entry option is composed in ahead of the dashboard handoff exactly
+// when live-key secrets surfaced (`liveKeys > 0`), so remediation is reachable
+// without displacing Open dashboard / Not now. When no live keys surfaced — even
+// with other important findings present (`worthALook > 0`, `liveKeys` 0) — the
+// plain dashboard handoff stands alone — offered exactly when
+// live-key secrets surfaced, and never otherwise.
+export function buildHandoffOffer(worthALook: number, liveKeys: number): SetupHandoffOffer {
+  const dashboardHandoff: SetupHandoffOffer['options'] = [
+    { id: 'open-dashboard', label: 'Open dashboard' },
+    { id: 'not-now', label: 'Not now' },
   ];
+  if (liveKeys > 0) {
+    return {
+      worthALook,
+      liveKeys,
+      options: [{ id: 'enter-remediation', label: 'Review leaked keys' }, ...dashboardHandoff],
+    };
+  }
+  return { worthALook, options: dashboardHandoff };
+}
+
+// `registry` is the installed skill registry (readRegisteredSkills()),
+// resolved at the caller's I/O boundary and threaded in so this stays a pure
+// formatter: the Try line's curated set is validated against it here, and an
+// unregistered curated skill throws rather than rendering.
+export function renderFirstRun(s: FirstRunSummary, registry: readonly string[]): string {
+  // Path-honest heading: the scan-path copy claims a scan only when one ran.
+  // The floor path is reached for three different causes — a deliberate
+  // "Not now" decline, a scan that ran clean, or a genuine no-history/failed
+  // scan — and this function can't tell them apart, so the floor copy stays
+  // cause-neutral rather than naming a failure that may not have happened.
+  const heading =
+    s.calibration === 'scan'
+      ? "✓ You're all set — tuned to this machine."
+      : "✓ You're all set — I've started you on safe defaults. Rerun the aka-setup skill anytime to calibrate from Codex's activity.";
+
+  // Nothing-surfaced degradation: with no findings in the store the numeric
+  // Health/detections/recommendations triple would read as a scan tally over an
+  // empty result. The stats line becomes an honest empty-state instead — an
+  // explicit zero-state, never a fabricated count. (The dashboard handoff is
+  // withheld on the same nothing-surfaced footing below.)
+  const statRow = `Health ${String(s.health)}/100 · ${String(s.findings)} detections · ${String(s.recommendations)} recommendations`;
+  // A warm one-line summary rides above the stat row, but only on the scan
+  // path: the floor path never scanned anything, so it renders the stat row
+  // alone rather than claiming a review that did not happen.
+  const warmSummary =
+    s.calibration === 'scan'
+      ? `Your store holds ${String(s.findings)} detections — ${String(s.worthALook ?? 0)} worth your attention.`
+      : undefined;
+  const stats =
+    s.findings === 0
+      ? "Nothing needs your attention — you're starting clean."
+      : [warmSummary, statRow].filter((line): line is string => line !== undefined).join('\n');
+
+  const trySkills = selectRegisteredSkills(TRY_SKILLS, registry);
+  const lines = [heading, '', indent(stats), '', indent(`Try: ${trySkills.join(' · ')}`)];
+
+  // Per-category posture — hidden when unreadable (fail-open upstream leaves
+  // it undefined/empty) so the card degrades gracefully instead of showing an
+  // empty section.
+  if (s.posture !== undefined && s.posture.length > 0) {
+    lines.push('', indent('Posture'), '', indent(s.posture));
+  }
+
+  // The divider mirrors the heading's scan-vs-floor honesty: no scan ran on
+  // the floor path, so it never claims one completed.
+  const divider = s.calibration === 'scan' ? 'First scan complete' : 'Safe defaults in place';
+  lines.push('', indent('─'.repeat(RULE_WIDTH)), '', indent(divider));
 
   // Top findings — a compact, severity-ranked glance at what the first scan
   // caught. Hidden on a clean scan so the card stays a tidy success state.
@@ -419,7 +489,18 @@ export function renderFirstRun(s: FirstRunSummary): string {
     );
   }
 
-  lines.push('', indent('Opening your health dashboard… use the aka-health skill anytime'));
+  // Dashboard handoff — the 'N worth a look' offer over the real surfaced count,
+  // pairing the question the prompt layer asks (Open dashboard / Not now).
+  // Shown only when something surfaced; when nothing surfaced a 0/absent
+  // count omits the line entirely rather than fabricating a '0 worth a look'.
+  if (s.worthALook !== undefined && s.worthALook > 0) {
+    lines.push(
+      '',
+      indent(`${String(s.worthALook)} worth a look — want to see them in the browser?`),
+      indent('Open dashboard · Not now'),
+    );
+  }
+
   return lines.join('\n');
 }
 

--- a/plugins/codex/src/scan-worker.ts
+++ b/plugins/codex/src/scan-worker.ts
@@ -1,0 +1,18 @@
+/**
+ * Build entry for `scripts/scan-worker.js` — the isolated scan's worker thread.
+ *
+ * It is the one emitted script `hooks.json` never names: nothing spawns it as a
+ * hook. `@akasecurity/plugin-sdk`'s isolated scanner starts it by path, from
+ * whichever hook script is running, and every hook script lands in the same
+ * `scripts/` directory as this one.
+ *
+ * It has to be a real entry rather than a file the loader finds at
+ * `src/scan-worker.ts`: the published plugin ships `scripts/` only, so a worker
+ * URL resolved against a source path would point at a file that was never
+ * shipped — and would work perfectly in the repo and under vitest right up
+ * until someone installed it. Without the sibling script, `resolveWorkerUrl()`
+ * answers `undefined` and every rule that cannot be bounded is dropped rather
+ * than run: built-in packs keep detecting, pulled and custom rules silently do
+ * not.
+ */
+import '@akasecurity/plugin-sdk/scan-worker';

--- a/plugins/codex/src/setup-frame-json.ts
+++ b/plugins/codex/src/setup-frame-json.ts
@@ -1,0 +1,36 @@
+/**
+ * Machine-readable frame payloads the /aka:setup wizard scripts emit ALONGSIDE
+ * their human-readable copy. A frame's structured JSON is wrapped in these
+ * markers so a harness (or the later model layer) can extract exactly one
+ * payload from a script's stdout without parsing the surrounding rendered card.
+ * The block is additive: the human copy is never replaced.
+ *
+ * The payload carries only masked/enum/count data by construction — the callers
+ * build it from raw-free plan/store values, never from raw detected content.
+ */
+
+export const FRAME_JSON_BEGIN = '<<<AKA_FRAME_JSON';
+export const FRAME_JSON_END = 'AKA_FRAME_JSON>>>';
+
+// Wrap a frame payload in the delimited block a script appends to its stdout.
+export function frameJsonBlock(payload: unknown): string {
+  return `${FRAME_JSON_BEGIN}\n${JSON.stringify(payload)}\n${FRAME_JSON_END}\n`;
+}
+
+// Extract and parse the single frame payload from a script's stdout, or
+// undefined when no block is present or its contents are not valid JSON. Shared
+// so the emitter and its readers (tests, harness) agree on the delimiters. A
+// malformed block resolves to undefined rather than throwing, so a reader can
+// treat "no readable frame" uniformly.
+export function readFrameJsonBlock(stdout: string): unknown {
+  const begin = stdout.indexOf(FRAME_JSON_BEGIN);
+  if (begin === -1) return undefined;
+  const from = begin + FRAME_JSON_BEGIN.length;
+  const end = stdout.indexOf(FRAME_JSON_END, from);
+  if (end === -1) return undefined;
+  try {
+    return JSON.parse(stdout.slice(from, end).trim());
+  } catch {
+    return undefined;
+  }
+}

--- a/plugins/codex/src/setup-show.ts
+++ b/plugins/codex/src/setup-show.ts
@@ -1,0 +1,91 @@
+/**
+ * User-facing SHOW regions the aka-setup wizard scripts emit. A script wraps
+ * everything the user should see — fenced cards and plain confirmation lines —
+ * in these markers; the wizard's global relay contract pastes the content
+ * between the markers verbatim. The markers are delimiters, never shown. This is
+ * the human-facing twin of setup-frame-json.ts's machine-frame markers: same
+ * delimiter style, opposite disposition (show vs hide).
+ */
+import { FRAME_JSON_BEGIN, FRAME_JSON_END } from './setup-frame-json.ts';
+
+export const SHOW_BEGIN = '<<<AKA_SHOW';
+export const SHOW_END = 'AKA_SHOW>>>';
+
+// Wrap a body in a SHOW region a script writes to stdout. The trailing newline
+// keeps the region on its own lines even when callers concatenate emissions.
+export function showBlock(body: string): string {
+  return `${SHOW_BEGIN}\n${body}\n${SHOW_END}\n`;
+}
+
+// Extract every SHOW region's content, in order. A region missing its end marker
+// is skipped rather than throwing, so a reader treats malformed output as "no
+// further show content" uniformly.
+export function readShowBlocks(stdout: string): string[] {
+  const blocks: string[] = [];
+  let from = 0;
+  for (;;) {
+    const begin = stdout.indexOf(SHOW_BEGIN, from);
+    if (begin === -1) break;
+    const contentStart = begin + SHOW_BEGIN.length;
+    const end = stdout.indexOf(SHOW_END, contentStart);
+    if (end === -1) break;
+    blocks.push(stdout.slice(contentStart, end).replace(/^\n/, '').replace(/\n$/, ''));
+    from = end + SHOW_END.length;
+  }
+  return blocks;
+}
+
+export interface Surface {
+  shows: string[];
+  frames: unknown[];
+  status: string;
+}
+
+// Partition a script's stdout into the three wizard output regions in a single
+// left-to-right walk, so every byte lands in exactly one of them: `shows` is
+// what the model relays verbatim; `frames` is machine-only parsed JSON (malformed
+// blocks are dropped); `status` is the untagged remainder (paths, errors) with
+// every show and frame region removed. A region missing its end marker stops the
+// walk but still appends everything from that marker onward — including any
+// trailing untagged text — to `status`, rather than dropping it.
+export function parseSurface(stdout: string): Surface {
+  const shows: string[] = [];
+  const frames: unknown[] = [];
+  let status = '';
+  let cursor = 0;
+  while (cursor < stdout.length) {
+    const nextShow = stdout.indexOf(SHOW_BEGIN, cursor);
+    const nextFrame = stdout.indexOf(FRAME_JSON_BEGIN, cursor);
+    const candidates = [nextShow, nextFrame].filter((i) => i !== -1);
+    if (candidates.length === 0) {
+      status += stdout.slice(cursor);
+      break;
+    }
+    const next = Math.min(...candidates);
+    status += stdout.slice(cursor, next);
+    if (next === nextShow) {
+      const contentStart = next + SHOW_BEGIN.length;
+      const end = stdout.indexOf(SHOW_END, contentStart);
+      if (end === -1) {
+        status += stdout.slice(next);
+        break;
+      }
+      shows.push(stdout.slice(contentStart, end).replace(/^\n/, '').replace(/\n$/, ''));
+      cursor = end + SHOW_END.length;
+    } else {
+      const from = next + FRAME_JSON_BEGIN.length;
+      const end = stdout.indexOf(FRAME_JSON_END, from);
+      if (end === -1) {
+        status += stdout.slice(next);
+        break;
+      }
+      try {
+        frames.push(JSON.parse(stdout.slice(from, end).trim()));
+      } catch {
+        // Malformed frame: drop it, mirroring readFrameJsonBlock's fail-soft.
+      }
+      cursor = end + FRAME_JSON_END.length;
+    }
+  }
+  return { shows, frames, status };
+}

--- a/plugins/codex/src/skills-registry.ts
+++ b/plugins/codex/src/skills-registry.ts
@@ -1,0 +1,85 @@
+// The installed skill registry and the per-surface selection over it. The
+// registry is the source of truth for skill EXISTENCE — the shipped
+// `skills/<dir>/SKILL.md` set — not for which skills a given surface suggests.
+// Each surface declares its own curated subset and validates it here, so no
+// rendered line can name a skill the installed plugin does not register.
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The shipped skill directories — one `skills/<dir>/SKILL.md` per registered
+// skill, invoked by the `name:` its frontmatter declares.
+const SKILLS_DIR = fileURLToPath(new URL('../skills', import.meta.url));
+
+// Extract the `name:` field from a SKILL.md's leading frontmatter block, or
+// undefined when the file has no frontmatter or no name entry.
+function frontmatterName(content: string): string | undefined {
+  const block = /^---\n([\s\S]*?)\n---/.exec(content);
+  if (block === null) return undefined;
+  const name = /^name:\s*(.+?)\s*$/m.exec(block[1] ?? '');
+  return name?.[1];
+}
+
+// The skills the installed plugin registers, read from the shipped
+// `skills/<dir>/SKILL.md` set and mapped to the invokable name each file's
+// frontmatter declares. This is the registry of skill existence a suggested
+// skill is validated against, read from disk so a renamed or removed skill is
+// reflected rather than drifting from a copy. A directory without a readable
+// SKILL.md name registers nothing.
+export function readRegisteredSkills(): string[] {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      let content: string;
+      try {
+        content = readFileSync(join(SKILLS_DIR, entry.name, 'SKILL.md'), 'utf8');
+      } catch {
+        return [];
+      }
+      const name = frontmatterName(content);
+      return name === undefined ? [] : [name];
+    });
+}
+
+// Resolve a surface's curated skill set against the installed registry: every
+// curated skill must be a registered skill, or this throws so an absent name
+// fails loud rather than shipping a call-to-action the user cannot invoke.
+// Returns the curated set unchanged (order preserved) once every entry validates.
+export function selectRegisteredSkills(
+  curated: readonly string[],
+  registry: readonly string[],
+): string[] {
+  const registered = new Set(registry);
+  const missing = curated.filter((c) => !registered.has(c));
+  if (missing.length > 0) {
+    throw new Error(
+      `Curated skill(s) not registered in the installed plugin: ${missing.join(', ')}`,
+    );
+  }
+  return [...curated];
+}
+
+// The chaining line names a single secret-scan continuation skill. It is
+// registered under one of two names — `aka-secretscan` where the dedicated
+// secret-scan skill exists, or `aka-scan` otherwise — so the curated
+// candidates list both, most-specific first, and the selection resolves to
+// whichever name the installed plugin registers.
+const SECRET_SCAN_CONTINUATION = ['aka-secretscan', 'aka-scan'] as const;
+
+// Select the chaining line's single secret-scan continuation skill: resolve the
+// curated candidates against the installed registry, then validate the one that
+// resolves through selectRegisteredSkills so the line names a registered skill
+// in either ship order. Throws when none is registered, so an absent continuation
+// fails the build rather than shipping a call-to-action the user cannot invoke.
+export function selectSecretScanContinuation(
+  registry: readonly string[] = readRegisteredSkills(),
+): string {
+  const curated = SECRET_SCAN_CONTINUATION.find((c) => registry.includes(c));
+  if (curated === undefined) {
+    throw new Error(
+      `No secret-scan continuation skill registered in the installed plugin (looked for ${SECRET_SCAN_CONTINUATION.join(', ')})`,
+    );
+  }
+  const [selected = curated] = selectRegisteredSkills([curated], registry);
+  return selected;
+}

--- a/plugins/codex/src/start-light.ts
+++ b/plugins/codex/src/start-light.ts
@@ -1,0 +1,82 @@
+/**
+ * Posture-card emitter for the aka-setup wizard's calibration frames. Two
+ * modes, both pure copy (read no store, record no consent, write only the card
+ * to stdout):
+ *
+ *   node scripts/start-light.js
+ *     Frame 0.3b — the Not-now branch's start-light card: the full 8×4 default posture
+ *     matrix seeded with the conservative severity-floor defaults, a per-pack
+ *     rationale, and the re-tune hint. The No-history branch touches no historical
+ *     data by construction.
+ *
+ *   node scripts/start-light.js --adjust-confirm --posture '<json>' [--recommended '<json>'] [--current '<json>']
+ *     Frame 0.4b — the Yes-path adjust loop's confirm card: the
+ *     'category │ recommended │ yours' table comparing the recommended posture
+ *     with the user's adjusted choices (the --posture map, the recommended base
+ *     with their overrides overlaid), both validated through parsePosture. The
+ *     recommended column is the --recommended map — the calibrated recommended
+ *     posture the preview printed — so a pack calibration escalated shows its
+ *     calibrated level, not the floor; it falls back to the severity floor when
+ *     --recommended is omitted. --current carries the store's existing
+ *     per-category action (the plan file's `current` map) so a choice that lowers
+ *     enforcement below it prints the downgrade WARNING; omitted, no baseline
+ *     exists and nothing can read as a downgrade.
+ */
+import { severityFloorPosture } from '@akasecurity/plugin-sdk';
+import { parseCurrent, parsePosture } from '@akasecurity/setup-wizard';
+
+import { fenced, show } from './present.ts';
+import { renderAdjustConfirm, renderStartLight } from './render.ts';
+
+const argv = process.argv.slice(2);
+
+function jsonArg(flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i === -1 ? undefined : argv[i + 1];
+}
+
+// The --posture flag carries the user's adjusted posture as JSON — the frame-0.4b
+// confirm card needs it; the frame-0.3b start-light card takes no arguments.
+function postureArg(): string {
+  const value = jsonArg('--posture');
+  if (value === undefined) throw new Error('--adjust-confirm requires --posture <json>');
+  return value;
+}
+
+// The recommended column of the 0.4b confirm table: the calibrated recommended
+// posture the preview printed (passed as --recommended), falling back to the
+// cold-start severity floor when the caller omits it.
+function recommendedPosture() {
+  const raw = jsonArg('--recommended');
+  return raw === undefined ? severityFloorPosture() : parsePosture(raw);
+}
+
+// The store's existing per-category action, for the downgrade comparison. This
+// script reads no store — the caller passes the snapshot it already holds (the
+// plan file's `current` map). Absent, the baseline is empty and nothing can read
+// as a downgrade.
+function currentPosture() {
+  const raw = jsonArg('--current');
+  return raw === undefined ? {} : parseCurrent(raw);
+}
+
+// Bad input (a missing --posture, malformed JSON, an unknown category or level)
+// must read as a plain line inside the user's Codex session, never a raw stack
+// trace, so every parse runs inside this guard.
+try {
+  const card = argv.includes('--adjust-confirm')
+    ? renderAdjustConfirm(recommendedPosture(), parsePosture(postureArg()), currentPosture())
+    : renderStartLight(severityFloorPosture());
+
+  // One Markdown code fence so the wizard can echo the card verbatim (space-aligned
+  // monospace collapses without the fence).
+  process.stdout.write(show(fenced(card)));
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stdout.write(`AKA setup failed: ${message}\n`);
+  process.exit(1);
+}
+
+// Match the other adapter scripts (intro.js, firstrun.js) which hard-exit on
+// completion so no stray handle can keep the process alive.
+process.exit(0);

--- a/plugins/codex/src/triage/consent.ts
+++ b/plugins/codex/src/triage/consent.ts
@@ -1,0 +1,13 @@
+/**
+ * Model-judge consent — the distinct opt-in that gates sending findings to the
+ * model API (the aka-setup judge's `codex exec` egress). This is separate from
+ * the historical-access grant, which only governs READING local rollouts.
+ * The judge refuses to run unless the stored consent is present AND matches the
+ * current payload-shape version.
+ *
+ * Both the version constant and the validity predicate live in
+ * `@akasecurity/schema` — the dashboard and CLI read the same definition, so
+ * "granted" cannot mean one thing to the judge and another to the settings UI.
+ * They are re-exported here so the plugin's triage code has one local import.
+ */
+export { isModelJudgeConsentValid, MODEL_JUDGE_PAYLOAD_VERSION } from '@akasecurity/schema';

--- a/plugins/codex/src/triage/judge.ts
+++ b/plugins/codex/src/triage/judge.ts
@@ -1,0 +1,188 @@
+/**
+ * The ephemeral setup-wizard judge runner (Codex CLI).
+ *
+ * The FP/severity judgment is the one place the wizard feeds the model RAW
+ * hits (rawMatch + surrounding context) — the locked rubric (the shared
+ * @akasecurity/setup-wizard asset)
+ * requires raw to judge accurately. To keep that raw out of the user's
+ * scannable rollout store (~/.codex/sessions), the judgment runs as a
+ * SEPARATE, transient `codex exec` subprocess that persists NO session file:
+ *
+ *   codex exec --ephemeral --skip-git-repo-check --output-last-message <file> -
+ *
+ * --ephemeral ("Run without persisting session files to disk", per the Codex
+ * CLI itself) is REQUIRED, not cosmetic: AKA's own backfill scans
+ * ~/.codex/sessions/**\/rollout-*.jsonl for leaked secrets, so a persisted
+ * judge session — whose prompt carries every raw hit — would be re-ingested
+ * as fresh findings on the next history scan. It suppresses only session
+ * persistence, NOT network egress: the raw values still leave the machine to
+ * the model API, because reaching the model is the point.
+ *
+ * The prompt (rubric + raw hits) rides on the child's stdin (the trailing `-`
+ * argument tells `codex exec` to read the prompt from stdin), not argv: argv
+ * is capped by the OS's ARG_MAX (~1MB on most platforms), and a large hit set
+ * would fail the spawn with E2BIG. stdin has no such ceiling, and keeps the
+ * raw hits off the process list and out of any argv-echoing error message.
+ *
+ * The verdict is read from the --output-last-message file (a fresh mkdtemp
+ * under os.tmpdir, removed in a finally), never from stdout — `codex exec`
+ * logs the whole run to stdout, which can echo raw content; that stream is
+ * captured and discarded, never forwarded to the parent command.
+ *
+ * The subprocess inherits the host environment untouched — `codex` must be
+ * found on PATH, and auth (CODEX_HOME / ~/.codex credentials) must survive.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { TriageHit, TriageRecommendation } from '@akasecurity/schema';
+import { parseRecommendation } from '@akasecurity/setup-wizard';
+
+const TRIAGE_DIR = dirname(fileURLToPath(import.meta.url));
+// src/triage/judge.ts -> packages/setup-wizard/assets/triage-rubric.md
+const DEFAULT_RUBRIC_PATH = join(
+  TRIAGE_DIR,
+  '..',
+  '..',
+  '..',
+  '..',
+  'packages',
+  'setup-wizard',
+  'assets',
+  'triage-rubric.md',
+);
+
+// -------------------------------------------------------------------------
+// Pure parse: last message -> verdict
+// -------------------------------------------------------------------------
+
+// Extract + validate the fenced TriageRecommendation from the model's final
+// message (the --output-last-message file's content) via the shared parser.
+// An empty or unparseable message is a hard failure, never a silent pass —
+// the caller must not act on a verdict we could not read.
+export function parseVerdict(lastMessage: string): TriageRecommendation {
+  // Never echo the subprocess output in an error: it may carry a raw hit the
+  // model failed to strip, and this error propagates to the parent command's
+  // stderr — outside the isolated judge process. Every failure reports only
+  // raw-free metadata, never the content.
+  if (lastMessage.trim() === '') {
+    throw new Error('codex exec returned an empty last message');
+  }
+  try {
+    return parseRecommendation(lastMessage);
+  } catch {
+    throw new Error('codex exec returned an unparseable TriageRecommendation');
+  }
+}
+
+// -------------------------------------------------------------------------
+// Subprocess env + spawn
+// -------------------------------------------------------------------------
+
+// Env for the ephemeral judge subprocess: the host environment, inherited
+// untouched. `codex` must resolve on PATH and its auth (CODEX_HOME /
+// ~/.codex credentials) must survive; session persistence is suppressed by
+// the --ephemeral flag on argv, not by any env var.
+export function judgeEnv(): NodeJS.ProcessEnv {
+  return { ...process.env };
+}
+
+// Real subprocess spawn used in production wiring. Kept separate from runJudge
+// so unit tests inject a fake and NEVER hit a live model. The prompt (which
+// carries the raw hits) rides on stdin rather than argv — argv has an OS
+// ceiling (ARG_MAX, ~1MB on most platforms) that a large hit set can exceed,
+// failing the spawn with E2BIG; stdin has no such limit. `codex exec`'s
+// stdout (run logging that can echo raw content) is captured here and
+// discarded — the verdict comes from the --output-last-message file instead.
+export function spawnCodex(argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string): void {
+  execFileSync('codex', [...argv], {
+    env,
+    input: stdin,
+    encoding: 'utf8',
+    timeout: 180_000,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+}
+
+// Raw-free description of a spawn failure. The prompt rides on stdin, not
+// argv, so an execFileSync error's `.message` (which echoes argv) cannot
+// carry the raw hits — but its captured stdout/stderr still might, and none
+// of it may cross back to the parent command. This stays belt-and-suspenders:
+// we surface ONLY the non-content metadata (exit status / signal / node error
+// code), never `.message`, `.stdout`, or `.stderr`.
+function spawnFailureMeta(err: unknown): string {
+  const e = err as { status?: number | null; signal?: string | null; code?: string };
+  const parts: string[] = [];
+  if (typeof e.status === 'number') parts.push(`exit ${String(e.status)}`);
+  if (typeof e.signal === 'string' && e.signal) parts.push(`signal ${e.signal}`);
+  if (typeof e.code === 'string' && e.code) parts.push(e.code);
+  return parts.length > 0 ? parts.join(', ') : 'unknown error';
+}
+
+// -------------------------------------------------------------------------
+// runJudge
+// -------------------------------------------------------------------------
+
+export interface JudgeDeps {
+  // Injected spawn seam: receives the argv AFTER `codex`, the subprocess env,
+  // and the prompt (fed on stdin, not argv — see spawnCodex). The final
+  // assistant message lands in the --output-last-message file named on argv;
+  // tests inject a fake that writes a canned verdict there so no real
+  // `codex exec` runs.
+  spawn: (argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string) => void;
+  // Override the rubric source (defaults to the shared package asset); injectable so
+  // tests need not read the real file.
+  loadRubric?: () => string;
+}
+
+// Build the judge prompt (rubric + raw hits as JSONL) and run it through the
+// ephemeral subprocess, returning the parsed verdict. The RAW hits ride in the
+// prompt on purpose (the rubric needs them); the prompt rides on stdin (not
+// argv) so a large hit set never trips the OS's ARG_MAX and so raw can't leak
+// via a spawn error's argv-echoing `.message`. --ephemeral is what keeps the
+// prompt out of ~/.codex/sessions. Always removes the temp output dir.
+export function runJudge(hits: readonly TriageHit[], deps: JudgeDeps): TriageRecommendation {
+  const rubric = deps.loadRubric?.() ?? readFileSync(DEFAULT_RUBRIC_PATH, 'utf8');
+  const hitsJsonl = hits.map((h) => JSON.stringify(h)).join('\n');
+  const fullPrompt = `${rubric}\n\n## Hits\n\n\`\`\`\n${hitsJsonl}\n\`\`\`\n`;
+
+  const outDir = mkdtempSync(join(tmpdir(), 'aka-judge-'));
+  const outFile = join(outDir, 'last-message.txt');
+  const argv = [
+    'exec',
+    '--ephemeral',
+    '--skip-git-repo-check',
+    '--output-last-message',
+    outFile,
+    '-',
+  ] as const;
+  try {
+    // The spawn is isolated from the parse: a spawn failure (execFileSync) throws
+    // an error whose captured stdout/stderr may carry raw content even though the
+    // prompt itself never rides argv. Re-throw it as raw-free metadata so nothing
+    // raw can ride the error out to the parent command's stderr.
+    try {
+      deps.spawn(argv, judgeEnv(), fullPrompt);
+    } catch (err) {
+      // Deliberately NOT chaining `err` as `cause`: the execFileSync error's captured
+      // stdout/stderr may carry raw content, and attaching it would re-expose
+      // exactly what this throw exists to strip. Only raw-free metadata is surfaced.
+      // eslint-disable-next-line preserve-caught-error -- caught error may carry raw; see above
+      throw new Error(`codex exec judge subprocess failed (${spawnFailureMeta(err)})`);
+    }
+    // A subprocess that exits 0 without writing the last-message file still
+    // fails loud (and raw-free) — an unreadable verdict must never pass.
+    let lastMessage: string;
+    try {
+      lastMessage = readFileSync(outFile, 'utf8');
+    } catch {
+      throw new Error('codex exec wrote no last-message file');
+    }
+    return parseVerdict(lastMessage);
+  } finally {
+    rmSync(outDir, { recursive: true, force: true });
+  }
+}

--- a/plugins/codex/src/triage/judge.ts
+++ b/plugins/codex/src/triage/judge.ts
@@ -95,9 +95,12 @@ export function judgeEnv(): NodeJS.ProcessEnv {
 // so unit tests inject a fake and NEVER hit a live model. The prompt (which
 // carries the raw hits) rides on stdin rather than argv — argv has an OS
 // ceiling (ARG_MAX, ~1MB on most platforms) that a large hit set can exceed,
-// failing the spawn with E2BIG; stdin has no such limit. `codex exec`'s
-// stdout (run logging that can echo raw content) is captured here and
+// failing the spawn with E2BIG; stdin has no such limit. BOTH of `codex exec`'s
+// output streams (run logging that can echo raw content) are captured here and
 // discarded — the verdict comes from the --output-last-message file instead.
+// The stdio option is explicit because execFileSync's default writes the
+// child's stderr through to the parent's stderr, which flows into the wizard
+// conversation — the transcript --ephemeral exists to keep raw content out of.
 export function spawnCodex(argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string): void {
   execFileSync('codex', [...argv], {
     env,
@@ -105,6 +108,7 @@ export function spawnCodex(argv: readonly string[], env: NodeJS.ProcessEnv, stdi
     encoding: 'utf8',
     timeout: 180_000,
     maxBuffer: 32 * 1024 * 1024,
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 }
 
@@ -167,6 +171,15 @@ export function toJudgePayload(
 }
 
 export function runJudge(hits: readonly TriageHit[], deps: JudgeDeps): TriageRecommendation {
+  // No live-spawn fallback: a caller that forgot the seam must fail as the
+  // programming error it is rather than be quietly routed to the real
+  // `codex`. First statement in the function, so it throws before the rubric
+  // is read, before any hit is projected, and before the temp output dir is
+  // minted — no raw is assembled for a call that cannot proceed.
+  if (typeof deps.spawn !== 'function') {
+    throw new TypeError('runJudge requires deps.spawn — there is no live-spawn fallback');
+  }
+
   const rubric = deps.loadRubric?.() ?? readFileSync(DEFAULT_RUBRIC_PATH, 'utf8');
   const hitsJsonl = hits.map((h) => JSON.stringify(toJudgePayload(h))).join('\n');
   const fullPrompt = `${rubric}\n\n## Hits\n\n\`\`\`\n${hitsJsonl}\n\`\`\`\n`;
@@ -205,6 +218,13 @@ export function runJudge(hits: readonly TriageHit[], deps: JudgeDeps): TriageRec
     }
     return parseVerdict(lastMessage);
   } finally {
-    rmSync(outDir, { recursive: true, force: true });
+    try {
+      rmSync(outDir, { recursive: true, force: true });
+    } catch {
+      // A throw here would REPLACE whatever the try block is throwing — the
+      // raw-free spawn/parse failure the caller has to act on — with an fs
+      // error about a throwaway path. The dir is a mkdtemp under tmpdir(),
+      // so leaking it beats losing the real failure.
+    }
   }
 }

--- a/plugins/codex/src/triage/judge.ts
+++ b/plugins/codex/src/triage/judge.ts
@@ -38,6 +38,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { maskText } from '@akasecurity/plugin-sdk';
 import type { TriageHit, TriageRecommendation } from '@akasecurity/schema';
 import { parseRecommendation } from '@akasecurity/setup-wizard';
 
@@ -144,9 +145,30 @@ export interface JudgeDeps {
 // argv) so a large hit set never trips the OS's ARG_MAX and so raw can't leak
 // via a spawn error's argv-echoing `.message`. --ephemeral is what keeps the
 // prompt out of ~/.codex/sessions. Always removes the temp output dir.
+
+// The minimized egress projection: what actually crosses to the model. The
+// finding's own rawMatch must cross (the rubric judges the value), and the
+// context window crosses only after re-masking, so any OTHER detectable secret
+// in the window never leaves raw. filePath, valueFingerprint, and keyVersion
+// are dropped before egress — a new TriageHit field is not disclosed to the
+// model unless this projection and the consent copy are updated together.
+// maskText is fail-secure: a masking fault over-redacts, never leaks.
+// The spread is load-bearing: it drops the fields from a COPY, never off the
+// source hit — the surfaced-secrets writeback still reads filePath off the
+// original in-memory hits, so mutating in place here would break that path.
+export function toJudgePayload(
+  hit: TriageHit,
+): Omit<TriageHit, 'filePath' | 'valueFingerprint' | 'keyVersion'> {
+  const payload: TriageHit = { ...hit, context: maskText(hit.context) };
+  delete payload.filePath;
+  delete payload.valueFingerprint;
+  delete payload.keyVersion;
+  return payload;
+}
+
 export function runJudge(hits: readonly TriageHit[], deps: JudgeDeps): TriageRecommendation {
   const rubric = deps.loadRubric?.() ?? readFileSync(DEFAULT_RUBRIC_PATH, 'utf8');
-  const hitsJsonl = hits.map((h) => JSON.stringify(h)).join('\n');
+  const hitsJsonl = hits.map((h) => JSON.stringify(toJudgePayload(h))).join('\n');
   const fullPrompt = `${rubric}\n\n## Hits\n\n\`\`\`\n${hitsJsonl}\n\`\`\`\n`;
 
   const outDir = mkdtempSync(join(tmpdir(), 'aka-judge-'));

--- a/plugins/codex/src/triage/presenter.ts
+++ b/plugins/codex/src/triage/presenter.ts
@@ -26,4 +26,7 @@ export const adapterPresenter: AdapterPresenter = {
   renderApplied: (categoriesTuned, dismissed) =>
     renderApplied(categoriesTuned, dismissed, readRegisteredSkills()),
   storeUnavailableNote: STORE_UNAVAILABLE_NOTE,
+  // The stale-plan refusal tells the user to restart the wizard by its Codex
+  // skill name — Codex has no slash commands, so this names the skill.
+  rerunHint: 'the aka-setup skill',
 };

--- a/plugins/codex/src/triage/presenter.ts
+++ b/plugins/codex/src/triage/presenter.ts
@@ -1,0 +1,28 @@
+/**
+ * The Codex CLI presentation wiring for the shared apply-suppressions
+ * orchestrator (@akasecurity/setup-wizard's runApply). Every member either
+ * carries Codex-branded copy, names a host skill, or reads the installed
+ * skill registry — the host-bound surface the shared core injects rather
+ * than owns. The Claude Code plugin wires its own equivalent of this file.
+ */
+import type { AdapterPresenter } from '@akasecurity/setup-wizard';
+
+import { frameCalibration, frameEmptyState } from '../calibration.ts';
+import { fenced, show } from '../present.ts';
+import { renderApplied, renderRecommendedPosture, STORE_UNAVAILABLE_NOTE } from '../render.ts';
+import { frameJsonBlock } from '../setup-frame-json.ts';
+import { readRegisteredSkills } from '../skills-registry.ts';
+
+export const adapterPresenter: AdapterPresenter = {
+  show,
+  fenced,
+  frameJsonBlock,
+  frameEmptyState,
+  frameCalibration,
+  renderRecommendedPosture,
+  // The applied card's Ready line resolves against the installed skill
+  // registry — closed over here so the shared core never reads it.
+  renderApplied: (categoriesTuned, dismissed) =>
+    renderApplied(categoriesTuned, dismissed, readRegisteredSkills()),
+  storeUnavailableNote: STORE_UNAVAILABLE_NOTE,
+};

--- a/plugins/codex/src/triage/presenter.ts
+++ b/plugins/codex/src/triage/presenter.ts
@@ -7,7 +7,7 @@
  */
 import type { AdapterPresenter } from '@akasecurity/setup-wizard';
 
-import { frameCalibration, frameEmptyState } from '../calibration.ts';
+import { frameCalibration, frameEmptyState, zeroCountFrame } from '../calibration.ts';
 import { fenced, show } from '../present.ts';
 import { renderApplied, renderRecommendedPosture, STORE_UNAVAILABLE_NOTE } from '../render.ts';
 import { frameJsonBlock } from '../setup-frame-json.ts';
@@ -19,6 +19,7 @@ export const adapterPresenter: AdapterPresenter = {
   frameJsonBlock,
   frameEmptyState,
   frameCalibration,
+  zeroCountFrame,
   renderRecommendedPosture,
   // The applied card's Ready line resolves against the installed skill
   // registry — closed over here so the shared core never reads it.

--- a/plugins/codex/test/backfill.test.ts
+++ b/plugins/codex/test/backfill.test.ts
@@ -1,0 +1,290 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import type { TriageHit } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BackfillDeps, BackfillIo } from '../src/backfill.ts';
+import { runBackfill, triageSentinel } from '../src/backfill.ts';
+import type { ScanSummary } from '../src/history/scan.ts';
+
+// --triage mode mints a real fingerprint key file via
+// @akasecurity/plugin-sdk's loadOrCreateFingerprintKey, so each test gets its
+// own scratch directory removed afterward rather than a fixed shared path.
+let dataDir: string;
+
+beforeEach(() => {
+  dataDir = mkdtempSync(join(tmpdir(), 'aka-backfill-test-'));
+});
+
+afterEach(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+function fakeIo(): { io: BackfillIo; stdout: string[]; stderr: string[]; failed: () => boolean } {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let didFail = false;
+  return {
+    io: {
+      stdout: (chunk) => stdout.push(chunk),
+      stderr: (chunk) => stderr.push(chunk),
+      fail: () => {
+        didFail = true;
+      },
+    },
+    stdout,
+    stderr,
+    failed: () => didFail,
+  };
+}
+
+function zeroSummary(): ScanSummary {
+  return { consented: true, scanned: 0, skipped: 0, findings: 0, bySeverity: {}, windowDays: 30 };
+}
+
+function baseDeps(overrides: Partial<BackfillDeps> = {}): BackfillDeps {
+  const { io } = fakeIo();
+  const config: PluginConfig = {
+    settings: {
+      specVersion: 3,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'full',
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'openai' },
+  };
+  return {
+    triage: false,
+    io,
+    loadConfig: () => config,
+    scanHistory: vi.fn(() => Promise.resolve(zeroSummary())),
+    reconcileHistory: vi.fn(() => Promise.resolve(undefined)),
+    ...overrides,
+  };
+}
+
+function fixtureHit(rawMatch: string): TriageHit {
+  return {
+    ruleId: 'secrets/aws-access-key',
+    category: 'secret',
+    severity: 'critical',
+    maskedMatch: '****',
+    rawMatch,
+    context: `leaked ${rawMatch} here`,
+    confidence: 0.9,
+  };
+}
+
+describe('triageSentinel', () => {
+  it('serializes done/count/status as a single trailing JSON line', () => {
+    expect(triageSentinel(3, 'complete')).toBe('{"done":true,"count":3,"status":"complete"}\n');
+  });
+});
+
+describe('runBackfill — triage mode', () => {
+  it('streams exactly N JSONL lines then a matching complete sentinel with nothing to stderr', async () => {
+    const { io, stdout, stderr } = fakeIo();
+    const hits = [fixtureHit('AKIAEXAMPLE1'), fixtureHit('AKIAEXAMPLE2')];
+    const scanHistory = vi.fn((_config, _opts, onHit?: (hit: TriageHit) => void) => {
+      for (const hit of hits) onHit?.(hit);
+      return Promise.resolve({ ...zeroSummary(), scanned: hits.length });
+    });
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout).toHaveLength(3);
+    const [first, second, third] = stdout;
+    expect((JSON.parse(first ?? '') as TriageHit).rawMatch).toBe('AKIAEXAMPLE1');
+    expect((JSON.parse(second ?? '') as TriageHit).rawMatch).toBe('AKIAEXAMPLE2');
+    expect(third).toBe(triageSentinel(2, 'complete'));
+    expect(stderr).toEqual([]);
+  });
+
+  it('emits a complete:no-history sentinel when the history set was genuinely empty (scanned === 0)', async () => {
+    const { io, stdout, stderr } = fakeIo();
+    // A completed, non-truncated scan that examined zero messages — a fresh
+    // machine with no Codex history to calibrate from.
+    const scanHistory = vi.fn(() => Promise.resolve({ ...zeroSummary(), scanned: 0 }));
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout).toEqual([triageSentinel(0, 'complete:no-history')]);
+    expect(stderr).toEqual([]);
+  });
+
+  it('emits a plain complete sentinel when history WAS scanned but nothing surfaced (scanned > 0)', async () => {
+    const { io, stdout } = fakeIo();
+    // Messages were examined but none leaked — scan-clean, not no-history.
+    const scanHistory = vi.fn(() => Promise.resolve({ ...zeroSummary(), scanned: 5 }));
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout).toEqual([triageSentinel(0, 'complete')]);
+  });
+
+  it('emits a plain complete sentinel on a fully-deduped rescan of real history (scanned === 0, skipped > 0)', async () => {
+    const { io, stdout } = fakeIo();
+    // A re-run over history already recorded on a prior scan: every message is
+    // deduped (skipped), none newly examined. History exists — this is NOT
+    // no-history, even though scanned is 0.
+    const scanHistory = vi.fn(() => Promise.resolve({ ...zeroSummary(), scanned: 0, skipped: 7 }));
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout).toEqual([triageSentinel(0, 'complete')]);
+  });
+
+  it('emits only the skipped:no-consent sentinel when consent is not full', async () => {
+    const { io, stdout } = fakeIo();
+    const config: PluginConfig = {
+      settings: {
+        specVersion: 3,
+        runMode: 'standalone',
+        policy: 'redact',
+        historicalAccess: 'session-only',
+        dataSharesInPlace: true,
+        vaultKeyCustody: 'file',
+        vaultInlineReveal: 'masked',
+      },
+      dataDir,
+      dbPath: join(dataDir, 'aka.db'),
+      settingsDir: dataDir,
+      onboarded: true,
+      provider: { provider: 'openai' },
+    };
+    const deps = baseDeps({ triage: true, io, loadConfig: () => config });
+
+    await runBackfill(deps);
+
+    expect(stdout).toEqual([triageSentinel(0, 'skipped:no-consent')]);
+  });
+
+  it('never writes a success sentinel on a mid-stream rejection, fails loud instead', async () => {
+    const { io, stdout, stderr, failed } = fakeIo();
+    const scanHistory = vi.fn(() => Promise.reject(new Error('boom: rollout read failed')));
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout.some((line) => line.includes('"status":"complete"'))).toBe(false);
+    expect(failed()).toBe(true);
+    expect(stderr.some((line) => line.includes('boom: rollout read failed'))).toBe(true);
+  });
+
+  it(
+    'never writes a success sentinel when an onHit write throws mid-stream, even though the ' +
+      'real scanHistory isolates and swallows that throw itself',
+    async () => {
+      const { io, stdout, stderr, failed } = fakeIo();
+      const hits = [
+        fixtureHit('AKIAEXAMPLE1'),
+        fixtureHit('AKIAEXAMPLE2'),
+        fixtureHit('AKIAEXAMPLE3'),
+      ];
+      // Mirrors scanHistory's own onHit isolation (history/scan.ts): a
+      // synchronous throw from onHit is caught right here and the sweep keeps
+      // going, so scanHistory still resolves normally afterward.
+      const scanHistory = vi.fn((_config, _opts, onHit?: (hit: TriageHit) => void) => {
+        for (const hit of hits) {
+          try {
+            onHit?.(hit);
+          } catch {
+            // scanHistory's real isolation: a misbehaving sink must not abort the sweep.
+          }
+        }
+        return Promise.resolve(zeroSummary());
+      });
+      let writes = 0;
+      const throwingIo: BackfillIo = {
+        ...io,
+        stdout: (chunk) => {
+          writes += 1;
+          if (writes === 2) throw new Error('EPIPE: downstream judge closed the pipe');
+          io.stdout(chunk);
+        },
+      };
+      const deps = baseDeps({ triage: true, io: throwingIo, scanHistory });
+
+      await runBackfill(deps);
+
+      expect(stdout.some((line) => line.includes('"status":"complete"'))).toBe(false);
+      expect(failed()).toBe(true);
+      expect(stderr.some((line) => line.includes('EPIPE'))).toBe(true);
+    },
+  );
+
+  it('forwards the self-contamination guard (beforeMs) into scanHistory', async () => {
+    const { io } = fakeIo();
+    const scanHistory = vi.fn(() => Promise.resolve(zeroSummary()));
+    const guard = { beforeMs: 1_700_000_000_000 };
+    const deps = baseDeps({ triage: true, io, scanHistory, guard });
+
+    await runBackfill(deps);
+
+    // The scan must actually RECEIVE the guard — a runBackfill that passed {}
+    // instead would leave the guard doing nothing in production.
+    expect(scanHistory).toHaveBeenCalledWith(expect.anything(), guard, expect.any(Function));
+  });
+
+  it('defaults the scan opts to {} when no guard is provided', async () => {
+    const { io } = fakeIo();
+    const scanHistory = vi.fn(() => Promise.resolve(zeroSummary()));
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(scanHistory).toHaveBeenCalledWith(expect.anything(), {}, expect.any(Function));
+  });
+
+  it('never leaks a raw value to stderr when an enriched hit fails validation', async () => {
+    const { io, stderr, failed } = fakeIo();
+    const raw = 'AKIAIOSFODNN7EXAMPLE';
+    // A hit that is invalid AFTER enrichment (bad severity) but still carries raw
+    // in context: TriageHit validation fails, and the error must not echo the raw.
+    const badHit = { ...fixtureHit(raw), severity: 'NOT_A_SEVERITY' } as unknown as TriageHit;
+    const scanHistory = vi.fn((_config, _opts, onHit?: (hit: TriageHit) => void) => {
+      try {
+        onHit?.(badHit);
+      } catch {
+        // scanHistory's real isolation
+      }
+      return Promise.resolve(zeroSummary());
+    });
+    const deps = baseDeps({ triage: true, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(failed()).toBe(true);
+    expect(stderr.join('')).not.toContain(raw);
+    expect(stderr.some((l) => l.includes('history scan failed'))).toBe(true);
+  });
+});
+
+describe('runBackfill — human mode (unchanged)', () => {
+  it('stays fail-open on a scanHistory rejection: friendly stdout message, no fail() call', async () => {
+    const { io, stdout, failed } = fakeIo();
+    const scanHistory = vi.fn(() => Promise.reject(new Error('boom')));
+    const deps = baseDeps({ triage: false, io, scanHistory });
+
+    await runBackfill(deps);
+
+    expect(stdout).toEqual([
+      'AKA could not scan your history right now. It will still protect everything from here on.\n',
+    ]);
+    expect(failed()).toBe(false);
+  });
+});

--- a/plugins/codex/test/calibration.test.ts
+++ b/plugins/codex/test/calibration.test.ts
@@ -1,0 +1,311 @@
+import {
+  CalibrationFrame,
+  type CalibrationPreview,
+  type FalsePositivePatternGroup,
+  type MaskedSecretFinding,
+  severityFloorPosture,
+} from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { frameCalibration, frameEmptyState } from '../src/calibration.ts';
+import { renderPostureGrid, renderRecommendedPosture } from '../src/render.ts';
+import { frameJsonBlock, readFrameJsonBlock } from '../src/setup-frame-json.ts';
+
+// A backfill + apply-suppressions preview with 161 findings of which 3 are surfaced
+// (genuine live secret keys) and 158 are suppressed FPs. Every count is carried in
+// from the preview breakdown — nothing is hardcoded in the module under test.
+const preview: CalibrationPreview = {
+  categories: [
+    { category: 'secret', genuineCount: 3, fpCount: 0, egress: false },
+    { category: 'pii', genuineCount: 0, fpCount: 100, egress: false },
+    { category: 'code_context', genuineCount: 0, fpCount: 50, egress: false },
+    { category: 'config', genuineCount: 0, fpCount: 8, egress: false },
+  ],
+  posture: {
+    secret: 'warn',
+    pii: 'warn',
+    financial: 'warn',
+    phi: 'warn',
+    code_flaw: 'warn',
+    custom: 'warn',
+    code_context: 'monitor',
+    config: 'monitor',
+  },
+};
+
+describe('frameCalibration', () => {
+  it('reports 161 detections, 3 important, 158 routine from the preview', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.counts).toEqual({ total: 161, important: 3, routine: 158 });
+  });
+
+  it('emits a valid CalibrationFrame shape', () => {
+    const { frame } = frameCalibration(preview);
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it("'important' equals the surfaced count and 'routine' equals the suppressed count", () => {
+    const surfaced = preview.categories.reduce((n, c) => n + c.genuineCount, 0);
+    const suppressed = preview.categories.reduce((n, c) => n + c.fpCount, 0);
+    const { frame } = frameCalibration(preview);
+    expect(frame.counts.important).toBe(surfaced);
+    expect(frame.counts.routine).toBe(suppressed);
+    // Emitter-enforced sum: total is exactly important + routine, no third source.
+    expect(frame.counts.total).toBe(frame.counts.important + frame.counts.routine);
+  });
+
+  it('partitions the surfaced and routine category lists', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.surfacedCategories).toEqual(['secret']);
+    expect(frame.routineCategories).toEqual(['pii', 'code_context', 'config']);
+  });
+
+  it('keeps a mixed category in both lists — its suppressed findings still count as routine', () => {
+    const mixed: CalibrationPreview = {
+      categories: [{ category: 'secret', genuineCount: 2, fpCount: 5, egress: false }],
+      posture: preview.posture,
+    };
+    const { frame } = frameCalibration(mixed);
+    expect(frame.surfacedCategories).toEqual(['secret']);
+    expect(frame.routineCategories).toEqual(['secret']);
+    expect(frame.counts).toEqual({ total: 7, important: 2, routine: 5 });
+  });
+
+  it('carries the egress-kind axis through into findingKinds', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.findingKinds).toContainEqual({ category: 'secret', count: 3, egress: false });
+    // Every finding kind carries the axis; none is dropped.
+    expect(frame.findingKinds.every((k) => typeof k.egress === 'boolean')).toBe(true);
+  });
+
+  it('templates the headline copy exactly over the preview values', () => {
+    const { copy } = frameCalibration(preview);
+    expect(copy).toBe(
+      "I went through Codex's recent work — 161 detections, 3 results worth a look. (live keys)",
+    );
+  });
+
+  it('uses the singular "detection"/"result" (no trailing s) when the total and important count are each exactly one', () => {
+    const singleImportant: CalibrationPreview = {
+      categories: [{ category: 'secret', genuineCount: 1, fpCount: 0, egress: false }],
+      posture: preview.posture,
+    };
+    const { copy } = frameCalibration(singleImportant);
+    expect(copy).toBe(
+      "I went through Codex's recent work — 1 detection, 1 result worth a look. (live keys)",
+    );
+  });
+
+  it('templates over a different preview — the numbers follow the input', () => {
+    const other: CalibrationPreview = {
+      categories: [
+        { category: 'secret', genuineCount: 2, fpCount: 0, egress: false },
+        { category: 'pii', genuineCount: 0, fpCount: 8, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { frame, copy } = frameCalibration(other);
+    expect(frame.counts).toEqual({ total: 10, important: 2, routine: 8 });
+    expect(copy).toBe(
+      "I went through Codex's recent work — 10 detections, 2 results worth a look. (live keys)",
+    );
+    expect(copy).not.toContain('161');
+  });
+
+  it('omits the kind parenthetical entirely when nothing surfaced (all suppressed)', () => {
+    const allSuppressed: CalibrationPreview = {
+      categories: [
+        { category: 'pii', genuineCount: 0, fpCount: 8, egress: false },
+        { category: 'config', genuineCount: 0, fpCount: 2, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { frame, copy } = frameCalibration(allSuppressed);
+    expect(frame.surfacedCategories).toEqual([]);
+    expect(frame.counts).toEqual({ total: 10, important: 0, routine: 10 });
+    expect(copy).toBe(
+      "I went through Codex's recent work — 10 detections, 0 results worth a look.",
+    );
+    // No dangling empty parenthetical.
+    expect(copy).not.toContain('()');
+    expect(copy).not.toContain('look. (');
+  });
+
+  it("derives the 'worth a look (…)' kind from the surfaced categories, not a fixed label", () => {
+    const piiSurfaced: CalibrationPreview = {
+      categories: [
+        { category: 'pii', genuineCount: 4, fpCount: 0, egress: false },
+        { category: 'secret', genuineCount: 0, fpCount: 20, egress: false },
+      ],
+      posture: preview.posture,
+    };
+    const { copy } = frameCalibration(piiSurfaced);
+    expect(copy).toBe(
+      "I went through Codex's recent work — 24 detections, 4 results worth a look. (personal data)",
+    );
+    expect(copy).not.toContain('live keys');
+  });
+});
+
+describe('frameCalibration — additive masked per-finding summaries', () => {
+  // Masked-only summaries — the same raw-free shape the finding table renders
+  // from and the finding-narration layer reads off of.
+  const masked: MaskedSecretFinding[] = [
+    {
+      provider: 'stripe',
+      maskedToken: 'sk_live_****',
+      where: { filePath: '~/.codex/sessions/2026/07/01/rollout-2026-07-01.jsonl' },
+      state: 'still-valid',
+    },
+    {
+      provider: 'aws',
+      maskedToken: 'AKIA****************',
+      where: { filePath: '/tmp/agent-dump.txt', span: { start: 12, end: 32 } },
+      state: 'still-valid',
+    },
+  ];
+
+  it('carries the masked summaries into the frame when secret findings exist', () => {
+    const { frame } = frameCalibration(preview, masked);
+    expect(frame.maskedFindings).toEqual(masked);
+    // Additive, not a reshape: the existing counts/category fields are untouched.
+    expect(frame.counts).toEqual({ total: 161, important: 3, routine: 158 });
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('omits maskedFindings when none are supplied — a pre-existing frame still validates', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.maskedFindings).toBeUndefined();
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('omits maskedFindings on an empty supplied set rather than emitting []', () => {
+    const { frame } = frameCalibration(preview, []);
+    expect(frame.maskedFindings).toBeUndefined();
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('carries the masked summaries through the real frame-JSON emission seam', () => {
+    // The emission seam the apply-suppressions preview uses: frameCalibration's
+    // frame is serialized by frameJsonBlock (the SAME function the adapter emits at
+    // stdout) and read back. Proves the additive field survives the actual JSON
+    // round-trip — a reachable path, not just an in-memory object — and reparses as
+    // a schema-valid CalibrationFrame with the masked summaries intact.
+    const { frame } = frameCalibration(preview, masked);
+    const emitted = readFrameJsonBlock(frameJsonBlock(frame));
+    const reparsed = CalibrationFrame.safeParse(emitted);
+    expect(reparsed.success).toBe(true);
+    expect(reparsed.success && reparsed.data.maskedFindings).toEqual(masked);
+  });
+
+  it('emits a frame with no maskedFindings key through the seam when none surfaced', () => {
+    // The pre-existing (zero-finding) frame still round-trips: the optional field is
+    // absent from the emitted JSON, and it reparses valid — the extension is additive.
+    const { frame } = frameCalibration(preview);
+    const emitted = readFrameJsonBlock(frameJsonBlock(frame)) as Record<string, unknown>;
+    expect('maskedFindings' in emitted).toBe(false);
+    expect(CalibrationFrame.safeParse(emitted).success).toBe(true);
+  });
+});
+
+describe('frameCalibration — additive masked false-positive pattern groups', () => {
+  const patterns: FalsePositivePatternGroup[] = [
+    {
+      pattern: 'test_sk_live_placeholder',
+      count: 12,
+      values: [
+        {
+          ruleId: 'secrets/stripe-live-key',
+          category: 'secret',
+          valueFingerprint: 'ab'.repeat(32),
+          keyVersion: 1,
+        },
+      ],
+    },
+  ];
+
+  it('carries the FP-pattern groups into the frame when patterns are supplied', () => {
+    const { frame } = frameCalibration(preview, [], patterns);
+    expect(frame.falsePositivePatterns).toEqual(patterns);
+    // Additive, not a reshape: the existing counts/category fields are untouched.
+    expect(frame.counts).toEqual({ total: 161, important: 3, routine: 158 });
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('omits falsePositivePatterns when none are supplied — a pre-existing frame still validates', () => {
+    const { frame } = frameCalibration(preview);
+    expect(frame.falsePositivePatterns).toBeUndefined();
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('omits falsePositivePatterns on an empty supplied set rather than emitting []', () => {
+    const { frame } = frameCalibration(preview, [], []);
+    expect(frame.falsePositivePatterns).toBeUndefined();
+    expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+  });
+
+  it('carries the FP-pattern groups through the real frame-JSON emission seam', () => {
+    const { frame } = frameCalibration(preview, [], patterns);
+    const emitted = readFrameJsonBlock(frameJsonBlock(frame));
+    const reparsed = CalibrationFrame.safeParse(emitted);
+    expect(reparsed.success).toBe(true);
+    expect(reparsed.success && reparsed.data.falsePositivePatterns).toEqual(patterns);
+  });
+
+  it('emits a frame with no falsePositivePatterns key through the seam when none surfaced', () => {
+    const { frame } = frameCalibration(preview);
+    const emitted = readFrameJsonBlock(frameJsonBlock(frame)) as Record<string, unknown>;
+    expect('falsePositivePatterns' in emitted).toBe(false);
+    expect(CalibrationFrame.safeParse(emitted).success).toBe(true);
+  });
+});
+
+describe('frameEmptyState', () => {
+  const posture = severityFloorPosture();
+
+  // The exact per-cause headlines, spelled out here (not sourced from the module)
+  // so the test pins the shipped copy rather than mirroring the implementation.
+  const SCAN_CLEAN_HEADLINE =
+    "I looked over Codex's recent work — nothing needs your attention right now. You're starting clean; here's what I'd recommend:";
+  const NO_HISTORY_HEADLINE =
+    "Nothing to learn from yet — Codex hasn't left any work on this machine. I'll start each detection category at a careful default:";
+
+  it('scan-ran-clean renders the exact clean copy over the recommended posture', () => {
+    const { copy } = frameEmptyState('scan-clean', posture);
+    expect(copy).toBe(`${SCAN_CLEAN_HEADLINE}\n${renderRecommendedPosture(posture)}`);
+  });
+
+  it('no-history renders the exact start-light copy over the default-posture table', () => {
+    const { copy } = frameEmptyState('no-history', posture);
+    expect(copy).toBe(`${NO_HISTORY_HEADLINE}\n${renderPostureGrid(posture)}`);
+  });
+
+  it('the two empty-state copies are distinct and each states why it is empty', () => {
+    const clean = frameEmptyState('scan-clean', posture).copy;
+    const noHistory = frameEmptyState('no-history', posture).copy;
+    expect(clean).not.toBe(noHistory);
+    // scan-ran-clean states a scan looked and found nothing.
+    expect(clean).toContain("I looked over Codex's recent work");
+    // no-history states there is nothing on this machine to learn from.
+    expect(noHistory).toContain("Codex hasn't left any work on this machine");
+  });
+
+  it('never renders a fabricated count — no "0 detections" theater', () => {
+    for (const cause of ['scan-clean', 'no-history'] as const) {
+      const { copy } = frameEmptyState(cause, posture);
+      expect(copy).not.toMatch(/\d+\s+detections/);
+    }
+  });
+
+  it('emits a valid zero-count CalibrationFrame', () => {
+    for (const cause of ['scan-clean', 'no-history'] as const) {
+      const { frame } = frameEmptyState(cause, posture);
+      expect(CalibrationFrame.safeParse(frame).success).toBe(true);
+      expect(frame.counts).toEqual({ total: 0, important: 0, routine: 0 });
+      expect(frame.surfacedCategories).toEqual([]);
+      expect(frame.routineCategories).toEqual([]);
+      expect(frame.findingKinds).toEqual([]);
+      expect(frame.posture).toEqual(posture);
+    }
+  });
+});

--- a/plugins/codex/test/dashboard-launch.test.ts
+++ b/plugins/codex/test/dashboard-launch.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dashboardUrl,
+  DEFAULT_PORT,
+  INSTALL_HINT,
+  parsePort,
+  startMessage,
+} from '../src/dashboard-launch.ts';
+
+describe('dashboard launcher helpers', () => {
+  it('parsePort: default, --port <n>, --port=<n>, and unrelated flags', () => {
+    expect(parsePort([])).toBe(DEFAULT_PORT);
+    expect(parsePort(['--port', '5000'])).toBe('5000');
+    expect(parsePort(['--port=6001'])).toBe('6001');
+    expect(parsePort(['--port'])).toBe(DEFAULT_PORT);
+    expect(parsePort(['--no-open'])).toBe(DEFAULT_PORT);
+  });
+
+  it('dashboardUrl: builds the /security URL for the chosen port', () => {
+    expect(dashboardUrl(DEFAULT_PORT)).toBe('http://localhost:4319/security');
+    expect(dashboardUrl('5000')).toBe('http://localhost:5000/security');
+  });
+
+  it('startMessage: names the URL and the local store', () => {
+    const msg = startMessage(dashboardUrl(DEFAULT_PORT));
+    expect(msg).toContain('http://localhost:4319/security');
+    expect(msg).toContain('~/.aka/data');
+  });
+
+  it('install hint: points at the aka CLI when the launcher cannot find it', () => {
+    expect(INSTALL_HINT).toContain('@akasecurity/cli');
+    expect(INSTALL_HINT).toContain('aka');
+  });
+});

--- a/plugins/codex/test/e2e/fail-open.e2e.test.ts
+++ b/plugins/codex/test/e2e/fail-open.e2e.test.ts
@@ -1,0 +1,416 @@
+/**
+ * CLAUDE.md's first principle: the plugin must never break a user's session.
+ * Every one of the five hook entry points wraps main() in a try/catch that
+ * falls back to writing nothing and exiting 0 — "allow" is silence, not a JSON
+ * decision. This suite drives the REAL built scripts (via runHook, from
+ * test/helpers/run-hook.ts) through the malformed-input and unavailable-store
+ * matrix the fail-open contract exists for, plus a regression pin on the wire
+ * protocol itself: no hook shape ever carries an `action` key (that's an
+ * internal CaptureResult field, never serialized).
+ *
+ * The peer of plugins/claude-code/test/e2e/fail-open.e2e.test.ts. The
+ * malformed-input and store-fault halves are harness-independent; the
+ * enforcement matrix at the bottom is not, because Codex's PostToolUse has no
+ * `updatedToolOutput` field — the emitted shape per cell is derived from this
+ * package's own hooks, not copied.
+ */
+import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { runHook, tempHomeEnv, withTempHome } from '../helpers/run-hook.ts';
+
+const SESSION_ID = 'fail-open-e2e-session';
+
+function projectDir(home: string): string {
+  const dir = join(home, 'project');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+interface HookCase {
+  readonly name: string;
+  // Builds a valid, store-touching payload for this hook under the given
+  // temp home. Must actually reach the store-open code path (not just be
+  // well-formed JSON) so the corrupt-store/read-only-home rows below
+  // exercise something real.
+  readonly validPayload: (home: string) => string;
+}
+
+const HOOKS: readonly HookCase[] = [
+  {
+    name: 'session-start',
+    validPayload: (home) =>
+      JSON.stringify({
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'SessionStart',
+        source: 'startup',
+      }),
+  },
+  {
+    name: 'user-prompt-submit',
+    validPayload: (home) =>
+      JSON.stringify({
+        prompt: 'what does this function do?',
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'UserPromptSubmit',
+      }),
+  },
+  {
+    // Bash's `command` field is in pre-tool-use-decision.ts's SCANNED_FIELDS
+    // map, so this reaches the store. Codex only reliably fires PreToolUse for
+    // Bash — the apply_patch entry there is forward-compatible, so Bash is
+    // also the only shape worth driving here.
+    name: 'pre-tool-use',
+    validPayload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hello' },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PreToolUse',
+      }),
+  },
+  {
+    // Bash's stdout/stderr are the only entries in tool-response.ts's
+    // RESPONSE_TEXT_PATHS map, so this reaches the store.
+    name: 'post-tool-use',
+    validPayload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hello' },
+        tool_response: { stdout: 'hello\n', stderr: '' },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PostToolUse',
+      }),
+  },
+  {
+    // Unlike the other four hooks, stop.ts never opens the store in-process —
+    // it only triggers a detached, unref'd reconcile.js worker. Its two
+    // store-condition rows below still verify the PARENT process fails open
+    // (which it does unconditionally), not that a corrupt/read-only store is
+    // observed synchronously.
+    name: 'stop',
+    validPayload: (home) => {
+      const cwd = projectDir(home);
+      return JSON.stringify({
+        session_id: SESSION_ID,
+        transcript_path: join(cwd, 'transcript.jsonl'),
+        cwd,
+        hook_event_name: 'Stop',
+        stop_hook_active: false,
+      });
+    },
+  },
+];
+
+// CLAUDE.md §1: `action` is a CaptureResult field that never crosses the wire,
+// and none of the shapes this package emits uses that key. This guards against
+// a refactor that starts serializing the internal decision object onto stdout.
+//
+// It is worth nothing on an EMPTY stdout, which every `expectFailsOpen` row
+// below has already asserted — `''` matches no pattern, so the check there is a
+// statement of intent rather than a test. What gives it teeth is the
+// enforcement matrix at the bottom of this file: real findings, driven through
+// the built hooks at every action level, each producing a payload this reads.
+function expectNoActionKey(stdout: string): void {
+  expect(stdout).not.toMatch(/"action"\s*:/);
+}
+
+function expectFailsOpen(status: number, stdout: string): void {
+  expect(status).toBe(0);
+  expect(stdout).toBe('');
+  expectNoActionKey(stdout);
+}
+
+describe('fail-open: malformed/hostile input never breaks a hook', () => {
+  const MALFORMED_JSON = '{ this is not valid json #$%^&*';
+  const TRUNCATED_JSON = '{"session_id": "fail-open-e2e-session", "cwd": "/tmp/unterminated';
+  // Non-text control/high-byte content, repeated — never valid JSON, never
+  // printable text. (execFileSync's `input` option is UTF-8 encoded from a JS
+  // string, so this can't carry byte sequences with no valid Unicode
+  // interpretation — but it still stresses readStdin()/JSON.parse with dense
+  // control-character and NUL-byte content, which is the failure mode this
+  // row exists to catch.)
+  const BINARY_STDIN = Array.from({ length: 256 }, (_, i) => String.fromCharCode(i))
+    .join('')
+    .repeat(4);
+  const HUGE_STDIN = 'x'.repeat(100 * 1024 * 1024); // 100 MB, not valid JSON
+
+  for (const hook of HOOKS) {
+    describe(hook.name, () => {
+      it('malformed JSON → exit 0, empty stdout', () => {
+        withTempHome((home) => {
+          const result = runHook(hook.name, MALFORMED_JSON, { env: tempHomeEnv(home) });
+          expectFailsOpen(result.status, result.stdout);
+        });
+      });
+
+      it('empty stdin → exit 0, empty stdout', () => {
+        withTempHome((home) => {
+          const result = runHook(hook.name, '', { env: tempHomeEnv(home) });
+          expectFailsOpen(result.status, result.stdout);
+        });
+      });
+
+      it('truncated JSON → exit 0, empty stdout', () => {
+        withTempHome((home) => {
+          const result = runHook(hook.name, TRUNCATED_JSON, { env: tempHomeEnv(home) });
+          expectFailsOpen(result.status, result.stdout);
+        });
+      });
+
+      it('binary stdin → exit 0, empty stdout', () => {
+        withTempHome((home) => {
+          const result = runHook(hook.name, BINARY_STDIN, { env: tempHomeEnv(home) });
+          expectFailsOpen(result.status, result.stdout);
+        });
+      });
+
+      it('100 MB stdin → exit 0, empty stdout, no OOM', () => {
+        withTempHome((home) => {
+          const result = runHook(hook.name, HUGE_STDIN, {
+            env: tempHomeEnv(home),
+            timeoutMs: 30_000,
+          });
+          expectFailsOpen(result.status, result.stdout);
+        });
+      }, 35_000);
+    });
+  }
+});
+
+describe('fail-open: an unavailable store never breaks a hook', () => {
+  // Non-header bytes → the first PRAGMA on open fails SQLITE_NOTADB, the
+  // exact read failure the fail-open path guards against.
+  function seedCorruptStore(home: string): void {
+    const storeDir = join(home, '.aka', 'data');
+    mkdirSync(storeDir, { recursive: true });
+    writeFileSync(
+      join(storeDir, 'aka.db'),
+      'AKA fail-open-e2e fixture — not a database\n'.repeat(64),
+    );
+  }
+
+  // ~/.aka exists but is unwritable, so any mkdir/write under it (a fresh
+  // data dir, settings.json, a throttle marker) hits EACCES.
+  function seedReadOnlyAkaHome(home: string): void {
+    const akaDir = join(home, '.aka');
+    mkdirSync(akaDir, { recursive: true });
+    chmodSync(akaDir, 0o555);
+  }
+
+  // chmod back before withTempHome's cleanup rmSync — a read-only dir can
+  // block recursive removal of anything the hook wrote inside it before
+  // hitting the fault.
+  function restoreAkaHome(home: string): void {
+    try {
+      chmodSync(join(home, '.aka'), 0o755);
+    } catch {
+      // Nothing to restore.
+    }
+  }
+
+  for (const hook of HOOKS) {
+    describe(hook.name, () => {
+      it('valid input, corrupt store → exit 0', () => {
+        withTempHome((home) => {
+          seedCorruptStore(home);
+          const payload = hook.validPayload(home);
+          const result = runHook(hook.name, payload, { env: tempHomeEnv(home) });
+          expect(result.status).toBe(0);
+          expectNoActionKey(result.stdout);
+        });
+      });
+
+      it('valid input, read-only ~/.aka → exit 0', () => {
+        withTempHome((home) => {
+          seedReadOnlyAkaHome(home);
+          try {
+            const payload = hook.validPayload(home);
+            const result = runHook(hook.name, payload, { env: tempHomeEnv(home) });
+            expect(result.status).toBe(0);
+            expectNoActionKey(result.stdout);
+          } finally {
+            restoreAkaHome(home);
+          }
+        });
+      });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The enforcement matrix: expectNoActionKey against real emitted payloads
+// ---------------------------------------------------------------------------
+
+// Every row above drives a hook that has NOTHING to say — malformed input, a
+// store it cannot open — so every one of them asserts an empty stdout, and
+// `expectNoActionKey` on `''` cannot fail. That left the wire-protocol pin
+// covering none of the paths that actually build a payload: the shape it guards
+// against is the internal decision object, and the internal decision object only
+// exists once something was found.
+//
+// So this drives a real finding through each enforcing hook at each action level
+// and reads what the built script really printed. The expected shape per cell is
+// asserted first and is the positive control — without it, a hook that silently
+// stopped emitting would turn every absence assertion below back into the
+// vacuous form this section exists to replace.
+
+// The value comes from a bundled rule's own `examples`, so no secret-shaped
+// literal lives in this file. The rule is one whose example matches no OTHER
+// bundled rule — two rules on overlapping spans degrade one-way and change the
+// emitted shape, which would make the matrix a statement about rule overlap
+// rather than about action levels.
+const ENFORCED_RULE_ID = 'secrets/twilio-key';
+
+function secretFixture(): { pack: ReturnType<typeof bundledDetections>[number]; example: string } {
+  const pack = bundledDetections().find((p) => p.rules.some((r) => r.id === ENFORCED_RULE_ID));
+  const example = pack?.rules.find((r) => r.id === ENFORCED_RULE_ID)?.examples?.[0];
+  if (pack === undefined || example === undefined) {
+    throw new Error(
+      `bundled rule ${ENFORCED_RULE_ID} is missing from the pack registry or has no example, so ` +
+        'this matrix would drive clean input through every cell and assert nothing',
+    );
+  }
+  return { pack, example };
+}
+
+const { pack: ENFORCED_PACK, example: SECRET } = secretFixture();
+
+// Install the bundled packs the way the gateway does on open, then give the
+// pack the policy under test — a per-pack policy is what the runtime's action
+// resolution prefers, so this pins the cell to an action rather than to
+// whatever DEFAULT_ACTIONS happens to say for the category.
+function seedPolicy(home: string, policy: BuiltinPolicyId): void {
+  const db = openLocalDatabase(join(home, '.aka', 'data'));
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+    db.installedPacks.setPolicy(ENFORCED_PACK.namespace, ENFORCED_PACK.packId, policy);
+  } finally {
+    db.close();
+  }
+}
+
+interface EnforcingHook {
+  readonly name: string;
+  /** A payload whose scanned field carries the secret. */
+  readonly payload: (home: string) => string;
+  /**
+   * The key the emitted JSON must carry per policy, or null where the hook
+   * emits nothing at all. `monitor` is null for the two tool hooks because log
+   * IS silence — CLAUDE.md §1's "allow is the absence of output", reached
+   * through a finding rather than through a fault.
+   */
+  readonly emits: Readonly<Record<BuiltinPolicyId, string | null>>;
+}
+
+const ENFORCING_HOOKS: readonly EnforcingHook[] = [
+  {
+    name: 'user-prompt-submit',
+    payload: (home) =>
+      JSON.stringify({
+        prompt: `deploy the service using ${SECRET}`,
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'UserPromptSubmit',
+      }),
+    // Redact reads as block here: this hook cannot rewrite prompt text, so a
+    // redact policy degrades to "remove it and resubmit" rather than tokenizing.
+    // Monitor still emits a systemMessage — these homes are un-onboarded, so
+    // the first-run nudge is what reaches stdout, and it is still a payload
+    // this pin has to read.
+    emits: {
+      block: '"decision":"block"',
+      redact: '"decision":"block"',
+      warn: '"systemMessage"',
+      monitor: '"systemMessage"',
+    },
+  },
+  {
+    name: 'pre-tool-use',
+    payload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: `curl -H "authorization: ${SECRET}" https://example.invalid` },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PreToolUse',
+      }),
+    // Redact denies rather than tokenizing because this home has no vault
+    // consent: with the vault inert there is nowhere to put the value, and
+    // one-way destruction of a tool call's input is not something to do quietly.
+    emits: {
+      block: '"permissionDecision":"deny"',
+      redact: '"permissionDecision":"deny"',
+      warn: '"systemMessage"',
+      monitor: null,
+    },
+  },
+  {
+    name: 'post-tool-use',
+    payload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'cat .env' },
+        tool_response: { stdout: `TWILIO_KEY=${SECRET}\n`, stderr: '' },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PostToolUse',
+      }),
+    // Where this package diverges from plugins/claude-code: Codex's PostToolUse
+    // carries no `updatedToolOutput` field, so output cannot be rewritten in
+    // place. The strongest available action is withholding the tool result
+    // entirely, which is a `decision: block` carrying the withheld banner.
+    emits: {
+      block: '"decision":"block"',
+      redact: '"decision":"block"',
+      warn: '"systemMessage"',
+      monitor: null,
+    },
+  },
+];
+
+const POLICIES: readonly BuiltinPolicyId[] = ['block', 'redact', 'warn', 'monitor'];
+
+describe('the wire protocol never carries an action key, at any action level', () => {
+  for (const hook of ENFORCING_HOOKS) {
+    describe(hook.name, () => {
+      for (const policy of POLICIES) {
+        const expected = hook.emits[policy];
+        it(`${policy} policy → ${expected === null ? 'emits nothing' : 'emits ' + expected}`, () => {
+          withTempHome((home) => {
+            seedPolicy(home, policy);
+            const result = runHook(hook.name, hook.payload(home), { env: tempHomeEnv(home) });
+
+            // Fail-open first: whatever it decided, it decided it without
+            // breaking the session.
+            expect(result.status).toBe(0);
+
+            // The positive control. Everything after it is an absence, and an
+            // absence over an unexpected payload — or none — proves nothing.
+            if (expected === null) {
+              expect(result.stdout).toBe('');
+            } else {
+              expect(result.stdout).toContain(expected);
+            }
+
+            expectNoActionKey(result.stdout);
+            // The raw value never rides along on any of these shapes. Run by
+            // run rather than whole: a branch echoing a truncated value is
+            // still echoing a live credential's prefix.
+            expectNoEchoOf(result.stdout, SECRET);
+          });
+        });
+      }
+    });
+  }
+});

--- a/plugins/codex/test/e2e/scan-worker-bundle.e2e.test.ts
+++ b/plugins/codex/test/e2e/scan-worker-bundle.e2e.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The isolated scan's worker has to be reachable from the PUBLISHED plugin, and
+ * that is the one thing source-level tests cannot show.
+ *
+ * The plugin ships `scripts/` and nothing else — no `src/`, no `node_modules`.
+ * A worker URL resolved against a source path therefore points at a file that
+ * was never packaged, and the trap is that it works perfectly in the repo and
+ * under vitest: every local test passes and only an installed plugin fails, by
+ * silently losing the bound it was installed for. So this suite drives the real
+ * built artifacts — the worker from a directory with nothing else in it, and a
+ * real hook whose own inlined resolver has to find it.
+ */
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections, ruleProbeKey } from '@akasecurity/plugin-sdk';
+import { Rule } from '@akasecurity/schema';
+import { afterAll, describe, expect, it } from 'vitest';
+
+// test/e2e -> plugins/codex
+const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SCRIPTS_DIR = join(PLUGIN_ROOT, 'scripts');
+
+// The filename the SDK's resolver probes for (packages/plugin-sdk/src/
+// isolated-scan.ts). tsup's entry key is what produces it, so the two have to
+// be changed together or the worker becomes unreachable at runtime.
+const WORKER_SCRIPT = 'scan-worker.js';
+
+// A string only `guarded-scan.ts` emits, and it is reachable only through
+// `createPluginRuntime`. Any emitted script carrying it therefore builds a
+// runtime, scans, and needs the worker beside it — which is what makes this a
+// derived list rather than one somebody has to remember to extend when a new
+// runtime-bearing hook is added.
+const RUNTIME_MARKER = 'isolated scanning is off for ';
+
+// The hooks that must be in the derived set. Not a substitute for deriving it:
+// this is the check that the marker itself has not been renamed away, which
+// would otherwise empty the set and make every assertion below vacuous.
+const KNOWN_RUNTIME_SCRIPTS = [
+  'pre-tool-use.js',
+  'post-tool-use.js',
+  'user-prompt-submit.js',
+  'filescan.js',
+  'backfill.js',
+];
+
+// The pulled pack the hook case installs. Its pattern is not among the bundled
+// rules, so the runtime treats it as unverified — which is the ONLY condition
+// under which a worker is started at all.
+const PULLED_PACK_RULE = Rule.parse({
+  specVersion: 1,
+  id: 'e2e-worker/marker',
+  name: 'Isolated-scan e2e marker',
+  category: 'secret',
+  severity: 'high',
+  matcher: { type: 'regex', pattern: 'ZQXJ[0-9]{8}', flags: 'g' },
+  examples: ['ZQXJ12345678'],
+});
+const PULLED_MATCH = 'ZQXJ12345678';
+
+const temps: string[] = [];
+
+function tempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+function runtimeBearingScripts(): string[] {
+  return readdirSync(SCRIPTS_DIR).filter(
+    (name) =>
+      name.endsWith('.js') &&
+      readFileSync(join(SCRIPTS_DIR, name), 'utf8').includes(RUNTIME_MARKER),
+  );
+}
+
+afterAll(() => {
+  for (const dir of temps) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('the built scan worker', () => {
+  it('is emitted beside every hook that builds a runtime', () => {
+    expect(existsSync(join(SCRIPTS_DIR, WORKER_SCRIPT))).toBe(true);
+
+    const derived = runtimeBearingScripts();
+    // If the marker string is ever reworded, this is what fails — rather than
+    // the set quietly becoming empty and every check below passing on nothing.
+    expect(derived).toEqual(expect.arrayContaining(KNOWN_RUNTIME_SCRIPTS));
+
+    for (const script of derived) {
+      // The inlined resolver looks for exactly this name next to itself. If the
+      // tsup entry is renamed or dropped, every isolated scan degrades to the
+      // built-in packs only — quietly, and only once installed.
+      expect(readFileSync(join(SCRIPTS_DIR, script), 'utf8')).toContain(WORKER_SCRIPT);
+    }
+  });
+
+  it('runs and scans with no node_modules anywhere above it', async () => {
+    // A temp dir has no node_modules anywhere above it, which is the property
+    // that makes this a test of self-containment rather than of the repo.
+    const dir = tempDir('aka-codex-scan-worker-');
+    cpSync(SCRIPTS_DIR, join(dir, 'scripts'), { recursive: true });
+
+    const worker = new Worker(join(dir, 'scripts', WORKER_SCRIPT), {
+      workerData: {
+        verified: [],
+        unverified: [
+          {
+            specVersion: 1,
+            id: 'pulled/aws-key',
+            name: 'AWS key',
+            category: 'secret',
+            severity: 'high',
+            matcher: { type: 'regex', pattern: 'AKIA[A-Z0-9]{16}', flags: 'g' },
+          },
+        ],
+      },
+    });
+
+    try {
+      const findings = await new Promise<{ ruleId: string; rawMatch: string }[]>(
+        (resolve, reject) => {
+          worker.on('error', reject);
+          worker.on('exit', () => {
+            reject(new Error('the worker exited before answering'));
+          });
+          worker.on('message', (message: { kind: string; findings?: never[] }) => {
+            // The worker announces itself before it will take work; the parent
+            // pool starts its deadline off exactly this message.
+            if (message.kind === 'ready') {
+              worker.postMessage({
+                kind: 'scan',
+                id: 1,
+                text: 'deploy with AKIA0123456789ABCDEF now',
+                attribute: false,
+              });
+            }
+            if (message.kind === 'result') resolve(message.findings ?? []);
+            if (message.kind === 'failed') reject(new Error('the worker reported a scan failure'));
+          });
+        },
+      );
+
+      expect(findings.map((f) => f.ruleId)).toEqual(['pulled/aws-key']);
+      expect(findings[0]?.rawMatch).toBe('AKIA0123456789ABCDEF');
+    } finally {
+      await worker.terminate();
+    }
+  });
+
+  it('is found by a real hook’s own resolver, from the built scripts', async () => {
+    // The assertions above prove the file is emitted and that it runs. Neither
+    // drives `resolveWorkerUrl()` as the SHIPPED bundle inlines it — and that
+    // is the half that fails only once installed. So this runs a built hook
+    // end to end against a throwaway home with a pulled regex rule installed,
+    // which is the one condition that starts a worker at all.
+    const home = tempDir('aka-codex-worker-home-');
+    const dataDir = join(home, '.aka', 'data');
+    mkdirSync(dataDir, { recursive: true });
+
+    const db = openLocalDatabase(dataDir);
+    try {
+      db.installedPacks.recordInventory([
+        ...bundledDetections(),
+        {
+          namespace: 'e2e-worker',
+          packId: 'marker',
+          version: '1.0.0',
+          name: 'Isolated-scan e2e pack',
+          rules: [PULLED_PACK_RULE],
+        },
+      ]);
+    } finally {
+      db.close();
+    }
+
+    // Codex's UserPromptSubmit carries the same stdin shape as Claude Code's.
+    const result = spawnSync(process.execPath, [join(SCRIPTS_DIR, 'user-prompt-submit.js')], {
+      input: JSON.stringify({
+        prompt: `here is a token ${PULLED_MATCH} for you`,
+        session_id: 'e2e-worker-session',
+        cwd: home,
+        hook_event_name: 'UserPromptSubmit',
+      }),
+      encoding: 'utf8',
+      // The scripts resolve ~/.aka through os.homedir(), which reads HOME on
+      // POSIX and USERPROFILE on Windows. Keep both pointed at the throwaway.
+      env: { ...processEnv(), HOME: home, USERPROFILE: home },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+
+    // Fail-open first: whatever else happened, the hook must not have broken.
+    expect(result.status).toBe(0);
+
+    const after = openLocalDatabase(dataDir);
+    try {
+      // Positive control, part one: the rule was measured. Only a rule the
+      // runtime treats as UNVERIFIED reaches the timing gate, and the gate runs
+      // in a worker of its own — so this row cannot exist unless the resolver
+      // found the script from inside the built hook.
+      const key = ruleProbeKey(PULLED_PACK_RULE);
+      expect(key).toBeDefined();
+      expect(after.ruleProbeCache.getVerdict(key ?? '')?.verdict).toBe('safe');
+
+      // Part two: being unverified, it runs ONLY in the scan worker. A hook
+      // that lost its worker drops these rules and keeps the built-in packs, so
+      // a finding from this rule is proof the isolated scan answered.
+      const recent = await after.findings.recentFindings({ limit: 50 });
+      expect(recent.map((f) => f.ruleId)).toContain('e2e-worker/marker');
+    } finally {
+      after.close();
+    }
+    // And the resolver never fell back. This is the line the shipped plugin
+    // would print, once, on every machine, if the worker URL pointed at a
+    // source path that was never packaged.
+    expect(result.stderr).not.toContain('the scan worker script was not found');
+  });
+});
+
+// The host env, read once so the child spawn inherits PATH/node while pointing
+// the home dir at a throwaway. Overriding the home is the only way to redirect
+// ~/.aka — the scripts must not (and do not) hard-resolve it.
+function processEnv(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line n/no-process-env -- an e2e spawn of the real scripts needs the host PATH
+  return process.env;
+}

--- a/plugins/codex/test/exception-guidance.test.ts
+++ b/plugins/codex/test/exception-guidance.test.ts
@@ -1,0 +1,182 @@
+// Tests the pure exception-guidance builders directly — NEVER via the hook
+// entry files (src/hooks/*.ts run main() on import and hang vitest collection).
+// Identical to plugins/claude-code/src/exception-guidance.test.ts — the
+// messaging is host-agnostic.
+import type { BlockedDetectionRef } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import {
+  blockMessage,
+  exceptionPointer,
+  withheldBanner,
+  withheldToolText,
+} from '../src/exception-guidance.ts';
+
+function ref(reference: string, maskedValue = 'F******E'): BlockedDetectionRef {
+  return { reference, ruleId: 'secrets/aws-access-key', maskedValue };
+}
+
+describe('blockMessage', () => {
+  it('block with a reference: copy-paste-complete approve command, masked preview, ≤ 5 lines', () => {
+    const out = blockMessage({
+      subject: 'prompt',
+      ruleIds: 'secrets/aws-access-key',
+      blockedRef: ref('3f2a91'),
+    });
+    const lines = out.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines[0]).toContain('AKA blocked this prompt — flagged secrets/aws-access-key');
+    expect(lines[0]).toContain('Remove the flagged content and resubmit.');
+    expect(lines[0]).toContain('(F******E)');
+    expect(out).toContain('If this is intentional and you accept the risk, grant an exception:');
+    expect(out).toContain('aka exception approve 3f2a91');
+    expect(out).toContain('(asks for scope + reason, then resubmit)');
+    expect(out).toContain('aka exception approve <value>');
+    expect(out).toContain('More: aka exception --help');
+  });
+
+  it('weaves an optional note between the flag preview and the removal advice', () => {
+    const out = blockMessage({
+      subject: 'Bash call',
+      ruleIds: 'core-pii/ip-address',
+      blockedRef: ref('3f2a91', '4******6'),
+      note: 'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead.',
+    });
+    const lines = out.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines[0]).toBe(
+      'AKA blocked this Bash call — flagged core-pii/ip-address (4******6). ' +
+        'Masking inside an executable command would silently change what runs, so a redact policy blocks it instead. ' +
+        'Remove the flagged content and resubmit.',
+    );
+  });
+
+  it('block without a reference: the approve command degrades to its bare form', () => {
+    const out = blockMessage({
+      subject: 'Bash call',
+      ruleIds: 'secrets/aws-access-key, core-pii/email',
+    });
+    expect(out).toContain(
+      'AKA blocked this Bash call — flagged secrets/aws-access-key, core-pii/email.',
+    );
+    expect(out).toContain('  aka exception approve       ');
+    expect(out).not.toMatch(/aka exception approve [0-9a-f]/);
+    expect(out).not.toContain('<value>');
+    expect(out.split('\n')[0]).not.toContain('(');
+  });
+});
+
+describe('exceptionPointer', () => {
+  it('points at the approve command when a reference exists', () => {
+    const out = exceptionPointer([ref('9c04d7'), ref('3f2a91')]);
+    expect(out).toBe(
+      ' To allow this exact value intentionally, run: aka exception approve 9c04d7.',
+    );
+  });
+
+  it('is empty when nothing was ledgered', () => {
+    expect(exceptionPointer(undefined)).toBe('');
+    expect(exceptionPointer([])).toBe('');
+  });
+});
+
+describe('withheldBanner', () => {
+  it('renders a shade-glyph banner with rule, masked preview, and approve command', () => {
+    const out = withheldBanner({
+      toolName: 'Bash',
+      action: 'withheld',
+      withheldRuleIds: 'secrets/aws-access-key',
+      blockedRef: ref('3f2a91'),
+    });
+    const lines = out.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(5);
+    expect(lines[0]).toContain('█▓▒░ AKA ░▒▓█');
+    expect(lines[0]).toContain('Bash output withheld');
+    for (const line of lines.slice(1)) expect(line.startsWith('█')).toBe(true);
+    expect(out).toContain('Withheld: secrets/aws-access-key');
+    expect(out).toContain('(F******E) intentionally: aka exception approve 3f2a91');
+    expect(out).toContain('never reached the model');
+  });
+
+  it('redacted variant names the action and keeps the approve pointer', () => {
+    const out = withheldBanner({
+      toolName: 'Bash',
+      action: 'redacted',
+      redactedRuleIds: 'core-pii/email',
+      blockedRef: ref('9c04d7', 'j***@e******.com'),
+    });
+    expect(out.split('\n')[0]).toContain('Bash output redacted');
+    expect(out).toContain('Redacted: core-pii/email');
+    expect(out).toContain('(j***@e******.com) intentionally: aka exception approve 9c04d7');
+  });
+
+  it('degrades to the bare approve command without a ledger reference', () => {
+    const out = withheldBanner({
+      toolName: 'Bash',
+      action: 'withheld',
+      withheldRuleIds: 'secrets/aws-access-key',
+    });
+    expect(out).toContain('aka exception approve\n');
+    expect(out).not.toContain('(F');
+  });
+
+  it('splits mixed outcomes into separate Withheld/Redacted lines', () => {
+    const out = withheldBanner({
+      toolName: 'Bash',
+      action: 'withheld',
+      withheldRuleIds: 'secrets/aws-access-key',
+      redactedRuleIds: 'core-pii/email',
+      blockedRef: ref('3f2a91'),
+    });
+    const lines = out.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(6);
+    expect(lines.some((line) => line.includes('Withheld: secrets/aws-access-key'))).toBe(true);
+    expect(lines.some((line) => line.includes('Redacted: core-pii/email'))).toBe(true);
+  });
+
+  it('surfaces warn-action rules from other fields on their own line', () => {
+    const out = withheldBanner({
+      toolName: 'Bash',
+      action: 'withheld',
+      withheldRuleIds: 'secrets/aws-access-key',
+      blockedRef: ref('3f2a91'),
+      warnedRuleIds: 'core-pii/email',
+    });
+    const lines = out.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(6);
+    expect(out).toContain('Also flagged (warn): core-pii/email');
+    const warnIndex = lines.findIndex((line) => line.includes('Also flagged'));
+    const claimIndex = lines.findIndex((line) => line.includes('never reached the model'));
+    expect(warnIndex).toBeGreaterThan(-1);
+    expect(claimIndex).toBeGreaterThan(warnIndex);
+  });
+});
+
+describe('withheldToolText', () => {
+  it('tells the model what happened and to inform the user, without the approve command', () => {
+    const out = withheldToolText('Bash', 'secrets/aws-access-key');
+    expect(out).toContain('[AKA SECURITY]');
+    expect(out).toContain('Bash output withheld');
+    expect(out).toContain('secrets/aws-access-key');
+    expect(out).toContain('not added to your context');
+    expect(out).toContain('Do not attempt to obtain the withheld content through other channels');
+    expect(out).toContain('Tell the user');
+    expect(out).toContain('re-run this same tool call');
+    expect(out).toContain('re-evaluates every capture');
+    expect(out).toContain('if it is safe to repeat');
+    expect(out).not.toContain('aka exception approve');
+  });
+
+  it('marks itself as a placeholder that must never be written back', () => {
+    const out = withheldToolText('Bash', 'secrets/aws-access-key', 'stdout');
+    expect(out).toContain('placeholder');
+    expect(out).toContain('never write this notice back');
+    expect(out).toContain('unchanged');
+  });
+
+  it('names the replaced field so a partial withhold does not read as total', () => {
+    const out = withheldToolText('Bash', 'secrets/aws-access-key', 'stderr');
+    expect(out).toContain('Bash stderr withheld');
+    expect(out).not.toContain('Bash output withheld');
+  });
+});

--- a/plugins/codex/test/firstrun-core.test.ts
+++ b/plugins/codex/test/firstrun-core.test.ts
@@ -1,0 +1,367 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { handleCapture, resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
+import { SetupHandoffOffer } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  parseLiveKeyCount,
+  parseSurfacedCount,
+  runFirstRun,
+  runFirstRunFailOpen,
+} from '../src/firstrun-core.ts';
+import { readPostureBlock } from '../src/posture.ts';
+import { readFrameJsonBlock } from '../src/setup-frame-json.ts';
+import { parseSurface } from '../src/setup-show.ts';
+import { readRegisteredSkills } from '../src/skills-registry.ts';
+
+// Composed at runtime so the repo's own secret scanning doesn't flag this file.
+const AWS_EXAMPLE_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+// Composed for the same reason — a literal address would be redacted on write.
+const PII_EMAIL = ['jane.doe', 'example.com'].join('@');
+
+// The skill names the shipped plugin registers (each skills/<dir>/SKILL.md's
+// frontmatter `name:`), read from disk so the Try line is checked against the
+// skills that actually resolve when invoked.
+const REGISTERED = new Set(readRegisteredSkills());
+
+function config(dataDir: string): PluginConfig {
+  return {
+    settings: {
+      specVersion: 3,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'openai' },
+  };
+}
+
+describe('parseSurfacedCount', () => {
+  it('reads a non-negative integer from --surfaced', () => {
+    expect(parseSurfacedCount(['--surfaced', '3'])).toBe(3);
+    expect(parseSurfacedCount(['--surfaced', '0'])).toBe(0);
+  });
+
+  it('returns undefined when the flag is absent or malformed — never a fabricated count', () => {
+    expect(parseSurfacedCount([])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', 'lots'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', '-1'])).toBeUndefined();
+    expect(parseSurfacedCount(['--surfaced', '2.5'])).toBeUndefined();
+  });
+});
+
+describe('parseLiveKeyCount', () => {
+  it('reads a non-negative integer from --live-keys', () => {
+    expect(parseLiveKeyCount(['--live-keys', '3'])).toBe(3);
+    expect(parseLiveKeyCount(['--live-keys', '0'])).toBe(0);
+  });
+
+  it('defaults to 0 when the flag is absent or malformed — the remediation gate stays shut', () => {
+    expect(parseLiveKeyCount([])).toBe(0);
+    expect(parseLiveKeyCount(['--surfaced', '3'])).toBe(0);
+    expect(parseLiveKeyCount(['--live-keys'])).toBe(0);
+    expect(parseLiveKeyCount(['--live-keys', 'lots'])).toBe(0);
+    expect(parseLiveKeyCount(['--live-keys', '-1'])).toBe(0);
+    expect(parseLiveKeyCount(['--live-keys', '2.5'])).toBe(0);
+  });
+});
+
+describe('runFirstRun — emits the handoff-offer payload alongside the card', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-firstrun-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function seedAndRun(argv: readonly string[]): Promise<string> {
+    const cfg = config(dir);
+    // Seed through the real write path so the card's stats trace to real data.
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'codex', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv,
+        gateway,
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    return out.join('');
+  }
+
+  it('composes the chain-entry offer alongside the dashboard handoff when live keys surfaced', async () => {
+    // 3 surfaced important findings, 2 of them live-key secrets.
+    const blob = await seedAndRun(['--surfaced', '3', '--live-keys', '2']);
+
+    // Additive: the human-readable install card is still present (not replaced).
+    // A surfaced count means a scan ran — the scan-path heading + divider.
+    expect(blob).toContain("You're all set — tuned to this machine.");
+    expect(blob).toContain('First scan complete');
+
+    const payload = readFrameJsonBlock(blob);
+    const parsed = SetupHandoffOffer.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    // 'M worth a look' is the surfaced/important count threaded in from the
+    // calibration preview — NOT the whole-store finding total (1 finding was seeded).
+    expect(parsed.data.worthALook).toBe(3);
+    // The live-key count is the narrower secret subset that gated the offer.
+    expect(parsed.data.liveKeys).toBe(2);
+    // The chain-entry offer composes with — never replaces — the dashboard
+    // handoff: Open dashboard + Not now stay reachable exactly as on the
+    // no-findings branch (the dashboard handoff does not regress).
+    expect(parsed.data.options).toEqual([
+      { id: 'enter-remediation', label: 'Review leaked keys' },
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('offers no remediation when important findings surfaced but zero live keys (negative branch)', async () => {
+    // The divergent case: 3 surfaced important findings, none of them live-key
+    // secrets (--live-keys 0). The gate is the live-key count, NOT the
+    // all-category surfaced count, so no remediation is offered even though
+    // worthALook > 0.
+    const blob = await seedAndRun(['--surfaced', '3', '--live-keys', '0']);
+
+    const payload = readFrameJsonBlock(blob);
+    const parsed = SetupHandoffOffer.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    expect(parsed.data.worthALook).toBe(3);
+    // No live keys → no chain entry: only the dashboard handoff, unchanged from
+    // the no-findings shape ('never otherwise').
+    expect(parsed.data.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('offers the plain dashboard handoff (no chain entry) when zero live keys surfaced', async () => {
+    const blob = await seedAndRun(['--surfaced', '0']);
+
+    const payload = readFrameJsonBlock(blob);
+    const parsed = SetupHandoffOffer.safeParse(payload);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    expect(parsed.data.worthALook).toBe(0);
+    // No remediation offered: only the dashboard handoff, unchanged from
+    // the no-findings shape.
+    expect(parsed.data.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('omits the handoff payload (never fabricates one) when no surfaced count is supplied', async () => {
+    const blob = await seedAndRun([]);
+
+    // The card still renders — only the machine-readable payload is withheld.
+    // No --surfaced means no scan ran — the floor-path heading + divider.
+    expect(blob).toContain("I've started you on safe defaults");
+    expect(blob).toContain('Safe defaults in place');
+    expect(readFrameJsonBlock(blob)).toBeUndefined();
+  });
+
+  it('degrades honestly over an empty store (no scanned findings) — omits the handoff payload, no fabricated count', async () => {
+    // No capture seeded: the store holds no scanned findings (the no-scan /
+    // found-nothing state). Running with no --surfaced must degrade honestly.
+    const cfg = config(dir);
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv: [],
+        gateway,
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+
+    // The install card still renders as a tidy success state, on the floor-path
+    // heading — no --surfaced was passed, so no scan ran…
+    expect(blob).toContain("I've started you on safe defaults");
+    // …with an honest empty-state stats line, never a fabricated scan tally…
+    expect(blob).toContain("you're starting clean");
+    expect(blob).not.toContain('worth a look');
+    // …and the machine-readable handoff payload is withheld, never fabricated.
+    expect(readFrameJsonBlock(blob)).toBeUndefined();
+  });
+
+  it('omits only the Posture section (rest of the card renders) when opening the posture store throws', async () => {
+    const cfg = config(dir);
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'codex', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv: ['--surfaced', '2'],
+        gateway,
+        // The posture opener throws (unopenable store). It degrades identically
+        // to a read fault: only the Posture section is hidden.
+        readPosture: () =>
+          readPostureBlock(() => {
+            throw new Error('cannot open database');
+          }),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+
+    // The rest of the install card still renders over the live gateway, on the
+    // scan-path heading — --surfaced was passed, so a scan ran…
+    expect(blob).toContain("You're all set — tuned to this machine.");
+    expect(blob).toContain('First scan complete');
+    expect(blob).toContain('detections');
+    // …and the handoff payload is still emitted.
+    expect(SetupHandoffOffer.safeParse(readFrameJsonBlock(blob)).success).toBe(true);
+    // …but the Posture section is omitted, not collapsed into the fail-open note.
+    expect(blob).not.toContain('Posture');
+    expect(blob).not.toContain("I couldn't check my records just now");
+  });
+
+  it('carries no raw detected value into the emitted frame block', async () => {
+    const blob = await seedAndRun(['--surfaced', '2']);
+    expect(blob).toContain('<<<AKA_FRAME_JSON');
+    expect(JSON.stringify(readFrameJsonBlock(blob))).not.toContain(AWS_EXAMPLE_KEY);
+    // The card masks matches, so the raw key never appears anywhere on stdout.
+    expect(blob).not.toContain(AWS_EXAMPLE_KEY);
+  });
+
+  it('install summary is a SHOW region; the handoff payload stays a frame', async () => {
+    const blob = await seedAndRun(['--surfaced', '2', '--live-keys', '1']);
+    const surface = parseSurface(blob);
+    // The install card (its "Health N/100" line) is relayed verbatim as a SHOW region.
+    expect(surface.shows.some((s) => s.includes('Health'))).toBe(true);
+    // The handoff payload stays a machine-only FRAME, never shown.
+    expect(surface.frames).toHaveLength(1);
+    // The card text never leaks into the untagged status remainder.
+    expect(surface.status).not.toContain('Health');
+  });
+
+  it('card stats trace to the seeded store, never a fixed literal', async () => {
+    const cfg = config(dir);
+    // Two distinct sensitive findings through the real write path: a critical
+    // secret and a medium PII match — two categories, two findings.
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'codex', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    await handleCapture({ kind: 'prompt', sourceTool: 'codex', text: `contact ${PII_EMAIL}` }, cfg);
+
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    let summaryFindings: number;
+    try {
+      // Read back what the store actually holds so the assertion is a genuine
+      // trace (card number === store number), not a hardcoded expectation.
+      summaryFindings = (await gateway.healthSummary()).findings;
+      await runFirstRun({
+        argv: [],
+        gateway,
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+
+    // The 'N detections' stat is the real whole-store total, not the render-unit
+    // fixture's literal.
+    expect(summaryFindings).toBe(2);
+    expect(blob).toContain(`${String(summaryFindings)} detections`);
+    expect(blob).not.toContain('142 detections');
+    // 'recommendations' mirrors the aka-recommend skill over the real findings:
+    // one per category (secret + pii) → 2.
+    expect(blob).toContain('2 recommendations');
+    // 'Health' is the derived score over the real summary, rendered out of 100 —
+    // never a fixed 82/100 sample.
+    expect(blob).toMatch(/Health \d+\/100/);
+    expect(blob).not.toContain('82/100');
+    // Every skill the rendered Try line names is one the shipped plugin
+    // registers — a subset-of-registry check, not a hardcoded skill snapshot.
+    const tryLine = blob.split('\n').find((l) => l.includes('Try:'));
+    expect(tryLine).toBeDefined();
+    const named = tryLine?.match(/aka-[a-z]+/g) ?? [];
+    // The line actually names skills (a vacuous empty match must not pass).
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of named) {
+      expect(REGISTERED.has(skill)).toBe(true);
+    }
+  });
+});
+
+describe('runFirstRunFailOpen — degrades to the store-unavailable note on a store-read failure', () => {
+  it('writes the honest note instead of throwing when the gateway read fails', async () => {
+    const out: string[] = [];
+    // A gateway whose store reads fail (missing / corrupt / locked db). runFirstRun
+    // throws on a read failure; the fail-open wrapper must catch it and substitute
+    // the honest note so no error escapes to break the Codex session.
+    const failingGateway = {
+      healthSummary: () =>
+        Promise.reject(new Error('SQLITE_CORRUPT: database disk image is malformed')),
+      recentFindings: () => Promise.reject(new Error('SQLITE_CORRUPT')),
+      close: () => Promise.resolve(),
+    } as unknown as DataGateway;
+
+    let threw: unknown;
+    try {
+      await runFirstRunFailOpen({
+        argv: ['--surfaced', '2'],
+        gateway: failingGateway,
+        readPosture: () => Promise.resolve(''),
+        stdout: (s) => out.push(s),
+      });
+    } catch (e) {
+      threw = e;
+    }
+    const blob = out.join('');
+
+    // Fail-open: no throw escaped, and the honest store-unavailable note stands in.
+    expect(threw).toBeUndefined();
+    expect(blob).toContain("I couldn't check my records just now");
+    // No fabricated card: the install card's stats never rendered over a dead store.
+    expect(blob).not.toContain('installed');
+
+    // The note is relayed as a SHOW region, not left in the untagged status remainder.
+    const surface = parseSurface(blob);
+    expect(surface.shows.some((s) => s.includes("I couldn't check my records just now"))).toBe(
+      true,
+    );
+    expect(surface.status).not.toContain("I couldn't check my records just now");
+  });
+});

--- a/plugins/codex/test/global-setup.ts
+++ b/plugins/codex/test/global-setup.ts
@@ -1,0 +1,14 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Builds the plugin's scripts/*.js once before the suite runs. The onboard and
+// start-light suites spawn those built scripts; Vitest runs globalSetup in the
+// main process to completion before any test worker starts, so the build
+// finishes before any worker can spawn a script — no worker ever reads a script
+// mid-rewrite. Runs once per `vitest run`, not per worker or per test file.
+const PLUGIN_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+export function setup(): void {
+  execFileSync('pnpm', ['run', 'build'], { cwd: PLUGIN_ROOT, stdio: 'pipe' });
+}

--- a/plugins/codex/test/helpers/no-echo.test.ts
+++ b/plugins/codex/test/helpers/no-echo.test.ts
@@ -1,0 +1,107 @@
+import { maskMatch } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { ECHO_RUN, errorFrom, expectNoEchoOf } from './no-echo.ts';
+
+// The helper an absence assertion leans on gets its own suite, or it can be
+// weakened back with nothing going red: raise ECHO_RUN past the value's length,
+// or empty the loop, and every caller keeps passing while proving nothing. Each
+// case here fails if that happens.
+//
+// Composed at runtime so the repo's own secret scan never flags this file.
+const VALUE = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+
+// Did the helper refuse this pairing? A vitest assertion failure is a throw, so
+// "the assertion would have gone red" is observable without failing this test.
+function refuses(haystack: string | undefined, value: string): boolean {
+  try {
+    expectNoEchoOf(haystack, value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('expectNoEchoOf', () => {
+  it('is eight characters — widening it is a deliberate act, not a drift', () => {
+    // The callers' comments cite this number as what makes a run-by-run check
+    // stronger than the whole-value form. Move it and that has to be re-derived.
+    expect(ECHO_RUN).toBe(8);
+    expect(VALUE.length).toBeGreaterThan(ECHO_RUN);
+  });
+
+  // The three cases below are the whole point: each output leaks a live
+  // credential's run, and each one passes the weaker whole-value form. The
+  // control assertion in each is what proves the new form is STRONGER rather
+  // than merely also-red — without it a green helper and a green predecessor
+  // look identical.
+  it('refuses a prefix echo that a whole-value assertion passes', () => {
+    const echoed = `judge failed near ${VALUE.slice(0, ECHO_RUN)}...`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE); // control: the form this replaced stays green
+  });
+
+  it('refuses a tail echo that a whole-value assertion passes', () => {
+    const echoed = `...${VALUE.slice(-ECHO_RUN)} was unparseable`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses an interior run that a whole-value assertion passes', () => {
+    const echoed = `near ${VALUE.slice(5, 5 + ECHO_RUN)}`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses a value shorter than the run, echoed whole', () => {
+    // The sliding loop cannot run at all here, so the short-value fallback is
+    // the only thing standing between this and a silent pass.
+    const short = 'ab12cd';
+    expect(short.length).toBeLessThan(ECHO_RUN);
+    expect(refuses(`unknown value ${short}`, short)).toBe(true);
+  });
+
+  it('refuses an undefined haystack — a never-thrown error proves nothing', () => {
+    expect(refuses(undefined, VALUE)).toBe(true);
+  });
+
+  it('accepts the masked preview of a generic secret, which callers do print', () => {
+    // Call the PRODUCT's mask, never a hand-rolled one. A locally built literal
+    // asserts that a string this file constructed lacks a run of another string
+    // this file constructed — true by construction, and it stays true however
+    // maskMatch changes. Wired here, widening maskMatch's generic branch goes
+    // red HERE, where the reason is written down, rather than in a caller that
+    // reads like an unrelated regression.
+    //
+    // @akasecurity/plugin-sdk re-exports it, so this crosses no package wall —
+    // src/remediation/surfaced-redact.ts imports it the same way.
+    expect(refuses(maskMatch(VALUE), VALUE)).toBe(false);
+  });
+
+  it('passes over empty bytes — the limit that makes a positive control mandatory', () => {
+    // Not a defect to fix here: `''` genuinely contains nothing. It is why a
+    // caller must never point this at a capture that can come back empty
+    // without also pinning that the capture is live.
+    expect(refuses('', VALUE)).toBe(false);
+  });
+});
+
+describe('errorFrom', () => {
+  it('returns the thrown error', () => {
+    const err = errorFrom(() => {
+      throw new Error('boom');
+    });
+    expect(err?.message).toBe('boom');
+  });
+
+  it('returns undefined when nothing throws, which expectNoEchoOf then refuses', () => {
+    // This is the whole reason the helper exists. The shape it replaces —
+    // `try { f(); throw new Error('expected f to throw') } catch (e) { … }` —
+    // catches the test's OWN error, so a caller asserting only absence stays
+    // green while `f` stopped throwing entirely. Here `undefined` reaches
+    // expectNoEchoOf's toBeDefined() guard and goes red.
+    const err = errorFrom(() => 'returned normally');
+    expect(err).toBeUndefined();
+    expect(refuses(err?.message, VALUE)).toBe(true);
+  });
+});

--- a/plugins/codex/test/helpers/no-echo.ts
+++ b/plugins/codex/test/helpers/no-echo.ts
@@ -1,0 +1,73 @@
+import { expect } from 'vitest';
+
+/**
+ * The shortest run of a raw value whose appearance is still a disclosure.
+ *
+ * A plain `not.toContain(value)` catches a WHOLE-value echo only — it stays
+ * green if a branch ever interpolates a truncated one, and "say which value
+ * failed" is exactly the well-meaning change that would do it. Eight characters
+ * is a substantial fraction of every value the bundled rules match, and for the
+ * shorter ones it is most of the secret.
+ */
+export const ECHO_RUN = 8;
+
+/**
+ * Assert `haystack` carries no run of `value` at all, not merely not all of it.
+ *
+ * Point this at a value that must not appear AT ALL — a raw hit on a hook's
+ * stdout, in an error that reaches the parent command's stderr, or in a message
+ * built for the user. Three limits decide where it belongs, and each one is
+ * pinned by this file's own suite:
+ *
+ * 1. **It proves nothing over bytes that came back empty.** Every `not.toContain`
+ *    passes on `''`, and the `toBeDefined()` guard below does not catch that —
+ *    it catches an `undefined` message, which is the shape a never-thrown error
+ *    arrives in. A builder returning `string` is never undefined, so the guard
+ *    is inert there. Pin a positive control on the same bytes first.
+ * 2. **A thrown-from-the-try guard defeats it.** `try { f(); throw new Error('expected
+ *    f to throw') } catch (e) { … }` catches the test's OWN error and asserts
+ *    against a message that never held a secret, so it passes while `f` stopped
+ *    throwing entirely. Capture the error outside the catch and assert what it
+ *    says before asserting what it omits.
+ * 3. **It is for a raw value, not a deliberately revealed fragment.** A masked
+ *    preview is built and shown on purpose, so assertions on one stay
+ *    whole-value — `remediation/render.test.ts` on the masked previews it
+ *    prints, and the surfaced-secret grant shapes beside it. A generic secret's
+ *    preview reveals two characters and cannot fill the window, which is what
+ *    lets a surface printing one be searched at all.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `cli/test/helpers/no-echo.ts`,
+ * `plugins/claude-code/test/helpers/no-echo.ts`, `web-ui/test/helpers/no-echo.ts`
+ * and `packages/setup-wizard/test/helpers/no-echo.ts` are peers of this file —
+ * each a copy that takes the `toBeDefined()` guard and a `no-echo.test.ts` with
+ * it, or the run length can be widened back with nothing going red.
+ */
+export function expectNoEchoOf(haystack: string | undefined, value: string): void {
+  // Catches a never-thrown error arriving as `undefined`, which would otherwise
+  // satisfy the loop vacuously. It does NOT catch an empty string — see limit 1.
+  expect(haystack).toBeDefined();
+  const text = haystack ?? '';
+  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
+    expect(text).not.toContain(value.slice(i, i + ECHO_RUN));
+  }
+  // Values shorter than the run length still must not appear at all.
+  if (value.length < ECHO_RUN) expect(text).not.toContain(value);
+}
+
+/**
+ * Run `fn` and return the error it threw, or `undefined` if it returned.
+ *
+ * The shape limit 2 above exists for: the caller asserts on the returned value,
+ * so a function that stopped throwing yields `undefined` and every assertion
+ * below it goes red — where a `throw` inside the `try` would have been caught
+ * by the same `catch` and quietly asserted against instead.
+ */
+export function errorFrom(fn: () => unknown): Error | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+}

--- a/plugins/codex/test/helpers/run-hook.ts
+++ b/plugins/codex/test/helpers/run-hook.ts
@@ -1,0 +1,101 @@
+/**
+ * Spawns a hook's BUILT script (scripts/<name>.js) exactly as Codex invokes it
+ * — the only layer that tests what ships, not the source. Hook entries call
+ * main() on import and exit the process, so they can never be imported directly
+ * by a test; spawning the compiled artifact is the only way to exercise them.
+ *
+ * `stdin` is a raw string, not a JS value the helper serializes — the fail-open
+ * matrix this harness exists for (malformed JSON, truncated JSON, binary
+ * garbage) requires feeding a hook exactly that kind of invalid payload, which
+ * a helper that only accepted JSON-serializable input could never produce.
+ * Callers who want valid input build it themselves, e.g.
+ * `runHook('session-start', JSON.stringify({ session_id: 'x' }))`.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/helpers -> plugins/codex
+const PLUGIN_ROOT = join(HERE, '..', '..');
+const SCRIPTS_DIR = join(PLUGIN_ROOT, 'scripts');
+
+export interface HookResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface RunHookOptions {
+  /** argv passed after the script path. */
+  args?: readonly string[];
+  /** The child's entire environment. */
+  env?: Readonly<Record<string, string>>;
+  timeoutMs?: number;
+}
+
+// Spawns the built scripts/<name>.js exactly as Codex invokes it: raw stdin in,
+// exit code + stdout/stderr out. `scripts/` is gitignored and only produced by
+// `pnpm run build` — fail with a clear message rather than a confusing ENOENT
+// if a caller runs this without building first (in normal use this package's
+// vitest.config.ts globalSetup already builds before any test file runs, so
+// this is a defensive fallback, not the primary guard).
+//
+// The child gets ONLY the env the caller passes — process.execPath is an
+// absolute node path, so nothing here needs the host PATH, and inheriting no
+// ambient environment keeps a developer's real CODEX_HOME or provider
+// credentials out of the spawn. Same choice as this package's per-suite
+// harnesses.
+export function runHook(name: string, stdin: string, options: RunHookOptions = {}): HookResult {
+  const scriptPath = join(SCRIPTS_DIR, `${name}.js`);
+  if (!existsSync(scriptPath)) {
+    throw new Error(
+      `runHook('${name}'): ${scriptPath} does not exist. scripts/ is gitignored and only ` +
+        'produced by `pnpm run build` (plugins/codex) — build the plugin before running this test.',
+    );
+  }
+
+  try {
+    const stdout = execFileSync(process.execPath, [scriptPath, ...(options.args ?? [])], {
+      input: stdin,
+      encoding: 'utf8',
+      timeout: options.timeoutMs ?? 15_000,
+      env: { ...options.env },
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return { status: 0, stdout, stderr: '' };
+  } catch (err) {
+    // A non-zero exit (or a killed/timed-out process) still carries the
+    // captured streams; surface them so a test can assert against the real
+    // output instead of a bare throw.
+    const e = err as { stdout?: string; stderr?: string; status?: number | null };
+    return {
+      status: e.status ?? 1,
+      stdout: e.stdout ?? '',
+      stderr: e.stderr ?? '',
+    };
+  }
+}
+
+// An isolated ~/.aka for one runHook() call: os.homedir() — which every hook
+// resolves its data dir through — honors $HOME on POSIX, so overriding it
+// points the whole chain at a throwaway temp home instead of a developer's real
+// store. Windows resolves the home dir from USERPROFILE instead of HOME, so
+// both are set in lockstep.
+export function withTempHome<T>(fn: (home: string) => T): T {
+  const home = mkdtempSync(join(tmpdir(), 'aka-codex-hook-e2e-'));
+  try {
+    return fn(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// Convenience: temp-home env vars for RunHookOptions.env, so a caller can
+// write `runHook(name, stdin, { env: tempHomeEnv(home) })` instead of
+// repeating the HOME/USERPROFILE pair at every call site.
+export function tempHomeEnv(home: string): Record<string, string> {
+  return { HOME: home, USERPROFILE: home };
+}

--- a/plugins/codex/test/history/reconcile-trigger.test.ts
+++ b/plugins/codex/test/history/reconcile-trigger.test.ts
@@ -1,0 +1,36 @@
+// Identical to plugins/claude-code/src/history/reconcile-trigger.test.ts —
+// no harness-specific logic here.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the detached spawn so the test never launches a real worker — we only assert
+// HOW OFTEN it would fire. `vi.hoisted` makes the spy exist before the mock factory.
+const { spawnSpy } = vi.hoisted(() => ({ spawnSpy: vi.fn(() => ({ unref: vi.fn() })) }));
+vi.mock('node:child_process', () => ({ spawn: spawnSpy }));
+
+// `throttled` (@akasecurity/plugin-sdk) is left REAL: it writes the on-disk
+// marker we're testing, against a temp dataDir.
+import { triggerReconcile } from '../../src/history/reconcile-trigger.ts';
+
+describe('triggerReconcile — per-session throttle', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-reconcile-'));
+    spawnSpy.mockClear();
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throttles per session, not globally — concurrent sessions each get their own spawn', () => {
+    triggerReconcile(dir, 'sess-A', '/t/a.jsonl');
+    triggerReconcile(dir, 'sess-A', '/t/a.jsonl');
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
+
+    triggerReconcile(dir, 'sess-B', '/t/b.jsonl');
+    expect(spawnSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/plugins/codex/test/history/scan.test.ts
+++ b/plugins/codex/test/history/scan.test.ts
@@ -7,9 +7,11 @@ import { join } from 'node:path';
 
 import { resolveDataGateway } from '@akasecurity/plugin-runtime';
 import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import { safeMaskedMatch } from '@akasecurity/plugin-sdk';
+import type { TriageHit } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { scanHistory } from '../../src/history/scan.ts';
+import { buildTriageHit, scanHistory } from '../../src/history/scan.ts';
 
 // In standalone mode the effective ruleset is the store's INSTALLED snapshot
 // (seeded from bundledDetections() by resolveDataGateway), not ad-hoc packs
@@ -153,5 +155,191 @@ describe('scanHistory', () => {
     } finally {
       await gateway.close();
     }
+  });
+});
+
+describe('buildTriageHit', () => {
+  it('slices the correct context window and carries safeMaskedMatch(rawMatch) as maskedMatch', () => {
+    const text = `padding before the leak ${BACKFILL_SECRET} padding after the leak`;
+    const start = text.indexOf(BACKFILL_SECRET);
+    const end = start + BACKFILL_SECRET.length;
+    const finding = {
+      ruleId: 'secrets/aws-access-key',
+      category: 'secret' as const,
+      severity: 'critical' as const,
+      rawMatch: BACKFILL_SECRET,
+      span: { start, end },
+      confidence: 0.9,
+    };
+
+    const hit = buildTriageHit(text, finding);
+
+    expect(hit.context).toBe(
+      text.slice(Math.max(0, start - 120), Math.min(text.length, end + 120)),
+    );
+    expect(hit.maskedMatch).toBe(safeMaskedMatch(BACKFILL_SECRET));
+    expect(hit.rawMatch).toBe(BACKFILL_SECRET);
+    // No source path was supplied, so filePath is absent — the finding derives
+    // '(location unavailable)' downstream rather than an empty-string path.
+    expect(hit.filePath).toBeUndefined();
+  });
+
+  it('carries the source rollout path when one is supplied, so a surfaced finding can be located and struck', () => {
+    const path = '/Users/me/.codex/sessions/2026/06/20/rollout-session.jsonl';
+    const text = `padding ${BACKFILL_SECRET} padding`;
+    const start = text.indexOf(BACKFILL_SECRET);
+    const finding = {
+      ruleId: 'secrets/aws-access-key',
+      category: 'secret' as const,
+      severity: 'critical' as const,
+      rawMatch: BACKFILL_SECRET,
+      span: { start, end: start + BACKFILL_SECRET.length },
+      confidence: 0.9,
+    };
+
+    const hit = buildTriageHit(text, finding, [], path);
+
+    expect(hit.filePath).toBe(path);
+  });
+
+  it('never sets maskedMatch to the raw value, even for a single-char-local-part email', () => {
+    const rawMatch = 'a@test.com';
+    const finding = {
+      ruleId: 'core-pii/email',
+      category: 'pii' as const,
+      severity: 'medium' as const,
+      rawMatch,
+      span: { start: 0, end: rawMatch.length },
+      confidence: 0.9,
+    };
+
+    const hit = buildTriageHit(rawMatch, finding);
+
+    expect(hit.maskedMatch).not.toBe(rawMatch);
+  });
+
+  it("redacts another finding's raw value inside the context window, keeping its own match legible", () => {
+    const otherSecret = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+    const text = `${otherSecret} close by, then ${BACKFILL_SECRET} is the real leak`;
+    const otherStart = text.indexOf(otherSecret);
+    const start = text.indexOf(BACKFILL_SECRET);
+    const finding = {
+      ruleId: 'secrets/aws-access-key',
+      category: 'secret' as const,
+      severity: 'critical' as const,
+      rawMatch: BACKFILL_SECRET,
+      span: { start, end: start + BACKFILL_SECRET.length },
+      confidence: 0.9,
+    };
+    const other = {
+      rawMatch: otherSecret,
+      span: { start: otherStart, end: otherStart + otherSecret.length },
+    };
+
+    const hit = buildTriageHit(text, finding, [other]);
+
+    expect(hit.context).toContain(BACKFILL_SECRET);
+    expect(hit.context).not.toContain(otherSecret);
+  });
+});
+
+describe('scanHistory — onHit sink', () => {
+  let dir: string;
+  let rollout: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-scan-onhit-data-'));
+    rollout = mkdtempSync(join(tmpdir(), 'aka-scan-onhit-tx-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(rollout, { recursive: true, force: true });
+  });
+
+  it('is called exactly once per finding, with context sliced from the correct message', async () => {
+    const otherSecret = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+    seedRollout(rollout, BACKFILL_SECRET);
+
+    const otherDayDir = join(rollout, '2026', '06', '21');
+    mkdirSync(otherDayDir, { recursive: true });
+    writeFileSync(
+      join(otherDayDir, 'rollout-other.jsonl'),
+      JSON.stringify({
+        timestamp: '2026-06-21T12:00:00.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: `here is another key ${otherSecret}` }],
+        },
+      }),
+    );
+
+    const hits: TriageHit[] = [];
+    await scanHistory(config(dir, 'full'), { dir: rollout, windowDays: 30, now: NOW }, (hit) => {
+      hits.push(hit);
+    });
+
+    expect(hits).toHaveLength(2);
+    for (const hit of hits) {
+      expect(hit.context).toContain(hit.rawMatch);
+    }
+    const backfillHit = hits.find((h) => h.rawMatch === BACKFILL_SECRET);
+    const otherHit = hits.find((h) => h.rawMatch === otherSecret);
+    expect(backfillHit?.context).not.toContain(otherSecret);
+    expect(otherHit?.context).not.toContain(BACKFILL_SECRET);
+    // Each streamed hit carries the real rollout file it was found in, so the
+    // remediation redact path can locate and strike the leaked key in place.
+    expect(backfillHit?.filePath).toBe(join(rollout, '2026', '06', '20', 'rollout-session.jsonl'));
+    expect(otherHit?.filePath).toBe(join(rollout, '2026', '06', '21', 'rollout-other.jsonl'));
+  });
+
+  it('redacts a neighboring secret from context when two findings share one message', async () => {
+    const otherSecret = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+    const dayDir = join(rollout, '2026', '06', '20');
+    mkdirSync(dayDir, { recursive: true });
+    writeFileSync(
+      join(dayDir, 'rollout-session.jsonl'),
+      JSON.stringify({
+        timestamp: LEAK_TS,
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: `key one ${BACKFILL_SECRET} and key two ${otherSecret}` },
+          ],
+        },
+      }),
+    );
+
+    const hits: TriageHit[] = [];
+    await scanHistory(config(dir, 'full'), { dir: rollout, windowDays: 30, now: NOW }, (hit) => {
+      hits.push(hit);
+    });
+
+    expect(hits).toHaveLength(2);
+    const backfillHit = hits.find((h) => h.rawMatch === BACKFILL_SECRET);
+    const otherHit = hits.find((h) => h.rawMatch === otherSecret);
+    // Each hit's own match stays legible, but its neighbor's raw value never does.
+    expect(backfillHit?.context).toContain(BACKFILL_SECRET);
+    expect(backfillHit?.context).not.toContain(otherSecret);
+    expect(otherHit?.context).toContain(otherSecret);
+    expect(otherHit?.context).not.toContain(BACKFILL_SECRET);
+  });
+
+  it('keeps scanning the rest of the history when the onHit sink throws', async () => {
+    seedRollout(rollout, BACKFILL_SECRET);
+
+    const summary = await scanHistory(
+      config(dir, 'full'),
+      { dir: rollout, windowDays: 30, now: NOW },
+      () => {
+        throw new Error('sink exploded');
+      },
+    );
+
+    // The throw is contained — the sweep still records the finding normally.
+    expect(summary.findings).toBe(1);
+    expect(summary.scanned).toBe(2);
   });
 });

--- a/plugins/codex/test/history/scan.test.ts
+++ b/plugins/codex/test/history/scan.test.ts
@@ -1,0 +1,157 @@
+// Adapted from plugins/claude-code/src/history/scan.test.ts — same
+// consent-gated backfill contract, exercised against a synthetic Codex
+// rollout file instead of a Claude Code transcript.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { scanHistory } from '../../src/history/scan.ts';
+
+// In standalone mode the effective ruleset is the store's INSTALLED snapshot
+// (seeded from bundledDetections() by resolveDataGateway), not ad-hoc packs
+// registered into the engine — so the backfill detects with a REAL bundled
+// rule (secrets/aws-access-key, critical). Composed at runtime so the repo's
+// own secret scanning doesn't flag this file.
+const BACKFILL_SECRET = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+
+const LEAK_TS = '2026-06-20T12:00:00.000Z';
+const NOW = Date.parse('2026-06-24T00:00:00.000Z');
+
+function config(dataDir: string, historicalAccess: 'full' | 'session-only'): PluginConfig {
+  return {
+    settings: {
+      specVersion: 3,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess,
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'openai' },
+  };
+}
+
+// Build a rollout root with one session file containing a leaking prompt, a
+// benign assistant reply, and a function_call (which the scan must ignore —
+// only `message` response_items carry scannable prose).
+function seedRollout(root: string, secret: string): void {
+  const dayDir = join(root, '2026', '06', '20');
+  mkdirSync(dayDir, { recursive: true });
+  const lines = [
+    JSON.stringify({
+      timestamp: LEAK_TS,
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: `here is a key ${secret}` }],
+      },
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-20T12:00:05.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text: 'nothing sensitive here' }],
+      },
+    }),
+    JSON.stringify({
+      timestamp: '2026-06-20T12:00:10.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        name: 'shell',
+        arguments: `{"command":"echo ${secret}"}`,
+        call_id: 'c1',
+      },
+    }),
+  ];
+  writeFileSync(join(dayDir, 'rollout-session.jsonl'), lines.join('\n'));
+}
+
+describe('scanHistory', () => {
+  let dir: string;
+  let rollout: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-scan-data-'));
+    rollout = mkdtempSync(join(tmpdir(), 'aka-scan-tx-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    rmSync(rollout, { recursive: true, force: true });
+  });
+
+  it('records pre-install findings with the original timestamp and never the raw secret', async () => {
+    const SECRET = BACKFILL_SECRET;
+    seedRollout(rollout, SECRET);
+
+    const summary = await scanHistory(config(dir, 'full'), {
+      dir: rollout,
+      windowDays: 30,
+      now: NOW,
+    });
+
+    expect(summary.consented).toBe(true);
+    expect(summary.scanned).toBe(2); // the prompt + the assistant reply; function_call ignored
+    expect(summary.findings).toBe(1);
+    expect(summary.bySeverity.critical).toBe(1);
+
+    const gateway = resolveDataGateway(config(dir, 'full'));
+    try {
+      const findings = await gateway.recentFindings({ limit: 25 });
+      expect(findings).toHaveLength(1);
+      expect(findings[0]?.ruleId).toBe('secrets/aws-access-key');
+      expect(findings[0]?.occurredAt).toBe(LEAK_TS);
+      expect(JSON.stringify(findings)).not.toContain(SECRET);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it('is idempotent — re-running records no duplicate findings', async () => {
+    seedRollout(rollout, BACKFILL_SECRET);
+    const opts = { dir: rollout, windowDays: 30, now: NOW };
+
+    const first = await scanHistory(config(dir, 'full'), opts);
+    expect(first.findings).toBe(1);
+    expect(first.skipped).toBe(0);
+
+    const second = await scanHistory(config(dir, 'full'), opts);
+    expect(second.findings).toBe(0);
+    expect(second.skipped).toBeGreaterThanOrEqual(1);
+
+    const gateway = resolveDataGateway(config(dir, 'full'));
+    try {
+      expect(await gateway.recentFindings({ limit: 25 })).toHaveLength(1);
+    } finally {
+      await gateway.close();
+    }
+  });
+
+  it('is a no-op without consent (session-only)', async () => {
+    seedRollout(rollout, BACKFILL_SECRET);
+    const summary = await scanHistory(config(dir, 'session-only'), {
+      dir: rollout,
+      windowDays: 30,
+      now: NOW,
+    });
+    expect(summary).toMatchObject({ consented: false, scanned: 0, findings: 0 });
+
+    const gateway = resolveDataGateway(config(dir, 'session-only'));
+    try {
+      expect(await gateway.recentFindings({ limit: 25 })).toHaveLength(0);
+    } finally {
+      await gateway.close();
+    }
+  });
+});

--- a/plugins/codex/test/history/tail.test.ts
+++ b/plugins/codex/test/history/tail.test.ts
@@ -1,0 +1,149 @@
+// Identical to plugins/claude-code/src/history/tail.test.ts — tail.ts is a
+// pure byte-offset fs reader with no knowledge of the transcript's own record
+// format, so it needs no Codex-specific test changes.
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readOffset, readTail, safeSessionId, writeOffset } from '../../src/history/tail.ts';
+
+describe('readTail — incremental byte-offset tail read', () => {
+  let dir: string;
+  let file: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-tail-'));
+    file = join(dir, 't.jsonl');
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('first pass consumes the whole file (up to the last newline) and records the offset', () => {
+    const content = 'line-a\nline-b\n';
+    writeFileSync(file, content);
+
+    const { chunk, nextOffset } = readTail(file, 0);
+    expect(chunk).toBe(content);
+    expect(nextOffset).toBe(Buffer.byteLength(content));
+  });
+
+  it('a second pass consumes ONLY the newly-appended tail, not the earlier lines', () => {
+    writeFileSync(file, 'line-a\nline-b\n');
+    const first = readTail(file, 0);
+    expect(first.chunk).toBe('line-a\nline-b\n');
+
+    appendFileSync(file, 'line-c\nline-d\n');
+    const second = readTail(file, first.nextOffset);
+    expect(second.chunk).toBe('line-c\nline-d\n');
+    expect(second.nextOffset).toBe(Buffer.byteLength('line-a\nline-b\nline-c\nline-d\n'));
+  });
+
+  it('does NOT consume a half-written final line until it is completed', () => {
+    writeFileSync(file, 'line-a\nhalf-writt');
+    const first = readTail(file, 0);
+    expect(first.chunk).toBe('line-a\n');
+    expect(first.nextOffset).toBe(Buffer.byteLength('line-a\n'));
+
+    appendFileSync(file, 'en-now\n');
+    const second = readTail(file, first.nextOffset);
+    expect(second.chunk).toBe('half-written-now\n');
+  });
+
+  it('returns an empty chunk when nothing new (or only an incomplete line) is present', () => {
+    writeFileSync(file, 'line-a\n');
+    const first = readTail(file, 0);
+    const second = readTail(file, first.nextOffset);
+    expect(second.chunk).toBe('');
+    expect(second.nextOffset).toBe(first.nextOffset);
+  });
+
+  it('resets to 0 and re-reads when the file shrank (rotation/truncation)', () => {
+    writeFileSync(file, 'old-a\nold-b\nold-c\n');
+    const first = readTail(file, 0);
+    expect(first.nextOffset).toBe(Buffer.byteLength('old-a\nold-b\nold-c\n'));
+
+    writeFileSync(file, 'new-a\n');
+    const after = readTail(file, first.nextOffset);
+    expect(after.chunk).toBe('new-a\n');
+    expect(after.nextOffset).toBe(Buffer.byteLength('new-a\n'));
+  });
+
+  it('fail-open: a missing file yields an empty chunk and the unchanged offset', () => {
+    const { chunk, nextOffset } = readTail(join(dir, 'does-not-exist.jsonl'), 42);
+    expect(chunk).toBe('');
+    expect(nextOffset).toBe(42);
+  });
+});
+
+describe('readOffset / writeOffset — per-session checkpoint', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-offset-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('a fresh session reads offset 0 and no seed', () => {
+    expect(readOffset(dir, 'sess-new')).toEqual({ offset: 0 });
+  });
+
+  it('round-trips offset + lastPromptId', () => {
+    writeOffset(dir, 'sess-1', { offset: 128, lastPromptId: 'p1' });
+    expect(readOffset(dir, 'sess-1')).toEqual({ offset: 128, lastPromptId: 'p1' });
+  });
+
+  it('omits lastPromptId from the marker when undefined', () => {
+    writeOffset(dir, 'sess-2', { offset: 64 });
+    expect(readOffset(dir, 'sess-2')).toEqual({ offset: 64 });
+  });
+
+  it('fail-open: a corrupt marker reads as a fresh start (offset 0)', () => {
+    mkdirSync(join(dir, 'usage-offsets'), { recursive: true });
+    writeFileSync(join(dir, 'usage-offsets', 'sess-3'), 'not json');
+    expect(readOffset(dir, 'sess-3')).toEqual({ offset: 0 });
+  });
+
+  it('normalizes a negative/non-finite stored offset to 0', () => {
+    mkdirSync(join(dir, 'usage-offsets'), { recursive: true });
+    writeFileSync(join(dir, 'usage-offsets', 'sess-4'), JSON.stringify({ offset: -5 }));
+    expect(readOffset(dir, 'sess-4')).toEqual({ offset: 0 });
+  });
+
+  it('a path-traversal session id never writes outside the offsets dir and still round-trips', () => {
+    const hostile = join('..', '..', 'escape-target');
+    writeOffset(dir, hostile, { offset: 7 });
+
+    expect(existsSync(join(dir, '..', 'escape-target'))).toBe(false);
+    expect(existsSync(join(dir, '..', '..', 'escape-target'))).toBe(false);
+    expect(readdirSync(join(dir, 'usage-offsets'))).toEqual([safeSessionId(hostile)]);
+    expect(readOffset(dir, hostile)).toEqual({ offset: 7 });
+  });
+});
+
+describe('safeSessionId — filesystem-safe session id', () => {
+  it('passes a normal harness-style id through unchanged', () => {
+    expect(safeSessionId('3f9c2d1e-8a4b-4c70-9e21-d5f0a6b7c8d9')).toBe(
+      '3f9c2d1e-8a4b-4c70-9e21-d5f0a6b7c8d9',
+    );
+    expect(safeSessionId('sess_01.A-b')).toBe('sess_01.A-b');
+  });
+
+  it('replaces separator-bearing, dot-only, and empty ids with a stable hash', () => {
+    for (const hostile of ['../../etc', 'a/b', 'a\\b', '.', '..', '', 'a b']) {
+      const safe = safeSessionId(hostile);
+      expect(safe).toMatch(/^[0-9a-f]{64}$/);
+      expect(safeSessionId(hostile)).toBe(safe);
+    }
+  });
+});

--- a/plugins/codex/test/history/transcripts.test.ts
+++ b/plugins/codex/test/history/transcripts.test.ts
@@ -63,13 +63,61 @@ describe('parseTranscript — prompt/response text', () => {
         kind: 'prompt',
         text: 'here is my api key sk-abc123',
         occurredAt: '2026-07-14T10:00:01.000Z',
+        filePath: '',
       },
       {
         kind: 'response',
         text: 'I will not echo that key back.',
         occurredAt: '2026-07-14T10:00:02.000Z',
+        filePath: '',
       },
     ]);
+  });
+
+  it('stamps the source rollout path onto every message so a surfaced finding can be located', () => {
+    const path = '/Users/me/.codex/sessions/2026/07/14/rollout-session.jsonl';
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'a prompt' }],
+        },
+      }),
+    ].join('\n');
+    const msgs = parseTranscript(jsonl, 0, Infinity, path);
+    expect(msgs.length).toBeGreaterThan(0);
+    for (const msg of msgs) expect(msg.filePath).toBe(path);
+  });
+
+  it('drops messages at/after the setup-start cutoff (beforeMs), keeps older ones', () => {
+    const jsonl = [
+      line({
+        timestamp: '2026-07-14T10:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'pre-install leak' }],
+        },
+      }),
+      line({
+        timestamp: '2026-07-16T10:00:00.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'post-install wizard output' }],
+        },
+      }),
+    ].join('\n');
+
+    const cutoff = Date.parse('2026-07-15T00:00:00.000Z'); // setup-start
+    const bounded = parseTranscript(jsonl, 0, cutoff).map((m) => m.text);
+    expect(bounded).toEqual(['pre-install leak']);
   });
 
   it('joins multiple text content blocks and skips input_image blocks', () => {
@@ -87,7 +135,12 @@ describe('parseTranscript — prompt/response text', () => {
       },
     });
     expect(parseTranscript(jsonl)).toEqual([
-      { kind: 'prompt', text: 'first line\nsecond line', occurredAt: '2026-07-14T10:00:01.000Z' },
+      {
+        kind: 'prompt',
+        text: 'first line\nsecond line',
+        occurredAt: '2026-07-14T10:00:01.000Z',
+        filePath: '',
+      },
     ]);
   });
 
@@ -256,10 +309,7 @@ describe('parseTranscriptUsage — token_count events', () => {
     const pass1 = parseTranscriptUsage([SESSION_META, first].join('\n'));
     const pass2 = parseTranscriptUsage(second, 0, 'sess-1'); // tail chunk: no session_meta
 
-    expect(wholeFile.map((r) => r.eventKey)).toEqual([
-      pass1[0]?.eventKey,
-      pass2[0]?.eventKey,
-    ]);
+    expect(wholeFile.map((r) => r.eventKey)).toEqual([pass1[0]?.eventKey, pass2[0]?.eventKey]);
     // The two turns never share a key — the collision the per-parse ordinal
     // scheme used to cause.
     expect(pass1[0]?.eventKey).not.toBe(pass2[0]?.eventKey);
@@ -267,7 +317,9 @@ describe('parseTranscriptUsage — token_count events', () => {
 
   it('disambiguates two token_count records sharing one timestamp, stably across filters', () => {
     const ts = '2026-07-14T10:00:04.000Z';
-    const both = parseTranscriptUsage([SESSION_META, tokenCountLine(ts), tokenCountLine(ts)].join('\n'));
+    const both = parseTranscriptUsage(
+      [SESSION_META, tokenCountLine(ts), tokenCountLine(ts)].join('\n'),
+    );
     expect(both.map((r) => r.eventKey)).toEqual([`sess-1:${ts}:1`, `sess-1:${ts}:2`]);
   });
 });

--- a/plugins/codex/test/history/transcripts.test.ts
+++ b/plugins/codex/test/history/transcripts.test.ts
@@ -1,0 +1,506 @@
+// Tests the Codex rollout-file parser against synthetic JSONL matching the
+// wire shape confirmed from openai/codex's own Rust types
+// (codex-rs/protocol/src/protocol.rs — RolloutLine/RolloutItem/EventMsg;
+// codex-rs/protocol/src/models.rs — ResponseItem/ContentItem). See the module
+// comment on transcripts.ts for the exact source pointers.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  parseTranscript,
+  parseTranscriptToolCalls,
+  parseTranscriptUsage,
+  peekSessionOriginator,
+} from '../../src/history/transcripts.ts';
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+const SESSION_META = line({
+  timestamp: '2026-07-14T10:00:00.000Z',
+  type: 'session_meta',
+  payload: {
+    session_id: 'sess-1',
+    id: 'thread-1',
+    timestamp: '2026-07-14T10:00:00.000Z',
+    cwd: '/home/me/proj',
+    originator: 'codex_cli_rs',
+    cli_version: '0.140.0',
+  },
+});
+
+describe('parseTranscript — prompt/response text', () => {
+  it('extracts a user message and an assistant reply from response_item lines', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_text', text: 'here is my api key sk-abc123' }],
+        },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:02.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'I will not echo that key back.' }],
+        },
+      }),
+    ].join('\n');
+
+    const messages = parseTranscript(jsonl);
+    expect(messages).toEqual([
+      {
+        kind: 'prompt',
+        text: 'here is my api key sk-abc123',
+        occurredAt: '2026-07-14T10:00:01.000Z',
+      },
+      {
+        kind: 'response',
+        text: 'I will not echo that key back.',
+        occurredAt: '2026-07-14T10:00:02.000Z',
+      },
+    ]);
+  });
+
+  it('joins multiple text content blocks and skips input_image blocks', () => {
+    const jsonl = line({
+      timestamp: '2026-07-14T10:00:01.000Z',
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [
+          { type: 'input_text', text: 'first line' },
+          { type: 'input_image', image_url: 'data:image/png;base64,xyz' },
+          { type: 'input_text', text: 'second line' },
+        ],
+      },
+    });
+    expect(parseTranscript(jsonl)).toEqual([
+      { kind: 'prompt', text: 'first line\nsecond line', occurredAt: '2026-07-14T10:00:01.000Z' },
+    ]);
+  });
+
+  it('skips non-message response_item payloads (function_call, reasoning, …)', () => {
+    const jsonl = [
+      line({
+        timestamp: '2026-07-14T10:00:01.000Z',
+        type: 'response_item',
+        payload: {
+          type: 'function_call',
+          name: 'shell',
+          arguments: '{"command":"ls"}',
+          call_id: 'c1',
+        },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:02.000Z',
+        type: 'response_item',
+        payload: { type: 'reasoning', summary: [], content: [] },
+      }),
+    ].join('\n');
+    expect(parseTranscript(jsonl)).toEqual([]);
+  });
+
+  it('skips malformed JSON lines without throwing', () => {
+    const jsonl = ['not json at all', SESSION_META, '{"broken":'].join('\n');
+    expect(() => parseTranscript(jsonl)).not.toThrow();
+    expect(parseTranscript(jsonl)).toEqual([]);
+  });
+
+  it('applies the sinceMs window bound', () => {
+    const jsonl = line({
+      timestamp: '2026-01-01T00:00:00.000Z',
+      type: 'response_item',
+      payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'old' }] },
+    });
+    const sinceMs = Date.parse('2026-06-01T00:00:00.000Z');
+    expect(parseTranscript(jsonl, sinceMs)).toEqual([]);
+  });
+});
+
+describe('parseTranscriptUsage — token_count events', () => {
+  it('threads session_id/cwd/cli_version from session_meta onto each usage record', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:03.000Z',
+        type: 'turn_context',
+        payload: { turn_id: 'turn-1', cwd: '/home/me/proj', model: 'gpt-5-codex' },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:04.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              input_tokens: 500,
+              cached_input_tokens: 100,
+              output_tokens: 50,
+              reasoning_output_tokens: 10,
+              total_tokens: 550,
+            },
+            last_token_usage: {
+              input_tokens: 500,
+              cached_input_tokens: 100,
+              output_tokens: 50,
+              reasoning_output_tokens: 10,
+              total_tokens: 550,
+            },
+            model_context_window: 200000,
+          },
+          rate_limits: null,
+        },
+      }),
+    ].join('\n');
+
+    const records = parseTranscriptUsage(jsonl);
+    expect(records).toEqual([
+      {
+        kind: 'usage',
+        sessionId: 'sess-1',
+        eventKey: 'sess-1:2026-07-14T10:00:04.000Z:1',
+        model: 'gpt-5-codex',
+        runKey: 'turn-1',
+        usage: {
+          input_tokens: 500,
+          output_tokens: 50,
+          cache_read_input_tokens: 100,
+          reasoning_output_tokens: 10,
+        },
+        occurredAt: '2026-07-14T10:00:04.000Z',
+        cwd: '/home/me/proj',
+        version: '0.140.0',
+        originator: 'codex_cli_rs',
+      },
+    ]);
+  });
+
+  it('drops an all-zero token_count event', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:04.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {},
+            last_token_usage: { input_tokens: 0, output_tokens: 0, cached_input_tokens: 0 },
+            model_context_window: null,
+          },
+          rate_limits: null,
+        },
+      }),
+    ].join('\n');
+    expect(parseTranscriptUsage(jsonl)).toEqual([]);
+  });
+
+  it('drops usage events before session_meta has been seen (unattributable)', () => {
+    const jsonl = line({
+      timestamp: '2026-07-14T10:00:04.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'token_count',
+        info: {
+          total_token_usage: {},
+          last_token_usage: { input_tokens: 10, output_tokens: 10 },
+          model_context_window: null,
+        },
+        rate_limits: null,
+      },
+    });
+    expect(parseTranscriptUsage(jsonl)).toEqual([]);
+  });
+
+  it('distinguishes a ChatGPT-desktop-hosted Codex session from a terminal one via originator', () => {
+    const desktopSessionMeta = line({
+      timestamp: '2026-07-14T10:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        session_id: 'sess-2',
+        id: 'thread-2',
+        timestamp: '2026-07-14T10:00:00.000Z',
+        cwd: '/home/me/proj',
+        originator: 'codex_desktop',
+        cli_version: '0.140.0',
+      },
+    });
+    const jsonl = [desktopSessionMeta, tokenCountLine('2026-07-14T10:00:04.000Z')].join('\n');
+
+    const records = parseTranscriptUsage(jsonl);
+    expect(records[0]?.originator).toBe('codex_desktop');
+  });
+
+  it('mints identical eventKeys for a record whether parsed whole-file or as a tail chunk', () => {
+    // The incremental tail path re-parses only the newly-appended chunk of a
+    // rollout file. A per-parse ordinal would restart at 1 there and collide
+    // every later turn's usage row with the first turn's — the keys must
+    // depend only on the record itself (timestamp + same-timestamp ordinal),
+    // never on where the parse window started.
+    const first = tokenCountLine('2026-07-14T10:00:04.000Z');
+    const second = tokenCountLine('2026-07-14T10:05:00.000Z');
+
+    const wholeFile = parseTranscriptUsage([SESSION_META, first, second].join('\n'));
+    const pass1 = parseTranscriptUsage([SESSION_META, first].join('\n'));
+    const pass2 = parseTranscriptUsage(second, 0, 'sess-1'); // tail chunk: no session_meta
+
+    expect(wholeFile.map((r) => r.eventKey)).toEqual([
+      pass1[0]?.eventKey,
+      pass2[0]?.eventKey,
+    ]);
+    // The two turns never share a key — the collision the per-parse ordinal
+    // scheme used to cause.
+    expect(pass1[0]?.eventKey).not.toBe(pass2[0]?.eventKey);
+  });
+
+  it('disambiguates two token_count records sharing one timestamp, stably across filters', () => {
+    const ts = '2026-07-14T10:00:04.000Z';
+    const both = parseTranscriptUsage([SESSION_META, tokenCountLine(ts), tokenCountLine(ts)].join('\n'));
+    expect(both.map((r) => r.eventKey)).toEqual([`sess-1:${ts}:1`, `sess-1:${ts}:2`]);
+  });
+});
+
+// A minimal single-line token_count event, for tests that only care about
+// which session_meta.originator ends up on the record.
+function tokenCountLine(timestamp: string): string {
+  return line({
+    timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {},
+        last_token_usage: { input_tokens: 10, output_tokens: 10 },
+        model_context_window: null,
+      },
+      rate_limits: null,
+    },
+  });
+}
+
+describe('parseTranscriptToolCalls — exec_command and patch_apply pairs', () => {
+  it('pairs an exec_command_begin/end into one shell ToolCallRecord', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:05.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_begin',
+          call_id: 'call-1',
+          turn_id: 'turn-1',
+          started_at_ms: 0,
+          command: ['ls', '-la'],
+          cwd: '/home/me/proj',
+          parsed_cmd: [],
+        },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:06.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_end',
+          call_id: 'call-1',
+          turn_id: 'turn-1',
+          completed_at_ms: 100,
+          command: ['ls', '-la'],
+          cwd: '/home/me/proj',
+          parsed_cmd: [],
+          stdout: 'file1\nfile2\n',
+          stderr: '',
+          aggregated_output: 'file1\nfile2\n',
+          exit_code: 0,
+          duration: '0.1s',
+          formatted_output: 'file1\nfile2\n',
+          status: 'completed',
+        },
+      }),
+    ].join('\n');
+
+    const calls = parseTranscriptToolCalls(jsonl);
+    expect(calls).toEqual([
+      {
+        sessionId: 'sess-1',
+        toolUseId: 'call-1',
+        toolName: 'shell',
+        runKey: 'turn-1',
+        occurredAt: '2026-07-14T10:00:05.000Z',
+        inputSize: 'ls -la'.length,
+        isError: false,
+        outputSize: 'file1\nfile2\n'.length,
+        target: 'ls -la',
+      },
+    ]);
+  });
+
+  it('marks a nonzero exit code as an error', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:05.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_begin',
+          call_id: 'call-2',
+          turn_id: 'turn-1',
+          command: ['false'],
+          cwd: '/home/me/proj',
+          parsed_cmd: [],
+        },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:06.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_end',
+          call_id: 'call-2',
+          turn_id: 'turn-1',
+          command: ['false'],
+          cwd: '/home/me/proj',
+          parsed_cmd: [],
+          stdout: '',
+          stderr: '',
+          aggregated_output: '',
+          exit_code: 1,
+          duration: '0.01s',
+          formatted_output: '',
+          status: 'completed',
+        },
+      }),
+    ].join('\n');
+
+    expect(parseTranscriptToolCalls(jsonl)[0]?.isError).toBe(true);
+  });
+
+  it('pairs a patch_apply_begin/end into one apply_patch ToolCallRecord', () => {
+    const jsonl = [
+      SESSION_META,
+      line({
+        timestamp: '2026-07-14T10:00:07.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'patch_apply_begin',
+          call_id: 'call-3',
+          turn_id: 'turn-2',
+          auto_approved: true,
+          changes: { '/home/me/proj/notes.txt': { type: 'update' } },
+        },
+      }),
+      line({
+        timestamp: '2026-07-14T10:00:08.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'patch_apply_end',
+          call_id: 'call-3',
+          turn_id: 'turn-2',
+          stdout: 'applied',
+          stderr: '',
+          success: true,
+          changes: { '/home/me/proj/notes.txt': { type: 'update' } },
+          status: 'completed',
+        },
+      }),
+    ].join('\n');
+
+    const calls = parseTranscriptToolCalls(jsonl);
+    expect(calls).toEqual([
+      {
+        sessionId: 'sess-1',
+        toolUseId: 'call-3',
+        toolName: 'apply_patch',
+        runKey: 'turn-2',
+        occurredAt: '2026-07-14T10:00:07.000Z',
+        inputSize: '/home/me/proj/notes.txt'.length,
+        isError: false,
+        outputSize: 'applied'.length,
+        target: '/home/me/proj/notes.txt',
+      },
+    ]);
+  });
+
+  it('drops calls before session_meta has been seen (unattributable)', () => {
+    const jsonl = line({
+      timestamp: '2026-07-14T10:00:06.000Z',
+      type: 'event_msg',
+      payload: {
+        type: 'exec_command_end',
+        call_id: 'orphan',
+        turn_id: 'turn-1',
+        command: ['ls'],
+        cwd: '/tmp',
+        parsed_cmd: [],
+        stdout: '',
+        stderr: '',
+        aggregated_output: '',
+        exit_code: 0,
+        duration: '0s',
+        formatted_output: '',
+        status: 'completed',
+      },
+    });
+    expect(parseTranscriptToolCalls(jsonl)).toEqual([]);
+  });
+});
+
+describe('peekSessionOriginator — cheap live-hook header read', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-peek-originator-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the originator off a real rollout file (terminal CLI)', () => {
+    const file = join(dir, 'rollout.jsonl');
+    writeFileSync(file, `${SESSION_META}\n${tokenCountLine('2026-07-14T10:00:04.000Z')}\n`);
+    expect(peekSessionOriginator(file)).toBe('codex_cli_rs');
+  });
+
+  it('reads a distinct originator for a ChatGPT-desktop-hosted session', () => {
+    const file = join(dir, 'rollout.jsonl');
+    const desktopSessionMeta = line({
+      timestamp: '2026-07-14T10:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        session_id: 'sess-2',
+        id: 'thread-2',
+        timestamp: '2026-07-14T10:00:00.000Z',
+        cwd: '/home/me/proj',
+        originator: 'codex_desktop',
+        cli_version: '0.140.0',
+      },
+    });
+    writeFileSync(file, `${desktopSessionMeta}\n`);
+    expect(peekSessionOriginator(file)).toBe('codex_desktop');
+  });
+
+  it('returns undefined for a missing file (fail-open)', () => {
+    expect(peekSessionOriginator(join(dir, 'does-not-exist.jsonl'))).toBeUndefined();
+  });
+
+  it('returns undefined when the first line is not session_meta', () => {
+    const file = join(dir, 'rollout.jsonl');
+    writeFileSync(file, `${tokenCountLine('2026-07-14T10:00:04.000Z')}\n`);
+    expect(peekSessionOriginator(file)).toBeUndefined();
+  });
+
+  it('returns undefined without throwing on garbage content', () => {
+    const file = join(dir, 'rollout.jsonl');
+    writeFileSync(file, 'not json at all\n');
+    expect(() => peekSessionOriginator(file)).not.toThrow();
+    expect(peekSessionOriginator(file)).toBeUndefined();
+  });
+});

--- a/plugins/codex/test/history/usage.test.ts
+++ b/plugins/codex/test/history/usage.test.ts
@@ -1,0 +1,581 @@
+// Adapted from plugins/claude-code/src/history/usage.test.ts, restructured
+// around Codex's simpler model: `turn_id` is stamped directly on each event
+// (see transcripts.ts), so there is no Claude-Code-style uuid→promptId join
+// to exercise here — the run_key assertions instead confirm each usage/tool
+// record carries its OWN turn_id straight through.
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  reconcileHistory,
+  reconcileSession,
+  reconcileSessionTail,
+} from '../../src/history/usage.ts';
+
+function config(dataDir: string): PluginConfig {
+  return {
+    settings: {
+      specVersion: 3,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'full',
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'openai' },
+  };
+}
+
+const SESSION = 'sess-abc';
+
+// The fixtures below carry absolute timestamps, but reconcileHistory's window
+// is relative to `now` — left unpinned, the fixtures age out of the window and
+// every backfill test silently starts reconciling zero records.
+const FIXTURE_NOW = Date.parse('2026-06-21T00:00:00.000Z');
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+const sessionMeta = line({
+  timestamp: '2026-06-20T10:00:00.000Z',
+  type: 'session_meta',
+  payload: {
+    session_id: SESSION,
+    id: 'thread-1',
+    timestamp: '2026-06-20T10:00:00.000Z',
+    cwd: '/Users/me/proj',
+    originator: 'codex_cli_rs',
+    cli_version: '0.140.0',
+  },
+});
+
+const turnContext = line({
+  timestamp: '2026-06-20T10:00:01.000Z',
+  type: 'turn_context',
+  payload: { turn_id: 'turn-1', cwd: '/Users/me/proj', model: 'gpt-5-codex' },
+});
+
+function tokenCount(
+  timestamp: string,
+  usage: { input: number; output: number; cached?: number },
+): string {
+  return line({
+    timestamp,
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: {},
+        last_token_usage: {
+          input_tokens: usage.input,
+          output_tokens: usage.output,
+          cached_input_tokens: usage.cached ?? 0,
+        },
+        model_context_window: 200000,
+      },
+      rate_limits: null,
+    },
+  });
+}
+
+// One turn: session_meta + turn_context + a single token_count event.
+function transcript(): string {
+  return [
+    sessionMeta,
+    turnContext,
+    tokenCount('2026-06-20T10:00:05.000Z', { input: 100, output: 50 }),
+  ].join('\n');
+}
+
+function seed(root: string, jsonl: string): void {
+  const dir = join(root, '2026', '06', '20');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `rollout-${SESSION}.jsonl`), jsonl);
+}
+
+function sessionAttrs(dataDir: string, sessionId: string): Record<string, unknown> | undefined {
+  const db = new DatabaseSync(join(dataDir, 'aka.db'));
+  try {
+    const row = db
+      .prepare("SELECT attributes FROM audit_events WHERE event_type = 'session' AND id = :id")
+      .get({ id: sessionId }) as { attributes: string } | undefined;
+    return row ? (JSON.parse(row.attributes) as Record<string, unknown>) : undefined;
+  } finally {
+    db.close();
+  }
+}
+
+function rows(dataDir: string): {
+  count: number;
+  attrsByOrdinal: Record<string, unknown>[];
+  sessionExists: boolean;
+} {
+  const db = new DatabaseSync(join(dataDir, 'aka.db'));
+  try {
+    const calls = db
+      .prepare("SELECT id, started_at, attributes FROM audit_events WHERE event_type = 'llm_call'")
+      .all() as { id: string; started_at: number; attributes: string }[];
+    const attrsByOrdinal = calls.map((c) => JSON.parse(c.attributes) as Record<string, unknown>);
+    const session = db
+      .prepare("SELECT id FROM audit_events WHERE event_type = 'session' AND id = :id")
+      .get({ id: SESSION });
+    return { count: calls.length, attrsByOrdinal, sessionExists: session != null };
+  } finally {
+    db.close();
+  }
+}
+
+describe('reconcileHistory — backfill', () => {
+  let dataDir: string;
+  let transcripts: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'aka-usage-data-'));
+    transcripts = mkdtempSync(join(tmpdir(), 'aka-usage-tx-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(transcripts, { recursive: true, force: true });
+  });
+
+  it('writes one llm_call per token_count event and a session root', async () => {
+    seed(transcripts, transcript());
+    const summary = await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+
+    expect(summary.sessions).toBe(1);
+    expect(summary.llmCalls).toBe(1);
+    expect(summary.skipped).toBe(0);
+
+    const r = rows(dataDir);
+    expect(r.count).toBe(1);
+    expect(r.sessionExists).toBe(true);
+  });
+
+  it('is idempotent — re-running yields the same row count (deterministic ids + INSERT OR IGNORE)', async () => {
+    seed(transcripts, transcript());
+    const opts = { dir: transcripts, now: FIXTURE_NOW };
+
+    const first = await reconcileHistory(config(dataDir), opts);
+    expect(first.llmCalls).toBe(1);
+    expect(rows(dataDir).count).toBe(1);
+
+    const second = await reconcileHistory(config(dataDir), opts);
+    expect(second.llmCalls).toBe(1);
+    expect(rows(dataDir).count).toBe(1);
+  });
+
+  it('run_key is the turn_id stamped on the event, and the model comes from turn_context', async () => {
+    seed(transcripts, transcript());
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+
+    const attrs = rows(dataDir).attrsByOrdinal[0];
+    expect(attrs).toMatchObject({
+      model: 'gpt-5-codex',
+      provider: 'openai', // heuristic from `gpt-…` (reconciler-created root)
+      input_tokens: 100,
+      output_tokens: 50,
+      run_key: 'turn-1',
+    });
+  });
+
+  it('stamps harness_interface from session_meta.originator onto the session root (backfill)', async () => {
+    seed(transcripts, transcript());
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+    expect(sessionAttrs(dataDir, SESSION)?.harness_interface).toBe('codex_cli_rs');
+  });
+
+  it('distinguishes a ChatGPT-desktop-hosted session from a terminal one via harness_interface', async () => {
+    const desktopSessionMeta = line({
+      timestamp: '2026-06-20T10:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        session_id: SESSION,
+        id: 'thread-1',
+        timestamp: '2026-06-20T10:00:00.000Z',
+        cwd: '/Users/me/proj',
+        originator: 'codex_desktop',
+        cli_version: '0.140.0',
+      },
+    });
+    seed(
+      transcripts,
+      [
+        desktopSessionMeta,
+        turnContext,
+        tokenCount('2026-06-20T10:00:05.000Z', { input: 100, output: 50 }),
+      ].join('\n'),
+    );
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+    expect(sessionAttrs(dataDir, SESSION)?.harness_interface).toBe('codex_desktop');
+  });
+
+  it('drops an all-zero token_count event (no billable turn)', async () => {
+    seed(
+      transcripts,
+      [
+        sessionMeta,
+        turnContext,
+        tokenCount('2026-06-20T10:00:05.000Z', { input: 0, output: 0 }),
+      ].join('\n'),
+    );
+    const summary = await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+    expect(summary.sessions).toBe(0);
+    expect(summary.llmCalls).toBe(0);
+  });
+});
+
+describe('reconcileHistory — tool calls', () => {
+  let dataDir: string;
+  let transcripts: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'aka-usage-tc-data-'));
+    transcripts = mkdtempSync(join(tmpdir(), 'aka-usage-tc-tx-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(transcripts, { recursive: true, force: true });
+  });
+
+  function toolCallRow(dir: string): {
+    parentId: string;
+    rootId: string;
+    attrs: Record<string, unknown>;
+  } {
+    const db = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      const row = db
+        .prepare(
+          "SELECT parent_id, root_session_id, attributes FROM audit_events WHERE event_type = 'tool_call'",
+        )
+        .get() as { parent_id: string; root_session_id: string; attributes: string };
+      return {
+        parentId: row.parent_id,
+        rootId: row.root_session_id,
+        attrs: JSON.parse(row.attributes) as Record<string, unknown>,
+      };
+    } finally {
+      db.close();
+    }
+  }
+
+  function toolCallCount(dir: string): number {
+    const db = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      return (
+        db
+          .prepare("SELECT COUNT(*) AS n FROM audit_events WHERE event_type = 'tool_call'")
+          .get() as { n: number }
+      ).n;
+    } finally {
+      db.close();
+    }
+  }
+
+  function shellTranscript(): string {
+    return [
+      sessionMeta,
+      turnContext,
+      tokenCount('2026-06-20T10:00:04.000Z', { input: 100, output: 50 }),
+      line({
+        timestamp: '2026-06-20T10:00:05.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_begin',
+          call_id: 'call-1',
+          turn_id: 'turn-1',
+          command: ['echo', 'hi'],
+          cwd: '/Users/me/proj',
+          parsed_cmd: [],
+        },
+      }),
+      line({
+        timestamp: '2026-06-20T10:00:06.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_end',
+          call_id: 'call-1',
+          turn_id: 'turn-1',
+          command: ['echo', 'hi'],
+          cwd: '/Users/me/proj',
+          parsed_cmd: [],
+          stdout: 'hi\n',
+          stderr: '',
+          aggregated_output: 'hi\n',
+          exit_code: 0,
+          duration: '0.01s',
+          formatted_output: 'hi\n',
+          status: 'completed',
+        },
+      }),
+    ].join('\n');
+  }
+
+  it('writes one tool_call per exec_command pair, parented on the session root, with run_key', async () => {
+    seed(transcripts, shellTranscript());
+    const summary = await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+
+    expect(summary.toolCalls).toBe(1);
+    const { parentId, rootId, attrs } = toolCallRow(dataDir);
+    expect(parentId).toBe(SESSION);
+    expect(rootId).toBe(SESSION);
+    expect(attrs).toMatchObject({
+      tool_name: 'shell',
+      tool_use_id: 'call-1',
+      is_error: false,
+      run_key: 'turn-1',
+      target: 'echo hi',
+    });
+    expect(attrs.output_size).toBe('hi\n'.length);
+  });
+
+  it('is idempotent — re-running yields the same tool_call count', async () => {
+    seed(transcripts, shellTranscript());
+    const opts = { dir: transcripts, now: FIXTURE_NOW };
+
+    await reconcileHistory(config(dataDir), opts);
+    expect(toolCallCount(dataDir)).toBe(1);
+
+    const second = await reconcileHistory(config(dataDir), opts);
+    expect(second.toolCalls).toBe(1);
+    expect(toolCallCount(dataDir)).toBe(1);
+  });
+
+  // The AWS key is ASSEMBLED at runtime so this source has no literal secret.
+  const AWS_KEY = ['AKIA', 'IOSFODNN7', 'EXAMPLE'].join('');
+  function secretTranscript(): string {
+    return [
+      sessionMeta,
+      turnContext,
+      tokenCount('2026-06-20T10:00:04.000Z', { input: 100, output: 50 }),
+      line({
+        timestamp: '2026-06-20T10:00:05.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_begin',
+          call_id: 'call-sec',
+          turn_id: 'turn-1',
+          command: ['aws', 'configure', 'set', 'aws_access_key_id', AWS_KEY],
+          cwd: '/Users/me/proj',
+          parsed_cmd: [],
+        },
+      }),
+      line({
+        timestamp: '2026-06-20T10:00:06.000Z',
+        type: 'event_msg',
+        payload: {
+          type: 'exec_command_end',
+          call_id: 'call-sec',
+          turn_id: 'turn-1',
+          command: ['aws', 'configure', 'set', 'aws_access_key_id', AWS_KEY],
+          cwd: '/Users/me/proj',
+          parsed_cmd: [],
+          stdout: '',
+          stderr: '',
+          aggregated_output: '',
+          exit_code: 0,
+          duration: '0.01s',
+          formatted_output: '',
+          status: 'completed',
+        },
+      }),
+    ].join('\n');
+  }
+
+  function inspectionRows(dir: string): {
+    eventType: string;
+    category: string;
+    maskedMatch: string;
+    target: string;
+  }[] {
+    const db = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      return db
+        .prepare(
+          `SELECT ae.event_type AS eventType, d.category AS category,
+                  f.masked_match AS maskedMatch,
+                  json_extract(ae.attributes,'$.target') AS target
+             FROM inspection_findings f
+             JOIN audit_events ae          ON ae.id = f.audit_event_id
+             JOIN inspection_definitions d ON d.id = f.inspection_definition_id`,
+        )
+        .all() as { eventType: string; category: string; maskedMatch: string; target: string }[];
+    } finally {
+      db.close();
+    }
+  }
+
+  it('writes an inspection_finding for a secret in a tool target, linked to the tool_call', async () => {
+    seed(transcripts, secretTranscript());
+    await reconcileHistory(config(dataDir), { dir: transcripts, now: FIXTURE_NOW });
+
+    const findings = inspectionRows(dataDir);
+    expect(findings.length).toBeGreaterThan(0);
+    const f = findings[0];
+    expect(f).toBeDefined();
+    expect(f?.eventType).toBe('tool_call');
+    expect(f?.category).toBeTruthy();
+    expect(f?.maskedMatch).not.toContain(AWS_KEY);
+    expect(f?.target).not.toContain(AWS_KEY);
+    expect(f?.target).toContain('[REDACTED');
+  });
+
+  it('inspection findings are idempotent (content-addressed) across re-runs', async () => {
+    seed(transcripts, secretTranscript());
+    const opts = { dir: transcripts, now: FIXTURE_NOW };
+    await reconcileHistory(config(dataDir), opts);
+    const first = inspectionRows(dataDir).length;
+    await reconcileHistory(config(dataDir), opts);
+    expect(inspectionRows(dataDir).length).toBe(first);
+  });
+});
+
+describe('reconcileSessionTail — the live per-turn path', () => {
+  let dataDir: string;
+  let transcriptPath: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'aka-usage-tail-data-'));
+    const txDir = mkdtempSync(join(tmpdir(), 'aka-usage-tail-tx-'));
+    transcriptPath = join(txDir, `rollout-${SESSION}.jsonl`);
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+    rmSync(transcriptPath, { recursive: true, force: true });
+  });
+
+  const execBegin = line({
+    timestamp: '2026-06-20T10:00:05.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'exec_command_begin',
+      call_id: 'call-1',
+      turn_id: 'turn-1',
+      command: ['echo', 'hi'],
+      cwd: '/Users/me/proj',
+      parsed_cmd: [],
+    },
+  });
+  const execEnd = line({
+    timestamp: '2026-06-20T10:00:06.000Z',
+    type: 'event_msg',
+    payload: {
+      type: 'exec_command_end',
+      call_id: 'call-1',
+      turn_id: 'turn-1',
+      command: ['echo', 'hi'],
+      cwd: '/Users/me/proj',
+      parsed_cmd: [],
+      stdout: 'hi\n',
+      stderr: '',
+      aggregated_output: 'hi\n',
+      exit_code: 0,
+      duration: '0.01s',
+      formatted_output: 'hi\n',
+      status: 'completed',
+    },
+  });
+
+  function toolCallAttrs(dir: string): Record<string, unknown> | undefined {
+    const db = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      const row = db
+        .prepare("SELECT attributes FROM audit_events WHERE event_type = 'tool_call'")
+        .get() as { attributes: string } | undefined;
+      return row ? (JSON.parse(row.attributes) as Record<string, unknown>) : undefined;
+    } finally {
+      db.close();
+    }
+  }
+
+  it('writes a tool_call when exec_command_begin/end land in one tail chunk', async () => {
+    const usageLine = tokenCount('2026-06-20T10:00:04.000Z', { input: 100, output: 50 });
+    writeFileSync(
+      transcriptPath,
+      `${sessionMeta}\n${turnContext}\n${usageLine}\n${execBegin}\n${execEnd}\n`,
+    );
+
+    const result = await reconcileSessionTail(config(dataDir), SESSION, transcriptPath);
+    expect(result.toolCalls).toBe(1);
+    expect(result.llmCalls).toBe(1);
+
+    const attrs = toolCallAttrs(dataDir);
+    expect(attrs).toMatchObject({
+      tool_name: 'shell',
+      tool_use_id: 'call-1',
+      is_error: false,
+      run_key: 'turn-1',
+      target: 'echo hi',
+    });
+    expect(attrs?.output_size).toBe('hi\n'.length);
+  });
+
+  it('a second tail pass consumes only the newly-appended turn', async () => {
+    const usageLine = tokenCount('2026-06-20T10:00:04.000Z', { input: 100, output: 50 });
+    writeFileSync(transcriptPath, `${sessionMeta}\n${turnContext}\n${usageLine}\n`);
+    const first = await reconcileSessionTail(config(dataDir), SESSION, transcriptPath);
+    expect(first.llmCalls).toBe(1);
+
+    appendFileSync(transcriptPath, `${execBegin}\n${execEnd}\n`);
+    const second = await reconcileSessionTail(config(dataDir), SESSION, transcriptPath);
+    expect(second.llmCalls).toBe(0); // no new token_count event
+    expect(second.toolCalls).toBe(1); // the new turn's tool call
+  });
+});
+
+describe('reconcileSession — FK-safety & provider inheritance', () => {
+  let dataDir: string;
+  beforeEach(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'aka-usage-fk-'));
+  });
+  afterEach(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  it('creates inventory + root then inserts leaves when SessionStart never ran (no FK error)', async () => {
+    const gateway = resolveDataGateway(config(dataDir));
+    try {
+      const { parseTranscriptUsage } = await import('../../src/history/transcripts.ts');
+      const records = parseTranscriptUsage(transcript());
+      const result = await reconcileSession(gateway, SESSION, records);
+      expect(result.llmCalls).toBe(1);
+      expect(result.skipped).toBe(0);
+    } finally {
+      await gateway.close();
+    }
+    const r = rows(dataDir);
+    expect(r.sessionExists).toBe(true);
+    expect(r.count).toBe(1);
+  });
+
+  it('inherits a SessionStart-written provider (gateway) onto the leaves', async () => {
+    const gateway = resolveDataGateway(config(dataDir));
+    try {
+      await gateway.ensureInventory({
+        host: { objectType: 'host', identityKey: 'm1', attributes: {} },
+      });
+      await gateway.recordAuditEvent({
+        id: SESSION,
+        eventType: 'session',
+        startedAt: '2026-06-20T09:59:00.000Z',
+        attributes: { provider: 'gateway' },
+      });
+      const { parseTranscriptUsage } = await import('../../src/history/transcripts.ts');
+      await reconcileSession(gateway, SESSION, parseTranscriptUsage(transcript()));
+    } finally {
+      await gateway.close();
+    }
+    // The model id (`gpt-5-codex`) heuristically resolves to 'openai', but the
+    // root's env-provider wins by first-write — the leaf reads 'gateway' back.
+    expect(rows(dataDir).attrsByOrdinal[0]?.provider).toBe('gateway');
+  });
+});

--- a/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
+++ b/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
@@ -18,7 +18,9 @@ import { describe, expect, it } from 'vitest';
 
 import type { PreToolUseOutput, ScannableField } from '../../src/hooks/pre-tool-use-decision.ts';
 import {
+  decideInputPointerDeny,
   decidePreToolUse,
+  denyPointerMessage,
   EXECUTABLE_REDACT_NOTE,
   SCANNABLE_FIELDS,
 } from '../../src/hooks/pre-tool-use-decision.ts';
@@ -297,5 +299,43 @@ describe('incident regression — the seed-cleanup DELETE, end to end', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+});
+
+// A shape-valid vault pointer (RFC 4648 base32 segments: 2-char key version,
+// 26-char pointer id, 16-char tag) — pointerTokenScanner matches on shape, so
+// any well-formed token exercises the deny.
+const POINTER = `[[aka:secret:AA.${'A'.repeat(26)}.${'A'.repeat(16)}]]`;
+
+describe('decideInputPointerDeny', () => {
+  it('denies a pointer in an executable field, in every consent state', () => {
+    const output = decideInputPointerDeny('Bash', { command: `echo ${POINTER}` }, [BASH_COMMAND]);
+    expect(output?.hookSpecificOutput.permissionDecision).toBe('deny');
+    const reason = output?.hookSpecificOutput.permissionDecisionReason ?? '';
+    expect(reason).toBe(denyPointerMessage('Bash'));
+    // The reason tells the user how to proceed without ever suggesting the
+    // plugin could substitute the value itself — the resolve path it names is
+    // the audited CLI reveal, not an exception grant this harness cannot honor.
+    expect(reason).toContain('aka vault show');
+    expect(reason).not.toContain('aka exception approve');
+  });
+
+  it('lets a pointer in a NON-executable field pass to the normal scan', () => {
+    // apply_patch content is durable text, not something the host executes —
+    // a pointer there is data, decided by the regular capture pipeline.
+    expect(
+      decideInputPointerDeny('apply_patch', { input: `body ${POINTER}` }, [APPLY_PATCH_INPUT]),
+    ).toBeNull();
+  });
+
+  it('ignores clean commands and lookalike tokens with an invented category', () => {
+    expect(decideInputPointerDeny('Bash', { command: 'ls -la' }, [BASH_COMMAND])).toBeNull();
+    // The category alternation is pinned to DetectionCategory members: a
+    // lookalike must not trip the deny (it cannot reach a de-reference path
+    // anywhere, so denying it would be pure friction).
+    const lookalike = `[[aka:bogus:AA.${'A'.repeat(26)}.${'A'.repeat(16)}]]`;
+    expect(
+      decideInputPointerDeny('Bash', { command: `echo ${lookalike}` }, [BASH_COMMAND]),
+    ).toBeNull();
   });
 });

--- a/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
+++ b/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
@@ -1,0 +1,301 @@
+// Tests the pure PreToolUse decision module directly — NEVER via the hook
+// entry file (src/hooks/*.ts run main() on import and hang vitest collection).
+//
+// The decision logic here is ported verbatim from
+// plugins/claude-code/src/hooks/pre-tool-use-decision.test.ts (same
+// hookSpecificOutput shape, same escalate-redact-on-executable-field rule);
+// only SCANNABLE_FIELDS differs, so this suite exercises it against Codex's
+// own Bash/apply_patch fields instead of Claude Code's Bash/Write/Edit/WebFetch.
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { CaptureResult, DataGateway } from '@akasecurity/plugin-sdk';
+import { createPluginRuntime } from '@akasecurity/plugin-sdk';
+import type { PolicyBundle, WorkspaceSettings } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import type { PreToolUseOutput, ScannableField } from '../../src/hooks/pre-tool-use-decision.ts';
+import {
+  decidePreToolUse,
+  EXECUTABLE_REDACT_NOTE,
+  SCANNABLE_FIELDS,
+} from '../../src/hooks/pre-tool-use-decision.ts';
+
+const IP = ['45', '79', '142', '6'].join('.');
+const EMAIL = ['user1', 'example.com'].join('@');
+
+const BASH_COMMAND: ScannableField = { field: 'command', executable: true };
+const APPLY_PATCH_INPUT: ScannableField = { field: 'input', executable: false };
+
+type Finding = CaptureResult['findings'][number];
+
+function finding(ruleId: string, rawMatch: string, text: string): Finding {
+  const start = text.indexOf(rawMatch);
+  return {
+    ruleId,
+    category: 'pii',
+    severity: 'low',
+    span: { start, end: start + rawMatch.length },
+    rawMatch,
+    confidence: 0.9,
+  };
+}
+
+function redactResult(
+  text: string,
+  ruleId: string,
+  rawMatch: string,
+  reference?: string,
+): CaptureResult {
+  return {
+    action: 'redact',
+    text: text.replace(rawMatch, '[REDACTED:PII]'),
+    findings: [finding(ruleId, rawMatch, text)],
+    ...(reference ? { blockedReferences: [{ reference, ruleId, maskedValue: '4******6' }] } : {}),
+  };
+}
+
+function denyReason(output: PreToolUseOutput | null): string {
+  if (output === null || !('hookSpecificOutput' in output)) {
+    throw new Error('expected a hookSpecificOutput decision');
+  }
+  const decision = output.hookSpecificOutput;
+  if (decision.permissionDecision !== 'deny') {
+    throw new Error(`expected deny, got ${decision.permissionDecision}`);
+  }
+  return decision.permissionDecisionReason;
+}
+
+describe('SCANNABLE_FIELDS', () => {
+  it('marks Bash command as executable and apply_patch input as stored', () => {
+    // The executable flag is the whole fix — flipping one silently reopens
+    // in-place rewriting of command text (or breaks stored-text redaction).
+    expect(SCANNABLE_FIELDS).toEqual({
+      Bash: [{ field: 'command', executable: true }],
+      apply_patch: [{ field: 'input', executable: false }],
+    });
+  });
+});
+
+describe('decidePreToolUse — redact on executable text escalates to deny', () => {
+  const COMMAND = `psql -c "DELETE FROM share_destination WHERE host = '${IP}';"`;
+
+  it('denies the Bash call instead of rewriting the command', () => {
+    const result = redactResult(COMMAND, 'core-pii/ip-address', IP, '3f2a91');
+    const output = decidePreToolUse('Bash', { command: COMMAND }, [{ spec: BASH_COMMAND, result }]);
+
+    const reason = denyReason(output);
+    expect(reason).toContain('AKA blocked this Bash call — flagged core-pii/ip-address');
+    expect(reason).toContain(EXECUTABLE_REDACT_NOTE);
+    expect(reason).toContain('aka exception approve 3f2a91');
+    expect(JSON.stringify(output)).not.toContain('updatedInput');
+    expect(JSON.stringify(output)).not.toContain('[REDACTED');
+  });
+
+  it('a plain block (no escalation) carries no escalation note', () => {
+    const blocked: CaptureResult = {
+      action: 'block',
+      text: null,
+      findings: [finding('secrets-infra/db-connection-string', IP, COMMAND)],
+    };
+    const reason = denyReason(
+      decidePreToolUse('Bash', { command: COMMAND }, [{ spec: BASH_COMMAND, result: blocked }]),
+    );
+    expect(reason).not.toContain(EXECUTABLE_REDACT_NOTE);
+  });
+});
+
+describe('decidePreToolUse — apply_patch stored text keeps true redaction', () => {
+  it('apply_patch input: allow with the redacted field in updatedInput', () => {
+    const input = `*** Begin Patch\n*** Update File: notes.txt\n+support = ${EMAIL}\n*** End Patch`;
+    const result = redactResult(input, 'core-pii/email', EMAIL, '9c04d7');
+    const output = decidePreToolUse('apply_patch', { input }, [
+      { spec: APPLY_PATCH_INPUT, result },
+    ]);
+
+    if (output === null || !('hookSpecificOutput' in output) || !('systemMessage' in output)) {
+      throw new Error('expected an allow decision with updatedInput');
+    }
+    expect(output.hookSpecificOutput.permissionDecision).toBe('allow');
+    expect(output.hookSpecificOutput.updatedInput).toEqual({
+      input: input.replace(EMAIL, '[REDACTED:PII]'),
+    });
+    expect(output.systemMessage).toBe(
+      'AKA redacted sensitive content in apply_patch input — flagged core-pii/email.' +
+        ' To allow this exact value intentionally, run: aka exception approve 9c04d7.',
+    );
+  });
+
+  it('warn stays a systemMessage; no findings stays silent', () => {
+    const text = 'uses share_destination table';
+    const warned: CaptureResult = {
+      action: 'warn',
+      text,
+      findings: [finding('core-code-context/db-table-name', 'share_destination', text)],
+    };
+    const output = decidePreToolUse('Bash', { command: text }, [
+      { spec: BASH_COMMAND, result: warned },
+    ]);
+    expect(output).toEqual({
+      systemMessage:
+        'AKA flagged sensitive content in Bash input (core-code-context/db-table-name).',
+    });
+
+    const clean: CaptureResult = { action: 'log', text, findings: [] };
+    expect(
+      decidePreToolUse('Bash', { command: text }, [{ spec: BASH_COMMAND, result: clean }]),
+    ).toBeNull();
+  });
+});
+
+// ————————————————————————————————————————————————————————————————————————————
+// End-to-end through the REAL runtime, with the enforcement posture pinned
+// explicitly (a `pii` category policy set to `redact`, exactly as an
+// operator's own policy would be) — cold-start defaults observe-first, so a
+// test relying on them would prove nothing about the escalation path. Mirrors
+// the incident regression in plugins/claude-code/src/hooks/
+// pre-tool-use-decision.test.ts, adapted to Codex's Bash field: while
+// clearing seed data, a Bash `docker exec … psql -c` command inserted five
+// host strings and deleted rows matching them; the pii/ip-address rule
+// matched the lone IP literal, the hook rewrote the command in place, and the
+// spliced `[REDACTED:PII]` executed — deleting only 4 of the 5 rows. Masking
+// executable text changes what runs, so redact must escalate to deny here.
+// The sensitive-looking literals are ASSEMBLED AT RUNTIME (see the IP/EMAIL
+// consts above) so this repo's own scanning never rewrites the fixtures.
+
+function settings(): WorkspaceSettings {
+  return {
+    specVersion: 1,
+    runMode: 'standalone',
+    policy: 'redact',
+    historicalAccess: 'session-only',
+    dataSharesInPlace: true,
+    vaultKeyCustody: 'file',
+    vaultInlineReveal: 'masked',
+  };
+}
+
+function bundle(): PolicyBundle {
+  return {
+    version: 'test',
+    policies: [
+      {
+        id: randomUUID(),
+        scope: 'global',
+        target: { category: 'pii' },
+        action: 'redact',
+        enabled: true,
+      },
+    ],
+    rules: [],
+    customKeywords: [],
+    fetchedAt: new Date().toISOString(),
+  };
+}
+
+// A fake gateway mirroring @akasecurity/plugin-sdk's runtime tests: fixed
+// policy bundle, no-op writes.
+function fakeGateway(b: PolicyBundle): DataGateway {
+  return {
+    recordCapture: () => Promise.resolve(),
+    ensureInventory: () => Promise.resolve({}),
+    recordAuditEvent: () => Promise.resolve(),
+    recordLlmCall: () => Promise.resolve(),
+    recordLlmCalls: () => Promise.resolve(),
+    recordToolCalls: () => Promise.resolve(),
+    recordConfigScan: () => Promise.resolve(),
+    configInventoryReport: () =>
+      Promise.resolve({
+        scannedAt: null,
+        skills: [],
+        hooks: [],
+        mcpServers: [],
+        configFiles: [],
+        topics: [],
+      }),
+    readSessionProvider: () => Promise.resolve(undefined),
+    facets: () => Promise.resolve({ hosts: [], harnesses: [], osVersions: [], projects: [] }),
+    getPolicyBundle: () => Promise.resolve(b),
+    consumeException: () => Promise.resolve(false),
+    recordBlockedDetection: () => Promise.resolve(),
+    recentFindings: () => Promise.resolve([]),
+    healthSummary: () =>
+      Promise.resolve({
+        findings: 0,
+        byAction: {} as never,
+        bySeverity: { critical: 0, high: 0, medium: 0, low: 0 },
+        coverage: 0,
+      }),
+    activityByDay: () => Promise.resolve([]),
+    tokenReports: () => Promise.resolve([]),
+    knownContentHashes: () => Promise.resolve(new Set<string>()),
+    scanLedger: () => Promise.resolve(new Map()),
+    recordScanned: () => Promise.resolve(),
+    openAtRestKeysForPath: () => Promise.resolve([]),
+    resolvedAtRestKeysForPath: () => Promise.resolve([]),
+    insertResolution: () => Promise.resolve(),
+    getRuleProbeVerdict: () => Promise.resolve(undefined),
+    setRuleProbeVerdict: () => Promise.resolve(),
+    recordProjectEgress: () =>
+      Promise.resolve({
+        destinations: 0,
+        endpoints: 0,
+        callSites: 0,
+        truncated: false,
+        droppedFiles: [],
+      }),
+    close: () => Promise.resolve(),
+  };
+}
+
+describe('incident regression — the seed-cleanup DELETE, end to end', () => {
+  const INCIDENT_COMMAND =
+    'docker exec aka-db psql -U aka -d aka -c "CREATE TEMP TABLE seed_hosts(host text); ' +
+    "INSERT INTO seed_hosts VALUES ('newrelic.com'),('stripe.com'),('datadoghq.com')," +
+    `('acme-partner.com'),('${IP}'); ` +
+    'DELETE FROM share_destination sd USING seed_hosts sh WHERE sd.host = sh.host;"';
+
+  it('runtime redacts the IP out of the SQL; the hook decision denies instead of executing it', async () => {
+    const rt = createPluginRuntime(fakeGateway(bundle()), settings());
+    const result = await rt.processText(INCIDENT_COMMAND);
+    await rt.close();
+
+    expect(result.action).toBe('redact');
+    expect(result.findings.map((f) => f.ruleId)).toContain('core-pii/ip-address');
+    expect(result.text).not.toContain(IP);
+    expect(result.text).toContain('[REDACTED:PII]');
+
+    const output = decidePreToolUse('Bash', { command: INCIDENT_COMMAND }, [
+      { spec: BASH_COMMAND, result },
+    ]);
+    const reason = denyReason(output);
+    expect(reason).toContain('core-pii/ip-address');
+    expect(reason).toContain(EXECUTABLE_REDACT_NOTE);
+    expect(JSON.stringify(output)).not.toContain('updatedInput');
+    expect(JSON.stringify(output)).not.toContain('[REDACTED');
+  });
+
+  it('drives the real ledger: the escalated deny surfaces a concrete approve ref', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'aka-codex-pre-tool-use-'));
+    try {
+      const rt = createPluginRuntime(fakeGateway(bundle()), settings(), { dataDir: dir });
+      const result = await rt.processText(INCIDENT_COMMAND);
+      await rt.close();
+
+      expect(result.action).toBe('redact');
+      const ref = result.blockedReferences?.[0]?.reference ?? '';
+      expect(ref).toMatch(/^[0-9a-f]{6}$/);
+
+      const output = decidePreToolUse('Bash', { command: INCIDENT_COMMAND }, [
+        { spec: BASH_COMMAND, result },
+      ]);
+      const reason = denyReason(output);
+      expect(reason).toContain(EXECUTABLE_REDACT_NOTE);
+      expect(reason).toContain(`aka exception approve ${ref}`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
+++ b/plugins/codex/test/hooks/pre-tool-use-decision.test.ts
@@ -23,6 +23,7 @@ import {
   denyPointerMessage,
   EXECUTABLE_REDACT_NOTE,
   SCANNABLE_FIELDS,
+  UNREDACTABLE_NOTE,
 } from '../../src/hooks/pre-tool-use-decision.ts';
 
 const IP = ['45', '79', '142', '6'].join('.');
@@ -106,6 +107,46 @@ describe('decidePreToolUse — redact on executable text escalates to deny', () 
       decidePreToolUse('Bash', { command: COMMAND }, [{ spec: BASH_COMMAND, result: blocked }]),
     );
     expect(reason).not.toContain(EXECUTABLE_REDACT_NOTE);
+  });
+});
+
+describe('decidePreToolUse — a redact carrying no text denies instead of allowing', () => {
+  // CaptureResult.text is `string | null`, so { action: 'redact', text: null }
+  // is protocol-legal. Allowing it emitted the ORIGINAL input back to Codex
+  // under the "AKA redacted sensitive content" systemMessage — the raw value
+  // sent, and the transcript claiming it was masked.
+  const PATCH = `*** Update File: notes.md\n+contact ${EMAIL}\n`;
+
+  const unredactable = (): CaptureResult => ({
+    action: 'redact',
+    text: null,
+    findings: [finding('core-pii/email-address', EMAIL, PATCH)],
+  });
+
+  it('denies the apply_patch call rather than passing the input through', () => {
+    const output = decidePreToolUse('apply_patch', { input: PATCH }, [
+      { spec: APPLY_PATCH_INPUT, result: unredactable() },
+    ]);
+
+    const reason = denyReason(output);
+    expect(reason).toContain('AKA blocked this apply_patch call — flagged core-pii/email-address');
+    expect(reason).toContain(UNREDACTABLE_NOTE);
+    expect(reason).not.toContain(EXECUTABLE_REDACT_NOTE);
+
+    const emitted = JSON.stringify(output);
+    expect(emitted).not.toContain('updatedInput');
+    expect(emitted).not.toContain('AKA redacted');
+    expect(emitted).not.toContain(EMAIL);
+  });
+
+  it('keeps the executable note when the field also executes', () => {
+    const reason = denyReason(
+      decidePreToolUse('Bash', { command: PATCH }, [
+        { spec: BASH_COMMAND, result: unredactable() },
+      ]),
+    );
+    expect(reason).toContain(EXECUTABLE_REDACT_NOTE);
+    expect(reason).not.toContain(UNREDACTABLE_NOTE);
   });
 });
 

--- a/plugins/codex/test/hooks/pre-tool-use.e2e.test.ts
+++ b/plugins/codex/test/hooks/pre-tool-use.e2e.test.ts
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { denyPointerMessage } from '../../src/hooks/pre-tool-use-decision.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/hooks -> plugins/codex
+const PLUGIN_ROOT = join(HERE, '..', '..');
+// The built entry (built before tests run — turbo's test task depends on
+// build). Driving it proves the emit ORDER, not just the exported decision.
+const HOOK_SCRIPT = join(PLUGIN_ROOT, 'scripts', 'pre-tool-use.js');
+
+interface HookRun {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Drive the real built hook against a throwaway ~/.aka home, feeding a Codex
+// PreToolUse payload on stdin. process.execPath is an absolute node path, so
+// the child needs no host PATH and inherits no ambient environment.
+function runHook(home: string, payload: unknown): HookRun {
+  try {
+    const stdout = execFileSync(process.execPath, [HOOK_SCRIPT], {
+      env: { HOME: home, USERPROFILE: home },
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  }
+}
+
+// A shape-valid vault pointer, never a minted one: 'secret' is a real
+// DetectionCategory and the three base32 segments carry the pinned widths
+// (2-char key version, 26-char pointer id, 16-char tag), so it matches
+// POINTER_TOKEN_PATTERN without any vault row existing anywhere.
+const POINTER = `[[aka:secret:AA.${'A'.repeat(26)}.${'A'.repeat(16)}]]`;
+
+// Replace the store the hook reads with unreadable bytes: not the
+// "SQLite format 3\0" header, so the first PRAGMA on open fails SQLITE_NOTADB.
+// The pointer deny below must fire anyway — it is decided BEFORE the store is
+// opened — while the secret scan cannot run and must fail open.
+function corruptStore(home: string): void {
+  const dataDir = join(home, '.aka', 'data');
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(join(dataDir, 'aka.db'), 'AKA corrupt-store fixture — not a database\n'.repeat(64));
+}
+
+function submitBash(home: string, command: string): HookRun {
+  return runHook(home, {
+    tool_name: 'Bash',
+    tool_input: { command },
+    session_id: 'sess-pointer-deny',
+    cwd: '/tmp',
+    hook_event_name: 'PreToolUse',
+  });
+}
+
+describe('pre-tool-use built hook — the pointer deny precedes the store open', () => {
+  it('denies a Bash command carrying a pointer even when the store cannot open', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ptu-pointer-'));
+    try {
+      corruptStore(home);
+      const run = submitBash(home, `echo ${POINTER}`);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as {
+        hookSpecificOutput?: { permissionDecision?: string; permissionDecisionReason?: string };
+      };
+      expect(payload.hookSpecificOutput?.permissionDecision).toBe('deny');
+      expect(payload.hookSpecificOutput?.permissionDecisionReason).toBe(denyPointerMessage('Bash'));
+      // A deny that depended on the store would have degraded to the
+      // store-unavailable warning instead — its absence pins the ordering.
+      expect(run.stdout).not.toContain('OFF for this session');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('stays fail-open on a clean command over the same corrupt store — never a deny', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ptu-failopen-'));
+    try {
+      corruptStore(home);
+      const run = submitBash(home, 'echo hello');
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('"permissionDecision":"deny"');
+      expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/codex/test/hooks/scan-response.test.ts
+++ b/plugins/codex/test/hooks/scan-response.test.ts
@@ -1,0 +1,110 @@
+// Tests the pure PostToolUse scan/emit module directly — NEVER via the hook
+// entry file. Pins the one real behavioral divergence from Claude Code: Codex
+// has no `updatedToolOutput` field, so both `block` AND `redact` outcomes
+// collapse into the same whole-result `decision:'block'` withhold — see the
+// module comment on scan-response.ts for why a partial in-place splice isn't
+// safe to attempt here.
+import type { CaptureResult } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { responseEmitPayload, scanResponseFields } from '../../src/hooks/scan-response.ts';
+import type { ScannableResponseField } from '../../src/hooks/tool-response.ts';
+
+type Finding = CaptureResult['findings'][number];
+
+function finding(ruleId: string, rawMatch: string, text: string): Finding {
+  const start = text.indexOf(rawMatch);
+  return {
+    ruleId,
+    category: 'secret',
+    severity: 'critical',
+    span: { start, end: start + rawMatch.length },
+    rawMatch,
+    confidence: 0.95,
+  };
+}
+
+describe('scanResponseFields + responseEmitPayload', () => {
+  it('a block outcome withholds the whole result via decision:block', async () => {
+    const stdout = 'AWS_SECRET_ACCESS_KEY=abcd1234';
+    const fields: ScannableResponseField[] = [{ path: ['stdout'], text: stdout }];
+    const capture = (): Promise<CaptureResult> =>
+      Promise.resolve({
+        action: 'block',
+        text: null,
+        findings: [finding('secrets/aws-secret-key', 'abcd1234', stdout)],
+        blockedReferences: [
+          { reference: 'aa11bb', ruleId: 'secrets/aws-secret-key', maskedValue: 'a******4' },
+        ],
+      });
+
+    const outcome = await scanResponseFields('Bash', fields, capture);
+    const payload = responseEmitPayload(outcome) as {
+      decision: string;
+      reason: string;
+      systemMessage: string;
+    };
+
+    expect(payload.decision).toBe('block');
+    expect(payload.reason).toContain('Bash output withheld');
+    expect(payload.reason).toContain('secrets/aws-secret-key');
+    // The reason string replaces the tool result — it must never leak the raw secret.
+    expect(payload.reason).not.toContain('abcd1234');
+    expect(payload.systemMessage).toContain('aka exception approve aa11bb');
+  });
+
+  it('a redact outcome ALSO withholds via decision:block (no partial splice on Codex)', async () => {
+    const stdout = 'db password is hunter2';
+    const fields: ScannableResponseField[] = [{ path: ['stdout'], text: stdout }];
+    const capture = (): Promise<CaptureResult> =>
+      Promise.resolve({
+        action: 'redact',
+        text: stdout.replace('hunter2', '[REDACTED:SECRET]'),
+        findings: [finding('secrets/generic-password', 'hunter2', stdout)],
+        blockedReferences: [
+          { reference: 'cc22dd', ruleId: 'secrets/generic-password', maskedValue: 'h*****2' },
+        ],
+      });
+
+    const outcome = await scanResponseFields('Bash', fields, capture);
+    const payload = responseEmitPayload(outcome) as { decision: string; reason: string };
+
+    // Escalated, exactly like PreToolUse's redact-on-executable rule — Codex
+    // has no field-level splice to fall back to.
+    expect(payload.decision).toBe('block');
+    expect(payload.reason).not.toContain('hunter2');
+    expect(payload.reason).not.toContain('[REDACTED:SECRET]');
+  });
+
+  it('a warn-only outcome passes the output through with a systemMessage', async () => {
+    const stdout = 'uses share_destination table';
+    const fields: ScannableResponseField[] = [{ path: ['stdout'], text: stdout }];
+    const capture = (): Promise<CaptureResult> =>
+      Promise.resolve({
+        action: 'warn',
+        text: stdout,
+        findings: [finding('core-code-context/db-table-name', 'share_destination', stdout)],
+      });
+
+    const outcome = await scanResponseFields('Bash', fields, capture);
+    const payload = responseEmitPayload(outcome);
+
+    expect(payload).toEqual({
+      systemMessage:
+        'AKA flagged sensitive content in Bash output (core-code-context/db-table-name).',
+    });
+  });
+
+  it('no findings emits nothing (pass through unchanged)', async () => {
+    const fields: ScannableResponseField[] = [{ path: ['stdout'], text: 'nothing interesting' }];
+    const capture = (): Promise<CaptureResult> =>
+      Promise.resolve({
+        action: 'log',
+        text: 'nothing interesting',
+        findings: [],
+      });
+
+    const outcome = await scanResponseFields('Bash', fields, capture);
+    expect(responseEmitPayload(outcome)).toBeUndefined();
+  });
+});

--- a/plugins/codex/test/hooks/stop-payload.test.ts
+++ b/plugins/codex/test/hooks/stop-payload.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseStopPayload } from '../../src/hooks/stop-payload.ts';
+
+describe('parseStopPayload', () => {
+  it('extracts session_id + transcript_path from a well-formed Stop payload', () => {
+    const trigger = parseStopPayload({
+      session_id: 'sess-abc',
+      transcript_path: '/home/me/.codex/sessions/2026/07/14/rollout-sess-abc.jsonl',
+      cwd: '/home/me/proj',
+      hook_event_name: 'Stop',
+    });
+    expect(trigger).toEqual({
+      sessionId: 'sess-abc',
+      transcriptPath: '/home/me/.codex/sessions/2026/07/14/rollout-sess-abc.jsonl',
+    });
+  });
+
+  it('returns undefined (fail-open) when transcript_path is missing', () => {
+    expect(parseStopPayload({ session_id: 'sess-abc' })).toBeUndefined();
+  });
+
+  it('returns undefined (fail-open) when session_id is missing', () => {
+    expect(parseStopPayload({ transcript_path: '/x.jsonl' })).toBeUndefined();
+  });
+
+  it('returns undefined for a null payload (unparseable stdin) without throwing', () => {
+    expect(() => parseStopPayload(null)).not.toThrow();
+    expect(parseStopPayload(null)).toBeUndefined();
+  });
+
+  it('returns undefined when a field is the wrong type (non-string)', () => {
+    expect(parseStopPayload({ session_id: 123, transcript_path: '/x.jsonl' })).toBeUndefined();
+    expect(parseStopPayload({ session_id: 's', transcript_path: ['x'] })).toBeUndefined();
+  });
+});

--- a/plugins/codex/test/hooks/store-health.test.ts
+++ b/plugins/codex/test/hooks/store-health.test.ts
@@ -1,0 +1,94 @@
+// Tests the store-health module directly — NEVER via the hook entry files
+// (src/hooks/*.ts run main() on import and hang vitest collection). Identical
+// to plugins/claude-code/src/hooks/store-health.test.ts — no harness-specific
+// logic here.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  claimStoreUnavailableWarning,
+  openGatewayOrNull,
+  storeUnavailableMessage,
+} from '../../src/hooks/store-health.ts';
+
+function configFor(dataDir: string): PluginConfig {
+  return {
+    settings: {
+      specVersion: 1,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: join(dataDir, 'settings'),
+    onboarded: false,
+    provider: { provider: 'openai' },
+  };
+}
+
+describe('openGatewayOrNull — observable store-open failure', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-store-health-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when aka.db is not a database (corrupt bytes)', () => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'aka.db'), 'garbage bytes, definitely not sqlite');
+
+    expect(openGatewayOrNull(configFor(dir))).toBeNull();
+  });
+
+  it('returns a working gateway for a healthy (fresh) data dir', async () => {
+    const gateway = openGatewayOrNull(configFor(dir));
+    expect(gateway).not.toBeNull();
+    await gateway?.close();
+  });
+});
+
+describe('claimStoreUnavailableWarning — once per session', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-store-warn-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('warns on the first claim of a session, then stays quiet for that session', () => {
+    expect(claimStoreUnavailableWarning(dir, 'sess-1')).toBe(true);
+    expect(claimStoreUnavailableWarning(dir, 'sess-1')).toBe(false);
+    expect(claimStoreUnavailableWarning(dir, 'sess-1')).toBe(false);
+  });
+
+  it('a NEW session warns again (single overwritten marker, not an accumulating set)', () => {
+    expect(claimStoreUnavailableWarning(dir, 'sess-1')).toBe(true);
+    expect(claimStoreUnavailableWarning(dir, 'sess-2')).toBe(true);
+    expect(claimStoreUnavailableWarning(dir, 'sess-2')).toBe(false);
+  });
+
+  it('with no session id it cannot dedupe and always warns', () => {
+    expect(claimStoreUnavailableWarning(dir, undefined)).toBe(true);
+    expect(claimStoreUnavailableWarning(dir, undefined)).toBe(true);
+  });
+});
+
+describe('storeUnavailableMessage', () => {
+  it('names the store path, says detection is off, and stays fail-open in tone', () => {
+    const message = storeUnavailableMessage('/home/u/.aka/data/aka.db');
+    expect(message).toContain('/home/u/.aka/data/aka.db');
+    expect(message).toContain('OFF for this session');
+    expect(message).toContain('fails open');
+  });
+});

--- a/plugins/codex/test/hooks/tool-response.test.ts
+++ b/plugins/codex/test/hooks/tool-response.test.ts
@@ -1,0 +1,74 @@
+// Adapted from plugins/claude-code/src/hooks/tool-response.test.ts. Only Bash
+// is mapped in RESPONSE_TEXT_PATHS today (see tool-response.ts's module
+// comment for why apply_patch has no entry), so the Read/WebFetch cases from
+// the Claude Code original don't apply here.
+import { describe, expect, it } from 'vitest';
+
+import { replaceResponseField, scannableResponseFields } from '../../src/hooks/tool-response.ts';
+
+describe('scannableResponseFields', () => {
+  it('treats a plain-string response as one scannable field at the root', () => {
+    expect(scannableResponseFields('Bash', 'some output')).toEqual([
+      { path: [], text: 'some output' },
+    ]);
+  });
+
+  it('extracts stdout and stderr from a structured Bash response', () => {
+    const response = {
+      stdout: 'out text',
+      stderr: 'err text',
+      interrupted: false,
+    };
+    expect(scannableResponseFields('Bash', response)).toEqual([
+      { path: ['stdout'], text: 'out text' },
+      { path: ['stderr'], text: 'err text' },
+    ]);
+  });
+
+  it('skips empty strings so hooks do not scan or rewrite blank fields', () => {
+    const response = { stdout: 'out', stderr: '', interrupted: false };
+    expect(scannableResponseFields('Bash', response)).toEqual([{ path: ['stdout'], text: 'out' }]);
+  });
+
+  it('returns nothing for tools without a known response shape (apply_patch, MCP tools)', () => {
+    expect(scannableResponseFields('apply_patch', { changes: {} })).toEqual([]);
+    expect(scannableResponseFields('mcp__server__tool', { result: 'x' })).toEqual([]);
+  });
+
+  it('returns nothing when the expected field is missing or not a string', () => {
+    expect(scannableResponseFields('Bash', { stdout: 42 })).toEqual([]);
+    expect(scannableResponseFields('Bash', null)).toEqual([]);
+    expect(scannableResponseFields('Bash', undefined)).toEqual([]);
+  });
+
+  it('does not resolve Object.prototype members as path tables', () => {
+    // A bare index lookup would return e.g. Object.prototype.constructor (a
+    // non-iterable function, not caught by ??) and crash the for-of.
+    expect(scannableResponseFields('constructor', { stdout: 'x' })).toEqual([]);
+    expect(scannableResponseFields('toString', { stdout: 'x' })).toEqual([]);
+    expect(scannableResponseFields('hasOwnProperty', { stdout: 'x' })).toEqual([]);
+  });
+});
+
+describe('replaceResponseField', () => {
+  it('replaces the whole response when the path is the root', () => {
+    expect(replaceResponseField('original text', [], '[replaced]')).toBe('[replaced]');
+  });
+
+  it('replaces a top-level field without disturbing siblings', () => {
+    const response = { stdout: 'to rewrite', stderr: 'keep', interrupted: false };
+    expect(replaceResponseField(response, ['stdout'], '[withheld]')).toEqual({
+      stdout: '[withheld]',
+      stderr: 'keep',
+      interrupted: false,
+    });
+    // The original is untouched — hooks may still need the raw text afterwards.
+    expect(response.stdout).toBe('to rewrite');
+  });
+
+  it('replaces a nested field while preserving the rest of the response shape', () => {
+    const response = { output: { stdout: 'original', meta: { exitCode: 0 } } };
+    const updated = replaceResponseField(response, ['output', 'stdout'], 'rewritten');
+    expect(updated).toEqual({ output: { stdout: 'rewritten', meta: { exitCode: 0 } } });
+  });
+});

--- a/plugins/codex/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/codex/test/hooks/user-prompt-submit.test.ts
@@ -1,0 +1,151 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/hooks -> plugins/codex
+const PLUGIN_ROOT = join(HERE, '..', '..');
+// The built entry (built before tests run — turbo's test task depends on
+// build). Driving it proves the emit SITE, not just the exported constants.
+const HOOK_SCRIPT = join(PLUGIN_ROOT, 'scripts', 'user-prompt-submit.js');
+
+interface HookRun {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Drive the real built hook against a throwaway ~/.aka home, feeding a Codex
+// UserPromptSubmit payload on stdin. process.execPath is an absolute node
+// path, so the child needs no host PATH and inherits no ambient environment.
+function runHook(home: string, payload: unknown): HookRun {
+  try {
+    const stdout = execFileSync(process.execPath, [HOOK_SCRIPT], {
+      env: { HOME: home, USERPROFILE: home },
+      input: JSON.stringify(payload),
+      encoding: 'utf8',
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  }
+}
+
+// The enforcement matrix, driven through the REAL built hook against a seeded
+// throwaway store. The secret value comes from the bundled rule's own
+// `examples` fixture so no secret-shaped literal lives in this file.
+const RULE_ID = 'secrets/twilio-key';
+function secretFixture(): { pack: ReturnType<typeof bundledDetections>[number]; example: string } {
+  const pack = bundledDetections().find((p) => p.rules.some((r) => r.id === RULE_ID));
+  const example = pack?.rules.find((r) => r.id === RULE_ID)?.examples?.[0];
+  if (pack === undefined || example === undefined) {
+    throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+  }
+  return { pack, example };
+}
+const { pack: SECRET_PACK, example: SECRET_EXAMPLE } = secretFixture();
+const SECRET_PROMPT = `please deploy using this key: ${SECRET_EXAMPLE}`;
+
+// Install the bundled packs the way the gateway does on open, then assign the
+// secrets pack the policy under test — per-rule pack policies are what the
+// runtime's action resolution prefers.
+function seedSecretPolicy(home: string, policyId: BuiltinPolicyId): void {
+  const db = openLocalDatabase(join(home, '.aka', 'data'));
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+    db.installedPacks.setPolicy(SECRET_PACK.namespace, SECRET_PACK.packId, policyId);
+  } finally {
+    db.close();
+  }
+}
+
+function submitSecretPrompt(home: string): HookRun {
+  return runHook(home, {
+    prompt: SECRET_PROMPT,
+    session_id: 'sess-enforce',
+    cwd: '/tmp',
+    hook_event_name: 'UserPromptSubmit',
+  });
+}
+
+describe('user-prompt-submit enforcement — redact blocks, it never leaks the raw prompt', () => {
+  it('redact policy → block with the removal message, raw never on stdout', () => {
+    // This hook has no prompt-rewrite channel, so a redact policy must STOP
+    // the prompt — warning and passing it through would send the raw secret
+    // to the model. Same semantics as the Claude Code hook.
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-redact-'));
+    try {
+      seedSecretPolicy(home, 'redact');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toContain('twilio-key');
+      expect(payload.reason).toContain('Remove the flagged content and resubmit');
+      // The never-leak assertion: the raw value appears nowhere on stdout.
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('block policy → the removal-based block, raw never on stdout', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-block-'));
+    try {
+      seedSecretPolicy(home, 'block');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toMatch(/^AKA blocked this prompt — flagged /);
+      expect(payload.reason).toContain('Remove the flagged content and resubmit');
+      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('warn policy → the prompt continues with a warning, never a block', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-warn-'));
+    try {
+      seedSecretPolicy(home, 'warn');
+      const run = submitSecretPrompt(home);
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('"decision":"block"');
+      const payload = JSON.parse(run.stdout) as { systemMessage?: string };
+      expect(payload.systemMessage).toContain('twilio-key');
+      expect(payload.systemMessage).toContain('sent unchanged');
+      // The stale claim that prompts cannot be redacted is gone.
+      expect(payload.systemMessage).not.toContain('cannot be redacted');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('emits no block on a clean prompt', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-clean-'));
+    try {
+      seedSecretPolicy(home, 'redact');
+      const run = runHook(home, {
+        prompt: 'what does this function do?',
+        session_id: 'sess-clean',
+        cwd: '/tmp',
+        hook_event_name: 'UserPromptSubmit',
+      });
+      expect(run.status).toBe(0);
+      expect(run.stderr).toBe('');
+      expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/codex/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/codex/test/hooks/user-prompt-submit.test.ts
@@ -15,6 +15,9 @@ const PLUGIN_ROOT = join(HERE, '..', '..');
 // The built entry (built before tests run — turbo's test task depends on
 // build). Driving it proves the emit SITE, not just the exported constants.
 const HOOK_SCRIPT = join(PLUGIN_ROOT, 'scripts', 'user-prompt-submit.js');
+// The onboarding writer — stamping onboardedAt is what retires the first-run
+// nudge, so the onboarded-home case below runs the real built script.
+const ONBOARD_SCRIPT = join(PLUGIN_ROOT, 'scripts', 'onboard.js');
 
 interface HookRun {
   stdout: string;
@@ -144,6 +147,53 @@ describe('user-prompt-submit enforcement — redact blocks, it never leaks the r
       expect(run.status).toBe(0);
       expect(run.stderr).toBe('');
       expect(run.stdout).not.toContain('"decision":"block"');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+function submitCleanPrompt(home: string, sessionId: string): HookRun {
+  return runHook(home, {
+    prompt: 'what does this function do?',
+    session_id: sessionId,
+    cwd: '/tmp',
+    hook_event_name: 'UserPromptSubmit',
+  });
+}
+
+describe('user-prompt-submit first-run nudge — once per session, retired by onboarding', () => {
+  it('nudges a clean prompt from an un-onboarded home, naming the setup skill', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-nudge-'));
+    try {
+      const first = submitCleanPrompt(home, 'sess-nudge');
+      expect(first.status).toBe(0);
+      const payload = JSON.parse(first.stdout) as { systemMessage?: string };
+      expect(payload.systemMessage).toContain('aka-setup');
+      expect(first.stdout).not.toContain('"decision":"block"');
+
+      // Same session id against the same home: the one-per-session claim keeps
+      // every later prompt silent instead of re-nudging on each submit.
+      const second = submitCleanPrompt(home, 'sess-nudge');
+      expect(second.status).toBe(0);
+      expect(second.stdout).toBe('');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('emits nothing once the home is onboarded', () => {
+    const home = mkdtempSync(join(tmpdir(), 'aka-codex-ups-onboarded-'));
+    try {
+      // The real onboarding writer stamps onboardedAt — the flag the nudge
+      // keys on — so this is the post-setup state, not a seeded lookalike.
+      execFileSync(process.execPath, [ONBOARD_SCRIPT, '--historical', 'session-only'], {
+        env: { HOME: home, USERPROFILE: home },
+        encoding: 'utf8',
+      });
+      const run = submitCleanPrompt(home, 'sess-onboarded');
+      expect(run.status).toBe(0);
+      expect(run.stdout).toBe('');
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/plugins/codex/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/codex/test/hooks/user-prompt-submit.test.ts
@@ -9,6 +9,8 @@ import { bundledDetections } from '@akasecurity/plugin-sdk';
 import type { BuiltinPolicyId } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test/hooks -> plugins/codex
 const PLUGIN_ROOT = join(HERE, '..', '..');
@@ -94,8 +96,10 @@ describe('user-prompt-submit enforcement — redact blocks, it never leaks the r
       expect(payload.decision).toBe('block');
       expect(payload.reason).toContain('twilio-key');
       expect(payload.reason).toContain('Remove the flagged content and resubmit');
-      // The never-leak assertion: the raw value appears nowhere on stdout.
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      // The never-leak assertion: no run of the raw value appears on stdout.
+      // Run by run rather than whole — a branch echoing a truncated value is
+      // still echoing a live credential's prefix.
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -111,7 +115,7 @@ describe('user-prompt-submit enforcement — redact blocks, it never leaks the r
       expect(payload.decision).toBe('block');
       expect(payload.reason).toMatch(/^AKA blocked this prompt — flagged /);
       expect(payload.reason).toContain('Remove the flagged content and resubmit');
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/plugins/codex/test/identity-consistency.test.ts
+++ b/plugins/codex/test/identity-consistency.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// The two manifests that name this plugin to the outside world: npm's
+// package.json and the Codex plugin manifest. The release workflow publishes
+// from package.json while the Codex host reads .codex-plugin/plugin.json, so a
+// version drift ships an artifact that reports two different versions.
+
+interface Manifest {
+  name?: string;
+  version?: string;
+}
+
+function readManifest(rel: string): Manifest {
+  return JSON.parse(readFileSync(new URL(rel, import.meta.url), 'utf8')) as Manifest;
+}
+
+describe('plugin identity consistency', () => {
+  it('plugin.json version equals package.json version (lockstep)', () => {
+    const plugin = readManifest('../.codex-plugin/plugin.json');
+    const pkg = readManifest('../package.json');
+    expect(plugin.version).toBe(pkg.version);
+  });
+});

--- a/plugins/codex/test/identity-consistency.test.ts
+++ b/plugins/codex/test/identity-consistency.test.ts
@@ -22,4 +22,15 @@ describe('plugin identity consistency', () => {
     const pkg = readManifest('../package.json');
     expect(plugin.version).toBe(pkg.version);
   });
+
+  it('cli, claude-code plugin, and codex plugin share one version line', () => {
+    // All three artifacts bundle the same @akasecurity/* workspace packages and
+    // release together, so a lone bump ships artifacts that disagree about
+    // which workspace state they carry.
+    const cli = readManifest('../../../cli/package.json');
+    const claudeCode = readManifest('../../../plugins/claude-code/package.json');
+    const codex = readManifest('../package.json');
+    expect(claudeCode.version).toBe(cli.version);
+    expect(codex.version).toBe(cli.version);
+  });
 });

--- a/plugins/codex/test/journey/no-model-judge-consent.journey.test.ts
+++ b/plugins/codex/test/journey/no-model-judge-consent.journey.test.ts
@@ -1,0 +1,356 @@
+/**
+ * aka-setup, model-judge consent DECLINED — proven end-to-end against the REAL
+ * built script chain (the scripts/*.js the skill actually shells out to).
+ *
+ * The distinct model-judge consent (step 3 of skills/setup/SKILL.md) is what
+ * authorizes the only egress in the product: apply-suppressions' `codex exec`
+ * judge. The adapter's unit tests inject the gate as a plain boolean, so the
+ * wiring that reads the real settings.json
+ * (apply-suppressions.ts: `loadConfig().settings.modelJudgeConsent`) is never
+ * exercised in the refusing direction. Inverting that boolean, or reading the
+ * wrong field, would leave every other test green.
+ *
+ * This leg closes that gap at the process boundary. Historical access IS
+ * granted (so the backfill really reads the seeded rollout and produces hits —
+ * the refusal is not a vacuous empty scan), the model-judge consent is NOT, and
+ * the preview then has to skip the judge:
+ *
+ *   onboard.js --historical full → backfill.js --triage
+ *            → apply-suppressions.js (preview, no consent)
+ *
+ * The load-bearing assertion is `judgeWasInvoked()`: the harness puts a stub
+ * `codex` first on the child PATH which touches a sentinel when executed, so
+ * this proves no judge subprocess ever ran — not merely that a mock went
+ * uncalled. Nothing can reach the model API on this path.
+ */
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test/journey -> plugins/codex
+const SCRIPTS_DIR = join(HERE, '..', '..', 'scripts');
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+// The seeded secret comes from the bundled rule's own `examples` fixture so no
+// secret-shaped literal lives in this file (mirrors hooks/user-prompt-submit.test.ts).
+const RULE_ID = 'secrets/twilio-key';
+function ruleExample(): string {
+  const example = bundledDetections()
+    .flatMap((pack) => pack.rules)
+    .find((rule) => rule.id === RULE_ID)?.examples?.[0];
+  if (example === undefined) {
+    throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+  }
+  return example;
+}
+const SURFACED_KEY = ruleExample();
+
+interface StepResult {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Drives the built wizard scripts in frame order against a throwaway home. The
+// scripts resolve ~/.aka and ~/.codex via os.homedir(), which honors $HOME on
+// POSIX, so pointing HOME at a temp dir isolates the whole chain — no
+// script-level flag or process.env read is added to shipped code. The child env
+// is built from scratch (never the host env): PATH carries only the stub-judge
+// bin dir plus node's own dir, so the stub `codex` is the ONLY resolvable judge
+// and the `#!/usr/bin/env node` shebang still finds node.
+class SetupJourney {
+  readonly home: string;
+  // The settings.json the onboarding writer records the consent into.
+  readonly settingsPath: string;
+  private readonly binDir: string;
+
+  constructor() {
+    this.home = mkdtempSync(join(tmpdir(), 'aka-codex-journey-home-'));
+    this.settingsPath = join(this.home, '.aka', 'settings', 'settings.json');
+    this.binDir = mkdtempSync(join(tmpdir(), 'aka-codex-journey-bin-'));
+    this.writeFakeJudge();
+  }
+
+  cleanup(): void {
+    rmSync(this.home, { recursive: true, force: true });
+    rmSync(this.binDir, { recursive: true, force: true });
+  }
+
+  // Whether the stub `codex` judge was actually executed. The stub touches a
+  // sentinel on every invocation, so a consent-gate test can assert the egress
+  // never happened at the process boundary — not merely that a mocked function
+  // went uncalled.
+  judgeWasInvoked(): boolean {
+    return existsSync(this.judgeSentinelPath);
+  }
+
+  private get judgeSentinelPath(): string {
+    return join(this.binDir, 'judge-invoked');
+  }
+
+  // Seed a prior Codex CLI rollout under the temp home carrying the bundled
+  // rule's example key, timestamped inside the retention window but before the
+  // scan starts, so the backfill has real history to calibrate from. The line
+  // shape matches history/transcripts.ts's parser: a `response_item` user
+  // message whose content is an `input_text` block.
+  seedRollout(): string {
+    const dayDir = join(this.home, '.codex', 'sessions', '2026', '07', '27');
+    mkdirSync(dayDir, { recursive: true });
+    const occurredAt = new Date(Date.now() - 3 * DAY_MS).toISOString();
+    const line = JSON.stringify({
+      timestamp: occurredAt,
+      type: 'response_item',
+      payload: {
+        type: 'message',
+        role: 'user',
+        content: [{ type: 'input_text', text: `please deploy with this key: ${SURFACED_KEY}` }],
+      },
+    });
+    const rolloutPath = join(dayDir, 'rollout-2026-07-27-consent.jsonl');
+    writeFileSync(rolloutPath, `${line}\n`);
+    return rolloutPath;
+  }
+
+  // Consent side effect — record the historical-review answer (`full` grants
+  // the scan permission to READ prior rollouts).
+  onboardHistorical(access: 'full' | 'session-only'): StepResult {
+    return this.run('onboard.js', ['--historical', access]);
+  }
+
+  // Consent side effect — record the DISTINCT model-judge egress consent the
+  // wizard collects (step 3) before piping findings into the judge.
+  onboardModelJudge(): StepResult {
+    return this.run('onboard.js', ['--model-judge-consent']);
+  }
+
+  // The backfill triage stream (JSONL + sentinel).
+  backfillTriage(): StepResult {
+    return this.run('backfill.js', ['--triage']);
+  }
+
+  // The calibration preview: judge (stubbed), plan, gate, frame JSON. Takes
+  // the backfill stream on stdin.
+  applyPreview(triageStream: string): StepResult {
+    return this.run('apply-suppressions.js', [], triageStream);
+  }
+
+  private run(script: string, args: string[], input?: string): StepResult {
+    const env: NodeJS.ProcessEnv = {
+      HOME: this.home,
+      // Windows resolves the home dir from USERPROFILE; keep both in lockstep.
+      USERPROFILE: this.home,
+      // Stub judge first on PATH so apply-suppressions' `codex exec` spawn hits
+      // it, never a live model; node's own dir second so the stub's
+      // `#!/usr/bin/env node` shebang resolves. Nothing else from the host
+      // environment reaches the chain.
+      PATH: `${this.binDir}:${dirname(process.execPath)}`,
+    };
+    // spawnSync (not execFileSync) so BOTH streams are captured on the success
+    // path too — the stderr assertions below must see what a wizard transcript
+    // would see, and execFileSync only surfaces stderr when the child fails.
+    const result = spawnSync(process.execPath, [join(SCRIPTS_DIR, script), ...args], {
+      env,
+      encoding: 'utf8',
+      ...(input !== undefined ? { input } : {}),
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      status: result.status ?? 1,
+    };
+  }
+
+  // A controlled `codex` on PATH: apply-suppressions' judge spawns
+  // `codex exec --ephemeral … --output-last-message <file> -` with the prompt
+  // on STDIN (never argv — see triage/judge.ts's spawnCodex). This stub reads
+  // stdin, parses the hits out of the prompt's trailing fenced block, and
+  // writes a deterministic, raw-free TriageRecommendation to the
+  // --output-last-message file — the first hit per (category, rule) surfaced
+  // (genuine), the rest marked routine false positives. No live model is ever
+  // hit.
+  private writeFakeJudge(): void {
+    const src = `#!/usr/bin/env node
+'use strict';
+// Record that the judge actually ran, so a test can prove the consent gate
+// stopped the egress at the process boundary (see judgeWasInvoked).
+require('node:fs').writeFileSync(${JSON.stringify(this.judgeSentinelPath)}, '');
+const args = process.argv.slice(2);
+const outIndex = args.indexOf('--output-last-message');
+const outFile = outIndex >= 0 ? args[outIndex + 1] : undefined;
+const prompt = require('node:fs').readFileSync(0, 'utf8');
+// Simulate codex exec's run logging on stderr, prompt content included. The
+// parent's spawnCodex must swallow this stream entirely: the parent command's
+// stderr flows into the wizard conversation, whose rollout files the backfill
+// later scans — exactly the store --ephemeral keeps raw content out of.
+process.stderr.write('JUDGE-STDERR-RUN-LOGGING ' + prompt);
+const fences = [...String(prompt).matchAll(/\`\`\`[a-z]*\\n([\\s\\S]*?)\`\`\`/g)];
+const block = fences.length ? fences[fences.length - 1][1] : '';
+const byCategory = new Map();
+for (const line of block.split('\\n')) {
+  const trimmed = line.trim();
+  if (!trimmed) continue;
+  let hit;
+  try { hit = JSON.parse(trimmed); } catch { continue; }
+  if (!hit || typeof hit.category !== 'string' || typeof hit.id !== 'string' || typeof hit.ruleId !== 'string') continue;
+  const byRule = byCategory.get(hit.category) ?? new Map();
+  const ids = byRule.get(hit.ruleId) ?? [];
+  ids.push(hit.id);
+  byRule.set(hit.ruleId, ids);
+  byCategory.set(hit.category, byRule);
+}
+const perCategory = [];
+for (const [category, byRule] of byCategory) {
+  let genuineCount = 0;
+  const fps = [];
+  for (const ids of byRule.values()) {
+    ids.sort();
+    genuineCount += 1;
+    fps.push(...ids.slice(1));
+  }
+  perCategory.push({
+    category,
+    action: 'warn',
+    reasoning: 'canonical example key — routine placeholder, no live credential',
+    genuineCount,
+    fpCount: fps.length,
+    fpIds: fps,
+  });
+}
+const verdict = { perCategory, notes: 'looks routine' };
+if (outFile) {
+  require('node:fs').writeFileSync(outFile, '\`\`\`json\\n' + JSON.stringify(verdict) + '\\n\`\`\`');
+}
+`;
+    const path = join(this.binDir, 'codex');
+    writeFileSync(path, src);
+    chmodSync(path, 0o755);
+  }
+}
+
+describe('aka-setup journey — model-judge consent declined', () => {
+  const journey = new SetupJourney();
+  let triageStream = '';
+  let preview: StepResult;
+
+  beforeAll(() => {
+    journey.seedRollout();
+    // Historical access granted: the scan may READ local rollouts. That grant
+    // deliberately does NOT carry model-judge consent — the two are separate.
+    journey.onboardHistorical('full');
+    triageStream = journey.backfillTriage().stdout;
+    preview = journey.applyPreview(triageStream);
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('reads real history, so the skip is a refusal and not an empty scan', () => {
+    // The backfill genuinely found the seeded key: there WAS something to judge.
+    expect(triageStream).toContain(SURFACED_KEY);
+  });
+
+  it('exits clean — the refusal is a handled branch, not a crash', () => {
+    expect(preview.status).toBe(0);
+  });
+
+  it('never spawns the judge subprocess — nothing reaches the model API', () => {
+    expect(journey.judgeWasInvoked()).toBe(false);
+  });
+
+  it('says plainly that nothing was sent, without claiming a clean bill of health', () => {
+    expect(preview.stdout).toContain(
+      "I didn't send anything to the model — model-judge consent wasn't granted.",
+    );
+    // The scan-ran-clean copy would report a clean result for a judgment that
+    // never ran. Hits existed; they were simply never rated.
+    expect(preview.stdout).not.toContain('nothing needs your attention');
+  });
+
+  it('still emits a parseable zero-count frame so the wizard can degrade', () => {
+    // The wizard reaches this pipe expecting a frame; a bare line would leave it
+    // mid-flow with nothing to read.
+    const frame = /<<<AKA_FRAME_JSON\s*([\s\S]*?)\s*AKA_FRAME_JSON>>>/.exec(preview.stdout);
+    expect(frame?.[1]).toBeDefined();
+    const parsed = JSON.parse(frame?.[1] ?? '{}') as { counts?: { total?: number } };
+    expect(parsed.counts?.total).toBe(0);
+  });
+
+  it('writes no calibration plan — there is no judged result to confirm', () => {
+    expect(preview.stdout).not.toContain('Plan saved to:');
+  });
+
+  it('records the historical grant but no model-judge consent in settings.json', () => {
+    const settings = JSON.parse(readFileSync(journey.settingsPath, 'utf8')) as {
+      historicalAccess?: string;
+      modelJudgeConsent?: unknown;
+    };
+    // The two grants are independent: reading history was allowed, sending was not.
+    expect(settings.historicalAccess).toBe('full');
+    expect(settings.modelJudgeConsent).toBeUndefined();
+  });
+});
+
+// The control for the leg above. `judgeWasInvoked() === false` only means
+// something if the sentinel would have been written had the judge run — so
+// drive the identical chain WITH consent and assert the spawn is detected.
+// Without this, a broken sentinel would make the no-consent assertion
+// vacuously green.
+describe('aka-setup journey — model-judge consent granted (control)', () => {
+  const journey = new SetupJourney();
+  // Captured mid-chain: the sentinel's state after the historical grant but
+  // BEFORE the model-judge consent, which is the moment that distinguishes the
+  // two grants.
+  let invokedBeforeConsent = true;
+  let preview: StepResult;
+
+  beforeAll(() => {
+    journey.seedRollout();
+    journey.onboardHistorical('full');
+    invokedBeforeConsent = journey.judgeWasInvoked();
+
+    journey.onboardModelJudge();
+    preview = journey.applyPreview(journey.backfillTriage().stdout);
+  });
+
+  afterAll(() => {
+    journey.cleanup();
+  });
+
+  it('does spawn the judge once consent is recorded', () => {
+    // Historical access alone does not authorize the egress...
+    expect(invokedBeforeConsent).toBe(false);
+    // ...the distinct model-judge consent does.
+    expect(journey.judgeWasInvoked()).toBe(true);
+  });
+
+  it('calibrates a plan from the judged verdict — the consented path completes', () => {
+    expect(preview.status).toBe(0);
+    expect(preview.stdout).toContain('Plan saved to:');
+  });
+
+  it("swallows the judge subprocess's stderr — run logging never reaches the transcript", () => {
+    // The stub codex writes its run logging (prompt included, so it carries the
+    // raw hit) to stderr. spawnCodex pipes and discards both child streams, so
+    // none of it may surface on the parent apply command's stdout or stderr.
+    expect(preview.stderr).not.toContain('JUDGE-STDERR-RUN-LOGGING');
+    expect(preview.stderr).not.toContain(SURFACED_KEY);
+    expect(preview.stdout).not.toContain('JUDGE-STDERR-RUN-LOGGING');
+  });
+});

--- a/plugins/codex/test/onboard.test.ts
+++ b/plugins/codex/test/onboard.test.ts
@@ -16,6 +16,7 @@ import { parsePosture } from '@akasecurity/setup-wizard';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { parseSurface } from '../src/setup-show.ts';
+import { isModelJudgeConsentValid, MODEL_JUDGE_PAYLOAD_VERSION } from '../src/triage/consent.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test -> plugins/codex
@@ -140,6 +141,43 @@ describe('onboard writes a valid store/settings state with the recommended postu
     // code_context keeps the default the store seeds on open ('log'); fill-gaps
     // never downgrades the already-calibrated 'secret' row.
     expect(db.policies.getCategoryAction('code_context')).toBe('log');
+  });
+});
+
+describe('onboard --model-judge-consent records the distinct model-judge egress consent', () => {
+  // Runs the BUILT script against a home dir it does NOT delete before reading,
+  // so the persisted settings.json can be re-read through the versioned schema.
+  function onboardRunKeepingHome(args: string[]): string {
+    const home = mkdtempSync(join(tmpdir(), 'aka-onboard-consent-test-'));
+    try {
+      execFileSync(process.execPath, [SCRIPT, ...args], {
+        env: { HOME: home, USERPROFILE: home },
+        encoding: 'utf8',
+      });
+      // The script resolves ~/.aka from HOME, so the settings.json lands under
+      // <home>/.aka — read it back through the versioned schema from there.
+      const read = readWorkspaceSettings(join(home, '.aka'));
+      return JSON.stringify(read);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }
+
+  it('persists modelJudgeConsent at the current payload version, and it reads back as valid', () => {
+    const settings = JSON.parse(onboardRunKeepingHome(['--model-judge-consent'])) as {
+      modelJudgeConsent?: { acknowledgedAt: string; payloadVersion: number };
+    };
+    expect(settings.modelJudgeConsent?.payloadVersion).toBe(MODEL_JUDGE_PAYLOAD_VERSION);
+    expect(settings.modelJudgeConsent?.acknowledgedAt).toEqual(expect.any(String));
+    expect(isModelJudgeConsentValid(settings.modelJudgeConsent)).toBe(true);
+  });
+
+  it('leaves modelJudgeConsent absent when the flag is not passed', () => {
+    const settings = JSON.parse(onboardRunKeepingHome(['--historical', 'session-only'])) as {
+      modelJudgeConsent?: unknown;
+    };
+    expect(settings.modelJudgeConsent).toBeUndefined();
+    expect(isModelJudgeConsentValid(undefined)).toBe(false);
   });
 });
 

--- a/plugins/codex/test/onboard.test.ts
+++ b/plugins/codex/test/onboard.test.ts
@@ -1,0 +1,160 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { openLocalDatabase, readWorkspaceSettings } from '@akasecurity/persistence';
+import {
+  applyCategoryPosture,
+  applyOnboarding,
+  severityFloorPosture,
+} from '@akasecurity/plugin-sdk';
+import { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
+import { parsePosture } from '@akasecurity/setup-wizard';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { parseSurface } from '../src/setup-show.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test -> plugins/codex
+const SCRIPT = join(HERE, '..', 'scripts', 'onboard.js');
+
+interface Run {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+// Runs the BUILT script the wizard actually shells out to, against a fresh,
+// throwaway ~/.aka home per call so this suite's assertions stay independent
+// of the real machine's store (mirrors start-light.test.ts's runStartLight).
+function onboardRun(args: string[] = []): Run {
+  const home = mkdtempSync(join(tmpdir(), 'aka-onboard-run-test-'));
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      env: { HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// The recommended-posture default map, frozen here so the test fails loudly if
+// severityFloorPosture() ever drifts from it (the "unchanged from before the
+// redesign" guarantee).
+const RECOMMENDED_DEFAULTS = {
+  secret: 'warn',
+  pii: 'warn',
+  financial: 'warn',
+  phi: 'warn',
+  code_flaw: 'warn',
+  custom: 'warn',
+  code_context: 'monitor',
+  config: 'monitor',
+} as const;
+
+describe('recommended (unadjusted) posture — the default map', () => {
+  it('severityFloorPosture() equals the recommended defaults exactly', () => {
+    // Reuse the schema helper the onboard path already writes on `--floor`; do not
+    // introduce a parallel constant.
+    expect(severityFloorPosture()).toEqual(RECOMMENDED_DEFAULTS);
+  });
+
+  it('seeds exactly 8 packs, each at a valid palette level', () => {
+    const posture = severityFloorPosture();
+    expect(Object.keys(posture).sort()).toEqual([...DetectionCategory.options].sort());
+    expect(Object.keys(posture)).toHaveLength(8);
+    for (const level of Object.values(posture)) {
+      expect(BuiltinPolicyId.safeParse(level).success).toBe(true);
+    }
+  });
+
+  it('round-trips through the onboard --posture seam (parsePosture)', () => {
+    // onboard.ts feeds `--posture <json>` through parsePosture; the recommended
+    // map must survive that path unchanged so the wizard can drive it.
+    const posture = severityFloorPosture();
+    expect(parsePosture(JSON.stringify(posture))).toEqual(RECOMMENDED_DEFAULTS);
+  });
+});
+
+describe('onboard writes a valid store/settings state with the recommended posture', () => {
+  let base: string;
+  let db: LocalDatabase;
+
+  beforeEach(() => {
+    base = mkdtempSync(join(tmpdir(), 'aka-onboard-test-'));
+    // The same real local store onboard.ts opens via openLocalDatabase(dataDir).
+    db = openLocalDatabase(join(base, 'data'));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(base, { recursive: true, force: true });
+  });
+
+  it('applyOnboarding writes a valid settings.json (session-only historical access)', () => {
+    const written = applyOnboarding({ historicalAccess: 'session-only' }, base);
+    expect(written.historicalAccess).toBe('session-only');
+    expect(written.onboardedAt).not.toBeNull();
+    // Re-read from disk through the versioned schema — proves the file parses.
+    const read = readWorkspaceSettings(base);
+    expect(read.historicalAccess).toBe('session-only');
+    expect(read.onboardedAt).not.toBeNull();
+  });
+
+  it('applyCategoryPosture persists the recommended map as 8 category rows (monitor→log)', async () => {
+    applyCategoryPosture(severityFloorPosture(), db.policies, 'overwrite');
+    const rows = await db.policies.readPolicies();
+    const byCategory = new Map(
+      rows
+        .map((p) => [(p.target as { category?: string }).category, p.action] as const)
+        .filter(([c]) => c !== undefined),
+    );
+    expect(byCategory.size).toBe(8);
+    // warn packs store as 'warn'; monitor packs store as 'log' (the palette→
+    // ActionTaken mapping), which surfaces back to the user as 'monitor'.
+    expect(byCategory.get('secret')).toBe('warn');
+    expect(byCategory.get('pii')).toBe('warn');
+    expect(byCategory.get('financial')).toBe('warn');
+    expect(byCategory.get('phi')).toBe('warn');
+    expect(byCategory.get('code_flaw')).toBe('warn');
+    expect(byCategory.get('custom')).toBe('warn');
+    expect(byCategory.get('code_context')).toBe('log');
+    expect(byCategory.get('config')).toBe('log');
+  });
+
+  it('the severity-floor fill-gaps write never downgrades an already-calibrated pack', () => {
+    // The `--floor` fallback path onboard.ts takes on a too-thin backfill uses the
+    // SAME map (severityFloorPosture) in fill-gaps mode: a confirmed calibration is
+    // preserved. This behavior is unchanged by the redesign.
+    db.policies.upsertCategoryAction('secret', 'block');
+    applyCategoryPosture(severityFloorPosture(), db.policies, 'fill-gaps');
+    expect(db.policies.getCategoryAction('secret')).toBe('block');
+    // code_context keeps the default the store seeds on open ('log'); fill-gaps
+    // never downgrades the already-calibrated 'secret' row.
+    expect(db.policies.getCategoryAction('code_context')).toBe('log');
+  });
+});
+
+describe('onboard emits user-facing output inside SHOW regions', () => {
+  it('--historical full wraps the warm confirmation as a SHOW region', () => {
+    const run = onboardRun(['--historical', 'full']);
+    const surface = parseSurface(run.stdout);
+    expect(surface.shows.join('\n')).toContain("Got it — I'll look over Codex's recent work");
+    expect(surface.status).not.toContain("Got it — I'll look over");
+  });
+
+  it('--floor wraps the applied-posture confirmation as a SHOW region', () => {
+    const run = onboardRun(['--floor']);
+    const surface = parseSurface(run.stdout);
+    expect(surface.shows.join('\n')).toContain('safe defaults');
+    expect(surface.status).not.toContain('safe defaults');
+  });
+});

--- a/plugins/codex/test/posture.test.ts
+++ b/plugins/codex/test/posture.test.ts
@@ -1,0 +1,70 @@
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { describe, expect, it } from 'vitest';
+
+import { readPostureBlock } from '../src/posture.ts';
+
+// A minimal LocalDatabase stand-in: only the policies read + close() that
+// readPostureBlock touches. Cast through unknown since the real interface has
+// many more repositories the helper never uses.
+function fakeDb(
+  readPolicies: () => Promise<unknown>,
+  onClose: () => void = () => undefined,
+): Pick<LocalDatabase, 'policies' | 'close'> {
+  return {
+    policies: { readPolicies },
+    close: onClose,
+  } as unknown as Pick<LocalDatabase, 'policies' | 'close'>;
+}
+
+describe('readPostureBlock', () => {
+  it('renders one row per category from the stored policies', async () => {
+    const db = fakeDb(() =>
+      Promise.resolve([
+        { target: { category: 'secret' }, action: 'redact' },
+        { target: { category: 'code_context' }, action: 'log' },
+      ]),
+    );
+    const block = await readPostureBlock(() => db);
+    expect(block).toContain('secret');
+    expect(block).toContain('redact');
+    // 'log' (ActionTaken) surfaces to the user as 'monitor'.
+    expect(block).toContain('monitor');
+  });
+
+  it('degrades to an empty block (not a throw) when the policies read faults', async () => {
+    let closed = false;
+    const db = fakeDb(
+      () => Promise.reject(new Error('store locked')),
+      () => {
+        closed = true;
+      },
+    );
+    // The fault must NOT propagate — that would collapse the whole install card
+    // into firstrun's fail-open note. It degrades to '' so only the Posture
+    // section is hidden, and the handle is still closed.
+    const block = await readPostureBlock(() => db);
+    expect(block).toBe('');
+    expect(closed).toBe(true);
+  });
+
+  it('degrades to an empty block when opening the store throws', async () => {
+    // A store-open fault must degrade identically to a read fault: the Posture
+    // section is hidden, nothing propagates to collapse the whole install card.
+    const block = await readPostureBlock(() => {
+      throw new Error('cannot open database');
+    });
+    expect(block).toBe('');
+  });
+
+  it('closes the database handle on the happy path too', async () => {
+    let closed = false;
+    const db = fakeDb(
+      () => Promise.resolve([]),
+      () => {
+        closed = true;
+      },
+    );
+    await readPostureBlock(() => db);
+    expect(closed).toBe(true);
+  });
+});

--- a/plugins/codex/test/remediation/entry-posture-close-fault.test.ts
+++ b/plugins/codex/test/remediation/entry-posture-close-fault.test.ts
@@ -1,0 +1,89 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { LocalDatabase } from '@akasecurity/persistence';
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A toggle a single test flips to make the store connection's `close()` throw —
+// every other case leaves it off, so the real teardown path still runs. The
+// underlying store operations stay real (only `close()` is wrapped), so this
+// proves the fix against a genuine SQLite connection, not a hand-rolled stub.
+// `vi.hoisted` makes it exist before the mock factory below runs.
+const { dbCloseShouldThrow } = vi.hoisted(() => ({ dbCloseShouldThrow: { value: false } }));
+
+vi.mock('@akasecurity/persistence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const realOpenLocalDatabase = actual.openLocalDatabase as (dir: string) => LocalDatabase;
+  return {
+    ...actual,
+    openLocalDatabase: (dir: string): LocalDatabase => {
+      const db = realOpenLocalDatabase(dir);
+      return {
+        ...db,
+        close: () => {
+          if (dbCloseShouldThrow.value) throw new Error('simulated db close fault');
+          db.close();
+        },
+      };
+    },
+  };
+});
+
+// The production entry's `writeSecretPosture` — guarded at the bottom of
+// entry.ts so importing it here never runs the CLI (reads stdin, calls
+// process.exit).
+import { writeSecretPosture } from '../../src/remediation/entry.ts';
+
+describe("entry.ts writeSecretPosture — a close() fault in the finally never rewrites the write's own result", () => {
+  let home: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    // writeSecretPosture calls loadConfig() with no override, resolving ~/.aka
+    // from $HOME — point it at a throwaway home so this test never touches the
+    // developer's real local store.
+    home = mkdtempSync(join(tmpdir(), 'aka-entry-posture-'));
+    // eslint-disable-next-line n/no-process-env -- test needs to redirect ~/.aka to a throwaway home
+    originalHome = process.env.HOME;
+    // eslint-disable-next-line n/no-process-env -- test needs to redirect ~/.aka to a throwaway home
+    process.env.HOME = home;
+  });
+
+  afterEach(() => {
+    dbCloseShouldThrow.value = false;
+    // eslint-disable-next-line n/no-process-env -- restore the host HOME after the test
+    if (originalHome === undefined) delete process.env.HOME;
+    // eslint-disable-next-line n/no-process-env -- restore the host HOME after the test
+    else process.env.HOME = originalHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('a db.close() fault after the posture write already succeeded still reports persisted:true — not a false failure', () => {
+    dbCloseShouldThrow.value = true;
+
+    const result = writeSecretPosture('redact');
+
+    // The write landed and returned before close() ever ran; a teardown fault
+    // must not overwrite that outcome with a false "not persisted".
+    expect(result).toEqual({ persisted: true, level: 'redact' });
+
+    // Durable: read back on a fresh connection (close() never swallows a real
+    // fault, but the wrapped connection above never got to release its own
+    // handle, so a fresh open proves the write is genuinely on disk).
+    dbCloseShouldThrow.value = false;
+    const verify = openLocalDatabase(join(home, '.aka', 'data'));
+    try {
+      expect(verify.policies.getCategoryAction('secret')).toBe('redact');
+    } finally {
+      verify.close();
+    }
+  });
+
+  it('with no close() fault, the write still reports persisted:true (baseline unaffected by the fix)', () => {
+    const result = writeSecretPosture('warn');
+
+    expect(result).toEqual({ persisted: true, level: 'warn' });
+  });
+});

--- a/plugins/codex/test/remediation/findings.test.ts
+++ b/plugins/codex/test/remediation/findings.test.ts
@@ -1,0 +1,129 @@
+import { type CalibrationPreview, type MaskedSecretFinding } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { frameCalibration } from '../../src/calibration.ts';
+import { loadSecretLeakFindings } from '../../src/remediation/findings.ts';
+import { frameJsonBlock } from '../../src/setup-frame-json.ts';
+
+// A backfill + apply-suppressions preview whose calibration recorded BOTH a
+// surfaced secret kind AND a non-secret (pii) kind, so "only secret-leak findings
+// reach the remediation flow" is an OBSERVABLE exclusion here, not a vacuous one: the
+// source frame genuinely carries pii activity in its findingKinds.
+const preview: CalibrationPreview = {
+  categories: [
+    { category: 'secret', genuineCount: 2, fpCount: 0, egress: false },
+    { category: 'pii', genuineCount: 1, fpCount: 100, egress: false },
+  ],
+  posture: {
+    secret: 'warn',
+    pii: 'warn',
+    financial: 'warn',
+    phi: 'warn',
+    code_flaw: 'warn',
+    custom: 'warn',
+    code_context: 'monitor',
+    config: 'monitor',
+  },
+};
+
+// The surfaced secret-leak summaries the calibration carried into the frame — the
+// raw-free MaskedSecretFinding shape the finding table renders from.
+const stripeFinding: MaskedSecretFinding = {
+  provider: 'stripe',
+  maskedToken: 'sk_live_****',
+  where: { filePath: '~/.codex/sessions/2026/07/01/rollout-2026-07-01T10-00-00-abc123.jsonl' },
+  state: 'still-valid',
+};
+const awsFinding: MaskedSecretFinding = {
+  provider: 'aws',
+  maskedToken: 'AKIA****************',
+  where: { filePath: '/tmp/agent-dump.txt', span: { start: 12, end: 32 } },
+  state: 'still-valid',
+};
+const maskedSecrets: MaskedSecretFinding[] = [stripeFinding, awsFinding];
+
+// A calibration frame that CARRIES masked secret summaries, serialized through the
+// same frameCalibration -> frameJsonBlock path the loader reads back, so the test
+// drives the loader's real read boundary (frameJsonBlock/readFrameJsonBlock +
+// CalibrationFrame.parse) over frame-shaped input — no hand-built JSON. The masked
+// summaries are supplied via frameCalibration's optional argument.
+function persistedFrame(masked: readonly MaskedSecretFinding[] = maskedSecrets): string {
+  return frameJsonBlock(frameCalibration(preview, [...masked]).frame);
+}
+
+describe('loadSecretLeakFindings — reads backfill findings from the calibration frame', () => {
+  it('loads the surfaced secret findings from the persisted calibration frame — not synthesized', () => {
+    const loaded = loadSecretLeakFindings(() => persistedFrame());
+    expect(loaded).toEqual(maskedSecrets);
+  });
+
+  it('templates over the real set — a different frame yields a different count (no hardcode)', () => {
+    const three = [...maskedSecrets, stripeFinding];
+    const loaded = loadSecretLeakFindings(() => persistedFrame(three));
+    expect(loaded).toHaveLength(3);
+
+    const one = loadSecretLeakFindings(() => persistedFrame([stripeFinding]));
+    expect(one).toHaveLength(1);
+  });
+
+  it('excludes non-secret kinds — the pii activity in the frame never enters the loaded set', () => {
+    // Guard against vacuity: the source frame genuinely records a non-secret (pii)
+    // finding kind, so the exclusion below is a real filter, not an empty set.
+    const frame = frameCalibration(preview, maskedSecrets).frame;
+    expect(frame.findingKinds.map((k) => k.category)).toContain('pii');
+
+    const surfacedSecretCount = preview.categories
+      .filter((c) => c.category === 'secret')
+      .reduce((n, c) => n + c.genuineCount, 0);
+    const loaded = loadSecretLeakFindings(() => persistedFrame());
+    // Only the secret-leak summaries reach the flow — count matches the surfaced
+    // secret findings, and every loaded entry is a secret summary (no pii row).
+    expect(loaded).toEqual(maskedSecrets);
+    expect(loaded).toHaveLength(surfacedSecretCount);
+  });
+
+  it('returns an empty set — distinct from a failure — when a scan surfaced no secret', () => {
+    // A successfully-read frame that carried no secret masked summaries: the load
+    // SUCCEEDED and there is simply nothing to remediate → [], never undefined.
+    const cleanFrame = frameJsonBlock(frameCalibration(preview).frame);
+    const loaded = loadSecretLeakFindings(() => cleanFrame);
+    expect(loaded).toEqual([]);
+  });
+});
+
+describe('loadSecretLeakFindings — fail-open on a store/read failure', () => {
+  it('catches a read throw at the findings-load seam — never propagates it', () => {
+    expect(() =>
+      loadSecretLeakFindings(() => {
+        throw new Error('store read failed (missing / corrupt / locked db)');
+      }),
+    ).not.toThrow();
+  });
+
+  it('claims no false success — returns undefined, fabricating no count and no findings', () => {
+    const loaded = loadSecretLeakFindings(() => {
+      throw new Error('store read failed');
+    });
+    // undefined is the "do not present a remediation decision, do not fabricate a count"
+    // signal — it carries neither a findings array nor a number.
+    expect(loaded).toBeUndefined();
+  });
+
+  it('keeps the failure signal DISTINCT from an honest empty read', () => {
+    const failed = loadSecretLeakFindings(() => {
+      throw new Error('store read failed');
+    });
+    const empty = loadSecretLeakFindings(() => frameJsonBlock(frameCalibration(preview).frame));
+    // A failed load must never be mistaken for "no secret findings surfaced":
+    // undefined (read failed) ≠ [] (read succeeded, nothing to remediate).
+    expect(failed).toBeUndefined();
+    expect(empty).toEqual([]);
+    expect(failed).not.toEqual(empty);
+  });
+
+  it('fails open on an unreadable / malformed persisted frame too', () => {
+    // A read that returns text with no valid frame block cannot yield findings —
+    // it degrades to the same "load failed" signal rather than a fabricated set.
+    expect(loadSecretLeakFindings(() => 'not a frame block at all')).toBeUndefined();
+  });
+});

--- a/plugins/codex/test/remediation/first-run-handoff.scenario.test.ts
+++ b/plugins/codex/test/remediation/first-run-handoff.scenario.test.ts
@@ -1,0 +1,342 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { handleCapture, resolveDataGateway } from '@akasecurity/plugin-runtime';
+import type { PluginConfig } from '@akasecurity/plugin-sdk';
+import type {
+  CalibrationPreview,
+  MaskedSecretFinding,
+  SetupHandoffOffer,
+} from '@akasecurity/schema';
+import { SetupHandoffOffer as SetupHandoffOfferSchema } from '@akasecurity/schema';
+import { presentBatchedRemediation } from '@akasecurity/setup-wizard';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { frameCalibration } from '../../src/calibration.ts';
+import { runFirstRun } from '../../src/firstrun-core.ts';
+import { readPostureBlock } from '../../src/posture.ts';
+import { loadSecretLeakFindings } from '../../src/remediation/findings.ts';
+import { frameJsonBlock, readFrameJsonBlock } from '../../src/setup-frame-json.ts';
+
+// The first-run handoff seam, driven at the APP-LEVEL: the real installed-summary
+// handoff-offer payload (runFirstRun → buildHandoffOffer) composed with the real
+// chain entry (loadSecretLeakFindings → presentBatchedRemediation), both surfaces
+// reading the SAME persisted calibration frame the wizard emitted at the
+// calibrated-result step. It proves the calibration and remediation boundaries
+// meet: remediation is entered exactly when the calibration scan surfaced
+// live-key secret findings and never otherwise, the installed summary's
+// dashboard handoff is retained (composed, not replaced) on the live-key branch,
+// and the count the remediation decision presents agrees with the surfaced
+// live-key count the calibration counted. The prompt-authored question issuance
+// is covered by the manual walkthrough; this is its automated app-level
+// companion.
+
+// Composed at runtime so the repo's own secret scan does not flag this file.
+const AWS_EXAMPLE_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+const MASKED_TOKEN = 'AKIA****************';
+
+function config(dataDir: string): PluginConfig {
+  return {
+    settings: {
+      specVersion: 3,
+      runMode: 'standalone',
+      policy: 'redact',
+      historicalAccess: 'session-only',
+      dataSharesInPlace: true,
+      vaultKeyCustody: 'file',
+      vaultInlineReveal: 'masked',
+    },
+    dataDir,
+    dbPath: join(dataDir, 'aka.db'),
+    settingsDir: dataDir,
+    onboarded: true,
+    provider: { provider: 'openai' },
+  };
+}
+
+// One masked per-secret summary the calibration frame carries for a surfaced
+// live-key finding — raw-free by construction (only the masked token, never the
+// raw key), the shape the finding table renders from.
+function secretFinding(i: number): MaskedSecretFinding {
+  return {
+    provider: 'aws',
+    maskedToken: MASKED_TOKEN,
+    where: { filePath: `/tmp/session-${String(i)}.jsonl` },
+    // Validity is unverifiable offline, so the honest default is 'unknown'.
+    state: 'unknown',
+  };
+}
+
+describe('first-run handoff seam: calibration findings trigger (or skip) remediation (app-level)', () => {
+  const dirs: string[] = [];
+
+  beforeEach(() => {
+    dirs.length = 0;
+  });
+  afterEach(() => {
+    for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+  });
+
+  // The calibrated-result step: build the calibration frame the wizard emits for
+  // a preview + its masked secret findings, persist it exactly as the wizard
+  // writes it, and read back the surfaced secret findings the remediation loader
+  // sees. This one persisted frame is the SINGLE source both the handoff gate and
+  // the remediation decision read, so their agreement below is genuine, not two
+  // hand-set literals.
+  function calibrate(preview: CalibrationPreview, masked: readonly MaskedSecretFinding[]) {
+    const frame = frameCalibration(preview, masked).frame;
+    const persisted = frameJsonBlock(frame);
+    const surfacedSecrets = loadSecretLeakFindings(() => persisted) ?? [];
+    return { frame, persisted, surfacedSecrets };
+  }
+
+  // The installed summary: run the REAL install-complete core over a real seeded
+  // store and return the structured handoff-offer payload it emits. `surfaced` is
+  // the calibration's all-category important count; `liveKeys` is the narrower
+  // surfaced live-key secret count — both derived from the persisted frame by the
+  // caller, never invented here (the wizard threads the same preview values in
+  // product).
+  async function installedSummaryHandoff(
+    surfaced: number,
+    liveKeys: number,
+  ): Promise<{
+    blob: string;
+    offer: SetupHandoffOffer;
+  }> {
+    const dir = mkdtempSync(join(tmpdir(), 'aka-first-run-handoff-'));
+    dirs.push(dir);
+    const cfg = config(dir);
+    // Seed through the real capture path so the card's stats trace to real data.
+    await handleCapture(
+      { kind: 'prompt', sourceTool: 'codex', text: `here is a key ${AWS_EXAMPLE_KEY}` },
+      cfg,
+    );
+    const gateway = resolveDataGateway(cfg);
+    const out: string[] = [];
+    try {
+      await runFirstRun({
+        argv: ['--surfaced', String(surfaced), '--live-keys', String(liveKeys)],
+        gateway,
+        readPosture: () => readPostureBlock(() => openLocalDatabase(cfg.dataDir)),
+        stdout: (s) => out.push(s),
+      });
+    } finally {
+      await gateway.close();
+    }
+    const blob = out.join('');
+    const parsed = SetupHandoffOfferSchema.parse(readFrameJsonBlock(blob));
+    return { blob, offer: parsed };
+  }
+
+  // The handoff→remediation entry the prompt layer performs: it routes on the
+  // offer's structured `enter-remediation` option (present exactly when live keys
+  // surfaced) and, when present, invokes the real chain over the findings loaded
+  // from the SAME persisted frame. Composition of real seams only — no mock.
+  function enterRemediation(offer: SetupHandoffOffer, persisted: string) {
+    const offersRemediation = offer.options.some((o) => o.id === 'enter-remediation');
+    if (!offersRemediation) return { entered: false as const };
+    const findings = loadSecretLeakFindings(() => persisted) ?? [];
+    return {
+      entered: true as const,
+      decision: presentBatchedRemediation(findings, { entrySource: 'first-run' }),
+    };
+  }
+
+  it('live-key branch: the installed summary composes the chain entry with the retained dashboard handoff, and the remediation decision agrees on N with the calibration', async () => {
+    // The calibration surfaced 3 live-key secrets AND one non-secret (pii) finding,
+    // so the all-category surfaced count (4) is strictly larger than the live-key
+    // count (3) — the gate below is the live-key subset, not the display count.
+    const preview: CalibrationPreview = {
+      categories: [
+        { category: 'secret', genuineCount: 3, fpCount: 10, egress: false },
+        { category: 'pii', genuineCount: 1, fpCount: 5, egress: false },
+      ],
+      posture: {
+        secret: 'warn',
+        pii: 'warn',
+        financial: 'warn',
+        phi: 'warn',
+        code_flaw: 'warn',
+        custom: 'warn',
+        code_context: 'monitor',
+        config: 'monitor',
+      },
+    };
+    const masked = [secretFinding(0), secretFinding(1), secretFinding(2)];
+    const { frame, persisted, surfacedSecrets } = calibrate(preview, masked);
+
+    // The calibration counted 3 surfaced secret findings ('M that matter (live
+    // keys)'), and the loader both surfaces read reproduces that count off the
+    // one frame.
+    const surfacedLiveKeys = surfacedSecrets.length;
+    expect(surfacedLiveKeys).toBe(3);
+
+    // The installed summary runs with the counts derived from that same frame:
+    // the broader all-category important count and the narrower live-key subset.
+    const { blob, offer } = await installedSummaryHandoff(frame.counts.important, surfacedLiveKeys);
+
+    // The all-category display count (4) is larger than the live-key count (3):
+    // the two are genuinely distinct, so the gate cannot be the display count.
+    expect(offer.worthALook).toBe(4);
+    expect(offer.liveKeys).toBe(3);
+
+    // The chain entry composes with, and never replaces, the installed summary's
+    // dashboard handoff: Open dashboard / Not now stay reachable exactly as on the
+    // no-findings branch (the dashboard handoff does not regress).
+    expect(offer.options).toEqual([
+      { id: 'enter-remediation', label: 'Review leaked keys' },
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+    // The rendered install card itself still carries the dashboard handoff line.
+    expect(blob).toContain('Open dashboard');
+
+    // Completing the installed summary hands off into the batched remediation
+    // decision, so calibration and the remediation tail form one continuous
+    // first-run flow.
+    const entry = enterRemediation(offer, persisted);
+    expect(entry.entered).toBe(true);
+    if (!entry.entered) return;
+    expect(entry.decision.kind).toBe('decision');
+    if (entry.decision.kind !== 'decision') return;
+
+    // The findings the remediation decision presents are the same surfaced secret
+    // findings the calibration counted: the two surfaces agree on N, and the count
+    // presented at the remediation decision equals the surfaced live-key count (3)
+    // — NOT the broader display count (4).
+    expect(entry.decision.secretCount).toBe(surfacedLiveKeys);
+    expect(entry.decision.secretCount).toBe(offer.liveKeys);
+    expect(entry.decision.prompt).toContain(
+      'I found 3 exposed secret keys sitting in old transcripts.',
+    );
+  });
+
+  it('no-findings branch — only non-secret findings surfaced: no remediation offered; dashboard handoff only', async () => {
+    // A surfaced pii finding but no secret: the display count is positive while the
+    // live-key count is zero, so the gate (the live-key subset) stays shut.
+    const preview: CalibrationPreview = {
+      categories: [{ category: 'pii', genuineCount: 1, fpCount: 5, egress: false }],
+      posture: {
+        secret: 'warn',
+        pii: 'warn',
+        financial: 'warn',
+        phi: 'warn',
+        code_flaw: 'warn',
+        custom: 'warn',
+        code_context: 'monitor',
+        config: 'monitor',
+      },
+    };
+    // No secret surfaced ⇒ the frame carries no maskedFindings.
+    const { frame, persisted, surfacedSecrets } = calibrate(preview, []);
+    expect(surfacedSecrets).toHaveLength(0);
+
+    const { offer } = await installedSummaryHandoff(frame.counts.important, surfacedSecrets.length);
+
+    // worthALook is positive (something surfaced) but no chain entry is offered:
+    // the gate is the live-key count, never the all-category display count.
+    expect(offer.worthALook).toBe(1);
+    expect(offer.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+
+    // The journey ends at the installed summary with the dashboard handoff only —
+    // no remediation decision, and even a forced load degrades honestly to no-decision.
+    const entry = enterRemediation(offer, persisted);
+    expect(entry.entered).toBe(false);
+    expect(
+      presentBatchedRemediation(loadSecretLeakFindings(() => persisted) ?? [], {
+        entrySource: 'first-run',
+      }),
+    ).toEqual({ kind: 'no-decision' });
+  });
+
+  it('no-findings branch — empty scan surfaced nothing: no remediation offered; dashboard handoff only', async () => {
+    // The scan ran and surfaced nothing (all suppressed): zero surfaced findings.
+    const preview: CalibrationPreview = {
+      categories: [{ category: 'secret', genuineCount: 0, fpCount: 10, egress: false }],
+      posture: {
+        secret: 'warn',
+        pii: 'warn',
+        financial: 'warn',
+        phi: 'warn',
+        code_flaw: 'warn',
+        custom: 'warn',
+        code_context: 'monitor',
+        config: 'monitor',
+      },
+    };
+    const { frame, persisted, surfacedSecrets } = calibrate(preview, []);
+    expect(surfacedSecrets).toHaveLength(0);
+
+    const { offer } = await installedSummaryHandoff(frame.counts.important, surfacedSecrets.length);
+
+    expect(offer.worthALook).toBe(0);
+    expect(offer.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+
+    const entry = enterRemediation(offer, persisted);
+    expect(entry.entered).toBe(false);
+  });
+
+  it('the remediation flow is entered exactly when the calibration surfaced secret-leak findings, and never otherwise', async () => {
+    const posture = {
+      secret: 'warn',
+      pii: 'warn',
+      financial: 'warn',
+      phi: 'warn',
+      code_flaw: 'warn',
+      custom: 'warn',
+      code_context: 'monitor',
+      config: 'monitor',
+    } as const;
+
+    // Three branches over one shared seam: live-key secrets surfaced, only
+    // non-secret findings surfaced, and an empty scan. Only the first enters.
+    const branches: { name: string; preview: CalibrationPreview; masked: MaskedSecretFinding[] }[] =
+      [
+        {
+          name: 'live-key secrets surfaced',
+          preview: {
+            categories: [{ category: 'secret', genuineCount: 2, fpCount: 4, egress: false }],
+            posture,
+          },
+          masked: [secretFinding(0), secretFinding(1)],
+        },
+        {
+          name: 'only non-secret findings surfaced',
+          preview: {
+            categories: [{ category: 'pii', genuineCount: 2, fpCount: 4, egress: false }],
+            posture,
+          },
+          masked: [],
+        },
+        {
+          name: 'empty scan',
+          preview: {
+            categories: [{ category: 'secret', genuineCount: 0, fpCount: 6, egress: false }],
+            posture,
+          },
+          masked: [],
+        },
+      ];
+
+    const entered: boolean[] = [];
+    for (const branch of branches) {
+      const { frame, persisted, surfacedSecrets } = calibrate(branch.preview, branch.masked);
+      const { offer } = await installedSummaryHandoff(
+        frame.counts.important,
+        surfacedSecrets.length,
+      );
+      entered.push(enterRemediation(offer, persisted).entered);
+    }
+
+    // Entered exactly when secret-leak findings surfaced, and never otherwise.
+    expect(entered).toEqual([true, false, false]);
+  });
+});

--- a/plugins/codex/test/remediation/production-redact.scenario.test.ts
+++ b/plugins/codex/test/remediation/production-redact.scenario.test.ts
@@ -1,0 +1,219 @@
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type { PluginRuntime } from '@akasecurity/plugin-sdk';
+import { safeMaskedMatch } from '@akasecurity/plugin-sdk';
+import type { MaskedSecretFinding } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// A toggle a single test flips to make the adapter's runtime `close()` throw —
+// every other test leaves it off, so the real teardown path still runs
+// everywhere else in this suite. `vi.hoisted` makes it exist before the mock
+// factory below runs.
+const { runtimeCloseShouldThrow } = vi.hoisted(() => ({
+  runtimeCloseShouldThrow: { value: false },
+}));
+
+vi.mock('@akasecurity/plugin-sdk', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const realCreatePluginRuntime = actual.createPluginRuntime as (
+    ...args: unknown[]
+  ) => PluginRuntime;
+  return {
+    ...actual,
+    createPluginRuntime: (...args: unknown[]): PluginRuntime => {
+      const runtime = realCreatePluginRuntime(...args);
+      return {
+        ...runtime,
+        close: async () => {
+          if (runtimeCloseShouldThrow.value) throw new Error('simulated runtime close fault');
+          await runtime.close();
+        },
+      };
+    },
+  };
+});
+
+import { deriveProvider } from '@akasecurity/setup-wizard';
+
+import { redactSurfacedSecrets } from '../../src/remediation/surfaced-redact.ts';
+
+// The PRODUCTION redaction adapter: unlike `redactLeakedKeys`,
+// which trusts whatever `RedactionScope` a caller builds, `redactSurfacedSecrets`
+// derives its own rollout/temp artifact scope and refuses a caller's attempt
+// to widen it into a project working tree. This suite proves both halves: a
+// legitimately-supplied temp root is honoured (genuine rollout/temp artifacts
+// are redacted), and a project root passed off as the temp scope is rejected —
+// the project file is left byte-identical no matter how it is offered.
+
+const AWS_RULE_ID = 'secrets/aws-access-key';
+const PROVIDER = deriveProvider(AWS_RULE_ID);
+
+// Canonical test AWS access-key ids, composed at runtime so the repo's own secret
+// scan does not flag this file (mirrors redact.test.ts). Each passes the real
+// detection engine's entropy validator (proven already by history/scan.test.ts,
+// which runs the same values through the same engine).
+const ROLLOUT_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+const TEMP_KEY = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+const PROJECT_KEY = ['AKIA', 'Z9YXWVUT5SRQPONM'].join('');
+
+function findingFor(filePath: string, rawValue: string): MaskedSecretFinding {
+  return {
+    provider: PROVIDER,
+    maskedToken: safeMaskedMatch(rawValue),
+    where: { filePath },
+    state: 'unknown',
+  };
+}
+
+// The day-sharded rollout directory Codex writes under a given home
+// (`<home>/.codex/sessions/YYYY/MM/DD`), created on demand for the fixtures.
+function rolloutDayDir(home: string): string {
+  const dir = join(home, '.codex', 'sessions', '2026', '07', '01');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe('redactSurfacedSecrets — the production redaction adapter', () => {
+  // A throwaway HOME (rollouts live at `<home>/.codex/sessions/...`, exactly
+  // what `transcriptsDir` derives) and a throwaway `~/.aka` base for the runtime's
+  // local store — so this suite never touches the developer's real machine state.
+  let home: string;
+  let dataDirBase: string;
+  // A genuinely bounded scratch directory a caller could legitimately name as its
+  // own temp root, and a directory standing in for a real project working tree
+  // (marked with a `.git` entry, exactly like a real repo root) that a caller
+  // might — wrongly — try to pass off as that same temp root.
+  let legitTempRoot: string;
+  let projectRoot: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'aka-prodredact-home-'));
+    dataDirBase = mkdtempSync(join(tmpdir(), 'aka-prodredact-store-'));
+    legitTempRoot = mkdtempSync(join(tmpdir(), 'aka-prodredact-temp-'));
+    projectRoot = mkdtempSync(join(tmpdir(), 'aka-prodredact-project-'));
+    mkdirSync(join(projectRoot, '.git'));
+  });
+
+  afterEach(() => {
+    for (const dir of [home, dataDirBase, legitTempRoot, projectRoot]) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('redacts genuine rollout and temp artifacts when a legitimate temp root is supplied', async () => {
+    const rolloutFile = join(rolloutDayDir(home), 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    writeFileSync(rolloutFile, `{"content":"a key ${ROLLOUT_KEY} in a prompt"}`);
+
+    const tempFile = join(legitTempRoot, 'agent-scratch.txt');
+    writeFileSync(tempFile, `scratch buffer ${TEMP_KEY} end`);
+
+    const findings = [findingFor(rolloutFile, ROLLOUT_KEY), findingFor(tempFile, TEMP_KEY)];
+
+    const result = await redactSurfacedSecrets(findings, {
+      home,
+      dataDirBase,
+      tempRoot: legitTempRoot,
+    });
+
+    expect(result.redactedKeys).toBe(2);
+    expect(result.unredacted).toEqual([]);
+    const rolloutAfter = readFileSync(rolloutFile, 'utf8');
+    expect(rolloutAfter).not.toContain(ROLLOUT_KEY);
+    expect(rolloutAfter).toContain('[REDACTED:SECRET]');
+    const tempAfter = readFileSync(tempFile, 'utf8');
+    expect(tempAfter).not.toContain(TEMP_KEY);
+    expect(tempAfter).toContain('[REDACTED:SECRET]');
+  });
+
+  it('rejects a project root offered as the temp scope — no project file is redacted, rollout artifacts still are, and the count reflects only real strikes', async () => {
+    const rolloutFile = join(rolloutDayDir(home), 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    writeFileSync(rolloutFile, `{"content":"a key ${ROLLOUT_KEY} in a prompt"}`);
+
+    // The "temp root" this call supplies is actually a project working tree
+    // (marked with `.git`) — an attempt to widen redaction beyond the
+    // rollout/temp artifact class by mislabeling it.
+    const projectFile = join(projectRoot, 'config.env');
+    writeFileSync(projectFile, `AWS_ACCESS_KEY_ID=${PROJECT_KEY}\n`);
+    const projectBytesBefore = readFileSync(projectFile);
+    const projectListingBefore = readdirSync(projectRoot);
+
+    const projectFinding = findingFor(projectFile, PROJECT_KEY);
+    const findings = [findingFor(rolloutFile, ROLLOUT_KEY), projectFinding];
+
+    const result = await redactSurfacedSecrets(findings, {
+      home,
+      dataDirBase,
+      tempRoot: projectRoot,
+    });
+
+    // Only the genuine rollout artifact was redacted — the project-root scope
+    // was refused outright, not partially honoured. The out-of-scope finding is
+    // reported back as unredacted, never silently dropped.
+    expect(result.redactedKeys).toBe(1);
+    expect(result.unredacted).toEqual([projectFinding]);
+    const rolloutAfter = readFileSync(rolloutFile, 'utf8');
+    expect(rolloutAfter).not.toContain(ROLLOUT_KEY);
+    expect(rolloutAfter).toContain('[REDACTED:SECRET]');
+
+    // The project file is byte-for-byte unchanged and its directory listing
+    // untouched — the rejected scope never widened redaction into it.
+    expect(readFileSync(projectFile)).toEqual(projectBytesBefore);
+    expect(readFileSync(projectFile, 'utf8')).toContain(PROJECT_KEY);
+    expect(readdirSync(projectRoot)).toEqual(projectListingBefore);
+  });
+
+  it('returns 0 and touches nothing for an empty findings set', async () => {
+    const result = await redactSurfacedSecrets([], { home, dataDirBase });
+    expect(result).toEqual({ redactedKeys: 0, unredacted: [] });
+  });
+
+  it('reports a vanished/unreadable artifact as unredacted rather than silently dropping it', async () => {
+    // The finding references a rollout path inside the enforced scope that was
+    // never actually written — mirrors a vanished/unreadable artifact at
+    // redact-time, distinct from an out-of-scope path.
+    const rolloutFile = join(rolloutDayDir(home), 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    const vanishedFinding = findingFor(rolloutFile, ROLLOUT_KEY);
+
+    const result = await redactSurfacedSecrets([vanishedFinding], { home, dataDirBase });
+
+    expect(result.redactedKeys).toBe(0);
+    expect(result.unredacted).toEqual([vanishedFinding]);
+  });
+
+  it('reports a finding whose content changed since the calibration scan as unredacted, not silently dropped', async () => {
+    const rolloutFile = join(rolloutDayDir(home), 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    // The artifact exists and is readable, but no longer contains the key the
+    // finding references — the re-scan at redact-time finds no matching occurrence.
+    writeFileSync(rolloutFile, 'this rollout no longer contains the leaked key');
+    const staleFinding = findingFor(rolloutFile, ROLLOUT_KEY);
+
+    const result = await redactSurfacedSecrets([staleFinding], { home, dataDirBase });
+
+    expect(result.redactedKeys).toBe(0);
+    expect(result.unredacted).toEqual([staleFinding]);
+  });
+
+  it('a runtime close() fault after targets were recovered does not drop them — the strike still lands and the count still reports it', async () => {
+    const rolloutFile = join(rolloutDayDir(home), 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    writeFileSync(rolloutFile, `{"content":"a key ${ROLLOUT_KEY} in a prompt"}`);
+    const finding = findingFor(rolloutFile, ROLLOUT_KEY);
+
+    runtimeCloseShouldThrow.value = true;
+    try {
+      const result = await redactSurfacedSecrets([finding], { home, dataDirBase });
+
+      // The teardown fault must not rewrite the outcome: the target was
+      // recovered and struck before close() ever ran, so it stays reported as
+      // redacted rather than being dropped to a false "0 keys" / "unredacted".
+      expect(result.redactedKeys).toBe(1);
+      expect(result.unredacted).toEqual([]);
+      const after = readFileSync(rolloutFile, 'utf8');
+      expect(after).not.toContain(ROLLOUT_KEY);
+      expect(after).toContain('[REDACTED:SECRET]');
+    } finally {
+      runtimeCloseShouldThrow.value = false;
+    }
+  });
+});

--- a/plugins/codex/test/remediation/redact.test.ts
+++ b/plugins/codex/test/remediation/redact.test.ts
@@ -1,0 +1,296 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  platformRedactionScope,
+  type RedactionScope,
+  redactLeakedKeys,
+  redactLeakedKeysDetailed,
+} from '../../src/remediation/redact.ts';
+
+// Canonical test AWS access-key ids, composed at runtime so the repo's own secret
+// scan does not flag this test file (mirrors history/scan.test.ts). Their exact
+// value is irrelevant to redaction — the module strikes a verbatim occurrence —
+// only that they are distinct and long enough to be a meaningful match.
+const ROLLOUT_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+const TEMP_KEY = ['AKIA', 'QZ7WXNTP4LMKD9VJ'].join('');
+const PROJECT_KEY = ['AKIA', 'Z9YXWVUT5SRQPONM'].join('');
+
+describe('redactLeakedKeys', () => {
+  // Two in-scope artifact roots (rollout + temp) and one out-of-scope project
+  // root, all distinct siblings under the OS temp dir — so the project root shares
+  // no ancestry with an artifact root and the scope limit is a structural, not a
+  // coincidental, boundary.
+  let rolloutRoot: string;
+  let tempRoot: string;
+  let projectRoot: string;
+  let scope: RedactionScope;
+
+  beforeEach(() => {
+    rolloutRoot = mkdtempSync(join(tmpdir(), 'aka-redact-rollouts-'));
+    tempRoot = mkdtempSync(join(tmpdir(), 'aka-redact-temp-'));
+    projectRoot = mkdtempSync(join(tmpdir(), 'aka-redact-project-'));
+    scope = { artifactRoots: [rolloutRoot, tempRoot] };
+  });
+
+  afterEach(() => {
+    rmSync(rolloutRoot, { recursive: true, force: true });
+    rmSync(tempRoot, { recursive: true, force: true });
+    rmSync(projectRoot, { recursive: true, force: true });
+  });
+
+  it('redacts leaked keys in rollout and temp artifacts, returning the real count', () => {
+    // A rollout artifact nested under the rollout root, in the year/month/day
+    // sharding Codex uses (sessions/YYYY/MM/DD/rollout-*.jsonl).
+    const dayDir = join(rolloutRoot, '2026', '07', '01');
+    mkdirSync(dayDir, { recursive: true });
+    const rolloutFile = join(dayDir, 'rollout-2026-07-01T10-00-00-abc123.jsonl');
+    writeFileSync(rolloutFile, `{"content":"here is a key ${ROLLOUT_KEY} in a prompt"}`);
+
+    // A temp artifact directly under the temp root.
+    const tempFile = join(tempRoot, 'agent-scratch.txt');
+    writeFileSync(tempFile, `scratch buffer ${TEMP_KEY} end`);
+
+    const count = redactLeakedKeys(
+      [
+        { where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY },
+        { where: { filePath: tempFile }, rawValue: TEMP_KEY },
+      ],
+      scope,
+    );
+
+    expect(count).toBe(2);
+
+    // The leaked keys are no longer readable in either artifact.
+    const rolloutAfter = readFileSync(rolloutFile, 'utf8');
+    expect(rolloutAfter).not.toContain(ROLLOUT_KEY);
+    expect(rolloutAfter).toContain('[REDACTED:SECRET]');
+
+    const tempAfter = readFileSync(tempFile, 'utf8');
+    expect(tempAfter).not.toContain(TEMP_KEY);
+    expect(tempAfter).toContain('[REDACTED:SECRET]');
+  });
+
+  it('leaves ordinary project files byte-identical — the binding scope limit', () => {
+    const rolloutFile = join(rolloutRoot, 'rollout-session.jsonl');
+    writeFileSync(rolloutFile, `leaked ${ROLLOUT_KEY}`);
+
+    // A finding references an ordinary project file too. It must never be touched:
+    // in-place redaction of arbitrary project files is out of scope for this flow.
+    const projectFile = join(projectRoot, 'config.env');
+    writeFileSync(projectFile, `AWS_ACCESS_KEY_ID=${PROJECT_KEY}\n`);
+    const projectBytesBefore = readFileSync(projectFile);
+
+    const count = redactLeakedKeys(
+      [
+        { where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY },
+        { where: { filePath: projectFile }, rawValue: PROJECT_KEY },
+      ],
+      scope,
+    );
+
+    // Only the rollout key was redacted; the project-file key is out of scope.
+    expect(count).toBe(1);
+
+    // The rollout artifact was redacted.
+    expect(readFileSync(rolloutFile, 'utf8')).not.toContain(ROLLOUT_KEY);
+
+    // The project file is byte-for-byte unchanged, key intact.
+    expect(readFileSync(projectFile)).toEqual(projectBytesBefore);
+    expect(readFileSync(projectFile, 'utf8')).toContain(PROJECT_KEY);
+  });
+
+  it('never writes outside the rollout/temp artifact set even for a full project batch', () => {
+    // Every finding in this batch references an out-of-scope project file.
+    const fileA = join(projectRoot, 'a.ts');
+    const fileB = join(projectRoot, 'nested', 'b.ts');
+    mkdirSync(join(projectRoot, 'nested'), { recursive: true });
+    writeFileSync(fileA, `const key = '${PROJECT_KEY}';\n`);
+    writeFileSync(fileB, `export const KEY = '${TEMP_KEY}';\n`);
+    const bytesA = readFileSync(fileA);
+    const bytesB = readFileSync(fileB);
+
+    const count = redactLeakedKeys(
+      [
+        { where: { filePath: fileA }, rawValue: PROJECT_KEY },
+        { where: { filePath: fileB }, rawValue: TEMP_KEY },
+      ],
+      scope,
+    );
+
+    expect(count).toBe(0);
+    expect(readFileSync(fileA)).toEqual(bytesA);
+    expect(readFileSync(fileB)).toEqual(bytesB);
+  });
+
+  it('redacts every occurrence of a key and counts only keys actually redacted', () => {
+    // One artifact holds the same key twice; another in-scope artifact does not
+    // hold its referenced key at all.
+    const multi = join(rolloutRoot, 'rollout-multi.jsonl');
+    writeFileSync(multi, `first ${ROLLOUT_KEY} middle ${ROLLOUT_KEY} last`);
+    const absent = join(rolloutRoot, 'rollout-absent.jsonl');
+    writeFileSync(absent, 'no secret in this rollout');
+
+    const count = redactLeakedKeys(
+      [
+        { where: { filePath: multi }, rawValue: ROLLOUT_KEY },
+        // In scope, but the referenced key is not present in the file.
+        { where: { filePath: absent }, rawValue: TEMP_KEY },
+      ],
+      scope,
+    );
+
+    // The absent key was never actually redacted, so it is not counted.
+    expect(count).toBe(1);
+
+    const multiAfter = readFileSync(multi, 'utf8');
+    expect(multiAfter).not.toContain(ROLLOUT_KEY);
+    // BOTH occurrences were struck.
+    expect(multiAfter.match(/\[REDACTED:SECRET\]/g)).toHaveLength(2);
+
+    // The file whose key was absent is untouched.
+    expect(readFileSync(absent, 'utf8')).toBe('no secret in this rollout');
+  });
+
+  it('counts every finding on a repeated value struck, not just the first', () => {
+    // The same raw secret value appears twice in one rollout and is surfaced
+    // as TWO findings (two targets sharing one rawValue). The first strike's
+    // replaceAll clears every occurrence, so the second target's value is already
+    // gone — it must still count as struck, never misreported as still exposed.
+    const rolloutFile = join(rolloutRoot, 'rollout-repeated.jsonl');
+    writeFileSync(rolloutFile, `one ${ROLLOUT_KEY} two ${ROLLOUT_KEY} done`);
+
+    const targets = [
+      { where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY },
+      { where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY },
+    ];
+    const detail = redactLeakedKeysDetailed(targets, scope);
+
+    // Both findings resolve on the single rewrite: counted and struck, so a
+    // caller diffing its input against `struck` finds nothing left unredacted.
+    expect(detail.redactedKeys).toBe(2);
+    expect(detail.struck).toEqual(targets);
+    expect(readFileSync(rolloutFile, 'utf8')).not.toContain(ROLLOUT_KEY);
+  });
+
+  it('the production default scope does not treat an arbitrary temp file as in-scope', () => {
+    // Under the real platform default scope (rollouts dir only), a leaked key in
+    // a file that merely lives under the OS temp dir is NOT redacted — proving the
+    // shipped default never grants redaction over the whole OS temp tree.
+    const strayFile = join(tempRoot, 'stray-under-tmp.txt');
+    writeFileSync(strayFile, `stray ${TEMP_KEY} value`);
+    const bytesBefore = readFileSync(strayFile);
+
+    const count = redactLeakedKeys([{ where: { filePath: strayFile }, rawValue: TEMP_KEY }]);
+
+    expect(count).toBe(0);
+    expect(readFileSync(strayFile)).toEqual(bytesBefore);
+    expect(readFileSync(strayFile, 'utf8')).toContain(TEMP_KEY);
+    // Sanity: the default scope is rollouts-only, not the OS temp dir.
+    expect(platformRedactionScope().artifactRoots).not.toContain(tmpdir());
+  });
+
+  it('a symlink inside an allowed root cannot redirect a write outside it', () => {
+    // The leaked key lives in an ordinary project file OUTSIDE every root.
+    const projectFile = join(projectRoot, 'secrets.env');
+    writeFileSync(projectFile, `AWS_ACCESS_KEY_ID=${PROJECT_KEY}\n`);
+    const projectBytesBefore = readFileSync(projectFile);
+
+    // A symlink placed INSIDE an allowed artifact root points at that external
+    // project file. A lexical prefix check would accept the symlink's path; the
+    // real-path containment check must reject it so the write never escapes.
+    const symlinkInRoot = join(rolloutRoot, 'rollout-escape.jsonl');
+    symlinkSync(projectFile, symlinkInRoot);
+
+    const count = redactLeakedKeys(
+      [{ where: { filePath: symlinkInRoot }, rawValue: PROJECT_KEY }],
+      scope,
+    );
+
+    expect(count).toBe(0);
+    expect(readFileSync(projectFile)).toEqual(projectBytesBefore);
+    expect(readFileSync(projectFile, 'utf8')).toContain(PROJECT_KEY);
+  });
+
+  it('is best-effort per file: a missing artifact does not abort the batch', () => {
+    // One in-scope artifact exists and holds its key; another in-scope target
+    // references a path that does not exist on disk.
+    const present = join(rolloutRoot, 'rollout-present.jsonl');
+    writeFileSync(present, `leaked ${ROLLOUT_KEY} here`);
+    const missing = join(tempRoot, 'never-written.txt');
+
+    const count = redactLeakedKeys(
+      [
+        // The missing target is listed first, so a batch-aborting throw would leave
+        // the present artifact un-redacted.
+        { where: { filePath: missing }, rawValue: TEMP_KEY },
+        { where: { filePath: present }, rawValue: ROLLOUT_KEY },
+      ],
+      scope,
+    );
+
+    // The missing artifact contributes nothing; the present one is still redacted.
+    expect(count).toBe(1);
+    expect(readFileSync(present, 'utf8')).not.toContain(ROLLOUT_KEY);
+    expect(readFileSync(present, 'utf8')).toContain('[REDACTED:SECRET]');
+  });
+
+  describe('.aka-redact.tmp cleanup', () => {
+    // Entries left behind matching the atomic-write sibling-temp-file naming.
+    function orphanedTmpEntries(dir: string): string[] {
+      return readdirSync(dir).filter((entry) => entry.endsWith('.aka-redact.tmp'));
+    }
+
+    it('leaves no .aka-redact.tmp sibling after a successful redaction', () => {
+      const rolloutFile = join(rolloutRoot, 'rollout-session.jsonl');
+      writeFileSync(rolloutFile, `leaked ${ROLLOUT_KEY} here`);
+
+      const count = redactLeakedKeys(
+        [{ where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY }],
+        scope,
+      );
+
+      expect(count).toBe(1);
+      expect(readFileSync(rolloutFile, 'utf8')).toContain('[REDACTED:SECRET]');
+      // The rename consumed the temp file — no orphan sibling remains.
+      expect(orphanedTmpEntries(rolloutRoot)).toEqual([]);
+    });
+
+    it('leaves no .aka-redact.tmp orphan and the original intact when the atomic write fails', () => {
+      const rolloutFile = join(rolloutRoot, 'rollout-session.jsonl');
+      const originalContent = `leaked ${ROLLOUT_KEY} here`;
+      writeFileSync(rolloutFile, originalContent);
+
+      // Pre-create a DIRECTORY at the exact sibling temp path the atomic write
+      // uses, so `writeFileSync(tmpPath, content)` throws EISDIR instead of
+      // writing — a deterministic, OS-level way to force the write/rename step
+      // to fail without touching the original file at all.
+      const tmpPath = `${rolloutFile}.aka-redact.tmp`;
+      mkdirSync(tmpPath);
+
+      const count = redactLeakedKeys(
+        [{ where: { filePath: rolloutFile }, rawValue: ROLLOUT_KEY }],
+        scope,
+      );
+
+      // The write failed, so nothing was redacted or counted.
+      expect(count).toBe(0);
+      // The cleanup catch removed the tmp entry — even though it turned out to be
+      // a directory rather than a partially written file — so no orphan survives.
+      expect(orphanedTmpEntries(rolloutRoot)).toEqual([]);
+      // The atomic-write guarantee: the original artifact is untouched.
+      expect(readFileSync(rolloutFile, 'utf8')).toBe(originalContent);
+    });
+  });
+});

--- a/plugins/codex/test/remediation/render.test.ts
+++ b/plugins/codex/test/remediation/render.test.ts
@@ -4,6 +4,7 @@ import { renderChecklistMarkdown } from '@akasecurity/setup-wizard';
 import { describe, expect, it } from 'vitest';
 
 import { renderRemediationDecision } from '../../src/remediation/render.ts';
+import { ECHO_RUN, expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // The RAW_* constants are what the underlying leak actually contains; each
 // fixture's `maskedToken` is the masked preview of the SAME raw value (raw prefix
@@ -82,14 +83,30 @@ describe('renderRemediationDecision — decision layout', () => {
     const out = renderRemediationDecision([stripeFinding(), awsFinding()], 0, REGISTRY_SCAN);
     // The masked preview is what surfaces; the raw value it derives from does not.
     // Guard the assertion against vacuity: the masked and raw forms must genuinely
-    // differ, so `not.toContain(RAW_*)` is a real check, not a tautology over a
-    // string the renderer was never given.
+    // differ, so the absence check is a real one, not a tautology over a string
+    // the renderer was never given.
     expect(MASKED_STRIPE).not.toEqual(RAW_STRIPE);
     expect(MASKED_AWS).not.toEqual(RAW_AWS);
     expect(out).toContain(MASKED_STRIPE);
     expect(out).toContain(MASKED_AWS);
     expect(out).not.toContain(RAW_STRIPE);
     expect(out).not.toContain(RAW_AWS);
+    // Then the run-by-run half, pointed at the secret MATERIAL rather than the
+    // whole raw value. The masked preview reveals the provider prefix on
+    // purpose (`sk_live_` is eight characters — exactly ECHO_RUN), so a run
+    // check against the whole raw would fire on the very fragment this table
+    // is supposed to print: the helper's limit 3. Everything past the revealed
+    // prefix is secret, and none of it may appear in any run — which a
+    // whole-value assertion alone would miss if the renderer ever truncated.
+    // The slice is derived from the mask, so revealing more adjusts it here.
+    const stripeSecret = RAW_STRIPE.slice(MASKED_STRIPE.indexOf('*'));
+    const awsSecret = RAW_AWS.slice(MASKED_AWS.indexOf('*'));
+    // Guard the slices: a tail shorter than ECHO_RUN would leave the sliding
+    // loop with nothing to run, and both assertions below would pass vacuously.
+    expect(stripeSecret.length).toBeGreaterThan(ECHO_RUN);
+    expect(awsSecret.length).toBeGreaterThan(ECHO_RUN);
+    expectNoEchoOf(out, stripeSecret);
+    expectNoEchoOf(out, awsSecret);
   });
 
   it('cannot be handed a raw value — the MaskedSecretFinding contract rejects it (.strict)', () => {

--- a/plugins/codex/test/remediation/render.test.ts
+++ b/plugins/codex/test/remediation/render.test.ts
@@ -1,0 +1,337 @@
+import { MaskedSecretFinding, type RotationChecklistEntry } from '@akasecurity/schema';
+import { renderRedactionOutcome, renderResolvedSummary } from '@akasecurity/setup-wizard';
+import { renderChecklistMarkdown } from '@akasecurity/setup-wizard';
+import { describe, expect, it } from 'vitest';
+
+import { renderRemediationDecision } from '../../src/remediation/render.ts';
+
+// The RAW_* constants are what the underlying leak actually contains; each
+// fixture's `maskedToken` is the masked preview of the SAME raw value (raw prefix
+// kept, tail masked). The decision layout must surface only the masked preview and
+// never the raw key it derives from (the raw-free boundary), so the raw-free
+// assertions below compare the rendered output against these real raw values.
+// Assembled at runtime so the source carries no contiguous key-shaped literal
+// (mirrors the AKIA fixtures) — the value is an obviously-fake example, not a key.
+const RAW_STRIPE = ['sk', 'live', '51H8xEXAMPLErawstripesecretVALUE0000'].join('_');
+const RAW_AWS = 'AKIAIOSFODNN7EXAMPLE';
+
+// Masked preview of RAW_STRIPE / RAW_AWS — the exact strings the table should
+// carry in place of the raw values above.
+const MASKED_STRIPE = 'sk_live_****';
+const MASKED_AWS = 'AKIA****************';
+
+// The loader emits state:'unknown' — validity is unverifiable under the
+// no-network OSS constraint — so the fixtures carry the state a real finding does.
+function stripeFinding(): MaskedSecretFinding {
+  return {
+    provider: 'stripe',
+    maskedToken: MASKED_STRIPE,
+    where: { filePath: '~/.codex/sessions/2026/07/01/rollout-2026-07-01T10-00-00-abc123.jsonl' },
+    state: 'unknown',
+  };
+}
+
+function awsFinding(): MaskedSecretFinding {
+  return {
+    provider: 'aws',
+    maskedToken: MASKED_AWS,
+    where: { filePath: '/tmp/agent-dump.txt', span: { start: 12, end: 32 } },
+    state: 'unknown',
+  };
+}
+
+// The chaining line's secret-scan continuation is registry-driven: `aka-scan`
+// today, or a dedicated secret-scan skill name if one is registered instead.
+const REGISTRY_SCAN = ['aka-dashboard', 'aka-scan'];
+const REGISTRY_SECRETSCAN = ['aka-dashboard', 'aka-secretscan'];
+
+describe('renderRemediationDecision — decision layout', () => {
+  it('renders one table row per masked finding with provider / token / where / state', () => {
+    const out = renderRemediationDecision([stripeFinding(), awsFinding()], 0, REGISTRY_SCAN);
+    // provider
+    expect(out).toContain('stripe');
+    expect(out).toContain('aws');
+    // masked token (masked preview, not the raw key)
+    expect(out).toContain('sk_live_****');
+    expect(out).toContain('AKIA****************');
+    // where-found
+    expect(out).toContain('~/.codex/sessions/2026/07/01/rollout-2026-07-01T10-00-00-abc123.jsonl');
+    expect(out).toContain('/tmp/agent-dump.txt');
+    // the honest per-finding state, rendered as human text — never an
+    // unverifiable 'still valid' claim over an unknown-state finding
+    expect(out).toContain('unknown');
+    expect(out).not.toContain('still valid');
+  });
+
+  it('renders each finding state as honest human text (still valid / unknown / invalid)', () => {
+    // The table shows whatever state a finding carries; validity is only claimed
+    // when it is genuinely known. 'still-valid' stays reachable for when a caller
+    // can verify a key, but the default unknown state never reads as valid.
+    expect(
+      renderRemediationDecision([{ ...stripeFinding(), state: 'still-valid' }], 0, REGISTRY_SCAN),
+    ).toContain('still valid');
+    expect(
+      renderRemediationDecision([{ ...stripeFinding(), state: 'unknown' }], 0, REGISTRY_SCAN),
+    ).toContain('unknown');
+    expect(
+      renderRemediationDecision([{ ...stripeFinding(), state: 'invalid' }], 0, REGISTRY_SCAN),
+    ).toContain('invalid');
+  });
+
+  it('never emits a raw secret value — masked tokens only (raw-free)', () => {
+    const out = renderRemediationDecision([stripeFinding(), awsFinding()], 0, REGISTRY_SCAN);
+    // The masked preview is what surfaces; the raw value it derives from does not.
+    // Guard the assertion against vacuity: the masked and raw forms must genuinely
+    // differ, so `not.toContain(RAW_*)` is a real check, not a tautology over a
+    // string the renderer was never given.
+    expect(MASKED_STRIPE).not.toEqual(RAW_STRIPE);
+    expect(MASKED_AWS).not.toEqual(RAW_AWS);
+    expect(out).toContain(MASKED_STRIPE);
+    expect(out).toContain(MASKED_AWS);
+    expect(out).not.toContain(RAW_STRIPE);
+    expect(out).not.toContain(RAW_AWS);
+  });
+
+  it('cannot be handed a raw value — the MaskedSecretFinding contract rejects it (.strict)', () => {
+    // The renderer emits only fields present on a MaskedSecretFinding, so the
+    // 'NO raw secret value ever emitted' property rests on raw never reaching it.
+    // The `.strict()` schema is that structural guard: a finding smuggling the raw
+    // key under an extra field fails validation at the boundary, so the renderer's
+    // input can never carry one.
+    const smuggled = { ...stripeFinding(), rawValue: RAW_STRIPE };
+    expect(MaskedSecretFinding.safeParse(smuggled).success).toBe(false);
+  });
+
+  it('renders the most-exposed-first recommendation line verbatim', () => {
+    const out = renderRemediationDecision([stripeFinding()], 0, REGISTRY_SCAN);
+    expect(out).toContain("I'd redact them and get you rotating, most-exposed first");
+  });
+
+  it('closes with the chaining line naming the registered secret-scan skill', () => {
+    const out = renderRemediationDecision([stripeFinding()], 1, REGISTRY_SCAN);
+    expect(out).toContain("1 more worth a look — run the aka-scan skill when you're ready.");
+  });
+
+  it('reflects the registry — names aka-secretscan when that is what is registered, not a hardcode', () => {
+    const out = renderRemediationDecision([stripeFinding()], 2, REGISTRY_SECRETSCAN);
+    expect(out).toContain("2 more worth a look — run the aka-secretscan skill when you're ready.");
+  });
+
+  it('fails loud when no secret-scan skill is registered', () => {
+    // Neither `aka-scan` nor `aka-secretscan` present ⇒ the chaining line would
+    // name a skill the plugin does not register, so selection throws rather than
+    // shipping an uninvokable call-to-action.
+    expect(() => renderRemediationDecision([stripeFinding()], 1, ['aka-dashboard'])).toThrow();
+  });
+});
+
+describe('renderResolvedSummary', () => {
+  const entries: readonly RotationChecklistEntry[] = [
+    {
+      provider: 'stripe',
+      maskedToken: MASKED_STRIPE,
+      consolePath: 'dashboard.stripe.com → Developers → API keys',
+      occurrenceSpread: 2,
+    },
+    {
+      provider: 'aws',
+      maskedToken: MASKED_AWS,
+      consolePath: 'console.aws.amazon.com → IAM → Security credentials',
+      occurrenceSpread: 1,
+    },
+  ];
+
+  it('renders real key and distinct-transcript counts independently with the dynamic location', () => {
+    const findings = [
+      stripeFinding(),
+      { ...stripeFinding(), maskedToken: 'sk_live_…2222' },
+      awsFinding(),
+    ];
+
+    const summary = renderResolvedSummary({
+      redactedKeys: 3,
+      findings,
+      unredactedFindings: [],
+      location: 'repo root',
+      entries,
+    });
+
+    expect(summary).toContain('Leaked secrets — resolved');
+    expect(summary).toContain('✓ Redacted 3 keys across 2 transcripts');
+    expect(summary).toContain('✓ I drafted a rotation checklist for you (repo root).');
+
+    // A fourth finding (all four struck: redactedKeys tracks findings.length so
+    // the "resolved" framing stays honest) proves the transcript count is
+    // independently derived from distinct filePaths, not the key count relabelled.
+    const threeTranscriptSummary = renderResolvedSummary({
+      redactedKeys: 4,
+      findings: [
+        ...findings,
+        { ...awsFinding(), where: { filePath: '/tmp/second-agent-dump.txt' } },
+      ],
+      unredactedFindings: [],
+      location: 'repo root',
+      entries,
+    });
+    expect(threeTranscriptSummary).toContain('✓ Redacted 4 keys across 3 transcripts');
+  });
+
+  it('renders singular key and transcript nouns from a single-key fixture', () => {
+    const summary = renderResolvedSummary({
+      redactedKeys: 1,
+      findings: [stripeFinding()],
+      unredactedFindings: [],
+      location: 'repo root',
+      entries: entries.slice(0, 1),
+    });
+
+    expect(summary).toContain('✓ Redacted 1 key across 1 transcript');
+  });
+
+  it('renders the inline preview entry-for-entry from the checklist file model', () => {
+    const summary = renderResolvedSummary({
+      redactedKeys: 2,
+      findings: [stripeFinding(), awsFinding()],
+      unredactedFindings: [],
+      location: 'repo root',
+      entries,
+    });
+    const previewLines = summary.split('\n').filter((line) => line.startsWith('- [ ] '));
+    const fileLines = renderChecklistMarkdown(entries).trimEnd().split('\n');
+
+    expect(previewLines).toEqual(fileLines);
+  });
+
+  it('never claims "resolved" on a partial strike — an honest partial message names the shortfall and the file still holding a live key', () => {
+    const secondAwsFinding = { ...awsFinding(), where: { filePath: '/tmp/second-agent-dump.txt' } };
+    const findings = [stripeFinding(), awsFinding(), secondAwsFinding];
+
+    // Two of the three findings were struck; the aws finding in the second file
+    // was not (e.g. it vanished or changed between the calibration scan and the
+    // redact-time re-scan) — a real, legitimate partial outcome.
+    const summary = renderResolvedSummary({
+      redactedKeys: 2,
+      findings,
+      unredactedFindings: [secondAwsFinding],
+      location: 'repo root',
+      entries,
+    });
+
+    // The clean "resolved" framing is never shown over a partial strike.
+    expect(summary).not.toContain('Leaked secrets — resolved');
+    expect(summary).toContain('Leaked secrets — partially redacted');
+    expect(summary).toContain(
+      'Redacted 2 of 3 keys; 1 key still needs attention in /tmp/second-agent-dump.txt',
+    );
+    // The checklist deliverable still lands — rotation is still owed regardless
+    // of whether the leaked text itself was struck.
+    expect(summary).toContain('✓ I drafted a rotation checklist for you (repo root).');
+  });
+
+  it('pluralizes the partial message correctly across more than one remaining key', () => {
+    const secondStripeFinding = {
+      ...stripeFinding(),
+      maskedToken: 'sk_live_…2222',
+      where: { filePath: '/tmp/second-agent-dump.txt' },
+    };
+    const findings = [stripeFinding(), secondStripeFinding, awsFinding()];
+
+    const summary = renderResolvedSummary({
+      redactedKeys: 1,
+      findings,
+      unredactedFindings: [secondStripeFinding, awsFinding()],
+      location: 'repo root',
+      entries,
+    });
+
+    expect(summary).toContain('Leaked secrets — partially redacted');
+    expect(summary).toContain('Redacted 1 of 3 keys; 2 keys still need attention in');
+    // Both remaining files are named, not just the first.
+    expect(summary).toContain('/tmp/second-agent-dump.txt');
+    expect(summary).toContain(awsFinding().where.filePath);
+  });
+
+  it('never renders "Redacted 0 keys" as a clean all-clear when nothing was struck', () => {
+    const findings = [stripeFinding(), awsFinding()];
+
+    const summary = renderResolvedSummary({
+      redactedKeys: 0,
+      findings,
+      unredactedFindings: findings,
+      location: 'repo root',
+      entries,
+    });
+
+    expect(summary).not.toContain('Leaked secrets — resolved');
+    expect(summary).toContain('Leaked secrets — partially redacted');
+    expect(summary).toContain('Redacted 0 of 2 keys; 2 keys still need attention in');
+  });
+
+  it('treats a degraded checklist-write note the same across the complete and partial framings', () => {
+    const findings = [stripeFinding()];
+    const partial = renderResolvedSummary({
+      redactedKeys: 0,
+      findings,
+      unredactedFindings: findings,
+      degradedNote: 'Could not draft rotation-checklist.md at /nowhere.',
+      entries,
+    });
+
+    expect(partial).toContain('Leaked secrets — partially redacted');
+    expect(partial).toContain('Could not draft rotation-checklist.md at /nowhere.');
+  });
+});
+
+describe('renderRedactionOutcome — redact-only confirmation', () => {
+  it('renders the clean confirmation when every finding was struck', () => {
+    const findings = [stripeFinding(), awsFinding()];
+    expect(renderRedactionOutcome({ redactedKeys: 2, findings, unredactedFindings: [] })).toBe(
+      '✓ Redacted 2 keys.',
+    );
+  });
+
+  it('pluralizes the clean confirmation over a single struck key', () => {
+    const findings = [stripeFinding()];
+    expect(renderRedactionOutcome({ redactedKeys: 1, findings, unredactedFindings: [] })).toBe(
+      '✓ Redacted 1 key.',
+    );
+  });
+
+  it('never claims a clean strike on a partial redact-only outcome — it names the shortfall and the file still holding a live key', () => {
+    const secondAwsFinding = { ...awsFinding(), where: { filePath: '/tmp/second-agent-dump.txt' } };
+    const findings = [stripeFinding(), awsFinding(), secondAwsFinding];
+
+    // Two of three struck; the aws finding in the second file was not (it vanished
+    // or changed between the calibration scan and the redact-time re-scan) — the
+    // redact-only route must disclose this exactly as the resolved summary does.
+    const outcome = renderRedactionOutcome({
+      redactedKeys: 2,
+      findings,
+      unredactedFindings: [secondAwsFinding],
+    });
+
+    expect(outcome).not.toContain('✓ Redacted');
+    expect(outcome).toBe(
+      'Redacted 2 of 3 keys; 1 key still needs attention in /tmp/second-agent-dump.txt',
+    );
+  });
+
+  it('pluralizes the partial confirmation across more than one remaining key', () => {
+    const secondStripeFinding = {
+      ...stripeFinding(),
+      maskedToken: 'sk_live_…2222',
+      where: { filePath: '/tmp/second-agent-dump.txt' },
+    };
+    const findings = [stripeFinding(), secondStripeFinding, awsFinding()];
+
+    const outcome = renderRedactionOutcome({
+      redactedKeys: 1,
+      findings,
+      unredactedFindings: [secondStripeFinding, awsFinding()],
+    });
+
+    expect(outcome).toContain('Redacted 1 of 3 keys; 2 keys still need attention in');
+    expect(outcome).toContain('/tmp/second-agent-dump.txt');
+    expect(outcome).toContain(awsFinding().where.filePath);
+  });
+});

--- a/plugins/codex/test/render.test.ts
+++ b/plugins/codex/test/render.test.ts
@@ -1,0 +1,398 @@
+import { severityFloorPosture } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import {
+  RE_TUNE_HINT,
+  renderAdjustConfirm,
+  renderApplied,
+  renderCategoriesTuned,
+  renderPosture,
+  renderPostureGrid,
+  renderRecommendedPosture,
+  renderStartLight,
+} from '../src/render.ts';
+import { readRegisteredSkills } from '../src/skills-registry.ts';
+
+describe('renderPosture', () => {
+  it('lists each category with its action, aligned', () => {
+    const out = renderPosture([
+      { category: 'secret', action: 'warn' },
+      { category: 'code_context', action: 'log' },
+    ]);
+    expect(out).toContain('secret');
+    expect(out).toContain('warn');
+    expect(out).toContain('code_context');
+    // 'log' (ActionTaken) surfaces to the user as 'monitor'
+    expect(out).toContain('monitor');
+    expect(out).not.toMatch(/\blog\b/);
+  });
+
+  it('orders rows canonically regardless of input order', () => {
+    // Rows arrive in whatever order the store returned them; the card must
+    // render in the schema's canonical category order so it stays stable.
+    const out = renderPosture([
+      { category: 'code_context', action: 'monitor' },
+      { category: 'secret', action: 'warn' },
+      { category: 'pii', action: 'warn' },
+      { category: 'financial', action: 'monitor' },
+    ]);
+    const order = out.split('\n').map((line) => line.trim().split(/\s+/)[0]);
+    expect(order).toEqual(['pii', 'financial', 'secret', 'code_context']);
+  });
+});
+
+describe('renderRecommendedPosture — condensed recommended view', () => {
+  it('shows each pack with its recommended level, compact and in canonical order', () => {
+    const out = renderRecommendedPosture(severityFloorPosture());
+    // One compact row per pack — the recommended level, not the full 8×4 grid of
+    // every level (that is the start-light branch's table).
+    const packs = out
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .map((line) => line.trim().split(/\s+/)[0]);
+    expect(packs).toEqual([
+      'pii',
+      'financial',
+      'secret',
+      'phi',
+      'code_context',
+      'code_flaw',
+      'custom',
+      'config',
+    ]);
+    // The recommendation: sensitive packs surface (warn); observe-only packs
+    // monitor. Palette vocabulary only — no DB 'log' leaks through.
+    expect(out).not.toMatch(/\blog\b/);
+    expect(out).not.toMatch(/\bblock\b/);
+    // The whole block, so a layout/copy regression is caught as a snapshot diff.
+    expect(out).toMatchInlineSnapshot(`
+      "  pii           warn
+        financial     warn
+        secret        warn
+        phi           warn
+        code_context  monitor
+        code_flaw     warn
+        custom        warn
+        config        monitor"
+    `);
+  });
+
+  it('renders whatever recommended map it is handed (no hardcoded levels)', () => {
+    const out = renderRecommendedPosture({
+      secret: 'block',
+      pii: 'redact',
+      financial: 'warn',
+      phi: 'warn',
+      code_context: 'monitor',
+      code_flaw: 'warn',
+      custom: 'warn',
+      config: 'monitor',
+    });
+    expect(out).toContain('secret');
+    expect(out).toContain('block');
+    expect(out).toContain('redact');
+  });
+});
+
+describe('renderPostureGrid — full 8×4 posture matrix', () => {
+  // The eight packs, in the schema's canonical category order — the same order
+  // renderPosture/renderRecommendedPosture use, and the order the grid must lock.
+  const CANONICAL = [
+    'pii',
+    'financial',
+    'secret',
+    'phi',
+    'code_context',
+    'code_flaw',
+    'custom',
+    'config',
+  ];
+
+  it('lays every pack against all four levels, marks the chosen one, in canonical order', () => {
+    const out = renderPostureGrid(severityFloorPosture());
+
+    // Every pack renders, once, in canonical category order (header and rule
+    // lines excluded by keeping only rows whose first token is a known pack).
+    const packs = out
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter((tok): tok is string => tok !== undefined && CANONICAL.includes(tok));
+    expect(packs).toEqual(CANONICAL);
+
+    // All four level labels head the grid — palette vocabulary only, never the
+    // DB action forms 'log'/'allow' (the full grid lays out every level per pack,
+    // unlike renderRecommendedPosture's condensed one-level glance).
+    expect(out).toContain('MONITOR');
+    expect(out).toContain('WARN');
+    expect(out).toContain('REDACT');
+    expect(out).toContain('BLOCK');
+    expect(out).not.toMatch(/\blog\b/);
+    expect(out).not.toMatch(/\ballow\b/);
+
+    // The whole 8×4 grid, so a layout regression is caught as a snapshot diff.
+    // Feeding the default posture map, the mark sits in monitor for the observe-only
+    // packs (code_context, config) and in warn for the rest.
+    expect(out).toMatchInlineSnapshot(`
+      "  CATEGORY       MONITOR   WARN   REDACT   BLOCK
+        ────────────   ───────   ────   ──────   ─────
+        pii                      ●                    
+        financial                ●                    
+        secret                   ●                    
+        phi                      ●                    
+        code_context   ●                              
+        code_flaw                ●                    
+        custom                   ●                    
+        config         ●                              "
+    `);
+  });
+});
+
+describe('renderStartLight — start-light card', () => {
+  // The eight packs in canonical category order — the order the embedded grid and
+  // the per-pack rationale block must both follow.
+  const CANONICAL = [
+    'pii',
+    'financial',
+    'secret',
+    'phi',
+    'code_context',
+    'code_flaw',
+    'custom',
+    'config',
+  ];
+  const posture = severityFloorPosture();
+
+  it('leads with the start-light heading', () => {
+    expect(renderStartLight(posture)).toContain('Starting light — your detection categories');
+  });
+
+  it('embeds the full 8×4 default posture grid, composed from the shared primitive', () => {
+    // The card composes renderPostureGrid seeded with the default posture, so a grid
+    // layout regression surfaces here too, not only in renderPostureGrid's own test.
+    expect(renderStartLight(posture)).toContain(renderPostureGrid(posture));
+  });
+
+  it('carries a per-pack rationale line for every pack, never omitted or placeholdered', () => {
+    const out = renderStartLight(posture);
+    for (const pack of CANONICAL) {
+      // A rationale line names the pack, its default level, then a non-empty reason.
+      const line = out.split('\n').find((l) => l.trim().startsWith(`${pack} —`));
+      expect(line, `rationale line for ${pack}`).toBeTruthy();
+      const reason = (line ?? '').split(':').slice(1).join(':').trim();
+      expect(reason.length, `rationale text for ${pack}`).toBeGreaterThan(0);
+      expect(reason, `rationale for ${pack} is not a placeholder`).not.toMatch(
+        /todo|tbd|placeholder|…|xxx/i,
+      );
+    }
+  });
+
+  it('closes with the re-tune hint, single-sourced from RE_TUNE_HINT', () => {
+    // The exported constant is what the setup skill's prose and the applied-frame
+    // copy single-source.
+    expect(RE_TUNE_HINT).toBe('Re-tune anytime with the aka-setup skill or the dashboard');
+    expect(renderStartLight(posture)).toContain(RE_TUNE_HINT);
+  });
+
+  it('matches the whole-card snapshot so copy/layout regressions surface', () => {
+    expect(renderStartLight(posture)).toMatchInlineSnapshot(`
+      "● Starting light — your detection categories
+
+        For now, each detection category starts at a careful default. Run the aka-setup skill whenever you like and I'll tune these from Codex's recent work.
+
+        CATEGORY       MONITOR   WARN   REDACT   BLOCK
+        ────────────   ───────   ────   ──────   ─────
+        pii                      ●                    
+        financial                ●                    
+        secret                   ●                    
+        phi                      ●                    
+        code_context   ●                              
+        code_flaw                ●                    
+        custom                   ●                    
+        config         ●                              
+
+        pii — warn: personal data carries real obligations, so I surface it before it moves.
+        financial — warn: card and account numbers are sensitive by default, so these come to you.
+        secret — warn: keys and credentials are the costliest thing to lose, so I bring those straight to you.
+        phi — warn: health information is regulated wherever it lands, so I flag it for your call.
+        code_context — monitor: proprietary code context is common and mostly benign, so I watch quietly and keep the record.
+        code_flaw — warn: an insecure pattern is worth a look before it ships, so I raise it.
+        custom — warn: your own policy matches start surfaced so nothing you care about slips by unseen.
+        config — monitor: config values are noisy, so I keep an eye on them without notifying you.
+
+        Re-tune anytime with the aka-setup skill or the dashboard"
+    `);
+  });
+});
+
+describe('renderAdjustConfirm — adjust-confirm table', () => {
+  // The eight packs in canonical category order — the order the confirm table
+  // rows must follow, recommended and yours side by side on each.
+  const CANONICAL = [
+    'pii',
+    'financial',
+    'secret',
+    'phi',
+    'code_context',
+    'code_flaw',
+    'custom',
+    'config',
+  ];
+  const recommended = severityFloorPosture();
+  // The user's chosen posture: the recommended base with two packs overridden
+  // (secret warn→redact, config monitor→warn), the other six kept as recommended.
+  const chosen: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+    ...recommended,
+    secret: 'redact',
+    config: 'warn',
+  };
+
+  it("heads a three-column 'category │ recommended │ yours' table", () => {
+    // Built from present.ts table(), which uppercases the column headers.
+    const out = renderAdjustConfirm(recommended, chosen);
+    expect(out).toContain('CATEGORY');
+    expect(out).toContain('RECOMMENDED');
+    expect(out).toContain('YOURS');
+  });
+
+  it('lays one row per pack in canonical order, recommended beside yours', () => {
+    const out = renderAdjustConfirm(recommended, chosen);
+    const order = out
+      .split('\n')
+      .map((l) => l.trim().split(/\s+/)[0])
+      .filter((tok): tok is string => tok !== undefined && CANONICAL.includes(tok));
+    expect(order).toEqual(CANONICAL);
+
+    // Both columns are visible on every row: a changed pack shows a different
+    // 'yours' value, an unchanged pack repeats the recommended level.
+    const row = (pack: string): string[] =>
+      (out.split('\n').find((l) => l.trim().startsWith(`${pack} `)) ?? '').trim().split(/\s+/);
+    // secret: recommended warn, yours redact (changed).
+    expect(row('secret')).toEqual(['secret', 'warn', 'redact']);
+    // config: recommended monitor, yours warn (changed).
+    expect(row('config')).toEqual(['config', 'monitor', 'warn']);
+    // pii: unchanged — recommended and yours both warn, both columns present.
+    expect(row('pii')).toEqual(['pii', 'warn', 'warn']);
+  });
+
+  // The adjust fork writes posture just like the confirm spine, so it must flag an
+  // enforcement downgrade the same way — a pack hardened out of band can otherwise
+  // be lowered here with nothing shown to the user.
+  describe('downgrade guard against the stored posture', () => {
+    it('appends the downgrade footer when a pick ranks below the stored action', () => {
+      // The store holds 'secret' at block; the user picks redact.
+      const out = renderAdjustConfirm(recommended, chosen, { secret: 'block' });
+      expect(out).toContain('Heads up — this would lower 1 detection level (secret) below');
+    });
+
+    it('names every lowered detection category and pluralizes the count', () => {
+      const out = renderAdjustConfirm(recommended, chosen, {
+        secret: 'block',
+        config: 'redact',
+      });
+      expect(out).toContain('Heads up — this would lower 2 detection levels (secret, config) below');
+    });
+
+    it('stays silent when every pick is the same or stronger than the stored action', () => {
+      // secret: stored warn -> picked redact (stronger). config: stored log
+      // ('monitor') -> picked warn (stronger).
+      const out = renderAdjustConfirm(recommended, chosen, { secret: 'warn', config: 'log' });
+      expect(out).not.toContain('WARNING');
+    });
+
+    it('has no baseline to compare against when current is omitted', () => {
+      expect(renderAdjustConfirm(recommended, chosen)).not.toContain('WARNING');
+    });
+  });
+
+  it('carries the adjust copy and the shared re-tune hint', () => {
+    const out = renderAdjustConfirm(recommended, chosen);
+    expect(out).toContain("I'll keep the rest as recommended");
+    // The re-tune pointer to the deep-tuning surface is single-sourced.
+    expect(out).toContain(RE_TUNE_HINT);
+  });
+
+  it('matches the whole-card snapshot so copy/layout regressions surface', () => {
+    expect(renderAdjustConfirm(recommended, chosen)).toMatchInlineSnapshot(`
+      "● Adjust — set the detection categories you want, keep the rest
+
+        CATEGORY       RECOMMENDED   YOURS  
+        ────────────   ───────────   ───────
+        pii            warn          warn   
+        financial      warn          warn   
+        secret         warn          redact 
+        phi            warn          warn   
+        code_context   monitor       monitor
+        code_flaw      warn          warn   
+        custom         warn          warn   
+        config         monitor       warn   
+
+        I'll keep the rest as recommended.
+
+        Re-tune anytime with the aka-setup skill or the dashboard"
+    `);
+  });
+});
+
+describe('renderApplied — applying confirmation', () => {
+  // The installed skill registry, resolved the way the shipped caller does and
+  // threaded into the pure renderer so the Ready line's curated set is validated
+  // against the skills the plugin actually registers.
+  const REGISTRY = readRegisteredSkills();
+  const REGISTERED = new Set(REGISTRY);
+
+  it('templates the real dismissed count and confirms the tuned category count', () => {
+    const out = renderApplied(8, 12, REGISTRY);
+    expect(out).toContain('✓ Set all 8 detection categories');
+    expect(out).toContain('set aside 12 routine results');
+    // N is templated from the real count — a different value flows straight
+    // through, never a baked-in literal.
+    expect(renderApplied(8, 3, REGISTRY)).toContain('set aside 3 routine results');
+    // Singular is grammatical when exactly one routine result was set aside.
+    expect(renderApplied(8, 1, REGISTRY)).toContain('set aside 1 routine result');
+    expect(renderApplied(8, 1, REGISTRY)).not.toContain('1 routine results');
+    // The tuned count is threaded too, not hardcoded to 8.
+    expect(renderApplied(5, 3, REGISTRY)).toContain('✓ Set all 5 detection categories');
+  });
+
+  it('renders an honest empty-state when nothing routine was set aside', () => {
+    const out = renderApplied(8, 0, REGISTRY);
+    expect(out).toContain('✓ Set all 8 detection categories');
+    // No fabricated 'set aside 0 routine results' — honest copy instead.
+    expect(out).not.toContain('set aside 0');
+    expect(out).toContain('nothing routine to set aside');
+  });
+
+  it('the Ready line names only skills the plugin actually registers, by their declared names', () => {
+    const ready = (renderApplied(8, 5, REGISTRY).split('Ready:')[1] ?? '').trim();
+    const named = ready.match(/aka-[a-z]+/g) ?? [];
+    // The line actually names skills (guards against an empty match passing).
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of named) {
+      // The plugin registers each skill under the name its SKILL.md frontmatter
+      // declares — the form the user invokes it by. The named skill must be a
+      // real registered one (never a hardcoded copy).
+      expect(REGISTERED.has(skill)).toBe(true);
+    }
+  });
+
+  it('builds the Ready line through the registry mechanism — an unregistered curated skill throws', () => {
+    // The Ready line's curated set is validated against the registry, not
+    // free-printed: a registry missing one of its curated skills fails loud
+    // rather than rendering a call-to-action the user cannot invoke.
+    const withoutHealth = REGISTRY.filter((s) => s !== 'aka-health');
+    expect(() => renderApplied(8, 5, withoutHealth)).toThrow(/aka-health/);
+  });
+
+  it("reads '✓ Set all 8 detection categories' from the real 8-pack the posture writer wrote", () => {
+    // onboard.ts feeds its confirmation the size of the posture it actually
+    // wrote: renderCategoriesTuned(Object.keys(posture).length). Drive that with
+    // the real recommended map so the '8' is the true pack count, not a
+    // literal — this is the segment that composes into the applying-confirmation line.
+    const packCount = Object.keys(severityFloorPosture()).length;
+    expect(packCount).toBe(8);
+    expect(renderCategoriesTuned(packCount)).toBe('✓ Set all 8 detection categories');
+    // Same phrase renderApplied composes — single-sourced, so the two can't drift.
+    expect(renderApplied(packCount, 5, REGISTRY)).toContain(renderCategoriesTuned(packCount));
+  });
+});

--- a/plugins/codex/test/render.test.ts
+++ b/plugins/codex/test/render.test.ts
@@ -1,18 +1,42 @@
+import { randomUUID } from 'node:crypto';
+
+import type { FindingView } from '@akasecurity/plugin-sdk';
 import { severityFloorPosture } from '@akasecurity/plugin-sdk';
 import type { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
+import { SetupHandoffOffer } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildHandoffOffer,
   RE_TUNE_HINT,
   renderAdjustConfirm,
   renderApplied,
   renderCategoriesTuned,
+  renderFirstRun,
   renderPosture,
   renderPostureGrid,
   renderRecommendedPosture,
   renderStartLight,
+  topFindings,
 } from '../src/render.ts';
 import { readRegisteredSkills } from '../src/skills-registry.ts';
+
+function finding(overrides: Partial<FindingView> = {}): FindingView {
+  return {
+    id: randomUUID(),
+    eventId: randomUUID(),
+    ruleId: 'secrets/aws-access-key',
+    category: 'secret',
+    severity: 'critical',
+    maskedMatch: 'AKIA…MPLE',
+    actionTaken: 'block',
+    confidence: 0.9,
+    occurredAt: '2026-06-19T11:14:53.000Z',
+    sourceTool: 'codex',
+    kind: 'prompt',
+    ...overrides,
+  };
+}
 
 describe('renderPosture', () => {
   it('lists each category with its action, aligned', () => {
@@ -290,7 +314,9 @@ describe('renderAdjustConfirm — adjust-confirm table', () => {
         secret: 'block',
         config: 'redact',
       });
-      expect(out).toContain('Heads up — this would lower 2 detection levels (secret, config) below');
+      expect(out).toContain(
+        'Heads up — this would lower 2 detection levels (secret, config) below',
+      );
     });
 
     it('stays silent when every pick is the same or stronger than the stored action', () => {
@@ -394,5 +420,255 @@ describe('renderApplied — applying confirmation', () => {
     expect(renderCategoriesTuned(packCount)).toBe('✓ Set all 8 detection categories');
     // Same phrase renderApplied composes — single-sourced, so the two can't drift.
     expect(renderApplied(packCount, 5, REGISTRY)).toContain(renderCategoriesTuned(packCount));
+  });
+});
+
+describe('renderFirstRun — installed card', () => {
+  // The skill names the shipped plugin registers — the Try line must never
+  // outrun this set, since a named skill with no matching SKILL.md would not
+  // resolve when the user invokes it. Read from disk (never a hardcoded copy)
+  // so a renamed or removed skill is caught here.
+  const REGISTRY = readRegisteredSkills();
+  const REGISTERED = new Set(REGISTRY);
+
+  const populated = (over: Partial<Parameters<typeof renderFirstRun>[0]> = {}): string =>
+    renderFirstRun(
+      {
+        calibration: 'scan',
+        posture: renderPosture([
+          { category: 'secret', action: 'redact' },
+          { category: 'code_context', action: 'log' },
+        ]),
+        health: 72,
+        findings: 142,
+        recommendations: 6,
+        worthALook: 2,
+        topFindings: [
+          finding({
+            ruleId: 'secrets/aws-access-key',
+            category: 'secret',
+            severity: 'critical',
+          }),
+        ],
+        ...over,
+      },
+      REGISTRY,
+    );
+
+  it('scan path: heading reads "You\'re all set — tuned to this machine."', () => {
+    const out = populated({ calibration: 'scan' });
+    expect(out).toContain("✓ You're all set — tuned to this machine.");
+    // The floor-path heading never leaks onto the scan path.
+    expect(out).not.toContain('safe defaults');
+  });
+
+  it('scan path: divider reads "First scan complete"', () => {
+    const out = populated({ calibration: 'scan' });
+    expect(out).toContain('First scan complete');
+    expect(out).not.toContain('Safe defaults in place');
+  });
+
+  it('floor path: heading reads the cause-neutral no-scan fallback copy', () => {
+    const out = populated({ calibration: 'floor' });
+    expect(out).toContain(
+      "✓ You're all set — I've started you on safe defaults. Rerun the aka-setup skill anytime to calibrate from Codex's activity.",
+    );
+    // The scan-path heading never leaks onto the floor path.
+    expect(out).not.toContain('tuned to this machine');
+  });
+
+  it('floor path: divider reads "Safe defaults in place" (no scan ran)', () => {
+    const out = populated({ calibration: 'floor' });
+    expect(out).toContain('Safe defaults in place');
+    expect(out).not.toContain('First scan complete');
+  });
+
+  it('stats line templates the real health · detections · recommendations, never a fixed literal', () => {
+    const out = populated();
+    expect(out).toContain('Health 72/100');
+    expect(out).toContain('142 detections');
+    expect(out).toContain('6 recommendations');
+    // A different set of real values flows straight through — proof it is
+    // templated over the store, not a baked-in literal.
+    const other = populated({ health: 91, findings: 3, recommendations: 1 });
+    expect(other).toContain('Health 91/100');
+    expect(other).toContain('3 detections');
+    expect(other).toContain('1 recommendations');
+    // The fixed sample numbers never appear.
+    expect(out).not.toContain('82/100');
+    expect(out).not.toContain('40 findings');
+  });
+
+  it('scan path: a warm summary line rides above the stat row, over the real counts', () => {
+    const out = populated({ findings: 142, worthALook: 2, calibration: 'scan' });
+    expect(out).toContain('Your store holds 142 detections — 2 worth your attention.');
+    // A different set of real values flows straight through.
+    const other = populated({ findings: 9, worthALook: 4, calibration: 'scan' });
+    expect(other).toContain('Your store holds 9 detections — 4 worth your attention.');
+  });
+
+  it('floor path: no warm summary line — the floor path never scanned anything', () => {
+    const out = populated({ calibration: 'floor' });
+    expect(out).not.toContain('Your store holds');
+    // The stat row still renders over the real store counts.
+    expect(out).toContain('Health 72/100');
+    expect(out).toContain('142 detections');
+    expect(out).toContain('6 recommendations');
+  });
+
+  it('shows the posture line the user chose', () => {
+    const out = populated();
+    expect(out).toContain('Posture');
+    expect(out).toContain('secret');
+    expect(out).toContain('redact');
+    // 'log' (ActionTaken) surfaces to the user as 'monitor'.
+    expect(out).toContain('monitor');
+  });
+
+  it("renders the '2 worth a look' handoff with the real surfaced count and the Open dashboard / Not now framing", () => {
+    const out = populated({ worthALook: 2 });
+    expect(out).toContain('2 worth a look — want to see them in the browser?');
+    expect(out).toContain('Open dashboard');
+    expect(out).toContain('Not now');
+    // The count is the surfaced value, echoed — a different count flows through.
+    expect(populated({ worthALook: 5 })).toContain('5 worth a look');
+  });
+
+  it('the Try line names only skills the plugin actually registers, by their declared names', () => {
+    const out = populated();
+    const tryLine = out.split('\n').find((l) => l.includes('Try:'));
+    expect(tryLine).toBeDefined();
+    const named = tryLine?.match(/aka-[a-z]+/g) ?? [];
+    // The line actually names skills (guards against an empty match passing).
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of named) {
+      expect(REGISTERED.has(skill)).toBe(true);
+    }
+    // The not-yet-shipped rename targets do not exist yet — the Try line must not print them.
+    expect(out).not.toContain('aka-secretscan');
+    expect(out).not.toContain('aka-codescan');
+  });
+
+  it('builds the Try line through the registry mechanism — an unregistered curated skill throws', () => {
+    // The Try line's curated set is validated against the registry, not
+    // free-printed: a registry missing one of its curated skills fails loud
+    // rather than rendering a call-to-action the user cannot invoke.
+    const withoutDashboard = REGISTRY.filter((s) => s !== 'aka-dashboard');
+    expect(() =>
+      renderFirstRun(
+        { calibration: 'floor', health: 72, findings: 0, recommendations: 0 },
+        withoutDashboard,
+      ),
+    ).toThrow(/aka-dashboard/);
+  });
+
+  it('clean scan hides the Top findings section', () => {
+    const out = populated({ topFindings: [], worthALook: 0 });
+    expect(out).not.toContain('Top findings');
+  });
+
+  it('nothing surfaced — stats degrade to an honest empty-state, no fabricated count, card stays tidy', () => {
+    // No scan surfaced anything: no worthALook, an empty store (0 findings /
+    // recommendations), a clean scan (no top findings). The card degrades
+    // honestly — the numeric stats triple becomes explicit empty-state copy
+    // rather than a bare '0 detections · 0 recommendations' scan tally, and the
+    // dashboard handoff is withheld (never a fabricated '0 worth a look').
+    const out = renderFirstRun(
+      {
+        calibration: 'scan',
+        posture: renderPosture([{ category: 'secret', action: 'redact' }]),
+        health: 40,
+        findings: 0,
+        recommendations: 0,
+        topFindings: [],
+        // worthALook intentionally omitted — nothing surfaced.
+      },
+      REGISTRY,
+    );
+
+    // No fabricated dashboard handoff, no bare numeric scan tally, and no
+    // fabricated warm-summary claim of a review over zero detections.
+    expect(out).not.toContain('worth a look');
+    expect(out).not.toContain('0 detections');
+    expect(out).not.toContain('0 recommendations');
+    expect(out).not.toContain('Your store holds');
+    // Instead, an explicit honest empty-state line.
+    expect(out).toContain("you're starting clean");
+    // The card still reads as a tidy success state: scan-path heading + posture.
+    expect(out).toContain("You're all set — tuned to this machine.");
+    expect(out).toContain('Posture');
+    expect(out).toContain('secret');
+    expect(out).toContain('redact');
+  });
+
+  it('lists the top findings table when the scan caught something', () => {
+    const out = populated({
+      topFindings: [
+        finding({ ruleId: 'secrets/aws-access-key', category: 'secret', severity: 'critical' }),
+        finding({ ruleId: 'pii/email', category: 'pii', severity: 'low' }),
+      ],
+    });
+    expect(out).toContain('Top findings (2)');
+    expect(out).toContain('secrets/aws-access-key');
+    expect(out).toContain('pii/email');
+    // The masked match shows; the raw secret never does (finding() masks it).
+    expect(out).toContain('AKIA…MPLE');
+  });
+});
+
+describe('buildHandoffOffer — the structured handoff payload', () => {
+  it('live-key branch — chain entry composed with the dashboard handoff', () => {
+    // 5 surfaced important findings, 3 of them live-key secrets.
+    const offer = buildHandoffOffer(5, 3);
+    expect(SetupHandoffOffer.safeParse(offer).success).toBe(true);
+    // Both counts are whatever the caller derived from the store — echoed, not invented.
+    expect(offer.worthALook).toBe(5);
+    expect(offer.liveKeys).toBe(3);
+    // A surfaced live-key count composes the chain-entry option AHEAD of — never
+    // in place of — the dashboard handoff.
+    expect(offer.options).toEqual([
+      { id: 'enter-remediation', label: 'Review leaked keys' },
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('important-but-no-secrets — surfaced findings without live keys offer no remediation', () => {
+    // 3 surfaced important findings, none of them live-key secrets: the gate is
+    // the live-key count, NOT the all-category surfaced count, so no chain entry.
+    const offer = buildHandoffOffer(3, 0);
+    expect(SetupHandoffOffer.safeParse(offer).success).toBe(true);
+    expect(offer.worthALook).toBe(3);
+    // No live keys → no remediation offered, just the dashboard handoff.
+    expect(offer.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+
+  it('honest zero — a clean store carries a real 0, plain dashboard handoff only', () => {
+    const offer = buildHandoffOffer(0, 0);
+    expect(SetupHandoffOffer.safeParse(offer).success).toBe(true);
+    expect(offer.worthALook).toBe(0);
+    // Nothing surfaced → no remediation offered, just the dashboard handoff.
+    expect(offer.options).toEqual([
+      { id: 'open-dashboard', label: 'Open dashboard' },
+      { id: 'not-now', label: 'Not now' },
+    ]);
+  });
+});
+
+describe('topFindings', () => {
+  it('ranks by severity then recency, capped to the limit', () => {
+    const ranked = topFindings(
+      [
+        finding({ ruleId: 'low-old', severity: 'low', occurredAt: '2026-06-19T08:00:00.000Z' }),
+        finding({ ruleId: 'crit', severity: 'critical', occurredAt: '2026-06-19T09:00:00.000Z' }),
+        finding({ ruleId: 'high-old', severity: 'high', occurredAt: '2026-06-19T08:00:00.000Z' }),
+        finding({ ruleId: 'high-new', severity: 'high', occurredAt: '2026-06-19T10:00:00.000Z' }),
+      ],
+      3,
+    );
+    expect(ranked.map((f) => f.ruleId)).toEqual(['crit', 'high-new', 'high-old']);
   });
 });

--- a/plugins/codex/test/setup-frame-json.test.ts
+++ b/plugins/codex/test/setup-frame-json.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { frameJsonBlock, readFrameJsonBlock } from '../src/setup-frame-json.ts';
+
+describe('frameJsonBlock / readFrameJsonBlock', () => {
+  it('round-trips a payload through the delimited block', () => {
+    const payload = { worthALook: 2, options: [] };
+    const block = readFrameJsonBlock(frameJsonBlock(payload));
+    expect(block).toEqual(payload);
+  });
+
+  it('extracts the block even when surrounded by human-readable copy', () => {
+    const stdout = `some card\n${frameJsonBlock({ a: 1 })}trailing note\n`;
+    expect(readFrameJsonBlock(stdout)).toEqual({ a: 1 });
+  });
+
+  it('returns undefined when no block is present', () => {
+    expect(readFrameJsonBlock('just a plain card, no frame here')).toBeUndefined();
+  });
+
+  it('returns undefined (never throws) when the block contents are malformed JSON', () => {
+    const broken = '<<<AKA_FRAME_JSON\n{ not: valid json ]\nAKA_FRAME_JSON>>>\n';
+    expect(readFrameJsonBlock(broken)).toBeUndefined();
+  });
+});

--- a/plugins/codex/test/setup-show.test.ts
+++ b/plugins/codex/test/setup-show.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { fenced, show } from '../src/present.ts';
+import { frameJsonBlock } from '../src/setup-frame-json.ts';
+import { parseSurface, readShowBlocks, showBlock } from '../src/setup-show.ts';
+
+describe('showBlock / readShowBlocks', () => {
+  it('round-trips a body through the delimited block', () => {
+    expect(readShowBlocks(showBlock('hello card'))).toEqual(['hello card']);
+  });
+
+  it('preserves a fenced multi-line body verbatim', () => {
+    const card = '```\n● AKA\n  line two\n```';
+    expect(readShowBlocks(showBlock(card))).toEqual([card]);
+  });
+
+  it('extracts every block when several are present amid other copy', () => {
+    const stdout = `${showBlock('one')}Plan saved to: /tmp/x\n${showBlock('two')}`;
+    expect(readShowBlocks(stdout)).toEqual(['one', 'two']);
+  });
+
+  it('returns [] when no block is present', () => {
+    expect(readShowBlocks('just a status line, no markers')).toEqual([]);
+  });
+
+  it('ignores a block whose end marker is missing (never throws)', () => {
+    expect(readShowBlocks('<<<AKA_SHOW\nunterminated')).toEqual([]);
+  });
+});
+
+describe('parseSurface — three-region partition', () => {
+  it('splits show regions, frames, and status with no overlap', () => {
+    const stdout =
+      show(fenced('● card headline')) +
+      frameJsonBlock({ counts: { important: 2 } }) +
+      '\nPlan saved to: /tmp/plan.json\n';
+    const surface = parseSurface(stdout);
+
+    expect(surface.shows).toEqual(['```\n● card headline\n```']);
+    expect(surface.frames).toEqual([{ counts: { important: 2 } }]);
+    // Status is the untagged remainder only — never the card text or a marker.
+    expect(surface.status).toContain('Plan saved to: /tmp/plan.json');
+    expect(surface.status).not.toContain('card headline');
+    expect(surface.status).not.toContain('AKA_SHOW');
+    expect(surface.status).not.toContain('AKA_FRAME_JSON');
+  });
+
+  it('show() delegates to showBlock (same delimiters)', () => {
+    expect(show('x')).toBe('<<<AKA_SHOW\nx\nAKA_SHOW>>>\n');
+  });
+
+  it('does not leak marker-shaped text inside a frame payload into shows', () => {
+    const stdout = frameJsonBlock({ note: '<<<AKA_SHOW\nx\nAKA_SHOW>>>' });
+    const surface = parseSurface(stdout);
+
+    expect(surface.frames).toEqual([{ note: '<<<AKA_SHOW\nx\nAKA_SHOW>>>' }]);
+    expect(surface.shows).toEqual([]);
+  });
+
+  it('keeps untagged status text that follows an unterminated show marker', () => {
+    const stdout = '<<<AKA_SHOW\nunterminated\nPlan saved to: /tmp/plan.json\n';
+    const surface = parseSurface(stdout);
+
+    expect(surface.status).toContain('Plan saved to: /tmp/plan.json');
+    expect(surface.shows).toEqual([]);
+  });
+});

--- a/plugins/codex/test/setup-skill-copy.test.ts
+++ b/plugins/codex/test/setup-skill-copy.test.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// The setup skill's consent surface is the disclosure the model-judge grant
+// rests on. These assertions pin its SUBSTANCE — a copy edit that drops one of
+// these facts changes what the user consented to, and must fail loudly here
+// rather than ship silently (mirrors the Claude Code plugin's
+// setup-vault-consent-copy.test.ts).
+const skillMd = readFileSync(
+  fileURLToPath(new URL('../skills/setup/SKILL.md', import.meta.url)),
+  'utf8',
+);
+
+describe('SKILL.md model-judge egress disclosure', () => {
+  it('names exactly what crosses: the raw value plus the re-masked ~120-character window', () => {
+    expect(skillMd).toContain('raw value');
+    expect(skillMd).toMatch(/120 characters of the\s+surrounding transcript text/);
+    expect(skillMd).toMatch(/re-masked first/);
+  });
+
+  it('names what is dropped before egress: the file path and the fingerprint', () => {
+    expect(skillMd).toMatch(
+      /rollout file's\s+path, the value's fingerprint, and the fingerprint key version are \*\*dropped\s+before egress\*\*/,
+    );
+  });
+
+  it('states the disclosure before the model-judge consent question is asked', () => {
+    const disclosure = skillMd.indexOf('dropped\nbefore egress');
+    const question = skillMd.indexOf('Send findings to the model to sort real leaks from noise?');
+    expect(disclosure).toBeGreaterThan(-1);
+    expect(question).toBeGreaterThan(disclosure);
+    // The step-3 restatement of the payload also precedes the question.
+    const restatement = skillMd.indexOf('restate plainly what leaves the');
+    expect(restatement).toBeGreaterThan(-1);
+    expect(question).toBeGreaterThan(restatement);
+  });
+
+  it('records the grant with exactly the --model-judge-consent flag', () => {
+    expect(skillMd).toContain('onboard.js" --model-judge-consent');
+    // No variant spelling of the flag anywhere in the skill.
+    expect(skillMd).not.toMatch(/--model-judge(?!-consent)/);
+    expect(skillMd).not.toContain('--judge-consent');
+  });
+
+  it('routes the No-consent option to the severity floor, never the pipe', () => {
+    const noConsent = skillMd.indexOf('If the user chose "No, keep it local"');
+    expect(noConsent).toBeGreaterThan(-1);
+    const branch = skillMd.slice(noConsent, skillMd.indexOf('Pipe the backfill', noConsent));
+    expect(branch).toContain('do **not** run the pipe');
+    expect(branch).toContain('onboard.js" --floor');
+  });
+});
+
+describe('SKILL.md known-limitation disclosure', () => {
+  it('keeps the section and discloses the vault deferral', () => {
+    expect(skillMd).toContain('## Known limitation');
+    expect(skillMd).toMatch(/reversible secret vault is\s+not yet wired for Codex/);
+  });
+});

--- a/plugins/codex/test/skills-registry.test.ts
+++ b/plugins/codex/test/skills-registry.test.ts
@@ -1,0 +1,161 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { READY_SKILLS, TRY_SKILLS } from '../src/render.ts';
+import {
+  readRegisteredSkills,
+  selectRegisteredSkills,
+  selectSecretScanContinuation,
+} from '../src/skills-registry.ts';
+
+// The real shipped skill set, read straight from disk the same way the plugin
+// registers skills — a renamed or removed SKILL.md is caught here, never a
+// hardcoded copy that silently rots.
+const SKILLS_DIR = fileURLToPath(new URL('../skills', import.meta.url));
+const REGISTERED = readdirSync(SKILLS_DIR, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => {
+    const content = readFileSync(join(SKILLS_DIR, entry.name, 'SKILL.md'), 'utf8');
+    return /^name:\s*(.+?)\s*$/m.exec(content)?.[1] ?? '';
+  })
+  .filter((name) => name !== '');
+
+describe('skill registry', () => {
+  it('reads the shipped skills/*/SKILL.md set as the frontmatter-declared names', () => {
+    const registry = readRegisteredSkills();
+    expect([...registry].sort()).toEqual([...REGISTERED].sort());
+    // A known shipped skill resolves under its declared name.
+    expect(registry).toContain('aka-dashboard');
+    expect(registry).toContain('aka-scan');
+  });
+
+  it('returns a curated set unchanged once every entry is a registered skill', () => {
+    expect(selectRegisteredSkills(['aka-dashboard', 'aka-scan'], REGISTERED)).toEqual([
+      'aka-dashboard',
+      'aka-scan',
+    ]);
+  });
+
+  it('throws loud when a curated skill is absent from the registry', () => {
+    expect(() => selectRegisteredSkills(['aka-nope'], REGISTERED)).toThrow(/aka-nope/);
+  });
+
+  it('selects a single specific skill — curation down to one, never a full-registry dump', () => {
+    // A one-element curated set resolves to exactly that one validated skill,
+    // not the whole registry. This is the property a chaining line that suggests a
+    // single specific continuation skill depends on to name exactly one.
+    expect(REGISTERED.length).toBeGreaterThan(1);
+    const one = selectRegisteredSkills(['aka-scan'], REGISTERED);
+    expect(one).toEqual(['aka-scan']);
+    expect(one).toHaveLength(1);
+  });
+});
+
+describe('per-surface curated sets resolve against the installed registry', () => {
+  // The build-failing guard: every surface's curated skill must exist in the
+  // shipped skill set, so no rendered line can name a skill the plugin does
+  // not register. A curated skill with no matching SKILL.md fails the build here.
+  it('the Try line curated set names only registered skills', () => {
+    const registry = readRegisteredSkills();
+    expect(() => selectRegisteredSkills(TRY_SKILLS, registry)).not.toThrow();
+    for (const skill of TRY_SKILLS) {
+      expect(registry).toContain(skill);
+    }
+  });
+
+  it('fails when a curated skill is removed from the registry', () => {
+    const withoutDashboard = readRegisteredSkills().filter((s) => s !== 'aka-dashboard');
+    expect(() => selectRegisteredSkills(TRY_SKILLS, withoutDashboard)).toThrow();
+  });
+
+  it('the Ready line curated set names only registered skills', () => {
+    const registry = readRegisteredSkills();
+    expect(() => selectRegisteredSkills(READY_SKILLS, registry)).not.toThrow();
+    for (const skill of READY_SKILLS) {
+      expect(registry).toContain(skill);
+    }
+  });
+
+  it('fails when a curated Ready skill is removed from the registry', () => {
+    const withoutHealth = readRegisteredSkills().filter((s) => s !== 'aka-health');
+    expect(() => selectRegisteredSkills(READY_SKILLS, withoutHealth)).toThrow();
+  });
+
+  it('curates a Ready subset deliberately distinct from the Try line', () => {
+    // The two surfaces suggest different subsets — neither is the whole registry
+    // and the Ready line names none of the Try line's skills.
+    expect([...READY_SKILLS]).not.toEqual([...TRY_SKILLS]);
+    const tryable = new Set<string>(TRY_SKILLS);
+    for (const skill of READY_SKILLS) {
+      expect(tryable.has(skill)).toBe(false);
+    }
+  });
+
+  it('neither surface enumerates the full registry — each names a strict curated subset', () => {
+    // The contract is per-surface curation, not a full-registry dump: with a
+    // registry of ~10 skills, each surface names only its own few. A surface
+    // that grew to name every registered skill would fail here.
+    const registry = readRegisteredSkills();
+    expect(registry.length).toBeGreaterThan(TRY_SKILLS.length);
+    expect(registry.length).toBeGreaterThan(READY_SKILLS.length);
+    // Combined, the two surfaces still do not cover the whole registry — proof
+    // no line is silently enumerating everything the plugin registers.
+    const named = new Set([...TRY_SKILLS, ...READY_SKILLS]);
+    expect(named.size).toBeLessThan(registry.length);
+  });
+});
+
+describe('chaining-line secret-scan continuation selection', () => {
+  // The chaining line names a single specific secret-scan continuation
+  // skill, resolved against the installed registry through the same per-surface
+  // selection mechanism — never a hardcoded bare string, never the full registry.
+  // The continuation is registered under `aka-scan` today and moves to
+  // `aka-secretscan` once the dedicated secret-scan skill exists; the selection
+  // resolves to whichever name is actually registered, in either ship order.
+  it('returns exactly one skill, a member of the registered set', () => {
+    const selected = selectSecretScanContinuation();
+    expect(typeof selected).toBe('string');
+    expect(readRegisteredSkills()).toContain(selected);
+  });
+
+  it('resolves to the single registered secret-scan skill today (aka-scan)', () => {
+    const registry = readRegisteredSkills();
+    expect(registry).toContain('aka-scan');
+    expect(registry).not.toContain('aka-secretscan');
+    expect(selectSecretScanContinuation()).toBe('aka-scan');
+  });
+
+  it('is a strict single-element curated subset, never the full registry', () => {
+    const registry = readRegisteredSkills();
+    expect(registry.length).toBeGreaterThan(1);
+    const selected = selectSecretScanContinuation(registry);
+    // One specific skill drawn from — but not equal to — the whole registry.
+    expect(Array.isArray(selected)).toBe(false);
+    expect(registry).toContain(selected);
+    expect(registry.filter((s) => s === selected)).toHaveLength(1);
+  });
+
+  it('resolves to aka-secretscan once the rename registers it (either ship order)', () => {
+    // Post-rename registry: the working-tree scan is `aka-codescan` and the new
+    // `aka-secretscan` carries the secret-scan continuation.
+    const renamed = ['aka-codescan', 'aka-secretscan', 'aka-dashboard'];
+    expect(selectSecretScanContinuation(renamed)).toBe('aka-secretscan');
+  });
+
+  it('prefers aka-secretscan when both names are briefly registered', () => {
+    const both = ['aka-scan', 'aka-secretscan', 'aka-dashboard'];
+    expect(selectSecretScanContinuation(both)).toBe('aka-secretscan');
+  });
+
+  it('fails the build (throws) when no secret-scan continuation is registered', () => {
+    // A stubbed registry with the curated skill removed — the selection must
+    // fail loud rather than render a call-to-action the user cannot invoke.
+    const withoutSecretScan = readRegisteredSkills().filter(
+      (s) => s !== 'aka-scan' && s !== 'aka-secretscan',
+    );
+    expect(() => selectSecretScanContinuation(withoutSecretScan)).toThrow();
+  });
+});

--- a/plugins/codex/test/start-light.test.ts
+++ b/plugins/codex/test/start-light.test.ts
@@ -1,0 +1,236 @@
+/**
+ * scripts/start-light.js — the 0.3b start-light frame emitter of the aka-setup
+ * Not-now branch. Runs the BUILT script the wizard actually shells out to and
+ * asserts it prints the default-posture start-light card, fenced, doing no I/O beyond
+ * writing to stdout (mirrors how the intro/firstrun scripts emit their cards).
+ *
+ * The script reads no store — --adjust-confirm takes its downgrade baseline
+ * from the --current flag alone. Every invocation here still runs against a
+ * throwaway, always-empty ~/.aka home so this suite's assertions stay
+ * independent of whatever the real machine's store happens to hold.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { severityFloorPosture } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId, DetectionCategory } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { fenced, show } from '../src/present.ts';
+import {
+  RE_TUNE_HINT,
+  renderAdjustConfirm,
+  renderPostureGrid,
+  renderStartLight,
+} from '../src/render.ts';
+import { parseSurface } from '../src/setup-show.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+// test -> plugins/codex
+const SCRIPT = join(HERE, '..', 'scripts', 'start-light.js');
+
+interface Run {
+  stdout: string;
+  stderr: string;
+  status: number;
+}
+
+function runStartLight(args: string[] = []): Run {
+  // A fresh, empty home per call, so every assertion below stays independent
+  // of the real machine's store.
+  const home = mkdtempSync(join(tmpdir(), 'aka-start-light-test-'));
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      env: { HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+    return { stdout, stderr: '', status: 0 };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string; status?: number };
+    return { stdout: e.stdout ?? '', stderr: e.stderr ?? '', status: e.status ?? 1 };
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+describe('scripts/start-light.js', () => {
+  const result = runStartLight();
+
+  it('prints the default-posture start-light card fenced, with no I/O beyond stdout', () => {
+    // Clean exit and empty stderr: the script reads no store and takes no consent,
+    // so nothing but the card reaches stdout.
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    // The whole card wrapped in the shared code fence, rendered from the severity floor.
+    expect(result.stdout.trim()).toBe(
+      show(fenced(renderStartLight(severityFloorPosture()))).trim(),
+    );
+  });
+
+  it('the fenced card carries the heading, the 8×4 default posture grid, and the re-tune hint', () => {
+    expect(result.stdout).toContain('Starting light — your detection categories');
+    expect(result.stdout).toContain(renderPostureGrid(severityFloorPosture()));
+    expect(result.stdout).toContain(RE_TUNE_HINT);
+  });
+
+  it('emits the start-light card inside a single SHOW region', () => {
+    const surface = parseSurface(result.stdout);
+    expect(surface.shows).toHaveLength(1);
+    expect(surface.shows[0]).toContain('Starting light');
+    expect(surface.status.trim()).toBe('');
+  });
+});
+
+describe('scripts/start-light.js --adjust-confirm', () => {
+  const recommended = severityFloorPosture();
+  // The user's adjusted posture: the recommended base with two packs overridden.
+  const chosen: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+    ...recommended,
+    secret: 'redact',
+    config: 'warn',
+  };
+  const result = runStartLight(['--adjust-confirm', '--posture', JSON.stringify(chosen)]);
+
+  it('prints the 0.4b adjust-confirm card fenced, with no I/O beyond stdout', () => {
+    // Clean exit, empty stderr: the emitter reads no store and takes no consent,
+    // so nothing but the confirm card reaches stdout.
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe('');
+    // The whole card wrapped in the shared fence, rendered from the recommended
+    // posture against the adjusted --posture map it was handed.
+    expect(result.stdout.trim()).toBe(
+      show(fenced(renderAdjustConfirm(recommended, chosen))).trim(),
+    );
+  });
+
+  it("carries the 'category │ recommended │ yours' columns, the changed pack, and the re-tune hint", () => {
+    expect(result.stdout).toContain('CATEGORY');
+    expect(result.stdout).toContain('RECOMMENDED');
+    expect(result.stdout).toContain('YOURS');
+    // The overridden pack shows a different 'yours' value than recommended.
+    expect(result.stdout).toMatch(/secret\s+warn\s+redact/);
+    expect(result.stdout).toContain("I'll keep the rest as recommended");
+    expect(result.stdout).toContain(RE_TUNE_HINT);
+  });
+
+  it('fails loudly when --adjust-confirm is given without a --posture map', () => {
+    const missing = runStartLight(['--adjust-confirm']);
+    expect(missing.status).not.toBe(0);
+    // A malformed invocation prints the clean one-line reason, not a raw stack.
+    expect(missing.stdout).toContain('AKA setup failed:');
+    expect(missing.stderr).toBe('');
+  });
+
+  it('fails cleanly on malformed --posture JSON, with no raw stack trace', () => {
+    const badJson = runStartLight(['--adjust-confirm', '--posture', '{not valid json']);
+    expect(badJson.status).not.toBe(0);
+    // The parse error is caught and reported as the clean setup-failure line; a
+    // raw uncaught throw would spill a stack to stderr instead.
+    expect(badJson.stdout).toContain('AKA setup failed:');
+    expect(badJson.stdout).not.toMatch(/\n\s+at\s/);
+    expect(badJson.stderr).toBe('');
+  });
+
+  // Bad input reaches the user as a plain line, never a stack trace — the same
+  // failure form onboard.js prints.
+  it.each([
+    ['a missing --posture map', ['--adjust-confirm']],
+    ['malformed --posture JSON', ['--adjust-confirm', '--posture', '{not json']],
+    ['an unknown category', ['--adjust-confirm', '--posture', '{"nope":"warn"}']],
+    [
+      'malformed --current JSON',
+      ['--adjust-confirm', '--posture', '{"secret":"warn"}', '--current', '{oops'],
+    ],
+  ])('reports %s as a friendly failure line and a non-zero exit', (_label, args) => {
+    const failed = runStartLight(args);
+    expect(failed.status).not.toBe(0);
+    expect(failed.stdout).toContain('AKA setup failed: ');
+    // A stack trace would name the throwing frame; the friendly path prints none.
+    expect(failed.stdout).not.toContain('    at ');
+    expect(failed.stderr).toBe('');
+  });
+
+  it('keys the recommended column on --recommended, not the severity floor', () => {
+    // A calibration that escalated the 'secret' pack above the floor: the
+    // recommended base carries the calibrated level.
+    const calibrated: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+      ...recommended,
+      secret: 'block',
+    };
+    // The user leaves 'secret' untouched but changes 'config'.
+    const merged: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+      ...calibrated,
+      config: 'warn',
+    };
+    const withRec = runStartLight([
+      '--adjust-confirm',
+      '--recommended',
+      JSON.stringify(calibrated),
+      '--posture',
+      JSON.stringify(merged),
+    ]);
+    expect(withRec.status).toBe(0);
+    expect(withRec.stdout.trim()).toBe(
+      show(fenced(renderAdjustConfirm(calibrated, merged))).trim(),
+    );
+    // The untouched escalated pack repeats its calibrated level in both columns —
+    // it does not render as a spurious change against the floor.
+    expect(withRec.stdout).toMatch(/secret\s+block\s+block/);
+  });
+
+  // The adjust fork can lower a pack the user hardened out of band, so the card
+  // must carry the same downgrade WARNING the confirm gate prints.
+  describe('--current downgrade guard', () => {
+    // 'secret' hardened to block in the store before the wizard ran.
+    const hardened = JSON.stringify({ secret: 'block' });
+
+    it('warns when the chosen level lowers enforcement below the stored action', () => {
+      // The user picks 'warn' for a pack the store holds at 'block'.
+      const lowered: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+        ...recommended,
+        secret: 'warn',
+      };
+      const run = runStartLight([
+        '--adjust-confirm',
+        '--posture',
+        JSON.stringify(lowered),
+        '--current',
+        hardened,
+      ]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).toContain('Heads up — this would lower 1 detection level (secret) below');
+      expect(run.stdout).toContain('Confirm you mean to lower it before I apply');
+    });
+
+    it('stays silent when the chosen level is the same or higher than the stored action', () => {
+      // The user picks 'block' — matching what the store already holds.
+      const kept: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+        ...recommended,
+        secret: 'block',
+      };
+      const run = runStartLight([
+        '--adjust-confirm',
+        '--posture',
+        JSON.stringify(kept),
+        '--current',
+        hardened,
+      ]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('WARNING');
+      expect(run.stdout).not.toContain('LOWERED');
+    });
+
+    it('has no baseline to warn against when --current is omitted', () => {
+      const lowered: Partial<Record<DetectionCategory, BuiltinPolicyId>> = {
+        ...recommended,
+        secret: 'warn',
+      };
+      const run = runStartLight(['--adjust-confirm', '--posture', JSON.stringify(lowered)]);
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toContain('WARNING');
+    });
+  });
+});

--- a/plugins/codex/test/triage/judge.test.ts
+++ b/plugins/codex/test/triage/judge.test.ts
@@ -1,9 +1,11 @@
-import { existsSync, writeFileSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 import { TriageHit } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
+import type { JudgeDeps } from '../../src/triage/judge.ts';
 import { judgeEnv, parseVerdict, runJudge, toJudgePayload } from '../../src/triage/judge.ts';
 
 const VERDICT_FENCE = [
@@ -24,7 +26,10 @@ const outFileOf = (argv: readonly string[]): string => {
 // A fake spawn that plays the subprocess's one observable role: writing the
 // last-message file at the argv-named path.
 const fakeSpawn =
-  (lastMessage: string, seen?: { argv?: readonly string[]; env?: NodeJS.ProcessEnv; stdin?: string }) =>
+  (
+    lastMessage: string,
+    seen?: { argv?: readonly string[]; env?: NodeJS.ProcessEnv; stdin?: string },
+  ) =>
   (argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string): void => {
     if (seen) {
       seen.argv = argv;
@@ -306,6 +311,84 @@ describe('runJudge', () => {
       // and the raw-bearing spawn error is NOT chained as `cause` — a future
       // `{ cause: err }` would re-expose the prompt via util.inspect/loggers.
       expect((err as Error).cause).toBeUndefined();
+    }
+  });
+
+  it('does not fall back to the live spawn when deps.spawn is missing', () => {
+    // The seam is required, not defaulted. A future `deps.spawn ?? spawnCodex`
+    // would turn any caller that forgot to inject into a live egress. It fails
+    // as the programming error it is — a TypeError before the rubric is read
+    // or any raw hit is assembled into a prompt.
+    const err = (() => {
+      try {
+        runJudge([hit], { loadRubric: () => 'RUBRIC' } as unknown as JudgeDeps);
+      } catch (e) {
+        return e as Error;
+      }
+      throw new Error('expected runJudge to throw');
+    })();
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.message).toBe('runJudge requires deps.spawn — there is no live-spawn fallback');
+    expect(err.message).not.toContain(hit.rawMatch);
+  });
+
+  it('a cleanup fault never replaces the error the judge is throwing', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('removability here is decided by POSIX mode bits');
+    }
+    // A directory its owner cannot write to cannot have its children unlinked,
+    // so a recursive remove of the parent fails with a real EACCES from the
+    // real syscall. Root ignores mode bits, and a cleanup that SUCCEEDS leaves
+    // the error unreplaced too — so this test passes for the wrong reason
+    // without first proving the fault takes for whoever is running it.
+    const lock = (parent: string): string => {
+      const locked = join(parent, 'locked');
+      mkdirSync(locked);
+      writeFileSync(join(locked, 'child'), 'x');
+      chmodSync(locked, 0o500);
+      return locked;
+    };
+    const scratch = mkdtempSync(join(tmpdir(), 'aka-judge-fault-probe-'));
+    const probeLocked = lock(scratch);
+    let faultTakes = false;
+    try {
+      rmSync(scratch, { recursive: true, force: true });
+    } catch {
+      faultTakes = true;
+    }
+    if (!faultTakes) ctx.skip('this user can remove a write-protected directory');
+    chmodSync(probeLocked, 0o700);
+    rmSync(scratch, { recursive: true, force: true });
+
+    let outDir = '';
+    let locked = '';
+    const threw = (() => {
+      try {
+        runJudge([hit], {
+          spawn: (argv) => {
+            outDir = dirname(outFileOf(argv));
+            locked = lock(outDir);
+            throw Object.assign(new Error(`Command failed: codex ${hit.rawMatch}`), { status: 7 });
+          },
+          loadRubric: () => 'RUBRIC',
+        });
+      } catch (e) {
+        return e as Error;
+      }
+      throw new Error('expected runJudge to throw');
+    })();
+    try {
+      // The fs error from the failed removal did NOT displace the raw-free one
+      // the caller has to act on — apply-suppressions prints exactly this
+      // message to the parent's stderr.
+      expect(threw.message).toBe('codex exec judge subprocess failed (exit 7)');
+      expect(threw.message).not.toContain(hit.rawMatch);
+      // The positive control: the dir survived, so the cleanup really did fail
+      // rather than this passing against a removal that quietly worked.
+      expect(existsSync(outDir)).toBe(true);
+    } finally {
+      if (locked !== '') chmodSync(locked, 0o700);
+      rmSync(outDir, { recursive: true, force: true });
     }
   });
 });

--- a/plugins/codex/test/triage/judge.test.ts
+++ b/plugins/codex/test/triage/judge.test.ts
@@ -1,10 +1,10 @@
 import { existsSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import type { TriageHit } from '@akasecurity/schema';
+import { TriageHit } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
-import { judgeEnv, parseVerdict, runJudge } from '../../src/triage/judge.ts';
+import { judgeEnv, parseVerdict, runJudge, toJudgePayload } from '../../src/triage/judge.ts';
 
 const VERDICT_FENCE = [
   '```json',
@@ -111,9 +111,11 @@ describe('runJudge', () => {
     // `-` = read the prompt from stdin, keeping raw off argv.
     expect(argv.at(-1)).toBe('-');
 
-    // The full raw hit (rawMatch + context) rides on stdin — that is the
-    // point; --ephemeral keeps it out of any persisted session, and stdin
-    // (unlike argv) keeps it off the process list and out of ARG_MAX.
+    // rawMatch rides on stdin — the rubric judges the actual value;
+    // --ephemeral keeps it out of any persisted session, and stdin (unlike
+    // argv) keeps it off the process list and out of ARG_MAX. filePath is
+    // dropped and context is masked before it crosses (covered below), so
+    // rawMatch is the only raw field that leaves.
     expect(seen.stdin).toContain('AKIAIOSFODNN7EXAMPLE');
     expect(seen.stdin).toContain('RUBRIC BODY');
     // The subprocess env is the inherited host env (PATH + CODEX_HOME auth),
@@ -153,14 +155,39 @@ describe('runJudge', () => {
     expect(existsSync(dirname(outFileOf(argv)))).toBe(false);
   });
 
-  // The consent copy in the setup skill and both READMEs enumerates what
-  // crosses to the model API field by field. runJudge serializes the whole
-  // TriageHit, so a new field on that schema silently widens the payload past
-  // what the user was told. Pin the exact key set: adding one here is a
-  // deliberate act that forces the disclosure copy to be updated with it.
-  it('sends exactly the disclosed TriageHit fields — no undisclosed payload', () => {
+  // Every field on the TriageHit schema is either DISCLOSED (crosses to the model
+  // inside the prompt) or DROPPED (stripped by toJudgePayload before egress).
+  // The consent copy in the setup skill enumerates the disclosed set field by
+  // field, so a new schema field must be placed in one bucket deliberately —
+  // and, if disclosed, added to that copy.
+  const DISCLOSED = [
+    'category',
+    'confidence',
+    'context',
+    'id',
+    'maskedMatch',
+    'rawMatch',
+    'ruleId',
+    'severity',
+  ] as const;
+  const DROPPED = ['filePath', 'valueFingerprint', 'keyVersion'] as const;
+
+  it('classifies every TriageHit field as disclosed or dropped — no third bucket', () => {
+    expect([...DISCLOSED, ...DROPPED].sort()).toEqual(Object.keys(TriageHit.shape).sort());
+  });
+
+  it('sends exactly the disclosed fields — drops filePath, valueFingerprint, keyVersion', () => {
+    // A fully-populated hit: id + valueFingerprint + keyVersion are set on every
+    // real hit reaching runJudge, and filePath when known.
+    const full: TriageHit = {
+      ...hit,
+      id: '7',
+      filePath: '/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl',
+      valueFingerprint: 'HMAC-of-the-secret',
+      keyVersion: 1,
+    };
     const seen: { stdin?: string } = {};
-    runJudge([hit], {
+    runJudge([full], {
       spawn: fakeSpawn(VERDICT_FENCE, seen),
       loadRubric: () => 'RUBRIC',
     });
@@ -174,26 +201,67 @@ describe('runJudge', () => {
     if (hitLine === undefined) throw new Error('no hit line on stdin');
 
     const sent = JSON.parse(hitLine) as Record<string, unknown>;
-    expect(Object.keys(sent).sort()).toEqual([
-      'category',
-      'confidence',
-      'context',
-      'maskedMatch',
-      'rawMatch',
-      'ruleId',
-      'severity',
-    ]);
-    // The three the disclosure calls out by name: the secret itself, the
-    // surrounding transcript window, and (when present) the source path.
-    expect(sent.rawMatch).toBe(hit.rawMatch);
-    expect(sent.context).toBe(hit.context);
+    expect(Object.keys(sent).sort()).toEqual([...DISCLOSED].sort());
 
-    const seenWithPath: { stdin?: string } = {};
-    runJudge([{ ...hit, filePath: '/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl' }], {
-      spawn: fakeSpawn(VERDICT_FENCE, seenWithPath),
+    // id rides verbatim — the rubric requires the model to echo it in fpIds.
+    expect(sent.id).toBe('7');
+    // rawMatch is the sole raw field — it rides legibly (the rubric judges the
+    // value). context is re-masked: the raw secret no longer appears in the
+    // window, but the non-secret scaffold survives (selective, not blanked).
+    expect(sent.rawMatch).toBe(hit.rawMatch);
+    expect(sent.context).not.toContain(hit.rawMatch);
+    expect(sent.context).toContain('export KEY=');
+    // The dropped provenance/correlator fields never reach the model.
+    expect(seen.stdin).not.toContain('/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl');
+    expect(seen.stdin).not.toContain('HMAC-of-the-secret');
+    expect(seen.stdin).not.toContain('filePath');
+    expect(seen.stdin).not.toContain('valueFingerprint');
+  });
+
+  it('drops filePath from the judge payload (it encodes the OS username and project dirs)', () => {
+    const seen: { stdin?: string } = {};
+    runJudge([{ ...hit, filePath: '/Users/alicesecret/projects/topsecret/rollout.jsonl' }], {
+      spawn: fakeSpawn(VERDICT_FENCE, seen),
       loadRubric: () => 'RUBRIC',
     });
-    expect(seenWithPath.stdin).toContain('/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl');
+    expect(seen.stdin).not.toContain('alicesecret');
+    expect(seen.stdin).not.toContain('topsecret');
+    expect(seen.stdin).not.toContain('filePath');
+  });
+
+  it('masks a secret that appears only in the context window; rawMatch stays legible', () => {
+    // A second, distinct AWS key living ONLY in the surrounding context — not the
+    // finding's own value. It must not cross to the model.
+    const contextOnlySecret = ['AKIA', 'ZYXWVUTSRQPONMLK'].join('');
+    const seen: { stdin?: string } = {};
+    runJudge([{ ...hit, context: `aws_a=${hit.rawMatch} aws_b=${contextOnlySecret}` }], {
+      spawn: fakeSpawn(VERDICT_FENCE, seen),
+      loadRubric: () => 'RUBRIC',
+    });
+    expect(seen.stdin).toContain(hit.rawMatch);
+    expect(seen.stdin).not.toContain(contextOnlySecret);
+    // Positive check: masking stays SELECTIVE, not a blanket redaction. If
+    // maskText fell back to its fail-secure `[REDACTED]` path, the two assertions
+    // above would still hold while the window the judge relies on was gone — so
+    // pin that the non-secret structure of the context survives.
+    expect(seen.stdin).toContain('aws_a=');
+  });
+
+  it('does not mutate the source hit (dropped fields survive for the writeback path)', () => {
+    // deriveSurfacedSecretFindings reads filePath/context off the ORIGINAL hits
+    // after runJudge, and dedupe/writeback key on valueFingerprint/keyVersion;
+    // toJudgePayload must project a copy, never mutate the dropped fields in place.
+    const src: TriageHit = {
+      ...hit,
+      filePath: '/Users/x/p/rollout.jsonl',
+      valueFingerprint: 'fp-hmac',
+      keyVersion: 3,
+    };
+    toJudgePayload(src);
+    expect(src.filePath).toBe('/Users/x/p/rollout.jsonl');
+    expect(src.valueFingerprint).toBe('fp-hmac');
+    expect(src.keyVersion).toBe(3);
+    expect(src.context).toBe(hit.context);
   });
 
   it('fails loud (and raw-free) when the subprocess writes no last-message file', () => {

--- a/plugins/codex/test/triage/judge.test.ts
+++ b/plugins/codex/test/triage/judge.test.ts
@@ -1,0 +1,243 @@
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { TriageHit } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { judgeEnv, parseVerdict, runJudge } from '../../src/triage/judge.ts';
+
+const VERDICT_FENCE = [
+  '```json',
+  '{"perCategory":[{"category":"secret","action":"block","reasoning":"real","genuineCount":2,"fpCount":2,"fpIds":[]}],"notes":""}',
+  '```',
+].join('\n');
+
+// The path `codex exec` writes the final assistant message to — named on argv
+// right after --output-last-message.
+const outFileOf = (argv: readonly string[]): string => {
+  const i = argv.indexOf('--output-last-message');
+  const path = i >= 0 ? argv[i + 1] : undefined;
+  if (path === undefined) throw new Error('no --output-last-message path on argv');
+  return path;
+};
+
+// A fake spawn that plays the subprocess's one observable role: writing the
+// last-message file at the argv-named path.
+const fakeSpawn =
+  (lastMessage: string, seen?: { argv?: readonly string[]; env?: NodeJS.ProcessEnv; stdin?: string }) =>
+  (argv: readonly string[], env: NodeJS.ProcessEnv, stdin: string): void => {
+    if (seen) {
+      seen.argv = argv;
+      seen.env = env;
+      seen.stdin = stdin;
+    }
+    writeFileSync(outFileOf(argv), lastMessage);
+  };
+
+describe('parseVerdict', () => {
+  it('parses the fenced verdict out of the last message', () => {
+    const rec = parseVerdict(`reasoning here...\n${VERDICT_FENCE}`);
+    expect(rec.perCategory[0]?.action).toBe('block');
+  });
+
+  it('uses the LAST json fence when the message carries an earlier illustrative one', () => {
+    const message = [
+      'Here is the shape I will use:',
+      '```json',
+      '{"perCategory":[{"category":"secret","action":"warn","reasoning":"illustrative","genuineCount":0,"fpCount":0,"fpIds":[]}],"notes":""}',
+      '```',
+      'Now the real verdict:',
+      VERDICT_FENCE,
+    ].join('\n');
+    expect(parseVerdict(message).perCategory[0]?.reasoning).toBe('real');
+  });
+
+  it('throws on an empty last message', () => {
+    expect(() => parseVerdict('')).toThrow();
+    expect(() => parseVerdict('  \n ')).toThrow();
+  });
+
+  it('never echoes the subprocess output in a failure (raw stays inside the judge)', () => {
+    const raw = 'AKIAIOSFODNN7EXAMPLE';
+    // An unparseable message and a non-JSON fence — both carrying the raw
+    // value. Neither thrown message may contain it.
+    const cases = [`no fence here, just ${raw}`, '```json\nnot json ' + raw + '\n```'];
+    for (const lastMessage of cases) {
+      try {
+        parseVerdict(lastMessage);
+        throw new Error('expected parseVerdict to throw');
+      } catch (err) {
+        expect((err as Error).message).not.toContain(raw);
+      }
+    }
+  });
+});
+
+describe('judgeEnv', () => {
+  it('inherits the host environment (PATH survives so `codex` resolves)', () => {
+    // Session persistence is suppressed by --ephemeral on argv, not by any
+    // env var, so the env is a plain inherit — PATH must survive.
+    const env = judgeEnv();
+    expect(env.PATH).toBeTruthy();
+  });
+});
+
+describe('runJudge', () => {
+  const hit: TriageHit = {
+    ruleId: 'core-secret/aws',
+    category: 'secret',
+    severity: 'high',
+    maskedMatch: 'A***Z',
+    rawMatch: 'AKIAIOSFODNN7EXAMPLE',
+    context: 'export KEY=AKIAIOSFODNN7EXAMPLE # prod',
+    confidence: 0.9,
+  };
+
+  it('spawns codex exec with --ephemeral + --skip-git-repo-check, the prompt on stdin, and the verdict from the last-message file', () => {
+    const seen: { argv?: readonly string[]; env?: NodeJS.ProcessEnv; stdin?: string } = {};
+    const rec = runJudge([hit], {
+      spawn: fakeSpawn(VERDICT_FENCE, seen),
+      loadRubric: () => 'RUBRIC BODY',
+    });
+
+    const argv = seen.argv ?? [];
+    expect(argv[0]).toBe('exec');
+    // --ephemeral is the session-persistence guard: without it the judge
+    // session (prompt = rubric + raw hits) lands under ~/.codex/sessions,
+    // where AKA's own backfill would re-ingest the raw findings.
+    expect(argv).toContain('--ephemeral');
+    expect(argv).toContain('--skip-git-repo-check');
+    expect(argv).toContain('--output-last-message');
+    // `-` = read the prompt from stdin, keeping raw off argv.
+    expect(argv.at(-1)).toBe('-');
+
+    // The full raw hit (rawMatch + context) rides on stdin — that is the
+    // point; --ephemeral keeps it out of any persisted session, and stdin
+    // (unlike argv) keeps it off the process list and out of ARG_MAX.
+    expect(seen.stdin).toContain('AKIAIOSFODNN7EXAMPLE');
+    expect(seen.stdin).toContain('RUBRIC BODY');
+    // The subprocess env is the inherited host env (PATH + CODEX_HOME auth),
+    // untouched — exactly what judgeEnv() snapshots.
+    expect(seen.env).toEqual(judgeEnv());
+
+    expect(rec.perCategory[0]?.action).toBe('block');
+  });
+
+  it('passes the prompt on stdin, never in argv, and cleans up the temp output dir', () => {
+    const seen: { argv?: readonly string[]; stdin?: string } = {};
+    const rec = runJudge(
+      [
+        {
+          ruleId: 'r',
+          category: 'secret',
+          severity: 'high',
+          maskedMatch: 'A***E',
+          rawMatch: 'AKIAREALKEY',
+          context: 'x',
+          confidence: 0.9,
+          id: '0',
+          valueFingerprint: 'fp1',
+          keyVersion: 1,
+        },
+      ],
+      {
+        spawn: fakeSpawn('```json\n{"perCategory":[],"notes":"ok"}\n```', seen),
+        loadRubric: () => 'RUBRIC',
+      },
+    );
+    const argv = seen.argv ?? [];
+    expect(argv.join(' ')).not.toContain('AKIAREALKEY');
+    expect(seen.stdin).toContain('AKIAREALKEY'); // raw rides stdin, isolated subprocess only
+    expect(rec.notes).toBe('ok');
+    // The mkdtemp dir holding the last-message file is removed after the run.
+    expect(existsSync(dirname(outFileOf(argv)))).toBe(false);
+  });
+
+  // The consent copy in the setup skill and both READMEs enumerates what
+  // crosses to the model API field by field. runJudge serializes the whole
+  // TriageHit, so a new field on that schema silently widens the payload past
+  // what the user was told. Pin the exact key set: adding one here is a
+  // deliberate act that forces the disclosure copy to be updated with it.
+  it('sends exactly the disclosed TriageHit fields — no undisclosed payload', () => {
+    const seen: { stdin?: string } = {};
+    runJudge([hit], {
+      spawn: fakeSpawn(VERDICT_FENCE, seen),
+      loadRubric: () => 'RUBRIC',
+    });
+
+    // The hits ride as JSONL inside the prompt's last fenced block.
+    const fenced = /```\n([\s\S]*?)\n```\n?$/.exec(seen.stdin ?? '');
+    if (fenced?.[1] === undefined) throw new Error('no fenced hit block on stdin');
+    const lines = fenced[1].split('\n').filter((l) => l !== '');
+    expect(lines).toHaveLength(1);
+    const [hitLine] = lines;
+    if (hitLine === undefined) throw new Error('no hit line on stdin');
+
+    const sent = JSON.parse(hitLine) as Record<string, unknown>;
+    expect(Object.keys(sent).sort()).toEqual([
+      'category',
+      'confidence',
+      'context',
+      'maskedMatch',
+      'rawMatch',
+      'ruleId',
+      'severity',
+    ]);
+    // The three the disclosure calls out by name: the secret itself, the
+    // surrounding transcript window, and (when present) the source path.
+    expect(sent.rawMatch).toBe(hit.rawMatch);
+    expect(sent.context).toBe(hit.context);
+
+    const seenWithPath: { stdin?: string } = {};
+    runJudge([{ ...hit, filePath: '/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl' }], {
+      spawn: fakeSpawn(VERDICT_FENCE, seenWithPath),
+      loadRubric: () => 'RUBRIC',
+    });
+    expect(seenWithPath.stdin).toContain('/Users/dev/.codex/sessions/2026/01/01/rollout-x.jsonl');
+  });
+
+  it('fails loud (and raw-free) when the subprocess writes no last-message file', () => {
+    // A spawn that exits cleanly but never writes the file — the verdict is
+    // unreadable and must not pass silently.
+    try {
+      runJudge([hit], { spawn: () => undefined, loadRubric: () => 'RUBRIC' });
+      throw new Error('expected runJudge to throw');
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).toContain('no last-message file');
+      expect(message).not.toContain(hit.rawMatch);
+    }
+  });
+
+  it('re-throws a spawn failure as raw-free metadata (execFileSync captures raw-bearing output)', () => {
+    // execFileSync throws an error whose captured .stdout/.stderr can carry raw
+    // content (`codex exec` logs the run, which can echo the prompt). Simulate
+    // that shape and assert the raw value never rides the re-thrown error out
+    // to the parent stderr.
+    const spawn = (): void => {
+      const err = new Error(`Command failed: codex exec`) as Error & {
+        status?: number;
+        stdout?: string;
+        stderr?: string;
+      };
+      err.status = 1;
+      err.stdout = `partial output leaking ${hit.rawMatch}`;
+      err.stderr = 'boom';
+      throw err;
+    };
+    try {
+      runJudge([hit], { spawn, loadRubric: () => 'RUBRIC' });
+      throw new Error('expected runJudge to throw');
+    } catch (err) {
+      const message = (err as Error).message;
+      expect(message).not.toContain(hit.rawMatch);
+      expect(message).not.toContain('export KEY=');
+      // still useful: it names the failure + surfaces the raw-free exit status
+      expect(message).toContain('judge subprocess failed');
+      expect(message).toContain('exit 1');
+      // and the raw-bearing spawn error is NOT chained as `cause` — a future
+      // `{ cause: err }` would re-expose the prompt via util.inspect/loggers.
+      expect((err as Error).cause).toBeUndefined();
+    }
+  });
+});

--- a/plugins/codex/test/triage/presenter.test.ts
+++ b/plugins/codex/test/triage/presenter.test.ts
@@ -1,0 +1,83 @@
+import type { ExceptionWriter } from '@akasecurity/plugin-sdk';
+import type { ActionTaken, DetectionCategory } from '@akasecurity/schema';
+import { runApply } from '@akasecurity/setup-wizard';
+import { describe, expect, it, vi } from 'vitest';
+
+import { adapterPresenter } from '../../src/triage/presenter.ts';
+
+const PLAN_PATH = '/sentinel/plan/setup-plan.json';
+
+// A fake store that records every write, so the refusal below is provably
+// write-free rather than merely non-zero-exit.
+function fakeDb() {
+  const posture: Record<string, ActionTaken> = { secret: 'redact' };
+  const created: unknown[] = [];
+  const exceptions: ExceptionWriter = {
+    create: (input) => {
+      created.push(input);
+      return Promise.resolve();
+    },
+  };
+  return {
+    posture,
+    created,
+    open: () => ({
+      policies: {
+        getCategoryAction: (c: DetectionCategory) => posture[c],
+        upsertCategoryAction: (c: DetectionCategory, a: ActionTaken) => {
+          posture[c] = a;
+        },
+      },
+      exceptions,
+      close: vi.fn(),
+    }),
+  };
+}
+
+describe('the Codex presenter supplies the stale-plan rerun hint', () => {
+  it('names the aka-setup skill in the drift refusal, so the user is never left without a next step', async () => {
+    const db = fakeDb();
+    const err: string[] = [];
+    // Previewed against `secret: 'warn'`; the store now holds 'redact', so the
+    // plan is stale and confirm must refuse.
+    const code = await runApply({
+      present: adapterPresenter,
+      argv: ['--confirmed', '--plan', PLAN_PATH],
+      readStream: (): never => {
+        throw new Error('confirm must not read the stream');
+      },
+      runJudge: (): never => {
+        throw new Error('confirm must not run the judge');
+      },
+      modelJudgeConsent: () => true,
+      openDb: db.open,
+      now: () => 0,
+      createdBy: () => 'tester',
+      stdout: vi.fn(),
+      stderr: (s) => err.push(s),
+      planIO: {
+        write: () => PLAN_PATH,
+        read: () => ({
+          version: 3 as const,
+          posture: { secret: 'block' as const },
+          entries: [],
+          showcase: [],
+          join: [],
+          notes: '',
+          current: { secret: 'warn' as const },
+        }),
+        delete: vi.fn(),
+      },
+    });
+
+    expect(code).toBe(1);
+    const refusal = err.join('');
+    expect(refusal).toMatch(/store changed/i);
+    // Codex has no slash commands, so the hint names the skill — and it is the
+    // same name the re-tune hint uses elsewhere in this plugin.
+    expect(refusal).toContain('re-run the aka-setup skill to review against the current store');
+    // Fail loud, write nothing.
+    expect(db.posture).toEqual({ secret: 'redact' });
+    expect(db.created).toEqual([]);
+  });
+});

--- a/plugins/codex/tsconfig.json
+++ b/plugins/codex/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/plugins/codex/tsup.config.ts
+++ b/plugins/codex/tsup.config.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { copyFileSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { defineConfig } from 'tsup';
@@ -57,6 +57,8 @@ export default defineConfig({
     // aka:dashboard — launches the web dashboard via the `aka` CLI
     dashboard: 'src/dashboard.ts',
     onboard: 'src/onboard.ts',
+    // aka:setup FP-writeback adapter (reads a backfill --triage stream)
+    'apply-suppressions': 'src/apply-suppressions.ts',
     intro: 'src/intro.ts',
     firstrun: 'src/firstrun.ts',
     backfill: 'src/backfill.ts',
@@ -71,5 +73,14 @@ export default defineConfig({
   noExternal: [/^@akasecurity\//, 'zod'],
   onSuccess: async () => {
     normalizeSqliteSpecifier('scripts');
+    // Ship the locked triage rubric next to apply-suppressions.js. runJudge's
+    // default path is not in the package `files`, so the adapter reads
+    // scripts/triage-rubric.md at runtime — copied here from the single source,
+    // the harness-agnostic rubric owned by @akasecurity/setup-wizard (the
+    // Claude Code plugin's build copies the same asset).
+    copyFileSync(
+      '../../packages/setup-wizard/assets/triage-rubric.md',
+      join('scripts', 'triage-rubric.md'),
+    );
   },
 });

--- a/plugins/codex/tsup.config.ts
+++ b/plugins/codex/tsup.config.ts
@@ -60,6 +60,8 @@ export default defineConfig({
     // aka:setup FP-writeback adapter (reads a backfill --triage stream)
     'apply-suppressions': 'src/apply-suppressions.ts',
     intro: 'src/intro.ts',
+    // aka-setup start-light card (Not-now branch)
+    'start-light': 'src/start-light.ts',
     firstrun: 'src/firstrun.ts',
     backfill: 'src/backfill.ts',
     filescan: 'src/filescan.ts',

--- a/plugins/codex/tsup.config.ts
+++ b/plugins/codex/tsup.config.ts
@@ -63,6 +63,9 @@ export default defineConfig({
     firstrun: 'src/firstrun.ts',
     backfill: 'src/backfill.ts',
     filescan: 'src/filescan.ts',
+    // aka-setup frame-0.6 "Review leaked keys" — the secret-leak remediation
+    // chain's production entry
+    remediate: 'src/remediation/entry.ts',
   },
   format: ['esm'],
   platform: 'node',

--- a/plugins/codex/tsup.config.ts
+++ b/plugins/codex/tsup.config.ts
@@ -1,0 +1,75 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { defineConfig } from 'tsup';
+
+// esbuild (on releases predating node:sqlite in its builtin list) externalizes
+// the import but strips the `node:` prefix, emitting a bare `sqlite` specifier —
+// a nonexistent npm package that crashes the hook at load. esbuild's own printer
+// re-applies that stripping even when an onResolve plugin pins the path, so we
+// restore the prefix on the emitted bundles instead. Same fix as
+// plugins/claude-code/tsup.config.ts — both bundle @akasecurity/persistence,
+// which imports node:sqlite.
+//
+// Hardened against the two ways a naive string-replace is fragile:
+//   - matches only real module-specifier positions (`… from "sqlite"`,
+//     `import("sqlite")`, `require("sqlite")`), so an incidental "sqlite" string
+//     in a bundled dependency is left untouched; both quote styles are handled.
+//   - re-scans each file afterward and throws if a bare specifier survives, so a
+//     future change to esbuild's emit fails the BUILD loudly rather than shipping
+//     a bundle that dies at load. A future esbuild that keeps `node:sqlite` on its
+//     own yields zero rewrites and zero leftovers — no false failure.
+const SPECIFIER_SOURCE = String.raw`(\bfrom\s*|\b(?:import|require)\(\s*)(['"])sqlite\2`;
+
+function normalizeSqliteSpecifier(outDir: string): void {
+  for (const name of readdirSync(outDir)) {
+    if (!name.endsWith('.js')) continue;
+    const file = join(outDir, name);
+    const before = readFileSync(file, 'utf8');
+    const after = before.replace(
+      new RegExp(SPECIFIER_SOURCE, 'g'),
+      (_match, prefix: string, quote: string) => `${prefix}${quote}node:sqlite${quote}`,
+    );
+    if (after !== before) writeFileSync(file, after);
+
+    if (new RegExp(SPECIFIER_SOURCE).test(after)) {
+      throw new Error(
+        `tsup: ${name} still imports a bare "sqlite" specifier after node:sqlite ` +
+          `normalization — esbuild's emit format may have changed. The hook would ` +
+          `crash at load; failing the build instead.`,
+      );
+    }
+  }
+}
+
+export default defineConfig({
+  // Named entries keep the output flat in scripts/ — hooks.json paths depend on it
+  entry: {
+    'session-start': 'src/hooks/session-start.ts',
+    'user-prompt-submit': 'src/hooks/user-prompt-submit.ts',
+    'pre-tool-use': 'src/hooks/pre-tool-use.ts',
+    'post-tool-use': 'src/hooks/post-tool-use.ts',
+    stop: 'src/hooks/stop.ts',
+    // Detached token-usage reconcile worker, spawned by the Stop hook (off the hot path)
+    reconcile: 'src/reconcile.ts',
+    // Read surface (aka:health · aka:findings · aka:recommend · aka:audit) + onboarding (aka:setup)
+    query: 'src/query.ts',
+    // aka:dashboard — launches the web dashboard via the `aka` CLI
+    dashboard: 'src/dashboard.ts',
+    onboard: 'src/onboard.ts',
+    intro: 'src/intro.ts',
+    firstrun: 'src/firstrun.ts',
+    backfill: 'src/backfill.ts',
+    filescan: 'src/filescan.ts',
+  },
+  format: ['esm'],
+  platform: 'node',
+  target: 'node24',
+  outDir: 'scripts',
+  splitting: false,
+  // Hook scripts must be self-contained: the user's machine has no node_modules
+  noExternal: [/^@akasecurity\//, 'zod'],
+  onSuccess: async () => {
+    normalizeSqliteSpecifier('scripts');
+  },
+});

--- a/plugins/codex/tsup.config.ts
+++ b/plugins/codex/tsup.config.ts
@@ -50,6 +50,10 @@ export default defineConfig({
     'pre-tool-use': 'src/hooks/pre-tool-use.ts',
     'post-tool-use': 'src/hooks/post-tool-use.ts',
     stop: 'src/hooks/stop.ts',
+    // The isolated scan's worker thread. No hook names it — plugin-sdk starts it
+    // by path from whichever hook script is running, so the emitted script has to
+    // land in this same directory. See src/scan-worker.ts.
+    'scan-worker': 'src/scan-worker.ts',
     // Detached token-usage reconcile worker, spawned by the Stop hook (off the hot path)
     reconcile: 'src/reconcile.ts',
     // Read surface (aka:health · aka:findings · aka:recommend · aka:audit) + onboarding (aka:setup)

--- a/plugins/codex/vitest.config.ts
+++ b/plugins/codex/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+// Every test file runs behind the no-network guard: it refuses any outbound
+// connection that is not loopback and names the call site that made it. Wired
+// per package because each one runs its own vitest;
+// packages/eslint-config/test/no-network-runtime.test.js fails the workspace
+// if a package drops the entry or points it at the wrong path.
+const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+
+// No globalSetup counterpart to the Claude Code plugin's: codex has no journey
+// harness driving built scripts/*.js, so the suite needs neither the pre-build
+// step nor its raised timeouts.
+export default defineConfig({
+  test: {
+    setupFiles: [noNetworkGuard],
+    environment: 'node',
+  },
+});

--- a/plugins/codex/vitest.config.ts
+++ b/plugins/codex/vitest.config.ts
@@ -9,12 +9,19 @@ import { defineConfig } from 'vitest/config';
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
 
-// No globalSetup counterpart to the Claude Code plugin's: codex has no journey
-// harness driving built scripts/*.js, so the suite needs neither the pre-build
-// step nor its raised timeouts.
+// globalSetup builds scripts/*.js once, in the main process, before any worker
+// runs — the onboard and start-light suites drive those built scripts.
+//
+// Those tests spawn the built scripts as real child processes, which runs
+// slowly under Turbo's parallel task load, so raise the per-test AND per-hook
+// timeouts above vitest's 5s/10s defaults (mirrors
+// plugins/claude-code/vitest.config.ts).
 export default defineConfig({
   test: {
     setupFiles: [noNetworkGuard],
     environment: 'node',
+    globalSetup: ['./test/global-setup.ts'],
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       '@akasecurity/schema':
         specifier: workspace:*
         version: link:../../packages/schema
+      '@akasecurity/setup-wizard':
+        specifier: workspace:*
+        version: link:../../packages/setup-wizard
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -528,6 +528,42 @@ importers:
         specifier: ^4.0.0
         version: 4.4.3
 
+  plugins/codex:
+    devDependencies:
+      '@akasecurity/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@akasecurity/persistence':
+        specifier: workspace:*
+        version: link:../../packages/persistence
+      '@akasecurity/plugin-runtime':
+        specifier: workspace:*
+        version: link:../../packages/plugin-runtime
+      '@akasecurity/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      '@akasecurity/scanner':
+        specifier: workspace:*
+        version: link:../../packages/scanner
+      '@akasecurity/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.4(jiti@2.7.0)
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
   tools/audit-gate:
     devDependencies:
       '@akasecurity/eslint-config':

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -4,7 +4,7 @@ import {
   CLI_PACKAGE,
   cliVersion,
   gatherReport,
-  installedPluginVersions,
+  installedAgentPluginVersions,
   pluginRef,
   readCache,
 } from '@akasecurity/local-ops';
@@ -40,7 +40,7 @@ export default function UpdatesPage() {
       const agent = AGENT_PLUGINS.find((a) => a.npmPackage === pkg);
       return agent ? (latestOf.get(agent.id) ?? null) : null;
     },
-    installed: installedPluginVersions(),
+    installed: installedAgentPluginVersions(),
     cliInstalled: cliVersion(process.cwd()),
   });
 


### PR DESCRIPTION
> **Stack** (merge bottom-up; each PR targets its parent, retarget to `main` as parents merge — CI re-runs on retarget):
> 1. `refactor/extract-setup-wizard-core` — the `@akasecurity/setup-wizard` extraction
> 2. `feat/codex-plugin` — the Codex CLI plugin
> 3. `feat/claude-ai-source` — the claude-ai source seam
> 4. `feat/browser-extension` — the Chrome extension
> 5. `chore/release-0.10.0` — the version bump
>
> **This PR is #2.**

## What

Adds **`plugins/codex`** — the AI Traffic Control plugin for the Codex CLI. It bundles the same `@akasecurity/plugin-runtime`/`plugin-sdk` core as the Claude Code plugin and differs only in the thin host layer: stdin/stdout hook glue matched to Codex's hook contract, skills instead of commands, provider resolution, and the tool-name → scannable-field table.

Highlights:
- **Hooks**: SessionStart, UserPromptSubmit, PreToolUse/PostToolUse (Bash), Stop — captured into the same local `~/.aka/data/aka.db`.
- **The full setup wizard** (calibration → triage → remediation), shared with Claude Code via `@akasecurity/setup-wizard` (parent PR). The judge spawns `codex exec --ephemeral --skip-git-repo-check --output-last-message <tmp> -` with the prompt on stdin; `--ephemeral` keeps the judge session out of `~/.codex/sessions` so AKA's own backfill can never re-ingest raw findings.
- **History backfill** sweeps prior Codex rollout files (`~/.codex/sessions`) with the same triage-stream contract, self-contamination guard, and dedup.
- **Model-judge privacy parity**: the judge sends the same minimized `toJudgePayload` projection as Claude Code (rawMatch legible, context re-masked, `filePath`/`valueFingerprint`/`keyVersion` dropped before egress), gated on the same distinct `modelJudgeConsent` opt-in, with the disclosure collected by the skill before anything crosses.
- **Semantics adopted from main's vault line** (the parts that apply without vault wiring): a redact-policy **prompt now blocks** instead of warning-and-passing the raw secret to the model; a vault **pointer in an executable field denies** the call in every consent state (pointers minted by the Claude Code plugin on the same machine can reach Codex Bash commands); the judge refuses to run without an injected spawn seam and a cleanup fault can't displace the real error.

## Deliberate deferrals (flagged, not hidden)

- **The vault is not wired for Codex** this round. The shared runtime never vaults on its own, so Codex captures stay one-way-redacted (the safe direction); the setup skill's Known-limitation section discloses this, including that pointers render as literal `[[aka:...]]` tokens in Codex output (Codex has no display-side hook equivalent to MessageDisplay). A follow-up can port the consent step + rollout scrubber as a package.
- Codex fires PreToolUse/PostToolUse only for `Bash` today, not `apply_patch` — the file-write entry is registered but inert upstream (tracking issue referenced in-source); backfill covers file content after the fact.
- The judge spawn shape is verified against the openai/codex source and pinned by tests with injected spawns; it has not been exercised against a live `codex` binary in CI.
- The Security page's `codex` row is set to coverage 80 / supported (judgment call reflecting the Bash-only hook gap) and pinned by a repository test.
- The plugin registers through the in-repo marketplace; listing in the external marketplace repo is a follow-up outside this tree.

Versions stay on main's 0.9.3 line — the 0.10.0 bump is the last PR of this stack.

## Verification

Full workspace `turbo run typecheck lint test` green at this tip (the plugin's suite includes built-script e2e tests: the enforcement matrix through the real prompt hook, the no-consent journey proving no `codex` subprocess spawns without the opt-in, pointer-deny before store-open, onboarding consent read-back, version lockstep). `pnpm install --frozen-lockfile` clean; dependency-audit gates pass.

## Post-draft deep review (internal) — applied

- The judge spawn now pins `stdio` explicitly: execFileSync's default teed the `codex exec` child's stderr into the parent command's stderr (the wizard transcript the backfill later scans). A journey test proves a stub judge's stderr logging never surfaces. The Claude Code judge on main has the same latent (lower-exposure) gap — flagged as a follow-up, not touched here.
- The executable-field pointer-deny copy no longer sends users to `aka exception approve` (this plugin never substitutes pointers); it points at `aka vault show` / the dashboard instead.
- The first-run nudge names the real skill (`aka-setup`); the release workflow's header and missing `concurrency:` group are fixed; the model-judge consent copy states the grant is machine-wide across harnesses; CLAUDE.md's env-opt-out table and release section are updated.

**Release prerequisite (not in this diff):** `@akasecurity/ai-tc-codex` is a new npm name with no Trusted Publisher — configure it for `release-plugin-codex.yml` on npmjs.com (or bootstrap-publish once) before the first `plugin-codex-v*` tag, or the publish fails masked as a 404. Also note the in-repo marketplace entry goes live when this merges, while the npm package appears only at the 0.10.0 tag — keep that window short.
