### PR TITLE
feat(cli): disclose the blocked-ledger cost before a key rotation

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -5,8 +5,10 @@ import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
 import type { BlockedDetection, LocalDatabase } from '@akasecurity/persistence';
 import type { CreateExceptionInput } from '@akasecurity/persistence';
 import {
+  BLOCKED_DETECTIONS_RETENTION_MS,
   createKeyProvider,
   keysDir,
+  keyStateOf,
   openLocalDatabase,
   readWorkspaceSettings,
   SecretVault,
@@ -21,12 +23,14 @@ import {
   registerBundledPacks,
   rotateFingerprintKey,
 } from '@akasecurity/plugin-sdk';
-import type { DetectionException, ResolvedScope } from '@akasecurity/schema';
+import type { DetectionException, FingerprintKeyState, ResolvedScope } from '@akasecurity/schema';
 import {
   DetectionCategory,
+  isMatchableUnder,
   isVaultConsentValid,
   PointerToken,
   resolveScopeFlags,
+  rotationBlockedLedgerNote,
   scopeFromAnswer,
 } from '@akasecurity/schema';
 
@@ -904,6 +908,34 @@ async function runRevoke(argv: string[], io: Prompter): Promise<void> {
   }
 }
 
+/**
+ * Blocked-ledger rows a rotation would take something from: the ones still
+ * matchable under the CURRENT key.
+ *
+ * Two choices here are load-bearing and are what the rotate disclosure rests on.
+ * The window is the ledger's whole RETENTION (a day), not `recentBlocked`'s
+ * 30-minute default — the default is the `approve` picker's lookback, and
+ * counting a one-way action's cost over it would understate it by the better
+ * part of a day. And a row recorded under an older key (or under one that is
+ * now missing or unreadable) is already unapprovable, so counting it would
+ * overstate the loss; `isMatchableUnder` is the same predicate every approve
+ * surface refuses on, so the number and the rows a user can act on agree.
+ *
+ * An unreadable key is not a reason to fail the rotation — it yields zero,
+ * which is true: nothing can be matched right now either way.
+ */
+async function countApprovableBlocked(db: LocalDatabase, dir: string): Promise<number> {
+  const key = ((): FingerprintKeyState => {
+    try {
+      return keyStateOf(readFingerprintKey(dir));
+    } catch {
+      return { status: 'unreadable' };
+    }
+  })();
+  const rows = await db.exceptions.recentBlocked(BLOCKED_DETECTIONS_RETENTION_MS);
+  return rows.filter((row) => isMatchableUnder(row.keyVersion, key)).length;
+}
+
 async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
   const { values } = parseArgs({
     args: argv,
@@ -926,6 +958,16 @@ async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
         io.out(`  ${shortId(ex.id)}  ${ex.ruleId}  ${ex.maskedValue}\n`);
       }
     }
+    // The grants above are only half of what rotation invalidates: the
+    // blocked-detections ledger holds keyed fingerprints too, is retained a day,
+    // and so routinely outlives a rotation. Stated UNCONDITIONALLY, count or no
+    // count — the ledger refills within minutes, so a caveat shown only
+    // sometimes reads as one that only sometimes applies. Same sentence the
+    // dashboard's rotate dialog shows, from the one copy in @akasecurity/schema.
+    // Its own paragraph, and left for the terminal to wrap: the dialog gives it
+    // a panel of its own, and run together with the grant list above it reads as
+    // a footnote to that list rather than the second thing rotation invalidates.
+    io.out(`\n${rotationBlockedLedgerNote(await countApprovableBlocked(db, dir))}\n\n`);
     if (values.yes !== true) {
       if (!io.isInteractive) {
         throw new Error('pass --yes to rotate non-interactively');

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -1,10 +1,11 @@
 import { chmodSync, mkdtempSync, readFileSync, rmSync, truncateSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import { getLoadedRules, maskMatch } from '@akasecurity/detections';
 import type { LocalDatabase } from '@akasecurity/persistence';
-import { openLocalDatabase } from '@akasecurity/persistence';
+import { BLOCKED_DETECTIONS_RETENTION_MS, openLocalDatabase } from '@akasecurity/persistence';
 import type { DataGateway } from '@akasecurity/plugin-sdk';
 import {
   createPluginRuntime,
@@ -16,7 +17,11 @@ import {
   rotateFingerprintKey,
 } from '@akasecurity/plugin-sdk';
 import type { DetectionException } from '@akasecurity/schema';
-import { defaultWorkspaceSettings } from '@akasecurity/schema';
+import {
+  defaultWorkspaceSettings,
+  LEDGER_WINDOW_HOURS,
+  rotationBlockedLedgerNote,
+} from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { runException } from '../../src/commands/exception.ts';
@@ -926,5 +931,227 @@ describe('aka exception list / revoke', () => {
     // The list is metadata-only even for reveal grants — masked, never raw.
     expectNoEchoOf(out, VALUE);
     expectNoEchoOf(out, OTHER_VALUE);
+  });
+});
+
+// Rotation is one-way, and the two stores holding GRANTABLE fingerprints are
+// the permanent grants and the blocked-detections ledger. This command listed
+// the first and said nothing about the second, while the dashboard's rotate
+// dialog disclosed both — two surfaces stating different costs for the same
+// irreversible action, and this is the one that runs unattended under `--yes`.
+//
+// The ledger half is the easy one to miss precisely because it degrades so
+// politely: those rows go on appearing under `aka exception approve`
+// afterwards, correctly refused, which is a worse place to learn it than in the
+// confirmation.
+describe('aka exception rotate-key — the cost it discloses before committing', () => {
+  // Seeds a ledger row under whatever key is current, the way the enforcement
+  // path writes one.
+  async function seedBlocked(reference: string): Promise<void> {
+    const key = loadOrCreateFingerprintKey(dir);
+    const db = openLocalDatabase(dir);
+    try {
+      await db.exceptions.recordBlocked({
+        reference,
+        ruleId: RULE_ID,
+        category: 'secret',
+        valueFingerprint: fingerprintValue(key, VALUE),
+        keyVersion: key.version,
+        maskedValue: maskMatch(VALUE),
+        sessionId: 'sess-rotate',
+        repo: null,
+      });
+    } finally {
+      db.close();
+    }
+  }
+
+  // `recordBlocked` stamps `blocked_at` with the wall clock, so ageing a row is
+  // the one thing the repository API cannot express. Written straight to the
+  // real store rather than by mocking a clock — the property under test is
+  // which WINDOW the command reads over, and a faked clock would move the
+  // command's cutoff along with the row and assert nothing.
+  function backdate(reference: string, ageMs: number): void {
+    const raw = new DatabaseSync(join(dir, 'aka.db'));
+    try {
+      const changes = raw
+        .prepare('UPDATE blocked_detections SET blocked_at = ? WHERE reference = ?')
+        .run(Date.now() - ageMs, reference).changes;
+      // An UPDATE matching nothing exits happily and would leave the row at
+      // `now`, where the assertion below passes for the wrong reason.
+      expect(Number(changes)).toBe(1);
+    } finally {
+      raw.close();
+    }
+  }
+
+  // Interactive prompter that also captures what had ALREADY been printed at
+  // the moment the confirm prompt was asked. `interactiveIo` above records the
+  // questions and the output separately, so it cannot tell a disclosure made
+  // before the decision from one made after it — which is the whole property
+  // here, not an incidental detail of layout.
+  function confirmIo(answer: string): Prompter & {
+    output: () => string;
+    printedBeforePrompt: () => string | null;
+  } {
+    const chunks: string[] = [];
+    let atPrompt: string | null = null;
+    return {
+      output: () => chunks.join(''),
+      printedBeforePrompt: () => atPrompt,
+      out: (text) => {
+        chunks.push(text);
+      },
+      err: (text) => {
+        chunks.push(text);
+      },
+      isInteractive: true,
+      ask: () => {
+        atPrompt = chunks.join('');
+        return Promise.resolve(answer);
+      },
+      askHidden: () => Promise.reject(new Error('no hidden prompt expected')),
+      readAllStdin: () => Promise.resolve(''),
+    };
+  }
+
+  function keyVersion(): number | undefined {
+    return readFingerprintKey(dir)?.version;
+  }
+
+  it('states the ledger cost under --yes, which skips the prompt but not the preamble', async () => {
+    await seedBlocked('a11ce5');
+
+    const io = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], io);
+
+    const out = io.output();
+    expect(out).toContain('invalidates EVERY existing exception grant');
+    expect(out).toContain(rotationBlockedLedgerNote(1));
+    // The unattended path is the one that most needs the disclosure and the
+    // least likely to be read, so pin that it really rotated — a version still
+    // at 1 would mean this asserted the copy on a run that did nothing.
+    expect(keyVersion()).toBe(2);
+  });
+
+  it('states it before the confirm prompt, not after the decision', async () => {
+    await seedBlocked('b22dee');
+
+    const io = confirmIo('n');
+    await runException(['rotate-key', '--home', home], io);
+
+    // Printed by the time the user was asked — "tell them before, not after" is
+    // the entire point, and a note emitted after the answer is worth nothing.
+    expect(io.printedBeforePrompt()).toContain(rotationBlockedLedgerNote(1));
+    expect(io.output()).toContain('Aborted — key unchanged.');
+    expect(keyVersion()).toBe(1);
+  });
+
+  it('counts over the ledger retention window, not the approve picker default', async () => {
+    // Two hours old: outside `recentBlocked`'s 30-minute default — which is the
+    // `aka exception approve` picker's lookback, not a retention bound — and
+    // well inside the day the ledger is actually kept for. A count taken over
+    // the default would report nothing here and understate a one-way action by
+    // the better part of a day.
+    await seedBlocked('c33fff');
+    backdate('c33fff', 2 * 60 * 60_000);
+
+    const io = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], io);
+
+    expect(io.output()).toContain(rotationBlockedLedgerNote(1));
+  });
+
+  it('counts only the rows still matchable under the current key', async () => {
+    await seedBlocked('d44aaa');
+    const rotated = rotateFingerprintKey(dir);
+    expect(rotated.version).toBe(2);
+    // Recorded under the key that is now current — the positive control. Without
+    // it a zero would be indistinguishable from a reader that finds nothing.
+    await seedBlocked('e55bbb');
+
+    const io = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], io);
+
+    const out = io.output();
+    // Two rows in the ledger, one of them already unapprovable because it was
+    // blocked under v1. Counting both would overstate what THIS rotation costs.
+    expect(out).toContain(rotationBlockedLedgerNote(1));
+    expect(out).not.toContain(rotationBlockedLedgerNote(2));
+  });
+
+  it('states the caveat with nothing approvable, on both paths', async () => {
+    // The ledger refills within minutes of a rotation, so a note shown only
+    // when the count is non-zero reads as a caveat that only sometimes applies.
+    // Asserted on both paths because they print through different branches.
+    const zero = rotationBlockedLedgerNote(0);
+
+    const interactive = confirmIo('n');
+    await runException(['rotate-key', '--home', home], interactive);
+    expect(interactive.output()).toContain(zero);
+
+    const unattended = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], unattended);
+    expect(unattended.output()).toContain(zero);
+  });
+
+  it('lists the permanent grants and the ledger cost together, without the value', async () => {
+    // `--yes` stands in for the retype a permanent grant asks for on a
+    // terminal; this suite is non-interactive.
+    await runException(
+      [
+        'add',
+        '--home',
+        home,
+        '--rule',
+        RULE_ID,
+        '--stdin',
+        '--permanent',
+        '--reason',
+        'pinned',
+        '--yes',
+      ],
+      scriptedIo(`${VALUE}\n`),
+    );
+    await seedBlocked('f66ccc');
+
+    const io = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], io);
+
+    const out = io.output();
+    // Both halves of what rotation invalidates, in the order the dashboard
+    // dialog shows them: the grants that stop applying, then the ledger rows
+    // that stop being approvable.
+    const grants = out.indexOf('Active PERMANENT exceptions');
+    const ledger = out.indexOf(rotationBlockedLedgerNote(1));
+    expect(grants).toBeGreaterThanOrEqual(0);
+    expect(ledger).toBeGreaterThan(grants);
+    // Everything here is metadata and masked previews; the raw value has no
+    // business on a screen that is only naming what stops working.
+    expectNoEchoOf(out, VALUE);
+  });
+
+  it('prints the dashboard dialog’s own sentence rather than a second copy', async () => {
+    // `rotationBlockedLedgerNote` is exported from @akasecurity/schema and
+    // re-exported by @akasecurity/dashboard-ui, so this command and the rotate
+    // dialog cannot word the same disclosure differently. Asserted against the
+    // shared function itself — a literal here would be the duplicate the shared
+    // helper exists to prevent, and would go green while the two drifted apart.
+    await seedBlocked('077ddd');
+
+    const io = scriptedIo();
+    await runException(['rotate-key', '--home', home, '--yes'], io);
+
+    expect(io.output()).toContain(rotationBlockedLedgerNote(1));
+  });
+
+  it('names a window that matches the one the count is actually taken over', () => {
+    // The sentence hard-codes 24 hours; the read passes
+    // BLOCKED_DETECTIONS_RETENTION_MS. @akasecurity/schema cannot import the
+    // authority (persistence depends on schema, not the reverse), so the two
+    // are pinned here — at the consumer that holds both. Widen the retention
+    // and this goes red rather than the copy quietly describing a window the
+    // count no longer spans.
+    expect(LEDGER_WINDOW_HOURS * 60 * 60 * 1000).toBe(BLOCKED_DETECTIONS_RETENTION_MS);
   });
 });

--- a/packages/dashboard-ui/src/exceptions/meta.ts
+++ b/packages/dashboard-ui/src/exceptions/meta.ts
@@ -9,6 +9,13 @@ import type {
 import { isMatchableUnder } from '@akasecurity/schema';
 import type { BadgeProps } from '@akasecurity/ui-kit';
 
+// The rotate-key disclosure is stated by two surfaces — this package's
+// RotateKeyDialog and `aka exception rotate-key` — so it lives in the one
+// package both may import, beside the `isMatchableUnder` predicate its count is
+// taken with. Re-exported rather than restated: a copy here is how the CLI and
+// the dashboard come to disclose different costs for the same one-way action.
+export { LEDGER_WINDOW_HOURS, rotationBlockedLedgerNote } from '@akasecurity/schema';
+
 export type Tone = NonNullable<BadgeProps['variant']>;
 
 // Derived exception lifecycle state — NEVER stored (mirrors the persistence
@@ -63,52 +70,6 @@ export function blockedRowBlockReason(
     default:
       return `Recorded under fingerprint key v${String(row.keyVersion)}; the key is now v${String(key.version)}, so a grant from it could never match. Trigger the detection again.`;
   }
-}
-
-/**
- * The blocked-ledger retention window, in hours, as the rotate note names it.
- *
- * The count the note carries is taken over the ledger's whole retention window,
- * while the strip behind the dialog shows whichever lookback chip is selected —
- * 30 minutes by default. So the number routinely exceeds what is on screen, and
- * a reader who cannot reconcile the two has been given a figure they cannot
- * trust. Naming the window is what makes it reconcilable.
- *
- * The authority is BLOCKED_DETECTIONS_RETENTION_MS in @akasecurity/persistence,
- * which this package does not depend on and must not. Hosts that have both pin
- * them together instead.
- */
-export const LEDGER_WINDOW_HOURS = 24;
-
-/**
- * What a key rotation costs the blocked-detections ledger, as a line the rotate
- * dialog shows before the user commits.
- *
- * The ledger is retained for a day, so it routinely outlives a rotation, and
- * every row in it carries a fingerprint recorded under the key that was current
- * when the detection was blocked. After rotating, none of them can be turned
- * into a grant. The rows are not removed — they stay as a record of what was
- * blocked — and the server-side refusal is the actual control; this is the
- * "tell them before, not after" half.
- *
- * `stillApprovable` counts the rows matchable under the CURRENT key — the same
- * predicate the strip disables its Approve button on, so the dialog's number
- * and the buttons the user can see agree. That is also its limit: like the
- * strip, it counts a row whose grant is already active, because neither models
- * grant state.
- */
-export function rotationBlockedLedgerNote(stillApprovable: number): string {
-  if (stillApprovable <= 0) {
-    // No number, so no window to name — this variant claims nothing the reader
-    // could try to reconcile with the strip behind the dialog.
-    return 'Recently blocked detections are invalidated too: the ledger outlives a rotation, so its rows stay listed as a record of what was blocked but stop being approvable. Trigger the detection again to approve it under the new key.';
-  }
-  const window = `from the last ${String(LEDGER_WINDOW_HOURS)} hours`;
-  const subject =
-    stillApprovable === 1
-      ? `1 recently blocked detection ${window} is still approvable; after rotating, none are`
-      : `${String(stillApprovable)} recently blocked detections ${window} are still approvable; after rotating, none are`;
-  return `${subject}. They stay listed as a record of what was blocked — trigger the detection again to approve under the new key.`;
 }
 
 export const STATE_TONE: Record<ExceptionState, Tone> = {

--- a/packages/dashboard-ui/test/exceptions/meta.test.ts
+++ b/packages/dashboard-ui/test/exceptions/meta.test.ts
@@ -3,7 +3,12 @@ import type {
   ExceptionDescriptor,
   FingerprintKeyState,
 } from '@akasecurity/schema';
-import { isMatchableUnder, toExceptionDescriptor } from '@akasecurity/schema';
+import {
+  isMatchableUnder,
+  LEDGER_WINDOW_HOURS as SCHEMA_LEDGER_WINDOW_HOURS,
+  rotationBlockedLedgerNote as schemaRotationBlockedLedgerNote,
+  toExceptionDescriptor,
+} from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -174,6 +179,20 @@ describe('rotationBlockedLedgerNote', () => {
   // it would not run at all. Keeping the sentence in meta.ts is what makes it
   // reachable — the dialog holds no copy of its own to drift from.
   const CASES = [0, 1, 2, 17];
+
+  // The sentence itself lives in @akasecurity/schema, beside the
+  // isMatchableUnder predicate its count is taken with, because TWO surfaces
+  // disclose this one-way action's cost — this dialog and
+  // `aka exception rotate-key` — and cli cannot import this package's view
+  // tree. What meta.ts exports has to stay that same function rather than a
+  // copy that happens to read alike today: identity is what a reintroduced
+  // local definition fails on, where an equal-output assertion would pass right
+  // up until someone edited one of the two. The window constant travels with
+  // it, since a forked note would fork the number it names.
+  it('re-exports the shared copy rather than restating it', () => {
+    expect(rotationBlockedLedgerNote).toBe(schemaRotationBlockedLedgerNote);
+    expect(LEDGER_WINDOW_HOURS).toBe(SCHEMA_LEDGER_WINDOW_HOURS);
+  });
 
   it.each(CASES)('names the blocked ledger and the way back, at %i approvable', (count) => {
     const note = rotationBlockedLedgerNote(count);

--- a/packages/schema/src/zod/exception.ts
+++ b/packages/schema/src/zod/exception.ts
@@ -191,3 +191,54 @@ export type FingerprintKeyState =
 export function isMatchableUnder(keyVersion: number, key: FingerprintKeyState): boolean {
   return key.status === 'present' && key.version === keyVersion;
 }
+
+/**
+ * The blocked-ledger retention window, in hours, as the rotate note names it.
+ *
+ * The count the note carries is taken over the ledger's whole retention window,
+ * while the dashboard strip behind the dialog shows whichever lookback chip is
+ * selected — 30 minutes by default. So the number routinely exceeds what is on
+ * screen, and a reader who cannot reconcile the two has been given a figure
+ * they cannot trust. Naming the window is what makes it reconcilable.
+ *
+ * The authority is BLOCKED_DETECTIONS_RETENTION_MS in @akasecurity/persistence,
+ * which this package does not depend on and must not — persistence depends on
+ * this one. Hosts that have both pin them together instead.
+ */
+export const LEDGER_WINDOW_HOURS = 24;
+
+/**
+ * What a key rotation costs the blocked-detections ledger, as a line the rotate
+ * surfaces show before the user commits.
+ *
+ * The ledger is retained for a day, so it routinely outlives a rotation, and
+ * every row in it carries a fingerprint recorded under the key that was current
+ * when the detection was blocked. After rotating, none of them can be turned
+ * into a grant. The rows are not removed — they stay as a record of what was
+ * blocked — and the server-side refusal is the actual control; this is the
+ * "tell them before, not after" half.
+ *
+ * `stillApprovable` counts the rows matchable under the CURRENT key — the same
+ * predicate every approve surface gates on, so the number and the rows a user
+ * can act on agree. That is also its limit: like the dashboard strip, it counts
+ * a row whose grant is already active, because neither models grant state.
+ *
+ * It lives here, beside `isMatchableUnder`, for the same reason that predicate
+ * does: `aka exception rotate-key` and the dashboard's rotate dialog disclose
+ * the cost of one irreversible action, and a second copy is how two surfaces
+ * come to state different costs for it. @akasecurity/dashboard-ui re-exports it
+ * so the views keep their existing import.
+ */
+export function rotationBlockedLedgerNote(stillApprovable: number): string {
+  if (stillApprovable <= 0) {
+    // No number, so no window to name — this variant claims nothing the reader
+    // could try to reconcile with the rows in front of them.
+    return 'Recently blocked detections are invalidated too: the ledger outlives a rotation, so its rows stay listed as a record of what was blocked but stop being approvable. Trigger the detection again to approve it under the new key.';
+  }
+  const window = `from the last ${String(LEDGER_WINDOW_HOURS)} hours`;
+  const subject =
+    stillApprovable === 1
+      ? `1 recently blocked detection ${window} is still approvable; after rotating, none are`
+      : `${String(stillApprovable)} recently blocked detections ${window} are still approvable; after rotating, none are`;
+  return `${subject}. They stay listed as a record of what was blocked — trigger the detection again to approve under the new key.`;
+}


### PR DESCRIPTION
## Summary

Rotating the exception fingerprint key is one-way — fingerprints cannot be re-keyed
because raw values are never stored, so everything recorded under the old key simply
stops matching. Two stores hold fingerprints a user can still act on: the permanent
grants, and the blocked-detections ledger.

The web rotate dialog names both before the user commits. `aka exception rotate-key`
named only the grants, so the same irreversible action disclosed a different cost
depending on the surface — and the CLI is the one that runs unattended under `--yes`.

The ledger half is the easy one to miss because it degrades politely: those rows keep
appearing afterwards, correctly refused, which is a worse place to learn it than in the
confirmation.

## Changes

- **`aka exception rotate-key` states the ledger cost before the confirm prompt** — that
  blocked-ledger rows awaiting approval stop being approvable too, and how many are still
  approvable under the current key. Counted over the ledger's **full retention window**
  (`BLOCKED_DETECTIONS_RETENTION_MS`), not `recentBlocked`'s 30-minute default, which is
  the approve picker's lookback and would understate a one-way action by most of a day.
  Rows already keyed to a rotated-away version are excluded, so the number and the rows a
  user can act on agree.
- **The copy moved to `@akasecurity/schema`**, beside `isMatchableUnder` — the predicate
  the count is taken with, which already lives there for the same stated reason ("a second
  copy is how the server and the UI come to disagree"). `@akasecurity/dashboard-ui`
  re-exports it, so every existing import resolves unchanged.
- **Stated unconditionally, including at zero** — the ledger refills within minutes of a
  rotation, so a caveat shown only sometimes reads as one that only sometimes applies.
- **`runRotateKey` had no test coverage at all.** Eight tests now cover it.

## Verification

`typecheck` + `lint` 30/30 · `test` 29/29 · `build` 15/15 · `format:check` clean ·
`lint:root` + `typecheck:root` clean — all run with `--force`, `Cached: 0`.

Every new test was mutation-checked; each mutation killed exactly its target and nothing
else:

| Mutation | Killed |
| --- | --- |
| Delete the disclosure | 7 of 8 (survivor is the constant pin, correctly) |
| `recentBlocked()` instead of the retention window | the window test |
| Count all rows, drop the key filter | the matchability test |
| Gate the note on `count > 0` | the zero test |
| Move the note after the confirm prompt | ordering + zero |
| Byte-identical fork of the copy in `dashboard-ui` | the identity pin |
| Widen `BLOCKED_DETECTIONS_RETENTION_MS` to 48h | the window pin |

The fork case is why the `dashboard-ui` pin asserts **identity** rather than equal output:
a verbatim copy produces an identical string, so only `toBe` catches it.

## Notes for review

- **No version bump.** Per the release rules this is the maintainer's call. For the record,
  the new copy lands in `cli/dist/cli.js` but appears in **no** plugin script — it is
  tree-shaken out — so only `cli` would need a bump on publish.
- The note is printed as its own paragraph and left for the terminal to soft-wrap. Run
  together with the grant list above it, it read as a footnote to that list rather than as
  the second thing a rotation invalidates.
- `CLAUDE.md`'s package graph does not list the `cli → dashboard-ui` edge that exists today
  (`cli/src/tui/report.ts` imports the `/recommendations` subpath). Left alone here —
  whether that edge is sanctioned or accidental is an architectural call, not a doc typo.
- Unrelated to this diff: `RotateKeyDialog`'s own docstring notes that
  `inspection_findings.finding_key` is derived from the same fingerprint, so a rotation
  moves it and a later re-scan can record a still-live secret as fixed at source. That is a
  write side effect neither surface discloses, and it is out of scope here.