### PR TITLE
test(eslint-config): read the lint opt-out tables instead of mirroring them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ The plugin **must never break a user's Claude session**. Every hook handler wrap
 
 ### 3. `process.env` is off by default
 
-ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Four places genuinely need the host environment and opt out:
+ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Four places in shipped source genuinely need the host environment and opt out — test harnesses that spawn the real hooks carry inline disables of their own and are out of this table's scope:
 
 | Site                                      | Mechanism                         | Why                                         |
 | ----------------------------------------- | --------------------------------- | ------------------------------------------- |
@@ -46,6 +46,8 @@ ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace �
 | `plugins/claude-code/src/triage/judge.ts` | inline `eslint-disable-next-line` | the judge subprocess must inherit PATH/auth |
 
 Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a fifth site means updating this table.
+
+That last sentence is enforced, not merely asked: `packages/eslint-config/test/effective-config.test.js` parses this table and drives each column against the thing it describes — the site against the tracked tree, the mechanism against the resolved config and the file's own text, the count word against the row count, and the row set against every opt-out shipped source actually carries. So a fifth site that never reaches the table fails CI, and so does a row that outlives the exception it describes. The `Why` column is prose about intent and is guarded by nothing.
 
 ### 4. No network calls
 
@@ -87,10 +89,15 @@ targets elsewhere. Two consequences for anyone adding a config:
   delete it.
 
 The reader itself — which invocations a green run makes, which config each runs under, and
-which paths each covers — is one shared module (`packages/eslint-config/test/helpers/`), used
-by both that audit and the per-package lint-coverage check in `effective-config.test.js`. Two
-readers of one shell string would be free to disagree about what runs, which is how a file
-ends up covered by one guard and audited by neither.
+which paths each covers — is one shared module
+(`packages/eslint-config/test/helpers/lint-invocations.js`), used by both that audit and the
+per-package lint-coverage check in `effective-config.test.js`. Two readers of one shell string
+would be free to disagree about what runs, which is how a file ends up covered by one guard
+and audited by neither. `trackedFiles()` sits there for the same reason and is the one
+`git ls-files` walk every audit in the package asks — including the ones below, which ask what
+the tree really holds rather than what a lint script says.
+
+`DOCUMENTED_OPT_OUTS` is a hand-written mirror of that table, and it is not what keeps the table true — it never opens this file. `packages/eslint-config/test/no-network.test.js` parses the table and asserts it twice: against that mirror, so the two cannot drift apart in either direction, and against the configs themselves, resolving each row's site through ESLint under the config the row names. The second is what covers the **Site** column, which the mirror does not carry and so cannot check — a row may not name a file the config never reaches, nor keep an exception that has been removed. Any entry in the **Allowed specifier** column that is neither a banned module nor a banned global marked `(inline)` fails rather than being skipped, since a token the module audit cannot see is enforced by nothing.
 
 Network access happens **only through child processes**. In the first three, this repo chooses the program and its arguments; in the fourth it chooses neither:
 

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@1": "^1.1.16",
-      "brace-expansion@5": "^5.0.8",
+      "brace-expansion@1": "^1.1.18",
+      "brace-expansion@5": "^5.0.9",
       "esbuild": "^0.28.1",
       "fast-uri": "^3.1.4",
       "js-yaml": "^4.3.0",

--- a/packages/eslint-config/test/claude-md.test.js
+++ b/packages/eslint-config/test/claude-md.test.js
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cardinalFor,
+  codeSpansOf,
+  CONVENTIONS_DOC,
+  countWordIn,
+  ordinalFor,
+  readConventions,
+  sectionOf,
+  tableOf,
+} from './helpers/claude-md.js';
+
+// The guards in no-network.test.js and effective-config.test.js assert their
+// findings by walking rows this parser returns. So every one of them passes
+// vacuously if the parser ever answers "nothing here" instead of throwing —
+// gutting the document would then read as the tables being correct. That is the
+// exact failure mode those guards exist to remove, so the parser's refusals are
+// tested here rather than assumed, and each refusal case also shows the
+// walk-the-rows form it protects going green on the empty result.
+
+/** How a caller uses the parser: collect findings by walking the rows. */
+const findingsFrom = (rows) => rows.filter(([, ok]) => ok !== 'yes').map(([name]) => name);
+
+const DOC = [
+  '## Principles',
+  '',
+  '### 1. First',
+  '',
+  'Two things opt out:',
+  '',
+  '| Site | Mechanism |',
+  '| ---- | --------- |',
+  '| `a.ts` | inline |',
+  '| `b.ts` (via `x.mjs`) | config |',
+  '',
+  '#### A deeper heading, still inside §1',
+  '',
+  'Adding a third site means updating this table.',
+  '',
+  '### 2. Second',
+  '',
+  '| Gate | Catches |',
+  '| ---- | ------- |',
+  '| lint | source  |',
+  '',
+  '## Elsewhere',
+].join('\n');
+
+describe('readConventions', () => {
+  it('reads the real conventions doc, and it holds the sections the guards slice', () => {
+    // A positive control on the I/O half: without it the parser could be pointed
+    // at a file that exists, is non-empty, and is not the document at all — every
+    // "section not found" throw below would then fire for the wrong reason.
+    const md = readConventions();
+    expect(md).toContain('### 3. `process.env` is off by default');
+    expect(md).toContain('### 4. No network calls');
+  });
+});
+
+describe('sectionOf', () => {
+  it('returns the text under a heading, up to the next same-level one', () => {
+    const section = sectionOf(DOC, '### 1. First');
+    expect(section).toContain('| `a.ts` | inline |');
+    expect(section).not.toContain('| Gate | Catches |');
+  });
+
+  it('runs past a DEEPER heading rather than stopping at it', () => {
+    expect(sectionOf(DOC, '### 1. First')).toContain('Adding a third site');
+  });
+
+  it('stops at a higher-level heading too', () => {
+    expect(sectionOf(DOC, '### 2. Second')).not.toContain('## Elsewhere');
+  });
+
+  it('throws when the heading is absent, rather than returning nothing', () => {
+    const err = errorFrom(() => sectionOf(DOC, '### 9. Renamed'));
+    expect(err?.message).toContain('found 0');
+    // What the throw is worth: the caller's own shape would have passed.
+    expect(findingsFrom([])).toEqual([]);
+  });
+
+  it('throws when the heading is not unique', () => {
+    // A repeated anchor silently moves the slice to whatever the second
+    // occurrence bounds, so the guard reads a section it did not mean to and
+    // still goes green.
+    const dup = `${DOC}\n\n### 1. First\n\nsomething else\n`;
+    expect(errorFrom(() => sectionOf(dup, '### 1. First'))?.message).toContain('found 2');
+  });
+});
+
+describe('tableOf', () => {
+  const section = sectionOf(DOC, '### 1. First');
+
+  it('returns one row of cells per body row', () => {
+    expect(tableOf(section, ['Site', 'Mechanism'])).toEqual([
+      ['`a.ts`', 'inline'],
+      ['`b.ts` (via `x.mjs`)', 'config'],
+    ]);
+  });
+
+  it('selects by header, not by position', () => {
+    // §4 holds two tables; "the first one" would follow whichever moved up.
+    expect(tableOf(sectionOf(DOC, '### 2. Second'), ['Gate', 'Catches'])).toEqual([
+      ['lint', 'source'],
+    ]);
+  });
+
+  it('throws when no table carries that header, rather than returning nothing', () => {
+    const err = errorFrom(() => tableOf(section, ['Site', 'Allowed specifier', 'Why']));
+    expect(err?.message).toContain('found 0');
+    expect(findingsFrom([])).toEqual([]);
+  });
+
+  it('throws when two tables share a header', () => {
+    const twice = `${section}\n\n| Site | Mechanism |\n| - | - |\n| \`c.ts\` | inline |\n`;
+    expect(errorFrom(() => tableOf(twice, ['Site', 'Mechanism']))?.message).toContain('found 2');
+  });
+
+  it('throws on a header with no body rows', () => {
+    const empty = '| Site | Mechanism |\n| ---- | --------- |\n';
+    const err = errorFrom(() => tableOf(empty, ['Site', 'Mechanism']));
+    expect(err?.message).toContain('no body rows');
+    expect(findingsFrom([])).toEqual([]);
+  });
+
+  it('throws when a row has more or fewer cells than the header', () => {
+    // Silently reading a column out of the wrong cell is worse than not reading
+    // it: the guard keeps asserting, on the wrong text.
+    const ragged = '| Site | Mechanism |\n| - | - |\n| `a.ts` | inline | extra |\n';
+    expect(errorFrom(() => tableOf(ragged, ['Site', 'Mechanism']))?.message).toContain(
+      'cell count differs',
+    );
+  });
+
+  it('throws when the separator row is missing', () => {
+    const noRule = '| Site | Mechanism |\n| `a.ts` | inline |\n';
+    expect(errorFrom(() => tableOf(noRule, ['Site', 'Mechanism']))?.message).toContain(
+      'no separator row',
+    );
+  });
+
+  it('does not split on an escaped pipe inside a cell', () => {
+    const piped = '| Site | Mechanism |\n| - | - |\n| `a.ts` | one \\| two |\n';
+    expect(tableOf(piped, ['Site', 'Mechanism'])).toEqual([['`a.ts`', 'one \\| two']]);
+  });
+});
+
+describe('codeSpansOf', () => {
+  it('returns every backticked span in order', () => {
+    expect(codeSpansOf('`b.ts` (via `x.mjs`)')).toEqual(['b.ts', 'x.mjs']);
+    expect(codeSpansOf('`node:net`, `node:dgram`, `fetch` (inline)')).toEqual([
+      'node:net',
+      'node:dgram',
+      'fetch',
+    ]);
+  });
+
+  it('returns nothing for a cell with no code span', () => {
+    // Callers assert on the count themselves — a row whose Site cell lost its
+    // backticks is a finding, not something for the parser to guess at.
+    expect(codeSpansOf('file-scoped ESLint config')).toEqual([]);
+  });
+});
+
+describe('cardinalFor / ordinalFor', () => {
+  it('spells the count the document spells', () => {
+    expect(cardinalFor(4)).toBe('four');
+    expect(cardinalFor(5)).toBe('five');
+    expect(ordinalFor(5)).toBe('fifth');
+    expect(ordinalFor(6)).toBe('sixth');
+  });
+
+  it('throws past the list rather than returning undefined', () => {
+    // `expect(word).toBe(undefined)` would fail loudly, but a caller that spread
+    // it into an allowed-values array would not — and the count would stop being
+    // checked at exactly the point the table got long enough to need it.
+    expect(errorFrom(() => cardinalFor(99))?.message).toContain('No cardinal word for 99');
+    expect(errorFrom(() => ordinalFor(-1))?.message).toContain('No ordinal word for -1');
+  });
+});
+
+describe('countWordIn', () => {
+  const RE = /(\w+) things opt out/g;
+
+  it('captures the word the sentence states, lower-cased', () => {
+    expect(countWordIn('Two things opt out:', RE, 'x')).toBe('two');
+  });
+
+  it('throws when the sentence is gone', () => {
+    expect(errorFrom(() => countWordIn('nothing here', RE, 'x'))?.message).toContain('found 0');
+  });
+
+  it('throws when the sentence appears twice', () => {
+    // Two copies means one of them can drift while the guard reads the other.
+    expect(
+      errorFrom(() => countWordIn('Two things opt out. Five things opt out.', RE, 'x'))?.message,
+    ).toContain('found 2');
+  });
+});
+
+/**
+ * The error `fn` throws, or undefined. Captured OUTSIDE a catch: a `try { fn();
+ * throw new Error('expected') } catch (e) { expect(e.message)… }` asserts on its
+ * own guard error and keeps passing after `fn` stops throwing entirely.
+ */
+function errorFrom(fn) {
+  try {
+    fn();
+  } catch (err) {
+    return /** @type {Error} */ (err);
+  }
+  return undefined;
+}

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,10 +1,21 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, posix, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { ESLint, Linter } from 'eslint';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
+import {
+  cardinalFor,
+  codeSpansOf,
+  CONVENTIONS_DOC,
+  countWordIn,
+  ordinalFor,
+  readConventions,
+  sectionOf,
+  tableOf,
+} from './helpers/claude-md.js';
 import {
   eslintInvocations,
   packageLintInvocations,
@@ -12,6 +23,8 @@ import {
   REPO_ROOT,
   ROOT_LINT_ENTRY_SCRIPT,
   rootLintInvocations,
+  trackedEslintConfigFiles,
+  trackedFiles,
   workspaceGlobs,
   workspacePackageDirs,
 } from './helpers/lint-invocations.js';
@@ -124,20 +137,7 @@ const LINTABLE_EXT = /\.[cm]?[jt]sx?$/;
 //     package-relative parent, so neither can answer "which files belong to no
 //     package at all"; that question needs the whole list.
 const LINTABLE_TRACKED = (() => {
-  let tracked;
-  try {
-    tracked = execFileSync('git', ['ls-files'], {
-      cwd: REPO_ROOT,
-      encoding: 'utf8',
-      maxBuffer: 64 << 20,
-    }).split('\n');
-  } catch (cause) {
-    throw new Error(
-      'Could not list tracked files with `git ls-files`. This suite audits the real workspace ' +
-        'layout, so it must run inside a git checkout.',
-      { cause },
-    );
-  }
+  const tracked = trackedFiles();
   /** @type {Map<string, Set<string>>} */
   const childDirs = new Map();
   /** @type {Map<string, Set<string>>} */
@@ -918,6 +918,26 @@ describe('every file outside every workspace package is linted by a repo-root pa
       'A file with one of these extensions is enumerated by this suite but left out of the turbo ' +
         `input glob, so adding one replays a cached green:\n  ${missing.join('\n  ')}`,
     ).toEqual([]);
+  });
+
+  it('turbo hashes the conventions doc this suite reads', () => {
+    // Same hazard as the extension check above, one file type over. Two describes
+    // in this package parse CLAUDE.md and assert its opt-out tables against the
+    // tree; none of the input globs reaches a .md, so without an entry of its own
+    // the document could be edited — or gutted — with this task's hash untouched,
+    // turbo replaying the cached pass and the guards never running on the change.
+    // A broader glob would do, but it has to be spelled here either way.
+    const turbo = readFileSync(join(REPO_ROOT, 'turbo.json'), 'utf8');
+    const inputs = /"@akasecurity\/eslint-config#test"[\s\S]*?"inputs"\s*:\s*\[([\s\S]*?)\]/.exec(
+      turbo,
+    );
+    expect(inputs, '@akasecurity/eslint-config#test declares no `inputs`').not.toBeNull();
+    const globs = [...inputs[1].matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+    expect(
+      globs,
+      `${CONVENTIONS_DOC} is parsed by this suite but hashed by none of its turbo inputs, so ` +
+        'editing it alone replays a cached green',
+    ).toContain(`$TURBO_ROOT$/${CONVENTIONS_DOC}`);
   });
 
   it('the script the gates run reaches at least one eslint invocation', () => {
@@ -2065,6 +2085,202 @@ describe('effective per-package config (composition / last-wins)', () => {
         'no-restricted-imports',
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The process.env opt-out table
+// ---------------------------------------------------------------------------
+
+// The check above holds the rule at `error` everywhere, which is the half a
+// severity assertion can see. §3's table makes three further claims it cannot:
+// WHICH files opt out, HOW each one does it, and that there are no others. All
+// three sat in prose no test read — the section could be deleted outright and
+// this package stayed green — and the table already carries a wrong `Why` for
+// one row, which is what an unread claim looks like after a while.
+//
+// So each column is driven against the thing it describes: the site against the
+// tree, the mechanism against the resolved config and the file's own text, and
+// the count against the row count. The `Why` column is prose about intent and
+// stays unguarded; nothing here should be read as covering it.
+const SECTION_3 = '### 3. `process.env` is off by default';
+const ENV_TABLE_HEADER = ['Site', 'Mechanism', 'Why'];
+/** "Four places in shipped source genuinely need the host environment…" */
+const ENV_COUNT_SENTENCE = /(\w+) places in shipped source genuinely need the host environment/g;
+/** "Adding a fifth site means updating this table." */
+const ENV_ADDING_SENTENCE = /Adding (?:an? )?(\w+)(?: opt-out)? site means updating this table/g;
+/** The two mechanisms the table distinguishes, spelled as it spells them. */
+const BY_CONFIG = 'file-scoped ESLint config';
+const BY_INLINE = 'inline `eslint-disable-next-line`';
+/** An actual disable DIRECTIVE for the rule — not a mention of it in prose. */
+const INLINE_DISABLE = /eslint-disable(?:-next-line|-line)?\b[^\n]*\bn\/no-process-env\b/;
+
+/**
+ * Test harnesses are deliberately out of the table's scope: several spawn the
+ * real hooks as child processes and need the host PATH, so they carry inline
+ * disables of their own. §3's sentence says "in shipped source" for exactly this
+ * reason, and this predicate is what that phrase has to mean for the sentence to
+ * be true. Widen one without the other and the count silently stops matching.
+ */
+const isTestPath = (file) => file.split('/').some((seg) => seg === 'test' || seg === '__tests__');
+
+/** Resolved configs report severity numerically; a config entry spells it. */
+const isOff = (severity) => severity === 0 || severity === 'off';
+
+/**
+ * The nearest ancestor of `file` that ships an `eslint.config.mjs` — the package
+ * whose config governs it, and the cwd its `lint` script runs in. Derived by
+ * walking up rather than by matching a `packages/`/`plugins/` prefix, which
+ * would silently pick the wrong directory for a repo-root package like `cli`.
+ */
+function owningConfigDir(file) {
+  for (let parts = file.split('/').slice(0, -1); parts.length; parts = parts.slice(0, -1)) {
+    const dir = parts.join('/');
+    if (existsSync(join(REPO_ROOT, dir, 'eslint.config.mjs'))) return dir;
+  }
+  throw new Error(`No ancestor of ${file} ships an eslint.config.mjs, so no config governs it.`);
+}
+
+describe(`the process.env opt-out table (${CONVENTIONS_DOC} §3)`, () => {
+  let section = '';
+  /** @type {{site: string, mechanism: string}[]} */
+  let rows = [];
+  /** @type {Error | undefined} */
+  let setupError;
+  /** Each tabled site's resolved `n/no-process-env` severity. */
+  const severityBySite = new Map();
+  /** Config entries that switch the rule off, as `<config>: <files pattern>`. */
+  const configOptOuts = [];
+
+  // Caught end to end, per the note on the hook above: an uncaught throw here
+  // SKIPS every test below instead of failing one, so a resolution that started
+  // erroring would read as a guard with nothing to say.
+  beforeAll(async () => {
+    try {
+      section = sectionOf(readConventions(), SECTION_3);
+      rows = tableOf(section, ENV_TABLE_HEADER).map(([site, mechanism], i) => {
+        const spans = codeSpansOf(site);
+        if (spans.length !== 1) {
+          throw new Error(`Row ${i + 1}: the Site cell must name exactly one file, got ${site}.`);
+        }
+        return { site: spans[0], mechanism };
+      });
+
+      for (const { site } of rows) {
+        const dir = owningConfigDir(site);
+        const config = await resolveConfig(join(REPO_ROOT, dir), site.slice(dir.length + 1));
+        severityBySite.set(site, severityOf(config, 'n/no-process-env'));
+      }
+
+      // Only configs that NAME the rule can be switching it off, so the module
+      // load is confined to those — one file today, rather than all eighteen.
+      // Enumerated through the shared reader, whose basename test accepts any
+      // extension ESLint honours: a `*.mjs` glob here would miss an opt-out in
+      // an `eslint.extra.config.js`, which ESLint applies exactly the same.
+      const candidates = trackedEslintConfigFiles().filter((f) =>
+        readFileSync(join(REPO_ROOT, f), 'utf8').includes('no-process-env'),
+      );
+      for (const file of candidates) {
+        const mod = await import(pathToFileURL(join(REPO_ROOT, file)).href);
+        for (const entry of mod.default) {
+          if (!isOff(severityOf(entry, 'n/no-process-env'))) continue;
+          // §3 prefers a file-scoped opt-out precisely because a package-wide one
+          // is invisible to a reader auditing the configs. Recorded as a finding
+          // rather than skipped, so it cannot vanish from the count below.
+          for (const pattern of entry.files ?? ['<package-wide>']) {
+            configOptOuts.push(`${file}: ${pattern}`);
+          }
+        }
+      }
+    } catch (cause) {
+      setupError = /** @type {Error} */ (cause);
+    }
+  }, RESOLVE_TIMEOUT_MS);
+
+  const parsed = () => {
+    if (setupError) throw setupError;
+    return rows;
+  };
+
+  it('reads a non-empty opt-out table out of the document', () => {
+    expect(parsed().length).toBeGreaterThan(0);
+  });
+
+  it('names a tracked file that really reads the host environment in every row', () => {
+    const tracked = new Set(LINTABLE_TRACKED.files);
+    const wrong = parsed().flatMap(({ site }) => {
+      if (!tracked.has(site)) return [`${site}: tabled site is not a tracked lintable file`];
+      return readFileSync(join(REPO_ROOT, site), 'utf8').includes('process.env')
+        ? []
+        : [`${site}: tabled as an opt-out but reads no process.env`];
+    });
+    expect(wrong, `${CONVENTIONS_DOC} §3 rows that do not describe the tree`).toEqual([]);
+  });
+
+  it('describes each site with the mechanism that really exempts it', () => {
+    // The two mechanisms are distinguishable from the outside: a config opt-out
+    // resolves the rule to `off` for that path, an inline one leaves it at error
+    // and puts a disable directive in the file. Swap a row's mechanism and one of
+    // the two halves fails, whichever direction the swap went.
+    const wrong = parsed().flatMap(({ site, mechanism }) => {
+      const severity = severityBySite.get(site);
+      const inline = INLINE_DISABLE.test(readFileSync(join(REPO_ROOT, site), 'utf8'));
+      if (mechanism === BY_CONFIG) {
+        return isOff(severity)
+          ? []
+          : [
+              `${site}: tabled as a config opt-out, but its config resolves the rule to ${severity}`,
+            ];
+      }
+      if (mechanism === BY_INLINE) {
+        return [
+          ...(inline
+            ? []
+            : [`${site}: tabled as an inline disable, but carries no such directive`]),
+          ...(isOff(severity)
+            ? [`${site}: tabled as an inline disable, but its config already exempts the file`]
+            : []),
+        ];
+      }
+      return [`${site}: unrecognised mechanism ${JSON.stringify(mechanism)}`];
+    });
+    expect(wrong, `${CONVENTIONS_DOC} §3's Mechanism column vs the real configs`).toEqual([]);
+  });
+
+  it('tables every opt-out shipped source actually carries', () => {
+    // The promise the section makes to the next author. Without this the count
+    // sentence is only arithmetic on the rows already there: a fifth site could
+    // land, be enforced, and never appear — which is the state the sentence
+    // exists to prevent.
+    const tabled = new Set(parsed().map((r) => r.site));
+    const undocumented = LINTABLE_TRACKED.files
+      .filter(
+        (f) => !isTestPath(f) && INLINE_DISABLE.test(readFileSync(join(REPO_ROOT, f), 'utf8')),
+      )
+      .filter((f) => !tabled.has(f))
+      .map((f) => `${f}: disables n/no-process-env inline and is in no §3 row`);
+    expect(
+      undocumented,
+      `These files opt out of n/no-process-env and ${CONVENTIONS_DOC} §3 does not table them`,
+    ).toEqual([]);
+
+    // The config half, counted by `files:` pattern rather than by entry: adding a
+    // path to an existing block is the way a second site hides behind the first.
+    expect(
+      configOptOuts.length,
+      `config-level opt-outs found: ${JSON.stringify(configOptOuts)}`,
+    ).toBe(parsed().filter((r) => r.mechanism === BY_CONFIG).length);
+    expect(configOptOuts.filter((o) => o.endsWith('<package-wide>'))).toEqual([]);
+  });
+
+  it('states a count that follows from the table rather than from memory', () => {
+    const n = parsed().length;
+    expect(countWordIn(section, ENV_COUNT_SENTENCE, 'how many places opt out')).toBe(
+      cardinalFor(n),
+    );
+    expect(['another', ordinalFor(n + 1)]).toContain(
+      countWordIn(section, ENV_ADDING_SENTENCE, 'what the next author must update'),
+    );
   });
 });
 

--- a/packages/eslint-config/test/helpers/claude-md.js
+++ b/packages/eslint-config/test/helpers/claude-md.js
@@ -1,0 +1,175 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Reads the conventions doc so a guard can assert against the TABLE a
+// contributor edits, not against a second copy of it kept in a test. A guard
+// that mirrors prose goes green whichever copy drifts; one that parses it can
+// only go green while the prose is true.
+//
+// Every function here THROWS rather than returning an empty result. That is the
+// point: a parser that yields `[]` for a section it could not find turns every
+// assertion downstream into a vacuous pass, which is the failure mode this whole
+// family of guards exists to remove. `claude-md.test.js` drives each throw.
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
+
+/** Path of the conventions doc, relative to the repo root. */
+export const CONVENTIONS_DOC = 'CLAUDE.md';
+
+/** The conventions doc's text. Throws if it is missing or empty. */
+export function readConventions() {
+  const path = join(REPO_ROOT, CONVENTIONS_DOC);
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (cause) {
+    throw new Error(`Could not read ${CONVENTIONS_DOC} at ${path}.`, { cause });
+  }
+  if (text.trim() === '') throw new Error(`${CONVENTIONS_DOC} is empty.`);
+  return text;
+}
+
+/**
+ * The text under `heading`, up to the next heading of the same or a higher
+ * level. Throws unless the heading line occurs EXACTLY once: a repeated anchor
+ * silently widens the slice to whatever the second occurrence bounds, so a guard
+ * that meant to read one section ends up reading a different one and still
+ * passes.
+ * @param {string} md the whole document
+ * @param {string} heading the full heading line, e.g. '### 4. No network calls'
+ */
+export function sectionOf(md, heading) {
+  const lines = md.split('\n');
+  const at = lines.reduce((hits, line, i) => (line === heading ? [...hits, i] : hits), []);
+  if (at.length !== 1) {
+    throw new Error(
+      `${CONVENTIONS_DOC}: expected exactly one ${JSON.stringify(heading)} heading, found ` +
+        `${at.length}. A guard that slices on a non-unique anchor reads the wrong section.`,
+    );
+  }
+  const level = /^#+/.exec(heading)?.[0].length ?? 0;
+  const boundary = new RegExp(`^#{1,${level}} `);
+  const start = at[0];
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => boundary.test(line));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/** A markdown table row's cells. Splits on unescaped pipes only. */
+function cellsOf(line) {
+  return line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split(/(?<!\\)\|/)
+    .map((cell) => cell.trim());
+}
+
+const isRow = (line) => line.trim().startsWith('|');
+const isSeparator = (line) => /^\|[\s:|-]+\|$/.test(line.trim());
+
+/**
+ * The body rows of the one table in `section` whose header equals `header`.
+ *
+ * Selected by header rather than by position because a section can carry more
+ * than one table — §4 holds both the opt-out table and the three-gates table —
+ * so "the first table" would quietly follow whichever one moved to the top.
+ * Throws unless exactly one table matches and it has at least one body row.
+ * @param {string} section text to search
+ * @param {string[]} header the header cells to match, in order
+ * @returns {string[][]} one array of cells per body row
+ */
+export function tableOf(section, header) {
+  const lines = section.split('\n');
+  /** @type {string[][][]} */
+  const runs = [];
+  for (const line of lines) {
+    if (!isRow(line)) {
+      if (runs.length && runs.at(-1).length) runs.push([]);
+      continue;
+    }
+    if (!runs.length) runs.push([]);
+    runs.at(-1).push(cellsOf(line));
+  }
+
+  const want = JSON.stringify(header);
+  const matches = runs.filter((run) => run.length >= 2 && JSON.stringify(run[0]) === want);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Expected exactly one table with header ${want}, found ${matches.length}. ` +
+        (matches.length === 0
+          ? 'The table was renamed, reshaped or deleted — the guard reading it would otherwise ' +
+            'pass on an empty match.'
+          : 'Two tables share a header, so the guard cannot tell which one it is asserting on.'),
+    );
+  }
+
+  const [head, separator, ...body] = matches[0];
+  if (!isSeparator(`|${separator.join('|')}|`)) {
+    throw new Error(`Table ${want} has no separator row, so its first data row was read as one.`);
+  }
+  if (body.length === 0) throw new Error(`Table ${want} has no body rows.`);
+  const wrong = body.filter((row) => row.length !== head.length);
+  if (wrong.length) {
+    throw new Error(
+      `Table ${want} has ${wrong.length} row(s) whose cell count differs from its ${head.length}-` +
+        'column header, so a column is being read out of the wrong cell.',
+    );
+  }
+  return body;
+}
+
+/** The backticked code spans in a cell, in order. */
+export function codeSpansOf(cell) {
+  return [...cell.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+}
+
+// Written out rather than pulled from Intl: the doc spells these in prose, and a
+// locale-dependent list would make the guard's expectation depend on the runner.
+const CARDINALS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+const ORDINALS = [
+  'zeroth',
+  'first',
+  'second',
+  'third',
+  'fourth',
+  'fifth',
+  'sixth',
+  'seventh',
+  'eighth',
+  'ninth',
+];
+
+/** The English word for `n`. Throws past the list rather than returning undefined. */
+function wordFor(words, n, kind) {
+  if (!Number.isInteger(n) || n < 0 || n >= words.length) {
+    throw new Error(
+      `No ${kind} word for ${n}. Extend the list in claude-md.js — returning undefined here ` +
+        'would compare against undefined and pass.',
+    );
+  }
+  return words[n];
+}
+
+export const cardinalFor = (n) => wordFor(CARDINALS, n, 'cardinal');
+export const ordinalFor = (n) => wordFor(ORDINALS, n, 'ordinal');
+
+/**
+ * The word `pattern` captures in `text`, lower-cased. `pattern` must capture one
+ * group and match exactly once — a sentence that was deleted or duplicated is a
+ * finding, not something to read past.
+ * @param {string} text
+ * @param {RegExp} pattern global-flagged, with one capture group
+ * @param {string} label what the sentence claims, for the failure message
+ */
+export function countWordIn(text, pattern, label) {
+  const found = [...text.matchAll(pattern)];
+  if (found.length !== 1) {
+    throw new Error(
+      `Expected exactly one sentence matching ${pattern} (${label}), found ${found.length}. ` +
+        'The sentence that states the count was reworded, removed or duplicated.',
+    );
+  }
+  return found[0][1].toLowerCase();
+}

--- a/packages/eslint-config/test/helpers/lint-invocations.js
+++ b/packages/eslint-config/test/helpers/lint-invocations.js
@@ -457,25 +457,38 @@ export const rootScripts = () =>
   JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')).scripts;
 
 /**
- * Every git-tracked file whose basename reads as an ESLint flat config, in
- * repo-relative posix form. Tracked-ness is what separates a real config from a
- * build artifact or a scratch file someone left behind.
+ * Every git-tracked file, in repo-relative posix form. Tracked-ness is what
+ * separates a real file from a build artifact or a scratch file someone left
+ * behind, so every audit that asks "does the tree really hold this?" starts
+ * here — and from ONE reader, for the same reason the invocation walk is one:
+ * two copies of this call would be free to disagree about what the tree holds.
  * @returns {string[]}
  */
-export function trackedEslintConfigFiles() {
-  let tracked;
+export function trackedFiles() {
   try {
-    tracked = execFileSync('git', ['ls-files'], {
+    return execFileSync('git', ['ls-files'], {
       cwd: REPO_ROOT,
       encoding: 'utf8',
       maxBuffer: 64 << 20,
-    }).split('\n');
+    })
+      .split('\n')
+      .filter(Boolean);
   } catch (cause) {
     throw new Error(
       'Could not list tracked files with `git ls-files`. This guard audits the real workspace ' +
-        'configs, so it must run inside a git checkout.',
+        'layout, so it must run inside a git checkout.',
       { cause },
     );
   }
-  return tracked.filter((file) => file && ESLINT_CONFIG_BASENAME.test(posix.basename(file))).sort();
+}
+
+/**
+ * Every git-tracked file whose basename reads as an ESLint flat config, in
+ * repo-relative posix form.
+ * @returns {string[]}
+ */
+export function trackedEslintConfigFiles() {
+  return trackedFiles()
+    .filter((file) => ESLINT_CONFIG_BASENAME.test(posix.basename(file)))
+    .sort();
 }

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { Linter } from 'eslint';
+import { ESLint, Linter } from 'eslint';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import {
@@ -16,11 +16,22 @@ import {
   noNetworkSyntax,
 } from '../src/index.js';
 import {
+  cardinalFor,
+  codeSpansOf,
+  CONVENTIONS_DOC,
+  countWordIn,
+  ordinalFor,
+  readConventions,
+  sectionOf,
+  tableOf,
+} from './helpers/claude-md.js';
+import {
   lintPassInvocations,
   REPO_ROOT,
   resolveInvocationConfig,
   rootScripts,
   trackedEslintConfigFiles,
+  trackedFiles,
   workspaceLintScripts,
 } from './helpers/lint-invocations.js';
 
@@ -820,5 +831,178 @@ describe('an odd-named config carrying an undocumented opt-out is audited (throw
       dir,
     );
     expect(found).toBe('pkg/eslint.extra.config.js');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The table the allowlist above is documented in
+// ---------------------------------------------------------------------------
+
+// DOCUMENTED_OPT_OUTS is a hand-written MIRROR of §4's table, and the audit
+// above never opens the document: delete the table, the intro sentence and the
+// "adding another site" promise from CLAUDE.md, leave every ESLint config
+// untouched, and this whole package stays green. The direction that matters most
+// was already closed — a third opt-out cannot land silently, because the
+// contributor has to edit DOCUMENTED_OPT_OUTS to get green — but at the moment
+// they do, nothing then required them to edit the table, and the document a
+// reader opens first would name two sites while three existed.
+//
+// So the table is read, and asserted twice over. Once against the mirror, which
+// is what the ACs above are stated in terms of and what keeps the two from
+// drifting apart in either direction. And once against the CONFIGS THEMSELVES,
+// through the same linter the workspace runs: a mirror can only ever be as true
+// as the thing it mirrors, and the site column carries a claim — WHICH file the
+// exception is for — that the mirror does not hold at all and so cannot check.
+const SECTION_4 = '### 4. No network calls';
+const OPT_OUT_TABLE_HEADER = ['Site', 'Allowed specifier', 'Why'];
+/** "Five files carry a genuine local-only opt-out:" */
+const SITE_COUNT_SENTENCE = /(\w+) files carry a genuine local-only opt-out/g;
+/** "Adding another opt-out site means updating this table." */
+const ADDING_SENTENCE = /Adding (?:an? )?(\w+)(?: opt-out)? site means updating this table/g;
+
+describe(`the opt-out table itself (${CONVENTIONS_DOC} §4)`, () => {
+  /** The section's text, and one entry per table row. */
+  let section = '';
+  /** @type {{site: string, via: string, specifiers: string[], other: string[], cell: string}[]} */
+  let rows = [];
+  /** @type {Error | undefined} */
+  let setupError;
+  /** Specifiers each row's config really permits for that row's site. */
+  const permittedBySite = new Map();
+
+  // Resolving five configs through ESLint costs what the audit above costs, and
+  // for the same reason; it shares that budget rather than the per-test default.
+  //
+  // EVERYTHING here is caught, not just the parse. An uncaught throw aborts the
+  // hook, and vitest then SKIPS every test in this describe — zero failures, no
+  // name, and a guard that silently stopped running. Captured, it is reported by
+  // the first assertion each test makes.
+  beforeAll(async () => {
+    try {
+      section = sectionOf(readConventions(), SECTION_4);
+      const shipped = bannedNamesOf(noNetworkImports());
+      rows = tableOf(section, OPT_OUT_TABLE_HEADER).map(([site, allowed], i) => {
+        const spans = codeSpansOf(site);
+        if (spans.length !== 2) {
+          throw new Error(
+            `Row ${i + 1}: the Site cell must name the file and the config that scopes it, as ` +
+              `\`<site>\` (via \`<config>\`). Found ${spans.length} code span(s) in ${site}.`,
+          );
+        }
+        const spelled = codeSpansOf(allowed);
+        return {
+          site: spans[0],
+          via: spans[1],
+          specifiers: spelled.filter((s) => shipped.has(s)),
+          other: spelled.filter((s) => !shipped.has(s)),
+          cell: allowed,
+        };
+      });
+
+      for (const { site, via } of rows) {
+        // The config's own directory is its cwd, which is what `--no-config-lookup
+        // -c <config>` gives it in the lint script. calculateConfigForFile then runs
+        // the real flat-config cascade — so a `files:` glob is matched by ESLint's
+        // own matcher rather than by a re-implementation of it here.
+        const cwd = join(REPO_ROOT, dirname(via));
+        const eslint = new ESLint({ cwd, overrideConfigFile: join(REPO_ROOT, via) });
+        const config = await eslint.calculateConfigForFile(join(REPO_ROOT, site));
+        permittedBySite.set(site, networkSpecifiersPermittedBy(config?.rules).sort());
+      }
+    } catch (cause) {
+      setupError = /** @type {Error} */ (cause);
+    }
+  }, CONFIG_LOAD_TIMEOUT_MS);
+
+  /** The parsed rows, or a failure naming why the table could not be read. */
+  const parsed = () => {
+    if (setupError) throw setupError;
+    return rows;
+  };
+
+  it('reads a non-empty opt-out table out of the document', () => {
+    // Every assertion below walks `rows`, so an empty parse would pass all of
+    // them. The parser throws rather than yielding [] for a section, table or
+    // row set it could not find; this is where that throw is reported.
+    expect(parsed().length).toBeGreaterThan(0);
+  });
+
+  it('documents exactly the opt-out sites the audit asserts', () => {
+    /** @type {Record<string, string[]>} */
+    const tabled = {};
+    for (const { via, specifiers } of parsed()) {
+      tabled[via] = [...new Set([...(tabled[via] ?? []), ...specifiers])].sort();
+    }
+    expect(tabled).toEqual(DOCUMENTED_OPT_OUTS);
+  });
+
+  it('names a real file and a real config in every row, the file under the config', () => {
+    const tracked = new Set(trackedFiles());
+    const wrong = parsed().flatMap(({ site, via }) => [
+      ...(tracked.has(site) ? [] : [`${site}: tabled site is not a tracked file`]),
+      ...(tracked.has(via) ? [] : [`${via}: tabled config is not a tracked file`]),
+      // A config only ever lints its own tree, so a row pairing a site with a
+      // config that could not reach it is a claim about an exception nobody has.
+      ...(dirname(via) === '.' || site.startsWith(`${dirname(via)}/`)
+        ? []
+        : [`${site}: sits outside ${dirname(via)}/, so ${via} never applies to it`]),
+    ]);
+    expect(wrong, `${CONVENTIONS_DOC} §4 rows that do not describe the workspace`).toEqual([]);
+  });
+
+  it('gives each site the specifiers its config really permits it', () => {
+    // The true-claim half: resolved through ESLint against the config the row
+    // itself names, so the table cannot say `node:net` where the workspace grants
+    // `node:http`, nor keep a row for a file whose exception has been removed.
+    const wrong = parsed().flatMap(({ site, via, specifiers }) => {
+      const real = permittedBySite.get(site) ?? [];
+      const tabled = [...specifiers].sort();
+      return JSON.stringify(real) === JSON.stringify(tabled)
+        ? []
+        : [
+            `${site} (via ${via}): table says ${JSON.stringify(tabled)}, config grants ${JSON.stringify(real)}`,
+          ];
+    });
+    expect(wrong, `${CONVENTIONS_DOC} §4's Allowed specifier column vs the real configs`).toEqual(
+      [],
+    );
+  });
+
+  it('marks any entry the module audit cannot see as the inline global it is', () => {
+    // §4's fifth row lists `fetch` alongside three modules, and says in prose why
+    // it is different: it is an inline eslint-disable, not a config `allow`, so
+    // the audit above — which diffs `no-restricted-imports` paths — is
+    // structurally blind to it. Without this, ANY unrecognised token in that
+    // column would be silently dropped by the `shipped.has` filter above and the
+    // set comparison would still pass: a typo'd `node:nett` would read as a
+    // documented opt-out and be enforced by nothing.
+    const globals = new Set(
+      noNetworkGlobals()
+        .slice(1)
+        .map((g) => g.name),
+    );
+    const unexplained = parsed().flatMap(({ site, other, cell }) =>
+      other
+        .filter((token) => !(globals.has(token) && cell.includes(`\`${token}\` (inline)`)))
+        .map(
+          (token) =>
+            `${site}: \`${token}\` is neither a banned module nor a banned global marked ` +
+            '`(inline)`, so no guard here covers it',
+        ),
+    );
+    expect(unexplained).toEqual([]);
+  });
+
+  it('states a count that follows from the table rather than from memory', () => {
+    const n = parsed().length;
+    expect(countWordIn(section, SITE_COUNT_SENTENCE, 'how many files carry an opt-out')).toBe(
+      cardinalFor(n),
+    );
+    // The promise to the next author. It may stay countless ("another"), but it
+    // must not name a WRONG one — "adding a third site" while five are tabled is
+    // the drift this pins, and deleting the sentence fails countWordIn outright.
+    expect(['another', ordinalFor(n + 1)]).toContain(
+      countWordIn(section, ADDING_SENTENCE, 'what the next author must update'),
+    );
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@1: ^1.1.16
-  brace-expansion@5: ^5.0.8
+  brace-expansion@1: ^1.1.18
+  brace-expansion@5: ^5.0.9
   esbuild: ^0.28.1
   fast-uri: ^3.1.4
   js-yaml: ^4.3.0
@@ -2373,11 +2373,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   browserslist@4.28.2:
@@ -5896,12 +5896,12 @@ snapshots:
 
   baseline-browser-mapping@2.10.36: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6979,11 +6979,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   mlly@1.8.2:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -82,6 +82,14 @@
         "$TURBO_ROOT$/tsconfig.root.json",
         "$TURBO_ROOT$/eslint.root*.config.mjs",
         "$TURBO_ROOT$/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
+        // CLAUDE.md is READ by this suite: §3's process.env table and §4's
+        // no-network opt-out table are each parsed and asserted against the tree
+        // they describe. Every other entry here is source; this one is prose,
+        // which is exactly why it is easy to leave out — and leaving it out is
+        // the whole hazard, because editing only the document would move no hash
+        // and turbo would replay a cached green at the one moment the guard
+        // exists to fire. No extension glob above reaches a .md.
+        "$TURBO_ROOT$/CLAUDE.md",
         "!$TURBO_ROOT$/**/node_modules/**",
         "!$TURBO_ROOT$/**/.next/**",
         "!$TURBO_ROOT$/**/dist/**",


### PR DESCRIPTION
CLAUDE.md §4 tables every file allowed to import a network module, and §3 tables every file allowed to read `process.env`. Both close with a promise that adding a site means updating the table.

§4 has an audit standing next to it — `no-network.test.js` walks the real ESLint configs and asserts they equal a `DOCUMENTED_OPT_OUTS` map. But that map is a **hand-typed copy of the table**, and nothing in the workspace opens `CLAUDE.md`. Deleting §4's table, its intro sentence and its promise outright — with every config untouched — left the package at **635/635 green**. §3's table had no guard on it at all.

So the tables are now read, and each column driven against the thing it describes.

## Changes

- **`test/helpers/claude-md.js`** — a markdown section/table parser that **throws** rather than returning empty. A parser answering "nothing here" turns every downstream walk-the-rows assertion into a vacuous pass, which is the failure mode this family of guards exists to remove. Selects a table by its header, not its position (§4 holds two), and refuses a non-unique heading anchor.
- **`test/claude-md.test.js`** (new, 21 tests) — the parser's own suite. Every refusal is driven, and each case *also* shows the walk-the-rows form going green on the empty result, so the throw's value is demonstrated rather than asserted.
- **§4 guard** (`no-network.test.js`) — the table is asserted twice: against `DOCUMENTED_OPT_OUTS` with `toEqual`, so the two cannot drift apart in either direction; and against the **configs themselves**, resolving each row's site through `ESLint#calculateConfigForFile` under the config that row names. The second covers the **Site** column, which the mirror doesn't carry and structurally cannot check. Any entry in **Allowed specifier** that is neither a banned module nor a banned global marked `(inline)` fails rather than being silently skipped — a token the module audit can't see is enforced by nothing.
- **§3 guard** (`effective-config.test.js`) — site against the tracked tree and against actually reading `process.env`; **Mechanism** against reality (a config opt-out must resolve the rule to `off`; an inline one must carry a real disable directive and not already be exempted by config); and **exhaustiveness** — every opt-out shipped source carries must appear in a row, config-level ones counted by `files:` pattern so a second path can't hide behind the first. The `Why` column is prose about intent and is explicitly left unguarded.
- **Count words derived, not copied** — "Five files carry…" is compared against the row count; the promise sentence must be `another` or the correct ordinal, so it can't say "third" while five are tabled, and deleting it fails outright.
- **`turbo.json`** — `$TURBO_ROOT$/CLAUDE.md` added to `@akasecurity/eslint-config#test` inputs. Every glob there spells source extensions and `$TURBO_DEFAULT$` covers only the package's own tree, so **none reached a `.md`**: a doc-only edit would have left the hash untouched and replayed a cached green at the one moment the guard exists to fire. Same hazard that block already documents for `ci.yml`. Pinned by a test.

## Two things found while writing it

- **§3's "Four places" was only true for shipped source.** Five files under `plugins/claude-code/test/` also carry inline `n/no-process-env` disables — they spawn the real hooks and need the host PATH. The exhaustiveness guard isn't honest without saying so, so §3 now reads "Four places **in shipped source** …", and the guard's `isTestPath` predicate is what that phrase has to mean.
- **An uncaught `beforeAll` throw reports its tests as _skipped_, not failed** (verified on vitest 4: `Tests 1 skipped`, nothing named). Both new hooks catch end to end into a `setupError` that the tests rethrow, so a resolution that started erroring names itself instead of going quiet.

## Verification

Thirteen mutations, each verified to have **landed** before running — a mutation matching nothing exits 0 and reads exactly like a guard holding — each required to go red, tree checksum-compared afterwards:

| Mutation | Result |
| --- | --- |
| §4 whole table + count sentence deleted | red (6 failing) |
| §4 row's allowed specifier changed | red (2) |
| §4 row's site path made up | red (2) |
| §4 row attributed to the wrong config | red (2) |
| §4 / §3 count word left at the old value | red (1 each) |
| §4 / §3 promise names a stale ordinal | red (1 each) |
| §4 grows an entry no guard can see | red (1) |
| §3 row's mechanism swapped | red (2) |
| §3 row deleted | red (2) |
| a fifth shipped-source opt-out lands untabled | red (1) |
| turbo stops hashing the doc the guards read | red (1) |

`@akasecurity/eslint-config` **668 passed** (was 635, +33). Full workspace `turbo run test --force` — **29/29 tasks, Cached: 0**. `pnpm lint` 15/15 + `lint:root`. `pnpm typecheck --force` 15/15 + `typecheck:root`. `prettier --check .` clean.

## Not fixed here

Two live drifts elsewhere in the doc, left alone because they're tracked separately: the cross-cutting-rules line still names **two** `process.env` sites where §3 names four, and §3's `backfill.ts` row gives the wrong reason (it reads `CLAUDE_CODE_BRIDGE_SESSION_ID` for the self-contamination guard, not the transcript root). Neither is covered by the new guards — the first is outside §3's section, the second is the unguarded `Why` column.