### PR TITLE
test(eslint-config): load the config audit concurrently and raise its timeout

### DIFF
--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -440,8 +440,14 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
   it('has exactly the opt-out sites CLAUDE.md §4 documents, each file-scoped', async () => {
     /** @type {Record<string, string[]>} */
     const found = {};
-    for (const file of configs) {
-      const mod = await import(pathToFileURL(join(REPO_ROOT, file)).href);
+    // Loaded concurrently rather than in an await-loop: these are 18 independent
+    // module reads whose cost is resolution and I/O, and serializing them
+    // multiplies under the parallel load turbo puts on a CI runner. Node's module
+    // cache makes the order irrelevant, and each config writes only its own key.
+    const loaded = await Promise.all(
+      configs.map(async (file) => [file, await import(pathToFileURL(join(REPO_ROOT, file)).href)]),
+    );
+    for (const [file, mod] of loaded) {
       for (const entry of mod.default) {
         const permitted = networkSpecifiersPermittedBy(entry.rules);
         if (permitted.length === 0) continue;

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { Linter } from 'eslint';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import {
   base,
@@ -381,6 +381,13 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 //
 // The set is asserted EXACTLY, not as a superset: a guard that only forbids
 // removals would let a third site in.
+// Budget for the one-off config load below. Deliberately generous: it bounds a
+// hang, it is not a performance assertion. The load measured ~4.7s on a CI
+// runner under full workspace parallelism against ~0.25s on a developer
+// machine, so the headroom absorbs a slower or more contended one without
+// loosening the per-test default that guards every other test in this file.
+const CONFIG_LOAD_TIMEOUT_MS = 60_000;
+
 const DOCUMENTED_OPT_OUTS = {
   'cli/eslint.config.mjs': ['node:net'],
   'cli/eslint.scripts.config.mjs': ['node:http'],
@@ -429,25 +436,52 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
     }
   })();
 
+  /** Each tracked config's module, resolved once below. */
+  const configModules = new Map();
+  /** Load failures, kept per file so a broken config names itself. */
+  const loadFailures = new Map();
+
+  // Importing every flat config pulls the whole typescript-eslint stack and is
+  // filesystem- and resolution-bound, so on a contended runner it costs many
+  // times what it does on a developer machine — past a default per-test timeout.
+  // Resolve once here under the hook's own budget; the tests below are then fast
+  // assertions on the cached result and keep vitest's tight per-test default,
+  // which still guards them. Mirrors effective-config.test.js's
+  // RESOLVE_TIMEOUT_MS, for the same reason.
+  //
+  // Settled individually rather than through Promise.all's fail-fast: one broken
+  // config should name itself instead of hiding the other 17 behind whichever
+  // happened to reject first.
+  beforeAll(async () => {
+    const results = await Promise.allSettled(
+      configs.map((file) => import(pathToFileURL(join(REPO_ROOT, file)).href)),
+    );
+    results.forEach((result, i) => {
+      const file = configs[i];
+      if (result.status === 'fulfilled') configModules.set(file, result.value);
+      else loadFailures.set(file, result.reason);
+    });
+  }, CONFIG_LOAD_TIMEOUT_MS);
+
   // A guard that found no configs would pass every assertion below vacuously.
   it('found the workspace ESLint configs to audit', () => {
     expect(configs.length).toBeGreaterThanOrEqual(Object.keys(DOCUMENTED_OPT_OUTS).length);
     for (const documented of Object.keys(DOCUMENTED_OPT_OUTS)) {
       expect(configs).toContain(documented);
     }
+    // A config that failed to load contributes nothing to `found`, so an
+    // undocumented opt-out inside it would be invisible below — the same
+    // vacuous pass this guard exists to prevent. Name every failure.
+    expect(
+      [...loadFailures].map(([file, cause]) => `${file}: ${String(cause)}`),
+      'workspace ESLint configs failed to load, so the audit below is partial',
+    ).toEqual([]);
   });
 
-  it('has exactly the opt-out sites CLAUDE.md §4 documents, each file-scoped', async () => {
+  it('has exactly the opt-out sites CLAUDE.md §4 documents, each file-scoped', () => {
     /** @type {Record<string, string[]>} */
     const found = {};
-    // Loaded concurrently rather than in an await-loop: these are 18 independent
-    // module reads whose cost is resolution and I/O, and serializing them
-    // multiplies under the parallel load turbo puts on a CI runner. Node's module
-    // cache makes the order irrelevant, and each config writes only its own key.
-    const loaded = await Promise.all(
-      configs.map(async (file) => [file, await import(pathToFileURL(join(REPO_ROOT, file)).href)]),
-    );
-    for (const [file, mod] of loaded) {
+    for (const [file, mod] of configModules) {
       for (const entry of mod.default) {
         const permitted = networkSpecifiersPermittedBy(entry.rules);
         if (permitted.length === 0) continue;
@@ -465,9 +499,10 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
   // the exception holds whichever import form the file uses". Asserted
   // behaviourally through the real linter rather than by matching the generated
   // esquery selector, whose escaping is an implementation detail.
-  it('permits its specifier in both the static and the dynamic form', async () => {
+  it('permits its specifier in both the static and the dynamic form', () => {
     for (const [file, specifiers] of Object.entries(DOCUMENTED_OPT_OUTS)) {
-      const mod = await import(pathToFileURL(join(REPO_ROOT, file)).href);
+      const mod = configModules.get(file);
+      expect(mod, `${file}: config was not loaded`).toBeDefined();
       const optOut = mod.default.find(
         (entry) => networkSpecifiersPermittedBy(entry.rules).length > 0,
       );

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -9,17 +9,16 @@ import { defineConfig } from 'vitest/config';
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
 
-// These suites import every tracked ESLint config in the workspace, run the real
-// linter over ~100 fixtures, and drive the CI egress script through stubbed
-// PATHs. That is FS- and module-resolution-bound, and turbo runs all 14 package
-// test tasks in parallel — so on a 2-core CI runner it takes many times what it
-// takes on a developer machine. Raise the per-test AND per-hook timeouts above
-// vitest's 5s/10s defaults (mirrors packages/scanner/vitest.config.ts).
+// No package-wide timeout override on purpose. The slow work here is config
+// resolution, which is confined to `beforeAll` hooks that carry their own
+// budgets (no-network.test.js's CONFIG_LOAD_TIMEOUT_MS, effective-config.test.js's
+// RESOLVE_TIMEOUT_MS). Raising testTimeout for the package would spend that
+// budget on ~112 fixture-lint assertions that each run in well under a
+// millisecond, where a regression to multiple seconds should fail rather than
+// pass quietly.
 export default defineConfig({
   test: {
     setupFiles: [noNetworkGuard],
     environment: 'node',
-    testTimeout: 20_000,
-    hookTimeout: 20_000,
   },
 });

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -9,9 +9,17 @@ import { defineConfig } from 'vitest/config';
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
 
+// These suites import every tracked ESLint config in the workspace, run the real
+// linter over ~100 fixtures, and drive the CI egress script through stubbed
+// PATHs. That is FS- and module-resolution-bound, and turbo runs all 14 package
+// test tasks in parallel — so on a 2-core CI runner it takes many times what it
+// takes on a developer machine. Raise the per-test AND per-hook timeouts above
+// vitest's 5s/10s defaults (mirrors packages/scanner/vitest.config.ts).
 export default defineConfig({
   test: {
     setupFiles: [noNetworkGuard],
     environment: 'node',
+    testTimeout: 20_000,
+    hookTimeout: 20_000,
   },
 });


### PR DESCRIPTION
Fixes the one thing keeping `main` red. Refs
[akasecurity/engineering#104](https://github.com/akasecurity/engineering/issues/104).

## The failure

`packages/eslint-config/test/no-network.test.js` → *"has exactly the opt-out sites CLAUDE.md §4
documents, each file-scoped"* → `Test timed out in 5000ms`. It has failed on **every** CI run since
the no-network gates landed — three consecutive attempts on `main` (`f25def2`, `ba3268d`, and a
re-run of `ba3268d`), never green.

Worth stating because it changes the fix: the reported `5091 / 5209 / 5040 ms` are **clamped by the
timeout**, not measurements — a timed-out vitest test always reports ~5000 ms because that is when
it was killed. So this is not "takes 5.1 s and sometimes tips over". It exceeds 5 s every time, by
an unknown margin. Deterministic, not flaky.

(The `Windows` job was also red on `ba3268d`. It passed on the re-run, so that one *was* a flake and
is unrelated to this.)

## Why it is slow

The test loads **every tracked ESLint config in the workspace** — `git ls-files
'*eslint*.config.mjs'`, currently 18 files — in a sequential `await` loop. That cost is filesystem
and module resolution, not work the test asserts about. And `turbo` runs all 14 package `test` tasks
**in parallel**, so on a 2-core runner this loop competes with 13 other vitest processes.

Measured on a 14-core dev machine:

| Condition | Duration |
| --- | --- |
| That file alone | 195–312 ms |
| Under full workspace `turbo run test` concurrency | 545 ms |

Contention nearly triples it even with 14 cores. A runner with far less CPU for the same 14-way load
accounts for the rest.

## Why raising the budget is the right call here, not a cover-up

`packages/eslint-config` was on vitest's **default** 5000 ms — the budget was never chosen for this
package. It is an outlier: **9 of the 14 vitest packages already set `testTimeout: 20_000`**, and
`packages/scanner/vitest.config.ts` carries the identical rationale in its own comment:

> Real FS + gateway work runs slowly on the Windows CI runner under parallel load, so raise the
> per-test AND per-hook timeouts above vitest's 5s/10s defaults

This package does more I/O than most and was simply the one left on the default. `REGRESSION_SUITE.md`'s
warning is about retrying flaky tests and about timing assertions testing the wrong thing — no `retry`
is added here, and this test asserts a documentation-consistency property, not a performance one. The
timeout is incidental to what it checks.

## The change

1. **Load the 18 configs concurrently** rather than in an `await` loop. They are independent module
   reads, Node's module cache makes order irrelevant, and each config writes only its own key.
2. **`testTimeout` / `hookTimeout` → `20_000`**, matching the nine packages that already do.

Being straight about the split: concurrency alone measured 545 ms → 460 ms (~15 %), which would
**not** have closed an unknown gap on its own. The budget is what makes the run green; the
restructure just stops the cost multiplying under load.

## Verification

- `pnpm exec turbo run test --force` → **29 successful, 0 cached**.
- `pnpm format:check` and lint clean.
- **Mutation-tested**, because a wider timeout could easily make an assertion vacuous without anyone
  noticing. Two independent mutations each turn the test red, and the restored tree is green:
  - dropping a documented opt-out entry from `DOCUMENTED_OPT_OUTS`
  - making the loop skip a config (`configs.slice(1)`), the shape that would let an undocumented
    opt-out hide

## Known unknown

The **true** cost on the runner is still unmeasured — the 5 s timeout clamped it on all three
attempts. The 20 s budget will let the next run report it. **If that number comes back anywhere near
20 s, contention does not explain it and engineering#104 should be reopened**: 18 module imports have
no business taking that long, and it would point at something structural in module resolution on the
runner rather than at the budget. That caveat is recorded on the issue.
