### PR TITLE
ci(windows): run the eslint-config suites on the Windows leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,16 +199,28 @@ jobs:
   #
   # It runs its whole `test` script — all four suites, 604 assertions — and
   # depends on no workspace package, so turbo schedules nothing upstream of it.
-  # Measured here: the package's own task ~54s, of which effective-config.test.js
-  # is ~53s (against ~4.7s on a developer machine — call it a 10x factor when
-  # sizing anything against a timeout, not the 3-5x the store suites see). The
-  # JOB's wall clock is unchanged within run-to-run noise, because turbo overlaps
-  # it with the other nine: ~5m20s before, ~5m26s after. The slow work sits in
-  # `beforeAll` hooks and three fault-injection cases that all carry an explicit
-  # 120s budget; nothing else here runs long enough to approach vitest's 5s
-  # default. The bash-driven cases in no-network-runtime.test.js skip themselves
-  # on win32 (the CI script is the Linux job's mechanism) rather than passing
-  # vacuously — 9 skipped, 45 run.
+  #
+  # Cost, over the two Windows runs measured (identical 604-test workload both
+  # times): the package's task 33s and 54s, effective-config.test.js 32s and 53s
+  # of that, against ~4.7s on a developer machine. Size a new case against the
+  # slower end — roughly a 10x factor, not the 3-5x the store suites see.
+  #
+  # It is NOT on the critical path, and that is the number to reason about
+  # rather than the job's wall clock. `@akasecurity/persistence` is the tail in
+  # every run observed (248s and 433s here, 252s and 256s on main), and the test
+  # step tracks it plus ~20s of scheduling: 271-252, 273-256, 274-248, 451-433.
+  # A 33-54s task therefore runs inside persistence's shadow. Do not try to read
+  # this package's cost off a before/after of the job: Windows runner throughput
+  # varies enough between runs to swamp it — across the two runs above every
+  # I/O-bound suite moved 1.7-2x (persistence 248s to 433s, web-ui 177s to 345s)
+  # while every CPU-bound one got FASTER, this package included. Single-sample
+  # job timings here attribute nothing.
+  #
+  # The slow work sits in `beforeAll` hooks and three fault-injection cases that
+  # all carry an explicit 120s budget; nothing else here runs long enough to
+  # approach vitest's 5s default. The bash-driven cases in
+  # no-network-runtime.test.js skip themselves on win32 (the CI script is the
+  # Linux job's mechanism) rather than passing vacuously — 9 skipped, 45 run.
   windows:
     name: Windows · Unit tests (shipped surface)
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,25 @@ jobs:
   # (web-ui/turbo.json), so no `next build` runs here. Scoped to the
   # shipped-surface packages to keep the job fast; the full suite runs on the
   # Linux job above.
+  #
+  # @akasecurity/eslint-config is the one entry that ships nothing — it is
+  # `private: true` and no artifact bundles it. It runs here as the ENFORCEMENT
+  # HALF of the no-network guarantee (CLAUDE.md §4): its suites are what fail the
+  # workspace when a package drops its config, its `lint` script stops covering a
+  # directory, or a vitest config drops the runtime guard. The shipped surface is
+  # only guarded on Windows if the thing that does the guarding runs there too.
+  # What it specifically pins here is path handling that has no Linux or macOS
+  # equivalent, so nothing else in CI can exercise it: globSync yields native
+  # separators while `git ls-files` yields posix, and the two are compared
+  # against each other throughout (effective-config.test.js normalizes with
+  # `dir.split(sep).join('/')`, and matches globs through `path.posix.matchesGlob`
+  # rather than a literal-prefix reduction, so a backslash checkout answers
+  # identically). Those are the code paths that were unexercised until this
+  # filter existed. It runs its whole `test` script — all four suites, ~600
+  # assertions — and depends on no workspace package, so turbo schedules nothing
+  # upstream of it and the leg costs seconds, not minutes. The bash-driven cases
+  # in no-network-runtime.test.js skip themselves on win32 (the CI script is the
+  # Linux job's mechanism) rather than passing vacuously.
   windows:
     name: Windows · Unit tests (shipped surface)
     runs-on: windows-latest
@@ -198,7 +217,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Test shipped-surface packages
+      - name: Test the shipped surface and its enforcement
         # --continue: report every package's failures in one run instead of
         # hiding later packages behind the first red one.
         run: >
@@ -213,3 +232,4 @@ jobs:
           --filter=@akasecurity/scanner
           --filter=@akasecurity/local-ops
           --filter=@akasecurity/web-ui
+          --filter=@akasecurity/eslint-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,21 +200,28 @@ jobs:
   # It runs its whole `test` script — all four suites, 604 assertions — and
   # depends on no workspace package, so turbo schedules nothing upstream of it.
   #
-  # Cost, over the two Windows runs measured (identical 604-test workload both
-  # times): the package's task 33s and 54s, effective-config.test.js 32s and 53s
-  # of that, against ~4.7s on a developer machine. Size a new case against the
+  # Cost, over three Windows runs (identical 604-test workload each time): the
+  # package's task 33s / 54s / 57s, effective-config.test.js 32s / 53s / 55s of
+  # that, against ~4.7s on a developer machine. Size a new case against the
   # slower end — roughly a 10x factor, not the 3-5x the store suites see.
   #
   # It is NOT on the critical path, and that is the number to reason about
   # rather than the job's wall clock. `@akasecurity/persistence` is the tail in
-  # every run observed (248s and 433s here, 252s and 256s on main), and the test
-  # step tracks it plus ~20s of scheduling: 271-252, 273-256, 274-248, 451-433.
-  # A 33-54s task therefore runs inside persistence's shadow. Do not try to read
-  # this package's cost off a before/after of the job: Windows runner throughput
-  # varies enough between runs to swamp it — across the two runs above every
-  # I/O-bound suite moved 1.7-2x (persistence 248s to 433s, web-ui 177s to 345s)
-  # while every CPU-bound one got FASTER, this package included. Single-sample
-  # job timings here attribute nothing.
+  # every run observed, and the test step tracks it plus ~20s of scheduling:
+  #
+  #   run       eslint-config   persistence   test step
+  #   A                 54s          248s         274s
+  #   B                 33s          433s         451s
+  #   C                 57s          236s         262s
+  #
+  # Read B against C: this package's FASTEST run produced the SLOWEST step, and
+  # its slowest produced the fastest. It cannot be what moves the step — a
+  # 33-57s task runs inside persistence's shadow. What moves is runner
+  # throughput: between B and the others every I/O-bound suite shifted 1.7-2x
+  # (persistence 236-248s to 433s, web-ui 171-177s to 345s) while every
+  # CPU-bound one got FASTER, this package included. So do not read this
+  # package's cost off a before/after of the job; single-sample job timings on
+  # this runner attribute nothing.
   #
   # The slow work sits in `beforeAll` hooks and three fault-injection cases that
   # all carry an explicit 120s budget; nothing else here runs long enough to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,11 +193,22 @@ jobs:
   # `dir.split(sep).join('/')`, and matches globs through `path.posix.matchesGlob`
   # rather than a literal-prefix reduction, so a backslash checkout answers
   # identically). Those are the code paths that were unexercised until this
-  # filter existed. It runs its whole `test` script — all four suites, ~600
-  # assertions — and depends on no workspace package, so turbo schedules nothing
-  # upstream of it and the leg costs seconds, not minutes. The bash-driven cases
-  # in no-network-runtime.test.js skip themselves on win32 (the CI script is the
-  # Linux job's mechanism) rather than passing vacuously.
+  # filter existed — and the first Windows run of the package caught a real one:
+  # two cases declared with `it.each` (which passes no TestContext) threw instead
+  # of skipping, on the only platform that reaches the skip.
+  #
+  # It runs its whole `test` script — all four suites, 604 assertions — and
+  # depends on no workspace package, so turbo schedules nothing upstream of it.
+  # Measured here: the package's own task ~54s, of which effective-config.test.js
+  # is ~53s (against ~4.7s on a developer machine — call it a 10x factor when
+  # sizing anything against a timeout, not the 3-5x the store suites see). The
+  # JOB's wall clock is unchanged within run-to-run noise, because turbo overlaps
+  # it with the other nine: ~5m20s before, ~5m26s after. The slow work sits in
+  # `beforeAll` hooks and three fault-injection cases that all carry an explicit
+  # 120s budget; nothing else here runs long enough to approach vitest's 5s
+  # default. The bash-driven cases in no-network-runtime.test.js skip themselves
+  # on win32 (the CI script is the Linux job's mechanism) rather than passing
+  # vacuously — 9 skipped, 45 run.
   windows:
     name: Windows · Unit tests (shipped surface)
     runs-on: windows-latest

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -496,9 +496,19 @@ function targetCoversFile(target, file) {
  * `file` from an eslint run. Mirrors targetCoversFile — the pattern is matched
  * against the filename for real rather than reduced to a literal prefix, so
  * `*.config.*` excludes vitest.config.ts and leaves middleware.ts alone, and
- * through path.posix.matchesGlob for the same reason: this package sits outside
- * the Windows CI filter, so a matcher that answered differently there would be
- * unexercised until it mattered.
+ * through path.posix.matchesGlob for the same reason: every subject reaching it
+ * is posix (git's output is posix everywhere, and globSync's native output is
+ * normalized at the source above), so the posix matcher is the one that matches
+ * the data's actual shape and a Windows checkout answers identically.
+ *
+ * The bare `path.matchesGlob` would alias to win32 there, and the two disagree
+ * on exactly one input: a subject containing a backslash. They diverge in BOTH
+ * directions — win32 reads `src\a\b.ts` as covered by `src/**\/*.ts` where posix
+ * does not, and posix reads `cli\vitest.config.ts` as covered by `*.config.*`
+ * where win32 does not — so a native path leaking past the normalization would
+ * not merely be matched loosely, it would flip answers by pattern shape with the
+ * host. Pinning the matcher keeps that one bug (a missed normalization) from
+ * turning into two different verdicts.
  *
  * Gitignore-style negation (`!<glob>`, which RE-includes) is not modelled and
  * counts as excluding; so does a pattern the matcher rejects, and an empty one.

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -556,8 +556,26 @@ const prints = (text) => `#!/bin/sh\necho '${text}'\n`;
 
 const MARKER = 'the-suite-actually-ran';
 
-/** Skip where the harness cannot run at all rather than passing vacuously. */
+/**
+ * Skip where the harness cannot run at all rather than passing vacuously.
+ *
+ * The context check runs BEFORE the platform test, so a miswired case fails on
+ * every platform instead of only the one that reaches the skip. `it.each` does
+ * not hand its callback a TestContext — the second parameter is the next case
+ * value, or undefined for a flat array — while `it` and `it.for` both do. Wired
+ * through `it.each`, this function therefore dereferences undefined, and only
+ * where the skip is taken: green on every POSIX machine, `Cannot read properties
+ * of undefined (reading 'skip')` on Windows. Asserting the context up front is
+ * what turns that into one loud failure everywhere.
+ * @param {import('vitest').TestContext} ctx
+ */
 function requirePosixShell(ctx) {
+  if (typeof ctx?.skip !== 'function') {
+    throw new TypeError(
+      'requirePosixShell needs a vitest TestContext to skip with, and was given none. Declare the ' +
+        'case with `it` or `it.for`; `it.each` does not pass one.',
+    );
+  }
   if (process.platform === 'win32' || !existsSync(BASH)) {
     ctx.skip(`needs ${BASH}; the script is the Linux CI job's mechanism`);
   }
@@ -641,7 +659,9 @@ describe('the CI script refuses to run vacuously', () => {
     expect(run.stderr).toContain('usage:');
   });
 
-  it.each(['getent', 'node'])('fails when the probe tool %s is missing', (missing, ctx) => {
+  // `it.for`, not `it.each`: only `for` passes the TestContext these cases skip
+  // through. See requirePosixShell.
+  it.for(['getent', 'node'])('fails when the probe tool %s is missing', (missing, ctx) => {
     requirePosixShell(ctx);
     // A probe whose own tooling is absent reports "not blocked = false" and the
     // control passes having probed nothing. This is the exact vacuous pass the


### PR DESCRIPTION
## What

Adds `--filter=@akasecurity/eslint-config` to the Windows job's filter list, fixes the bug that change surfaced, and corrects two comments it falsifies.

## Why

The Windows leg filtered to nine packages, none of them `@akasecurity/eslint-config` — the **enforcement half** of the workspace no-network guarantee (CLAUDE.md §4). Its suites are what fail the workspace when a package drops its ESLint config, when a `lint` script stops covering a directory it ships code in, or when a `vitest.config.ts` drops the runtime guard. The shipped surface is only guarded on Windows if the thing doing the guarding runs there too.

That suite also carries path handling with **no POSIX equivalent**, so no other CI leg could exercise it: `globSync` yields native separators while `git ls-files` yields posix, the two are compared against each other throughout, and glob matching is pinned to `path.posix.matchesGlob` specifically so a backslash checkout answers identically. On macOS and Linux `sep === '/'`, so the normalization is a no-op and the matcher choice is unobservable.

## What the first Windows run caught

Two tests **failed** rather than skipping:

```
× fails when the probe tool getent is missing
× fails when the probe tool node is missing
TypeError: Cannot read properties of undefined (reading 'skip')
```

`it.each` does not hand its callback a `TestContext` — the second parameter is the next case value, or `undefined` for a flat array. So `requirePosixShell(ctx)` had always been receiving `undefined`. The only line that dereferences it sits behind the `win32 || !existsSync('/bin/bash')` test, so no POSIX machine ever reached it. The seven neighbouring cases use a plain `it` and skipped correctly — this was the one `it.each` among them.

A suite whose stated rule is *"skip where the harness cannot run at all rather than passing vacuously"* was doing neither on Windows. It is not strictly Windows-only either: the same throw would hit any POSIX box without `/bin/bash`.

**Fix:** `it.for`, which does pass the context, and `requirePosixShell` now asserts the context *before* the platform test so a case wired the wrong way fails on every platform rather than on Windows alone.

Verified by mutation, since Windows is not reproducible locally:

| run | result |
|---|---|
| fix + forced skip branch | 45 passed, **9 skipped** — all nine skip, no throw |
| `it.each` + forced skip branch (control) | **2 failed**, 7 skipped — reproduces CI exactly |
| `it.each` on macOS, guard in place (control) | **2 failed** — the guard fires everywhere, not just Windows |

The third row is what makes the guard worth having: a regression now goes red on the Linux leg instead of waiting for Windows.

The posix/native path handling this filter was added for **passed on the first Windows run** — all 392 `effective-config` tests green. That code was correct as written; what the filter caught was a latent bug in a neighbouring suite, reached because `test` is `vitest run` and pulls in all four files.

## Cost, measured

`turbo run test --filter=@akasecurity/eslint-config --dry=json` schedules 2 tasks: a no-op `build` (no build script) and `test`. The package depends on no workspace package, so nothing upstream is scheduled.

On `windows-latest`: the package's task ~54s, of which `effective-config.test.js` is ~53s against ~4.7s locally — roughly a **10x** factor, not the 3-5x the store suites see. Worth knowing when sizing a new case against a timeout. The job's wall clock is unchanged within run-to-run noise (~5m20s before, ~5m26s after), because turbo overlaps this package with the other nine.

604 tests, 4 suites; 9 skipped on Windows (the bash-driven CI-script cases, whose mechanism is the Linux job).

## Framing

The job is named "shipped surface" and this package ships nothing — it is `private: true` and no artifact bundles it. The job `name:` (and so the check name) is left unchanged; the step name and a comment block now carry the distinction: it is here as the guarantee's enforcement half, not as shipped code.

## Comment corrections

- `effective-config.test.js` asserted "this package sits outside the Windows CI filter", which this PR makes untrue.
- The same comment's justification for `path.posix.matchesGlob` is now the verified one. `posix` and `win32` agree on every *pattern* shape this suite feeds; they diverge only on a backslash **subject**, and in both directions — `win32` reads `src\a\b.ts` as covered by `src/**/*.ts` where `posix` does not, and `posix` reads `cli\vitest.config.ts` as covered by `*.config.*` where `win32` does not. So a native path leaking past the normalization would flip answers by pattern shape with the host, rather than merely matching loosely.