### PR TITLE
test(eslint-config): derive the audited configs from the lint scripts that run them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,30 @@ Five files carry a genuine local-only opt-out:
 
 All are **file-scoped**, never package-wide, and drop the static and dynamic bans together (`noNetworkImports` + `noNetworkSyntax`) so the exception holds whichever import form the file uses; every other network module stays banned in those same files. The one **global** opt-out — the runtime suite's deliberate `fetch()`, marked `fetch` (inline) above — is an inline `eslint-disable`, not a config `allow`, because `noNetworkGlobals()` (unlike its import/syntax siblings) takes no `allow` option, so §3's preference for a config opt-out cannot be met for a global today. It is pinned instead by the raw-guard measure in `no-network-runtime.test.js` (which lints with inline config **off**, so it sees the disabled `fetch` and would catch a second one), not by the `DOCUMENTED_OPT_OUTS` audit, which reads `no-restricted-imports` paths and structurally cannot see a global. Adding another opt-out site means updating this table.
 
+**Which configs that audit reads is derived, not globbed.** An ESLint config enforces
+something exactly when a `lint` script points ESLint at it, so `no-network.test.js` walks the
+eslint invocations a green `pnpm lint` really runs — every `-c` / `--config` / `--config=`
+target, plus, for an invocation carrying none, the config ordinary flat-config lookup finds
+from the directory that invocation runs in (asked of ESLint's own `findConfigFile`, not
+modelled). A filename glob was the earlier answer and is a hole one rename wide: ESLint
+honours `-c eslint.extra.config.js` exactly like the two conventional names, so a third
+config was referenced by the lint script, applied on every pass, and inspected by nobody —
+while the suite's own test count went _up_, because the extra invocation generates more probe
+targets elsewhere. Two consequences for anyone adding a config:
+
+- **Name it anything and it is still audited** — but an opt-out in it must then appear in
+  `DOCUMENTED_OPT_OUTS` and in the table above, exactly as for the conventional names.
+- **A config no invocation runs is a failure, not a no-op.** Dead config enforces nothing
+  while reading like a lint surface, so the audit differences the tree's `*eslint*.config.*`
+  files against the derived set and names anything left over. Wire it into a `lint` script or
+  delete it.
+
+The reader itself — which invocations a green run makes, which config each runs under, and
+which paths each covers — is one shared module (`packages/eslint-config/test/helpers/`), used
+by both that audit and the per-package lint-coverage check in `effective-config.test.js`. Two
+readers of one shell string would be free to disagree about what runs, which is how a file
+ends up covered by one guard and audited by neither.
+
 Network access happens **only through child processes**. In the first three, this repo chooses the program and its arguments; in the fourth it chooses neither:
 
 1. `@akasecurity/local-ops` shelling out to package managers (`npm`/`claude`) for update-and-apply.

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,10 +1,20 @@
 import { execFileSync } from 'node:child_process';
-import { existsSync, globSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { dirname, join, posix, resolve, sep } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, posix, sep } from 'node:path';
 
 import { ESLint, Linter } from 'eslint';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  eslintInvocations,
+  packageLintInvocations,
+  parseWorkspaceGlobs,
+  REPO_ROOT,
+  ROOT_LINT_ENTRY_SCRIPT,
+  rootLintInvocations,
+  workspaceGlobs,
+  workspacePackageDirs,
+} from './helpers/lint-invocations.js';
 
 // This file guards the per-package ESLint configs three ways.
 //
@@ -61,8 +71,13 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 // no package at all. A new package that forgets its config fails (1); one whose
 // config fails to wire the ban fails (2); one whose root files cannot be linted
 // at all fails (3); a repo-root file no pass targets fails (4).
-
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+//
+// The reading of the `lint` scripts themselves — which invocations a green run
+// makes, and which config each one runs under — lives in ./helpers, shared with
+// no-network.test.js. That suite asks which CONFIGS the same scripts point ESLint
+// at; a second reader would be two models of one shell string, free to disagree
+// about what runs, and a file could then read as covered by one and audited by
+// neither. Its unit tests stay here, next to the coverage predicates they feed.
 
 // --- Workspace package enumeration (derived from pnpm-workspace.yaml) --------
 
@@ -182,62 +197,10 @@ const extendsSharedConfig = (abs) =>
   IMPORTS_SHARED_CONFIG.test(stripComments(readFileSync(abs, 'utf8')));
 
 /**
- * Parse the package globs declared under `packages:` in a pnpm-workspace.yaml
- * document, without a YAML dependency. Pure over its input string so the parse —
- * the most fragile part of this file — is unit-tested on synthetic YAML below
- * (CRLF, interspersed comments, quoting) rather than only against the one real
- * on-disk manifest. Walks line by line: enter the block at a bare `packages:`
- * line, collect each `- <scalar>` sequence entry (quoted or bare), tolerate
- * blank and comment lines inside the block, and stop at the next column-0 key.
- * Flow style (`packages: [ … ]`) is intentionally NOT parsed — it yields an
- * empty list, which the vacuous-pass guard turns into a loud failure rather than
- * a silent under-enumeration. An exclusion glob throws for the same reason:
- * globSync would treat `!pkg` as a literal pattern that matches nothing, leaving
- * the excluded directory in the enumeration under a misleading failure.
- * @param {string} rawYaml
- * @returns {string[]}
- */
-function parseWorkspaceGlobs(rawYaml) {
-  const globs = [];
-  let inBlock = false;
-  // Normalize CRLF → LF first so a Windows checkout (core.autocrlf) does not
-  // trail a `\r` into each glob (which would break globSync).
-  for (const rawLine of rawYaml.replace(/\r\n/g, '\n').split('\n')) {
-    // Strip comments up front (workspace globs never contain `#`), so an inline
-    // or whole-line comment neither terminates the block nor pollutes an entry.
-    const line = rawLine.replace(/#.*$/, '');
-    if (!inBlock) {
-      if (/^packages:[ \t]*$/.test(line)) inBlock = true;
-      continue;
-    }
-    if (/^\S/.test(line)) break; // a new column-0 key ends the packages block
-    const m = line.match(/^[ \t]+-[ \t]*['"]?([^'"\n]+?)['"]?[ \t]*$/);
-    if (!m) continue;
-    const glob = m[1].trim();
-    if (glob.startsWith('!')) {
-      throw new Error(
-        `pnpm-workspace.yaml declares the exclusion glob "${glob}", which this parser does not ` +
-          'model. Teach parseWorkspaceGlobs/discoverWorkspacePackages to honour negation before ' +
-          'relying on the enumeration.',
-      );
-    }
-    globs.push(glob);
-  }
-  return globs;
-}
-
-/**
- * The package globs from the repo's real pnpm-workspace.yaml.
- * @returns {string[]}
- */
-function workspaceGlobs() {
-  return parseWorkspaceGlobs(readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8'));
-}
-
-/**
- * Every workspace package on disk, resolved from pnpm-workspace.yaml: expand each
- * glob and keep the directories that hold a package.json. `label` is what every
- * failure message prints — a package.json may legally omit `name`, and a bare
+ * Every workspace package on disk, resolved from pnpm-workspace.yaml (the
+ * enumeration itself lives in ./helpers, shared with the opt-out audit, which
+ * has to walk the same packages' lint scripts). `label` is what every failure
+ * message prints — a package.json may legally omit `name`, and a bare
  * `undefined` in a violation list tells the reader nothing about which directory
  * to fix.
  * @returns {{
@@ -248,14 +211,7 @@ function workspaceGlobs() {
  * }[]}
  */
 function discoverWorkspacePackages() {
-  const dirs = [
-    ...new Set(
-      workspaceGlobs()
-        .flatMap((g) => globSync(g, { cwd: REPO_ROOT }))
-        .filter((rel) => existsSync(join(REPO_ROOT, rel, 'package.json'))),
-    ),
-  ].sort();
-  return dirs.map((dir) => {
+  return workspacePackageDirs().map((dir) => {
     // git reports posix paths on every platform; globSync yields native ones.
     const posixDir = dir.split(sep).join('/');
     const pkg = JSON.parse(readFileSync(join(REPO_ROOT, dir, 'package.json'), 'utf8'));
@@ -320,125 +276,6 @@ const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
 // The packages that MUST ship a network-guarded config (everything except the
 // opt-outs). Fed to both the structural guard and the behavioral suite.
 const GUARDED_PACKAGES = WORKSPACE_PACKAGES.filter((p) => !OPT_OUT_NAMES.has(p.name));
-
-// eslint flags that consume the NEXT argument, so its value is not mistaken for
-// a lint target (`-c eslint.scripts.config.mjs scripts` targets scripts, not the
-// config file). Boolean flags are skipped by the leading-dash test alone.
-const ESLINT_VALUE_FLAGS = new Set([
-  '-c',
-  '--config',
-  '--ext',
-  '--rulesdir',
-  '--plugin',
-  '--rule',
-  '--parser',
-  '--parser-options',
-  '--resolve-plugins-relative-to',
-  '--ignore-pattern',
-  '--ignore-path',
-  '--format',
-  '-f',
-  '--output-file',
-  '-o',
-  '--max-warnings',
-  '--global',
-  '--flag',
-  '--concurrency',
-]);
-
-// The two value flags that SUBTRACT from a run instead of adding to it, so their
-// values are kept per invocation rather than skipped with the rest. A target and
-// an ignore of the same path cancel out: `eslint *.config.* --ignore-pattern
-// vitest.config.ts` reads as covering vitest.config.ts if only the targets are
-// parsed, while eslint skips the file — leaving exactly the hole a script that
-// never named the file at all leaves, a fetch() there passing `pnpm lint` with
-// CI green. The flat-config spelling of the same exclusion (`{ ignores: [...] }`
-// in eslint.config.mjs) is caught by the isPathIgnored assertion in the
-// fault-injection suite below; these live in package.json, where ESLint's own
-// API never sees them.
-//
-// `--ignore-path` is listed for completeness rather than because it works: under
-// flat config the CLI rejects the flag outright ("Invalid option
-// '--ignore-path'", exit 2), so an invocation carrying one lints NOTHING. It is
-// modelled as excluding everything, which is what that run really covers.
-const IGNORE_VALUE_FLAGS = new Set(['--ignore-pattern', '--ignore-path']);
-
-const unquote = (token) => token.replace(/^['"]|['"]$/g, '');
-
-/**
- * Every eslint invocation in a `lint` script, in order — its `-c`/`--config`
- * override (undefined when the invocation uses ordinary config lookup), its
- * positional path targets, and the ignore flags that subtract from them. Kept as
- * invocations rather than one flat target list for two reasons. The
- * fault-injection run below has to reproduce ONE of them faithfully: cli lints
- * `src test *.config.*` under eslint.config.mjs and `scripts` under
- * eslint.scripts.config.mjs, so running the flattened target list under either
- * config lints half the package with the wrong ruleset. And an ignore flag binds
- * to the single eslint call it sits on, so flattening would let one invocation's
- * exclusion silently narrow another's targets.
- *
- * Only the `-c <file>` form is read for the config — the repo uses it
- * everywhere, and `--config=<file>` falls through as a plain flag, which costs
- * the config override but never a target. The ignore flags read **both**
- * spellings, because there the fallthrough costs the exclusion itself: an
- * unparsed `--ignore-pattern=<glob>` leaves the file reading as covered while
- * eslint skips it, which is the whole property this models.
- * @param {string} lintScript
- * @returns {{
- *   configName: string | undefined, targets: string[],
- *   ignorePatterns: string[], ignorePaths: string[],
- * }[]}
- */
-function eslintInvocations(lintScript) {
-  const invocations = [];
-  for (const command of lintScript.split(/&&|\|\||;/)) {
-    const tokens = command.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
-    const start = tokens.findIndex((t) => /(?:^|\/)eslint$/.test(unquote(t)));
-    if (start === -1) continue;
-    /**
-     * @type {{
-     *   configName: string | undefined, targets: string[],
-     *   ignorePatterns: string[], ignorePaths: string[],
-     * }}
-     */
-    const invocation = { configName: undefined, targets: [], ignorePatterns: [], ignorePaths: [] };
-    // Repeatable: every ignore flag on one invocation ADDS to its set, so
-    // reading only the last would drop the earlier exclusions. A flag left with
-    // no value records '', which the predicates below read as excluding
-    // everything — eslint itself refuses such a command, so a script that lints
-    // nothing must not parse as one that lints all of it.
-    const pushIgnore = (flag, value) =>
-      (flag === '--ignore-path' ? invocation.ignorePaths : invocation.ignorePatterns).push(value);
-    for (let i = start + 1; i < tokens.length; i++) {
-      const token = unquote(tokens[i]);
-      if (token.startsWith('-')) {
-        const eq = token.indexOf('=');
-        const name = eq === -1 ? token : token.slice(0, eq);
-        if (eq !== -1 && IGNORE_VALUE_FLAGS.has(name)) {
-          // The tokenizer splits `--ignore-pattern='<glob>'` into the flag with
-          // a trailing `=` plus the quoted glob, so an empty inline value takes
-          // the next token.
-          const inline = token.slice(eq + 1);
-          pushIgnore(name, inline === '' ? unquote(tokens[++i] ?? '') : inline);
-          continue;
-        }
-        if (ESLINT_VALUE_FLAGS.has(token)) {
-          const next = tokens[i + 1];
-          if (token === '-c' || token === '--config') {
-            if (next !== undefined) invocation.configName = unquote(next);
-          } else if (IGNORE_VALUE_FLAGS.has(token)) {
-            pushIgnore(token, next === undefined ? '' : unquote(next));
-          }
-          i++;
-        }
-        continue;
-      }
-      invocation.targets.push(token);
-    }
-    invocations.push(invocation);
-  }
-  return invocations;
-}
 
 /**
  * The positional path targets of every eslint invocation in a `lint` script.
@@ -620,19 +457,6 @@ const invocationsCoverFile = (invocations, file) =>
   coveringInvocation(invocations, file) !== undefined;
 
 /**
- * Every eslint invocation a package's `lint` script actually runs on a green
- * pass. One helper rather than a bare `eslintInvocations(lintScript)` at each
- * call site, for the same reason `coveringInvocation` exists: the coverage check
- * and the fault injection that reproduces it must read the script by ONE rule,
- * or a script whose segments disagree could be blessed by one and reproduced
- * from the other. `unconditionalSegments` is that rule — see it for why only
- * `&&` counts.
- * @param {string} lintScript
- */
-const packageLintInvocations = (lintScript) =>
-  unconditionalSegments(lintScript).flatMap(eslintInvocations);
-
-/**
  * Split the guarded packages by how they fail the config requirement. Pure over
  * its input so the failure paths are testable with synthetic packages — a real,
  * healthy tree produces none by construction.
@@ -725,97 +549,6 @@ const EXPECTED_NON_PACKAGE_FILES = [
   'test/setup/no-network.ts',
   'tools/ci/egress-probe.mjs',
 ];
-
-// The root script the gates run: lefthook's pre-push hook, the CI lint step and
-// both release workflows all invoke `pnpm lint`. Coverage is walked FROM it, not
-// collected from every script in the manifest, because an invocation nothing runs
-// covers nothing: a conventional `"lint:fix": "eslint . --fix"` sitting in the
-// manifest would otherwise satisfy the check below however narrow the real pass
-// got, and the guard would go green while the ban stopped reaching these files.
-const ROOT_LINT_ENTRY_SCRIPT = 'lint';
-
-/**
- * The commands a script body runs UNCONDITIONALLY, and whose failure fails the
- * script. `a && b` is the only form that is both: b runs whenever a succeeded,
- * and the script exits non-zero when b does. A segment carrying any other
- * operator is dropped whole rather than read up to it, because the operator
- * defangs the command on EITHER side of itself — `||` both withholds what follows
- * (`a || b` runs b only when a FAILED) and discards what precedes it
- * (`b || true` runs b and swallows its exit code) — while `;` lets an earlier
- * failure be masked, `|` pipes, a bare `&` backgrounds, and `#` comments the rest
- * out. A form this does not model is simply not read, so whatever it would have
- * contributed goes uncredited: loud, and on the side that fails rather than the
- * side that ships unlinted.
- *
- * Both halves of the root walk go through this — the scripts a script chains AND
- * the eslint calls it makes directly. Reading the two by different rules is what
- * lets `eslint <targets> || eslint <other targets>` read as covering both while
- * the second only runs once the first has already failed, which is a file
- * reported as linted that no green run ever lints.
- * @param {string} script
- * @returns {string[]} the segments that run unconditionally
- */
-const unconditionalSegments = (script) =>
-  script.split('&&').filter((part) => !/\||;|&|#/.test(part));
-
-/**
- * The other package scripts a script body runs unconditionally.
- * @param {string} script
- * @returns {string[]} the script names it runs
- */
-function scriptReferences(script) {
-  const names = [];
-  for (const part of unconditionalSegments(script)) {
-    const tokens = part.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
-    const pm = tokens.findIndex((t) => /^(?:pnpm|npm|yarn)$/.test(unquote(t)));
-    if (pm === -1) continue;
-    // Skip the package manager's own flags, then the optional `run` verb. A flag
-    // that takes a SEPARATE value (`--filter <pkg>`) leaves that value as the
-    // candidate name; it will not be a script key, so nothing is followed —
-    // under-approximating again rather than crediting the wrong script.
-    let i = pm + 1;
-    while (i < tokens.length && unquote(tokens[i]).startsWith('-')) i++;
-    if (unquote(tokens[i] ?? '') === 'run') i++;
-    if (i < tokens.length) names.push(unquote(tokens[i]));
-  }
-  return names;
-}
-
-/**
- * Every eslint invocation `pnpm <entry>` really runs, following the root scripts
- * it chains. Read out of the script BODIES rather than by the name of the pass,
- * so renaming `lint:root` cannot blind this — a rename has to update the caller,
- * which this walk reads. Deleting the chain, or making it conditional, empties
- * the list instead and every file below is reported as uncovered.
- *
- * Each unconditional segment is parsed on its own rather than handing the whole
- * body to eslintInvocations, which splits on `||` and `;` too and so credits an
- * eslint call that a green run never reaches. That parser is shared with the
- * per-package check, where a lint script is the whole command; here the command
- * is one segment of a chain and the operator between segments is the thing being
- * measured.
- * @param {Record<string, unknown> | undefined} scripts
- * @param {string} entry the script the gates invoke
- */
-function rootLintInvocations(scripts, entry = ROOT_LINT_ENTRY_SCRIPT) {
-  const all = scripts ?? {};
-  const invocations = [];
-  const seen = new Set();
-  /** @param {string} name */
-  const walk = (name) => {
-    // A script that calls itself (or a cycle through two) must not spin.
-    if (seen.has(name)) return;
-    seen.add(name);
-    const script = all[name];
-    if (typeof script !== 'string') return;
-    for (const segment of unconditionalSegments(script)) {
-      invocations.push(...eslintInvocations(segment));
-    }
-    for (const referenced of scriptReferences(script)) walk(referenced);
-  };
-  walk(entry);
-  return invocations;
-}
 
 const ROOT_MANIFEST = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
 const ROOT_LINT_INVOCATIONS = rootLintInvocations(ROOT_MANIFEST.scripts);
@@ -1262,6 +995,7 @@ describe('rootLintInvocations (walking the root manifest from the script the gat
     ).toEqual([
       {
         configName: 'eslint.root.config.mjs',
+        noConfigLookup: false,
         targets: ['*.config.*'],
         ignorePatterns: ['commitlint.*'],
         ignorePaths: [],
@@ -1692,12 +1426,14 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
     ).toEqual([
       {
         configName: undefined,
+        noConfigLookup: false,
         targets: ['src', 'test', '*.config.*'],
         ignorePatterns: [],
         ignorePaths: [],
       },
       {
         configName: 'eslint.scripts.config.mjs',
+        noConfigLookup: true,
         targets: ['scripts'],
         ignorePatterns: [],
         ignorePaths: [],
@@ -1723,6 +1459,7 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
     );
     expect(invocation).toEqual({
       configName: undefined,
+      noConfigLookup: false,
       targets: ['src', 'test', '*.config.*'],
       ignorePatterns: ['x.config.ts'],
       ignorePaths: [],
@@ -1737,9 +1474,9 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
   });
 
   it('reads the `=` spelling of an ignore flag, bare and quoted', () => {
-    // `--config=<file>` deliberately falls through as a plain flag; an ignore
-    // must not, because an unread exclusion reads as full coverage. The quoted
-    // form tokenizes as `--ignore-pattern=` plus the glob, so both are pinned.
+    // An unread exclusion reads as full coverage, so both spellings are parsed.
+    // The quoted form tokenizes as `--ignore-pattern=` plus the glob, so both
+    // are pinned.
     expect(
       eslintInvocations('eslint . --ignore-pattern=vitest.config.ts')[0].ignorePatterns,
     ).toEqual(['vitest.config.ts']);
@@ -1760,12 +1497,14 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
     ).toEqual([
       {
         configName: undefined,
+        noConfigLookup: false,
         targets: ['src', 'test', '*.config.*'],
         ignorePatterns: ['vitest.config.ts'],
         ignorePaths: [],
       },
       {
         configName: 'eslint.scripts.config.mjs',
+        noConfigLookup: true,
         targets: ['scripts'],
         ignorePatterns: [],
         ignorePaths: [],
@@ -1777,6 +1516,26 @@ describe('eslintTargets / targetCoversDir / targetCoversFile (the lint-coverage 
     expect(eslintTargets('eslint --no-error-on-unmatched-pattern --config=x.mjs src')).toEqual([
       'src',
     ]);
+  });
+
+  it('reads every spelling of the config flag, and records --no-config-lookup', () => {
+    // `-c <file>` is what the repo writes today; the other two are what a
+    // contributor or a generated script may write tomorrow. Which config an
+    // invocation runs under is read here and acted on by the §4 opt-out audit,
+    // so an unread spelling is a real ruleset the audit never inspects — not a
+    // cosmetic gap. `--no-config-lookup` is the third state: with it and no
+    // `-c`, the run uses NO config file rather than the one lookup would find.
+    for (const flag of ['-c x.config.js', '--config x.config.js', '--config=x.config.js']) {
+      expect(eslintInvocations(`eslint ${flag} src`)[0].configName, flag).toBe('x.config.js');
+      expect(eslintTargets(`eslint ${flag} src`), flag).toEqual(['src']);
+    }
+    expect(eslintInvocations("eslint --config='x.config.js' src")[0].configName).toBe(
+      'x.config.js',
+    );
+    expect(eslintInvocations('eslint src')[0].noConfigLookup).toBe(false);
+    expect(eslintInvocations('eslint --no-config-lookup src')[0].noConfigLookup).toBe(true);
+    // A repeated config flag: eslint keeps the last, so this does too.
+    expect(eslintInvocations('eslint -c a.mjs --config b.mjs src')[0].configName).toBe('b.mjs');
   });
 
   it('returns nothing when the script never invokes eslint', () => {

--- a/packages/eslint-config/test/helpers/lint-invocations.js
+++ b/packages/eslint-config/test/helpers/lint-invocations.js
@@ -1,0 +1,481 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, globSync, readFileSync } from 'node:fs';
+import { dirname, join, posix, relative, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ESLint } from 'eslint';
+
+// The one reader of this repo's `lint` scripts, shared by the two suites next to
+// it. Both ask the same question of the same strings and act on the answer in
+// different ways — effective-config.test.js asks which PATHS a green run lints,
+// no-network.test.js asks which CONFIGS it lints them under — so a second reader
+// would be two models of one shell string, free to disagree about what runs. A
+// file could then read as covered by one and be audited by neither.
+//
+// Everything here is pure over its inputs except the four workspace readers at
+// the bottom (which read the real manifest / the real checkout) and
+// resolveInvocationConfig (which asks ESLint itself). That split is deliberate:
+// the derivations are unit-testable on synthetic input, and the one question
+// with a real answer is put to the tool that owns it rather than modelled.
+
+export const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/** git reports posix paths on every platform; globSync and join yield native ones. */
+export const toPosix = (p) => p.split(sep).join('/');
+
+// eslint flags that consume the NEXT argument, so its value is not mistaken for
+// a lint target (`-c eslint.scripts.config.mjs scripts` targets scripts, not the
+// config file). Boolean flags are skipped by the leading-dash test alone.
+export const ESLINT_VALUE_FLAGS = new Set([
+  '-c',
+  '--config',
+  '--ext',
+  '--rulesdir',
+  '--plugin',
+  '--rule',
+  '--parser',
+  '--parser-options',
+  '--resolve-plugins-relative-to',
+  '--ignore-pattern',
+  '--ignore-path',
+  '--format',
+  '-f',
+  '--output-file',
+  '-o',
+  '--max-warnings',
+  '--global',
+  '--flag',
+  '--concurrency',
+]);
+
+// The two value flags that SUBTRACT from a run instead of adding to it, so their
+// values are kept per invocation rather than skipped with the rest. A target and
+// an ignore of the same path cancel out: `eslint *.config.* --ignore-pattern
+// vitest.config.ts` reads as covering vitest.config.ts if only the targets are
+// parsed, while eslint skips the file — leaving exactly the hole a script that
+// never named the file at all leaves, a fetch() there passing `pnpm lint` with
+// CI green. The flat-config spelling of the same exclusion (`{ ignores: [...] }`
+// in eslint.config.mjs) is caught by the isPathIgnored assertion in the
+// fault-injection suite; these live in package.json, where ESLint's own API
+// never sees them.
+//
+// `--ignore-path` is listed for completeness rather than because it works: under
+// flat config the CLI rejects the flag outright ("Invalid option
+// '--ignore-path'", exit 2), so an invocation carrying one lints NOTHING. It is
+// modelled as excluding everything, which is what that run really covers.
+export const IGNORE_VALUE_FLAGS = new Set(['--ignore-pattern', '--ignore-path']);
+
+// The flags that name the config an invocation runs under. Both spellings of
+// both, and both are read: an unread config flag does not cost a target, it
+// costs the whole question of WHICH RULES that run enforced — the config drops
+// out of the opt-out audit while ESLint honours it exactly like the others.
+export const CONFIG_VALUE_FLAGS = new Set(['-c', '--config']);
+
+/** Every value flag whose value this parser keeps rather than skips. */
+const READ_VALUE_FLAGS = new Set([...CONFIG_VALUE_FLAGS, ...IGNORE_VALUE_FLAGS]);
+
+export const unquote = (token) => token.replace(/^['"]|['"]$/g, '');
+
+/**
+ * Every eslint invocation in a `lint` script, in order — its `-c`/`--config`
+ * override (undefined when the invocation uses ordinary config lookup), whether
+ * `--no-config-lookup` suppressed that lookup, its positional path targets, and
+ * the ignore flags that subtract from them. Kept as invocations rather than one
+ * flat target list for three reasons. The fault-injection runs have to reproduce
+ * ONE of them faithfully: cli lints `src test *.config.*` under eslint.config.mjs
+ * and `scripts` under eslint.scripts.config.mjs, so running the flattened target
+ * list under either config lints half the package with the wrong ruleset. An
+ * ignore flag binds to the single eslint call it sits on, so flattening would let
+ * one invocation's exclusion silently narrow another's targets. And a config is
+ * a property of one call, not of the script — which is what makes an odd-named
+ * config discoverable at all.
+ *
+ * Both spellings of every flag this parser READS are handled — `-c <file>`,
+ * `--config <file>`, `--config=<file>` and the same three for the ignores —
+ * because for all of them the fallthrough costs the thing being modelled: an
+ * unparsed `--ignore-pattern=<glob>` leaves a file reading as covered while
+ * eslint skips it, and an unparsed `--config=<file>` leaves a real ruleset
+ * outside the opt-out audit. Flags this parser does not read still fall through
+ * as plain flags, which costs a value it never wanted.
+ *
+ * A config flag with no value after it leaves `configName` undefined, so the
+ * invocation reads as using ordinary lookup. eslint refuses such a command
+ * outright, so that run lints nothing and `pnpm lint` is already red; crediting
+ * it with the package's own config audits one config more than the broken run
+ * reaches, which is the harmless direction.
+ * @param {string} lintScript
+ * @returns {{
+ *   configName: string | undefined, noConfigLookup: boolean, targets: string[],
+ *   ignorePatterns: string[], ignorePaths: string[],
+ * }[]}
+ */
+export function eslintInvocations(lintScript) {
+  const invocations = [];
+  for (const command of lintScript.split(/&&|\|\||;/)) {
+    const tokens = command.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
+    const start = tokens.findIndex((t) => /(?:^|\/)eslint$/.test(unquote(t)));
+    if (start === -1) continue;
+    /**
+     * @type {{
+     *   configName: string | undefined, noConfigLookup: boolean, targets: string[],
+     *   ignorePatterns: string[], ignorePaths: string[],
+     * }}
+     */
+    const invocation = {
+      configName: undefined,
+      noConfigLookup: false,
+      targets: [],
+      ignorePatterns: [],
+      ignorePaths: [],
+    };
+    // Repeatable: every ignore flag on one invocation ADDS to its set, so
+    // reading only the last would drop the earlier exclusions. A flag left with
+    // no value records '', which the coverage predicates read as excluding
+    // everything — eslint itself refuses such a command, so a script that lints
+    // nothing must not parse as one that lints all of it. A repeated config flag
+    // is the opposite shape: eslint keeps the LAST one, so this does too.
+    const setValue = (flag, value) => {
+      if (CONFIG_VALUE_FLAGS.has(flag)) {
+        if (value !== '') invocation.configName = value;
+        return;
+      }
+      (flag === '--ignore-path' ? invocation.ignorePaths : invocation.ignorePatterns).push(value);
+    };
+    for (let i = start + 1; i < tokens.length; i++) {
+      const token = unquote(tokens[i]);
+      if (token.startsWith('-')) {
+        const eq = token.indexOf('=');
+        const name = eq === -1 ? token : token.slice(0, eq);
+        // The one boolean flag that changes which config a run uses: with it,
+        // an invocation carrying no `-c` runs under NO config file at all
+        // rather than under the one ordinary lookup would find.
+        if (name === '--no-config-lookup') {
+          invocation.noConfigLookup = true;
+          continue;
+        }
+        if (eq !== -1 && READ_VALUE_FLAGS.has(name)) {
+          // The tokenizer splits `--flag='<value>'` into the flag with a
+          // trailing `=` plus the quoted value, so an empty inline value takes
+          // the next token.
+          const inline = token.slice(eq + 1);
+          setValue(name, inline === '' ? unquote(tokens[++i] ?? '') : inline);
+          continue;
+        }
+        if (ESLINT_VALUE_FLAGS.has(token)) {
+          const next = tokens[i + 1];
+          if (READ_VALUE_FLAGS.has(token)) setValue(token, next === undefined ? '' : unquote(next));
+          i++;
+        }
+        continue;
+      }
+      invocation.targets.push(token);
+    }
+    invocations.push(invocation);
+  }
+  return invocations;
+}
+
+/**
+ * The commands a script body runs UNCONDITIONALLY, and whose failure fails the
+ * script. `a && b` is the only form that is both: b runs whenever a succeeded,
+ * and the script exits non-zero when b does. A segment carrying any other
+ * operator is dropped whole rather than read up to it, because the operator
+ * defangs the command on EITHER side of itself — `||` both withholds what follows
+ * (`a || b` runs b only when a FAILED) and discards what precedes it
+ * (`b || true` runs b and swallows its exit code) — while `;` lets an earlier
+ * failure be masked, `|` pipes, a bare `&` backgrounds, and `#` comments the rest
+ * out. A form this does not model is simply not read, so whatever it would have
+ * contributed goes uncredited: loud, and on the side that fails rather than the
+ * side that ships unlinted.
+ *
+ * Every walk goes through this — the scripts a script chains AND the eslint calls
+ * it makes directly. Reading the two by different rules is what lets
+ * `eslint <targets> || eslint <other targets>` read as covering both while the
+ * second only runs once the first has already failed, which is a file reported as
+ * linted that no green run ever lints.
+ * @param {string} script
+ * @returns {string[]} the segments that run unconditionally
+ */
+export const unconditionalSegments = (script) =>
+  script.split('&&').filter((part) => !/\||;|&|#/.test(part));
+
+/**
+ * The other package scripts a script body runs unconditionally.
+ * @param {string} script
+ * @returns {string[]} the script names it runs
+ */
+export function scriptReferences(script) {
+  const names = [];
+  for (const part of unconditionalSegments(script)) {
+    const tokens = part.match(/[^\s"']+|"[^"]*"|'[^']*'/g) ?? [];
+    const pm = tokens.findIndex((t) => /^(?:pnpm|npm|yarn)$/.test(unquote(t)));
+    if (pm === -1) continue;
+    // Skip the package manager's own flags, then the optional `run` verb. A flag
+    // that takes a SEPARATE value (`--filter <pkg>`) leaves that value as the
+    // candidate name; it will not be a script key, so nothing is followed —
+    // under-approximating again rather than crediting the wrong script.
+    let i = pm + 1;
+    while (i < tokens.length && unquote(tokens[i]).startsWith('-')) i++;
+    if (unquote(tokens[i] ?? '') === 'run') i++;
+    if (i < tokens.length) names.push(unquote(tokens[i]));
+  }
+  return names;
+}
+
+// The root script the gates run: lefthook's pre-push hook, the CI lint step and
+// both release workflows all invoke `pnpm lint`. Coverage is walked FROM it, not
+// collected from every script in the manifest, because an invocation nothing runs
+// covers nothing: a conventional `"lint:fix": "eslint . --fix"` sitting in the
+// manifest would otherwise satisfy every check below however narrow the real pass
+// got, and the guards would go green while the ban stopped reaching these files.
+export const ROOT_LINT_ENTRY_SCRIPT = 'lint';
+
+/**
+ * Every eslint invocation `pnpm <entry>` really runs, following the root scripts
+ * it chains. Read out of the script BODIES rather than by the name of the pass,
+ * so renaming `lint:root` cannot blind this — a rename has to update the caller,
+ * which this walk reads. Deleting the chain, or making it conditional, empties
+ * the list instead.
+ *
+ * Each unconditional segment is parsed on its own rather than handing the whole
+ * body to eslintInvocations, which splits on `||` and `;` too and so credits an
+ * eslint call that a green run never reaches. That parser is shared with the
+ * per-package check, where a lint script is the whole command; here the command
+ * is one segment of a chain and the operator between segments is the thing being
+ * measured.
+ * @param {Record<string, unknown> | undefined} scripts
+ * @param {string} entry the script the gates invoke
+ */
+export function rootLintInvocations(scripts, entry = ROOT_LINT_ENTRY_SCRIPT) {
+  const all = scripts ?? {};
+  const invocations = [];
+  const seen = new Set();
+  /** @param {string} name */
+  const walk = (name) => {
+    // A script that calls itself (or a cycle through two) must not spin.
+    if (seen.has(name)) return;
+    seen.add(name);
+    const script = all[name];
+    if (typeof script !== 'string') return;
+    for (const segment of unconditionalSegments(script)) {
+      invocations.push(...eslintInvocations(segment));
+    }
+    for (const referenced of scriptReferences(script)) walk(referenced);
+  };
+  walk(entry);
+  return invocations;
+}
+
+/**
+ * Every eslint invocation a package's `lint` script actually runs on a green
+ * pass. One helper rather than a bare `eslintInvocations(lintScript)` at each
+ * call site, for the same reason coveringInvocation exists: the coverage check
+ * and the fault injection that reproduces it must read the script by ONE rule,
+ * or a script whose segments disagree could be blessed by one and reproduced
+ * from the other. `unconditionalSegments` is that rule.
+ * @param {string} lintScript
+ */
+export const packageLintInvocations = (lintScript) =>
+  unconditionalSegments(lintScript).flatMap(eslintInvocations);
+
+// --- Which config each invocation runs under ---------------------------------
+
+/**
+ * Every eslint invocation a green `pnpm <entry>` runs anywhere in the workspace,
+ * each paired with the directory it runs in. The repo-root pass runs at the repo
+ * root; `turbo run lint` drives each package's own `lint` script with that
+ * package as the working directory, which is what decides where a bare
+ * `eslint src` looks for its config.
+ *
+ * Pure over its inputs so the failure paths are testable on synthetic manifests;
+ * the real tree is healthy and produces none by construction.
+ * @param {{
+ *   rootScripts: Record<string, unknown> | undefined,
+ *   packages: { dir: string, lintScript: string }[],
+ *   entry?: string,
+ * }} input
+ * @returns {{ cwd: string, invocation: ReturnType<typeof eslintInvocations>[number] }[]}
+ */
+export function lintPassInvocations({ rootScripts, packages, entry = ROOT_LINT_ENTRY_SCRIPT }) {
+  const found = rootLintInvocations(rootScripts, entry).map((invocation) => ({
+    cwd: '',
+    invocation,
+  }));
+  for (const { dir, lintScript } of packages) {
+    for (const invocation of packageLintInvocations(lintScript)) {
+      found.push({ cwd: toPosix(dir), invocation });
+    }
+  }
+  return found;
+}
+
+/**
+ * The config file one invocation runs under, as a repo-relative posix path, or
+ * undefined when it runs under none.
+ *
+ * Put to ESLint rather than modelled. Ordinary flat-config lookup is a search
+ * order over six filenames that walks UP from the working directory, and any
+ * model of it is a second implementation free to drift from the one that
+ * actually decides — the failure being that a config ESLint honours reads as
+ * belonging to no lint pass and drops out of the audit, which is the whole
+ * defect this derivation exists to close. `overrideConfigFile` is the API
+ * spelling of the two flags: a path for `-c <file>`, `true` for
+ * `--no-config-lookup`.
+ *
+ * A `-c` naming a file that does not exist comes back as that path, not as
+ * undefined, so a referenced-but-missing config is reported rather than silently
+ * dropped.
+ * @param {{ cwd: string, invocation: { configName?: string, noConfigLookup: boolean } }} entry
+ * @param {string} repoRoot
+ * @returns {Promise<string | undefined>}
+ */
+export async function resolveInvocationConfig({ cwd, invocation }, repoRoot = REPO_ROOT) {
+  const cwdAbs = cwd ? resolve(repoRoot, ...cwd.split('/')) : repoRoot;
+  // `resolve`, not `join`: a `-c` may name an absolute path, which join would
+  // graft onto the working directory instead of honouring.
+  const overrideConfigFile = invocation.configName
+    ? resolve(cwdAbs, ...invocation.configName.split('/'))
+    : invocation.noConfigLookup
+      ? true
+      : undefined;
+  const found = await new ESLint({
+    cwd: cwdAbs,
+    ...(overrideConfigFile === undefined ? {} : { overrideConfigFile }),
+  }).findConfigFile();
+  return found === undefined ? undefined : toPosix(relative(repoRoot, found));
+}
+
+// A tracked file whose NAME reads as an ESLint flat config, matched on the
+// basename alone. This is the DISCOVERY half, and it answers a different
+// question from the derivation above: which files a reader would take for a lint
+// surface, whether or not any invocation names one. The difference between the
+// two sets is the drift — a config no pass references enforces nothing while
+// looking exactly like the ones that do, and a config a pass references under an
+// unconventional name enforces everything while matching no filename convention.
+//
+// Deliberately wider than the two conventional names and deliberately narrower
+// than "any file a `-c` could name": a config called something with no `eslint`
+// in it at all is still AUDITED (the derivation finds it through the invocation
+// that names it) but is not DISCOVERED, so it cannot be reported as dead. That
+// is the limit of what a name can tell you, and it falls on the quiet side of a
+// file nothing runs.
+export const ESLINT_CONFIG_BASENAME = /eslint.*\.config\.[cm]?[jt]s$/;
+
+// --- The real workspace ------------------------------------------------------
+
+/**
+ * Parse the package globs declared under `packages:` in a pnpm-workspace.yaml
+ * document, without a YAML dependency. Pure over its input string so the parse —
+ * the most fragile part of this module — is unit-tested on synthetic YAML rather
+ * than only against the one real on-disk manifest. Walks line by line: enter the
+ * block at a bare `packages:` line, collect each `- <scalar>` sequence entry
+ * (quoted or bare), tolerate blank and comment lines inside the block, and stop at
+ * the next column-0 key. Flow style (`packages: [ … ]`) is intentionally NOT
+ * parsed — it yields an empty list, which the vacuous-pass guards turn into a loud
+ * failure rather than a silent under-enumeration. An exclusion glob throws for the
+ * same reason: globSync would treat `!pkg` as a literal pattern that matches
+ * nothing, leaving the excluded directory in the enumeration under a misleading
+ * failure.
+ * @param {string} rawYaml
+ * @returns {string[]}
+ */
+export function parseWorkspaceGlobs(rawYaml) {
+  const globs = [];
+  let inBlock = false;
+  // Normalize CRLF → LF first so a Windows checkout (core.autocrlf) does not
+  // trail a `\r` into each glob (which would break globSync).
+  for (const rawLine of rawYaml.replace(/\r\n/g, '\n').split('\n')) {
+    // Strip comments up front (workspace globs never contain `#`), so an inline
+    // or whole-line comment neither terminates the block nor pollutes an entry.
+    const line = rawLine.replace(/#.*$/, '');
+    if (!inBlock) {
+      if (/^packages:[ \t]*$/.test(line)) inBlock = true;
+      continue;
+    }
+    if (/^\S/.test(line)) break; // a new column-0 key ends the packages block
+    const m = line.match(/^[ \t]+-[ \t]*['"]?([^'"\n]+?)['"]?[ \t]*$/);
+    if (!m) continue;
+    const glob = m[1].trim();
+    if (glob.startsWith('!')) {
+      throw new Error(
+        `pnpm-workspace.yaml declares the exclusion glob "${glob}", which this parser does not ` +
+          'model. Teach parseWorkspaceGlobs/workspacePackageDirs to honour negation before ' +
+          'relying on the enumeration.',
+      );
+    }
+    globs.push(glob);
+  }
+  return globs;
+}
+
+/**
+ * The package globs from the repo's real pnpm-workspace.yaml.
+ * @returns {string[]}
+ */
+export function workspaceGlobs() {
+  return parseWorkspaceGlobs(readFileSync(join(REPO_ROOT, 'pnpm-workspace.yaml'), 'utf8'));
+}
+
+/**
+ * Every workspace package directory on disk, resolved from pnpm-workspace.yaml:
+ * expand each glob and keep the directories that hold a package.json. Native
+ * separators, as globSync yields them.
+ * @returns {string[]}
+ */
+export function workspacePackageDirs() {
+  return [
+    ...new Set(
+      workspaceGlobs()
+        .flatMap((g) => globSync(g, { cwd: REPO_ROOT }))
+        .filter((rel) => existsSync(join(REPO_ROOT, rel, 'package.json'))),
+    ),
+  ].sort();
+}
+
+/**
+ * A workspace package's parsed manifest.
+ * @param {string} dir package directory, relative to the repo root
+ */
+export const readPackageManifest = (dir) =>
+  JSON.parse(readFileSync(join(REPO_ROOT, dir, 'package.json'), 'utf8'));
+
+/**
+ * Every workspace package's `lint` script, in the shape lintPassInvocations
+ * takes. A package with no `lint` script contributes an empty string, which
+ * parses to no invocations — turbo skips such a package silently, and that hole
+ * is the per-package structural guard's business, not this one's.
+ * @returns {{ dir: string, lintScript: string }[]}
+ */
+export const workspaceLintScripts = () =>
+  workspacePackageDirs().map((dir) => ({
+    dir,
+    lintScript: readPackageManifest(dir).scripts?.lint ?? '',
+  }));
+
+/** The root manifest's `scripts` block. */
+export const rootScripts = () =>
+  JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).scripts;
+
+/**
+ * Every git-tracked file whose basename reads as an ESLint flat config, in
+ * repo-relative posix form. Tracked-ness is what separates a real config from a
+ * build artifact or a scratch file someone left behind.
+ * @returns {string[]}
+ */
+export function trackedEslintConfigFiles() {
+  let tracked;
+  try {
+    tracked = execFileSync('git', ['ls-files'], {
+      cwd: REPO_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 << 20,
+    }).split('\n');
+  } catch (cause) {
+    throw new Error(
+      'Could not list tracked files with `git ls-files`. This guard audits the real workspace ' +
+        'configs, so it must run inside a git checkout.',
+      { cause },
+    );
+  }
+  return tracked.filter((file) => file && ESLINT_CONFIG_BASENAME.test(posix.basename(file))).sort();
+}

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -1,9 +1,10 @@
-import { execFileSync } from 'node:child_process';
-import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { Linter } from 'eslint';
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
   base,
@@ -14,6 +15,14 @@ import {
   noNetworkProperties,
   noNetworkSyntax,
 } from '../src/index.js';
+import {
+  lintPassInvocations,
+  REPO_ROOT,
+  resolveInvocationConfig,
+  rootScripts,
+  trackedEslintConfigFiles,
+  workspaceLintScripts,
+} from './helpers/lint-invocations.js';
 
 // These tests lint snippets with the SHIPPED rule values (imported from the
 // config, not re-declared here), so a regression that weakens the ban — a
@@ -358,8 +367,6 @@ describe('noEnterpriseImports merge', () => {
   });
 });
 
-const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
-
 // ---------------------------------------------------------------------------
 // The documented opt-out allowlist
 // ---------------------------------------------------------------------------
@@ -381,6 +388,20 @@ const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 //
 // The set is asserted EXACTLY, not as a superset: a guard that only forbids
 // removals would let a third site in.
+//
+// WHICH configs it inspects is derived the same way: from the eslint invocations
+// a green `pnpm lint` really runs — each one's `-c`/`--config` override, and for
+// an invocation carrying none, the config ordinary flat-config lookup finds from
+// the directory that invocation runs in. A filename glob was the earlier answer
+// and is a hole one rename wide: ESLint honours `-c eslint.extra.config.js`
+// exactly like the two conventional names, so a config under any other name was
+// referenced by a lint script, applied on every pass, and inspected by nobody —
+// while the suite's own count went UP, because the extra invocation generates
+// more probe targets elsewhere. The reverse drift is reported too: a config
+// sitting in the tree that no invocation runs enforces nothing while looking
+// exactly like the ones that do, and silently ignoring it reopens the same hole
+// from the other side.
+//
 // Budget for the one-off config load below. Deliberately generous: it bounds a
 // hang, it is not a performance assertion. The load measured ~4.7s on a CI
 // runner under full workspace parallelism against ~0.25s on a developer
@@ -421,26 +442,41 @@ function networkSpecifiersPermittedBy(rules) {
   return [...shipped].filter((name) => !banned.has(name));
 }
 
-describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
-  /** Every tracked ESLint flat config in the workspace. */
-  const configs = (() => {
-    try {
-      return execFileSync('git', ['ls-files', '*eslint*.config.mjs'], {
-        cwd: REPO_ROOT,
-        encoding: 'utf8',
-      })
-        .split('\n')
-        .filter(Boolean);
-    } catch (cause) {
-      throw new Error(
-        'Could not list tracked files with `git ls-files`. This guard audits the real workspace ' +
-          'configs, so it must run inside a git checkout.',
-        { cause },
-      );
-    }
-  })();
+/**
+ * Every config a green `pnpm lint` really points ESLint at, repo-relative posix
+ * and deduplicated, plus the ones a lint invocation names that are not on disk.
+ * @param {{ rootScripts?: Record<string, unknown>, packages: { dir: string, lintScript: string }[] }} manifests
+ * @param {string} repoRoot
+ */
+async function configsInPlay({ rootScripts: scripts, packages }, repoRoot = REPO_ROOT) {
+  const inPlay = [];
+  const missing = [];
+  const seen = new Set();
+  for (const entry of lintPassInvocations({ rootScripts: scripts, packages })) {
+    const file = await resolveInvocationConfig(entry, repoRoot);
+    if (file === undefined || seen.has(file)) continue;
+    seen.add(file);
+    // A `-c` naming a file that is not there means that invocation exits 2 and
+    // lints nothing. Reported on its own rather than folded into a load failure,
+    // which would name the same file for a much less obvious reason.
+    (existsSync(join(repoRoot, ...file.split('/'))) ? inPlay : missing).push(file);
+  }
+  return { inPlay: inPlay.sort(), missing: missing.sort() };
+}
 
-  /** Each tracked config's module, resolved once below. */
+describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
+  /** The configs a green `pnpm lint` runs — the set this suite audits. */
+  let configs = [];
+  /** Configs a lint invocation names that are not on disk. */
+  let missingConfigs = [];
+  /**
+   * Configs whose NAME reads as an ESLint flat config, whatever runs them. The
+   * discovery half, kept separate from the derivation above so the two can be
+   * differenced: what one finds and the other does not is the drift.
+   */
+  const trackedConfigs = trackedEslintConfigFiles();
+
+  /** Each audited config's module, resolved once below. */
   const configModules = new Map();
   /** Load failures, kept per file so a broken config names itself. */
   const loadFailures = new Map();
@@ -457,6 +493,10 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
   // config should name itself instead of hiding the other 17 behind whichever
   // happened to reject first.
   beforeAll(async () => {
+    ({ inPlay: configs, missing: missingConfigs } = await configsInPlay({
+      rootScripts: rootScripts(),
+      packages: workspaceLintScripts(),
+    }));
     const results = await Promise.allSettled(
       configs.map((file) => import(pathToFileURL(join(REPO_ROOT, file)).href)),
     );
@@ -471,7 +511,11 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
   it('found the workspace ESLint configs to audit', () => {
     expect(configs.length).toBeGreaterThanOrEqual(Object.keys(DOCUMENTED_OPT_OUTS).length);
     for (const documented of Object.keys(DOCUMENTED_OPT_OUTS)) {
-      expect(configs).toContain(documented);
+      expect(
+        configs,
+        `${documented} carries a documented opt-out but no eslint invocation reachable from ` +
+          '`pnpm lint` runs it, so nothing here inspects it',
+      ).toContain(documented);
     }
     // A config that failed to load contributes nothing to `found`, so an
     // undocumented opt-out inside it would be invisible below — the same
@@ -479,6 +523,49 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
     expect(
       [...loadFailures].map(([file, cause]) => `${file}: ${String(cause)}`),
       'workspace ESLint configs failed to load, so the audit below is partial',
+    ).toEqual([]);
+  });
+
+  it('every config a lint invocation names is on disk', () => {
+    expect(
+      missingConfigs,
+      missingConfigs.length
+        ? 'A `lint` script points eslint at these config files with -c/--config and they are not ' +
+            `there. That invocation exits 2 having linted nothing:\n  ${missingConfigs.join('\n  ')}`
+        : undefined,
+    ).toEqual([]);
+  });
+
+  it('runs every ESLint config the tree ships — none is dead, none is unnamed', () => {
+    // Both directions of the same drift, asserted together because each is only
+    // half the property. A config the tree ships that no invocation runs
+    // enforces nothing while reading like a lint surface; a config an invocation
+    // runs whose name no convention matches enforces everything while being
+    // findable by nobody looking for configs. The first is caught by
+    // differencing the tracked set against the derived one, the second by the
+    // derived set being what the audit below actually inspects.
+    const dead = trackedConfigs.filter((file) => !configs.includes(file));
+    expect(
+      dead,
+      dead.length
+        ? 'These files are named like ESLint flat configs and no eslint invocation reachable from ' +
+            '`pnpm lint` runs any of them. A dead config enforces nothing while looking exactly ' +
+            'like the ones that do — point a `lint` script at it, or delete it:\n  ' +
+            dead.join('\n  ')
+        : undefined,
+    ).toEqual([]);
+    // The other side is not an error — a config may legitimately be named
+    // anything — but it is worth seeing, so it is asserted as the empty set the
+    // tree has today rather than left unobserved.
+    const unnamed = configs.filter((file) => !trackedConfigs.includes(file));
+    expect(
+      unnamed,
+      unnamed.length
+        ? 'These configs are run by a `lint` script under a name no filename convention matches. ' +
+            'They ARE audited (the derivation finds them through the invocation that names them), ' +
+            'but nothing looking for configs by name will find them — rename to `*eslint*.config.*` ' +
+            `or accept this list deliberately:\n  ${unnamed.join('\n  ')}`
+        : undefined,
     ).toEqual([]);
   });
 
@@ -526,5 +613,212 @@ describe('documented no-network opt-outs (CLAUDE.md §4)', () => {
         ).toHaveLength(0);
       }
     }
+  });
+});
+
+describe('which configs the audit inspects (tested on synthetic manifests)', () => {
+  // The real tree is healthy, so the derivation above only ever sees the shape
+  // that works. Drive it directly on the shapes that broke it.
+  const invocationsOf = (packages, scripts) =>
+    lintPassInvocations({ rootScripts: scripts, packages });
+  const configsOf = (packages, scripts) =>
+    invocationsOf(packages, scripts).map((e) => [e.cwd, e.invocation.configName]);
+
+  it('reads a config named outside the two conventional names', () => {
+    // The hole this derivation closes. `eslint.extra.config.js` is referenced by
+    // the lint script and honoured by ESLint exactly like its two neighbours,
+    // and matches neither the name effective-config.test.js requires nor the
+    // `*eslint*.config.mjs` glob that used to decide what got audited.
+    expect(
+      configsOf([
+        {
+          dir: 'cli',
+          lintScript:
+            'eslint src test *.config.* && ' +
+            'eslint --no-config-lookup -c eslint.extra.config.js scripts',
+        },
+      ]),
+    ).toEqual([
+      ['cli', undefined],
+      ['cli', 'eslint.extra.config.js'],
+    ]);
+  });
+
+  it('reads the `--config=<file>` spelling as well as `-c <file>`', () => {
+    // Three spellings of one flag. An unread one does not cost a lint target —
+    // it costs the whole question of which rules that invocation enforced, and
+    // the config drops out of the audit while ESLint honours it.
+    for (const flag of ['-c x.config.js', '--config x.config.js', '--config=x.config.js']) {
+      expect(configsOf([{ dir: 'pkg', lintScript: `eslint ${flag} src` }]), flag).toEqual([
+        ['pkg', 'x.config.js'],
+      ]);
+    }
+    // The quoted `=` form tokenizes as the flag with a trailing `=` plus the
+    // quoted value, so it takes the next token.
+    expect(configsOf([{ dir: 'pkg', lintScript: "eslint --config='x.config.js' src" }])).toEqual([
+      ['pkg', 'x.config.js'],
+    ]);
+  });
+
+  it('records --no-config-lookup, so an invocation that runs under no config is not credited one', () => {
+    const [bare] = invocationsOf([{ dir: 'pkg', lintScript: 'eslint src' }]);
+    expect(bare.invocation.noConfigLookup).toBe(false);
+    const [suppressed] = invocationsOf([
+      { dir: 'pkg', lintScript: 'eslint --no-config-lookup src' },
+    ]);
+    expect(suppressed.invocation.noConfigLookup).toBe(true);
+  });
+
+  it('pairs each invocation with the directory it runs in', () => {
+    // `turbo run lint` runs each package's script with that package as the
+    // working directory, which is what decides where a bare `eslint src` looks
+    // for its config. The root pass runs at the repo root, spelled ''.
+    expect(
+      configsOf(
+        [
+          { dir: 'cli', lintScript: 'eslint src' },
+          { dir: 'packages/schema', lintScript: 'eslint -c eslint.scripts.config.mjs scripts' },
+        ],
+        {
+          lint: 'turbo run lint && pnpm lint:root',
+          'lint:root': 'eslint -c eslint.root.config.mjs .',
+        },
+      ),
+    ).toEqual([
+      ['', 'eslint.root.config.mjs'],
+      ['cli', undefined],
+      ['packages/schema', 'eslint.scripts.config.mjs'],
+    ]);
+  });
+
+  it('does NOT credit a config to an invocation a green run never reaches', () => {
+    // The same rule the coverage check applies, and for the same reason: behind
+    // a `||` the second call runs only once the first has failed, so a green
+    // pass never enforces whatever that config says. Auditing it would report a
+    // ruleset nothing runs; the loud direction is to leave it uncredited, where
+    // the dead-config check names it.
+    for (const lintScript of [
+      'eslint src || eslint -c eslint.extra.config.js scripts',
+      'eslint -c eslint.extra.config.js scripts || true',
+      'eslint src ; eslint -c eslint.extra.config.js scripts',
+    ]) {
+      expect(
+        configsOf([{ dir: 'pkg', lintScript }]).map(([, config]) => config),
+        lintScript,
+      ).not.toContain('eslint.extra.config.js');
+    }
+    // The control: chained with `&&`, the same call IS credited — otherwise
+    // every case above would pass on a derivation that had stopped reading
+    // config flags at all.
+    expect(
+      configsOf([
+        { dir: 'pkg', lintScript: 'eslint src && eslint -c eslint.extra.config.js scripts' },
+      ]),
+    ).toEqual([
+      ['pkg', undefined],
+      ['pkg', 'eslint.extra.config.js'],
+    ]);
+  });
+
+  it('finds nothing when no script invokes eslint', () => {
+    expect(configsOf([{ dir: 'pkg', lintScript: "echo 'no self-lint'" }], {})).toEqual([]);
+  });
+});
+
+describe('an odd-named config carrying an undocumented opt-out is audited (throwaway tree)', () => {
+  // The end of the chain, run against real ESLint in a tree of its own. The two
+  // suites either side of this one reason about strings; this one plants the
+  // exact shape the filename glob missed — a config the lint script references
+  // under a third name, carrying a network opt-out nothing documents — and
+  // asserts the derivation reaches it AND that the rule it replaced does not.
+  //
+  // Built outside the repo rather than in a package root: the tree's own
+  // derivations read `git ls-files`, and a planted sibling would race the suites
+  // that walk it.
+  let dir = '';
+  const SHARED = pathToFileURL(join(REPO_ROOT, 'packages/eslint-config/src/index.js')).href;
+  const config = (allow) =>
+    `import { networkGuard, noNetworkImports, noNetworkSyntax } from ${JSON.stringify(SHARED)};\n` +
+    'export default [\n' +
+    '  ...networkGuard,\n' +
+    '  {\n' +
+    "    files: ['**/*.mjs'],\n" +
+    '    rules: {\n' +
+    `      'no-restricted-imports': noNetworkImports({ allow: ${JSON.stringify(allow)} }),\n` +
+    `      'no-restricted-syntax': noNetworkSyntax({ allow: ${JSON.stringify(allow)} }),\n` +
+    '    },\n' +
+    '  },\n' +
+    '];\n';
+
+  const PACKAGES = [
+    {
+      dir: 'pkg',
+      lintScript:
+        'eslint src test *.config.* && eslint --no-config-lookup -c eslint.extra.config.js scripts',
+    },
+  ];
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-lint-config-audit-'));
+    const pkgDir = join(dir, 'pkg');
+    mkdirSync(pkgDir, { recursive: true });
+    // The two configs the package really runs: the conventional one ordinary
+    // lookup finds, and the odd-named one the lint script names with `-c`. Only
+    // the second carries an opt-out.
+    writeFileSync(join(pkgDir, 'eslint.config.mjs'), config([]));
+    writeFileSync(join(pkgDir, 'eslint.extra.config.js'), config(['undici']));
+  });
+
+  afterAll(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('finds exactly the two configs the lint script runs', async () => {
+    const { inPlay, missing } = await configsInPlay({ rootScripts: {}, packages: PACKAGES }, dir);
+    // Both branches of the derivation at once: the first invocation carries no
+    // `-c` and resolves through ordinary lookup, the second names a file no
+    // filename convention matches.
+    expect(inPlay).toEqual(['pkg/eslint.config.mjs', 'pkg/eslint.extra.config.js']);
+    expect(missing).toEqual([]);
+  });
+
+  it('reports its undocumented opt-out, where the filename glob reported nothing', async () => {
+    const { inPlay } = await configsInPlay({ rootScripts: {}, packages: PACKAGES }, dir);
+
+    /** The opt-out map the audit above builds, over an arbitrary file list. */
+    const optOutsOf = async (files) => {
+      /** @type {Record<string, string[]>} */
+      const found = {};
+      for (const file of files) {
+        const mod = await import(pathToFileURL(join(dir, ...file.split('/'))).href);
+        for (const entry of mod.default) {
+          const permitted = networkSpecifiersPermittedBy(entry.rules);
+          if (permitted.length) found[file] = permitted.sort();
+        }
+      }
+      return found;
+    };
+
+    expect(await optOutsOf(inPlay)).toEqual({ 'pkg/eslint.extra.config.js': ['undici'] });
+
+    // The control, and the whole point: the rule this derivation replaced —
+    // `git ls-files '*eslint*.config.mjs'` — matches the conventional config and
+    // not the one carrying the opt-out, so it reports an empty map and the
+    // suite goes green with a live, unreviewed exception in the tree. Without
+    // this half, the assertion above would also pass on a derivation that
+    // happened to inspect everything for some unrelated reason.
+    const byFilenameGlob = ['pkg/eslint.config.mjs', 'pkg/eslint.extra.config.js'].filter((f) =>
+      /(?:^|\/)[^/]*eslint[^/]*\.config\.mjs$/.test(f),
+    );
+    expect(byFilenameGlob).toEqual(['pkg/eslint.config.mjs']);
+    expect(await optOutsOf(byFilenameGlob)).toEqual({});
+
+    // …and ESLint really does honour the odd-named config, so the opt-out above
+    // is a live exception rather than a rule value nothing applies.
+    const found = await resolveInvocationConfig(
+      { cwd: 'pkg', invocation: { configName: 'eslint.extra.config.js', noConfigLookup: true } },
+      dir,
+    );
+    expect(found).toBe('pkg/eslint.extra.config.js');
   });
 });


### PR DESCRIPTION
The §4 no-network opt-out audit asserts that the workspace's real file-scoped
exceptions **equal** `DOCUMENTED_OPT_OUTS` exactly, so a new one cannot appear
unreviewed. Everything downstream of that was sound. The weakness was one level
up: it discovered the configs to inspect with a filename glob.

```js
execFileSync('git', ['ls-files', '*eslint*.config.mjs'], …)
```

ESLint does not care what a config is called. A `lint` script saying
`-c eslint.extra.config.js` gets that config applied on every pass, exactly like
the two conventional names — while matching neither the name
`effective-config.test.js` requires nor the glob above. Such a config was
referenced by the lint script, enforced on every run, and inspected by nobody.

## Reproduction, before this change

A config under a third name, wired into `cli`'s `lint` script and allowing
`undici`:

- the full `@akasecurity/eslint-config` suite reported **640 passed, 0 failed** —
  and *grew* by five tests, because the extra lint invocation generates more
  probe targets elsewhere, so the count going up read as more coverage;
- with that config as the only pass over `scripts/`, a live
  `import { request } from 'undici'` passed `pnpm lint` with **exit 0**.

## What changed

- **The audit derives its config set from the lint scripts.** Every eslint
  invocation a green `pnpm lint` really runs — per package via turbo, plus the
  repo-root pass — paired with the directory it runs in. `-c`, `--config` and
  `--config=` are all read; an invocation carrying none resolves through
  ordinary flat-config lookup, and `--no-config-lookup` is recorded so such an
  invocation is not credited a config it never uses.
- **The lookup is asked of ESLint, not modelled.** `findConfigFile()` answers
  it as ESLint itself decides, so the six-filename search order and its upward
  walk are not a second implementation free to drift. A `-c` naming a file that
  is not there comes back as that path, so referenced-but-missing is reported
  rather than silently dropped.
- **A config the tree ships that no invocation runs is reported.** Dead config
  enforces nothing while reading exactly like a lint surface, and ignoring it
  reopens the same hole from the other side. Both directions are asserted.
- **One reader, shared.** The lint-script parsing moved to
  `packages/eslint-config/test/helpers/lint-invocations.js`, used by this audit
  (which configs run) and by the per-package coverage check (which paths are
  covered). Two readers of one shell string can disagree, which is how a file
  ends up covered by one guard and audited by neither.
- `CLAUDE.md` §4 records the new contract: name a config anything and it is
  still audited, but an opt-out in it must appear in the table — and a config
  no invocation runs is a failure, not a no-op.

## Verification

Each property was demonstrated **red** by mutation, not only reasoned about:

| Mutation | Result |
| --- | --- |
| Odd-named config wired in, carrying an undocumented opt-out | Audit names `cli/eslint.extra.config.js: ["node:http", "undici"]` |
| Same, written `--config=<file>` | Same failure — the `=` spelling reaches the audit |
| Config left in the tree, referenced by nothing | *"no eslint invocation reachable from `pnpm lint` runs any of them"* |
| Derivation stubbed to return `[]` | Vacuity guard fires: *"expected 0 to be greater than or equal to 4"*, 11 tests red |

A throwaway-tree case runs the whole chain against real ESLint outside the repo,
including the control that the filename glob it replaced reports an empty
opt-out map on the same two configs — so the assertion is stronger than the one
it replaces, not merely also-green.

Gates: `turbo run lint typecheck test --force` → 47/47 successful, `Cached: 0`
(nothing replayed from cache) · `pnpm lint:root` · `pnpm typecheck:root` ·
`prettier --check .` clean · eslint-config suite 646 passing (635 before, +11).

Test and docs only — no shipped source touched, so no version bump.