### PR TITLE
fix(audit-gate): refuse a pnpm mute the audit payload cannot reveal

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,22 @@
 name: CodeQL
 
 # Static analysis via GitHub CodeQL over the TypeScript/JavaScript workspace
-# and the Actions workflow files themselves. Runs on every PR to main, on main
-# pushes, and weekly so newly released queries sweep the unchanged tree.
-# Findings land in the repository's Security tab.
+# and the Actions workflow files themselves. Runs on every PR, on main pushes,
+# and weekly so newly released queries sweep the unchanged tree. Findings land
+# in the repository's Security tab.
 
 on:
   push:
     branches: [main]
+  # No `branches:` filter, so a stacked PR (one based on another feature branch
+  # rather than on main) is analysed too. That is also what keeps the default
+  # event types sufficient here: `ci.yml` has to listen for `edited` because
+  # retargeting a PR's BASE fires only that event, and its `branches: [main]`
+  # filter means a stacked PR matches no event until it is retargeted. With no
+  # filter the run already happened when the PR was opened, so a retarget has
+  # nothing to re-trigger — and this check cannot end up permanently absent on
+  # a PR that is required to have it.
   pull_request:
-    branches: [main]
   schedule:
     - cron: '30 6 * * 1'
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,10 +264,16 @@ both audits reported green. `assertNothingMuted` is kept as the payload-side hal
 a later pnpm does populate the field; `assertNoAuditConfigMutes` is the half that fires.
 
 Both channels are real and were measured; `.npmrc` is not one, in either the flattened or
-the camelCase spelling. `findAuditConfigMutes` refuses on the **presence** of the key
-rather than on the ignore lists having entries, so a third key added by a later pnpm is
-caught without a code change. Its tests pin the discriminating case directly: a payload
-reporting nothing muted **and** a manifest configuring `auditConfig` must still be
+the camelCase spelling. `findAuditConfigMutes` refuses on the **presence** of the
+`auditConfig` key — in **both** channels alike, and whether or not the ignore lists under
+it carry entries. So an empty one is refused too, and a third key added by a later pnpm is
+caught without a code change, because the key names are never enumerated. The two halves
+have to answer alike here or the rule stops being statable: the YAML half cannot tell an
+empty `auditConfig` from a populated one without a parser. A file that **exists but cannot
+be read** is refused rather than read as "no config here" — absence means `ENOENT` and
+nothing else, since a failed read that returned "nothing to see" would reach the exact
+outcome this check exists to prevent. Its tests pin the discriminating case directly: a
+payload reporting nothing muted **and** a manifest configuring `auditConfig` must still be
 refused — delete the file read and that case, alone, goes red.
 
 ## Package dependency rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,8 +252,23 @@ next's own pins), by bumping that package once upstream moves. Only when an advi
 has no fixed release reachable from the tree, add an **expiring** waiver to
 `.github/audit-waivers.json`, scoped to the audit it applies to — format and process
 in CONTRIBUTING.md ("Dependency advisories and waivers").
-`pnpm.auditConfig.ignoreCves`/`ignoreGhsas` is not an approved suppression route: the
-gate refuses to run while anything is muted there.
+`auditConfig.ignoreCves`/`ignoreGhsas` is not an approved suppression route, and the
+gate refuses to run (exit 3) when it is set. **It is detected by reading the two files
+pnpm takes the setting from — the root `package.json`'s `pnpm.auditConfig` and
+`pnpm-workspace.yaml`'s top-level `auditConfig` — not by inspecting what pnpm returns.**
+The payload cannot reveal it: pnpm removes a muted advisory from `advisories`, decrements
+the `metadata` severity counts to match, and leaves the top-level `muted` array **empty**,
+so a muted run is byte-for-byte the shape of a clean one. A guard reading `muted` is
+therefore correct in isolation and unreachable in practice — which is what it was, while
+both audits reported green. `assertNothingMuted` is kept as the payload-side half in case
+a later pnpm does populate the field; `assertNoAuditConfigMutes` is the half that fires.
+
+Both channels are real and were measured; `.npmrc` is not one, in either the flattened or
+the camelCase spelling. `findAuditConfigMutes` refuses on the **presence** of the key
+rather than on the ignore lists having entries, so a third key added by a later pnpm is
+caught without a code change. Its tests pin the discriminating case directly: a payload
+reporting nothing muted **and** a manifest configuring `auditConfig` must still be
+refused — delete the file read and that case, alone, goes red.
 
 ## Package dependency rules
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,8 @@ Two security workflows run alongside the main build:
   it only adds a comment when a **new** advisory id appears, so a known long-lived
   finding does not ping daily.
 - **CodeQL** (`.github/workflows/codeql.yml`) — static analysis of the TypeScript
-  workspace and the workflow files on every PR to `main` and weekly; findings appear
-  under the repository's **Security** tab.
+  workspace and the workflow files on every PR (including a PR stacked on another
+  branch) and weekly; findings appear under the repository's **Security** tab.
 
 When the workspace audit fails, fix first: upgrade the dependency, or raise its floor
 via `pnpm.overrides` in the root `package.json` (the existing entries there are exactly
@@ -95,10 +95,18 @@ from our dependency tree, add a waiver to `.github/audit-waivers.json`:
   (for example the registry matching a workspace importer name against an unrelated
   public package). Set `"class": "false-positive"`, say so plainly in `reason`, and a
   longer expiry is acceptable there.
-- Waivers are reviewed like any other code change.
-- `pnpm.auditConfig.ignoreCves` / `ignoreGhsas` is **not** an approved suppression
-  route: pnpm-native ignores carry no expiry, no reason, and no report row, so the gate
-  refuses to run while anything is muted.
+- **Anyone may open a waiver PR; only a maintainer may approve one.** A waiver is a
+  decision to ship a known advisory, so it needs the same approval as any other change
+  to `main` — which branch protection already requires. Say in the PR description what
+  you tried before reaching for it.
+- `auditConfig.ignoreCves` / `ignoreGhsas` is **not** an approved suppression route:
+  pnpm-native ignores carry no expiry, no reason, and no report row. The gate refuses
+  to run — exit 3, the same code as a malformed waiver file — when `auditConfig` is set
+  in **either** place pnpm reads it from: the root `package.json` (`pnpm.auditConfig`)
+  or `pnpm-workspace.yaml` (top-level `auditConfig`). It is read off disk rather than
+  detected in pnpm's output, because pnpm removes a muted advisory from `advisories`,
+  decrements the severity counts to match and leaves `muted` **empty** — so a muted run
+  is indistinguishable from a clean one by its result alone.
 
 ## Contributing detection rules
 
@@ -116,6 +124,33 @@ so we don't ship false positives.
 2. Keep PRs focused; write a clear description.
 3. Ensure `pnpm typecheck`, `pnpm lint`, `pnpm test`, and `pnpm format:check` pass.
 4. Be responsive to review feedback.
+
+### Checks that gate `main`
+
+Merging to `main` needs an approving review and these status checks. The names are the
+job names GitHub reports, and they are what branch protection matches on — **a renamed
+job silently stops being required**, because protection keeps waiting for a check name
+nothing produces any more. So renaming a job here means updating this table in the same
+PR; `packages/eslint-config/test/required-checks.test.js` reads this table and fails when
+a name in it no longer belongs to a real job.
+
+| Check                                     | Workflow     |
+| ----------------------------------------- | ------------ |
+| `Lint · Typecheck · Test · Build`         | `ci.yml`     |
+| `No-network · Full suite, egress blocked` | `ci.yml`     |
+| `Windows · Unit tests (shipped surface)`  | `ci.yml`     |
+| `Dependency audit`                        | `audit.yml`  |
+| `CodeQL (javascript-typescript)`          | `codeql.yml` |
+| `CodeQL (actions)`                        | `codeql.yml` |
+
+Whether each is _actually_ enforced lives in repository settings, not in this tree, so
+this table cannot assert it — but the state is readable without admin, which is worth
+knowing since the branch-protection REST endpoint 404s to non-admins and reads like
+"no protection at all":
+
+```bash
+gh api graphql -f query='{repository(owner:"akasecurity",name:"ai-tc"){pullRequest(number:PR){commits(last:1){nodes{commit{statusCheckRollup{contexts(first:50){nodes{... on CheckRun{name isRequired(pullRequestNumber:PR)}}}}}}}}}}'
+```
 
 By contributing you agree that your contributions are licensed under the
 repository's [LICENSE](LICENSE). Please also read our

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -1,0 +1,135 @@
+// CONTRIBUTING.md ("Checks that gate `main`") lists the status checks branch
+// protection matches on. Protection matches by NAME, so a renamed job does not
+// fail — it stops being produced, protection goes on waiting for a name nothing
+// emits, and the check is silently no longer required. That failure is invisible
+// in a diff and invisible in a green run, which is why the table is read here
+// and driven against the workflows rather than being trusted.
+//
+// What this cannot see is repository settings: whether each name is actually
+// configured as required lives outside the tree. This pins the half that is in
+// the tree — that every name in the table still belongs to a real job.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
+const WORKFLOWS = join(REPO_ROOT, '.github', 'workflows');
+
+const readWorkflow = (file) => readFileSync(join(WORKFLOWS, file), 'utf8');
+
+// A job's `name:` sits at four spaces (`jobs:` → job key at two → its keys at
+// four). A step's is deeper and carries a `- `, so this matches job names only.
+const JOB_NAME = /^ {4}name: (.+)$/gm;
+
+// One `${{ matrix.<key> }}` in a job name, which is how a matrix job produces
+// one check per value. Anything more elaborate is not in use and would show up
+// here as an unexpanded name that matches nothing in the table.
+const MATRIX_REF = /\$\{\{\s*matrix\.([a-zA-Z0-9_-]+)\s*\}\}/;
+
+function matrixValues(source, key) {
+  const inline = new RegExp(`^\\s*${key}: \\[(.+)\\]$`, 'm').exec(source);
+  if (inline === null) return [];
+  return inline[1].split(',').map((value) => value.trim().replace(/^['"]|['"]$/g, ''));
+}
+
+// Every check name a workflow can emit, with matrix jobs expanded to the names
+// GitHub actually reports.
+function checkNames(file) {
+  const source = readWorkflow(file);
+  const names = [];
+  for (const [, rawName] of source.matchAll(JOB_NAME)) {
+    const name = rawName.trim();
+    const ref = MATRIX_REF.exec(name);
+    if (ref === null) {
+      names.push(name);
+      continue;
+    }
+    for (const value of matrixValues(source, ref[1])) {
+      names.push(name.replace(MATRIX_REF, value));
+    }
+  }
+  return names;
+}
+
+// The table itself: | `Check name` | `workflow.yml` |
+function requiredChecks() {
+  const contributing = readFileSync(join(REPO_ROOT, 'CONTRIBUTING.md'), 'utf8');
+  const section = /## Pull requests[\s\S]*?### Checks that gate `main`([\s\S]*?)```bash/.exec(
+    contributing,
+  );
+  expect(section).not.toBeNull();
+  return [...section[1].matchAll(/^\| `([^`]+)`\s*\| `([^`]+)`\s*\|$/gm)].map(
+    ([, check, file]) => ({
+      check,
+      file,
+    }),
+  );
+}
+
+describe('the required-check table in CONTRIBUTING.md', () => {
+  const rows = requiredChecks();
+
+  // A table that parsed to nothing would satisfy every per-row assertion below
+  // without checking anything, so pin the count first. The three CI jobs, the
+  // audit, and CodeQL's two matrix legs.
+  it('parses, and covers every gate the table is supposed to list', () => {
+    expect(rows).toHaveLength(6);
+    expect(rows.map((row) => row.file)).toEqual(
+      expect.arrayContaining(['ci.yml', 'audit.yml', 'codeql.yml']),
+    );
+  });
+
+  it.each(rows)('$check is a real job in $file', ({ check, file }) => {
+    expect(checkNames(file)).toContain(check);
+  });
+
+  // The matrix expander is load-bearing for the two CodeQL rows: without it
+  // they would read as the literal `CodeQL (${{ matrix.language }})` and match
+  // nothing. Pin that it expands rather than trusting the rows above, which
+  // would also pass if the table itself drifted to the unexpanded spelling.
+  it('expands a matrix job into the names GitHub reports', () => {
+    const names = checkNames('codeql.yml');
+    expect(names).toContain('CodeQL (javascript-typescript)');
+    expect(names).toContain('CodeQL (actions)');
+    expect(names.some((name) => name.includes('matrix.'))).toBe(false);
+  });
+
+  // The audit workflow's second job reports a check too, and it is deliberately
+  // NOT required — it only ever runs on the schedule, so requiring it would
+  // block every PR on a check that is permanently skipped there.
+  it('does not require the scheduled advisory-reporting job', () => {
+    expect(checkNames('audit.yml')).toContain('File advisory issue (scheduled runs)');
+    expect(rows.map((row) => row.check)).not.toContain('File advisory issue (scheduled runs)');
+  });
+});
+
+describe('the workflows behind those checks', () => {
+  // `Dependency audit` and the CodeQL legs are only "on every PR" if neither
+  // workflow filters `pull_request` by base branch. A `branches:` filter there
+  // excludes a stacked PR entirely — no run, no check — and for a required
+  // check that means a PR that can never satisfy it.
+  // The block ends at the next sibling KEY, and a `#` comment is not one — an
+  // end-of-block test that stopped at the first two-space non-space character
+  // would end at a comment line instead, so a `branches:` filter written below
+  // one would sit outside the captured block and be missed.
+  it.each(['audit.yml', 'codeql.yml'])('%s runs on every PR, whatever its base', (file) => {
+    const source = readWorkflow(file);
+    const trigger = /^ {2}pull_request:[^\S\n]*$([\s\S]*?)^ {2}[^\s#]/m.exec(source);
+    expect(trigger).not.toBeNull();
+    expect(trigger[1]).not.toMatch(/^\s*branches:/m);
+  });
+
+  it('both run daily or weekly as well as on PRs', () => {
+    expect(readWorkflow('audit.yml')).toMatch(/^\s*- cron: '[^']+'$/m);
+    expect(readWorkflow('codeql.yml')).toMatch(/^\s*- cron: '[^']+'$/m);
+  });
+
+  // Code scanning cannot upload results without it, so the analysis would run
+  // and report nothing.
+  it('codeql.yml grants security-events: write', () => {
+    expect(readWorkflow('codeql.yml')).toMatch(/^\s*security-events: write$/m);
+  });
+});

--- a/tools/audit-gate/src/audit-dependencies.ts
+++ b/tools/audit-gate/src/audit-dependencies.ts
@@ -34,6 +34,7 @@ import { basename, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
+  assertNoAuditConfigMutes,
   assertNothingMuted,
   type AuditMode,
   type AuditPayload,
@@ -52,6 +53,8 @@ import {
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const WAIVERS_PATH = join(REPO_ROOT, '.github', 'audit-waivers.json');
 const CLI_MANIFEST_PATH = join(REPO_ROOT, 'cli', 'package.json');
+const ROOT_MANIFEST_PATH = join(REPO_ROOT, 'package.json');
+const WORKSPACE_YAML_PATH = join(REPO_ROOT, 'pnpm-workspace.yaml');
 const REPORT_PATHS: Record<AuditMode, string> = {
   workspace: join(REPO_ROOT, 'audit-report.md'),
   artifact: join(REPO_ROOT, 'artifact-audit-report.md'),
@@ -95,7 +98,23 @@ function withRetries<T>(attemptFn: () => T): T {
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+// Absent is not an error: only a file that exists is inspected, so a checkout
+// without a workspace manifest simply contributes nothing to look at.
+const readIfPresent = (path: string): string | undefined => {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return undefined;
+  }
+};
+
 function runWorkspaceAudit(): AuditPayload {
+  // Before spawning anything: a pnpm-side mute would leave the payload looking
+  // clean, so this has to be read off disk rather than detected in the result.
+  assertNoAuditConfigMutes({
+    manifest: readIfPresent(ROOT_MANIFEST_PATH),
+    workspaceYaml: readIfPresent(WORKSPACE_YAML_PATH),
+  });
   return withRetries(() => {
     const result = spawnSync('pnpm', ['audit', '--json'], { ...SPAWN_OPTIONS, cwd: REPO_ROOT });
     if (result.error) {

--- a/tools/audit-gate/src/audit-dependencies.ts
+++ b/tools/audit-gate/src/audit-dependencies.ts
@@ -99,12 +99,20 @@ function withRetries<T>(attemptFn: () => T): T {
 }
 
 // Absent is not an error: only a file that exists is inspected, so a checkout
-// without a workspace manifest simply contributes nothing to look at.
+// without a workspace manifest simply contributes nothing to look at. Absent
+// means ENOENT and nothing else — a file that exists but cannot be read is
+// refused rather than reported as "no config here", which is how the JSON
+// parse failure in findAuditConfigMutes already behaves. Reading a mute as
+// absence is the one outcome this check exists to prevent, so it must not be
+// reachable through a failed read either.
 const readIfPresent = (path: string): string | undefined => {
   try {
     return readFileSync(path, 'utf8');
-  } catch {
-    return undefined;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw new WaiverConfigError(
+      `${basename(path)} exists but could not be read (${errorMessage(error)}), so its pnpm config is unknown`,
+    );
   }
 };
 

--- a/tools/audit-gate/src/lib.ts
+++ b/tools/audit-gate/src/lib.ts
@@ -254,10 +254,13 @@ export interface AuditConfigSources {
 const WORKSPACE_AUDIT_CONFIG = /^["']?auditConfig["']?\s*:/m;
 
 // Names every place `auditConfig` is configured, so the refusal can point at
-// the file to edit. Presence is enough — the gate never needs to know which
-// advisories are named, and an unrecognized key added by a later pnpm is
-// caught for free. An `auditConfig` that is present but empty suppresses
-// nothing and is allowed through.
+// the file to edit. **Presence of the key is enough, in both channels** — the
+// gate never needs to know which advisories are named, so the key names are
+// never enumerated and one added by a later pnpm is caught for free. An
+// `auditConfig` that is present but empty suppresses nothing, and is refused
+// anyway: it is a stub with no other purpose, and the two channels cannot
+// answer differently without the rule becoming one nobody can state. The YAML
+// half could not tell empty from non-empty without a parser regardless.
 export function findAuditConfigMutes(sources: AuditConfigSources): string[] {
   const found: string[] = [];
 
@@ -272,10 +275,11 @@ export function findAuditConfigMutes(sources: AuditConfigSources): string[] {
     }
     const auditConfig = (parsed as { pnpm?: { auditConfig?: unknown } } | null)?.pnpm?.auditConfig;
     if (auditConfig !== null && typeof auditConfig === 'object') {
-      const keys = Object.keys(auditConfig);
-      if (keys.length > 0) {
-        found.push(`package.json "pnpm.auditConfig" (${keys.sort().join(', ')})`);
-      }
+      const keys = Object.keys(auditConfig).sort();
+      // An empty object has no keys to name, so the suffix is dropped rather
+      // than rendering as an empty pair of parentheses.
+      const detail = keys.length > 0 ? ` (${keys.join(', ')})` : '';
+      found.push(`package.json "pnpm.auditConfig"${detail}`);
     }
   }
 

--- a/tools/audit-gate/src/lib.ts
+++ b/tools/audit-gate/src/lib.ts
@@ -218,16 +218,80 @@ export function normalizeNpmAudit(payload: NpmAuditPayload): AuditPayload {
   return { advisories, metadata: { vulnerabilities: counts } };
 }
 
-// pnpm's own suppression channel (`pnpm.auditConfig.ignoreCves`/`ignoreGhsas`)
-// filters advisories out of the payload and into `muted` — with no expiry, no
-// reason, and no report row. The gate refuses to run while anything is muted
-// so audit-waivers.json stays the only suppression route.
+// pnpm's own suppression channel (`auditConfig.ignoreCves`/`ignoreGhsas`) drops
+// an advisory with no expiry, no reason and no report row. The gate refuses to
+// run while it is configured, so audit-waivers.json stays the only suppression
+// route.
+//
+// The payload cannot reveal it. pnpm 10 does carry a top-level `muted` array,
+// but a muted advisory is filtered out of `advisories` and `muted` stays EMPTY
+// — and the severity counts in `metadata` are decremented to match, so nothing
+// in the output is inconsistent with a clean tree. The setting is therefore
+// read from the files pnpm takes it from, not inferred from what pnpm returns.
 export function assertNothingMuted(payload: AuditPayload): void {
   const muted = payload.muted ?? [];
   if (muted.length > 0) {
     throw new WaiverConfigError(
-      `pnpm.auditConfig mutes ${String(muted.length)} advisor${muted.length === 1 ? 'y' : 'ies'}; ` +
+      `pnpm auditConfig mutes ${String(muted.length)} advisor${muted.length === 1 ? 'y' : 'ies'}; ` +
         'muted advisories carry no expiry or review trail — use .github/audit-waivers.json instead',
+    );
+  }
+}
+
+// The two files pnpm reads `auditConfig` from. `.npmrc` is not one of them —
+// neither the flattened nor the camelCase spelling has any effect there — so
+// these two are the whole surface. Each is optional: a caller passes undefined
+// for a file that does not exist, which `exactOptionalPropertyTypes` makes a
+// distinct thing from omitting the property — so both spellings are allowed.
+export interface AuditConfigSources {
+  manifest?: string | undefined;
+  workspaceYaml?: string | undefined;
+}
+
+// A top-level `auditConfig:` mapping key, quoted or not. Anchored with no
+// leading whitespace on purpose: a nested key of the same name belongs to
+// something else and is not pnpm's setting.
+const WORKSPACE_AUDIT_CONFIG = /^["']?auditConfig["']?\s*:/m;
+
+// Names every place `auditConfig` is configured, so the refusal can point at
+// the file to edit. Presence is enough — the gate never needs to know which
+// advisories are named, and an unrecognized key added by a later pnpm is
+// caught for free. An `auditConfig` that is present but empty suppresses
+// nothing and is allowed through.
+export function findAuditConfigMutes(sources: AuditConfigSources): string[] {
+  const found: string[] = [];
+
+  if (sources.manifest !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(sources.manifest);
+    } catch {
+      throw new WaiverConfigError(
+        'package.json is not valid JSON, so its pnpm config is unreadable',
+      );
+    }
+    const auditConfig = (parsed as { pnpm?: { auditConfig?: unknown } } | null)?.pnpm?.auditConfig;
+    if (auditConfig !== null && typeof auditConfig === 'object') {
+      const keys = Object.keys(auditConfig);
+      if (keys.length > 0) {
+        found.push(`package.json "pnpm.auditConfig" (${keys.sort().join(', ')})`);
+      }
+    }
+  }
+
+  if (sources.workspaceYaml !== undefined && WORKSPACE_AUDIT_CONFIG.test(sources.workspaceYaml)) {
+    found.push('pnpm-workspace.yaml "auditConfig"');
+  }
+
+  return found;
+}
+
+export function assertNoAuditConfigMutes(sources: AuditConfigSources): void {
+  const found = findAuditConfigMutes(sources);
+  if (found.length > 0) {
+    throw new WaiverConfigError(
+      `pnpm auditConfig is set in ${found.join(' and ')}; it suppresses advisories with no expiry, ` +
+        'no reason and no report row — remove it and use .github/audit-waivers.json instead',
     );
   }
 }

--- a/tools/audit-gate/test/audit-gate.test.ts
+++ b/tools/audit-gate/test/audit-gate.test.ts
@@ -289,8 +289,16 @@ describe('findAuditConfigMutes', () => {
     ).toHaveLength(1);
   });
 
-  it('allows an auditConfig that is present but empty — it suppresses nothing', () => {
-    expect(findAuditConfigMutes({ manifest: manifestWith({ auditConfig: {} }) })).toEqual([]);
+  // Both channels answer the same way about an empty `auditConfig`. It
+  // suppresses nothing either way, so this is about the rule being statable:
+  // the YAML half cannot tell empty from non-empty without a parser, so if the
+  // manifest half allowed it the two would disagree and "refuses on presence"
+  // would be true of only one of them.
+  it('refuses an empty auditConfig in either channel, and names no keys for it', () => {
+    const manifest = findAuditConfigMutes({ manifest: manifestWith({ auditConfig: {} }) });
+    expect(manifest).toEqual(['package.json "pnpm.auditConfig"']);
+    expect(manifest[0]).not.toContain('()');
+    expect(findAuditConfigMutes({ workspaceYaml: 'auditConfig:\n' })).toHaveLength(1);
   });
 
   // The second channel: pnpm 10 reads the same setting from the workspace file,

--- a/tools/audit-gate/test/audit-gate.test.ts
+++ b/tools/audit-gate/test/audit-gate.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  assertNoAuditConfigMutes,
   assertNothingMuted,
   type AuditAdvisory,
   type AuditPayload,
   buildReport,
   classify,
+  findAuditConfigMutes,
   mdEscape,
   normalizeNpmAudit,
   type NpmAuditPayload,
@@ -218,13 +220,160 @@ describe('assertNothingMuted', () => {
     }).not.toThrow();
   });
 
-  it('fails closed when pnpm.auditConfig mutes an advisory', () => {
+  it('fails closed when a payload reports muted advisories', () => {
     expect(() => {
       assertNothingMuted(payload({ muted: [{ id: 1 }] }));
     }).toThrow(WaiverConfigError);
     expect(() => {
       assertNothingMuted(payload({ muted: [{ id: 1 }] }));
     }).toThrow(/audit-waivers\.json/);
+  });
+});
+
+// What pnpm 10.30.1 actually does with `auditConfig.ignoreGhsas` /
+// `ignoreCves`: the advisory leaves `advisories`, `muted` stays EMPTY, and the
+// severity counts are decremented to match. So the payload alone is
+// indistinguishable from a clean tree, and assertNothingMuted — which reads
+// only the payload — never fires. These cases drive the file-reading check
+// that covers it. The shapes below are the two real files, not invented ones.
+const MUTED_PNPM_PAYLOAD: AuditPayload = {
+  advisories: {},
+  muted: [],
+  metadata: { vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 } },
+};
+
+const manifestWith = (pnpmSection: Record<string, unknown>): string =>
+  JSON.stringify({ name: 'ai-tc', private: true, pnpm: pnpmSection });
+
+describe('findAuditConfigMutes', () => {
+  it('finds nothing when neither file configures auditConfig', () => {
+    expect(
+      findAuditConfigMutes({
+        manifest: manifestWith({ overrides: { 'left-pad': '^1.3.0' } }),
+        workspaceYaml: "packages:\n  - 'packages/*'\n\nonlyBuiltDependencies:\n  - esbuild\n",
+      }),
+    ).toEqual([]);
+  });
+
+  it('finds nothing when both files are absent', () => {
+    expect(findAuditConfigMutes({})).toEqual([]);
+  });
+
+  it('names the manifest channel and the keys it carries', () => {
+    const found = findAuditConfigMutes({
+      manifest: manifestWith({ auditConfig: { ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'] } }),
+    });
+    expect(found).toHaveLength(1);
+    expect(found[0]).toContain('package.json');
+    expect(found[0]).toContain('ignoreGhsas');
+  });
+
+  it('names ignoreCves too, and both keys when both are set', () => {
+    expect(
+      findAuditConfigMutes({
+        manifest: manifestWith({ auditConfig: { ignoreCves: ['CVE-1'] } }),
+      })[0],
+    ).toContain('ignoreCves');
+    const both = findAuditConfigMutes({
+      manifest: manifestWith({ auditConfig: { ignoreGhsas: ['G'], ignoreCves: ['C'] } }),
+    });
+    expect(both[0]).toContain('ignoreCves, ignoreGhsas');
+  });
+
+  // The gate refuses on presence, so a key pnpm adds later needs no code change.
+  it('catches an unrecognized auditConfig key', () => {
+    expect(
+      findAuditConfigMutes({
+        manifest: manifestWith({ auditConfig: { ignoreSomethingNew: ['x'] } }),
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('allows an auditConfig that is present but empty — it suppresses nothing', () => {
+    expect(findAuditConfigMutes({ manifest: manifestWith({ auditConfig: {} }) })).toEqual([]);
+  });
+
+  // The second channel: pnpm 10 reads the same setting from the workspace file,
+  // where it works identically and `pnpm config get auditConfig` reports it
+  // (it does NOT report the manifest one, which is why both are read here).
+  it('names the workspace-file channel', () => {
+    const found = findAuditConfigMutes({
+      workspaceYaml:
+        "packages:\n  - 'packages/*'\n\nauditConfig:\n  ignoreGhsas:\n    - GHSA-aaaa-bbbb-cccc\n",
+    });
+    expect(found).toEqual(['pnpm-workspace.yaml "auditConfig"']);
+  });
+
+  it('reads the workspace key through a quoted spelling and CRLF line endings', () => {
+    expect(
+      findAuditConfigMutes({
+        workspaceYaml: "packages:\r\n  - 'a'\r\n'auditConfig':\r\n  ignoreCves: []\r\n",
+      }),
+    ).toHaveLength(1);
+  });
+
+  it('ignores a commented-out or nested key of the same name', () => {
+    expect(
+      findAuditConfigMutes({
+        workspaceYaml:
+          '# auditConfig:\n#   ignoreGhsas: []\nsomethingElse:\n  auditConfig:\n    a: b\n',
+      }),
+    ).toEqual([]);
+  });
+
+  it('reports both channels when both are set', () => {
+    expect(
+      findAuditConfigMutes({
+        manifest: manifestWith({ auditConfig: { ignoreCves: ['CVE-1'] } }),
+        workspaceYaml: 'auditConfig:\n  ignoreGhsas: []\n',
+      }),
+    ).toHaveLength(2);
+  });
+
+  it('refuses an unparseable manifest rather than reading it as unmuted', () => {
+    expect(() => findAuditConfigMutes({ manifest: '{"pnpm":' })).toThrow(WaiverConfigError);
+  });
+});
+
+describe('assertNoAuditConfigMutes', () => {
+  it('passes on the real repository shape', () => {
+    expect(() => {
+      assertNoAuditConfigMutes({
+        manifest: manifestWith({ overrides: {} }),
+        workspaceYaml: "packages:\n  - 'packages/*'\n",
+      });
+    }).not.toThrow();
+  });
+
+  it('fails closed and points at the file to edit', () => {
+    const sources = { manifest: manifestWith({ auditConfig: { ignoreGhsas: ['GHSA-a-b-c'] } }) };
+    expect(() => {
+      assertNoAuditConfigMutes(sources);
+    }).toThrow(WaiverConfigError);
+    expect(() => {
+      assertNoAuditConfigMutes(sources);
+    }).toThrow(/package\.json/);
+    expect(() => {
+      assertNoAuditConfigMutes(sources);
+    }).toThrow(/audit-waivers\.json/);
+  });
+
+  // The case that separates this check from the one it backs up. Under the
+  // payload-only guard this combination passed: pnpm had already dropped the
+  // advisory and reported nothing muted, so the gate saw a clean tree and
+  // exited 0. Deleting the file read makes this case — and only this case —
+  // go red.
+  it('catches the mute that the payload guard cannot see', () => {
+    expect(() => {
+      assertNothingMuted(MUTED_PNPM_PAYLOAD);
+    }).not.toThrow();
+    expect(classify(MUTED_PNPM_PAYLOAD, [], TODAY).blocking).toEqual([]);
+
+    expect(() => {
+      assertNoAuditConfigMutes({
+        manifest: manifestWith({ auditConfig: { ignoreGhsas: ['GHSA-aaaa-bbbb-cccc'] } }),
+      });
+    }).toThrow(WaiverConfigError);
   });
 });
 

--- a/turbo.json
+++ b/turbo.json
@@ -76,7 +76,15 @@
         "$TURBO_ROOT$/*/*/eslint*.config.mjs",
         "$TURBO_ROOT$/*/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
         "$TURBO_ROOT$/*/*/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
+        // ci.yml, audit.yml and codeql.yml are all READ by this suite — the
+        // first for the repo-root lint/typecheck passes and the egress script,
+        // the other two by required-checks.test.js, which drives every job name
+        // and PR trigger behind a required check. A glob would be wrong here:
+        // an unread workflow in the same directory would then bust this hash on
+        // every edit.
         "$TURBO_ROOT$/.github/workflows/ci.yml",
+        "$TURBO_ROOT$/.github/workflows/audit.yml",
+        "$TURBO_ROOT$/.github/workflows/codeql.yml",
         "$TURBO_ROOT$/tools/ci/**",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/tsconfig.root.json",
@@ -90,6 +98,10 @@
         // and turbo would replay a cached green at the one moment the guard
         // exists to fire. No extension glob above reaches a .md.
         "$TURBO_ROOT$/CLAUDE.md",
+        // CONTRIBUTING.md the same way: required-checks.test.js parses its
+        // "Checks that gate `main`" table and drives every row against the
+        // workflows.
+        "$TURBO_ROOT$/CONTRIBUTING.md",
         "!$TURBO_ROOT$/**/node_modules/**",
         "!$TURBO_ROOT$/**/.next/**",
         "!$TURBO_ROOT$/**/dist/**",


### PR DESCRIPTION
## Summary

Three lines in the root `package.json` could switch the dependency-audit gate off with no
error, no report row and no trace anywhere. This closes that, runs CodeQL on every PR, and
writes down the checks that gate `main` with a guard that keeps the list honest.

## The bypass

`auditConfig.ignoreCves` / `ignoreGhsas` was documented in both `CLAUDE.md` and
`CONTRIBUTING.md` as a route the gate refuses. It was not. pnpm removes a muted advisory
from `advisories`, decrements the `metadata` severity counts to match, and leaves the
top-level `muted` array **empty** — so a muted run is byte-for-byte the shape of a clean
one, and the guard reading `muted` was correct in isolation and unreachable in practice.

Measured against the workspace advisory with `BLOCKING_SEVERITIES` temporarily lowered so
it counts, before the fix:

| Run | Exit |
| --- | --- |
| Control, no mute | `1` — blocks, as intended |
| Same advisory, mute set | `0` — passes silently |

The fix reads the setting off disk instead. Both files pnpm takes it from are covered, and
the second was a surprise: `pnpm config get auditConfig` reports the workspace-file channel
but **not** the manifest one, so neither source alone is sufficient. `.npmrc` is not a
channel, in either the flattened or the camelCase spelling.

After, with the gate at its real threshold:

| Case | Exit |
| --- | --- |
| Control, no mute | `0` |
| `package.json` → `pnpm.auditConfig.ignoreGhsas` | `3` |
| `package.json` → `pnpm.auditConfig.ignoreCves` | `3` |
| `pnpm-workspace.yaml` → `auditConfig` | `3` |
| `--artifact` mode, unchanged | `0` |

`findAuditConfigMutes` refuses on the key's **presence** rather than on the ignore lists
having entries, so a third key in a later pnpm is caught without a code change. An
`auditConfig` that is present but empty suppresses nothing and is allowed through.

## Also here

- **CodeQL runs on every PR.** `codeql.yml` filtered `pull_request` to `branches: [main]`,
  so a PR stacked on another feature branch got no analysis at all. Dropping the filter
  also dissolves the missing-`edited` problem rather than patching it: `ci.yml` has to
  listen for `edited` because retargeting a PR's base fires only that event, but with no
  branch filter the run already happened when the PR opened, so a retarget has nothing to
  re-trigger — and the check can never end up permanently absent on a PR required to have it.
- **A required-check table in `CONTRIBUTING.md`,** plus
  `packages/eslint-config/test/required-checks.test.js`, which parses it and drives every
  row against the real workflow job names with matrix legs expanded. Branch protection
  matches on the name, so a renamed job stops being produced and protection goes on waiting
  for a name nothing emits — invisible in a diff and invisible in a green run.
- **`turbo.json`:** `CONTRIBUTING.md`, `audit.yml` and `codeql.yml` added to the
  `@akasecurity/eslint-config#test` inputs. A doc-reading guard whose doc is not in the
  cache key replays a cached green at exactly the moment it should fire.
- **Doc corrections,** and `CONTRIBUTING.md` now says anyone may open a waiver PR but only
  a maintainer may approve one.

## Verification

- `turbo run test --force --concurrency=2` → **29/29, `Cached: 0`**. `audit-gate` 45 → 59
  tests; the new guard is 13.
- `pnpm lint`, `pnpm typecheck`, `pnpm format:check` green.
- Both audits re-run against the real dependency tree and still pass; waiver expiry
  re-checked at the inclusive boundary (`expires == today` suppresses, `today − 1` lapses
  and reports stale), and five malformed waiver shapes still fail closed at exit 3.
- The new guard was mutation-tested — renaming a job, restoring the `branches:` filter,
  shrinking the CodeQL matrix, removing `security-events: write`, dropping a table row, and
  hiding a `branches:` filter below a comment inside the trigger block. All six go red; the
  control returns green. The last one caught a real hole in the first version of the
  end-of-block match.
- Each new `turbo.json` input was confirmed to bust the hash (`cache miss, executing`).
  Note a bare `touch` does not — turbo hashes content.

## Not in scope

Making these checks **required** is a repository-settings change and cannot be done from a
PR. The exact names are in the new `CONTRIBUTING.md` table; the four to add are
`Dependency audit`, `CodeQL (javascript-typescript)`, `CodeQL (actions)` and
`No-network · Full suite, egress blocked`. `Lint · Typecheck · Test · Build` and
`Windows · Unit tests (shipped surface)` are already required — which is readable without
admin via the `isRequired` query the table links, worth knowing since the branch-protection
REST endpoint 404s to non-admins and reads like no protection at all.

The open CodeQL alerts are also left alone here; triaging them is its own change.