### PR TITLE
fix(rules): remove start-position amplification in gcp-service-account

### DIFF
--- a/rules/secrets/fixtures/gcp-service-account.json
+++ b/rules/secrets/fixtures/gcp-service-account.json
@@ -56,5 +56,43 @@
     "label": "local part too short",
     "text": "ab@my-project.iam.gserviceaccount.com",
     "shouldMatch": false
+  },
+  {
+    "label": "long hyphenated prefix glued to the address",
+    "text": "a-really-long-hyphenated-prefix-goes-here-before-the-actual-deploy-bot@my-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 105
+      }
+    ]
+  },
+  {
+    "label": "underscore predecessor",
+    "text": "deploy_bot@my-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 7,
+        "end": 45
+      }
+    ]
+  },
+  {
+    "label": "all-hyphen local part",
+    "text": "---@my-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 38
+      }
+    ]
+  },
+  {
+    "label": "run longer than the 200-char ceiling",
+    "text": "abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-a@my-project.iam.gserviceaccount.com",
+    "shouldMatch": false
   }
 ]

--- a/rules/secrets/fixtures/gcp-service-account.json
+++ b/rules/secrets/fixtures/gcp-service-account.json
@@ -29,5 +29,26 @@
         "end": 64
       }
     ]
+  },
+  {
+    "label": "deleted line in a unified diff",
+    "text": "-deploy-bot@sample-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 50
+      }
+    ]
+  },
+  {
+    "label": "uppercase-prefixed token",
+    "text": "ENV=Xdeploy-bot@sample-project.iam.gserviceaccount.com",
+    "shouldMatch": true
+  },
+  {
+    "label": "local part too short",
+    "text": "ab@my-project.iam.gserviceaccount.com",
+    "shouldMatch": false
   }
 ]

--- a/rules/secrets/fixtures/gcp-service-account.json
+++ b/rules/secrets/fixtures/gcp-service-account.json
@@ -44,7 +44,13 @@
   {
     "label": "uppercase-prefixed token",
     "text": "ENV=Xdeploy-bot@sample-project.iam.gserviceaccount.com",
-    "shouldMatch": true
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 5,
+        "end": 54
+      }
+    ]
   },
   {
     "label": "local part too short",

--- a/rules/secrets/fixtures/gcp-service-account.json
+++ b/rules/secrets/fixtures/gcp-service-account.json
@@ -91,8 +91,36 @@
     ]
   },
   {
-    "label": "run longer than the 200-char ceiling",
+    "label": "hyphenated run past any fixed ceiling",
     "text": "abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-abcd-a@my-project.iam.gserviceaccount.com",
-    "shouldMatch": false
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 236
+      }
+    ]
+  },
+  {
+    "label": "63-char hyphenated local part",
+    "text": "serviceaccount-for-the-production-data-pipeline-worker-node-bot@my-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 98
+      }
+    ]
+  },
+  {
+    "label": "trailing hyphen before the @",
+    "text": "deploy-bot-@my-project.iam.gserviceaccount.com",
+    "shouldMatch": true,
+    "expectedSpans": [
+      {
+        "start": 0,
+        "end": 46
+      }
+    ]
   }
 ]

--- a/rules/secrets/gcp-service-account.json
+++ b/rules/secrets/gcp-service-account.json
@@ -6,7 +6,7 @@
   "severity": "critical",
   "matcher": {
     "type": "regex",
-    "pattern": "(?<![a-z0-9-])[a-z0-9-]{3,61}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
+    "pattern": "(?<![a-z0-9-])[a-z0-9-]{3,200}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
     "flags": "g"
   },
   "examples": [

--- a/rules/secrets/gcp-service-account.json
+++ b/rules/secrets/gcp-service-account.json
@@ -6,7 +6,7 @@
   "severity": "critical",
   "matcher": {
     "type": "regex",
-    "pattern": "\\b[a-z0-9][a-z0-9-]{2,60}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
+    "pattern": "(?<![a-z0-9-])[a-z0-9-]{3,61}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
     "flags": "g"
   },
   "examples": [

--- a/rules/secrets/gcp-service-account.json
+++ b/rules/secrets/gcp-service-account.json
@@ -6,7 +6,7 @@
   "severity": "critical",
   "matcher": {
     "type": "regex",
-    "pattern": "(?<![a-z0-9-])[a-z0-9-]{3,200}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
+    "pattern": "(?<![a-z0-9-])[a-z0-9-]{3,}@[a-z0-9][a-z0-9-]{2,60}\\.iam\\.gserviceaccount\\.com\\b",
     "flags": "g"
   },
   "examples": [


### PR DESCRIPTION
## Problem

`secrets/gcp-service-account` was the slowest bundled rule under the ReDoS probe battery — **rank 1 of 102**. The cost that matters is the **constant factor on large input**. On a single maximal hyphenated run, measured cold in fresh processes:

| payload | old | new |
|---|---|---|
| 40 KB | 2.2ms | 0.2ms |
| 1 MB | 26.9ms | 2.4ms |
| 4 MB | **100.7–129.4ms** (5 runs) | 9–14ms |

`BUDGET_MS = 100`. The old pattern **crosses the hook-path budget** on a multi-MB payload; the new one uses about a tenth of it. That is the reason to change the pattern.

## Root cause

```
\b[a-z0-9][a-z0-9-]{2,60}@[a-z0-9][a-z0-9-]{2,60}\.iam\.gserviceaccount\.com\b
```

The pattern led with `\b` before a character class containing `-`. Because `-` is a non-word character, `\b` matched before **every** alphanumeric run in hyphenated text, so the battery's 40001-char `abc-abc-…` probe opened roughly 10,000 candidate match positions. At each one the engine greedily scanned up to 61 characters, then backtracked through 59 shorter lengths that could never succeed — the class excludes `@`, so only the *maximal* run can ever be followed by one.

That is O(n·60) with heavy overlap. It is not catastrophic backtracking, which is why it slipped past authoring review.

## Fix

```
(?<![a-z0-9-])[a-z0-9-]{3,}@[a-z0-9][a-z0-9-]{2,60}\.iam\.gserviceaccount\.com\b
```

The negative lookbehind anchors the match to the head of a maximal `[a-z0-9-]` run, so every interior start is rejected in a single comparison and the scan is linear.

**There is no ceiling on the local part, deliberately.** Anchoring to the run head means the whole run must fit inside the quantifier, so *any* fixed ceiling becomes a recall boundary: past it there is no legal start position left at all, where the old `\b` form could start at an interior segment boundary and match a suffix. Earlier revisions of this PR used `{3,61}` and then `{3,200}`; both simply placed the cliff somewhere. The ceiling was never load-bearing — `[a-z0-9-]` cannot match `@`, so the greedy run terminates at the `@` on its own, and the lookbehind still kills every interior start in one comparison.

## Recall

A boundary sweep over the run length before `@`, against the pattern on `main`:

| run before `@` | old | `{3,61}` | `{3,200}` | `{3,}` (this PR) |
|---|---|---|---|---|
| 61 | `[0,96]` | `[0,96]` | `[0,96]` | `[0,96]` |
| 62 | `[5,97]` | **none** | `[0,97]` | `[0,97]` |
| 201 | `[140,236]` | **none** | **none** | `[0,236]` |
| 5000 | `[4940,5035]` | **none** | **none** | `[0,5035]` |

A 400k-input randomized differential finds **0** cases the old pattern matched and this one misses. Recall *gains*, all pinned by fixtures — the lookbehind relaxes the predecessor from "non-word character" to "not `[a-z0-9-]`":

| Input | Old | New |
|---|---|---|
| `-deploy-bot@…` (diff deletion line) | `[1,50]`, hyphen dropped | `[0,50]` |
| `ENV=Xdeploy-bot@…` (uppercase prefix) | `[12,54]` → `bot@…` | `[5,54]` → `deploy-bot@…` |
| `deploy_bot@…` (underscore prefix) | **no match at all** | `[7,45]` |
| `serviceaccount-for-the-…-bot@…` (63-char run) | `[15,98]` | `[0,98]` |

The wider spans mean redaction covers the whole address instead of a trailing fragment of it. The trade-off of an unbounded local part is that a very long hyphenated run glued to an address yields a correspondingly long span — over-redaction rather than a miss, which is the safe direction for a `critical` rule.

**Known consequence:** folding the first character into the class also admits an all-hyphen local part — `---@my-project.iam.gserviceaccount.com` now matches where it previously did not. Not a false-positive risk in practice, since `.iam.gserviceaccount.com` is decisive, and it is pinned by a fixture. Tightening it away with `[a-z0-9-]{2,}[a-z0-9]@` is **not** safe: that also drops a trailing hyphen before the `@` (`deploy-bot-@…`, which the old pattern matched at `[0,46]`), trading a harmless false positive for a real miss. A fixture pins that too.

## Verification

Timing measured as the gate measures — **cold first touch, one measurement, fresh process**. Per the note on `main` in `redos-probe.ts`, a best-of-N figure measures V8's native tier and understates the interpreted cost a short-lived hook process actually pays.

| gate worst probe | old | `{3,}` |
|---|---|---|
| cold, fresh process | 1.46ms | **0.33ms** |

- `pnpm --filter @akasecurity/detections test` — **1230/1230** pass
- `pnpm --filter @akasecurity/plugin-sdk test` — **303/303** pass
- Fixtures: 14 total, 9 span-pinned, 3 negative
- **Mutation check**, each reverting only the pattern:
  - → `{3,200}`: 1 red (run past any fixed ceiling)
  - → `{3,61}`: 3 red
  - → `[a-z0-9-]{2,}[a-z0-9]@`: 2 red (all-hyphen *and* trailing hyphen)
  - → main's `\b` pattern: 7 red

Rebased onto current `main` (`109a87e`). The diff is two files, both under `rules/secrets/`.
