### PR TITLE
chore(release): 0.10.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka-codex",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-codex",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
> **Stack** (merge bottom-up; each PR targets its parent, retarget to `main` as parents merge — CI re-runs on retarget):
> 1. `refactor/extract-setup-wizard-core` — the `@akasecurity/setup-wizard` extraction
> 2. `feat/codex-plugin` — the Codex CLI plugin
> 3. `feat/claude-ai-source` — the claude-ai source seam
> 4. `feat/browser-extension` — the Chrome extension
> 5. `chore/release-0.10.0` — the version bump
>
> **This PR is #5.**

## What

`chore(release): 0.10.0` — the minor bump for this stack, kept out of the feature PRs so each of them stays reviewable against main's 0.9.3 line.

Five files move together (the shared version line per CLAUDE.md's release rules):

- `cli/package.json` → 0.10.0
- `plugins/claude-code/package.json` + `.claude-plugin/plugin.json` → 0.10.0
- `plugins/codex/package.json` + `.codex-plugin/plugin.json` → 0.10.0

Minor (not patch) because the stack adds new surface: the Codex CLI plugin, the claude-ai source seam, the browser extension + `aka extension` command, and the `@akasecurity/setup-wizard` extraction bundled into all three artifacts.

## Guardrails

Both plugins carry a version-lockstep test (plugin manifest === package.json), and the codex suite adds a three-way shared-line assertion (cli === claude-code plugin === codex plugin), so a partial bump now fails CI instead of publishing mismatched artifacts. `@akasecurity/plugin-browser-extension` stays private/unpublished and is deliberately not on the shared line.

## Verification

Full workspace `turbo run typecheck lint test` green at this tip; `pnpm install --frozen-lockfile` clean; both dependency-audit gates (workspace + cli artifact) pass.
