### PR TITLE
test: cover the at-rest mode lines a mutation audit found uncovered

### DIFF
--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -1,4 +1,4 @@
-import { existsSync, lstatSync, readlinkSync, realpathSync, statSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readlinkSync, realpathSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import * as readline from 'node:readline/promises';
 import { parseArgs } from 'node:util';
@@ -61,6 +61,36 @@ function storeTargets(home: string): string[] {
   return [...storeContents(home).keys()];
 }
 
+// Every path whose owner-only MODE this command stands behind. The layout above
+// has to stay enumerated — some of it does not exist yet on a first run, and an
+// absent target is not a loose one — but the artifacts beside the store are not
+// a fixed list, so they are walked instead. SQLite's `-wal`/`-shm`/`-journal`
+// appear with whichever journal mode is active, and the legacy drop leaves an
+// `aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the prompt corpus
+// — on every run, including a first one. `tightenPerms`/`tightenFile` already
+// hold all of them at 0600, so each is a path a rejected chmod can strand; a
+// hardcoded list here would never name one, and could not name whatever the
+// next migration adds.
+function storeModeTargets(home: string): string[] {
+  const targets = new Set(storeTargets(home));
+  const data = dataDir(home);
+  try {
+    for (const name of readdirSync(data)) {
+      // A `.partial` is the one artifact deliberately left at the umask: it
+      // exists for the whole of the `VACUUM INTO` that writes it and is only
+      // tightened just before the rename, so a copy cut short by a kill leaves
+      // a 0644 one behind on purpose (see snapshotStore). Reporting it would
+      // blame the filesystem for a mode nothing tried to apply — the wrong
+      // diagnosis, which is the same reason a symlinked path is skipped below.
+      if (name.endsWith('.partial')) continue;
+      targets.add(join(data, name));
+    }
+  } catch {
+    // absent or unreadable data dir — the enumerated layout still applies
+  }
+  return [...targets];
+}
+
 // The store paths whose owner-only mode could not be applied. `aka init` tightens
 // all of them; any that stay group/other-readable means the filesystem rejected
 // chmod (a root-owned home, an SMB/NFS/DrvFs mount), so the store has no at-rest
@@ -69,7 +99,7 @@ function storeTargets(home: string): string[] {
 // actionable. POSIX-only — Windows never applies these modes (see SECURITY.md).
 export function looseStorePaths(home: string): string[] {
   if (process.platform === 'win32') return [];
-  return storeTargets(home).filter((p) => {
+  return storeModeTargets(home).filter((p) => {
     try {
       // A symlinked path is deliberately never chmod'd (see symlinkedStorePaths),
       // so reporting its target's mode here would blame the filesystem for a

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -17,6 +17,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
 import type * as LocalOps from '@akasecurity/local-ops';
+import { cachePath, writeCache } from '@akasecurity/local-ops';
 import { dataDir, dbPath, settingsDir } from '@akasecurity/plugin-sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -288,6 +289,36 @@ describe('looseStorePaths', () => {
     chmodSync(sidecar, 0o644);
 
     expect(looseStorePaths(dir).sort()).toEqual([backup, sidecar].sort());
+  });
+
+  it('stays silent about the update-check cache, which is a real store file held at 0600', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // Driven by the REAL writer, not a stand-in, because the property is that
+    // `writeCache`'s own mode agrees with what this walk stands behind. When it
+    // wrote at the caller's umask, walking data/ turned an ordinary `aka init`
+    // into "this filesystem rejects chmod" — nothing had rejected one, and
+    // nothing had attempted one. That misattribution is exactly what the
+    // `.partial` skip below exists to avoid, so it must not reappear here by a
+    // different route.
+    //
+    // Not reachable through runInit: the notice that writes this cache runs in
+    // main() after the handler returns, so only the writer itself can set it up.
+    mkdirSync(dataDir(dir), { recursive: true });
+    mkdirSync(settingsDir(dir), { recursive: true });
+    for (const p of [dir, settingsDir(dir), dataDir(dir)]) chmodSync(p, 0o700);
+
+    writeCache(dir, {
+      checkedAt: Date.now(),
+      report: { statuses: [], availablePlugins: [] },
+      notifiedPluginIds: [],
+    });
+
+    expect(existsSync(cachePath(dir))).toBe(true); // precondition: the walk has it to find
+    expect(statSync(cachePath(dir)).mode & 0o777).toBe(0o600);
+    expect(looseStorePaths(dir)).toEqual([]);
   });
 
   it('does not report a `.partial` (loose by design mid-copy, not a rejected chmod)', (ctx) => {

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -217,6 +217,57 @@ describe('looseStorePaths', () => {
     expect(looseStorePaths(dir)).toEqual([file]);
   });
 
+  it('reports a loose artifact beside the store that no enumerated target names', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // The layout is a fixed list; what sits beside the store is not. The legacy
+    // drop leaves an `aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of
+    // the prompt corpus — on every run, and the SQLite sidecars appear with
+    // whichever journal mode is active. tightenFile/tightenPerms hold all of
+    // them at 0600, so one left group-readable is a rejected chmod, which is
+    // exactly what this warning exists to surface. Before this walk the store's
+    // only at-rest control could fail on the largest file in the directory and
+    // the user would never be told.
+    const settings = settingsDir(dir);
+    mkdirSync(settings, { recursive: true });
+    mkdirSync(dataDir(dir), { recursive: true });
+    const file = join(settings, 'settings.json');
+    writeFileSync(file, '{}');
+    for (const p of [dir, settings, dataDir(dir), file]) chmodSync(p, p === file ? 0o600 : 0o700);
+    expect(looseStorePaths(dir)).toEqual([]); // precondition: nothing enumerated is loose
+
+    const backup = join(dataDir(dir), 'aka.db.pre-drop.1785500790653.545ee74f.bak');
+    writeFileSync(backup, 'prompt corpus');
+    chmodSync(backup, 0o644);
+    const sidecar = join(dataDir(dir), 'aka.db-wal');
+    writeFileSync(sidecar, '');
+    chmodSync(sidecar, 0o644);
+
+    expect(looseStorePaths(dir).sort()).toEqual([backup, sidecar].sort());
+  });
+
+  it('does not report a `.partial` (loose by design mid-copy, not a rejected chmod)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // snapshotStore tightens its staging copy only just before the rename, so
+    // the file exists at the caller's umask for the whole VACUUM INTO and a copy
+    // cut short by a kill leaves a 0644 `.partial` behind on purpose. Naming it
+    // here would blame the filesystem for a mode nothing tried to apply — the
+    // same wrong diagnosis the symlink case below avoids.
+    mkdirSync(dataDir(dir), { recursive: true });
+    mkdirSync(settingsDir(dir), { recursive: true });
+    for (const p of [dir, settingsDir(dir), dataDir(dir)]) chmodSync(p, 0o700);
+    const partial = join(dataDir(dir), 'aka.db.pre-drop.1.aaaaaaaa.bak.partial');
+    writeFileSync(partial, 'half a copy');
+    chmodSync(partial, 0o644);
+
+    expect(looseStorePaths(dir)).toEqual([]);
+  });
+
   it('makes `aka init` print a warning when a mode could not be applied', async () => {
     // macOS-only fault injection: chflags freezes the settings dir so init's
     // tighten of settings.json fails, and init must surface that (data/ stays

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -5,6 +5,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -51,6 +52,15 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+// Every path under `home`, the home itself included. A hardcoded list of the
+// paths init writes cannot cover what a later change adds — the migration's
+// `aka.db.pre-drop.<ts>.bak`, a byte-for-byte copy of the store, is already one
+// such file and no list here names it.
+function storeTree(home: string): string[] {
+  const entries = readdirSync(home, { withFileTypes: true, recursive: true });
+  return [home, ...entries.map((e) => join(e.parentPath, e.name))];
+}
+
 describe('plugin-install offer identity', () => {
   it('emits offer copy carrying the canonical product name and tagline', async () => {
     const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
@@ -96,6 +106,60 @@ describe('runInit contract', () => {
     expect(mode(dataDir(dir))).toBe(0o700);
     expect(mode(join(settingsDir(dir), 'settings.json'))).toBe(0o600);
     expect(mode(dbPath(dir))).toBe(0o600);
+  });
+
+  it('holds every path under ~/.aka owner-only whatever umask the caller has', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    // What this pins is narrower than it looks, so state it exactly. No umask
+    // can loosen 0700/0600 — a umask only ever CLEARS bits, and neither mode has
+    // a group or other bit left to clear — so this case does NOT stand behind
+    // the chmod; the loose-home case above is what does. What it stands behind
+    // is that the modes never come from the caller's umask happening to be
+    // tight: anything created here with no explicit mode lands 0777/0666, where
+    // a default `umask 022` host would have shown the same bug as a milder
+    // 0755/0644, and a `umask 077` host would have hidden it outright.
+    //
+    // The walk is the other half — see storeTree.
+    //
+    // The umask is process-global and restored in the `finally`; vitest runs a
+    // file's tests in sequence, so the window is this case only. It also needs
+    // the default `forks` pool — setting the umask raises
+    // ERR_WORKER_UNSUPPORTED_OPERATION on a worker thread, so a switch to
+    // `pool: 'threads'` fails this case loudly rather than skipping it.
+    const outside = mkdtempSync(join(tmpdir(), 'aka-umask-control-'));
+    const control = join(outside, 'no-mode');
+
+    try {
+      const previousUmask = process.umask(0o000);
+      try {
+        writeFileSync(control, ''); // no explicit mode — the precondition below
+        await runInit(['--home', dir]);
+      } finally {
+        process.umask(previousUmask);
+      }
+
+      // Precondition: a no-mode file lands 0666 only under a genuinely
+      // permissive umask. Without it the case passes vacuously wherever the
+      // umask is ignored.
+      expect(statSync(control).mode & 0o777).toBe(0o666);
+
+      const tree = storeTree(dir);
+      // ...and the walk has to have reached the store, or "nothing is loose"
+      // holds vacuously over an empty tree.
+      expect(tree).toContain(dbPath(dir));
+      expect(tree).toContain(join(settingsDir(dir), 'settings.json'));
+      expect(tree.filter((p) => (statSync(p).mode & 0o077) !== 0)).toEqual([]);
+
+      // The user-facing signal has to agree with the disk.
+      const out = stdout.mock.calls.map((c) => String(c[0])).join('');
+      expect(out).not.toContain('could not enforce owner-only permissions');
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
   });
 
   it('re-tightens a pre-existing loose settings.json on re-run (tighten is not gated on creating it)', async () => {

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -56,9 +56,30 @@ afterEach(() => {
 // paths init writes cannot cover what a later change adds — the migration's
 // `aka.db.pre-drop.<ts>.bak`, a byte-for-byte copy of the store, is already one
 // such file and no list here names it.
+//
+// Deliberately its own walk rather than a call into looseStorePaths: a test that
+// reuses the implementation it is checking cannot catch a bug in that walk.
 function storeTree(home: string): string[] {
   const entries = readdirSync(home, { withFileTypes: true, recursive: true });
   return [home, ...entries.map((e) => join(e.parentPath, e.name))];
+}
+
+// Is one walked path group/other-readable? `lstat`, not `stat`: stat follows a
+// link and would report its TARGET's mode as a store failure, and the mode a
+// symlinked store path keeps was never ours to set (see chmodBestEffort). A
+// sibling that vanished between the readdir and here — an atomic write's `.tmp`
+// — is not a finding; every other error must throw rather than read as clean,
+// so a permission denial can never empty the haystack an absence assertion
+// searches. The paths that must exist are asserted unguarded by the caller.
+function looseInTree(path: string): boolean {
+  try {
+    const stats = lstatSync(path);
+    if (stats.isSymbolicLink()) return false;
+    return (stats.mode & 0o077) !== 0;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
 }
 
 describe('plugin-install offer identity', () => {
@@ -152,9 +173,12 @@ describe('runInit contract', () => {
       // holds vacuously over an empty tree.
       expect(tree).toContain(dbPath(dir));
       expect(tree).toContain(join(settingsDir(dir), 'settings.json'));
-      expect(tree.filter((p) => (statSync(p).mode & 0o077) !== 0)).toEqual([]);
+      expect(tree.filter(looseInTree)).toEqual([]);
 
-      // The user-facing signal has to agree with the disk.
+      // The user-facing signal has to agree with the disk. It can: looseStorePaths
+      // walks data/ rather than naming a fixed set, so a loose backup or sidecar
+      // reaches this assertion. Before that fix it could not disagree about the
+      // one artifact the walk above exists to catch.
       const out = stdout.mock.calls.map((c) => String(c[0])).join('');
       expect(out).not.toContain('could not enforce owner-only permissions');
     } finally {

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -82,6 +82,22 @@ function looseInTree(path: string): boolean {
   }
 }
 
+const mode = (p: string): number => statSync(p).mode & 0o777;
+
+// The five paths `aka init` creates and holds to a documented mode, with that
+// mode. Kept as a pair so a case can assert the CONTRACT (0700 dirs, 0600 files)
+// rather than only owner-only-ness: `& 0o077` alone passes a 0400 file and a
+// 0700 one, neither of which is what SECURITY.md's "Data at rest" note promises.
+function documentedModes(home: string): [path: string, mode: number][] {
+  return [
+    [home, 0o700],
+    [settingsDir(home), 0o700],
+    [dataDir(home), 0o700],
+    [join(settingsDir(home), 'settings.json'), 0o600],
+    [dbPath(home), 0o600],
+  ];
+}
+
 describe('plugin-install offer identity', () => {
   it('emits offer copy carrying the canonical product name and tagline', async () => {
     const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
@@ -121,12 +137,7 @@ describe('runInit contract', () => {
     await runInit(['--home', dir]);
 
     if (process.platform === 'win32') return;
-    const mode = (p: string): number => statSync(p).mode & 0o777;
-    expect(mode(dir)).toBe(0o700);
-    expect(mode(settingsDir(dir))).toBe(0o700);
-    expect(mode(dataDir(dir))).toBe(0o700);
-    expect(mode(join(settingsDir(dir), 'settings.json'))).toBe(0o600);
-    expect(mode(dbPath(dir))).toBe(0o600);
+    for (const [path, expected] of documentedModes(dir)) expect(mode(path)).toBe(expected);
   });
 
   it('holds every path under ~/.aka owner-only whatever umask the caller has', async (ctx) => {
@@ -168,11 +179,18 @@ describe('runInit contract', () => {
       // umask is ignored.
       expect(statSync(control).mode & 0o777).toBe(0o666);
 
+      // The documented contract first, exactly — 0700 dirs and 0600 files, not
+      // merely "no group or other bit". These five also stat unguarded, so a
+      // store artifact that vanished under the walk below cannot pass as clean.
+      for (const [path, expected] of documentedModes(dir)) expect(mode(path)).toBe(expected);
+
       const tree = storeTree(dir);
       // ...and the walk has to have reached the store, or "nothing is loose"
       // holds vacuously over an empty tree.
       expect(tree).toContain(dbPath(dir));
       expect(tree).toContain(join(settingsDir(dir), 'settings.json'));
+      // Everything ELSE it found is owner-only too — the part a five-path list
+      // cannot cover, and where the pre-drop backup is caught.
       expect(tree.filter(looseInTree)).toEqual([]);
 
       // The user-facing signal has to agree with the disk. It can: looseStorePaths

--- a/packages/local-ops/src/update-cache.ts
+++ b/packages/local-ops/src/update-cache.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { dataDir } from '@akasecurity/persistence';
+import { dataDir, writeOwnerOnlyFileSync } from '@akasecurity/persistence';
 import type { UpdateCache } from '@akasecurity/schema';
 
 import { reinvokeArgv } from './self-exec.ts';
@@ -37,10 +37,20 @@ export function readCache(home: string): UpdateCache | null {
 
 // Persist the cache, but never provision ~/.aka — if the local store dir doesn't
 // exist the user hasn't run `aka init`, and a passive check must not create it.
+//
+// Written owner-only through the shared store writer, like every other file under
+// ~/.aka. A bare writeFileSync left this at the caller's umask — 0644 on a default
+// host — and it is the one file in data/ nothing ever tightens, so `aka init`
+// reported it as a store path whose chmod the filesystem had rejected. Nothing had
+// rejected one; nothing had attempted one. Routing through the shared writer keeps
+// that report meaning what it says: every file in data/ is one this product holds
+// to a mode. It also makes the write atomic (per-pid tmp + rename), which matters
+// because the detached `__update-refresh` child can be writing while the parent
+// command writes its notifiedPluginIds update.
 export function writeCache(home: string, cache: UpdateCache): void {
   if (!existsSync(dataDir(home))) return;
   try {
-    writeFileSync(cachePath(home), `${JSON.stringify(cache, null, 2)}\n`);
+    writeOwnerOnlyFileSync(cachePath(home), `${JSON.stringify(cache, null, 2)}\n`);
   } catch {
     // best-effort — a failed cache write must never break a command
   }

--- a/packages/local-ops/test/update-cache.test.ts
+++ b/packages/local-ops/test/update-cache.test.ts
@@ -1,0 +1,91 @@
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { dataDir } from '@akasecurity/persistence';
+import type { UpdateCache } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cachePath, readCache, writeCache } from '../src/update-cache.ts';
+
+// update-check.json lives in ~/.aka/data alongside the store, so it is held to the
+// same owner-only mode as everything else there. It was the one file in that
+// directory nothing tightened: a bare writeFileSync left it at the caller's umask,
+// and `aka init` then reported it as a store path whose chmod the filesystem had
+// rejected — a diagnosis with no rejected chmod behind it.
+
+let home: string;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-update-cache-'));
+  mkdirSync(dataDir(home), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+const cache = (): UpdateCache => ({
+  checkedAt: 1_700_000_000_000,
+  report: { statuses: [], availablePlugins: [] },
+  notifiedPluginIds: [],
+});
+
+describe('writeCache', () => {
+  it('lands the cache owner-only (0600), not at the caller’s umask', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    writeCache(home, cache());
+
+    expect(statSync(cachePath(home)).mode & 0o777).toBe(0o600);
+  });
+
+  it('rewrites an existing loose cache to 0600 rather than preserving its mode', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // The upgrade path: a cache an older build left at 0644 is replaced, not
+    // written through. The writer renames a fresh owner-only inode over it, so the
+    // next refresh self-heals a file this build inherited loose.
+    writeCache(home, cache());
+    chmodSync(cachePath(home), 0o644);
+    expect(statSync(cachePath(home)).mode & 0o777).toBe(0o644); // precondition
+
+    writeCache(home, { ...cache(), checkedAt: 1_700_000_001_000 });
+
+    expect(statSync(cachePath(home)).mode & 0o777).toBe(0o600);
+  });
+
+  it('round-trips through readCache and leaves no tmp behind', () => {
+    writeCache(home, cache());
+
+    expect(readCache(home)?.checkedAt).toBe(1_700_000_000_000);
+    expect(readdirSync(dataDir(home)).filter((f) => f.includes('.tmp'))).toEqual([]);
+    expect(readFileSync(cachePath(home), 'utf8').endsWith('\n')).toBe(true);
+  });
+
+  it('never provisions the store dir when the user has not run `aka init`', () => {
+    // A passive update check must not create ~/.aka behind the user's back, so an
+    // absent data dir is a silent no-op rather than a mkdir.
+    const fresh = mkdtempSync(join(tmpdir(), 'aka-uninitialized-'));
+    try {
+      writeCache(fresh, cache());
+      expect(existsSync(dataDir(fresh))).toBe(false);
+      expect(existsSync(cachePath(fresh))).toBe(false);
+    } finally {
+      rmSync(fresh, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/persistence/test/paths.test.ts
+++ b/packages/persistence/test/paths.test.ts
@@ -89,6 +89,27 @@ describe('ensureDataDirSync', () => {
     expect(mode(dir)).toBe(DATA_DIR_MODE);
   });
 
+  it('holds every level it creates at 0700, not just the leaf it tightens', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // The tighten reaches the LEAF only, so the mode passed to mkdir is the one
+    // thing holding the levels above it — and those are real store paths:
+    // openLocalDatabase(dataDir(home)) creates ~/.aka itself as a parent when
+    // the home does not exist yet, which is every first hook on a machine that
+    // has never run `aka init`. Drop the mkdir mode and data/ still self-heals
+    // through the tighten while ~/.aka is left at the caller's umask — 0755 on a
+    // default host, 0777 under a permissive one.
+    const dir = join(base, 'a', 'b', 'c');
+
+    ensureDataDirSync(dir);
+
+    for (const p of [join(base, 'a'), join(base, 'a', 'b'), dir]) {
+      expect(mode(p)).toBe(DATA_DIR_MODE);
+    }
+  });
+
   it('never chmods THROUGH a directory symlink (a victim dir keeps its mode)', (ctx) => {
     if (process.platform === 'win32') {
       ctx.skip('unprivileged symlink creation is not available on Windows');


### PR DESCRIPTION
Pins the store's at-rest modes where nothing was standing behind them, and fixes two
places where `aka init` could not tell the truth about them.

The POSIX modes are the store's only at-rest control — there is no encryption — so the
lines that decide them deserve tests that go red when they are removed. Two of them did
not have any.

## The premise this started from does not hold

Recorded here because it was measured rather than argued, so it is not re-derived later.

- **A permissive umask cannot loosen these modes.** A umask only ever *clears* bits, and
  `0700`/`0600` have none left to clear. `mkdirSync(dir, { mode })` is not umask-masked in
  any way that matters, and SQLite's `aka.db` is `0644` under both `022` and `000`. The
  umask that hides a missing tighten is a **restrictive** one (`077`), not a permissive
  one.
- **Removing the chmod is already caught.** Deleting `tightenDir(dir)` from
  `ensureDataDirSync` turns **6 existing tests** red (5 in `persistence`, 1 in `cli`). What
  catches it is that the directory *pre-exists loose* — not the umask.

## What this does instead

A mutation audit of every line that decides the store's at-rest modes — 22 mutants across
`paths.ts`, `local-layout.ts`, `database.ts`, `internal/snapshot.ts`, `fingerprint.ts`,
`warn-era-cap.ts`, `vault/key-provider.ts` and `cli/src/commands/init.ts`, each deleted in
turn against the `persistence` and `cli` suites. **8 survived.** The rest are tracked
separately.

### `test(persistence)` — pin the dir mode on every level `ensureDataDirSync` creates

`tightenDir` chmods the **leaf only**, so the mode passed to `mkdir` is the sole thing
holding the levels above it — and those are real store paths:
`openLocalDatabase(dataDir(home))` creates `~/.aka` itself as a parent when the home does
not exist yet, which is every first hook on a machine that never ran `aka init`. Verified
directly: with the mode arg dropped, `~/.aka` lands `0777` while `data/` self-heals to
`0700`.

Dropping that arg survived the entire suite before this. It now fails exactly here — one
failure across both suites, and nowhere else.

### `test(cli)` — walk the whole store under a permissive umask

Two independent properties, and the docstring is careful about which is which:

- **The walk** covers what an enumerated list cannot. A fresh `aka init` leaves an
  `aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the store — in `data/`, and
  the neighbouring five-path assertion names neither it nor whatever the next migration
  adds. It is **not** the only detector of a loose backup — `snapshot.test.ts` and
  `database.test.ts` already cover that write directly. What the walk adds is that it goes
  red on the next artifact of its kind with nobody remembering to look.
- **The `umask 000` window** kills nothing today and does not claim to. It pins that the
  store's modes never come from the caller's umask happening to be tight: anything created
  with no explicit mode lands `0777`/`0666` here, where a default `umask 022` host shows
  the same bug as a milder `0755`/`0644` and a `umask 077` host hides it outright.

A no-mode control file asserts the umask was genuinely in force, so the case cannot pass
vacuously where the umask is ignored.

### `fix(cli)` — report every loose artifact beside the store

Writing the walk surfaced a real product gap. `looseStorePaths` filtered a **fixed
six-path list**, so a rejected chmod on the largest file in `data/` was never surfaced —
the pre-drop backup (present after every run, first run included) and the SQLite
`-wal`/`-shm`/`-journal` sidecars are all held at `0600` by `tightenFile`/`tightenPerms`,
and none of them was named. The runtime tighten is silent by design, so `aka init` is the
only channel that can tell a user the store's one at-rest control failed — and it could
not name the file.

The layout stays enumerated (an absent target is not a loose one); only the artifacts
beside the store are walked. A `.partial` is excluded deliberately: `snapshotStore`
tightens it just before the rename, so a killed copy leaves a `0644` one *on purpose*, and
naming it would blame the filesystem for a mode nothing tried to apply.

### `fix(local-ops)` — write the update-check cache owner-only (from review)

Walking `data/` immediately exposed a second gap, found in review: `update-check.json` is
the one file in that directory nothing ever tightened. `writeCache` used a bare
`writeFileSync`, so it landed at the caller's umask — `0644` on a default host — and it is
not a `.partial`, so the exclusion above did not cover it. Reproduced with the real writer:
`looseStorePaths` goes `[]` → `["…/data/update-check.json"]` under `umask 022`, and
`main.ts` runs `notifyFromCache` after every command outside `SKIP_NOTICE` (`init`
included), so a user would see it on the second `aka init` and every one after.

Nothing had rejected a chmod and nothing had attempted one — the exact misattribution the
`.partial` exclusion exists to avoid. Fixed at the writer rather than by a second
exclusion, which would have left a world-readable file in the store that no surface
mentions and falsified this walk's own docstring. `writeOwnerOnlyFileSync` also makes the
write atomic, where the old fixed-path bare write could publish a torn file between the
parent command and the detached `__update-refresh` child.

`writeCache` had no test at all, which is how this survived;
`packages/local-ops/test/update-cache.test.ts` plus a `cli` case driven by the real writer
now cover it. A cache an older build left at `0644` is replaced rather than written
through, so the next refresh self-heals it.

## Verification

- Full workspace `turbo run lint typecheck test --force` — **47/47 tasks, `Cached: 0`** —
  plus `build` (15/15, `Cached: 0`). `cli` **147**, `local-ops` **83**, `persistence`
  **793 passed / 1 skipped**.
- Repo-wide `format:check` clean.
- Every new case verified to fail when the line it guards is removed, and the persistence
  one verified to be the *only* failure for its mutant. The documented-mode loop was
  verified by flipping one expected mode.
- Every mutation in the audit was reverted and the restore verified with `git diff --quiet`.
- All new cases use `ctx.skip(reason)` on Windows. Existing `return`-style guards in these
  files are left alone — converting them is separate work.

## Known limit, deliberately not addressed here

**`@akasecurity/cli` is absent from the Windows job's filter in `ci.yml`**, so the CLI
`ctx.skip` guards have never executed on Windows; the `persistence` one has. Adding the
package to a required check it has never run under does not belong in a change of this
size.
