### PR TITLE
feat(schema): add claude-ai as a first-class source

### DIFF
--- a/packages/dashboard-ui/src/activity/meta.ts
+++ b/packages/dashboard-ui/src/activity/meta.ts
@@ -31,6 +31,7 @@ export const HARNESS_KIND: Record<Harness, string> = {
   windsurf: 'IDE',
   claudedesktop: 'Desktop app',
   chatgpt: 'Web app',
+  claudeai: 'Web app',
   api: 'API',
 };
 
@@ -43,6 +44,7 @@ export const HARNESS_IDS: Harness[] = [
   'windsurf',
   'claudedesktop',
   'chatgpt',
+  'claudeai',
   'api',
 ];
 

--- a/packages/dashboard-ui/src/shared/Provider.tsx
+++ b/packages/dashboard-ui/src/shared/Provider.tsx
@@ -14,6 +14,7 @@ export const PROVIDERS = {
   codex: { label: 'Codex CLI', short: 'Cx', color: '#10A37F' },
   copilot: { label: 'GitHub Copilot', short: 'Co', color: '#0581D4' },
   chatgpt: { label: 'ChatGPT', short: 'GP', color: '#0d8f6f' },
+  claudeai: { label: 'Claude.ai', short: 'Ca', color: '#D97757' },
   api: { label: 'Anthropic API', short: 'AP', color: '#6058E9' },
 } satisfies Record<string, ProviderMeta>;
 

--- a/packages/dashboard-ui/test/activity/meta.test.ts
+++ b/packages/dashboard-ui/test/activity/meta.test.ts
@@ -1,0 +1,26 @@
+import { Harness } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { HARNESS_IDS, HARNESS_KIND } from '../../src/activity/meta.ts';
+import { PROVIDERS } from '../../src/shared/Provider.tsx';
+
+// The harness vocabulary lives in the schema; the filter list, kind labels,
+// and lettermarks live here. A harness added upstream can therefore arrive
+// without any of the three — these pin all of them to the enum.
+describe('HARNESS_IDS', () => {
+  it('covers exactly the schema Harness vocabulary', () => {
+    expect([...HARNESS_IDS].sort()).toEqual([...Harness.options].sort());
+  });
+
+  it('gives every harness a non-empty kind label', () => {
+    for (const id of HARNESS_IDS) {
+      expect(HARNESS_KIND[id].trim()).not.toBe('');
+    }
+  });
+
+  it('gives every harness a PROVIDERS lettermark entry', () => {
+    for (const id of HARNESS_IDS) {
+      expect(PROVIDERS[id]).toBeDefined();
+    }
+  });
+});

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -56,6 +56,7 @@ const SCAN_COVERAGE: readonly { provider: Provider; coverage: number; supported:
   { provider: 'claudecode', coverage: 100, supported: true },
   { provider: 'cursor', coverage: 0, supported: false },
   { provider: 'codex', coverage: 80, supported: true },
+  { provider: 'claudeai', coverage: 0, supported: false },
   { provider: 'chatgpt', coverage: 0, supported: false },
   { provider: 'copilot', coverage: 0, supported: false },
   { provider: 'api', coverage: 0, supported: false },

--- a/packages/persistence/test/repositories/activity.test.ts
+++ b/packages/persistence/test/repositories/activity.test.ts
@@ -379,6 +379,17 @@ describe('listSessions', () => {
     expect(res.items.map((s) => s.id).sort()).toEqual(['A', 'Z']);
   });
 
+  it('surfaces a claudeai root as claudeai, not the claudecode default', async () => {
+    // 'claudeai' is a Harness enum member — the read-side validation must pass
+    // it through rather than coalesce it to the claudecode fail-open.
+    insertSession({ id: 'W', startedAt: NOW - 2 * HOUR_MS, attributes: { harness: 'claudeai' } });
+    const res = await activity().listSessions({ limit: 50 });
+    expect(res.items.find((s) => s.id === 'W')?.harness).toBe('claudeai');
+
+    const filtered = await activity().listSessions({ limit: 50, harness: ['claudeai'] });
+    expect(filtered.items.map((s) => s.id)).toEqual(['W']);
+  });
+
   it('matches q against a descendant event detail', async () => {
     const res = await activity().listSessions({ limit: 50, q: 'masked' });
     expect(res.items.map((s) => s.id)).toEqual(['A']);
@@ -575,6 +586,11 @@ describe('harnessFacets', () => {
     insertSession({ id: 'Z', startedAt: NOW - 2 * HOUR_MS, attributes: {} }); // bare → claudecode
     const facets = await activity().harnessFacets();
     expect([...facets].sort()).toEqual(['claudecode', 'cursor']);
+  });
+
+  it('surfaces a claudeai root as claudeai, not the claudecode fail-open', async () => {
+    insertSession({ id: 'W', startedAt: NOW, attributes: { harness: 'claudeai' } });
+    expect(await activity().harnessFacets()).toEqual(['claudeai']);
   });
 
   it('a store of only bare roots surfaces exactly [claudecode]', async () => {

--- a/packages/persistence/test/repositories/security.test.ts
+++ b/packages/persistence/test/repositories/security.test.ts
@@ -616,10 +616,24 @@ describe('scanCoverage', () => {
       'claudecode',
       'cursor',
       'codex',
+      'claudeai',
       'chatgpt',
       'copilot',
       'api',
     ]);
+  });
+
+  it('pins the claudeai row: listed, not yet supported', async () => {
+    // The claude-ai source exists in the schema before any capture surface
+    // ships for it, so the coverage table names it explicitly at zero rather
+    // than omitting it — an omitted provider reads as an oversight, a zero
+    // row reads as a decision.
+    const res = await security().scanCoverage('30d');
+    expect(res.providers.find((p) => p.provider === 'claudeai')).toEqual({
+      provider: 'claudeai',
+      coverage: 0,
+      supported: false,
+    });
   });
 
   it('pins the codex row: supported at partial (80) coverage', async () => {

--- a/packages/schema/src/zod/event.ts
+++ b/packages/schema/src/zod/event.ts
@@ -24,6 +24,7 @@ export const SourceTool = z
     'claude-desktop',
     'cursor',
     'chatgpt',
+    'claude-ai',
     'github-copilot',
     'codex',
     'cli',

--- a/packages/schema/src/zod/finding.ts
+++ b/packages/schema/src/zod/finding.ts
@@ -69,7 +69,7 @@ export type FindingAction = z.infer<typeof FindingAction>;
 // FindingProvider: API-facing provider enum. 'claudedesktop' is a new value
 // (maps from source_tool = 'claude-desktop'). Never merged with 'claudecode'.
 export const FindingProvider = z
-  .enum(['claudecode', 'claudedesktop', 'cursor', 'copilot', 'chatgpt', 'codex', 'api'])
+  .enum(['claudecode', 'claudedesktop', 'cursor', 'copilot', 'chatgpt', 'claudeai', 'codex', 'api'])
   .meta({ id: 'FindingProvider' });
 export type FindingProvider = z.infer<typeof FindingProvider>;
 

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -93,9 +93,10 @@ export function toDbCategory(apiVal: FindingCategory): string {
  */
 export function toApiProvider(sourceTool: string): FindingProvider {
   // Shares the single TOOL_TO_HARNESS table (harness-map.ts) with
-  // `harnessFromTool`; every mapped value is a valid FindingProvider, and an
+  // `harnessFromTool`. The table's value type is `Harness & FindingProvider`,
+  // so every mapped value is a FindingProvider by construction — no cast. An
   // unknown tool falls back to 'api' (whereas harnessFromTool passes it through).
-  return (TOOL_TO_HARNESS[sourceTool] as FindingProvider | undefined) ?? 'api';
+  return TOOL_TO_HARNESS[sourceTool] ?? 'api';
 }
 
 /**

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -89,7 +89,7 @@ export function toDbCategory(apiVal: FindingCategory): string {
  * distinct values and must never be merged).
  *   claude-code → claudecode · claude-desktop → claudedesktop ·
  *   github-copilot → copilot · cursor → cursor · chatgpt → chatgpt ·
- *   codex → codex · else → api
+ *   claude-ai → claudeai · codex → codex · else → api
  */
 export function toApiProvider(sourceTool: string): FindingProvider {
   // Shares the single TOOL_TO_HARNESS table (harness-map.ts) with
@@ -110,6 +110,7 @@ export function toDbProviderFilter(apiProvider: FindingProvider): string[] {
     copilot: ['github-copilot'],
     cursor: ['cursor'],
     chatgpt: ['chatgpt'],
+    claudeai: ['claude-ai'],
     codex: ['codex'],
     api: [], // 'api' catches unknown tools — applied in-memory (no single DB value)
   };

--- a/packages/schema/src/zod/harness-map.ts
+++ b/packages/schema/src/zod/harness-map.ts
@@ -1,10 +1,18 @@
 // The canonical harness vocabulary and the single source of truth for mapping a
 // harness inventory *tool* id (the value the plugin hashes its harness identity
 // on, e.g. 'claude-code') onto the `Harness` / `FindingProvider` enum value the
-// read surfaces render ('claudecode'). One table, so consumers (`harnessFromTool`
-// on the capture writers, `toApiProvider` in findings-group-build.ts on the
-// findings read side) can never silently drift.
+// read surfaces render ('claudecode'). One table, so the *mapped* rows cannot
+// drift between consumers (`harnessFromTool` on the capture writers,
+// `toApiProvider` in findings-group-build.ts on the findings read side).
+//
+// The miss path is not shared, and the two consumers answer differently: an
+// unmapped tool id passes through `harnessFromTool` and the read side coalesces
+// an unrecognised value to 'claudecode', while `toApiProvider` falls back to
+// 'api'. One uninstrumented tool's events therefore read as Claude Code on the
+// Activity surfaces and as API on the findings surfaces.
 import { z } from 'zod';
+
+import type { FindingProvider } from './finding.ts';
 
 /**
  * Instrumented coding assistant. The open-ended harness vocabulary shared by
@@ -26,7 +34,10 @@ export const Harness = z
   .meta({ id: 'Harness' });
 export type Harness = z.infer<typeof Harness>;
 
-export const TOOL_TO_HARNESS: Record<string, string> = {
+// Values are typed to the intersection of both consumer enums, so a row whose
+// target is a `Harness` but not a `FindingProvider` (e.g. 'windsurf') fails to
+// compile rather than reaching `toApiProvider` as an unchecked `undefined`.
+export const TOOL_TO_HARNESS: Record<string, Harness & FindingProvider> = {
   'claude-code': 'claudecode',
   'claude-desktop': 'claudedesktop',
   'github-copilot': 'copilot',

--- a/packages/schema/src/zod/harness-map.ts
+++ b/packages/schema/src/zod/harness-map.ts
@@ -12,7 +12,17 @@ import { z } from 'zod';
  * `Harness` export; extend this one (single canonical registry).
  */
 export const Harness = z
-  .enum(['claudecode', 'cursor', 'copilot', 'codex', 'windsurf', 'claudedesktop', 'chatgpt', 'api'])
+  .enum([
+    'claudecode',
+    'cursor',
+    'copilot',
+    'codex',
+    'windsurf',
+    'claudedesktop',
+    'chatgpt',
+    'claudeai',
+    'api',
+  ])
   .meta({ id: 'Harness' });
 export type Harness = z.infer<typeof Harness>;
 
@@ -23,6 +33,7 @@ export const TOOL_TO_HARNESS: Record<string, string> = {
   cursor: 'cursor',
   chatgpt: 'chatgpt',
   codex: 'codex',
+  'claude-ai': 'claudeai',
 };
 
 // Map a harness inventory *tool* id — the value the plugin hashes its harness

--- a/packages/schema/src/zod/security.ts
+++ b/packages/schema/src/zod/security.ts
@@ -212,7 +212,7 @@ export type TopSourcesQuery = z.infer<typeof TopSourcesQuery>;
 // Order matches the dashboard display order (and SCAN_COVERAGE) so the generated
 // OpenAPI enum list reads the same as the returned `providers` array.
 export const Provider = z
-  .enum(['claudecode', 'cursor', 'codex', 'chatgpt', 'copilot', 'api'])
+  .enum(['claudecode', 'cursor', 'codex', 'claudeai', 'chatgpt', 'copilot', 'api'])
   .meta({ id: 'Provider' });
 export type Provider = z.infer<typeof Provider>;
 

--- a/packages/schema/test/zod/findings-group-build.test.ts
+++ b/packages/schema/test/zod/findings-group-build.test.ts
@@ -61,12 +61,14 @@ describe('provider mappers', () => {
     expect(toApiProvider('cursor')).toBe('cursor');
     expect(toApiProvider('chatgpt')).toBe('chatgpt');
     expect(toApiProvider('codex')).toBe('codex');
+    expect(toApiProvider('claude-ai')).toBe('claudeai');
     expect(toApiProvider('mystery-tool')).toBe('api');
   });
   it('maps API provider → DB filter values', () => {
     expect(toDbProviderFilter('claudecode')).toEqual(['claude-code']);
     expect(toDbProviderFilter('claudedesktop')).toEqual(['claude-desktop']);
     expect(toDbProviderFilter('codex')).toEqual(['codex']);
+    expect(toDbProviderFilter('claudeai')).toEqual(['claude-ai']);
     expect(toDbProviderFilter('api')).toEqual([]);
   });
 });

--- a/packages/schema/test/zod/harness-map.test.ts
+++ b/packages/schema/test/zod/harness-map.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { SourceTool } from '../../src/zod/event.ts';
+import { FindingProvider } from '../../src/zod/finding.ts';
+import { toApiProvider } from '../../src/zod/findings-group-build.ts';
 import { Harness, harnessFromTool, TOOL_TO_HARNESS } from '../../src/zod/harness-map.ts';
 
 describe('SourceTool enum', () => {
@@ -9,10 +11,13 @@ describe('SourceTool enum', () => {
   });
 });
 
-// TOOL_TO_HARNESS is typed Record<string, string>, so nothing forces its rows
-// through the enums at compile time. These pin every member — including any
-// future addition — into BOTH vocabularies: keys are the tool ids the capture
-// side stamps (SourceTool), values are what the read surfaces render (Harness).
+// TOOL_TO_HARNESS is typed `Record<string, Harness & FindingProvider>`, so a row
+// landing in only one vocabulary is already a compile error. These pin the same
+// invariant at runtime, so widening the type or reintroducing a cast still fails
+// here: keys are the tool ids the capture side stamps (SourceTool), values are
+// what BOTH read surfaces render — Activity via `Harness`, findings via
+// `FindingProvider`. `Harness` carries ids `FindingProvider` does not
+// ('windsurf'), and `toApiProvider` returns the mapped value unchecked.
 describe('TOOL_TO_HARNESS', () => {
   it('keys only valid SourceTool ids', () => {
     for (const tool of Object.keys(TOOL_TO_HARNESS)) {
@@ -26,7 +31,26 @@ describe('TOOL_TO_HARNESS', () => {
     }
   });
 
+  it('maps onto valid FindingProvider ids only', () => {
+    for (const harness of Object.values(TOOL_TO_HARNESS)) {
+      expect(FindingProvider.safeParse(harness).success).toBe(true);
+    }
+  });
+
+  it('routes every mapped tool through toApiProvider onto a FindingProvider', () => {
+    for (const tool of Object.keys(TOOL_TO_HARNESS)) {
+      expect(FindingProvider.safeParse(toApiProvider(tool)).success).toBe(true);
+    }
+  });
+
   it('routes claude-ai onto the claudeai harness', () => {
     expect(harnessFromTool('claude-ai')).toBe('claudeai');
+  });
+
+  // The miss path is not shared: harnessFromTool passes an unmapped id through
+  // (the read side coalesces it to 'claudecode'), toApiProvider answers 'api'.
+  it('answers an unmapped tool differently on each side', () => {
+    expect(harnessFromTool('not-a-tool')).toBe('not-a-tool');
+    expect(toApiProvider('not-a-tool')).toBe('api');
   });
 });

--- a/packages/schema/test/zod/harness-map.test.ts
+++ b/packages/schema/test/zod/harness-map.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { SourceTool } from '../../src/zod/event.ts';
+import { Harness, harnessFromTool, TOOL_TO_HARNESS } from '../../src/zod/harness-map.ts';
+
+describe('SourceTool enum', () => {
+  it('accepts claude-ai as a first-class source', () => {
+    expect(SourceTool.safeParse('claude-ai').success).toBe(true);
+  });
+});
+
+// TOOL_TO_HARNESS is typed Record<string, string>, so nothing forces its rows
+// through the enums at compile time. These pin every member — including any
+// future addition — into BOTH vocabularies: keys are the tool ids the capture
+// side stamps (SourceTool), values are what the read surfaces render (Harness).
+describe('TOOL_TO_HARNESS', () => {
+  it('keys only valid SourceTool ids', () => {
+    for (const tool of Object.keys(TOOL_TO_HARNESS)) {
+      expect(SourceTool.safeParse(tool).success).toBe(true);
+    }
+  });
+
+  it('maps onto valid Harness ids only', () => {
+    for (const harness of Object.values(TOOL_TO_HARNESS)) {
+      expect(Harness.safeParse(harness).success).toBe(true);
+    }
+  });
+
+  it('routes claude-ai onto the claudeai harness', () => {
+    expect(harnessFromTool('claude-ai')).toBe('claudeai');
+  });
+});


### PR DESCRIPTION
> **Stack** (merge bottom-up; each PR targets its parent, retarget to `main` as parents merge — CI re-runs on retarget):
> 1. `refactor/extract-setup-wizard-core` — the `@akasecurity/setup-wizard` extraction
> 2. `feat/codex-plugin` — the Codex CLI plugin
> 3. `feat/claude-ai-source` — the claude-ai source seam
> 4. `feat/browser-extension` — the Chrome extension
> 5. `chore/release-0.10.0` — the version bump
>
> **This PR is #3.**

## What

Adds **`claude-ai`** (Claude's web chat at claude.ai) as a first-class source across the schema and dashboard, the seam the browser extension (next PR) records through:

- `SourceTool` gains `'claude-ai'`; `Harness`/`TOOL_TO_HARNESS` gain the `claudeai` mapping (`packages/schema/src/zod/event.ts`, `harness-map.ts`)
- `FindingProvider`/`toApiProvider`/`toDbProviderFilter` route `claude-ai` findings to their own provider bucket instead of the `api` catch-all (`finding.ts`, `findings-group-build.ts`)
- the dashboard gets the `claudeai` lettermark and activity-filter entry (`dashboard-ui` `PROVIDERS` map, `HARNESS_IDS`)

No DDL: the affected columns are text-typed, so the enum widening is TypeScript/Zod-level only — main's migration journal (0015–0018) is untouched.

## Tests

The seam is pinned three ways: `SourceTool` accepts the new member and a derived invariant ties every `TOOL_TO_HARNESS` key/value to the `SourceTool`/`Harness` enums (future members auto-covered); `HARNESS_IDS` is asserted set-equal to `Harness.options` with a `HARNESS_KIND`/`PROVIDERS` entry for each (a missing lettermark now fails CI); the activity repository surfaces a `claudeai`-stamped session as `claudeai` rather than the `claudecode` fail-open.

## Verification

Full workspace `turbo run typecheck lint test` green at this tip; `pnpm install --frozen-lockfile` clean.

## Post-draft deep review (internal) — applied

The Security page's `Provider` enum and `SCAN_COVERAGE` table now name `claudeai` explicitly (coverage 0, unsupported) rather than omitting it — an omitted provider reads as an oversight, a zero row reads as a decision. Flipping it to supported is deliberately deferred until the extension is distributable beyond load-unpacked.
