### PR TITLE
chore(deps): raise the fast-uri floor past the host-confusion advisory

### DIFF
--- a/.github/audit-waivers.json
+++ b/.github/audit-waivers.json
@@ -1,13 +1,6 @@
 {
   "waivers": [
     {
-      "advisory": "GHSA-mh99-v99m-4gvg",
-      "scope": "workspace",
-      "module": "brace-expansion",
-      "reason": "No patched release on the 1.x line — the fix ships only in 5.0.8, and the advisory's <=5.0.7 range sweeps every earlier major. The 1.x copy is reached solely through eslint > minimatch@3 (lint-time dev tooling, not part of any shipped bundle); the fix becomes reachable only via the ESLint 10 major bump tracked separately — drop this waiver when that lands.",
-      "expires": "2026-08-26"
-    },
-    {
       "advisory": "GHSA-6g55-p6wh-862q",
       "scope": "artifact",
       "module": "postcss",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
       "brace-expansion@1": "^1.1.18",
       "brace-expansion@5": "^5.0.9",
       "esbuild": "^0.28.1",
-      "fast-uri": "^3.1.4",
+      "fast-uri": "^3.1.5",
       "js-yaml": "^4.3.0",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   brace-expansion@1: ^1.1.18
   brace-expansion@5: ^5.0.9
   esbuild: ^0.28.1
-  fast-uri: ^3.1.4
+  fast-uri: ^3.1.5
   js-yaml: ^4.3.0
   postcss: ^8.5.18
   sharp: ^0.35.0
@@ -2895,8 +2895,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -5797,7 +5797,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6441,7 +6441,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:


### PR DESCRIPTION
The dependency audit is failing on every open PR. The cause is on `main`, not in any of them: a newly published high advisory, [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (`fast-uri`, host confusion via a backslash authority introducer). Because `audit.yml` re-runs `pnpm audit` against the live registry on every PR, a fresh advisory turns them all red at once with no code change anywhere.

## Changes

- **Raise the `fast-uri` override to `^3.1.5`.** The floor was already `^3.1.4`, but an override is a floor rather than a pin that updates itself — the lockfile stayed resolved at `3.1.4`, so the advisory still matched. The fix ships on the same major (`3.1.5`), so no waiver is needed. `fast-uri` is reached only through `ajv` as lint-time dev tooling; the advisory was workspace-scoped and the shipped-artifact audit was unaffected, so no artifact version moves.
- **Drop the stale `brace-expansion` waiver.** Non-blocking cleanup: the gate emits a `::notice::` for it, not an error, but it was showing up on every run. The floors raised earlier put the tree at `1.1.18`/`5.0.9`, above the advisory's patched `1.1.17`/`5.0.8`, so it matches nothing. Its stated reason had also gone factually wrong — it claimed no patch existed on the 1.x line, but the advisory lists `1.1.17`.

## Verification

Both audit scopes gate separately, so both were run locally:

| Check | Result |
| --- | --- |
| `audit-dependencies.ts` (workspace) | passes, exit 0, no notices |
| `audit-dependencies.ts --artifact` | passes, exit 0 (3 waived) |
| `audit-gate` tests | 45/45 |
| Lint | 15/15, `Cached: 0` |
| Full test suite | 29/29, `Cached: 0` |
| Typecheck (`--force`) | 15/15, `Cached: 0` |
| `format:check` | clean |

The cached tasks were forced and `Cached: 0` confirmed throughout, so every task really executed against the new lockfile rather than replaying another worktree's logs.

The lockfile move was verified from the diff's actual version lines (`3.1.4` → `3.1.5` on all four entries) and the resolved on-disk copy, not from an "already up to date" install message.

## Follow-on

The PRs currently red on this will not go green on their own — each needs to pick up `main` once this lands:

- https://github.com/akasecurity/ai-tc/pull/199
- https://github.com/akasecurity/ai-tc/pull/200
- https://github.com/akasecurity/ai-tc/pull/202