### PR TITLE
test(plugin-sdk): assert the battery's blindness structurally, not by a clock

### DIFF
--- a/packages/plugin-sdk/test/isolated-scan.test.ts
+++ b/packages/plugin-sdk/test/isolated-scan.test.ts
@@ -8,9 +8,9 @@
  * asserts the property the battery cannot give — whatever the pattern, the work
  * ends:
  *
- *   - one the battery CLEARS in microseconds and that then never returns on
- *     text the battery has no way to construct, which is what the isolated
- *     `scan` exists for;
+ *   - one the battery CLEARS without ever reaching its nested quantifier, and
+ *     that then never returns on text the battery has no way to construct,
+ *     which is what the isolated `scan` exists for;
  *   - one that hangs the BATTERY ITSELF, which is what the isolated `probe`
  *     exists for. Measuring a rule means driving its own pattern into
  *     backtracking, so the measurement is an unbounded run of an untrusted
@@ -28,8 +28,9 @@ import { createIsolatedScanner } from '../src/isolated-scan.ts';
 // at the `zzq` literal before it ever reaches the nested quantifier. The rule
 // measures as safe and is admitted to the ruleset. Text that does carry the
 // literal then drives `(a+)+$` into exponential backtracking.
-const BATTERY_BLIND_PATTERN = String.raw`(?:zzq)(a+)+$`;
-const BATTERY_BLIND_TEXT = `zzq${'a'.repeat(34)}!`;
+const BATTERY_BLIND_LITERAL = 'zzq';
+const BATTERY_BLIND_PATTERN = String.raw`(?:${BATTERY_BLIND_LITERAL})(a+)+$`;
+const BATTERY_BLIND_TEXT = `${BATTERY_BLIND_LITERAL}${'a'.repeat(34)}!`;
 
 // The other half of the gap. This one has no literal prefix at all, so the
 // battery's own derived probe is `'a'.repeat(23) + '!'` — and four identical
@@ -87,7 +88,28 @@ describe('the residual risk the probe battery leaves open', () => {
     // than deleting the case: the gap is in the approach, not in one pattern.
     const verdict = checkRuleTiming(HOSTILE);
     expect(verdict.safe).toBe(true);
-    expect(verdict.worstMs).toBeLessThan(10);
+
+    // WHY it clears, stated structurally rather than as a millisecond ceiling.
+    // The battery's slowest probe never carries the literal this pattern
+    // requires, so the nested quantifier behind that literal is unreachable and
+    // nothing backtracks. Move the literal out of the group so `literalPrefix`
+    // can see it and both assertions flip together — the derived probes carry
+    // it, the battery spends hundreds of milliseconds, and the rule reports
+    // unsafe.
+    //
+    // A ceiling asserts the same property by proxy and measures the runner
+    // instead. The whole battery costs hundredths of a millisecond for this
+    // rule — V8 locates the required literal by substring search before running
+    // the regex, so even the 40KB polynomial probes are nearly free — which
+    // leaves a scheduler pause on a loaded machine orders of magnitude above the
+    // signal being measured. A ratio against a second rule's battery is no
+    // better here, because both numbers are that small.
+    //
+    // The length check is the positive control: `worstProbeMs` leaves `probe`
+    // empty if no probe ever measures above zero, and an empty string satisfies
+    // the absence check vacuously.
+    expect(verdict.probe.length).toBeGreaterThan(0);
+    expect(verdict.probe).not.toContain(BATTERY_BLIND_LITERAL);
   });
 });
 

--- a/packages/plugin-sdk/test/isolated-scan.test.ts
+++ b/packages/plugin-sdk/test/isolated-scan.test.ts
@@ -37,6 +37,10 @@ import { countWorkerStarts } from './helpers/worker-starts.ts';
 // at the `zzq` literal before it ever reaches the nested quantifier. The rule
 // measures as safe and is admitted to the ruleset. Text that does carry the
 // literal then drives `(a+)+$` into exponential backtracking.
+// Keep this free of regex metacharacters: it is interpolated into the pattern
+// below, and `String.raw` leaves interpolations untouched, so anything with a
+// meaning to the engine would change what the pattern matches rather than being
+// matched literally. It is also the plain text prefix the hostile input carries.
 const BATTERY_BLIND_LITERAL = 'zzq';
 const BATTERY_BLIND_PATTERN = String.raw`(?:${BATTERY_BLIND_LITERAL})(a+)+$`;
 const BATTERY_BLIND_TEXT = `${BATTERY_BLIND_LITERAL}${'a'.repeat(34)}!`;


### PR DESCRIPTION
## The flake

`packages/plugin-sdk/test/isolated-scan.test.ts` paired the battery-blind rule's `safe` verdict with `expect(verdict.worstMs).toBeLessThan(10)`. That ceiling failed at **13.09ms** on a loaded runner, on a change touching neither this package nor the engine, while the identical code passed on sibling PRs in the same push.

## Why a ceiling cannot work here

Measured locally, the **whole battery for this rule costs 0.01–0.08 ms**. `(?:zzq)(a+)+$` requires the literal `zzq`, and V8 locates that literal by substring search before running the regex — so even the nine 40,000-character polynomial probes are nearly free. The ceiling was sitting about three orders of magnitude above the signal it guarded, which makes it a measurement of the runner rather than of the rule.

Two alternatives were considered and rejected:

- **A scale-free ratio** against a second rule's battery (the `backtrackRatio` / `CATASTROPHIC_RATIO` idiom the engine's own gate uses). A ratio cancels machine speed only when both measurements are dominated by work rather than noise. Both numbers here are hundredths of a millisecond, so a scheduler pause in either one swings it wildly.
- **Re-measuring and keeping the lower sample.** Ruled out by the rule written into `worstProbeMs`: V8 runs the interpreted Irregexp tier first and tiers up to native afterwards, so a second sample measures the faster tier and keeping it admits a genuinely over-budget rule — permanently, since the verdict is cached.

## The change

The clock was only ever a proxy. The battery clears this rule because `literalPrefix` stops at the opening `(`, so no probe it constructs ever carries `zzq`, leaving the nested quantifier behind that literal unreachable. That is now asserted directly, with no timing component:

```ts
expect(verdict.safe).toBe(true);
expect(verdict.probe.length).toBeGreaterThan(0);
expect(verdict.probe).not.toContain(BATTERY_BLIND_LITERAL);
```

The length check is the positive control — `worstProbeMs` leaves `probe` empty if no probe ever measures above zero, and an empty string satisfies the absence check vacuously. `zzq` is lifted into `BATTERY_BLIND_LITERAL` so the pattern, the hostile text, and the assertion cannot drift apart. The file header's "CLEARS in microseconds" is corrected, since the suite no longer makes a timing claim.

## Verification

The property was broken in both directions rather than trusting a green run:

- Moving the literal out of the group (`zzq(a+)+$`) makes `literalPrefix` see it. The derived probes then carry `zzq`, the battery spends **424ms**, and the rule reports `safe: false` — both assertions flip together, which is exactly the "good news" case the existing comment anticipates.
- Pointing the absence check at a literal the probes do contain fails on `'aaaaaaaaaaaaaaaaaaaaaaa!'`, confirming the probe string is genuinely non-empty and inspected.

Full `@akasecurity/plugin-sdk` suite passes (303 tests, 25 files), along with lint, typecheck and Prettier.

## Noted, not changed

`isolated-scan.test.ts:126`'s `expect(outcome.worstMs).toBeLessThan(100)` is exactly equivalent to the `outcome.safe` assertion three lines above it, since `safe` is defined as `ms < BUDGET_MS` and `BUDGET_MS` is 100. It cannot fail independently so it is not a flake risk, but its comment describes it as a loose ceiling chosen to survive a Windows runner, which misstates what it checks.