### PR TITLE
Pin CLAUDE.md §1's emit() enumeration to the code, and close two guard residuals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,14 +35,31 @@ _absence_ of output, not a payload.
 field that never crosses the wire; the internal fallback `handleCapture` returns when the runtime
 throws is `{ action: 'log' }`, and `'allow'` is only ever assigned to an **excepted** finding.
 Emitting a real opinion means writing one JSON object to stdout via `emit()`
-(`plugins/claude-code/src/hooks/shared.ts`), whose four shapes are `decision`, `systemMessage`,
-`hookSpecificOutput.permissionDecision` and `hookSpecificOutput.updatedToolOutput` — the write is
-awaited, because `process.exit` does not flush a pending pipe write and a truncated object reads
-as invalid JSON, passing the original payload through unscanned.
+(`plugins/claude-code/src/hooks/shared.ts`), which takes the `HookOutput` union rather than
+`unknown`, so a payload outside that union cannot reach the wire at all. Its six shapes are
+`decision` and `systemMessage` at the top level, plus one `hookSpecificOutput` per hook —
+`PreToolUse`'s `permissionDecision`, `PostToolUse`'s `updatedToolOutput`, `MessageDisplay`'s
+`displayContent` and `SessionStart`'s `additionalContext`. The write is awaited, because
+`process.exit` does not flush a pending pipe write and a truncated object reads as invalid JSON,
+passing the original payload through unscanned.
+
+That enumeration is derived rather than remembered, because this is the sentence that drifted last
+time — it claimed four shapes while six were reaching stdout, and the two it omitted belong to the
+two hooks nothing else in this file mentions. `plugins/claude-code/test/hook-output-shapes.test.ts`
+reads it and drives it against the union: the count word, the two top-level keys, and each
+`hookEventName` paired with the field that distinguishes it. A seventh variant added to
+`HookOutput` fails to compile until that test's map names it, and fails that test until this
+sentence does.
 
 `plugins/claude-code/test/e2e/fail-open.e2e.test.ts` is what holds this rather than review: it
 drives the built hooks against malformed, truncated, binary and oversized stdin, asserting exit 0
 and empty stdout, and its `expectNoActionKey` fails any emitted payload carrying an `action` key.
+That last check is worth **nothing** on the rows above it, which have already asserted the stdout
+is empty — `''` matches no pattern. So the file also drives a real finding through each enforcing
+hook at block, redact, warn and log, asserts the shape each cell is expected to emit (the positive
+control, without which a hook that stopped emitting would turn every absence assertion back into
+the vacuous form), and reads `expectNoActionKey` over the payload that produced. Keep both halves:
+the fault rows prove silence, and only the enforcement rows can prove what the noise looks like.
 
 ### 2. Contracts before code
 

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { join, posix, sep } from 'node:path';
+import { join, matchesGlob, posix, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { ESLint, Linter } from 'eslint';
@@ -18,6 +18,7 @@ import {
 } from './helpers/claude-md.js';
 import {
   eslintInvocations,
+  lintableTrackedFiles,
   LINTABLE_EXT,
   packageLintInvocations,
   parseWorkspaceGlobs,
@@ -912,6 +913,48 @@ describe('every file outside every workspace package is linted by a repo-root pa
       missing,
       'A file with one of these extensions is enumerated by this suite but left out of the turbo ' +
         `input glob, so adding one replays a cached green:\n  ${missing.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  it('turbo hashes every tracked file this suite actually reads', () => {
+    // The extension check above asks whether the globs SPELL the right file
+    // types. This asks whether they REACH the files — a different question, and
+    // the one the repo-root entry exists for: `$TURBO_ROOT$/*/**/*.{…}` requires
+    // a directory segment, so a file at the root matches no per-package glob
+    // however its extension is spelled. Same hazard at the other end of the
+    // tree, where a `!` exclusion can take back a path the positive globs cover.
+    //
+    // inline-disables.test.js reads every one of these files, so a path outside
+    // the hash is a file someone can add a disable to while turbo replays a
+    // cached green and the inventory never runs.
+    const turbo = readFileSync(join(REPO_ROOT, 'turbo.json'), 'utf8');
+    const inputs = /"@akasecurity\/eslint-config#test"[\s\S]*?"inputs"\s*:\s*\[([\s\S]*?)\]/.exec(
+      turbo,
+    );
+    expect(inputs, '@akasecurity/eslint-config#test declares no `inputs`').not.toBeNull();
+    const declared = [...inputs[1].matchAll(/"([^"]*)"/g)].map((m) => m[1]);
+    const rooted = (prefix) =>
+      declared.filter((g) => g.startsWith(prefix)).map((g) => g.slice(prefix.length));
+    const included = rooted('$TURBO_ROOT$/');
+    const excluded = rooted('!$TURBO_ROOT$/');
+
+    const files = lintableTrackedFiles();
+    expect(files.length, 'no tracked lintable files, so this asserts nothing').toBeGreaterThan(0);
+    expect(included.length, 'no repo-rooted input globs to match against').toBeGreaterThan(0);
+
+    // `path.matchesGlob` folds case on macOS and Windows. That can only make
+    // this MORE permissive, and every glob here is structural (`*`, `**`, an
+    // extension list) rather than a spelled path, so no verdict below turns on
+    // it — but a future entry naming a real path should not rely on the case.
+    const unhashed = files.filter(
+      (file) =>
+        !included.some((glob) => matchesGlob(file, glob)) ||
+        excluded.some((glob) => matchesGlob(file, glob)),
+    );
+    expect(
+      unhashed,
+      "These tracked files are read by this package's suites but hashed by none of the task's " +
+        `turbo inputs, so editing one alone replays a cached green:\n  ${unhashed.join('\n  ')}`,
     ).toEqual([]);
   });
 

--- a/packages/eslint-config/test/inline-disables.test.js
+++ b/packages/eslint-config/test/inline-disables.test.js
@@ -7,7 +7,13 @@ import tseslint from 'typescript-eslint';
 import { describe, expect, it } from 'vitest';
 
 import { base, networkGuard } from '../src/index.js';
-import { CONVENTIONS_DOC } from './helpers/claude-md.js';
+import {
+  cardinalFor,
+  CONVENTIONS_DOC,
+  countWordIn,
+  readConventions,
+  sectionOf,
+} from './helpers/claude-md.js';
 import { lintableTrackedFiles, REPO_ROOT } from './helpers/lint-invocations.js';
 
 // The third mechanism, and the one no other guard in this package can see.
@@ -574,6 +580,34 @@ describe(`inline disables of the guarded rules (${CONVENTIONS_DOC} §3 and §4)`
       "Unused eslint-disable directive (no problems were reported from 'n/no-process-env').",
     ]);
     expect(messages.every((m) => m.severity === 2)).toBe(true);
+  });
+
+  it(`states the size of the network half in ${CONVENTIONS_DOC} §4`, () => {
+    // The table in §4 is pinned to `DOCUMENTED_OPT_OUTS` by no-network.test.js,
+    // but the SENTENCE this suite added beside it — "that set is one entry
+    // long" — was pinned by nothing, and a hand-written mirror is exactly what
+    // a count sentence drifts away from. Measured: adding a second network
+    // inline disable and tabling it above leaves the whole package green while
+    // §4 goes on claiming one, which is the drift this file exists to stop, one
+    // level up from where it stops it.
+    //
+    // Derived from the expectation rather than restated, so the two cannot be
+    // edited apart: the doc is asserted against the same map the tree is.
+    const network = Object.entries(EXPECTED_INLINE_DISABLES).filter(([, rules]) =>
+      rules.some((rule) => NETWORK_RULES.includes(rule)),
+    );
+    const section = sectionOf(readConventions(), '### 4. No network calls');
+    const stated = countWordIn(
+      section,
+      /That set is (\w+) entr(?:y|ies) long/gu,
+      'the size of the inline-disable set for the network bans',
+    );
+    expect(stated).toBe(cardinalFor(network.length));
+    // And that the noun agrees, which the pattern above deliberately does not
+    // decide: a second entry makes the count word wrong AND "one entry" wrong,
+    // and a sentence half-corrected reads as true to everyone who skims it.
+    const noun = network.length === 1 ? 'entry' : 'entries';
+    expect(section).toContain(`That set is ${cardinalFor(network.length)} ${noun} long`);
   });
 
   it('finds each tabled disable really suppressing something', () => {

--- a/plugins/claude-code/src/hooks/scan-response.ts
+++ b/plugins/claude-code/src/hooks/scan-response.ts
@@ -11,6 +11,7 @@ import { uniqueRuleIds } from '@akasecurity/plugin-sdk';
 import { withheldBanner, withheldToolText } from '../exception-guidance.ts';
 import type { RealizedRewrite } from '../protocol/notes.ts';
 import type { FieldTokenizer } from './pre-tool-use-decision.ts';
+import type { HookOutput } from './shared.ts';
 import type { ScannableResponseField } from './tool-response.ts';
 import { replaceResponseField } from './tool-response.ts';
 
@@ -112,7 +113,7 @@ export function responseEmitPayload(
   toolName: string,
   outcome: ResponseScanOutcome,
   notes?: { note?: string | null | undefined; disclosure?: string | null | undefined },
-): unknown {
+): HookOutput | undefined {
   const { withheldFindings, redactedFindings, warnedFindings } = outcome;
   if (withheldFindings.length > 0 || redactedFindings.length > 0) {
     const action = withheldFindings.length > 0 ? 'withheld' : 'redacted';

--- a/plugins/claude-code/src/hooks/shared.ts
+++ b/plugins/claude-code/src/hooks/shared.ts
@@ -69,6 +69,11 @@ export function getString(record: Record<string, unknown>, key: string): string 
 // one `hookSpecificOutput` per hook, discriminated by `hookEventName`.
 export type HookOutput =
   | { decision: 'block'; reason: string }
+  // Spelled here even though `PreToolUseOutput` below ends in the same arm, so
+  // that a bare systemMessage — what UserPromptSubmit and the store-unavailable
+  // paths emit — does not depend on a type named for a different hook. The two
+  // are structurally identical, so deleting this line still compiles and no test
+  // can object: it is a silent downgrade rather than a cleanup.
   | { systemMessage: string }
   | PreToolUseOutput
   | {

--- a/plugins/claude-code/src/hooks/shared.ts
+++ b/plugins/claude-code/src/hooks/shared.ts
@@ -5,6 +5,8 @@
 import { resolveRepo } from '@akasecurity/plugin-sdk';
 import type { EventMetadata } from '@akasecurity/schema';
 
+import type { PreToolUseOutput } from './pre-tool-use-decision.ts';
+
 // An 'error' event on an EventEmitter with no listener throws — and because it
 // fires asynchronously, that throw lands as an uncaughtException outside any
 // `try { await main() } catch {}` wrapper, turning a stalled/broken stdin into
@@ -60,6 +62,26 @@ export function getString(record: Record<string, unknown>, key: string): string 
   return typeof value === 'string' ? value : undefined;
 }
 
+// Every JSON object a hook may write to stdout, as one union. `emit` takes this
+// rather than `unknown`, so a new output shape cannot reach the wire without
+// being added here first — which is what makes the enumeration in CLAUDE.md §1
+// checkable instead of remembered. Two shapes sit at the top level; the rest are
+// one `hookSpecificOutput` per hook, discriminated by `hookEventName`.
+export type HookOutput =
+  | { decision: 'block'; reason: string }
+  | { systemMessage: string }
+  | PreToolUseOutput
+  | {
+      hookSpecificOutput: {
+        hookEventName: 'PostToolUse';
+        updatedToolOutput: unknown;
+        additionalContext?: string;
+      };
+      systemMessage: string;
+    }
+  | { hookSpecificOutput: { hookEventName: 'MessageDisplay'; displayContent: string } }
+  | { hookSpecificOutput: { hookEventName: 'SessionStart'; additionalContext: string } };
+
 // Hook output protocol: write one JSON object to stdout and exit 0.
 // Writing nothing and exiting 0 means "no opinion" (allow).
 //
@@ -67,7 +89,7 @@ export function getString(record: Record<string, unknown>, key: string): string 
 // main(), and exit does not wait for pending pipe writes — anything past the
 // ~64KB pipe buffer is dropped, Claude Code sees invalid JSON, and the
 // original (possibly secret-bearing) payload passes through untouched.
-export function emit(output: unknown): Promise<void> {
+export function emit(output: HookOutput): Promise<void> {
   return new Promise((resolve) => {
     let settled = false;
     const finish = (): void => {

--- a/plugins/claude-code/test/e2e/fail-open.e2e.test.ts
+++ b/plugins/claude-code/test/e2e/fail-open.e2e.test.ts
@@ -11,8 +11,12 @@
 import { chmodSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 import { runHook, tempHomeEnv, withTempHome } from '../helpers/run-hook.ts';
 
 const SESSION_ID = 'fail-open-e2e-session';
@@ -104,12 +108,18 @@ const HOOKS: readonly HookCase[] = [
   },
 ];
 
-// CLAUDE.md: "no hook ever emits {action:'allow'}, and the internal fallback
-// is {action:'log'}" — `action` is a CaptureResult field that never crosses
-// the wire; the four real hook-output shapes (`decision`, `systemMessage`,
-// `hookSpecificOutput.permissionDecision`, `hookSpecificOutput.updatedToolOutput`)
-// never use that key. Pinning this guards against a future refactor that
-// starts serializing the internal decision object onto stdout.
+// CLAUDE.md §1: "no hook ever emits {action:'allow'}, and the internal fallback
+// is {action:'log'}" — `action` is a CaptureResult field that never crosses the
+// wire, and none of the shapes in the `HookOutput` union uses that key (which
+// shapes those are is pinned by test/hook-output-shapes.test.ts). This guards
+// against a refactor that starts serializing the internal decision object onto
+// stdout.
+//
+// It is worth nothing on an EMPTY stdout, which every `expectFailsOpen` row
+// below has already asserted — `''` matches no pattern, so the check there is a
+// statement of intent rather than a test. What gives it teeth is the enforcement
+// matrix at the bottom of this file: real findings, driven through the built
+// hooks at every action level, each producing a payload this then reads.
 function expectNoActionKey(stdout: string): void {
   expect(stdout).not.toMatch(/"action"\s*:/);
 }
@@ -234,6 +244,170 @@ describe('fail-open: an unavailable store never breaks a hook', () => {
           }
         });
       });
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// The enforcement matrix: expectNoActionKey against real emitted payloads
+// ---------------------------------------------------------------------------
+
+// Every row above drives a hook that has NOTHING to say — malformed input, a
+// store it cannot open — so every one of them asserts an empty stdout, and
+// `expectNoActionKey` on `''` cannot fail. That left the wire-protocol pin
+// covering none of the paths that actually build a payload: the shape it guards
+// against is the internal decision object, and the internal decision object only
+// exists once something was found.
+//
+// So this drives a real finding through each enforcing hook at each action level
+// and reads what the built script really printed. The expected shape per cell is
+// asserted first and is the positive control — without it, a hook that silently
+// stopped emitting would turn every absence assertion below back into the
+// vacuous form this section exists to replace.
+
+// The value comes from a bundled rule's own `examples`, so no secret-shaped
+// literal lives in this file. The rule is one whose example matches no OTHER
+// bundled rule — two rules on overlapping spans degrade one-way and change the
+// emitted shape, which would make the matrix a statement about rule overlap
+// rather than about action levels.
+const ENFORCED_RULE_ID = 'secrets/twilio-key';
+
+function secretFixture(): { pack: ReturnType<typeof bundledDetections>[number]; example: string } {
+  const pack = bundledDetections().find((p) => p.rules.some((r) => r.id === ENFORCED_RULE_ID));
+  const example = pack?.rules.find((r) => r.id === ENFORCED_RULE_ID)?.examples?.[0];
+  if (pack === undefined || example === undefined) {
+    throw new Error(
+      `bundled rule ${ENFORCED_RULE_ID} is missing from the pack registry or has no example, so ` +
+        'this matrix would drive clean input through every cell and assert nothing',
+    );
+  }
+  return { pack, example };
+}
+
+const { pack: ENFORCED_PACK, example: SECRET } = secretFixture();
+
+// Install the bundled packs the way the gateway does on open, then give the
+// pack the policy under test — a per-pack policy is what the runtime's action
+// resolution prefers, so this pins the cell to an action rather than to
+// whatever DEFAULT_ACTIONS happens to say for the category.
+function seedPolicy(home: string, policy: BuiltinPolicyId): void {
+  const db = openLocalDatabase(join(home, '.aka', 'data'));
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+    db.installedPacks.setPolicy(ENFORCED_PACK.namespace, ENFORCED_PACK.packId, policy);
+  } finally {
+    db.close();
+  }
+}
+
+interface EnforcingHook {
+  readonly name: string;
+  /** A payload whose scanned field carries the secret. */
+  readonly payload: (home: string) => string;
+  /**
+   * The key the emitted JSON must carry per policy, or null where the hook
+   * emits nothing at all. `monitor` is null for the two tool hooks because log
+   * IS silence — CLAUDE.md §1's "allow is the absence of output", reached
+   * through a finding rather than through a fault.
+   */
+  readonly emits: Readonly<Record<BuiltinPolicyId, string | null>>;
+}
+
+const ENFORCING_HOOKS: readonly EnforcingHook[] = [
+  {
+    name: 'user-prompt-submit',
+    payload: (home) =>
+      JSON.stringify({
+        prompt: `deploy the service using ${SECRET}`,
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'UserPromptSubmit',
+      }),
+    // Redact reads as block here: this hook cannot rewrite prompt text, so a
+    // redact policy degrades to "remove it and resubmit" rather than tokenizing.
+    // Monitor emits the calibration nudge — a systemMessage that is not an
+    // enforcement opinion, and still a payload this pin has to read.
+    emits: {
+      block: '"decision":"block"',
+      redact: '"decision":"block"',
+      warn: '"systemMessage"',
+      monitor: '"systemMessage"',
+    },
+  },
+  {
+    name: 'pre-tool-use',
+    payload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: `curl -H "authorization: ${SECRET}" https://example.invalid` },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PreToolUse',
+      }),
+    // Redact denies rather than tokenizing because this home has no vault
+    // consent: with the vault inert there is nowhere to put the value, and
+    // one-way destruction of a tool call's input is not something to do quietly.
+    emits: {
+      block: '"permissionDecision":"deny"',
+      redact: '"permissionDecision":"deny"',
+      warn: '"systemMessage"',
+      monitor: null,
+    },
+  },
+  {
+    name: 'post-tool-use',
+    payload: (home) =>
+      JSON.stringify({
+        tool_name: 'Bash',
+        tool_input: { command: 'cat .env' },
+        tool_response: { stdout: `TWILIO_KEY=${SECRET}\n`, stderr: '' },
+        session_id: SESSION_ID,
+        cwd: projectDir(home),
+        hook_event_name: 'PostToolUse',
+      }),
+    // Output is the model's to read, not the user's to resend, so both
+    // enforcing levels rewrite it in place rather than refusing.
+    emits: {
+      block: '"updatedToolOutput"',
+      redact: '"updatedToolOutput"',
+      warn: '"systemMessage"',
+      monitor: null,
+    },
+  },
+];
+
+const POLICIES: readonly BuiltinPolicyId[] = ['block', 'redact', 'warn', 'monitor'];
+
+describe('the wire protocol never carries an action key, at any action level', () => {
+  for (const hook of ENFORCING_HOOKS) {
+    describe(hook.name, () => {
+      for (const policy of POLICIES) {
+        const expected = hook.emits[policy];
+        it(`${policy} policy → ${expected === null ? 'emits nothing' : 'emits ' + expected}`, () => {
+          withTempHome((home) => {
+            seedPolicy(home, policy);
+            const result = runHook(hook.name, hook.payload(home), { env: tempHomeEnv(home) });
+
+            // Fail-open first: whatever it decided, it decided it without
+            // breaking the session.
+            expect(result.status).toBe(0);
+
+            // The positive control. Everything after it is an absence, and an
+            // absence over an unexpected payload — or none — proves nothing.
+            if (expected === null) {
+              expect(result.stdout).toBe('');
+            } else {
+              expect(result.stdout).toContain(expected);
+            }
+
+            expectNoActionKey(result.stdout);
+            // The raw value never rides along on any of these shapes. Run by
+            // run rather than whole: a branch echoing a truncated value is
+            // still echoing a live credential's prefix.
+            expectNoEchoOf(result.stdout, SECRET);
+          });
+        });
+      }
     });
   }
 });

--- a/plugins/claude-code/test/hook-output-shapes.test.ts
+++ b/plugins/claude-code/test/hook-output-shapes.test.ts
@@ -1,0 +1,186 @@
+/**
+ * CLAUDE.md §1 enumerates the shapes `emit()` may write to stdout. That
+ * enumeration drifted once already — it said four while six were reaching the
+ * wire, and the two it omitted (`MessageDisplay`, `SessionStart`) were the two
+ * hooks the section never names, so nothing about the sentence looked wrong.
+ *
+ * The drift was possible because `emit` took `unknown`: a new shape reached
+ * stdout without passing anything that could be counted. It now takes the
+ * `HookOutput` union, which makes the chain checkable end to end:
+ *
+ *   call site → union     the compiler, via `emit`'s parameter type
+ *   union → this map      the compile-time pins below
+ *   this map → the doc    the assertions below
+ *
+ * Each link is enforced by something, so a seventh shape cannot land quietly at
+ * any of them. What none of it covers is a hook that writes to stdout WITHOUT
+ * going through `emit` — that is `fail-open.e2e.test.ts`'s ground, which reads
+ * what the built scripts really print.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import type { emit, HookOutput } from '../src/hooks/shared.ts';
+
+// plugins/claude-code/test -> the repo root
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const CONVENTIONS_DOC = 'CLAUDE.md';
+const SECTION_HEADING = '### 1. Fail-open everywhere in the plugin';
+
+/** The shapes that sit at the top level of the emitted object. */
+const TOP_LEVEL_SHAPES = ['decision', 'systemMessage'] as const;
+
+/**
+ * One `hookSpecificOutput` variant per hook, mapped to the field that carries
+ * its opinion — which is how the doc names each one, and the only part of the
+ * variant a reader needs to tell them apart. `hookEventName` is the
+ * discriminant, not the shape.
+ */
+const SHAPE_FIELD_BY_EVENT = {
+  PreToolUse: 'permissionDecision',
+  PostToolUse: 'updatedToolOutput',
+  MessageDisplay: 'displayContent',
+  SessionStart: 'additionalContext',
+} as const;
+
+// ---------------------------------------------------------------------------
+// The compile-time half — `pnpm typecheck` covers test/, so these are gates
+// ---------------------------------------------------------------------------
+
+type EmittedEventName = Extract<
+  HookOutput,
+  { hookSpecificOutput: { hookEventName: string } }
+>['hookSpecificOutput']['hookEventName'];
+
+// Both directions, because they fail differently. A variant added to the union
+// and not to the map is a shape nothing counts (the drift that happened); a map
+// entry whose variant is gone is an expectation outliving what it described,
+// which leaves the doc naming a shape no hook can emit.
+type EveryVariantNamed = [EmittedEventName] extends [keyof typeof SHAPE_FIELD_BY_EVENT]
+  ? true
+  : never;
+type EveryNameEmitted = [keyof typeof SHAPE_FIELD_BY_EVENT] extends [EmittedEventName]
+  ? true
+  : never;
+
+// And that `emit` still narrows at all: were its parameter widened back to
+// `unknown`, this stops being assignable and the union above becomes decoration
+// that the compiler no longer enforces at a single call site.
+type EmitNarrowsToHookOutput = [Parameters<typeof emit>[0]] extends [HookOutput] ? true : never;
+
+const everyVariantNamed: EveryVariantNamed = true;
+const everyNameEmitted: EveryNameEmitted = true;
+const emitNarrows: EmitNarrowsToHookOutput = true;
+
+// ---------------------------------------------------------------------------
+// Reading the sentence
+// ---------------------------------------------------------------------------
+
+// Written out rather than derived from Intl: the doc spells the count in prose,
+// and a locale-dependent list would make this expectation depend on the runner.
+const CARDINALS = ['zero', 'one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine'];
+
+/** The text under `heading`, to the next heading of the same or a higher level. */
+function sectionOf(md: string, heading: string): string {
+  const lines = md.split('\n');
+  const at = lines.flatMap((line, i) => (line === heading ? [i] : []));
+  const [start, ...extra] = at;
+  if (start === undefined || extra.length > 0) {
+    throw new Error(
+      `${CONVENTIONS_DOC}: expected exactly one ${JSON.stringify(heading)} heading, found ` +
+        `${String(at.length)}. A guard slicing on a non-unique anchor reads the wrong section.`,
+    );
+  }
+  const level = /^#+/.exec(heading)?.[0].length ?? 0;
+  const boundary = new RegExp(`^#{1,${String(level)}} `);
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => boundary.test(line));
+  return (end === -1 ? rest : rest.slice(0, end)).join('\n');
+}
+
+/**
+ * The count word and body of the one "Its <n> shapes are …" sentence.
+ *
+ * Throws unless it occurs exactly once. A reworded sentence this cannot find is
+ * a guard that would otherwise assert nothing and pass — the same failure the
+ * enumeration itself had, one level up.
+ */
+function shapesSentence(section: string): { count: string; body: string } {
+  // `\s+` around the wrapping, not a literal space: the doc is hard-wrapped, so
+  // any of these gaps can be a newline on the next reflow.
+  const found = [...section.matchAll(/Its\s+(\w+)\s+shapes\s+are\s+([\s\S]*?)\.\s/gu)];
+  const [match, ...extra] = found;
+  const count = match?.[1];
+  const body = match?.[2];
+  if (count === undefined || body === undefined || extra.length > 0) {
+    throw new Error(
+      `${CONVENTIONS_DOC} §1: expected exactly one "Its <n> shapes are …" sentence, found ` +
+        `${String(found.length)}. It was reworded, removed or duplicated, and this guard cannot ` +
+        'read what it is meant to be asserting.',
+    );
+  }
+  return { count: count.toLowerCase(), body };
+}
+
+/** The backticked code spans in `text`, in order. */
+const codeSpansOf = (text: string): string[] =>
+  [...text.matchAll(/`([^`]+)`/gu)].flatMap((m) => (m[1] === undefined ? [] : [m[1]]));
+
+const SECTION = sectionOf(readFileSync(join(REPO_ROOT, CONVENTIONS_DOC), 'utf8'), SECTION_HEADING);
+const SENTENCE = shapesSentence(SECTION);
+
+const EVENTS = Object.entries(SHAPE_FIELD_BY_EVENT);
+const SHAPE_COUNT = TOP_LEVEL_SHAPES.length + EVENTS.length;
+
+describe(`${CONVENTIONS_DOC} §1's emit() shape enumeration`, () => {
+  it('is pinned to the union at compile time', () => {
+    // These are `true` only because the conditional types above resolved to
+    // `true`; had either resolved to `never`, `pnpm typecheck` would already
+    // have failed and this file would not run. Asserting them here is what
+    // stops them being unused declarations someone deletes as dead weight.
+    expect([everyVariantNamed, everyNameEmitted, emitNarrows]).toEqual([true, true, true]);
+  });
+
+  it('reads a sentence that is really there', () => {
+    // Every assertion below is about a set parsed out of prose, and all of them
+    // pass on the empty set. This separates "the doc says nothing" from "the doc
+    // agrees".
+    expect(SECTION.length, 'the fail-open section is empty').toBeGreaterThan(0);
+    expect(SENTENCE.body.length, 'the shapes sentence has no body').toBeGreaterThan(0);
+    expect(SHAPE_COUNT, 'no shapes derived from the union').toBeGreaterThan(0);
+  });
+
+  it('states the number of shapes the union carries', () => {
+    const word = CARDINALS[SHAPE_COUNT];
+    expect(word, `no cardinal word for ${String(SHAPE_COUNT)} — extend CARDINALS`).toBeDefined();
+    expect(SENTENCE.count).toBe(word);
+  });
+
+  it('names every shape, and no others', () => {
+    // A set rather than a sequence: the doc is free to reorder or reword around
+    // them. What it is not free to do is drop one, or name one that no variant
+    // of the union carries.
+    const expected = [
+      ...TOP_LEVEL_SHAPES,
+      'hookSpecificOutput',
+      ...EVENTS.flatMap(([event, field]) => [event, field]),
+    ].sort();
+    expect([...new Set(codeSpansOf(SENTENCE.body))].sort()).toEqual([...new Set(expected)].sort());
+  });
+
+  it('pairs each hook with the field that distinguishes it', () => {
+    // The set check above passes on a sentence that lists all ten spans in a
+    // heap. This is the substantive claim: `MessageDisplay`'s field is
+    // `displayContent` and not `updatedToolOutput`, which a reader acts on.
+    // Whitespace-normalised first: the doc is hard-wrapped, so a pair can sit
+    // either side of a newline and does today.
+    const flat = SENTENCE.body.replace(/\s+/gu, ' ');
+    const unpaired = EVENTS.filter(
+      ([event, field]) => !flat.includes(`\`${event}\`'s \`${field}\``),
+    ).map(([event, field]) => `${event} is not paired with ${field}`);
+    expect(unpaired).toEqual([]);
+  });
+});

--- a/plugins/claude-code/test/hooks/shared.test.ts
+++ b/plugins/claude-code/test/hooks/shared.test.ts
@@ -73,8 +73,11 @@ describe('emit', () => {
       return true;
     }) as typeof process.stdout.write);
 
-    await expect(emit({ ok: true })).resolves.toBeUndefined();
-    expect(writeSpy).toHaveBeenCalledWith(JSON.stringify({ ok: true }), expect.any(Function));
+    await expect(emit({ systemMessage: 'ok' })).resolves.toBeUndefined();
+    expect(writeSpy).toHaveBeenCalledWith(
+      JSON.stringify({ systemMessage: 'ok' }),
+      expect.any(Function),
+    );
 
     writeSpy.mockRestore();
   });
@@ -85,7 +88,7 @@ describe('emit', () => {
       // A broken pipe (EPIPE) surfaces as an 'error' event, not a write callback.
       .mockImplementation(() => true);
 
-    const promise = emit({ ok: true });
+    const promise = emit({ systemMessage: 'ok' });
     process.stdout.emit('error', new Error('EPIPE'));
 
     await expect(promise).resolves.toBeUndefined();
@@ -102,7 +105,7 @@ describe('emit', () => {
       return true;
     }) as typeof process.stdout.write);
 
-    await emit({ ok: true });
+    await emit({ systemMessage: 'ok' });
 
     // Deliberately NOT removed (see shared.ts) — one more listener than
     // before, guarding against any stdout error between resolving and exit.


### PR DESCRIPTION
## Summary

Follow-ups found while verifying the inline-disable inventory. Three defects, each closed by a
guard that goes red under mutation rather than by an edit.

## 1. §1 enumerated four `emit()` shapes; six were reaching stdout

It omitted `MessageDisplay`'s `displayContent` and `SessionStart`'s `additionalContext` — the two
hooks §1 never names, so nothing about the sentence read as wrong. That sentence was added by the
change that fixed §1's previous drift, which makes it the sharpest available example of the rule
the section is about: a test standing next to a claim guards it only if it **reads** the claim.

The miscount was possible because `emit` took `unknown`, so a new shape reached the wire without
passing through anything that could count it. It now takes a `HookOutput` union, and each link is
enforced by something:

| Link                      | Enforced by                                                                  |
| ------------------------- | ---------------------------------------------------------------------------- |
| call site → union         | the compiler, via `emit`'s parameter type                                    |
| union → the shape map     | conditional-type pins in `test/hook-output-shapes.test.ts`, both directions   |
| the shape map → the prose | the same test parsing §1: count word, keys, and each hook/field pairing       |

`responseEmitPayload` returns `HookOutput | undefined` for the same reason — it was the one `emit()`
argument the parameter type could not see.

## 2. `expectNoActionKey` never ran on a payload

Every row in `fail-open.e2e.test.ts` asserts an empty stdout before calling the wire-protocol pin,
and `''` matches no pattern. Injecting an `action` key onto every emitted payload reddened **3 of
35** cases, all three store faults; no case in the file produced a payload from a finding at all.

The file now also drives the bundled rule's own example through each enforcing hook at block,
redact, warn and log — 12 cells, each asserting the shape it is expected to emit **first**. That
control is not optional: without it a hook that stopped emitting turns every absence assertion back
into the vacuous form. `log` is silence for the two tool hooks, which is the same contract the fault
rows assert, reached through a finding instead.

## 3. §4's count sentence was pinned by nothing

The §4 table is held to `DOCUMENTED_OPT_OUTS`; the sentence written beside it was not. Measured: a
second live `node:https` import behind an inline disable, tabled in `EXPECTED_INLINE_DISABLES`, left
the package at **748/748** while §4 went on claiming the set was one entry long. The cardinal is now
derived from that same map, and the noun has to agree.

Separately, `effective-config.test.js` checked that the turbo input globs spell the right
extensions but not that they **reach** the files. This suite reads the whole workspace from a task
whose inputs are hand-written; dropping the repo-root glob leaves `commitlint.config.mjs` hashed by
nothing, and a stray exclusion can take back a whole package — either way turbo replays a cached
pass over a tree the guard never saw.

## Verification

Ten mutations, each red by the assertion it should be:

| Mutation | Caught by |
| --- | --- |
| §1 says four shapes and names four | count + set + pairing (3 of 5) |
| §1 pairs `MessageDisplay` with the wrong field | set + pairing |
| A seventh `HookOutput` variant, named nowhere | `tsc` — `Type 'true' is not assignable to type 'never'` |
| `emit()` widened back to `unknown` | the same pin |
| An `action` key on every emitted payload | **13 of 47**, up from 3 of 35 |
| A hook that stops emitting | 10 of 47 — the positive controls |
| A second network inline disable, tabled | the §4 count — previously 748/748 green |
| §4's sentence alone drifts | the same |
| Turbo's repo-root glob dropped | names `commitlint.config.mjs` |
| An over-broad `!` exclusion | names every `cli/src` file |

`pnpm lint` · `pnpm typecheck` · `pnpm format:check` all exit 0.
`turbo run test --force`: 29/29 tasks, 0 cached. `eslint-config` 750 tests, plugin 1113.

Closes the last acceptance criteria of https://github.com/akasecurity/engineering/issues/39. The
QA-plan companion is https://github.com/akasecurity/engineering/pull/147.
