### PR TITLE
fix(vault): keep the fingerprint key off every read-only path

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -469,7 +469,6 @@ async function runApproveReveal(
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings(base).vaultKeyCustody, keysDir(base)),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       // Read live so a consent revocation applies to the very next call.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
     });
@@ -960,7 +959,6 @@ async function runRotateKey(argv: string[], io: Prompter): Promise<void> {
       const vault = new SecretVault({
         repo: db.secretVault,
         keys: createKeyProvider(readWorkspaceSettings(base).vaultKeyCustody, keysDir(base)),
-        fingerprintKey: next,
         isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
       });
       const refreshed = await vault.refreshFingerprints(next);

--- a/cli/src/commands/vault.ts
+++ b/cli/src/commands/vault.ts
@@ -4,7 +4,6 @@ import {
   createKeyProvider,
   dataDir,
   keysDir,
-  loadOrCreateFingerprintKey,
   openLocalDatabase,
   readWorkspaceSettings,
   SecretVault,
@@ -73,7 +72,6 @@ async function runShow(argv: string[], io: Prompter): Promise<void> {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings(base).vaultKeyCustody, keysDir(base)),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       // Read live so a consent revocation applies to the very next call.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
     });

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -6,6 +6,7 @@ import {
   applyOnboarding,
   createKeyProvider,
   dataDir,
+  EXCEPTION_KEY_FILENAME,
   fingerprintValue,
   keysDir,
   loadOrCreateFingerprintKey,
@@ -85,14 +86,17 @@ async function seedPointer(): Promise<string> {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings(home).vaultKeyCustody, keysDir(home)),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(home).vaultConsent),
     });
-    const pointer = await vault.tokenize(RAW, {
-      ruleId: RULE_ID,
-      category: 'secret',
-      maskedMatch: MASKED,
-    });
+    const pointer = await vault.tokenize(
+      RAW,
+      {
+        ruleId: RULE_ID,
+        category: 'secret',
+        maskedMatch: MASKED,
+      },
+      () => loadOrCreateFingerprintKey(dir),
+    );
     if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
     return pointer;
   } finally {
@@ -325,6 +329,88 @@ describe('aka exception approve <pointer> --reveal', () => {
       } finally {
         db.close();
       }
+    });
+  });
+
+  // Approving a reveal reads: the grant's identity is the vault ROW's triple,
+  // which the row carries, so nothing here needs the key that is current now.
+  // The command must therefore leave the store's key footprint as it found it.
+  describe('fingerprint key footprint', () => {
+    const keyFile = (): string => join(dataDir(home), EXCEPTION_KEY_FILENAME);
+
+    it('mints nothing when approving a reveal on a store with no key', async () => {
+      const pointer = await seedPointer();
+      const rowKey = loadOrCreateFingerprintKey(dataDir(home));
+      // Seeding tokenized, which mints legitimately. Take the key away exactly
+      // as the CLI's own corrupt-key guidance tells an operator to.
+      rmSync(keyFile());
+
+      await runException(
+        approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'no key on this store'),
+        scriptedIo(),
+      );
+
+      // Positive control: the grant was really minted, from the row's own
+      // identity, with no key file in existence at any point above. Without
+      // this the absence below would also hold for a command that refused.
+      const grant = (await openAndList())[0];
+      if (!grant) throw new Error('grant row missing — the reveal approve was refused');
+      expect(grant.capability).toBe('reveal_to_model');
+      expect(grant.valueFingerprint).toBe(fingerprintValue(rowKey, RAW));
+      expect(grant.keyVersion).toBe(rowKey.version);
+
+      expect(existsSync(keyFile())).toBe(false);
+    });
+
+    // The diagnostic this protects. `keyAccessHint` tells an operator holding a
+    // corrupt key to delete it and start fresh. If a reveal in between put a
+    // key back, a later ledger approve would read a version that is merely
+    // NEWER than the row's and report a rotation — sending the operator after a
+    // rotation nobody performed. With nothing re-minting, the same state
+    // reports the truth: the key is gone.
+    it('leaves a later ledger approve reporting the key as missing, not rotated', async () => {
+      const rowKey = loadOrCreateFingerprintKey(dataDir(home));
+      const pointer = await seedPointer();
+      const db = openLocalDatabase(dataDir(home));
+      try {
+        await db.exceptions.recordBlocked({
+          reference: '9c4e17',
+          ruleId: RULE_ID,
+          category: 'secret',
+          valueFingerprint: fingerprintValue(rowKey, RAW),
+          keyVersion: rowKey.version,
+          maskedValue: MASKED,
+          sessionId: 'sess-1',
+          repo: null,
+        });
+      } finally {
+        db.close();
+      }
+
+      rmSync(keyFile());
+      // The reveal is the step that used to re-mint. Everything after it is the
+      // observation.
+      await runException(
+        approveArgs(pointer, '--reveal', '--for', '1h', '--reason', 'reveal before the approve'),
+        scriptedIo(),
+      );
+
+      const io = scriptedIo();
+      const err = await runException(approveArgs('9c4e17', '--once', '--reason', 'x'), io).then(
+        () => undefined,
+        (e: unknown) => e as Error,
+      );
+      // Captured outside its own catch: a command that stopped refusing arrives
+      // here as undefined rather than as a passing absence assertion.
+      expect(err).toBeDefined();
+      // Naming the branch is the point — the two refusals differ only in their
+      // explanation, so asserting merely that SOME error was raised would hold
+      // for the wrong one just as well.
+      expect(err?.message).toContain('the fingerprint key file is missing');
+      // The version-mismatch branch, spelled as it spells itself. A re-mint
+      // makes it fire with a version the row never saw.
+      expect(err?.message).not.toContain('and the key is now v');
+      expect(existsSync(keyFile())).toBe(false);
     });
   });
 });

--- a/cli/test/commands/vault.test.ts
+++ b/cli/test/commands/vault.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -8,6 +8,7 @@ import {
   createKeyProvider,
   dataDir,
   dbPath,
+  EXCEPTION_KEY_FILENAME,
   keysDir,
   loadOrCreateFingerprintKey,
   openLocalDatabase,
@@ -75,14 +76,17 @@ async function seedPointer(): Promise<string> {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings(home).vaultKeyCustody, keysDir(home)),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(home).vaultConsent),
     });
-    const pointer = await vault.tokenize(RAW, {
-      ruleId: 'secrets/test-rule',
-      category: 'secret',
-      maskedMatch: 'vau…est',
-    });
+    const pointer = await vault.tokenize(
+      RAW,
+      {
+        ruleId: 'secrets/test-rule',
+        category: 'secret',
+        maskedMatch: 'vau…est',
+      },
+      () => loadOrCreateFingerprintKey(dir),
+    );
     if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
     return pointer;
   } finally {
@@ -160,5 +164,26 @@ describe('aka vault show', () => {
     const io = scriptedIo();
     await runVault([], io);
     expect(io.output()).toContain('aka vault show');
+  });
+
+  // A reveal reads. The fingerprint key is a different key from the vault's —
+  // it keys the exception ledger, and opening a stored value never consults it
+  // — so a reveal on a store without one must resolve normally and leave the
+  // store's key footprint exactly as it found it.
+  it('mints no fingerprint key', async () => {
+    const pointer = await seedPointer();
+    // Seeding tokenized, which mints legitimately. Remove the key exactly as
+    // the CLI's own corrupt-key guidance tells an operator to, so what the
+    // reveal does next is the only thing under test.
+    const keyFile = join(dataDir(home), EXCEPTION_KEY_FILENAME);
+    rmSync(keyFile);
+
+    const io = scriptedIo();
+    await runVault(['show', pointer, '--home', home], io);
+
+    // Positive control: the reveal really ran. Without it the absence below
+    // would also hold for a command that failed before reaching the vault.
+    expect(io.output().startsWith(`${RAW}\n`)).toBe(true);
+    expect(existsSync(keyFile)).toBe(false);
   });
 });

--- a/packages/persistence/src/vault/vault.ts
+++ b/packages/persistence/src/vault/vault.ts
@@ -117,9 +117,6 @@ function parsePointer(token: string): ParsedPointerToken | null {
 export interface SecretVaultDeps {
   repo: SqliteSecretVaultRepository;
   keys: KeyProvider;
-  // The exception-key epoch a value's fingerprint is derived under. This is a
-  // different key from the vault's, with different rotation semantics.
-  fingerprintKey: FingerprintKey;
   // Read live on every call, so revoking consent takes effect immediately
   // rather than at the next process start.
   isConsented: () => boolean;
@@ -141,7 +138,6 @@ export interface SecretVaultDeps {
 export class SecretVault {
   readonly #repo: SqliteSecretVaultRepository;
   readonly #keys: KeyProvider;
-  readonly #fingerprintKey: FingerprintKey;
   readonly #isConsented: () => boolean;
   readonly #verifyGrant:
     ((grantId: string, identity: PointerIdentity) => Promise<boolean>) | undefined;
@@ -150,7 +146,6 @@ export class SecretVault {
   constructor(deps: SecretVaultDeps) {
     this.#repo = deps.repo;
     this.#keys = deps.keys;
-    this.#fingerprintKey = deps.fingerprintKey;
     this.#isConsented = deps.isConsented;
     this.#verifyGrant = deps.verifyGrant;
     this.#now = deps.now ?? ((): number => Date.now());
@@ -160,11 +155,28 @@ export class SecretVault {
    * Store a value and return the pointer that stands for it. The same value
    * always yields the same pointer on this machine — one row, one pointer id,
    * one category — which is what makes dedup and reuse counting work.
+   *
+   * `fingerprintKey` is the exception-key epoch this value's fingerprint is
+   * derived under — a different key from the vault's, with different rotation
+   * semantics. It is a parameter of the WRITE rather than a constructor dep,
+   * and a thunk rather than a value, so that the only way to reach a key is to
+   * store something: a read-only caller never names it, and a caller whose
+   * source mints on absence mints only once consent has actually opened the
+   * write. `refreshFingerprints` takes its key the same way, for the same
+   * reason.
+   *
+   * Resolved once per call, so the fingerprint and the version it is recorded
+   * under can never come from two different epochs.
    */
-  async tokenize(raw: string, meta: TokenizeMeta): Promise<TokenizeResult> {
+  async tokenize(
+    raw: string,
+    meta: TokenizeMeta,
+    fingerprintKey: () => FingerprintKey,
+  ): Promise<TokenizeResult> {
     if (!this.#isConsented()) return CONSENT_ABSENT;
 
-    const valueFingerprint = fingerprintValue(this.#fingerprintKey, raw);
+    const fpKey = fingerprintKey();
+    const valueFingerprint = fingerprintValue(fpKey, raw);
     const existing = this.#repo.byValueFingerprint(valueFingerprint);
     const now = this.#now();
 
@@ -186,7 +198,7 @@ export class SecretVault {
       {
         pointerId: base32Encode(pointerId),
         valueFingerprint,
-        fingerprintKeyVersion: this.#fingerprintKey.version,
+        fingerprintKeyVersion: fpKey.version,
         keyVersion: version,
         // Recorded so the row stays OPENABLE if the wire-format constant ever
         // moves: it is part of this row's AEAD AAD. It is not a tag input —

--- a/packages/persistence/test/vault/vault.test.ts
+++ b/packages/persistence/test/vault/vault.test.ts
@@ -5,6 +5,7 @@ import type { DatabaseSync } from 'node:sqlite';
 import { POINTER_FORMAT_VERSION, PointerToken } from '@akasecurity/schema';
 import { beforeEach, describe, expect, it } from 'vitest';
 
+import type { FingerprintKey } from '../../src/fingerprint.ts';
 import {
   fingerprintValue,
   loadOrCreateFingerprintKey,
@@ -44,12 +45,16 @@ describe('SecretVault', () => {
   let repo: SqliteSecretVaultRepository;
   let vault: SecretVault;
   let consented: boolean;
+  // The epoch writes fingerprint under. A variable rather than a constructor
+  // dep because the vault no longer holds one — a rotation test moves this and
+  // the same vault instance writes under the new epoch.
+  let fingerprintKey: FingerprintKey;
+  const fpKey = (): FingerprintKey => fingerprintKey;
 
   const build = (): SecretVault =>
     new SecretVault({
       repo,
       keys: new FileKeyProvider(join(dir, 'keys')),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       isConsented: () => consented,
     });
 
@@ -62,15 +67,20 @@ describe('SecretVault', () => {
     db = store.openRaw();
     repo = new SqliteSecretVaultRepository(db);
     consented = true;
+    fingerprintKey = loadOrCreateFingerprintKey(dir);
     vault = build();
   });
 
   const tokenize = async (raw: string, category = 'secret'): Promise<string> => {
-    const result = await vault.tokenize(raw, {
-      ruleId: 'aws-access-key-id',
-      category: category as 'secret',
-      maskedMatch: 'A******E',
-    });
+    const result = await vault.tokenize(
+      raw,
+      {
+        ruleId: 'aws-access-key-id',
+        category: category as 'secret',
+        maskedMatch: 'A******E',
+      },
+      fpKey,
+    );
     if (typeof result !== 'string') throw new Error('expected a pointer');
     return result;
   };
@@ -136,7 +146,7 @@ describe('SecretVault', () => {
     it('does not vault anything without consent', async () => {
       consented = false;
       await expect(
-        vault.tokenize(SECRET, { ruleId: 'r', category: 'secret', maskedMatch: 'A***E' }),
+        vault.tokenize(SECRET, { ruleId: 'r', category: 'secret', maskedMatch: 'A***E' }, fpKey),
       ).resolves.toBe(CONSENT_ABSENT);
       expect(repo.countEntries()).toBe(0);
     });
@@ -344,7 +354,6 @@ describe('SecretVault', () => {
         new SecretVault({
           repo,
           keys: new FileKeyProvider(join(dir, 'keys')),
-          fingerprintKey: loadOrCreateFingerprintKey(dir),
           isConsented: () => consented,
           verifyGrant,
         });
@@ -508,13 +517,10 @@ describe('SecretVault', () => {
       ).resolves.toBe(SECRET);
 
       // Re-tokenizing under the new key must find the refreshed row, not mint a
-      // second one — otherwise the reuse count fragments.
-      vault = new SecretVault({
-        repo,
-        keys: new FileKeyProvider(join(dir, 'keys')),
-        fingerprintKey: next,
-        isConsented: () => consented,
-      });
+      // second one — otherwise the reuse count fragments. The SAME vault
+      // instance writes under the new epoch: the key reaches the write as a
+      // per-call argument, so moving it needs no reconstruction.
+      fingerprintKey = next;
       expect(await tokenize(SECRET)).toBe(token);
       expect(repo.countEntries()).toBe(1);
     });
@@ -573,7 +579,6 @@ describe('SecretVault', () => {
       const vaultOverLyingRepo = new SecretVault({
         repo: lying,
         keys: new FileKeyProvider(join(dir, 'keys')),
-        fingerprintKey: loadOrCreateFingerprintKey(dir),
         isConsented: () => consented,
       });
 

--- a/packages/plugin-sdk/src/tokenize.ts
+++ b/packages/plugin-sdk/src/tokenize.ts
@@ -16,7 +16,7 @@
 // sees LESS, never more.
 import type { MatchResult } from '@akasecurity/detections';
 import { getLoadedRules, maskMatch, scan } from '@akasecurity/detections';
-import type { ExceptionPolicyProvider } from '@akasecurity/persistence';
+import type { ExceptionPolicyProvider, FingerprintKey } from '@akasecurity/persistence';
 import {
   createKeyProvider,
   defaultDataDir,
@@ -505,10 +505,16 @@ export interface CreateVaultGlueOptions {
 }
 
 /**
- * Build the glue over a live vault. Opening the store, the key provider, or the
- * fingerprint key can all fail; when anything does, the returned glue is a
- * degraded one whose tokenize destroys values one-way and whose detokenize
- * resolves nothing — the two fail postures above, decided once at construction.
+ * Build the glue over a live vault. Opening the store or the key provider can
+ * fail; when either does, the returned glue is a degraded one whose tokenize
+ * destroys values one-way and whose detokenize resolves nothing — the two fail
+ * postures above, decided once at construction.
+ *
+ * The fingerprint key is NOT resolved here, so it cannot fail here: it is
+ * needed only to write, and is loaded on the first write instead. A fault
+ * there lands in `tokenizeValue`'s catch and degrades that value one-way,
+ * which is the same posture on a narrower blast radius — the reads this glue
+ * also serves keep working.
  */
 export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
   if (options?.vault) return new SecretVaultGlue(options.vault, options.revealResolver);
@@ -526,7 +532,6 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(settings.vaultKeyCustody, keysDir(base)),
-      fingerprintKey: loadOrCreateFingerprintKey(dir),
       // Read live so a revocation applies to the very next call, not the next
       // process.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings(base).vaultConsent),
@@ -547,11 +552,20 @@ export function createVaultGlue(options?: CreateVaultGlueOptions): VaultGlue {
         return decision.allow;
       },
     });
+    // Resolved on the first WRITE that gets past the consent gate, never at
+    // construction: this glue also backs render and reveal, and a session that
+    // only reads must leave the store's key footprint alone. Memoized because
+    // one message can tokenize many findings, and the load re-reads the file
+    // and re-tightens its mode each time.
+    let fingerprintKey: FingerprintKey | undefined;
+    const fingerprintKeyForWrite = (): FingerprintKey =>
+      (fingerprintKey ??= loadOrCreateFingerprintKey(dir));
+
     // The vault core plus the sighting recorder: SecretVault owns crypto and
     // audit; where a pointer LANDED is repository bookkeeping, wired in here so
     // the glue's callers never touch the store directly.
     const vaultWithSightings: VaultCore = {
-      tokenize: (raw, meta) => vault.tokenize(raw, meta),
+      tokenize: (raw, meta) => vault.tokenize(raw, meta, fingerprintKeyForWrite),
       detokenize: (token, opts) => vault.detokenize(token, opts),
       describePointer: (token) => vault.describePointer(token),
       resolvePointerIdentity: (token) => vault.resolvePointerIdentity(token),

--- a/packages/plugin-sdk/test/tokenize.test.ts
+++ b/packages/plugin-sdk/test/tokenize.test.ts
@@ -1,10 +1,14 @@
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import type { MatchResult } from '@akasecurity/detections';
-import { applyOnboarding, openLocalDatabase } from '@akasecurity/persistence';
+import {
+  applyOnboarding,
+  EXCEPTION_KEY_FILENAME,
+  openLocalDatabase,
+} from '@akasecurity/persistence';
 import { PointerToken, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -191,6 +195,85 @@ describe('vault glue', () => {
         expect(db.secretVault.countEntries()).toBe(0);
         db.close();
         ungranted.close();
+      } finally {
+        removeTree(bare);
+      }
+    });
+  });
+
+  // The exception fingerprint key is a WRITE dependency: it keys the ledger a
+  // vaulted value can later be approved from, and nothing the glue does on the
+  // read side consults it. This glue is built once per process and serves both
+  // sides, so a session that only renders or reveals must leave the key
+  // footprint it found — otherwise a store whose key was deleted (which the
+  // CLI's own corrupt-key guidance tells operators to do) silently gets a
+  // fresh one back, and the next approve reports a rotation that never
+  // happened instead of the missing key.
+  describe('fingerprint key footprint', () => {
+    const keyFile = (b: string): string => join(dataDir(b), EXCEPTION_KEY_FILENAME);
+
+    it('mints on a write', async () => {
+      const fresh = createVaultGlue({ base });
+      try {
+        const token = await fresh.tokenizeValue(SECRET, {
+          ruleId: 'aws-access-key',
+          category: 'secret',
+          maskedMatch: 'A******E',
+        });
+        // Positive control: the write really stored something. A degraded
+        // tokenize returns the one-way placeholder and would mint nothing.
+        expect(PointerToken.safeParse(token).success).toBe(true);
+        expect(existsSync(keyFile(base))).toBe(true);
+      } finally {
+        fresh.close();
+      }
+    });
+
+    it('mints nothing on the read side', async () => {
+      // Seed through the shared glue so there is a real pointer to read back,
+      // then take the key away — the reads below must not put one back.
+      const token = await glue.tokenizeValue(SECRET, {
+        ruleId: 'aws-access-key',
+        category: 'secret',
+        maskedMatch: 'A******E',
+      });
+      rmSync(keyFile(base));
+
+      const reader = createVaultGlue({ base });
+      try {
+        const back = await reader.detokenizeText(`v=${token}`, {
+          target: 'human',
+          reason: 'explicit-reveal',
+        });
+        // Positive control: the read side really worked without the key, so
+        // the absence below is about minting rather than about a broken glue.
+        expect(back.text).toBe(`v=${SECRET}`);
+        expect(existsSync(keyFile(base))).toBe(false);
+      } finally {
+        reader.close();
+      }
+    });
+
+    // A refused write is not a write. A user who never granted vault consent
+    // keeps a zero key footprint, exactly as one who never trips enforcement
+    // does.
+    it('mints nothing on a write refused for want of consent', async () => {
+      const bare = mkdtempSync(join(tmpdir(), 'aka-glue-nokey-'));
+      try {
+        const ungranted = createVaultGlue({ base: bare });
+        try {
+          // Positive control: this is the refusal path, not a passthrough.
+          await expect(
+            ungranted.tokenizeValue(SECRET, {
+              ruleId: 'aws-access-key',
+              category: 'secret',
+              maskedMatch: 'A******E',
+            }),
+          ).resolves.toBe('[REDACTED:SECRET]');
+          expect(existsSync(keyFile(bare))).toBe(false);
+        } finally {
+          ungranted.close();
+        }
       } finally {
         removeTree(bare);
       }

--- a/web-ui/app/(app)/exceptions/actions.ts
+++ b/web-ui/app/(app)/exceptions/actions.ts
@@ -337,7 +337,6 @@ export async function grantRevealFromPointer(input: {
     const vault = new SecretVault({
       repo: db().secretVault,
       keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
       // Read live so a consent revocation applies to the very next call.
       isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
     });
@@ -474,7 +473,6 @@ export async function rotateKey(confirmation: string): Promise<ActionResult> {
     const vault = new SecretVault({
       repo: db().secretVault,
       keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-      fingerprintKey: next,
       isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
     });
     await vault.refreshFingerprints(next);

--- a/web-ui/app/(app)/vault/actions.ts
+++ b/web-ui/app/(app)/vault/actions.ts
@@ -2,9 +2,7 @@
 
 import {
   createKeyProvider,
-  dataDir,
   keysDir,
-  loadOrCreateFingerprintKey,
   readWorkspaceSettings,
   SecretVault,
 } from '@akasecurity/persistence';
@@ -26,7 +24,6 @@ function buildVault(): SecretVault {
   return new SecretVault({
     repo: db().secretVault,
     keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-    fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
     isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
   });
 }

--- a/web-ui/test/actions/exceptions-reveal.test.ts
+++ b/web-ui/test/actions/exceptions-reveal.test.ts
@@ -80,15 +80,18 @@ async function seedPointer(): Promise<string> {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
       isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
     });
-    const pointer = await vault.tokenize(RAW, {
-      ruleId: RULE_ID,
-      category: 'secret',
-      provider: 'aws',
-      maskedMatch: MASKED,
-    });
+    const pointer = await vault.tokenize(
+      RAW,
+      {
+        ruleId: RULE_ID,
+        category: 'secret',
+        provider: 'aws',
+        maskedMatch: MASKED,
+      },
+      () => loadOrCreateFingerprintKey(dataDir()),
+    );
     if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
     return pointer;
   } finally {

--- a/web-ui/test/actions/vault-manage.test.ts
+++ b/web-ui/test/actions/vault-manage.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,6 +9,7 @@ import {
   createKeyProvider,
   dataDir,
   dbPath,
+  EXCEPTION_KEY_FILENAME,
   keysDir,
   loadOrCreateFingerprintKey,
   type LocalDatabase,
@@ -79,7 +80,6 @@ function buildVault(db: LocalDatabase): SecretVault {
   return new SecretVault({
     repo: db.secretVault,
     keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-    fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
     isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
   });
 }
@@ -89,12 +89,16 @@ function buildVault(db: LocalDatabase): SecretVault {
 async function seedPointer(): Promise<string> {
   const db = openLocalDatabase(dataDir());
   try {
-    const pointer = await buildVault(db).tokenize(RAW, {
-      ruleId: 'secrets/test-rule',
-      category: 'secret',
-      provider: 'aws',
-      maskedMatch: 'vau…est',
-    });
+    const pointer = await buildVault(db).tokenize(
+      RAW,
+      {
+        ruleId: 'secrets/test-rule',
+        category: 'secret',
+        provider: 'aws',
+        maskedMatch: 'vau…est',
+      },
+      () => loadOrCreateFingerprintKey(dataDir()),
+    );
     if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
     return pointer;
   } finally {
@@ -225,6 +229,69 @@ describe('purgeVault', () => {
     // Every pointer is now permanently unresolvable.
     const after = await revealEntry({ pointerId });
     expect(after).toEqual({ ok: true, value: null });
+  });
+});
+
+// The exception fingerprint key is a WRITE dependency: it keys the ledger, and
+// none of these surfaces writes a fingerprint. A dashboard left open is a
+// long-lived process serving every one of them, so any of them re-minting a
+// deleted key would silently undo the fresh start the corrupt-key guidance
+// tells an operator to take — and leave the next approve reporting a rotation
+// that never happened.
+describe('fingerprint key footprint', () => {
+  const keyFile = (): string => join(dataDir(), EXCEPTION_KEY_FILENAME);
+
+  // Seed, then take the key away exactly as the corrupt-key guidance says to,
+  // so what each action does next is the only thing under test.
+  async function seedThenDropKey(): Promise<string> {
+    const pointer = await seedPointer();
+    rmSync(keyFile());
+    resetSingleton();
+    return pointer;
+  }
+
+  it('revealEntry mints nothing', async () => {
+    await seedThenDropKey();
+    const result = await revealEntry({ pointerId: seededPointerId() });
+
+    // Positive control on every case here: the action really ran. Without one,
+    // the absence would hold just as well for an action that failed early.
+    expect(result).toEqual({ ok: true, value: RAW });
+    expect(existsSync(keyFile())).toBe(false);
+  });
+
+  it('grantRevealFromPointer mints nothing', async () => {
+    const pointer = await seedThenDropKey();
+    const granted = await grantRevealFromPointer({
+      pointer,
+      scope: '1h',
+      justification: 'no key on this store',
+    });
+
+    expect(granted.ok).toBe(true);
+    // The grant really landed, keyed to the vault row's own epoch — which the
+    // row carries, so no current key was needed to write it.
+    expect(inventory()[0]?.revealGrantId).not.toBeNull();
+    expect(existsSync(keyFile())).toBe(false);
+  });
+
+  it('purgeVault mints nothing', async () => {
+    await seedThenDropKey();
+    const result = await purgeVault({ confirmation: 'purge' });
+
+    expect(result).toEqual({ ok: true, destroyed: 1 });
+    expect(entryCount()).toBe(0);
+    expect(existsSync(keyFile())).toBe(false);
+  });
+
+  it('rotateVaultKey mints nothing', async () => {
+    await seedThenDropKey();
+    const result = await rotateVaultKey();
+
+    // Rotating the VAULT key touches a different key entirely — the one under
+    // keys/, not exception.key.
+    expect(result).toMatchObject({ ok: true, reEncrypted: 1 });
+    expect(existsSync(keyFile())).toBe(false);
   });
 });
 

--- a/web-ui/test/actions/vault.test.ts
+++ b/web-ui/test/actions/vault.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -9,6 +9,7 @@ import {
   createKeyProvider,
   dataDir,
   dbPath,
+  EXCEPTION_KEY_FILENAME,
   keysDir,
   loadOrCreateFingerprintKey,
   type LocalDatabase,
@@ -71,15 +72,18 @@ async function seedPointer(): Promise<string> {
     const vault = new SecretVault({
       repo: db.secretVault,
       keys: createKeyProvider(readWorkspaceSettings().vaultKeyCustody, keysDir()),
-      fingerprintKey: loadOrCreateFingerprintKey(dataDir()),
       isConsented: () => isVaultConsentValid(readWorkspaceSettings().vaultConsent),
     });
-    const pointer = await vault.tokenize(RAW, {
-      ruleId: 'secrets/test-rule',
-      category: 'secret',
-      provider: 'aws',
-      maskedMatch: 'vau…est',
-    });
+    const pointer = await vault.tokenize(
+      RAW,
+      {
+        ruleId: 'secrets/test-rule',
+        category: 'secret',
+        provider: 'aws',
+        maskedMatch: 'vau…est',
+      },
+      () => loadOrCreateFingerprintKey(dataDir()),
+    );
     if (typeof pointer !== 'string') throw new Error('seeding tokenize was refused');
     return pointer;
   } finally {
@@ -149,5 +153,23 @@ describe('revealPointer', () => {
     // and in particular nothing claiming a reveal happened.
     expect(derefRows().filter((r) => r.outcome === 'revealed')).toEqual([]);
     expect(derefRows()).toEqual([]);
+  });
+
+  // A reveal reads. The exception fingerprint key is a different key from the
+  // vault's — opening a stored value never consults it — so a reveal on a store
+  // without one must resolve normally and leave the key footprint alone.
+  it('mints no fingerprint key', async () => {
+    const pointer = await seedPointer();
+    // Seeding tokenized, which mints legitimately. Take the key away exactly as
+    // the dashboard's own corrupt-key guidance tells an operator to.
+    const keyFile = join(dataDir(), EXCEPTION_KEY_FILENAME);
+    rmSync(keyFile);
+
+    const result = await revealPointer({ pointer });
+
+    // Positive control: the reveal really ran. Without it the absence below
+    // would hold just as well for an action that failed before the vault.
+    expect(result).toMatchObject({ ok: true, value: RAW });
+    expect(existsSync(keyFile)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

`SecretVault` took the exception fingerprint key as a constructor dependency, but only
`tokenize()` ever read it — at `vault.ts:167` and `:189`. Every other method ignored it, and
`refreshFingerprints(next)` already took the key it needs as a parameter.

Every read-only construction site still passed `loadOrCreateFingerprintKey(...)`, which **mints
key material when the file is absent**. So a pointer lookup, a human reveal, a vault purge and a
vault-key rotation each created a fingerprint key as a side effect and then never read it.

This is a hygiene and diagnostics defect, not a live security hole — minting exposes nothing and
grants nothing. What it costs is a **diagnostic, in the exact state the CLI's own recovery
guidance produces**. `keyAccessHint` tells an operator with a corrupt key to delete
`exception.key` and start fresh. If they do, any reveal silently re-mints it, and a later
`aka exception approve` reports:

```
it was blocked under fingerprint key v1 and the key is now v2
```

instead of the accurate *"the fingerprint key file is missing"* — sending the operator after a
rotation nobody performed. It is also dead coupling: several call sites resolve and pass a
dependency that is provably unread.

## Changes

- **`SecretVaultDeps` no longer carries `fingerprintKey`.** It is now a lazy third parameter of
  `tokenize()` (`fingerprintKey: () => FingerprintKey`), mirroring how `refreshFingerprints`
  already takes its key. Only the write path can reach a key, and a read-only caller cannot name
  one — that is enforced by the type, not by convention, so a new read-only caller cannot
  reintroduce this.
- **`createVaultGlue` resolves the key lazily and memoized, on the first write.** This is the
  larger half of the fix: that glue is built **once per plugin process** and backs render and
  reveal as well as tokenize, so it re-minted a deleted key on paths that only read. Memoized
  because one message can tokenize many findings and the load re-reads the file and re-tightens
  its mode each time — the same shape `local-ops/src/fs-scan.ts` already uses.
- **Six construction sites drop the dead dependency**: `aka vault show`, `aka exception approve
  <pointer> --reveal`, `aka exception rotate-key`, the dashboard's `buildVault`,
  `grantRevealFromPointer`, and the dashboard `rotateKey`. The last two passed an
  already-rotated key, so they were dead coupling rather than minting.
- **A write refused for want of consent now mints nothing.** The thunk resolves after the consent
  gate, so a user who never granted vault consent keeps a zero key footprint — the principle
  `keyForLedger` already states for the ledger path.

## Tests

Ten new cases, all **mutation-proved**: re-injecting the eager mint at each of the five
production sites turns nine of them red. The tenth (`mints on a write`) correctly stays green —
it pins that the write path still mints, which the old code also did.

| Surface | Test |
| --- | --- |
| `aka vault show` | `cli/test/commands/vault.test.ts` |
| `aka exception approve <pointer> --reveal` | `cli/test/commands/exception-reveal.test.ts` |
| Ledger approve reports **missing**, not a version mismatch | `cli/test/commands/exception-reveal.test.ts` |
| Glue write mints / read side does not / refused write does not | `packages/plugin-sdk/test/tokenize.test.ts` |
| `revealPointer` | `web-ui/test/actions/vault.test.ts` |
| `revealEntry`, `grantRevealFromPointer`, `purgeVault`, `rotateVaultKey` | `web-ui/test/actions/vault-manage.test.ts` |

Each case carries a positive control that the action actually ran — `existsSync(keyFile) === false`
holds just as well for a command that failed before reaching the vault. The diagnostic test pins
the wrong branch's **own wording** (`and the key is now v`) rather than a paraphrase, because the
misleading message never uses the word "rotated".

Gates, all run with `--force` so nothing was replayed from the shared Turbo cache (`Cached: 0`):
test 29/29 · typecheck 15/15 · lint 15/15 · build 15/15 · format clean.

## Behaviour changes worth a reviewer's eye

- A corrupt `exception.key` no longer fails `aka vault show` or a pointer reveal grant. Those
  paths never needed that key — a reveal grant keys off the vault **row's** own
  `(ruleId, valueFingerprint, fingerprintKeyVersion)` triple, which the row carries. Previously
  the eager `loadOrCreate` threw and took the whole command with it.
- A fingerprint-key fault on the plugin write path now lands in `tokenizeValue`'s catch and
  degrades that one value one-way, rather than degrading the whole glue at construction. Same
  fail-secure posture, narrower blast radius — the reads that glue also serves keep working.

## Release note

Not version-bumped. `persistence` and `plugin-sdk` are bundled into **both** the CLI and the
plugin, and `web-ui` changed too, so publishing needs `cli` and `plugins/claude-code` bumped
together — and the release type is a deliberate call, not a side effect of this PR.
