### PR TITLE
fix(dashboard-ui): render the rotate token in the case it must be typed

### DIFF
--- a/packages/dashboard-ui/src/exceptions/RotateKeyDialog.tsx
+++ b/packages/dashboard-ui/src/exceptions/RotateKeyDialog.tsx
@@ -129,7 +129,12 @@ export function RotateKeyDialog({
 
           <div>
             <div className="mb-1.5 text-label font-semibold uppercase tracking-wider text-text-3">
-              Type “{ROTATE_CONFIRMATION}” to confirm
+              Type{' '}
+              {/* normal-case is load-bearing: the label is uppercased for style but the
+                  match below is case-sensitive, so the token has to render in the case
+                  the user must actually type. */}
+              <span className="font-mono normal-case tracking-normal">“{ROTATE_CONFIRMATION}”</span>{' '}
+              to confirm
             </div>
             <Input
               value={typed}
@@ -137,6 +142,7 @@ export function RotateKeyDialog({
                 setTyped(e.target.value);
               }}
               autoComplete="off"
+              className="font-mono"
             />
           </div>
 


### PR DESCRIPTION
## Summary

The rotate-key dialog told the user to type a token it rendered in the wrong case. `ROTATE_CONFIRMATION` is `'rotate'`, but it was interpolated **inside** a `uppercase` label, so the dialog read `TYPE "ROTATE" TO CONFIRM`. The confirm button matches case-sensitively (`typed !== ROTATE_CONFIRMATION`), and the server action re-checks `confirmation !== 'rotate'` — so a user typing exactly what they saw got a permanently disabled button with nothing on screen explaining why.

This is the only confirmation surface in the codebase that puts the literal token inside a transformed element. `ApproveExceptionDialog` passes the value as `placeholder={entry.maskedValue}`, and the vault purge uses `placeholder="Type 'purge' to confirm"` — both sit outside the uppercased label and were never affected.

## Changes

- Wrap the token in a `normal-case tracking-normal font-mono` span, so the label keeps its uppercase styling while the token renders in the case the check actually wants. Mirrors the existing precedent in `SessionDetailView.tsx`.
- Give the confirmation input `font-mono`, matching every other confirmation input here (`ApproveExceptionDialog`, `AddExceptionForm`, vault purge), so what the user types is visually comparable to the token.

## Verification

`typecheck`, `lint`, `prettier --check` and the package's 182 tests all pass. Pre-push lint ran clean across the workspace.

## Notes for the reviewer

Two things this deliberately does **not** do:

- **The comparison stays case-sensitive.** Accepting `ROTATE` client-side would arm the button and then fail server-side anyway, since `rotateKey` hardcodes `!== 'rotate'` — trading a dead button for a confusing error. Making the confirmation case-insensitive is a product call, not a bug fix; it would be a two-line change in both places plus the pin in `web-ui/test/actions/exceptions.test.ts`.
- **No regression test.** `packages/dashboard-ui` runs vitest in a `node` environment with no jsdom and no testing-library, and its `vitest.config.ts` says to add them "if interactive component tests are introduced later". The dialogs are also out of reach of the SSR tests that do exist — `fingerprint-egress.test.tsx` documents that both mount through a Radix portal that renders nothing under `react-dom/server`, which is why they carry compile-time pins only. There is no seam that could catch a regression here without adding jsdom to the package. Happy to do that in a follow-up if it's wanted.

No version bump: this touches `dashboard-ui`, which the CLI bundles via the web-ui, so a publish would need a `cli` bump — but that's a release decision, not part of this change.