### PR TITLE
test(web-ui): pin which ledger read feeds the rotate dialog's count

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,6 +653,33 @@ scans against the **DB snapshot**, not the engine's process-global registry.
 `@akasecurity/plugin-sdk` is a **dev-only** dependency of `web-ui` for exactly this, which
 is not a runtime package-wall crossing.
 
+### Testing a web-ui page
+
+An async Server Component is a plain async function that returns an element, so a route's
+own data work — which store reads it issues, and which one it hands to which consumer — is
+testable by **calling the page and reading the props it hands down**. No renderer, no DOM,
+no jsdom. `element.props` carries them; assert `element.type` alongside, so a page that
+starts returning a wrapper fails naming that rather than reading every prop as `undefined`.
+`web-ui/test/pages/exceptions-page.test.ts` is the worked example. The four steps above
+apply unchanged (a read-only page needs no `next/cache` mock).
+
+This is not the browser tier — nothing mounts, no event fires, no client component runs.
+It covers the seam between the store and the props, which is where a route's derivations
+live and where nothing else can see them.
+
+**The one thing that makes it work is a config line.** `web-ui/tsconfig.json` sets
+`"jsx": "preserve"` because Next's own compiler consumes untransformed JSX, and vitest
+inherits it — so the page's JSX survives into the output and the parser that reads it next
+rejects it. `oxc.jsx` in `web-ui/vitest.config.ts` overrides that for the test run only. It
+is already wired; a new suite needs no change, but a parse error on a `.tsx` import is what
+its absence looks like, and it names neither JSX nor the tsconfig.
+
+A route that issues **more than one read of the same table** is the case worth writing a
+page test for at all: a count derived from the wrong one of two windows is still a number,
+so it typechecks, lints, and satisfies every assertion aimed at the pieces. Make the fixture
+straddle the two windows and **pin the straddle itself** — with rows that all fall inside
+both, the assertions pass whichever read the page used, and the suite proves nothing.
+
 An at-rest leak scan must read **every file in the data dir**, not `aka.db` plus a
 hardcoded `-wal`/`-shm` pair. This is not a corner case: a migration leaves an
 `aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the pre-migration store — in that

--- a/web-ui/test/pages/exceptions-page.test.ts
+++ b/web-ui/test/pages/exceptions-page.test.ts
@@ -1,0 +1,263 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { BLOCKED_WINDOW_MS, isBlockedRowApprovable } from '@akasecurity/dashboard-ui';
+import { maskMatch } from '@akasecurity/detections';
+import {
+  BLOCKED_DETECTIONS_RETENTION_MS,
+  dataDir,
+  fingerprintValue,
+  loadOrCreateFingerprintKey,
+  type LocalDatabase,
+  openLocalDatabase,
+  readFingerprintKey,
+} from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BlockedDetectionInput } from '@akasecurity/schema';
+import type { ComponentProps, ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ExceptionsClient } from '../../app/(app)/exceptions/ExceptionsClient.tsx';
+import ExceptionsPage from '../../app/(app)/exceptions/page.tsx';
+
+// The exceptions route issues TWO reads of the same blocked-detections ledger,
+// over two different windows, and hands both to the client — and which read
+// feeds which consumer is the whole point:
+//
+//   the strip   — the lookback chip the user picked, 30 minutes by default
+//   the dialog  — the full retention window, because the rotate confirmation
+//                 has to name what a one-way action costs, and rotation
+//                 invalidates every row in the ledger, not just the visible ones
+//
+// Every piece of that is covered somewhere else. The predicate is pinned in
+// dashboard-ui's meta suite, the copy alongside it, and the agreement between
+// the retention constant and the hours the copy names in the actions suite.
+// What none of them can see is the WIRING, because a count is just a number:
+// feed the dialog the 30-minute read and it understates a destructive action by
+// however many rows fell outside the chip — silently, with the type, the lint
+// and every existing assertion still green.
+//
+// So this suite drives the page itself. It is an async Server Component, which
+// is a plain async function returning an element, so calling it and reading the
+// props it hands down needs no renderer and no DOM. The store, the fingerprint
+// key file and the ledger writes are all real (the repository's house style);
+// only `homedir()` is redirected, since the page resolves ~/.aka from it and
+// `n/no-process-env` rules out an env override.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+
+let home: string;
+let dir: string;
+
+// app/lib/db memoises its handle on globalThis across requests and HMR reloads,
+// so a suite that does not drop it reads the PREVIOUS test's temp store.
+function resetSingleton(): void {
+  const store = globalThis as unknown as { __akaDb?: LocalDatabase };
+  store.__akaDb?.close();
+  delete store.__akaDb;
+}
+
+// A value from the bundled rule's own `examples`, so no secret-shaped literal
+// lives in this file and the fixture stays in step with the rule definition.
+const RULE_ID = 'secrets/aws-access-key';
+const example = bundledDetections()
+  .flatMap((p) => p.rules)
+  .find((r) => r.id === RULE_ID)?.examples?.[0];
+if (example === undefined) {
+  throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+}
+const VALUE: string = example;
+
+// One ledger row shaped as the hook writes it: the keyed fingerprint and masked
+// preview of the detected value, never the value.
+function ledgerEntry(overrides: Partial<BlockedDetectionInput> = {}): BlockedDetectionInput {
+  const key = loadOrCreateFingerprintKey(dir);
+  return {
+    reference: 'blk-0001',
+    ruleId: RULE_ID,
+    category: 'secret',
+    valueFingerprint: fingerprintValue(key, VALUE),
+    keyVersion: key.version,
+    maskedValue: maskMatch(VALUE),
+    sessionId: null,
+    repo: null,
+    ...overrides,
+  };
+}
+
+// Write a ledger row through the real repository, optionally back-dated.
+// `blocked_at` is stamped inside the write from `Date.now()` and exceptions.ts
+// takes no injectable clock, so moving the clock across that one call is the
+// only seam — which keeps the row shape in step with `recordBlocked` instead of
+// hand-rolling its SQL. The handle opens BEFORE the clock moves so migrations
+// and default seeding still stamp real times.
+async function seedBlocked(entry: BlockedDetectionInput, agedMs = 0): Promise<void> {
+  const at = Date.now() - agedMs;
+  const store = openLocalDatabase(dir);
+  const clock = vi.spyOn(Date, 'now').mockReturnValue(at);
+  try {
+    await store.exceptions.recordBlocked(entry);
+  } finally {
+    clock.mockRestore();
+    store.close();
+  }
+}
+
+type ClientProps = ComponentProps<typeof ExceptionsClient>;
+
+// Render the route the way Next calls it — `searchParams` arrives as a promise —
+// and return the props it hands the client component.
+//
+// `element.type` is asserted rather than assumed: if the page ever returns a
+// wrapper instead, every prop below reads `undefined`, and a suite that only
+// checked the numbers would report the wrong reason for going red.
+async function renderPage(params: { all?: string; window?: string } = {}): Promise<ClientProps> {
+  const element = (await ExceptionsPage({
+    searchParams: Promise.resolve(params),
+  })) as ReactElement<ClientProps>;
+  expect(element.type).toBe(ExceptionsClient);
+  return element.props;
+}
+
+// Two rows outside the default chip but inside retention, one row inside both.
+// The gap between the two windows IS the property under test, so the fixture
+// has to straddle it: with every row recent, both reads return the same list
+// and the assertions below hold whichever one the page passes down.
+const AGED_MS = 12 * 60 * 60 * 1000;
+const RECENT = 'blk-recent';
+const AGED = ['blk-aged-1', 'blk-aged-2'];
+
+async function seedStraddlingFixture(): Promise<void> {
+  await seedBlocked({ ...ledgerEntry(), reference: RECENT });
+  for (const reference of AGED) {
+    await seedBlocked({ ...ledgerEntry(), reference }, AGED_MS);
+  }
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-exp-'));
+  osHome.dir = home;
+  dir = dataDir();
+  const db = openLocalDatabase(dir);
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+  } finally {
+    db.close();
+  }
+  resetSingleton();
+});
+
+afterEach(() => {
+  resetSingleton();
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('the exceptions route wires each ledger read to the consumer that needs it', () => {
+  it('is a fixture the two windows disagree on', async () => {
+    // The control for everything below. If the aged rows ever stop falling
+    // outside the default chip — the chip widens, the retention window
+    // narrows, the ageing seam stops working — the assertions that follow go
+    // on passing while proving nothing, because both reads would return the
+    // same three rows. Pin the disagreement itself so that failure is loud.
+    expect(AGED_MS).toBeGreaterThan(BLOCKED_WINDOW_MS['30m']); // the default chip
+    expect(AGED_MS).toBeGreaterThan(BLOCKED_WINDOW_MS['1h']); // the other chip driven below
+    expect(AGED_MS).toBeLessThan(BLOCKED_DETECTIONS_RETENTION_MS);
+
+    await seedStraddlingFixture();
+    const props = await renderPage();
+    expect(props.blocked.map((b) => b.reference)).toEqual([RECENT]);
+  });
+
+  it('counts the rotate cost over the whole retention window, not the selected chip', async () => {
+    await seedStraddlingFixture();
+
+    const props = await renderPage();
+
+    // Three rows are still approvable and rotation invalidates all three. The
+    // strip shows one of them. Taking the count from the strip's read would
+    // put "1" in front of a user about to make every one of them unapprovable.
+    expect(props.approvableBlocked).toBe(1 + AGED.length);
+    expect(props.blocked).toHaveLength(1);
+  });
+
+  it('keeps the strip on the selected chip while the count stays whole', async () => {
+    await seedStraddlingFixture();
+
+    // The mirror of the case above: widening the STRIP's read to retention
+    // would make the two agree again — and pass the assertion above — while
+    // silently overriding the window the user chose.
+    const props = await renderPage({ window: '1h' });
+
+    expect(props.blockedWindow).toBe('1h');
+    expect(props.blocked.map((b) => b.reference)).toEqual([RECENT]);
+    expect(props.approvableBlocked).toBe(1 + AGED.length);
+  });
+
+  it('agrees with the strip only when the chip spans the retention window', async () => {
+    await seedStraddlingFixture();
+
+    // The widest chip is exactly the retention window, so here the two reads
+    // legitimately coincide. Recorded so a future red is never "fixed" by
+    // defaulting the chip wider: this is the one setting under which the
+    // property this suite guards is invisible.
+    expect(BLOCKED_WINDOW_MS['24h']).toBe(BLOCKED_DETECTIONS_RETENTION_MS);
+
+    const props = await renderPage({ window: '24h' });
+
+    expect(props.blocked).toHaveLength(1 + AGED.length);
+    expect(props.approvableBlocked).toBe(1 + AGED.length);
+  });
+
+  it('counts only the rows a rotation actually takes something from', async () => {
+    // A row recorded under a superseded key is already unapprovable, so
+    // counting it would overstate the loss — the count is a filter over the
+    // retention read, not its length. Both halves of the derivation are
+    // therefore load-bearing, and this pins the half the window cases cannot
+    // see: they would all pass with the predicate dropped.
+    await seedStraddlingFixture();
+    const current = loadOrCreateFingerprintKey(dir);
+    await seedBlocked(
+      { ...ledgerEntry(), reference: 'blk-old-key', keyVersion: current.version - 1 },
+      AGED_MS,
+    );
+
+    const props = await renderPage();
+
+    expect(props.approvableBlocked).toBe(1 + AGED.length);
+    // The row is retained and listed under the widest chip — invalidated, not
+    // deleted — so its absence from the count is the predicate at work rather
+    // than the row having aged out of the read.
+    const widest = await renderPage({ window: '24h' });
+    expect(
+      widest.blocked
+        .filter((b) => !isBlockedRowApprovable(b, widest.keyState))
+        .map((b) => b.reference),
+    ).toEqual(['blk-old-key']);
+  });
+
+  it('reports nothing approvable when the fingerprint key file is gone', async () => {
+    // No key means no row can be matched, so the note must claim no cost at
+    // all rather than a count the reader cannot act on. The page resolves the
+    // key defensively; this pins that an absent key reaches the count as zero
+    // instead of taking the route down.
+    await seedStraddlingFixture();
+    expect(readFingerprintKey(dir)).not.toBeNull();
+    rmSync(join(dir, 'exception.key'), { force: true });
+    // The removal is asserted through the reader rather than trusted: a
+    // renamed key file would otherwise leave this case deleting nothing and
+    // asserting a state the page never reaches.
+    expect(readFingerprintKey(dir)).toBeNull();
+
+    const props = await renderPage();
+
+    expect(props.keyState.status).toBe('absent');
+    expect(props.approvableBlocked).toBe(0);
+    // Still listed: the ledger is a record of what was blocked either way.
+    expect(props.blocked).toHaveLength(1);
+  });
+});

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -26,7 +26,15 @@ const noNetworkGuard = fileURLToPath(new URL('../test/setup/no-network.ts', impo
 //
 // `include` is pinned to test/ so `vitest run` never globs a built `.next/`
 // (left by any `next build`) into the run.
+//
+// `oxc.jsx` overrides tsconfig.json's `"jsx": "preserve"`, which Next requires
+// (its own compiler consumes the untransformed JSX) and which vitest otherwise
+// inherits — leaving JSX in the output for a parser that then rejects it. Any
+// test importing a page or a component fails at parse time without this, so a
+// route's data derivation could only be tested by reading its source as text.
+// It applies to `.tsx` alone; the suites that import no component are unchanged.
 export default defineConfig({
+  oxc: { jsx: { runtime: 'automatic' } },
   test: {
     setupFiles: [noNetworkGuard],
     environment: 'node',


### PR DESCRIPTION
The exceptions route reads the blocked-detections ledger **twice**, over two different windows, and which read feeds which consumer is the point:

- **the strip** — the lookback chip the user picked, 30 minutes by default
- **the rotate dialog** — the full retention window, because the confirmation has to name what a one-way action costs, and rotation invalidates every row in the ledger rather than the visible ones

Every piece of that was covered and the **wiring** was not. A count is just a number, so feeding the dialog the strip's read understates a destructive action by however many rows fell outside the chip — and it stayed green through the type checker, the linter and all 243 existing `web-ui` tests. The mutation that keeps both bindings live (transposing the two window arguments) passed all three together.

## Changes

- **`web-ui/test/pages/exceptions-page.test.ts`** (new) — drives the route directly. An async Server Component is a plain async function returning an element, so calling it and reading `element.props` needs no renderer and no DOM. Six cases against a real store, a real fingerprint key file and real ledger writes; only `homedir()` is redirected.
- **`web-ui/vitest.config.ts`** — `oxc.jsx` overrides `tsconfig.json`'s `"jsx": "preserve"` for the test run. Next needs that setting (its own compiler consumes untransformed JSX) and vitest inherits it, so any page or component import otherwise dies at parse, naming neither JSX nor the tsconfig.
- **`CLAUDE.md`** — a "Testing a web-ui page" section beside the Server Action harness, including the rule that a fixture straddling two windows has to pin the straddle itself.

## Why drive the page rather than extract the derivation

Extracting the count into `dashboard-ui`'s `meta.ts` would have moved the untested seam, not closed it: that package must not depend on `persistence` — which is why `LEDGER_WINDOW_HOURS` is a hand-mirrored literal there — so the *window choice* can never live beside the other derivations. Only the filter-and-count could move, and the page would still be free to hand it the wrong array.

## Verification

Four cases assert behaviour; two are controls that stop the others passing vacuously. `is a fixture the two windows disagree on` pins that the aged rows really do fall outside both chips the suite drives and inside retention — without it, both reads return the same list and every assertion holds whichever one the page used.

Five mutations on `page.tsx`, each diffed against a pristine copy first so a regex matching nothing is reported rather than read as the guard holding:

| Mutation | Result |
| --- | --- |
| dialog count taken from the chip read | 3 failed \| 3 passed |
| the two window reads transposed | 5 failed \| 1 passed |
| the approvable predicate dropped | 2 failed \| 4 passed |
| the strip read widened to retention | 4 failed \| 2 passed |
| the retention read narrowed to the chip | 3 failed \| 3 passed |

Tree reverted afterwards; `git diff` on `page.tsx` is empty — **no product code changed**, so no version bump.

Gates: `turbo run test --force` 29/29 with `Cached: 0`; `web-ui` 249 passed (was 243); `dashboard-ui` 182 passed; lint, typecheck and format clean.