### PR TITLE
test: assert raw-value absence run by run, not whole-value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,18 +569,86 @@ violation on `aka.db` must throw.
 
 Assert a raw value is absent from an **error** run by run, not whole. `not.toContain(value)`
 stays green if a branch echoes a _truncated_ value, which is still a live credential's
-prefix. `expectNoEchoOf` is the **required form for every error assertion in a suite that
-already defines it** — today `web-ui/test/actions/exceptions.test.ts` and
-`plugins/claude-code/test/triage/judge.test.ts` — including the ones a newly covered action
-or seam brings with it; a plain `not.toContain(rawValue)` on an error is a defect, not a
-style choice. It is not reachable across a package wall, so a third suite that needs it
-copies it rather than importing it, and copies the `expect(value).toBeDefined()` guard with
-it — without that guard an `undefined` message satisfies the loop vacuously.
-This applies to a **raw value** in an **error** only. At-rest and grant-shape assertions
-stay whole-value, because `maskMatch` deliberately keeps a fragment visible and that
-fragment is stored on purpose; and an assertion that some non-secret string is absent — an
-internal error-class name, say — is a different property that `expectNoEchoOf` does not
-express.
+prefix. `expectNoEchoOf` is the **required form for every raw-value absence assertion in a
+package that carries it** — today `web-ui/test/actions/exceptions.test.ts`, the CLI's
+`cli/test/helpers/no-echo.ts` (imported by `exception.test.ts` and `exception-reveal.test.ts`)
+and the plugin's `plugins/claude-code/test/helpers/no-echo.ts` (imported by `triage/judge.test.ts`,
+`triage/adapter.test.ts`, `triage/writeback.test.ts` and `hooks/resubmit-message.test.ts`) —
+including the ones a newly covered action or seam brings with it; a plain
+`not.toContain(rawValue)` is a defect, not a style choice. It binds by **package**, not by
+file: a suite that sits beside a helper does not get to keep the weaker form because it was
+written first.
+
+**Share it inside a package, copy it across a wall — and a copy takes the suite with it.**
+The CLI's and the plugin's suites each import a `test/helpers/no-echo.ts` with its own tests
+in `no-echo.test.ts`: each case drives the helper with an output that leaks a run, and
+asserts both that the helper refuses it **and** that the whole-value form it replaced would
+have passed. That second half is what shows the assertion is _stronger_ rather than merely
+also-red, and it is why raising the run length or emptying the loop cannot go unnoticed —
+widening `ECHO_RUN` leaves every **caller** green, so the helper's own suite is the only
+thing that goes red. A package wall blocks the import, not the pattern, so a third package
+copies **both** files — including the `expect(value).toBeDefined()` guard, without which an
+`undefined` message satisfies the loop vacuously.
+
+**Capture the error outside the `catch`.** This shape passes while the function under test
+stops throwing entirely:
+
+```ts
+try {
+  parse(input);
+  throw new Error('expected parse to throw'); // caught by its own catch, below
+} catch (err) {
+  expect((err as Error).message).not.toContain(RAW); // asserts on THAT message
+}
+```
+
+The guard error carries no secret, so the absence check is satisfied by the test's own
+throw. Use `errorFrom(() => parse(input))` (the plugin's helper) or the CLI's
+`.then(() => undefined, (e) => e as Error)`, then assert what the error **says** before
+asserting what it **omits** — a never-thrown error arrives as `undefined` and `toBeDefined()`
+catches it. Naming the expected refusal is also the positive control: without it a case
+proves only that _some_ error said nothing, not that the guarded branch was the one reached.
+
+**Never point it at bytes that can come back empty.** Every `not.toContain` passes on `''`,
+and `toBeDefined()` does not catch that: it catches a never-thrown error arriving as
+`undefined`, while a Prompter's `output()` returns `string` and is never undefined, so the
+guard is **inert on stdout**. Where a path prints nothing at all, assert that —
+`expect(io.output()).toBe('')` — which goes red on anything printed there, raw or not.
+Where it does print, pin a **positive control** on the same bytes first.
+
+This applies to a **raw value**, in an **error** and on whatever further surface a suite
+binds below. At-rest and grant-shape assertions stay whole-value, because `maskMatch`
+deliberately keeps a fragment visible and that fragment is stored on purpose; and an
+assertion that some non-secret string is absent — an internal error-class name, say — is a
+different property that `expectNoEchoOf` does not express. Drive the window with a
+**high-entropy** fixture: against an English-phrase literal an eight-character window
+collides with ordinary output text instead of catching a leak. High-entropy does **not**
+mean credential-shaped — this repo is public, and a fixture that looks like a real secret
+does not belong in it. Where a suite needs both (`cli/test/commands/exception-reveal.test.ts`
+tokenizes a value the engine never scans), a random-looking string that matches no rule
+satisfies them together; where the value must match a rule, take it from that rule's own
+`examples` so no secret-shaped literal is written by hand.
+
+The CLI's `exception` suites bind it **wider than an error** — to their **stdout**
+assertions too, because a CLI's terminal output is where a leaked value gets scrolled,
+pasted into a bug report and captured by CI logs. That is safe rather than fragile **for
+the values those suites use**: what they print of a blocked **generic** secret is
+`maskMatch`'s first-and-last preview (`A******E`), two characters, which cannot fill an
+eight-character window. **It does not generalize to every value `maskMatch` handles.** The
+email branch reveals the first local character plus the **whole domain**
+(`user@example.com` → `u***@example.com`), and a single-character local part returns the
+input unchanged — both fill the window on purpose. A surface printing a pii/email preview is
+out of scope for the stdout half, not a leak it found; `no-echo.test.ts` pins both branches
+so that boundary is written down rather than re-derived. If the **generic** branch is ever
+widened past two characters, that suite goes red first, which is the correct answer and not
+a reason to loosen the callers back.
+
+**Bind it per assertion, never per file.** `cli/test/commands/vault.test.ts` is the worked
+example: its forged-pointer refusal pins absence like any other, but `aka vault show`'s
+success path prints the raw value **on purpose** and asserts `output().startsWith(RAW)`, so
+a run-by-run rule over that case would assert the opposite of the command's contract. Exempt
+the case, not the file — a file-level exemption also disarms the refusal paths in it, which
+are the ones a leak actually travels through.
 
 Assert against the value **that call supplied**, never a module constant the case does not
 send. A case driven with an inert literal and asserted against a shared `VALUE` cannot fail

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,26 +569,41 @@ violation on `aka.db` must throw.
 
 Assert a raw value is absent from an **error** run by run, not whole. `not.toContain(value)`
 stays green if a branch echoes a _truncated_ value, which is still a live credential's
-prefix. `expectNoEchoOf` is the **required form for every raw-value absence assertion in a
-package that carries it** — today `web-ui/test/actions/exceptions.test.ts`, the CLI's
-`cli/test/helpers/no-echo.ts` (imported by `exception.test.ts` and `exception-reveal.test.ts`)
-and the plugin's `plugins/claude-code/test/helpers/no-echo.ts` (imported by `triage/judge.test.ts`,
-`triage/adapter.test.ts`, `triage/writeback.test.ts` and `hooks/resubmit-message.test.ts`) —
-including the ones a newly covered action or seam brings with it; a plain
-`not.toContain(rawValue)` is a defect, not a style choice. It binds by **package**, not by
-file: a suite that sits beside a helper does not get to keep the weaker form because it was
-written first.
+prefix. `expectNoEchoOf` is the **required form for every raw-value absence assertion that is
+newly written or newly touched** in a package carrying the helper — `cli/test/helpers/no-echo.ts`,
+`plugins/claude-code/test/helpers/no-echo.ts` and `web-ui/test/helpers/no-echo.ts`. A plain
+`not.toContain(rawValue)` in a new or edited assertion is a defect, not a style choice, and
+editing a file means its in-class assertions come along rather than being left beside converted
+ones.
+
+**Older assertions are a backlog, not a clean tree.** `plugins/claude-code` still carries around
+twenty whole-value raw-value assertions in files this convention has not reached —
+`history/`, `journey/`, `remediation/`, `render.test.ts`, `triage/plan-file.test.ts`,
+`hooks/pointer-substitution.test.ts` and `backfill.test.ts` among them. Do not read the rule
+above as a claim that the package is clean. Two shapes are genuinely **exempt** and stay
+whole-value: an assertion on a masked preview (`writeback.test.ts` on `maskedValue`,
+`triage/surfaced-secrets.test.ts` on `maskedToken`), because that fragment is revealed on
+purpose; and the deliberate **control** assertions inside each `no-echo.test.ts`, which exist
+to show the whole-value form would have passed.
 
 **Share it inside a package, copy it across a wall — and a copy takes the suite with it.**
-The CLI's and the plugin's suites each import a `test/helpers/no-echo.ts` with its own tests
-in `no-echo.test.ts`: each case drives the helper with an output that leaks a run, and
-asserts both that the helper refuses it **and** that the whole-value form it replaced would
-have passed. That second half is what shows the assertion is _stronger_ rather than merely
-also-red, and it is why raising the run length or emptying the loop cannot go unnoticed —
-widening `ECHO_RUN` leaves every **caller** green, so the helper's own suite is the only
-thing that goes red. A package wall blocks the import, not the pattern, so a third package
-copies **both** files — including the `expect(value).toBeDefined()` guard, without which an
-`undefined` message satisfies the loop vacuously.
+All three packages import a `test/helpers/no-echo.ts` with its own tests in `no-echo.test.ts`:
+each case drives the helper with an output that leaks a run, and asserts both that the helper
+refuses it **and** that the whole-value form it replaced would have passed. That second half is
+what shows the assertion is _stronger_ rather than merely also-red, and it is why raising the
+run length or emptying the loop cannot go unnoticed — widening `ECHO_RUN` leaves every
+**caller** green, so the helper's own suite is the only thing that goes red. `web-ui` is the
+worked example of that failure: its copy was inline with no suite, and all 86 of its action
+tests passed with `ECHO_RUN` set to 64. A package wall blocks the import, not the pattern, so a
+fourth package copies **both** files — including the `expect(value).toBeDefined()` guard,
+without which an `undefined` message satisfies the loop vacuously.
+
+**A masked-preview control calls the product's mask, never a hand-rolled one.** A locally built
+literal asserts that a string the test constructed lacks a run of another string the test
+constructed — true by construction, and it stays true however `maskMatch` changes. Each
+`no-echo.test.ts` calls `maskMatch` itself (`@akasecurity/plugin-sdk` re-exports it, so the
+plugin crosses no package wall), which is what makes widening its generic branch go red where
+the reason is written down.
 
 **Capture the error outside the `catch`.** This shape passes while the function under test
 stops throwing entirely:

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -20,6 +20,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { runException } from '../../src/commands/exception.ts';
 import type { Prompter } from '../../src/lib/prompter.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // `aka exception approve <pointer> --reveal` is the sanctioned door for "the
 // agent legitimately needs this raw value": it mints a reveal_to_model grant
@@ -27,11 +28,18 @@ import type { Prompter } from '../../src/lib/prompter.ts';
 // activeRevealGrant. The suite runs against the REAL node:sqlite store and
 // REAL key files (no vault mocking), mirroring vault.test.ts.
 
-// Not secret-shaped on purpose: tokenize never scans, and a plain string keeps
-// secret-looking literals out of this public file.
-const RAW = 'vaulted-value-for-reveal-grant-test';
+// Two constraints meet here. Not secret-SHAPED, because tokenize never scans
+// and a credential-looking literal has no business in a public file; but still
+// high-ENTROPY, because the absence check below slides an eight-character
+// window over this value, and against an English-phrase fixture those windows
+// are ordinary words that collide with the message's own wording instead of
+// catching a leak. Random-looking and rule-shaped for nothing satisfies both.
+const RAW = 'zq7vk2mx9tw4hb6njf3pd8sr5gc1ly';
 const RULE_ID = 'secrets/test-rule';
-const MASKED = 'vau…est';
+// Derived so the two cannot drift apart. Seven characters, which is shorter
+// than the echo window on purpose: this preview is stored and shown, so it must
+// never be able to fill it.
+const MASKED = `${RAW.slice(0, 3)}…${RAW.slice(-3)}`;
 
 // Scripted, non-interactive Prompter with captured output.
 function scriptedIo(): Prompter & { output: () => string } {
@@ -137,8 +145,12 @@ describe('aka exception approve <pointer> --reveal', () => {
     expect(out).toContain('RAW form');
     expect(out).toContain('audited');
     expect(out).toContain(`aka exception revoke ${grant.id.slice(0, 6)}`);
-    // The raw value itself never reaches the output.
-    expect(out).not.toContain(RAW);
+    // The raw value itself never reaches the output — not even a run of it.
+    // This is the confirmation for the grant that lets the model receive the
+    // value raw later, so the one surface that must not show it now is this one.
+    // The four assertions above are its positive control: the capture is live
+    // and full, so an absence within it means something.
+    expectNoEchoOf(out, RAW);
   });
 
   it('rejects a pointer without --reveal and creates nothing', async () => {

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSy
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { getLoadedRules } from '@akasecurity/detections';
+import { getLoadedRules, maskMatch } from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
 import { openLocalDatabase } from '@akasecurity/persistence';
 import type { DataGateway } from '@akasecurity/plugin-sdk';
@@ -22,6 +22,7 @@ import { runException } from '../../src/commands/exception.ts';
 import { homeBase } from '../../src/lib/args.ts';
 import type { Prompter } from '../../src/lib/prompter.ts';
 import { main } from '../../src/main.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // The test value comes from the bundled rule's own `examples` fixture, so no
 // secret-shaped literal lives in this file and the value stays in step with
@@ -34,6 +35,31 @@ if (exampleValue === undefined) throw new Error(`bundled rule ${RULE_ID} has no 
 // Re-bound after the guard so the narrowing survives into the hoisted
 // `function` helpers below (tsc drops it there for the original binding).
 const VALUE: string = exampleValue;
+
+// A second value the SAME rule detects: the ASIA form of the fixture. Distinct
+// from VALUE with identical entropy, derived rather than written out, and it
+// masks to the same `A******E` preview — which is the point wherever a test
+// needs two values one surface must keep apart.
+const SECOND_VALUE = `ASIA${VALUE.slice(4)}`;
+
+// A value the engine detects under a DIFFERENT rule, for the branch that builds
+// the "did you mean" hint out of the other matches — the one rejection in this
+// command that composes a message while holding the raw value in scope.
+const OTHER_RULE_ID = 'secrets/gitlab-token';
+const otherExample = getLoadedRules().find((r) => r.id === OTHER_RULE_ID)?.examples?.[0];
+if (otherExample === undefined) throw new Error(`bundled rule ${OTHER_RULE_ID} has no example`);
+const OTHER_VALUE: string = otherExample;
+
+// expectNoEchoOf is shared across this package's suites (see its own tests in
+// test/helpers/no-echo.test.ts), and this file applies it to BOTH surfaces the
+// command has, which is wider than the web-ui original it mirrors: an ERROR,
+// where no part of the value has any business appearing, and STDOUT, where the
+// only thing this command ever prints of a blocked SECRET is maskMatch's
+// first-and-last-character preview (`A******E`) — two characters, so it cannot
+// fill the window. That scoping is load-bearing: maskMatch's email branch
+// reveals the whole domain, so the stdout half does not extend to a surface
+// printing a pii/email preview. Where a path prints nothing at all, assert the
+// emptiness instead — searching empty bytes proves nothing.
 
 // Scripted, non-interactive Prompter: output captured, value via "stdin".
 function scriptedIo(stdin = ''): Prompter & { output: () => string } {
@@ -209,13 +235,83 @@ describe('aka exception add → enforcement full loop', () => {
     }
   });
 
+  // `add` is the ONLY verb here that holds a raw value in this process: it reads
+  // it from stdin and composes every refusal below with that value still in
+  // scope (approve works from a ledger row and never sees one). So this is where
+  // an echo would come from, and each rejection is asserted run by run against
+  // the value THAT call piped in.
   it('refuses a value that does not match the rule (no dangling grant)', async () => {
-    await expect(
-      runException(
-        ['add', '--home', home, '--rule', RULE_ID, '--stdin', '--once', '--reason', 'nope'],
-        scriptedIo('not-a-credential\n'),
-      ),
-    ).rejects.toThrow(/does not match rule/);
+    // High-entropy but rule-shaped for nothing: an English-phrase fixture would
+    // put ordinary words in the sliding window, where they can collide with the
+    // message's own wording instead of catching a leak.
+    const supplied = 'zq7vk2mx9tw4hb6n';
+    const io = scriptedIo(`${supplied}\n`);
+    const err = await runException(
+      ['add', '--home', home, '--rule', RULE_ID, '--stdin', '--once', '--reason', 'nope'],
+      io,
+    ).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+    expect(err?.message).toMatch(/does not match rule/);
+    // Nothing else matched, so the "did you mean" hint is absent — pin that, or
+    // the case cannot be told apart from the one below it.
+    expect(err?.message).not.toMatch(/did you mean/);
+    expectNoEchoOf(err?.message, supplied);
+    // The refusal prints NOTHING. Asserted as emptiness rather than as an
+    // absence within it: `not.toContain` over bytes that are always empty
+    // passes however the branch is worded.
+    expect(io.output()).toBe('');
+
+    const db = openLocalDatabase(dir);
+    try {
+      expect(await db.exceptions.list()).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('names the rule that DID match without echoing the value it was handed', async () => {
+    const io = scriptedIo(`${OTHER_VALUE}\n`);
+    const err = await runException(
+      ['add', '--home', home, '--rule', RULE_ID, '--stdin', '--once', '--reason', 'wrong rule'],
+      io,
+    ).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+    // Positive control: the hint branch really ran, so the message under test is
+    // the one built FROM the scan of the piped value — not the bare rejection.
+    expect(err?.message).toMatch(/does not match rule/);
+    expect(err?.message).toContain(OTHER_RULE_ID);
+    // Rule ids are the only thing that branch may carry out of the scan.
+    expectNoEchoOf(err?.message, OTHER_VALUE);
+    expect(io.output()).toBe('');
+
+    const db = openLocalDatabase(dir);
+    try {
+      expect(await db.exceptions.list()).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('refuses an input holding two distinct values for the rule, echoing neither', async () => {
+    const io = scriptedIo(`${VALUE} and ${SECOND_VALUE}\n`);
+    const err = await runException(
+      ['add', '--home', home, '--rule', RULE_ID, '--stdin', '--once', '--reason', 'two spans'],
+      io,
+    ).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+    // The count is what the operator needs; the spans themselves are two live
+    // credentials, and they mask identically, so the message could not name one
+    // usefully even if it were safe to.
+    expect(err?.message).toMatch(/contains 2 distinct values/);
+    expectNoEchoOf(err?.message, VALUE);
+    expectNoEchoOf(err?.message, SECOND_VALUE);
+    expect(io.output()).toBe('');
 
     const db = openLocalDatabase(dir);
     try {
@@ -310,8 +406,12 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
     } finally {
       db.close();
     }
-    // The raw value must never be echoed back.
-    expect(io.output()).not.toContain(VALUE);
+    // Positive control FIRST: this path really does print, and what it prints of
+    // the value is the masked preview. Without it the assertion below could not
+    // tell a clean confirmation from a capture that stopped receiving anything.
+    expect(io.output()).toContain('A******E');
+    // The raw value must never be echoed back — not even a run of it.
+    expectNoEchoOf(io.output(), VALUE);
   });
 
   it('trims paste artifacts (embedded newlines) from the selector', async () => {
@@ -339,7 +439,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
       (e: unknown) => e as Error,
     );
     expect(err?.message).toMatch(/no blocked detection matches/);
-    expect(err?.message).not.toContain(unmatched);
+    expectNoEchoOf(err?.message, unmatched);
   });
 
   it('refuses a value blocked under multiple rules — the rule choice is real', async () => {
@@ -488,7 +588,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
         (e: unknown) => e as Error,
       );
       expect(err?.message).toMatch(/needs the fingerprint key/);
-      expect(err?.message).not.toContain(unmatched);
+      expectNoEchoOf(err?.message, unmatched);
       expect(readFingerprintKey(dir)).toBeNull();
     });
 
@@ -644,8 +744,12 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
         expect(err?.message).toMatch(/no blocked detection matches/);
         expect(await grants()).toHaveLength(0);
         // The selector may be a live secret however the refusal is reached.
-        expect(err?.message).not.toContain(VALUE);
-        expect(io.output()).not.toContain(VALUE);
+        expectNoEchoOf(err?.message, VALUE);
+        // This path prints nothing at all before it throws, so the property is
+        // emptiness — asserted directly. Pointing expectNoEchoOf at a capture
+        // that is always empty would pass however the branch is worded, and this
+        // form goes red the moment anything at all is printed here.
+        expect(io.output()).toBe('');
       });
 
       it('grants nothing by value when the version moved but the material did not', async () => {
@@ -681,8 +785,9 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
         // site reporting a stale version.
         expect(err?.message).toMatch(/no blocked detection matches/);
         expect(await grants()).toHaveLength(0);
-        expect(err?.message).not.toContain(VALUE);
-        expect(io.output()).not.toContain(VALUE);
+        expectNoEchoOf(err?.message, VALUE);
+        // Same refusal site, same reason for asserting emptiness as above.
+        expect(io.output()).toBe('');
       });
     });
   });
@@ -698,7 +803,7 @@ describe('aka exception list / revoke', () => {
     const listIo = scriptedIo();
     await runException(['list', '--home', home], listIo);
     expect(listIo.output()).toContain(RULE_ID);
-    expect(listIo.output()).not.toContain(VALUE);
+    expectNoEchoOf(listIo.output(), VALUE);
 
     const db = openLocalDatabase(dir);
     let id: string;
@@ -743,11 +848,15 @@ describe('aka exception list / revoke', () => {
     const db = openLocalDatabase(dir);
     try {
       await db.exceptions.create({
-        ruleId: 'secrets/generic-credential',
+        ruleId: OTHER_RULE_ID,
         category: 'secret',
-        valueFingerprint: fingerprintValue(key, 'not-the-listed-value'),
+        // A different value from the suppress row's, and a high-entropy one:
+        // the absence check below slides an eight-character window over it, and
+        // an English-phrase fixture invites a collision with ordinary output
+        // text rather than catching a leak.
+        valueFingerprint: fingerprintValue(key, OTHER_VALUE),
         keyVersion: key.version,
-        maskedValue: 'gh*…ret',
+        maskedValue: maskMatch(OTHER_VALUE),
         capability: 'reveal_to_model',
         scope: 'temporary',
         expiresAt: new Date(Date.now() + 60 * 60_000).toISOString(),
@@ -764,11 +873,13 @@ describe('aka exception list / revoke', () => {
     const listIo = scriptedIo();
     await runException(['list', '--home', home], listIo);
     const out = listIo.output();
-    // Only the reveal row carries the tag; the suppress row is unchanged.
-    expect(out).toContain('gh*…ret · REVEALS-TO-MODEL');
+    // Only the reveal row carries the tag; the suppress row is unchanged. The
+    // two previews differ, so the tag is pinned to a nameable row rather than to
+    // whichever one the renderer happened to emit.
+    expect(out).toContain(`${maskMatch(OTHER_VALUE)} · REVEALS-TO-MODEL`);
     expect(out.match(/REVEALS-TO-MODEL/g)).toHaveLength(1);
     // The list is metadata-only even for reveal grants — masked, never raw.
-    expect(out).not.toContain(VALUE);
-    expect(out).not.toContain('not-the-listed-value');
+    expectNoEchoOf(out, VALUE);
+    expectNoEchoOf(out, OTHER_VALUE);
   });
 });

--- a/cli/test/commands/vault.test.ts
+++ b/cli/test/commands/vault.test.ts
@@ -137,8 +137,13 @@ describe('aka vault show', () => {
     await expect(runVault(['show', forge(pointer), '--home', home], io)).rejects.toThrow(
       /could not be resolved/,
     );
-    // The raw value never reached the output.
-    expect(io.output()).not.toContain(RAW);
+    // The refusal prints NOTHING — the success case above is the only path in
+    // this command that writes the raw value, and it is reached only after
+    // detokenize returns one. Asserted as emptiness rather than as an absence
+    // within it: `not.toContain` over a capture that is always empty passes
+    // however the branch is worded, while this goes red on anything printed
+    // here at all, raw or not.
+    expect(io.output()).toBe('');
     // A token nobody can vouch for is unattributable: no audit row at all.
     expect(derefRows()).toEqual([]);
   });

--- a/cli/test/helpers/no-echo.test.ts
+++ b/cli/test/helpers/no-echo.test.ts
@@ -1,0 +1,99 @@
+import { getLoadedRules, maskMatch } from '@akasecurity/detections';
+import { registerBundledPacks } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { ECHO_RUN, expectNoEchoOf } from './no-echo.ts';
+
+// The helper an absence assertion leans on gets its own suite, or it can be
+// weakened back with nothing going red: raise ECHO_RUN past the value's length,
+// or empty the loop, and every caller keeps passing while proving nothing. Each
+// case here fails if that happens.
+//
+// The fixture comes from the bundled rule's own `examples`, so no secret-shaped
+// literal lives in this file and the value stays in step with the rule.
+registerBundledPacks();
+const GENERIC = getLoadedRules().find((r) => r.id === 'secrets/aws-access-key')?.examples?.[0];
+if (GENERIC === undefined) throw new Error('bundled rule secrets/aws-access-key has no example');
+const VALUE: string = GENERIC;
+
+// Did the helper refuse this pairing? A vitest assertion failure is a throw, so
+// "the assertion would have gone red" is observable without failing this test.
+function refuses(haystack: string | undefined, value: string): boolean {
+  try {
+    expectNoEchoOf(haystack, value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('expectNoEchoOf', () => {
+  it('is eight characters — widening it is a deliberate act, not a drift', () => {
+    // A caller's comment cites this number as the reason a masked preview is
+    // safe to print. Move it and that reasoning has to be re-derived.
+    expect(ECHO_RUN).toBe(8);
+    expect(VALUE.length).toBeGreaterThan(ECHO_RUN);
+  });
+
+  // The three cases below are the whole point: each output leaks a live
+  // credential's run, and each one passes the weaker whole-value form. The
+  // control assertion in each is what proves the new form is STRONGER rather
+  // than merely also-red — without it a green helper and a green predecessor
+  // look identical.
+  it('refuses a prefix echo that a whole-value assertion passes', () => {
+    const echoed = `did you mean ${VALUE.slice(0, ECHO_RUN)}...?`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE); // control: the form this replaced stays green
+  });
+
+  it('refuses a tail echo that a whole-value assertion passes', () => {
+    const echoed = `...${VALUE.slice(-ECHO_RUN)} was not found`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses an interior run that a whole-value assertion passes', () => {
+    const echoed = `near ${VALUE.slice(5, 5 + ECHO_RUN)}`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses a value shorter than the run, echoed whole', () => {
+    // The sliding loop cannot run at all here, so the short-value fallback is
+    // the only thing standing between this and a silent pass.
+    const short = 'ab12cd';
+    expect(short.length).toBeLessThan(ECHO_RUN);
+    expect(refuses(`unknown value ${short}`, short)).toBe(true);
+  });
+
+  it('refuses an undefined haystack — a never-thrown error proves nothing', () => {
+    expect(refuses(undefined, VALUE)).toBe(true);
+  });
+
+  it('accepts the masked preview of a generic secret, which callers do print', () => {
+    // The coexistence the CLI's stdout assertions depend on: a generic secret's
+    // preview reveals its first and last character around fixed asterisks, so it
+    // cannot fill the window. Widen maskMatch past that and this goes red HERE,
+    // where the reason is written down, rather than in a caller that reads like
+    // an unrelated regression.
+    expect(refuses(maskMatch(VALUE), VALUE)).toBe(false);
+  });
+
+  it('refuses an email preview — why the stdout rule is scoped to generic secrets', () => {
+    // maskMatch's email branch reveals the WHOLE domain, and a single-character
+    // local part returns the input unchanged. Both fill the window legitimately,
+    // so a surface printing a pii/email preview is out of scope for this helper
+    // rather than a leak it found.
+    const email = 'user@example.com';
+    expect(maskMatch(email)).toContain('example.com');
+    expect(refuses(maskMatch(email), email)).toBe(true);
+    expect(maskMatch('a@b.com')).toBe('a@b.com');
+  });
+
+  it('passes over empty bytes — the limit that makes a positive control mandatory', () => {
+    // Not a defect to fix here: `''` genuinely contains nothing. It is why a
+    // caller must never point this at a capture that can come back empty
+    // without also pinning that the capture is live.
+    expect(refuses('', VALUE)).toBe(false);
+  });
+});

--- a/cli/test/helpers/no-echo.ts
+++ b/cli/test/helpers/no-echo.ts
@@ -1,0 +1,56 @@
+import { expect } from 'vitest';
+
+/**
+ * The shortest run of a raw value whose appearance is still a disclosure.
+ *
+ * A plain `not.toContain(value)` catches a WHOLE-value echo only — it stays
+ * green if a branch ever interpolates a truncated one, and "help the user spot
+ * their typo" is exactly the well-meaning change that would do it. Eight
+ * characters is a substantial fraction of every value the bundled rules match,
+ * and for the shorter ones it is most of the secret.
+ */
+export const ECHO_RUN = 8;
+
+/**
+ * Assert `haystack` carries no run of `value` at all, not merely not all of it.
+ *
+ * Point this at a value that must not appear AT ALL — a raw secret in an error,
+ * or on a surface that only ever prints a masked preview of it. Three limits
+ * decide where it belongs, and each one is pinned by this file's own suite:
+ *
+ * 1. **It proves nothing over bytes that came back empty.** Every `not.toContain`
+ *    passes on `''`, and the `toBeDefined()` guard below does not catch that —
+ *    it catches an `undefined` message, which is the shape a never-thrown error
+ *    arrives in. A capture that returns `string` (a Prompter's `output()`) is
+ *    never undefined, so the guard is inert there. Where a path prints nothing
+ *    at all, assert THAT — `expect(io.output()).toBe('')` — rather than
+ *    searching empty bytes; where it prints something, assert a positive control
+ *    on the same bytes first.
+ * 2. **It is for a raw value, not a deliberately revealed fragment.** A masked
+ *    preview is stored and printed on purpose, so at-rest and grant-shape
+ *    assertions stay whole-value.
+ * 3. **A masked preview only stays under the window for a GENERIC secret.**
+ *    `maskMatch` reveals a generic secret's first and last character around six
+ *    fixed asterisks — two characters, which cannot fill an eight-character
+ *    window. Its email branch reveals the first local character plus the WHOLE
+ *    DOMAIN, and a single-character local part returns the input unchanged, so
+ *    an email's own preview fills the window legitimately. Do not point this at
+ *    a surface that prints the preview of a pii/email value.
+ *
+ * Shared by the CLI suites because they sit in one package. Across a package
+ * wall it cannot be imported, so `web-ui/test/actions/exceptions.test.ts` and
+ * `plugins/claude-code/test/triage/judge.test.ts` carry their own copies — a
+ * copy takes the `toBeDefined()` guard and this file's suite with it, or the
+ * run length can be widened back with nothing going red.
+ */
+export function expectNoEchoOf(haystack: string | undefined, value: string): void {
+  // Catches a never-thrown error arriving as `undefined`, which would otherwise
+  // satisfy the loop vacuously. It does NOT catch an empty string — see limit 1.
+  expect(haystack).toBeDefined();
+  const text = haystack ?? '';
+  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
+    expect(text).not.toContain(value.slice(i, i + ECHO_RUN));
+  }
+  // Values shorter than the run length still must not appear at all.
+  if (value.length < ECHO_RUN) expect(text).not.toContain(value);
+}

--- a/cli/test/helpers/no-echo.ts
+++ b/cli/test/helpers/no-echo.ts
@@ -38,9 +38,9 @@ export const ECHO_RUN = 8;
  *    a surface that prints the preview of a pii/email value.
  *
  * Shared by the CLI suites because they sit in one package. Across a package
- * wall it cannot be imported, so `web-ui/test/actions/exceptions.test.ts` and
- * `plugins/claude-code/test/triage/judge.test.ts` carry their own copies — a
- * copy takes the `toBeDefined()` guard and this file's suite with it, or the
+ * wall it cannot be imported, so `plugins/claude-code/test/helpers/no-echo.ts`
+ * and `web-ui/test/helpers/no-echo.ts` are peers of this file — each a copy
+ * that takes the `toBeDefined()` guard and a `no-echo.test.ts` with it, or the
  * run length can be widened back with nothing going red.
  */
 export function expectNoEchoOf(haystack: string | undefined, value: string): void {

--- a/plugins/claude-code/test/helpers/no-echo.test.ts
+++ b/plugins/claude-code/test/helpers/no-echo.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { ECHO_RUN, errorFrom, expectNoEchoOf } from './no-echo.ts';
+
+// The helper an absence assertion leans on gets its own suite, or it can be
+// weakened back with nothing going red: raise ECHO_RUN past the value's length,
+// or empty the loop, and every caller keeps passing while proving nothing. Each
+// case here fails if that happens.
+//
+// Composed at runtime so the repo's own secret scan never flags this file (the
+// same reason resubmit-message.test.ts builds its fixture this way).
+const VALUE = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
+
+// Did the helper refuse this pairing? A vitest assertion failure is a throw, so
+// "the assertion would have gone red" is observable without failing this test.
+function refuses(haystack: string | undefined, value: string): boolean {
+  try {
+    expectNoEchoOf(haystack, value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('expectNoEchoOf', () => {
+  it('is eight characters — widening it is a deliberate act, not a drift', () => {
+    // The callers' comments cite this number as what makes a run-by-run check
+    // stronger than the whole-value form. Move it and that has to be re-derived.
+    expect(ECHO_RUN).toBe(8);
+    expect(VALUE.length).toBeGreaterThan(ECHO_RUN);
+  });
+
+  // The three cases below are the whole point: each output leaks a live
+  // credential's run, and each one passes the weaker whole-value form. The
+  // control assertion in each is what proves the new form is STRONGER rather
+  // than merely also-red — without it a green helper and a green predecessor
+  // look identical.
+  it('refuses a prefix echo that a whole-value assertion passes', () => {
+    const echoed = `judge failed near ${VALUE.slice(0, ECHO_RUN)}...`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE); // control: the form this replaced stays green
+  });
+
+  it('refuses a tail echo that a whole-value assertion passes', () => {
+    const echoed = `...${VALUE.slice(-ECHO_RUN)} was unparseable`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses an interior run that a whole-value assertion passes', () => {
+    const echoed = `near ${VALUE.slice(5, 5 + ECHO_RUN)}`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses a value shorter than the run, echoed whole', () => {
+    // The sliding loop cannot run at all here, so the short-value fallback is
+    // the only thing standing between this and a silent pass.
+    const short = 'ab12cd';
+    expect(short.length).toBeLessThan(ECHO_RUN);
+    expect(refuses(`unknown value ${short}`, short)).toBe(true);
+  });
+
+  it('refuses an undefined haystack — a never-thrown error proves nothing', () => {
+    expect(refuses(undefined, VALUE)).toBe(true);
+  });
+
+  it('accepts a masked preview, which is built and shown on purpose', () => {
+    // The plugin's own mask keeps the first and last character around fixed
+    // asterisks, so it cannot fill the window. Widen that and this goes red
+    // HERE, where the reason is written down, rather than in a caller that
+    // reads like an unrelated regression.
+    const masked = `${VALUE[0] ?? ''}${'*'.repeat(VALUE.length - 2)}${VALUE.at(-1) ?? ''}`;
+    expect(refuses(masked, VALUE)).toBe(false);
+  });
+
+  it('passes over empty bytes — the limit that makes a positive control mandatory', () => {
+    // Not a defect to fix here: `''` genuinely contains nothing. It is why a
+    // caller must never point this at a capture that can come back empty
+    // without also pinning that the capture is live.
+    expect(refuses('', VALUE)).toBe(false);
+  });
+});
+
+describe('errorFrom', () => {
+  it('returns the thrown error', () => {
+    const err = errorFrom(() => {
+      throw new Error('boom');
+    });
+    expect(err?.message).toBe('boom');
+  });
+
+  it('returns undefined when nothing throws, which expectNoEchoOf then refuses', () => {
+    // This is the whole reason the helper exists. The shape it replaces —
+    // `try { f(); throw new Error('expected f to throw') } catch (e) { … }` —
+    // catches the test's OWN error, so a caller asserting only absence stays
+    // green while `f` stopped throwing entirely. Here `undefined` reaches
+    // expectNoEchoOf's toBeDefined() guard and goes red.
+    const err = errorFrom(() => 'returned normally');
+    expect(err).toBeUndefined();
+    expect(refuses(err?.message, VALUE)).toBe(true);
+  });
+});

--- a/plugins/claude-code/test/helpers/no-echo.test.ts
+++ b/plugins/claude-code/test/helpers/no-echo.test.ts
@@ -1,3 +1,4 @@
+import { maskMatch } from '@akasecurity/plugin-sdk';
 import { describe, expect, it } from 'vitest';
 
 import { ECHO_RUN, errorFrom, expectNoEchoOf } from './no-echo.ts';
@@ -65,13 +66,17 @@ describe('expectNoEchoOf', () => {
     expect(refuses(undefined, VALUE)).toBe(true);
   });
 
-  it('accepts a masked preview, which is built and shown on purpose', () => {
-    // The plugin's own mask keeps the first and last character around fixed
-    // asterisks, so it cannot fill the window. Widen that and this goes red
-    // HERE, where the reason is written down, rather than in a caller that
+  it('accepts the masked preview of a generic secret, which callers do print', () => {
+    // Call the PRODUCT's mask, never a hand-rolled one. A locally built literal
+    // asserts that a string this file constructed lacks a run of another string
+    // this file constructed — true by construction, and it stays true however
+    // maskMatch changes. Wired here, widening maskMatch's generic branch goes
+    // red HERE, where the reason is written down, rather than in a caller that
     // reads like an unrelated regression.
-    const masked = `${VALUE[0] ?? ''}${'*'.repeat(VALUE.length - 2)}${VALUE.at(-1) ?? ''}`;
-    expect(refuses(masked, VALUE)).toBe(false);
+    //
+    // @akasecurity/plugin-sdk re-exports it, so this crosses no package wall —
+    // src/remediation/surfaced-redact.ts imports it the same way.
+    expect(refuses(maskMatch(VALUE), VALUE)).toBe(false);
   });
 
   it('passes over empty bytes — the limit that makes a positive control mandatory', () => {

--- a/plugins/claude-code/test/helpers/no-echo.ts
+++ b/plugins/claude-code/test/helpers/no-echo.ts
@@ -31,16 +31,18 @@ export const ECHO_RUN = 8;
  *    says before asserting what it omits.
  * 3. **It is for a raw value, not a deliberately revealed fragment.** A masked
  *    preview is built and shown on purpose, so at-rest and grant-shape
- *    assertions stay whole-value. No surface in this package prints a masked
- *    preview into bytes this helper searches; `cli/test/helpers/no-echo.ts`
- *    carries that boundary, including why an email preview fills the window
- *    legitimately while a generic secret's does not.
+ *    assertions stay whole-value — `triage/writeback.test.ts` on `maskedValue`
+ *    and `triage/surfaced-secrets.test.ts` on `maskedToken` are the two here.
+ *    A generic secret's preview reveals two characters and cannot fill the
+ *    window, which is what lets a surface printing one be searched at all;
+ *    `cli/test/helpers/no-echo.ts` carries the rest of that boundary, including
+ *    why an email preview fills the window legitimately.
  *
  * Shared by this package's suites because they sit behind one package wall.
  * Across a wall it cannot be imported, so `cli/test/helpers/no-echo.ts` and
- * `web-ui/test/actions/exceptions.test.ts` carry their own — a copy takes the
- * `toBeDefined()` guard and this file's suite with it, or the run length can be
- * widened back with nothing going red.
+ * `web-ui/test/helpers/no-echo.ts` are peers of this file — each a copy that
+ * takes the `toBeDefined()` guard and a `no-echo.test.ts` with it, or the run
+ * length can be widened back with nothing going red.
  */
 export function expectNoEchoOf(haystack: string | undefined, value: string): void {
   // Catches a never-thrown error arriving as `undefined`, which would otherwise

--- a/plugins/claude-code/test/helpers/no-echo.ts
+++ b/plugins/claude-code/test/helpers/no-echo.ts
@@ -1,0 +1,72 @@
+import { expect } from 'vitest';
+
+/**
+ * The shortest run of a raw value whose appearance is still a disclosure.
+ *
+ * A plain `not.toContain(value)` catches a WHOLE-value echo only — it stays
+ * green if a branch ever interpolates a truncated one, and "say which value
+ * failed" is exactly the well-meaning change that would do it. Eight characters
+ * is a substantial fraction of every value the bundled rules match, and for the
+ * shorter ones it is most of the secret.
+ */
+export const ECHO_RUN = 8;
+
+/**
+ * Assert `haystack` carries no run of `value` at all, not merely not all of it.
+ *
+ * Point this at a value that must not appear AT ALL — a raw hit in an error
+ * that reaches the parent command's stderr, or in a message built for the user.
+ * Three limits decide where it belongs, and each one is pinned by this file's
+ * own suite:
+ *
+ * 1. **It proves nothing over bytes that came back empty.** Every `not.toContain`
+ *    passes on `''`, and the `toBeDefined()` guard below does not catch that —
+ *    it catches an `undefined` message, which is the shape a never-thrown error
+ *    arrives in. A builder returning `string` is never undefined, so the guard
+ *    is inert there. Pin a positive control on the same bytes first.
+ * 2. **A thrown-from-the-try guard defeats it.** `try { f(); throw new Error('expected
+ *    f to throw') } catch (e) { … }` catches the test's OWN error and asserts
+ *    against a message that never held a secret, so it passes while `f` stopped
+ *    throwing entirely. Capture the error outside the catch and assert what it
+ *    says before asserting what it omits.
+ * 3. **It is for a raw value, not a deliberately revealed fragment.** A masked
+ *    preview is built and shown on purpose, so at-rest and grant-shape
+ *    assertions stay whole-value. No surface in this package prints a masked
+ *    preview into bytes this helper searches; `cli/test/helpers/no-echo.ts`
+ *    carries that boundary, including why an email preview fills the window
+ *    legitimately while a generic secret's does not.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `cli/test/helpers/no-echo.ts` and
+ * `web-ui/test/actions/exceptions.test.ts` carry their own — a copy takes the
+ * `toBeDefined()` guard and this file's suite with it, or the run length can be
+ * widened back with nothing going red.
+ */
+export function expectNoEchoOf(haystack: string | undefined, value: string): void {
+  // Catches a never-thrown error arriving as `undefined`, which would otherwise
+  // satisfy the loop vacuously. It does NOT catch an empty string — see limit 1.
+  expect(haystack).toBeDefined();
+  const text = haystack ?? '';
+  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
+    expect(text).not.toContain(value.slice(i, i + ECHO_RUN));
+  }
+  // Values shorter than the run length still must not appear at all.
+  if (value.length < ECHO_RUN) expect(text).not.toContain(value);
+}
+
+/**
+ * Run `fn` and return the error it threw, or `undefined` if it returned.
+ *
+ * The shape limit 2 above exists for: the caller asserts on the returned value,
+ * so a function that stopped throwing yields `undefined` and every assertion
+ * below it goes red — where a `throw` inside the `try` would have been caught
+ * by the same `catch` and quietly asserted against instead.
+ */
+export function errorFrom(fn: () => unknown): Error | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+}

--- a/plugins/claude-code/test/hooks/resubmit-message.test.ts
+++ b/plugins/claude-code/test/hooks/resubmit-message.test.ts
@@ -4,6 +4,7 @@ import type { BlockedDetectionRef } from '@akasecurity/plugin-sdk';
 import { describe, expect, it } from 'vitest';
 
 import { resubmitMessage } from '../../src/hooks/resubmit-message.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // Composed at runtime so the repo's own secret scan never flags this file.
 const RAW_KEY = ['AKIA', 'IOSFODNN7EXAMPLE'].join('');
@@ -49,7 +50,14 @@ describe('resubmitMessage', () => {
       clipboardWrote: true,
       blockedRef: REF,
     });
-    expect(message).not.toContain(RAW_KEY);
+    // Positive control on the SAME bytes: the rewrite is embedded verbatim, so
+    // a message that stopped carrying it would go red here rather than passing
+    // the absence check below on bytes that lost their content. A builder
+    // returns `string`, so expectNoEchoOf's toBeDefined() guard is inert on it.
+    expect(message).toContain(POINTERIZED);
+    // Run by run — this message is handed straight to the user, and a rewrite
+    // that pointerized only part of the value would leave a live prefix in it.
+    expectNoEchoOf(message, RAW_KEY);
   });
 
   it('mentions the clipboard only when the write succeeded', () => {

--- a/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
+++ b/plugins/claude-code/test/hooks/user-prompt-submit.test.ts
@@ -11,6 +11,7 @@ import { VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { ONBOARDING_NUDGE } from '../../src/hooks/onboarding-nudge.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 const CANONICAL_NUDGE =
   'AKA Security is installed but not calibrated — run /aka:setup to tune notifications to this machine (about a minute).';
@@ -194,7 +195,7 @@ describe('user-prompt-submit enforcement — redact blocks in every consent stat
       // Consent-off surfaces never touch the vault: no pointer, no vault talk.
       expect(run.stdout).not.toContain('[[aka:');
       // The never-leak assertion: the raw value appears nowhere on stdout.
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -213,7 +214,7 @@ describe('user-prompt-submit enforcement — redact blocks in every consent stat
       expect(payload.reason).toContain('[[aka:');
       expect(payload.reason).toContain('paste and resubmit');
       // The raw value appears nowhere in the pointerized output.
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -230,7 +231,7 @@ describe('user-prompt-submit enforcement — redact blocks in every consent stat
       expect(payload.reason).toMatch(/^AKA blocked this prompt — flagged /);
       expect(payload.reason).toContain('Remove the flagged content and resubmit');
       expect(run.stdout).not.toContain('[[aka:');
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }
@@ -246,7 +247,7 @@ describe('user-prompt-submit enforcement — redact blocks in every consent stat
       const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
       expect(payload.decision).toBe('block');
       expect(payload.reason).toContain('[[aka:');
-      expect(run.stdout).not.toContain(SECRET_EXAMPLE);
+      expectNoEchoOf(run.stdout, SECRET_EXAMPLE);
     } finally {
       rmSync(home, { recursive: true, force: true });
     }

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -985,9 +985,13 @@ describe('runApply — preview emits the calibration frame JSON alongside the hu
       stderr: vi.fn(),
     });
     const blob = out.join('');
-    // The frame block itself never echoes the raw hit value.
     expect(blob).toContain('<<<AKA_FRAME_JSON');
-    expect(JSON.stringify(readFrameJsonBlock(blob))).not.toContain(RAW);
+    // The frame block itself never echoes the raw hit value — not even a run.
+    const frameJson = JSON.stringify(readFrameJsonBlock(blob));
+    // Positive control on the SAME bytes the absence check reads: a block that
+    // failed to parse serializes to 'null', which passes every absence check.
+    expect(frameJson).toContain('"counts"');
+    expectNoEchoOf(frameJson, RAW);
   });
 });
 
@@ -1088,7 +1092,11 @@ describe('runApply — preview derives surfaced secret findings into the frame',
     const { frame } = await previewFrame(
       hit({ id: '0', filePath: '~/.claude/transcripts/2026-07-01.jsonl' }),
     );
-    expect(JSON.stringify(frame.maskedFindings)).not.toContain(RAW);
+    const serialized = JSON.stringify(frame.maskedFindings);
+    // Positive control on the same bytes: an empty findings array serializes to
+    // '[]', which passes every absence check without proving anything.
+    expect(serialized).toContain(safeMaskedMatch(RAW));
+    expectNoEchoOf(serialized, RAW);
   });
 
   it('surfaces only the genuine hit on a mixed stream — the FP stays dismissed and counts stay coherent', async () => {
@@ -1148,9 +1156,12 @@ describe('runApply — preview derives surfaced secret findings into the frame',
     ]);
     // The remediation count and the frame's important (genuine) count agree.
     expect(frame.maskedFindings).toHaveLength(frame.counts.important);
-    // No raw value from either hit rides into the emitted summaries.
-    expect(JSON.stringify(frame.maskedFindings)).not.toContain(RAW);
-    expect(JSON.stringify(frame.maskedFindings)).not.toContain(OTHER);
+    // No raw value from either hit rides into the emitted summaries — not even
+    // a run. The toEqual above is the positive control: the findings really are
+    // populated, so an absence within them means something.
+    const serialized = JSON.stringify(frame.maskedFindings);
+    expectNoEchoOf(serialized, RAW);
+    expectNoEchoOf(serialized, OTHER);
   });
 });
 
@@ -1185,7 +1196,9 @@ describe('runApply — preview derives the masked false-positive pattern signal 
         ],
       },
     ]);
-    expect(JSON.stringify(frame.falsePositivePatterns)).not.toContain(RAW);
+    // The toMatchObject above is the positive control: the pattern group is
+    // populated, so an absence within its serialization means something.
+    expectNoEchoOf(JSON.stringify(frame.falsePositivePatterns), RAW);
   });
 
   it('omits falsePositivePatterns when nothing was marked a false positive', async () => {

--- a/plugins/claude-code/test/triage/adapter.test.ts
+++ b/plugins/claude-code/test/triage/adapter.test.ts
@@ -18,6 +18,7 @@ import { readFrameJsonBlock } from '../../src/setup-frame-json.ts';
 import { parseSurface } from '../../src/setup-show.ts';
 import { runApply } from '../../src/triage/adapter.ts';
 import { readPlanFile, writePlanFile } from '../../src/triage/plan-file.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 const RAW = 'AKIAIOSFODNN7EXAMPLE';
 const FP = 'ab'.repeat(32);
@@ -357,8 +358,12 @@ describe('runApply — preview is a raw-free egress boundary by construction', (
       throw new Error(`judge blew up near ${RAW} — export KEY=${RAW}`);
     });
     expect(thrown).toBeInstanceOf(Error);
-    expect((thrown as Error).message).not.toContain(RAW);
+    // Positive control first: the boundary really did replace the message, so
+    // the absence below is a property of the replacement rather than of an
+    // error that never carried anything. Then run by run — a boundary that
+    // withheld only PART of the value would still hand over a live prefix.
     expect((thrown as Error).message).toMatch(/withheld/i);
+    expectNoEchoOf((thrown as Error).message, RAW);
   });
 
   it('passes a raw-free error message through unchanged (keeps useful diagnostics)', async () => {

--- a/plugins/claude-code/test/triage/gate-display.test.ts
+++ b/plugins/claude-code/test/triage/gate-display.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../src/triage/gate-display.ts';
 import type { JoinEntry } from '../../src/triage/join-file.ts';
 import type { ShowcaseCategory } from '../../src/triage/writeback.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 const FP_A = 'ab'.repeat(32);
 const FP_B = 'cd'.repeat(32);
@@ -84,8 +85,12 @@ describe('renderSuppressionGate', () => {
     // The real raw value never enters this function; assert it never appears in output.
     const RAW = 'AKIAIOSFODNN7EXAMPLE';
     const out = renderSuppressionGate([entry()], [join()]);
-    expect(out).not.toContain(RAW);
-    expect(out).not.toContain('AKIAIOSFODNN7');
+    // Positive control: the gate really rendered, so an absence within it means
+    // something rather than describing an empty string.
+    expect(out.length).toBeGreaterThan(0);
+    // Run by run. This replaces a hardcoded 13-character prefix check, which
+    // covered one fixed offset and neither the tail nor the interior.
+    expectNoEchoOf(out, RAW);
   });
 
   it('returns a stable message for an empty suppression list', () => {

--- a/plugins/claude-code/test/triage/judge.test.ts
+++ b/plugins/claude-code/test/triage/judge.test.ts
@@ -23,6 +23,7 @@ import {
   spawnClaude,
   toJudgePayload,
 } from '../../src/triage/judge.ts';
+import { errorFrom, expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // No test in this file may reach a live model. EVERY child-process entry point
 // node exposes is routed to one throwing spy, not just the execFileSync
@@ -72,20 +73,6 @@ afterEach(() => {
   while (OWNED.length > 0) rmSync(OWNED.pop() ?? '', { recursive: true, force: true });
 });
 
-// A raw value is absent from an error only if no RUN of it survives: a branch
-// that echoed a truncated value would still hand a live credential's prefix to
-// the parent command's stderr, and a whole-value `not.toContain` stays green on
-// exactly that. Mirrors expectNoEchoOf in web-ui/test/actions/exceptions.test.ts.
-const ECHO_RUN = 8;
-function expectNoEchoOf(message: string | undefined, value: string): void {
-  expect(message).toBeDefined();
-  const haystack = message ?? '';
-  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
-    expect(haystack).not.toContain(value.slice(i, i + ECHO_RUN));
-  }
-  if (value.length < ECHO_RUN) expect(haystack).not.toContain(value);
-}
-
 // Every value the env holds under `name`, whatever its casing. Windows' env
 // block is case-INSENSITIVE but case-PRESERVING: `process.env.PATH` reads it,
 // yet spreading process.env into a plain object (which judgeEnv does) can yield
@@ -131,19 +118,30 @@ describe('parseVerdict', () => {
   it('never echoes the subprocess output in a failure (raw stays inside the judge)', () => {
     const raw = 'AKIAIOSFODNN7EXAMPLE';
     // A malformed envelope, a non-JSON envelope, and an unparseable result — all
-    // carrying the raw value. None of the thrown messages may contain it.
-    const cases = [
-      JSON.stringify({ is_error: true, result: `failed near ${raw}` }),
-      `not json at all ${raw}`,
-      JSON.stringify({ is_error: false, result: `no fence here, just ${raw}` }),
+    // carrying the raw value. None of the thrown messages may contain it, and
+    // none may contain a RUN of it either: this message reaches the parent
+    // command's stderr, outside the isolated judge, so a truncated echo hands
+    // over a live credential's prefix. Each case names the refusal it expects,
+    // which is the positive control — without it a case proves only that some
+    // error said nothing, not that the guarded branch was the one reached.
+    const cases: { stdout: string; refusal: RegExp }[] = [
+      {
+        stdout: JSON.stringify({ is_error: true, result: `failed near ${raw}` }),
+        refusal: /no usable result/,
+      },
+      { stdout: `not json at all ${raw}`, refusal: /non-JSON envelope/ },
+      {
+        stdout: JSON.stringify({ is_error: false, result: `no fence here, just ${raw}` }),
+        refusal: /unparseable TriageRecommendation/,
+      },
     ];
-    for (const stdout of cases) {
-      try {
-        parseVerdict(stdout);
-        throw new Error('expected parseVerdict to throw');
-      } catch (err) {
-        expect((err as Error).message).not.toContain(raw);
-      }
+    for (const { stdout, refusal } of cases) {
+      // Captured OUTSIDE the catch: a `throw` inside the `try` would be caught
+      // by that same `catch` and asserted against, so the case stayed green
+      // while parseVerdict stopped throwing at all.
+      const err = errorFrom(() => parseVerdict(stdout));
+      expect(err?.message).toMatch(refusal);
+      expectNoEchoOf(err?.message, raw);
     }
   });
 });

--- a/plugins/claude-code/test/triage/writeback.test.ts
+++ b/plugins/claude-code/test/triage/writeback.test.ts
@@ -11,6 +11,7 @@ import {
   SCRUBBED_NOTES,
   TRIAGE_STATUSES as CONSUMER_STATUSES,
 } from '../../src/triage/writeback.ts';
+import { errorFrom, expectNoEchoOf } from '../helpers/no-echo.ts';
 
 const RAW = 'AKIAIOSFODNN7EXAMPLE';
 const FP = 'ab'.repeat(32);
@@ -124,25 +125,25 @@ describe('parseTriageStream', () => {
     // A crash mid-write leaves a partial last line carrying raw context. JSON.parse
     // would echo it in a SyntaxError — assert the thrown message stays raw-free.
     const stream = `{"rawMatch":"${RAW}","context":"export KEY=${RAW}`; // truncated, no newline/sentinel
-    try {
-      parseTriageStream(stream);
-      throw new Error('expected parseTriageStream to throw');
-    } catch (err) {
-      expect((err as Error).message).not.toContain(RAW);
-    }
+    // Captured OUTSIDE a catch: a `throw` inside a `try` would be caught by
+    // that same `catch` and asserted against, so the case stayed green while
+    // parseTriageStream stopped throwing at all.
+    const err = errorFrom(() => parseTriageStream(stream));
+    // Positive control: the truncation refusal is the branch under test, not
+    // some earlier validation error that never held the raw.
+    expect(err?.message).toMatch(/truncat|sentinel/i);
+    expectNoEchoOf(err?.message, RAW);
   });
 
   it('never leaks the raw value when a hit line fails JSON/TriageHit validation', () => {
     const badHit = `{"ruleId":"x","rawMatch":"${RAW}","context":"${RAW}","severity":"NOT_A_SEVERITY"}`;
     const stream =
       badHit + '\n' + JSON.stringify({ done: true, count: 1, status: 'complete' }) + '\n';
-    try {
-      parseTriageStream(stream);
-      throw new Error('expected parseTriageStream to throw');
-    } catch (err) {
-      expect((err as Error).message).not.toContain(RAW);
-      expect((err as Error).message).toMatch(/hit line 0/);
-    }
+    const err = errorFrom(() => parseTriageStream(stream));
+    // Which line failed is the positive control — it names the validation
+    // branch, so the absence below describes that branch's own message.
+    expect(err?.message).toMatch(/hit line 0/);
+    expectNoEchoOf(err?.message, RAW);
   });
 });
 

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -40,6 +40,7 @@ import {
   revokeException,
   rotateKey,
 } from '../../app/(app)/exceptions/actions.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 import { storeBytes } from '../helpers/store-bytes.ts';
 
 // Every mutating Server Action on the exceptions surface, each covered against a
@@ -143,28 +144,13 @@ async function grants(): Promise<DetectionException[]> {
   }
 }
 
-// The shortest run of a raw value whose appearance in an error is still a leak.
-// `not.toContain(value)` alone only catches an error that echoes the value
-// WHOLE — it stays green if a branch ever interpolates a truncated one, and
-// "help the user spot their typo" is exactly the well-meaning change that would
-// do it. Eight characters of a 40-character token is a real disclosure, and for
-// the shorter values other bundled rules match it is most of the secret.
-// This applies to ERRORS only, where no part of the value has any business
-// appearing. The at-rest and grant-shape assertions stay whole-value
-// (`not.toContain`) because `maskMatch` deliberately keeps a fragment visible —
-// that fragment IS the masked preview, and it is stored on purpose.
-const ECHO_RUN = 8;
-
-// Assert an error carries no run of `value` at all, not merely not all of it.
-function expectNoEchoOf(error: string | undefined, value: string): void {
-  expect(error).toBeDefined();
-  const haystack = error ?? '';
-  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
-    expect(haystack).not.toContain(value.slice(i, i + ECHO_RUN));
-  }
-  // Values shorter than the run length still must not appear at all.
-  if (value.length < ECHO_RUN) expect(haystack).not.toContain(value);
-}
+// expectNoEchoOf now lives in test/helpers/no-echo.ts with its own suite. It was
+// inline here, which meant its run length could be widened back with nothing
+// going red — every test in this file passed with ECHO_RUN set to 64. It applies
+// to ERRORS here, where no part of the value has any business appearing; the
+// at-rest and grant-shape assertions stay whole-value (`not.toContain`) because
+// `maskMatch` deliberately keeps a fragment visible, and that fragment IS the
+// masked preview, stored on purpose.
 
 function keyFile(): string {
   return join(dir, 'exception.key');

--- a/web-ui/test/helpers/no-echo.test.ts
+++ b/web-ui/test/helpers/no-echo.test.ts
@@ -1,0 +1,100 @@
+import { maskMatch } from '@akasecurity/detections';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { ECHO_RUN, expectNoEchoOf } from './no-echo.ts';
+
+// The helper an absence assertion leans on gets its own suite, or it can be
+// weakened back with nothing going red: raise ECHO_RUN past the value's length,
+// or empty the loop, and every caller keeps passing while proving nothing. This
+// package's action suite is 86 tests and every one of them stayed green with
+// ECHO_RUN set to 64 before this file existed.
+//
+// The fixture comes from the bundled rule's own `examples`, so no secret-shaped
+// literal lives in this file and the value stays in step with the rule.
+const RULE_ID = 'secrets/aws-access-key';
+const example = bundledDetections()
+  .flatMap((p) => p.rules)
+  .find((r) => r.id === RULE_ID)?.examples?.[0];
+if (example === undefined) throw new Error(`bundled rule ${RULE_ID} has no example`);
+const VALUE: string = example;
+
+// Did the helper refuse this pairing? A vitest assertion failure is a throw, so
+// "the assertion would have gone red" is observable without failing this test.
+function refuses(haystack: string | undefined, value: string): boolean {
+  try {
+    expectNoEchoOf(haystack, value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('expectNoEchoOf', () => {
+  it('is eight characters — widening it is a deliberate act, not a drift', () => {
+    expect(ECHO_RUN).toBe(8);
+    expect(VALUE.length).toBeGreaterThan(ECHO_RUN);
+  });
+
+  // The three cases below are the whole point: each output leaks a live
+  // credential's run, and each one passes the weaker whole-value form. The
+  // control assertion in each is what proves the new form is STRONGER rather
+  // than merely also-red — without it a green helper and a green predecessor
+  // look identical.
+  it('refuses a prefix echo that a whole-value assertion passes', () => {
+    const echoed = `did you mean ${VALUE.slice(0, ECHO_RUN)}...?`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE); // control: the form this replaced stays green
+  });
+
+  it('refuses a tail echo that a whole-value assertion passes', () => {
+    const echoed = `...${VALUE.slice(-ECHO_RUN)} was not found`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses an interior run that a whole-value assertion passes', () => {
+    const echoed = `near ${VALUE.slice(5, 5 + ECHO_RUN)}`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses a value shorter than the run, echoed whole', () => {
+    // The sliding loop cannot run at all here, so the short-value fallback is
+    // the only thing standing between this and a silent pass.
+    const short = 'ab12cd';
+    expect(short.length).toBeLessThan(ECHO_RUN);
+    expect(refuses(`unknown value ${short}`, short)).toBe(true);
+  });
+
+  it('refuses an undefined haystack — an action that never errored proves nothing', () => {
+    expect(refuses(undefined, VALUE)).toBe(true);
+  });
+
+  it('accepts the masked preview of a generic secret, which is stored on purpose', () => {
+    // Call the PRODUCT's mask, never a hand-rolled one: a locally built literal
+    // asserts that a string this file constructed lacks a run of another string
+    // this file constructed, which is true by construction however maskMatch
+    // changes. Widen its generic branch past two revealed characters and this
+    // goes red HERE, where the reason is written down.
+    expect(refuses(maskMatch(VALUE), VALUE)).toBe(false);
+  });
+
+  it('refuses an email preview — why this is scoped to generic secrets', () => {
+    // maskMatch's email branch reveals the WHOLE domain, and a single-character
+    // local part returns the input unchanged. Both fill the window on purpose,
+    // so a surface printing a pii/email preview is out of scope for this helper
+    // rather than a leak it found.
+    const email = 'user@example.com';
+    expect(maskMatch(email)).toContain('example.com');
+    expect(refuses(maskMatch(email), email)).toBe(true);
+    expect(maskMatch('a@b.com')).toBe('a@b.com');
+  });
+
+  it('passes over empty bytes — the limit that makes a positive control mandatory', () => {
+    // Not a defect to fix here: `''` genuinely contains nothing. It is why a
+    // caller must never point this at a capture that can come back empty
+    // without also pinning that the capture is live.
+    expect(refuses('', VALUE)).toBe(false);
+  });
+});

--- a/web-ui/test/helpers/no-echo.ts
+++ b/web-ui/test/helpers/no-echo.ts
@@ -1,0 +1,53 @@
+import { expect } from 'vitest';
+
+/**
+ * The shortest run of a raw value whose appearance is still a disclosure.
+ *
+ * A plain `not.toContain(value)` catches a WHOLE-value echo only — it stays
+ * green if a branch ever interpolates a truncated one, and "help the user spot
+ * their typo" is exactly the well-meaning change that would do it. Eight
+ * characters of a 40-character token is a real disclosure, and for the shorter
+ * values other bundled rules match it is most of the secret.
+ */
+export const ECHO_RUN = 8;
+
+/**
+ * Assert `haystack` carries no run of `value` at all, not merely not all of it.
+ *
+ * Point this at a value that must not appear AT ALL — a raw secret in a Server
+ * Action's error. Three limits decide where it belongs, and each one is pinned
+ * by this file's own suite:
+ *
+ * 1. **It proves nothing over bytes that came back empty.** Every `not.toContain`
+ *    passes on `''`, and the `toBeDefined()` guard below does not catch that —
+ *    it catches an action returning no error at all, which is the shape a
+ *    never-failed call arrives in. Where the searched bytes could be empty, pin
+ *    a positive control on them first.
+ * 2. **It is for a raw value, not a deliberately revealed fragment.** The
+ *    at-rest and grant-shape assertions stay whole-value (`not.toContain`)
+ *    because `maskMatch` keeps a fragment visible on purpose — that fragment IS
+ *    the masked preview, and it is stored deliberately.
+ * 3. **A masked preview only stays under the window for a GENERIC secret.**
+ *    `maskMatch` reveals a generic secret's first and last character around six
+ *    fixed asterisks — two characters, which cannot fill an eight-character
+ *    window. Its email branch reveals the first local character plus the WHOLE
+ *    DOMAIN, and a single-character local part returns the input unchanged, so
+ *    an email's own preview fills the window legitimately.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `cli/test/helpers/no-echo.ts` and
+ * `plugins/claude-code/test/helpers/no-echo.ts` carry their own — a copy takes
+ * the `toBeDefined()` guard and this file's suite with it, or the run length can
+ * be widened back with nothing going red.
+ */
+export function expectNoEchoOf(haystack: string | undefined, value: string): void {
+  // Catches an action that returned no error, which would otherwise satisfy the
+  // loop vacuously. It does NOT catch an empty string — see limit 1.
+  expect(haystack).toBeDefined();
+  const text = haystack ?? '';
+  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
+    expect(text).not.toContain(value.slice(i, i + ECHO_RUN));
+  }
+  // Values shorter than the run length still must not appear at all.
+  if (value.length < ECHO_RUN) expect(text).not.toContain(value);
+}


### PR DESCRIPTION
## Summary

Tests only — no product source changes.

A `not.toContain(secret)` is a **whole-value** check. If a branch ever echoes a *truncated*
value it stays green, and a run of a high-entropy credential is still a live credential's
prefix. The CLI and plugin suites asserted raw-value absence that way; this makes them assert
absence **run by run**, over an eight-character sliding window.

Both packages now have a shared `test/helpers/no-echo.ts` with **its own suite**. That matters
because widening `ECHO_RUN` or emptying the loop leaves every *caller* green — the helper's own
tests are the only thing that goes red, so each case asserts both that the helper refuses a
leaked run and that the form it replaced would have passed.

### What changed

**`cli`** — `exception.test.ts`, `exception-reveal.test.ts`, `vault.test.ts` (13 run-by-run
assertions + 6 emptiness assertions):

- Bound to **stdout** as well as errors. A terminal is where a leaked value gets scrolled,
  pasted into a bug report, and captured by CI logs. Safe for these values: what these commands
  print of a blocked generic secret is `maskMatch`'s two-character preview, which cannot fill an
  eight-character window.
- Where a path prints nothing at all, assert `output()` **is empty** rather than that a secret
  is absent from it — every `not.toContain` passes on `''`.
- Bound **per assertion, not per file**: `aka vault show`'s success path prints the raw value on
  purpose, so its exemption is scoped to that case while the refusal paths in the same file are
  tightened.
- Added cases for two branches that compose a message while holding the raw value in scope (the
  "did you mean" rule hint, and an input holding two distinct values).
- Raised the reveal fixture's entropy from 14 distinct characters to 30. It stays non-credential-shaped
  — this repo is public — but an English-phrase literal puts ordinary words in the window, where
  they collide with output text instead of catching a leak.

**`plugins/claude-code`** — `judge`, `adapter`, `writeback`, `resubmit-message`:

- `judge.test.ts` kept a local, untested copy of the helper while three sibling suites in the
  same package still asserted whole-value. Replaced with the shared helper.
- Fixed a second, quieter defect at four sites:

  ```ts
  try {
    parse(input);
    throw new Error('expected parse to throw'); // caught by its own catch, below
  } catch (err) {
    expect(err.message).not.toContain(RAW);     // asserts on THAT message
  }
  ```

  The guard error carries no secret, so the case passes while the function under test stopped
  throwing entirely. Errors are now captured outside the catch via `errorFrom()`, and each case
  names the refusal it expects.

**`CLAUDE.md`** — the rule bound individual files, so a suite sitting beside a helper could keep
the weaker form because it was written first. It now binds by **package**, and records the
limits above.

## Verification

Every assertion was proven by mutation **plus a control run** — breaking the property, confirming
the new form goes red, then restoring the *predecessor* assertion under the identical mutation and
confirming it goes green. Without that second step you have only shown the new assertion is red,
not that it is stronger.

Representative results:

| Mutation | Predecessor form | New form |
| --- | --- | --- |
| `maskedValue: first.slice(0, 12)` instead of `maskMatch(first)`, so `aka exception list` prints a raw prefix | 26/26 green | red |
| 12-char selector echo in the "no blocked detection matches" refusal | 26/26 green | red (3 tests) |
| 12-char selector echo in the approve confirmation (stdout) | 26/26 green | red |
| 16-char run echoed in the plugin's stream-truncation refusal | 23/23 green | red |
| `parseVerdict` stops throwing (isolated to the one test) | green | red |

The first row is the one worth noting: the old assertions stayed **fully green** while a 12-character
prefix of a live credential was written to the store *and* printed to the terminal.

The helpers were also mutated directly — widening `ECHO_RUN` to 64, emptying the sliding loop,
dropping the `toBeDefined()` guard, and dropping the short-value fallback each go red in the helper's
own suite. Widening `ECHO_RUN` notably leaves both calling suites green, which is why the suite exists.

## Checklist

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes

Verified with `pnpm exec turbo run test lint typecheck --force` — **47/47 tasks, `Cached: 0`** (a
forced run, not a cache replay).
