### PR TITLE
test(eslint-config): match lint targets case-sensitively so the coverage guard tracks the shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,8 +422,11 @@ tools/                repo tooling: installer one-liners + the audit-gate worksp
    the root is named explicitly, not folded into a directory glob (the same rule
    step 5 draws inside a package). `*.config.*` is the standing lint target for root
    config and catches the root ESLint config and commitlint's; any other root
-   file is named by hand. A root file carrying `// @ts-check` (as `eslint.root.config.mjs`
-   does) is also named in `tsconfig.root.json`'s `include`, or the directive is
+   file is named by hand — including one whose `.config.` segment is capitalized,
+   since a shell glob is case-sensitive on every platform and `*.config.*` reaches
+   `aka.config.mjs` but not `aka.Config.mjs`. A root file carrying `// @ts-check`
+   (as `eslint.root.config.mjs` does) is also named in `tsconfig.root.json`'s
+   `include`, or the directive is
    decorative — nothing runs `tsc` over it and a real type error surfaces nowhere.
    Miss the pass and esbuild strips its types unchecked and nothing lints it.
 

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -311,6 +311,47 @@ function targetCoversDir(target, dir) {
   return dir === base || dir.startsWith(`${base}/`);
 }
 
+// --- Case: the matcher must answer the way the shell does --------------------
+//
+// Node's glob folds case on macOS and Windows and offers no way to turn it off.
+// matchGlobPattern sets `nocase: isMacOS || isWindows` with `nocaseMagicOnly:
+// true`, so a LITERAL pattern stays case-sensitive while a MAGIC one does not:
+// `matchesGlob('a.Config.mjs', '*.config.*')` is true on macOS and false on
+// Linux, and `globSync('*.config.*')` returns the mis-cased file there too. The
+// shell that expands a lint script's targets is case-sensitive on every
+// platform, so the file eslint actually receives is only ever the lower-cased
+// one. Left folded, the guard credits coverage the shell will not give, and a
+// root file one capital letter away from the target glob reads as linted while
+// nothing lints it — with the drift guard's own message inviting the reader to
+// pin it as expected.
+//
+// There is no option to pass, so the fold is removed by re-asking the same
+// matcher in an alphabet it cannot fold: each ASCII letter maps to a distinct
+// Private Use Area code point, which has no case mapping and is not a glob
+// metacharacter. The map is one character to one character, so `?` arity, `/`
+// separators, `**` crossing, ranges and brace lists all keep their exact
+// semantics — `[a-z]` maps to a range of the same width, and an upper-case
+// subject lands outside it the way it should.
+//
+// The raw match is kept as a conjunct so this can only ever be STRICTER than
+// Node: an encoding bug costs a loud "uncovered" failure, never a silent pass.
+const CASELESS_ALPHABET_BASE = 0xe000;
+
+const encodeCase = (s) =>
+  s.replace(/[A-Za-z]/g, (c) => {
+    const code = c.charCodeAt(0);
+    return String.fromCharCode(CASELESS_ALPHABET_BASE + (code >= 97 ? code - 97 : code - 65 + 26));
+  });
+
+/**
+ * `path.posix.matchesGlob` minus the case folding Node applies on macOS and
+ * Windows, so every platform answers the way the shell does.
+ * @param {string} file package-relative posix path
+ * @param {string} pattern
+ */
+const caseSensitiveMatchesGlob = (file, pattern) =>
+  posix.matchesGlob(file, pattern) && posix.matchesGlob(encodeCase(file), encodeCase(pattern));
+
 /**
  * Whether an eslint path target lints the package-relative file `file`. A target
  * covers it when it IS the file, when it is `.` or a directory the file sits
@@ -322,9 +363,10 @@ function targetCoversDir(target, dir) {
  * file that is the wrong question — it would let `*.config.*` vacuously "cover"
  * middleware.ts, which is exactly the uncovered-root-file case this bucket
  * exists to catch. So the glob is matched against the filename for real, via
- * path.posix.matchesGlob so a Windows checkout answers identically. A pattern
- * the matcher rejects counts as NOT covering: the guard then names the file as
- * uncovered, which is the side to fail on.
+ * caseSensitiveMatchesGlob: posix so a Windows checkout answers identically on
+ * separators, case-sensitive so macOS and Windows answer identically on case. A
+ * pattern the matcher rejects counts as NOT covering: the guard then names the
+ * file as uncovered, which is the side to fail on.
  * @param {string} target
  * @param {string} file package-relative posix path
  */
@@ -334,7 +376,7 @@ function targetCoversFile(target, file) {
   if (normalized === file) return true;
   if (file.startsWith(`${normalized}/`)) return true;
   try {
-    return posix.matchesGlob(file, normalized);
+    return caseSensitiveMatchesGlob(file, normalized);
   } catch {
     return false;
   }
@@ -354,10 +396,13 @@ function targetCoversFile(target, file) {
  * `file` from an eslint run. Mirrors targetCoversFile — the pattern is matched
  * against the filename for real rather than reduced to a literal prefix, so
  * `*.config.*` excludes vitest.config.ts and leaves middleware.ts alone, and
- * through path.posix.matchesGlob for the same reason: every subject reaching it
- * is posix (git's output is posix everywhere, and globSync's native output is
+ * through caseSensitiveMatchesGlob for the same reason: every subject reaching
+ * it is posix (git's output is posix everywhere, and globSync's native output is
  * normalized at the source above), so the posix matcher is the one that matches
- * the data's actual shape and a Windows checkout answers identically.
+ * the data's actual shape and a Windows checkout answers identically. Case is
+ * pinned for the matching reason on the other axis — eslint matches an ignore
+ * pattern case-sensitively on every platform, so a folded match here would
+ * report a file as skipped that eslint in fact lints.
  *
  * The bare `path.matchesGlob` would alias to win32 there, and the two disagree
  * on exactly one input: a subject containing a backslash. They diverge in BOTH
@@ -379,7 +424,7 @@ function ignoreExcludesFile(pattern, file) {
   if (normalized === file) return true;
   if (file.startsWith(`${normalized}/`)) return true;
   try {
-    return posix.matchesGlob(file, normalized);
+    return caseSensitiveMatchesGlob(file, normalized);
   } catch {
     return true;
   }
@@ -1630,6 +1675,37 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
     expect(targetCoversFile('*.config.*', 'src/a.config.ts')).toBe(false);
   });
 
+  it('matches case-sensitively, the way the shell that expands the target does', () => {
+    // A lint script's targets are expanded by the SHELL, which is case-sensitive
+    // on every platform, so `eslint *.config.*` only ever hands eslint the
+    // lower-cased file. A folded match credits coverage nothing gives: the file
+    // reads as linted and no pass lints it.
+    expect(targetCoversFile('*.config.*', 'a.Config.mjs')).toBe(false);
+    expect(targetCoversFile('*.config.*', 'A.CONFIG.MJS')).toBe(false);
+    expect(targetCoversFile('*.CONFIG.*', 'a.config.mjs')).toBe(false);
+    expect(targetCoversFile('**/*.TS', 'src/a.ts')).toBe(false);
+    // Positive control on the same patterns — without these the case above is
+    // satisfied by a predicate that stopped matching anything at all.
+    expect(targetCoversFile('*.config.*', 'a.config.mjs')).toBe(true);
+    expect(targetCoversFile('**/*.ts', 'src/a.ts')).toBe(true);
+    // A range maps to a range of the same width, so it narrows by case too.
+    expect(targetCoversFile('[a-z]*.ts', 'abc.ts')).toBe(true);
+    expect(targetCoversFile('[a-z]*.ts', 'Abc.ts')).toBe(false);
+    expect(targetCoversFile('[A-Z]*.ts', 'Abc.ts')).toBe(true);
+    expect(targetCoversFile('[A-Z]*.ts', 'abc.ts')).toBe(false);
+  });
+
+  it('does not inherit the raw matcher, which folds case on some hosts', () => {
+    // The positive control for the case above: on macOS and Windows the raw
+    // matcher answers the OPPOSITE, which is the defect targetCoversFile used to
+    // carry. Pinning the disagreement rather than a fixed value keeps this
+    // meaningful on both kinds of host, and turns a future Node that stops
+    // folding into a red test rather than a silently redundant workaround.
+    const rawFolds = posix.matchesGlob('a.Config.mjs', '*.config.*');
+    expect(rawFolds).toBe(process.platform === 'darwin' || process.platform === 'win32');
+    expect(targetCoversFile('*.config.*', 'a.Config.mjs')).toBe(false);
+  });
+
   it('accepts the real repo forms for top-level files', () => {
     // Targets only, as above — the ignore flags that subtract from them have
     // their own describe.
@@ -1711,6 +1787,16 @@ describe('ignore flags subtract from what an invocation covers', () => {
     // `*.config.*` does not reach middleware.ts, so it must stay covered — the
     // same asymmetry targetCoversFile draws, applied to the exclusion side.
     expect(covers('file', 'eslint . --ignore-pattern "*.config.*"', 'middleware.ts')).toBe(true);
+  });
+
+  it('matches an ignore glob case-sensitively, as eslint does', () => {
+    // eslint matches an ignore pattern case-sensitively on every platform. A
+    // folded match here reports a file as skipped that eslint in fact lints —
+    // the guard would name a covered file as uncovered and send someone to
+    // widen a pass that was already reaching it.
+    expect(covers('file', 'eslint . --ignore-pattern "*.config.*"', 'a.Config.mjs')).toBe(true);
+    // Positive control: the same ignore on the correctly-cased file still bites.
+    expect(covers('file', 'eslint . --ignore-pattern "*.config.*"', 'a.config.mjs')).toBe(false);
   });
 
   it('excludes a whole source dir, so lintNotWired can see it', () => {


### PR DESCRIPTION
## What

The lint-coverage guard decides whether a repo-root file is reached by a lint pass by matching that pass's targets with `path.posix.matchesGlob`. Node folds case there on macOS and Windows — `matchGlobPattern` sets `nocase: isMacOS || isWindows` with `nocaseMagicOnly: true`, and there is no option to turn it off — while the shell that actually expands `eslint *.config.*` is case-sensitive on every platform.

So a wildcard target was credited with covering a file the shell never hands eslint. A tracked repo-root `aka.Config.mjs` holding a live `fetch()` left `pnpm lint` at EXIT=0 while the guard reported full coverage — and the guard's own failure message invites the reader to pin exactly such a file as expected.

Linux CI answers case-sensitively, so this was a local false green rather than a shipping hole. But making the answer platform-independent is the guard's job, and the comment that pinned `posix.matchesGlob` over the bare `path.matchesGlob` had reasoned carefully about separators while leaving case host-dependent.

## Changes

- **`caseSensitiveMatchesGlob`**, used by both `targetCoversFile` and `ignoreExcludesFile`. `path.matchesGlob` takes no options object (it silently ignores a third argument), so the fold is removed by re-asking the same matcher in an alphabet it cannot fold: each ASCII letter maps to a distinct Private Use Area code point. The map is **one character to one character**, which is what keeps `?` arity, `/` separators, `**` crossing, `[a-z]` ranges and brace lists exact — a range maps to a range of the same width. The raw match is kept as a conjunct, so the result can only ever be *stricter* than Node: an encoding bug costs a loud "uncovered" failure, never a silent pass.
- **Three tests** — case behaviour on the target side (with positive controls, and ranges), a check that the raw matcher still folds where Node documents it does, and the ignore side.
- **CLAUDE.md** records that a shell glob is case-sensitive, so `*.config.*` reaches `aka.config.mjs` but not `aka.Config.mjs`.

## Verification

- Baseline 635 tests → **638**. Reverting the two call sites turns **exactly the three new tests** red.
- End to end, with a tracked `aka.Config.mjs` holding a live `fetch()` and pinned in `EXPECTED_NON_PACKAGE_FILES` as the guard's own message instructs: the coverage check **passes with the fix reverted** and **fails with it present**, while `pnpm lint` stays EXIT=0 either way — so the failing verdict is the truthful one.
- `ignoreExcludesFile` was only changed after confirming against eslint itself that `--ignore-pattern` is case-sensitive: with a positive control, `*.config.*` excluded `b.config.mjs` and left `a.Config.mjs` reporting. Case-sensitive there models eslint rather than weakening the guard.
- `pnpm exec turbo run test --force` → **29/29, `Cached: 0`**. `lint`, `typecheck`, `format:check` all EXIT=0.

Test and docs only — no product source, so no version bump.

## Follow-ups, not included here

- Nothing asserts that adding a repo-root file actually **moves** the `@akasecurity/eslint-config#test` turbo hash. The extension list is checked; the hash movement is measured by hand. If it ever stops moving, turbo replays a cached green in which this check never ran.
- `pnpm lint` is ubuntu-only in CI, so whether `*.config.*` expands under `cmd.exe` is still unobserved.
