### PR TITLE
test(plugin-sdk): put worker startup in the isolation elapsed ceilings

### DIFF
--- a/packages/plugin-sdk/test/runtime-isolation.test.ts
+++ b/packages/plugin-sdk/test/runtime-isolation.test.ts
@@ -87,6 +87,26 @@ const BUDGET_MS = 1_500;
 // start budget pass their own value, which wins over this one.
 const START_MS = 30_000;
 
+// An elapsed ceiling for a path that runs in a worker. Every such path pays a
+// worker START before it can spend a BUDGET, and the start is granted START_MS
+// above — so a ceiling derived from the budgets alone bounds the wrong term. It
+// is also the term that moves: a budget is a wall-clock deadline and costs the
+// same everywhere, while a cold start is whatever the runner makes it, and on
+// Windows the observed elapsed for the two-cycle case below was 16.6s against a
+// budgets-only ceiling of 15s. That case then failed on startup this file had
+// deliberately granted 30s for, which is the same "the runner decides whether
+// the assertion runs at all" failure START_MS exists to prevent.
+//
+// `starts` is how many times the path builds a worker; `budgetUnits` keeps
+// whatever multiple of BUDGET_MS the case already justified.
+const isolationCeilingMs = (starts: number, budgetUnits: number): number =>
+  starts * START_MS + budgetUnits * BUDGET_MS;
+
+// Above the ceilings below, so a path that blows its bound fails on the
+// assertion — which names what was exceeded — rather than on vitest's 20s
+// package default, which just says the test timed out.
+const ISOLATION_CASE_TIMEOUT_MS = 120_000;
+
 // Points the isolated scanner at a module that throws on load, so a case that
 // must not reach a worker fails loudly if it ever does.
 const CRASHING_WORKER = new URL('./helpers/crashing-scan-worker.ts', import.meta.url);
@@ -217,37 +237,42 @@ afterEach(() => {
 });
 
 describe('a pulled rule that never returns', () => {
-  it('is terminated, and the capture still decides on the built-in packs', async () => {
-    silenceStderr();
-    const gw = fakeGateway(bundle([HOSTILE]), clearedByPreflight(HOSTILE));
-    const rt = createPluginRuntime(gw, settings(), {
-      scanIsolation: { budgetMs: BUDGET_MS, minAttributionMs: 50, startBudgetMs: START_MS },
-    });
-    try {
-      const text = `${HOSTILE_TEXT} and SECRET_MARKER`;
-      const started = performance.now();
-      const result = await rt.capture({ kind: 'prompt', sourceTool: 'claude-code', text });
-      const elapsedMs = performance.now() - started;
+  it(
+    'is terminated, and the capture still decides on the built-in packs',
+    async () => {
+      silenceStderr();
+      const gw = fakeGateway(bundle([HOSTILE]), clearedByPreflight(HOSTILE));
+      const rt = createPluginRuntime(gw, settings(), {
+        scanIsolation: { budgetMs: BUDGET_MS, minAttributionMs: 50, startBudgetMs: START_MS },
+      });
+      try {
+        const text = `${HOSTILE_TEXT} and SECRET_MARKER`;
+        const started = performance.now();
+        const result = await rt.capture({ kind: 'prompt', sourceTool: 'claude-code', text });
+        const elapsedMs = performance.now() - started;
 
-      // Fail-open in the sense that matters: the call returns. Left in-process
-      // this text runs longer than the harness would ever wait, and a hook the
-      // harness kills lets the whole tool call through unscanned. Worst case
-      // here is TWO budgets — the scan, then the retry that names the rule —
-      // and the ceiling is loose on top of that.
-      expect(elapsedMs).toBeLessThan(BUDGET_MS * 10);
-      // The bundled rule in the same text is untouched by the termination.
-      expect(result.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
-      expect(result.action).toBe('warn');
-      // Anything keyed on the ruleset fingerprint has to stop writing now: the
-      // fingerprint still names the pulled rule that is no longer running.
-      expect(rt.scanIsolationDegraded()).toBe(true);
-      // And the event was still persisted, with the finding masked as usual.
-      expect(gw.records).toHaveLength(1);
-      expect(gw.records[0]?.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
-    } finally {
-      await rt.close();
-    }
-  });
+        // Fail-open in the sense that matters: the call returns. Left in-process
+        // this text runs longer than the harness would ever wait, and a hook the
+        // harness kills lets the whole tool call through unscanned. Worst case
+        // here is TWO budgets — the scan, then the retry that names the rule —
+        // and TWO worker starts to spend them on, which is what the ceiling has
+        // to cover; see isolationCeilingMs.
+        expect(elapsedMs).toBeLessThan(isolationCeilingMs(2, 10));
+        // The bundled rule in the same text is untouched by the termination.
+        expect(result.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
+        expect(result.action).toBe('warn');
+        // Anything keyed on the ruleset fingerprint has to stop writing now: the
+        // fingerprint still names the pulled rule that is no longer running.
+        expect(rt.scanIsolationDegraded()).toBe(true);
+        // And the event was still persisted, with the finding masked as usual.
+        expect(gw.records).toHaveLength(1);
+        expect(gw.records[0]?.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
+      } finally {
+        await rt.close();
+      }
+    },
+    ISOLATION_CASE_TIMEOUT_MS,
+  );
 
   it('is quarantined, so the next process never loads it again', async () => {
     silenceStderr();
@@ -284,33 +309,41 @@ describe('a pulled rule that never returns', () => {
 });
 
 describe('a pulled rule that hangs the timing battery itself', () => {
-  it('is terminated during the pre-flight, and the capture still decides', async () => {
-    // The gate that decides whether a pulled rule is safe works by running the
-    // rule. Measured on this thread it never returns, the hook is killed by the
-    // harness at 10s, and a killed hook fails open — the whole tool call goes
-    // through unscanned. That is the same bypass the scan bound exists for, one
-    // call earlier, so the measurement runs where it can be killed too.
-    silenceStderr();
-    const verdicts = new Map<string, RuleProbeVerdictEntry>();
-    const rt = createPluginRuntime(fakeGateway(bundle([BATTERY_KILLER]), verdicts), settings(), {
-      scanIsolation: { probeBudgetMs: BUDGET_MS, startBudgetMs: START_MS },
-    });
-    try {
-      const started = performance.now();
-      const result = await rt.processText('deploy with SECRET_MARKER now');
-      expect(performance.now() - started).toBeLessThan(BUDGET_MS * 8);
+  it(
+    'is terminated during the pre-flight, and the capture still decides',
+    async () => {
+      // The gate that decides whether a pulled rule is safe works by running the
+      // rule. Measured on this thread it never returns, the hook is killed by the
+      // harness at 10s, and a killed hook fails open — the whole tool call goes
+      // through unscanned. That is the same bypass the scan bound exists for, one
+      // call earlier, so the measurement runs where it can be killed too.
+      silenceStderr();
+      const verdicts = new Map<string, RuleProbeVerdictEntry>();
+      const rt = createPluginRuntime(fakeGateway(bundle([BATTERY_KILLER]), verdicts), settings(), {
+        scanIsolation: { probeBudgetMs: BUDGET_MS, startBudgetMs: START_MS },
+      });
+      try {
+        const started = performance.now();
+        const result = await rt.processText('deploy with SECRET_MARKER now');
+        // Same shape as the two-cycle case above: the pre-flight builds a worker
+        // to measure in, so the start belongs in the ceiling. This one has not
+        // gone red, but on the Windows numbers it was inside ~1.5x of its
+        // budgets-only bound, which is the margin the other case was flaking at.
+        expect(performance.now() - started).toBeLessThan(isolationCeilingMs(1, 8));
 
-      // A measurement that had to be terminated is the strongest unsafe verdict
-      // there is, and it is cached, so the next process never loads the rule.
-      const key = ruleProbeKey(BATTERY_KILLER);
-      expect(key).toBeDefined();
-      expect(verdicts.get(key ?? '')?.verdict).toBe('quarantined');
-      // …and the built-in packs are untouched by any of it.
-      expect(result.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
-    } finally {
-      await rt.close();
-    }
-  });
+        // A measurement that had to be terminated is the strongest unsafe verdict
+        // there is, and it is cached, so the next process never loads the rule.
+        const key = ruleProbeKey(BATTERY_KILLER);
+        expect(key).toBeDefined();
+        expect(verdicts.get(key ?? '')?.verdict).toBe('quarantined');
+        // …and the built-in packs are untouched by any of it.
+        expect(result.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);
+      } finally {
+        await rt.close();
+      }
+    },
+    ISOLATION_CASE_TIMEOUT_MS,
+  );
 });
 
 // The pointer shield's guarantee is "no rule ever sees a pointer, whatever rules

--- a/packages/plugin-sdk/test/runtime-isolation.test.ts
+++ b/packages/plugin-sdk/test/runtime-isolation.test.ts
@@ -99,6 +99,19 @@ const START_MS = 30_000;
 //
 // `starts` is how many times the path builds a worker; `budgetUnits` keeps
 // whatever multiple of BUDGET_MS the case already justified.
+//
+// THE RESULT IS MOSTLY FORCED, WHICH IS THE POINT — do not retune the multiple.
+// A start is allowed to take START_MS before the scanner gives up and reports
+// `unavailable`, so any ceiling budgeting less than START_MS per start can be
+// blown by a start this file explicitly permits. That is the contradiction the
+// helper exists to remove, and a smaller multiple puts it back one line lower.
+// For the two-cycle case that fixes 60s of the 75s; the remaining 15s is the
+// x10 cushion that case already carried and is the only part anyone chose.
+//
+// The single lever is START_MS, and it has little travel. At START_MS = 10_000
+// the two-cycle ceiling is 35s against a 16.6s Windows observation — 2.1x, which
+// sits inside the 3.2x spread already seen between runners on this very case
+// (5176ms and 16645ms), so a runner slower than any yet observed would blow it.
 const isolationCeilingMs = (starts: number, budgetUnits: number): number =>
   starts * START_MS + budgetUnits * BUDGET_MS;
 
@@ -257,6 +270,20 @@ describe('a pulled rule that never returns', () => {
         // here is TWO budgets — the scan, then the retry that names the rule —
         // and TWO worker starts to spend them on, which is what the ceiling has
         // to cover; see isolationCeilingMs.
+        //
+        // Be clear about what this does NOT say. The SHIPPED budgets are
+        // ISOLATED_START_BUDGET_MS = 5_000 and ISOLATED_SCAN_BUDGET_MS = 2_000,
+        // so the product's worst case on this path is ~14s, and the ceiling is
+        // 75s — about 5x that, the whole gap being the test-environment startup
+        // grant START_MS documents. So this is not a check on the product's
+        // latency contract; it is a SHAPE check that happens to be denominated in
+        // milliseconds, and a regression of one extra budget would vanish inside
+        // it. What it still separates is "this path got slower" from "this path
+        // stopped terminating", which the 120s timeout alone cannot: a path that
+        // slows but returns fails here and names what it exceeded, where a hang
+        // fails there. Asserting the COUNT of worker starts would recover the
+        // real property and be runner-independent, but counting across threads
+        // needs a channel this file does not have.
         expect(elapsedMs).toBeLessThan(isolationCeilingMs(2, 10));
         // The bundled rule in the same text is untouched by the termination.
         expect(result.findings.map((f) => f.ruleId)).toEqual(['isolation/secret-marker']);


### PR DESCRIPTION
Fixes the second of the two things that were keeping `main` red. The other was
[#165](https://github.com/akasecurity/ai-tc/pull/165), now merged. Refs
[akasecurity/engineering#110](https://github.com/akasecurity/engineering/issues/110).

> **Review tip:** use `git diff -w`. The real change is **40 insertions / 7 deletions**; the rest is
> prettier re-indenting two test bodies because `it()` gained a third argument.

## The failure

`Windows · Unit tests (shipped surface)`, intermittently — 16752 ms, 16671 ms and 16645 ms observed
against a 15000 ms bound, passing on most runs.

```
FAIL test/runtime-isolation.test.ts
  > a pulled rule that never returns
  > is terminated, and the capture still decides on the built-in packs
AssertionError: expected 16645.0548 to be less than 15000
```

## It is a unit mismatch, not a number that is too small

```ts
const started = performance.now();
const result = await rt.capture({ … });
const elapsedMs = performance.now() - started;
expect(elapsedMs).toBeLessThan(BUDGET_MS * 10);   // 15_000
```

`elapsedMs` wraps the whole `capture()`, which **builds a worker before it can spend a budget** — and
this file grants that startup `START_MS = 30_000`. So the case asserted that startup plus two budgets
fits in 15 s while separately permitting 30 s of startup *per worker*. Those cannot both hold.

The `START_MS` comment already describes the hazard:

> CI runs the type-stripped `.ts` worker under vitest with the whole workspace's suites in parallel;
> **a cold start on that path has been seen past 5s on a Windows runner** … Leaving these on the
> product's own `ISOLATED_START_BUDGET_MS` lets the runner's speed decide whether the assertion under
> test runs at all

That is exactly what happened — reintroduced one line later by a ceiling derived from the wrong term.

**Why retuning the number didn't hold.** The two terms behave differently. A budget is a wall-clock
deadline enforced by the terminator, so it costs the same everywhere. A cold start is whatever the
runner makes it:

| | elapsed | of which budgets |
| --- | --- | --- |
| 14-core dev machine | **3203 ms** | ~3000 ms |
| Windows CI runner | **16645 ms** | ~3000 ms |

Identical budgets; the ~13.4 s difference is startup and teardown for the two worker cycles this path
makes (the scan, then the retry that names the rule). This ceiling was already retuned three times on
2026-07-30 (`e04f8f5`, `e6049bc`, `6655455`) and still flaked, which is what a wrong denominator looks
like.

## The change

- `isolationCeilingMs(starts, budgetUnits)` — a ceiling now covers the worker **starts** a path makes
  as well as the budgets it spends. Each case keeps whatever budget multiple it had already justified.
- Applied to the failing case (2 starts → 75 s) and to *"is terminated during the pre-flight"*
  (1 start → 42 s). The pre-flight case has the identical flaw and sat inside ~1.5× of its bound on the
  same Windows numbers — the margin the other one was flaking at, so it is the next to go red.
- Both cases get a per-test budget above their ceiling. The package default is `20_000` and the
  legitimate Windows worst case is already ~16.6 s, so without this the timeout simply becomes the new
  flake.

## Verification

`format:check`, `typecheck` (15/15), `lint` (15/15), and `turbo run test --force` (29/29, 0 cached) all
green.

Mutation-tested — a looser bound is exactly the kind of change that goes quietly vacuous, so each path
was broken deliberately:

| Injection | Result |
| --- | --- |
| force the two-cycle elapsed past its ceiling | `AssertionError: expected 203195.47 to be less than 75000` |
| force the pre-flight elapsed past its ceiling | `AssertionError: expected 201592.19 to be less than 42000` |
| a real 130 s stall | `Error: Test timed out in 120000ms` |

So both ceilings still fire, and a genuine hang is still caught by the timeout backstop.

## What this ceiling can and cannot catch — worth being explicit

Once it correctly includes the startup grant the bound is necessarily loose: a third budget would
disappear inside it. What remains is catching a change of *shape* — many more worker cycles — and
giving a failure that names what was exceeded instead of a bare timeout.

That is the same trade-off the `startupMs < 10_000` ceiling in this file already documents
(*"Ceilings, not measurements — CI runners are far too noisy to assert a real timing"*), and I would
rather state it than imply the assertion is tighter than it is.

**If you would rather delete the elapsed assertion entirely** and let the per-test timeout be the sole
hang detector, that is a defensible alternative and I'm happy to switch — the behavioural assertions in
the same test (findings, `action`, `scanIsolationDegraded()`) already carry the load-bearing part. I
kept it because it is your test and the reasoning behind it was deliberate.
