### PR TITLE
feat(schema,persistence): add instance-level findings reads and page the grouped list

### DIFF
--- a/packages/persistence/src/internal/keyset-cursor.ts
+++ b/packages/persistence/src/internal/keyset-cursor.ts
@@ -1,0 +1,39 @@
+import { parseJsonObject } from './json.ts';
+
+// Opaque base64url keyset cursors for the most-recent-first lists.
+//
+// A cursor names the last row of the page just served, as the tuple its ORDER BY
+// sorts on — a timestamp plus a tie-breaking id. The next page asks for rows
+// strictly after it, which is why the reads compare an expanded tuple rather
+// than using an offset: rows are written to this store by processes the reader
+// does not coordinate with (plugin hooks, the CLI), so an offset would skip or
+// repeat rows whenever one arrived between pages.
+//
+// A cursor that does not decode restarts from the top rather than throwing. It
+// is opaque state a client hands back, not something a caller composes, so the
+// only ways to hold a bad one are a hand-edited URL or a store that has since
+// been reset — in both cases the first page is the useful answer.
+
+/** The tuple a most-recent-first list resumes from. */
+export interface KeysetCursor {
+  startedAtMs: number;
+  id: string;
+}
+
+export function encodeKeysetCursor(payload: KeysetCursor): string {
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+export function decodeKeysetCursor(cursor: string): KeysetCursor | null {
+  const parsed = parseJsonObject(Buffer.from(cursor, 'base64url').toString('utf8'));
+  if (
+    parsed !== undefined &&
+    'startedAtMs' in parsed &&
+    'id' in parsed &&
+    typeof parsed.startedAtMs === 'number' &&
+    typeof parsed.id === 'string'
+  ) {
+    return parsed as unknown as KeysetCursor;
+  }
+  return null;
+}

--- a/packages/persistence/src/ports.ts
+++ b/packages/persistence/src/ports.ts
@@ -32,6 +32,10 @@ import type {
   ListAssetsResponse,
   ListDetectionsQuery,
   ListDetectionsResponse,
+  ListFindingInstancesQuery,
+  ListFindingInstancesResponse,
+  ListFindingLocationsQuery,
+  ListFindingLocationsResponse,
   ListGroupedFindingsQuery,
   ListGroupedFindingsResponse,
   ListHarnessesResponse,
@@ -80,6 +84,20 @@ export interface GroupedFindingsView {
   /** How many live-enforced findings belong to this session — a bare COUNT, so
    * a caller labeling a link never pays the grouped pipeline. */
   sessionFindingsCount(sessionId: string): Promise<number>;
+}
+
+/**
+ * Instance-level findings reads: the flat newest-first list, and the same
+ * findings folded by location (repo → file).
+ *
+ * Separate from GroupedFindingsView because the unit differs — these page and
+ * count FINDINGS where the grouped view pages and counts RULES — and because
+ * their status filter matches each instance's own derived status rather than
+ * its group's fold. Both are served by the same store as the grouped view.
+ */
+export interface FindingInstancesView {
+  listFindingInstances(query: ListFindingInstancesQuery): Promise<ListFindingInstancesResponse>;
+  listFindingLocations(query: ListFindingLocationsQuery): Promise<ListFindingLocationsResponse>;
 }
 
 /** Aggregated dashboard reads — independent of the findings row shape. */

--- a/packages/persistence/src/repositories/activity.ts
+++ b/packages/persistence/src/repositories/activity.ts
@@ -26,7 +26,8 @@ import {
   SessionStatus,
 } from '@akasecurity/schema';
 
-import { parseJsonObject, safeJson } from '../internal/json.ts';
+import { safeJson } from '../internal/json.ts';
+import { decodeKeysetCursor, encodeKeysetCursor } from '../internal/keyset-cursor.ts';
 import { allRows, countScalar, getRow, intToBool, mapRowsTolerant } from '../internal/rows.ts';
 import { containsPattern, placeholders } from '../internal/sql-text.ts';
 import type { ActivityReadPort } from '../ports.ts';
@@ -117,32 +118,6 @@ export function todayWindow(timeZone: string, nowMs: number): TodayWindow {
 function utcWindow(nowMs: number): TodayWindow {
   const startMs = Math.floor(nowMs / DAY_MS) * DAY_MS;
   return { startMs, endMs: startMs + DAY_MS };
-}
-
-interface SessionCursor {
-  startedAtMs: number;
-  id: string;
-}
-
-// Opaque base64url keyset cursor of the last item's {startedAtMs, id}, most-
-// recent-first (same convention as services/activity.ts). A stale/undecodable
-// cursor restarts from the top rather than throwing.
-function encodeCursor(payload: SessionCursor): string {
-  return Buffer.from(JSON.stringify(payload)).toString('base64url');
-}
-
-function decodeCursor(cursor: string): SessionCursor | null {
-  const parsed = parseJsonObject(Buffer.from(cursor, 'base64url').toString('utf8'));
-  if (
-    parsed !== undefined &&
-    'startedAtMs' in parsed &&
-    'id' in parsed &&
-    typeof parsed.startedAtMs === 'number' &&
-    typeof parsed.id === 'string'
-  ) {
-    return parsed as unknown as SessionCursor;
-  }
-  return null;
 }
 
 // DB event_type → contract AuditEventKind. `tool_call` renames to `tool`; the
@@ -419,7 +394,7 @@ export class SqliteActivityRepository implements ActivityReadPort {
   }
 
   listSessions(query: ListActivitySessionsQuery): Promise<ListActivitySessionsResponse> {
-    const cursor = query.cursor ? decodeCursor(query.cursor) : null;
+    const cursor = query.cursor ? decodeKeysetCursor(query.cursor) : null;
     const toMs = query.to ? isoToEpochMillis(query.to) : this.now();
     const fromMs = query.from ? isoToEpochMillis(query.from) : undefined;
 
@@ -516,7 +491,7 @@ export class SqliteActivityRepository implements ActivityReadPort {
 
     const last = page[page.length - 1];
     const nextCursor =
-      hasMore && last ? encodeCursor({ startedAtMs: last.started_at, id: last.id }) : null;
+      hasMore && last ? encodeKeysetCursor({ startedAtMs: last.started_at, id: last.id }) : null;
 
     return Promise.resolve({ items, nextCursor, emptyCount });
   }

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -1,33 +1,59 @@
-import type { DatabaseSync } from 'node:sqlite';
+import type { DatabaseSync, SQLInputValue } from 'node:sqlite';
 
 import type {
   ActionTaken,
   DayActivity,
+  FindingGroup,
   FindingGroupAggregate,
+  FindingInstanceDetail,
+  FindingLocationFile,
   FindingStatus,
   FindingView,
+  FlatFindingRow,
   GroupableFindingRow,
   HealthSummary,
+  InstanceFilterOptions,
+  ListFindingInstancesQuery,
+  ListFindingInstancesResponse,
+  ListFindingLocationsQuery,
+  ListFindingLocationsResponse,
   ListGroupedFindingsQuery,
   ListGroupedFindingsResponse,
+  LocationAccumulator,
 } from '@akasecurity/schema';
 import {
   ACTION_TAKEN_KEYS,
+  addToLocation,
   applyFindingFilters,
   buildFindingGroups,
   CAPTURE_EVENT_TYPES_SQL,
+  compareFindingGroupOrder,
   computeFindingFacets,
   countInstancesByStatus,
+  createInstanceFacetAccumulator,
+  DEFAULT_FLAT_FINDINGS_LIMIT,
   DEFAULT_GROUPED_FINDINGS_LIMIT,
   deriveFindingStatus,
   ENFORCEABLE_CATEGORIES,
   epochMillisToIso,
+  foldGroupStatus,
+  isoToEpochMillis,
+  matchesInstanceFilters,
+  newLocationAccumulator,
   sortFindingGroups,
+  toInstanceDetail,
 } from '@akasecurity/schema';
 
+import { parseJsonObject } from '../internal/json.ts';
+import { decodeKeysetCursor, encodeKeysetCursor } from '../internal/keyset-cursor.ts';
 import { allRows, countBy, countScalar } from '../internal/rows.ts';
-import type { DashboardViews, FindingsReadPort, GroupedFindingsView } from '../ports.ts';
-import { LATEST_RESOLUTION_BY_KEY_SQL } from './resolution-sql.ts';
+import type {
+  DashboardViews,
+  FindingInstancesView,
+  FindingsReadPort,
+  GroupedFindingsView,
+} from '../ports.ts';
+import { LATEST_RESOLUTION_BY_KEY_SQL, latestResolutionStatusSql } from './resolution-sql.ts';
 
 // How many of each group's newest instances listGroupedFindings materializes.
 // Group-wide numbers (instanceCount, providers, actions, status, latest, search
@@ -37,6 +63,37 @@ import { LATEST_RESOLUTION_BY_KEY_SQL } from './resolution-sql.ts';
 // (distinct rule_ids × this) however large the store grows; SQLite still scans
 // the table to count, so time grows with it while memory does not.
 const PREVIEW_INSTANCES_PER_GROUP = 200;
+
+// How many rows one batch of the flat scan pulls. The scan is a sequence of
+// these rather than one result set, so a store far larger than any page keeps
+// memory flat while the totals and facets are counted.
+const SCAN_BATCH_ROWS = 1000;
+
+// Repos returned by listFindingLocations when the query names no limit.
+const DEFAULT_LOCATIONS_LIMIT = 100;
+
+// Distinct rules named on one location row. The row renders them as chips and
+// the instance count is what conveys scale, so the list is a sample, not a tally.
+const LOCATION_RULE_IDS_CAP = 20;
+
+/** Location rows sort like groups: worst severity first, then most recent. */
+function compareLocationOrder(
+  a: { maxSeverity: string; latestDetectedAt: string },
+  b: { maxSeverity: string; latestDetectedAt: string },
+): number {
+  return compareFindingGroupOrder(
+    {
+      severity: a.maxSeverity as FindingGroup['severity'],
+      latestDetectedAt: a.latestDetectedAt,
+      id: '',
+    },
+    {
+      severity: b.maxSeverity as FindingGroup['severity'],
+      latestDetectedAt: b.latestDetectedAt,
+      id: '',
+    },
+  );
+}
 
 // group_concat's list separator. SQLite allows a custom separator only when the
 // aggregate has a single argument, and DISTINCT already claims that slot, so the
@@ -80,6 +137,8 @@ interface FindingGroupRowJoined {
   repo: string | null;
   file: string | null;
   tool_name: string | null;
+  event_id: string;
+  session_id: string | null;
   // Status-derivation inputs — mirrors SqliteSecurityRepository.severitySummary's
   // atRest/latest-resolution-wins predicate (see deriveInstanceStatus below).
   kind: string;
@@ -104,6 +163,63 @@ function deriveInstanceStatus(row: {
     findingKey: row.finding_key,
     latestResolutionStatus: row.latest_status,
   });
+}
+
+// The grouped list's cursor: the sort key of the last group on the page just
+// served. Its own codec rather than the shared keyset one, because this list
+// sorts by (severity, latestDetectedAt, id) — not by a timestamp and an id — so
+// resuming needs all three. Undecodable restarts from the top, matching the
+// convention the other paginated reads follow.
+type GroupCursorPayload = Pick<FindingGroup, 'severity' | 'latestDetectedAt' | 'id'>;
+
+function encodeGroupCursor(group: GroupCursorPayload): string {
+  const payload = {
+    sev: group.severity,
+    t: group.latestDetectedAt,
+    id: group.id,
+  };
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+function decodeGroupCursor(cursor: string): GroupCursorPayload | null {
+  const parsed = parseJsonObject(Buffer.from(cursor, 'base64url').toString('utf8'));
+  if (
+    parsed !== undefined &&
+    typeof parsed.sev === 'string' &&
+    typeof parsed.t === 'string' &&
+    typeof parsed.id === 'string'
+  ) {
+    // `sev` is not checked against the Severity enum: an out-of-enum value ranks
+    // below every known severity (see compareFindingGroupOrder), so a garbage
+    // cursor sorts before the whole list and degrades to a restart from the top
+    // — the same outcome as an undecodable one.
+    return {
+      severity: parsed.sev as FindingGroup['severity'],
+      latestDetectedAt: parsed.t,
+      id: parsed.id,
+    };
+  }
+  return null;
+}
+
+/** Index of the first group strictly after the cursor, or the length when none. */
+function firstAfter(sorted: FindingGroup[], cursor: GroupCursorPayload): number {
+  const index = sorted.findIndex((g) => compareFindingGroupOrder(g, cursor) > 0);
+  return index === -1 ? sorted.length : index;
+}
+
+/**
+ * The group a `?finding=` deep link names, when it is not already on the page:
+ * either the group itself, or the group holding the named instance. Returns
+ * undefined when the id is unknown or already present.
+ */
+function findDeepLinked(
+  sorted: FindingGroup[],
+  page: FindingGroup[],
+  id: string,
+): FindingGroup | undefined {
+  if (page.some((g) => g.id === id || g.instances.some((i) => i.id === id))) return undefined;
+  return sorted.find((g) => g.id === id || g.instances.some((i) => i.id === id));
 }
 
 const DAY_MS = 86_400_000;
@@ -133,7 +249,7 @@ interface FindingRowJoined {
  * tenant), so there is no tenant predicate on any query.
  */
 export class SqliteFindingsRepository
-  implements FindingsReadPort, DashboardViews, GroupedFindingsView
+  implements FindingsReadPort, DashboardViews, GroupedFindingsView, FindingInstancesView
 {
   constructor(private readonly db: DatabaseSync) {}
 
@@ -250,10 +366,16 @@ export class SqliteFindingsRepository
     // never surface, the same universe the old `events` table was already
     // limited to.
     const sessionPredicate = query.sessionId ? ` AND e.root_session_id = :sessionId` : '';
-    const predicate = `WHERE e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})${sessionPredicate}`;
-    const sessionParams: Record<string, string> = query.sessionId
-      ? { sessionId: query.sessionId }
-      : {};
+    // The time bound is a SQL predicate for the same reason: totals, facets and
+    // aggregates must all speak for the window, not just the rows that survived
+    // into the preview.
+    const fromMs = query.from === undefined ? undefined : isoToEpochMillis(query.from);
+    const fromPredicate = fromMs === undefined ? '' : ` AND e.started_at >= :fromMs`;
+    const predicate = `WHERE e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})${sessionPredicate}${fromPredicate}`;
+    const sessionParams: Record<string, string | number> = {
+      ...(query.sessionId ? { sessionId: query.sessionId } : {}),
+      ...(fromMs === undefined ? {} : { fromMs }),
+    };
 
     // The search text is the one aggregate column whose size tracks the store
     // rather than the rule count, so fetch it only for a request that can use
@@ -266,7 +388,8 @@ export class SqliteFindingsRepository
     const rows = allRows<FindingGroupRowJoined>(
       this.db.prepare(
         `SELECT id, rule_id, category, severity, masked_match, action_taken, confidence,
-                occurred_at, source_tool, repo, file, tool_name, kind, finding_key, latest_status
+                occurred_at, source_tool, repo, file, tool_name, event_id, session_id,
+                kind, finding_key, latest_status
          FROM (
            SELECT f.id AS id, d.rule_id AS rule_id, d.category AS category,
                   d.severity AS severity, f.masked_match AS masked_match,
@@ -276,6 +399,7 @@ export class SqliteFindingsRepository
                   json_extract(e.attributes, '$.repo') AS repo,
                   json_extract(e.attributes, '$.file_path') AS file,
                   json_extract(e.attributes, '$.tool_name') AS tool_name,
+                  f.audit_event_id AS event_id, e.root_session_id AS session_id,
                   e.event_type AS kind, f.finding_key AS finding_key,
                   latest.status AS latest_status,
                   ROW_NUMBER() OVER (
@@ -308,6 +432,8 @@ export class SqliteFindingsRepository
       repo: r.repo ?? '',
       file: r.file ?? '',
       ...(r.tool_name === null ? {} : { toolName: r.tool_name }),
+      eventId: r.event_id,
+      ...(r.session_id === null ? {} : { sessionId: r.session_id }),
       status: deriveInstanceStatus(r),
     }));
 
@@ -349,6 +475,33 @@ export class SqliteFindingsRepository
     };
 
     const limit = query.limit ?? DEFAULT_GROUPED_FINDINGS_LIMIT;
+
+    // Page the sorted groups by keyset rather than offset. Both are equally
+    // cheap here — the whole filtered set is already sorted in memory — but the
+    // store is written by processes this read does not coordinate with, and an
+    // offset skips or repeats a group whenever a write reorders one between
+    // pages. compareFindingGroupOrder is a total order, so "strictly after the
+    // cursor" always names exactly one position.
+    const cursor = query.cursor === undefined ? null : decodeGroupCursor(query.cursor);
+    const start = cursor === null ? 0 : firstAfter(sorted, cursor);
+    const page = sorted.slice(start, start + limit);
+    // From the page, BEFORE any deep-link append: the appended group is out of
+    // sort order, and minting the cursor from it would skip everything between
+    // the real page end and wherever it sorts.
+    const lastOnPage = page.at(-1);
+    const nextCursor =
+      start + limit < sorted.length && lastOnPage ? encodeGroupCursor(lastOnPage) : null;
+
+    // Keep the ?finding= deep link resolving once the list pages: its target may
+    // sort past the page the cursor landed on, and scanning forward for it would
+    // be unbounded work for what is often a stale id. Matched against the
+    // un-narrowed preview so a status filter cannot hide the instance the link
+    // names. Appended out of order, and never counted in totals or the cursor.
+    const deepLinked =
+      query.includeId === undefined || query.includeId === ''
+        ? undefined
+        : findDeepLinked(sorted, page, query.includeId);
+
     // Under a status filter, narrow each group's instance PREVIEW to the
     // requested statuses so every rendered location matches the filter (the
     // group-level folds still describe the whole group). The preview holds only
@@ -356,20 +509,22 @@ export class SqliteFindingsRepository
     // group the filter correctly kept — every matching instance may be older
     // than the preview window; views render an explicit notice for that case.
     const statusSet = statusFilter.length > 0 ? new Set<string>(statusFilter) : null;
-    const items = sorted.slice(0, limit).map((g) =>
+    const narrow = (g: FindingGroup): FindingGroup =>
       statusSet
         ? {
             ...g,
             instances: g.instances.filter((i) => i.status !== undefined && statusSet.has(i.status)),
           }
-        : g,
-    );
+        : g;
+    // The appended group is narrowed like the rest: it is one more row in the
+    // same table, and an unnarrowed one would show locations the filter excluded.
+    const items = [...page, ...(deepLinked ? [deepLinked] : [])].map(narrow);
 
     return Promise.resolve({
       totals,
       facets,
       items,
-      nextCursor: null,
+      nextCursor,
       ...(query.sessionId ? { sessionFirings: this.sessionFirings(query.sessionId) } : {}),
     });
   }
@@ -402,9 +557,318 @@ export class SqliteFindingsRepository
    * request actually carries a `q`. (Substring matching is unaffected by a
    * path repeating across tuples.)
    */
+  /**
+   * The instance-level (flat) findings list: one row per finding, newest first,
+   * paged by keyset.
+   *
+   * SQL owns SCOPE, JS owns every FILTER DIMENSION. The session and the time
+   * bound are SQL predicates: nothing counts them, so narrowing the scan by
+   * them changes no reported number. Severity, subtype, provider, action,
+   * status, tool, repo, file and `q` all stay in JS — each has a facet, and a
+   * facet excludes its own filter, so a row the filter rejects still has to be
+   * counted. Pushing any of them into SQL would silently empty its own facet.
+   * Several could not be expressed there anyway: status comes from the one
+   * shared classifier (deriveFindingStatus), and provider 'api' means "a tool
+   * none of the mappers names", which no IN-list can say.
+   *
+   * The scan runs from the top of the scope on every request, not from the
+   * cursor: `totals` and `facets` describe the whole filtered scope and must not
+   * move as the caller pages. Rows are pulled in batches so memory stays flat
+   * while the counting runs, and only the page itself is retained.
+   */
+  listFindingInstances(query: ListFindingInstancesQuery): Promise<ListFindingInstancesResponse> {
+    const opts: InstanceFilterOptions = {
+      severity: query.severity,
+      subtype: query.subtype,
+      providers: query.provider,
+      actions: query.action,
+      statuses: query.status,
+      tools: query.tool,
+      repo: query.repo,
+      file: query.file,
+      q: query.q,
+    };
+    const limit = query.limit ?? DEFAULT_FLAT_FINDINGS_LIMIT;
+    const cursor = query.cursor === undefined ? null : decodeKeysetCursor(query.cursor);
+
+    const accumulator = createInstanceFacetAccumulator(opts);
+    const items: FindingInstanceDetail[] = [];
+    let total = 0;
+    let last: FlatFindingRow | undefined;
+    // Whether the page is full and at least one further row matched — the
+    // cursor is minted from the last COLLECTED row, so no matching row between
+    // the page's end and the batch's end is ever skipped.
+    let hasMore = false;
+
+    for (const row of this.scanFindingRows({
+      sessionId: query.sessionId,
+      from: query.from,
+    })) {
+      accumulator.add(row);
+      if (!matchesInstanceFilters(row, opts)) continue;
+      total += 1;
+      if (items.length < limit) {
+        items.push(toInstanceDetail(row));
+        last = row;
+      } else {
+        hasMore = true;
+      }
+    }
+
+    const nextCursor =
+      hasMore && last
+        ? encodeKeysetCursor({ startedAtMs: isoToEpochMillis(last.occurredAt), id: last.id })
+        : null;
+
+    // The cursor selects the page out of the fully-counted scope rather than
+    // narrowing the scan, so paging cannot change what totals and facets say.
+    if (cursor !== null) {
+      const resumed = this.pageAfter(cursor, opts, limit, query);
+      return Promise.resolve({
+        totals: { findings: total },
+        facets: accumulator.facets(),
+        items: resumed.items,
+        nextCursor: resumed.nextCursor,
+      });
+    }
+
+    return Promise.resolve({
+      totals: { findings: total },
+      facets: accumulator.facets(),
+      items,
+      nextCursor,
+    });
+  }
+
+  /**
+   * The page of matching rows strictly after `cursor`. Separate from the
+   * counting pass because that one starts at the top of the scope by design;
+   * this one narrows the scan with the same keyset predicate the activity list
+   * uses, so a later page costs less than the first rather than more.
+   */
+  private pageAfter(
+    cursor: { startedAtMs: number; id: string },
+    opts: InstanceFilterOptions,
+    limit: number,
+    query: ListFindingInstancesQuery,
+  ): { items: FindingInstanceDetail[]; nextCursor: string | null } {
+    const items: FindingInstanceDetail[] = [];
+    let last: FlatFindingRow | undefined;
+    let hasMore = false;
+
+    for (const row of this.scanFindingRows({
+      sessionId: query.sessionId,
+      from: query.from,
+      after: cursor,
+    })) {
+      if (!matchesInstanceFilters(row, opts)) continue;
+      if (items.length < limit) {
+        items.push(toInstanceDetail(row));
+        last = row;
+      } else {
+        hasMore = true;
+        break;
+      }
+    }
+
+    return {
+      items,
+      nextCursor:
+        hasMore && last
+          ? encodeKeysetCursor({ startedAtMs: isoToEpochMillis(last.occurredAt), id: last.id })
+          : null,
+    };
+  }
+
+  /**
+   * The same findings folded by location: repository, then file within it.
+   *
+   * The grouping keys come from the capturing event's attributes, which is what
+   * the local store relates a finding to — there is no finding↔asset row to
+   * group by instead. A repo or file the event did not record folds into the
+   * empty-string bucket, which the view renders but does not link, since no
+   * filter can name it.
+   */
+  listFindingLocations(query: ListFindingLocationsQuery): Promise<ListFindingLocationsResponse> {
+    const opts: InstanceFilterOptions = {
+      severity: query.severity,
+      subtype: query.subtype,
+      providers: query.provider,
+      actions: query.action,
+      statuses: query.status,
+      tools: query.tool,
+      q: query.q,
+    };
+    const limit = query.limit ?? DEFAULT_LOCATIONS_LIMIT;
+
+    // Bounded by distinct (repo, file) pairs rather than by the store's size —
+    // the same cardinality the grouped path's search-text aggregate already
+    // carries, holding counts instead of paths.
+    const byRepo = new Map<string, Map<string, LocationAccumulator>>();
+    let total = 0;
+
+    for (const row of this.scanFindingRows({
+      sessionId: query.sessionId,
+      from: query.from,
+    })) {
+      if (!matchesInstanceFilters(row, opts)) continue;
+      total += 1;
+      let files = byRepo.get(row.repo);
+      if (files === undefined) {
+        files = new Map<string, LocationAccumulator>();
+        byRepo.set(row.repo, files);
+      }
+      let acc = files.get(row.file);
+      if (acc === undefined) {
+        acc = newLocationAccumulator();
+        files.set(row.file, acc);
+      }
+      addToLocation(acc, row);
+    }
+
+    let fileCount = 0;
+    const repos = [...byRepo.entries()].map(([repo, files]) => {
+      fileCount += files.size;
+      const fileRows: FindingLocationFile[] = [...files.entries()]
+        .map(([file, acc]) => ({
+          file,
+          instanceCount: acc.instanceCount,
+          maxSeverity: acc.maxSeverity as FindingLocationFile['maxSeverity'],
+          latestDetectedAt: acc.latestDetectedAt,
+          ...(foldGroupStatus(acc.statuses) === undefined
+            ? {}
+            : { status: foldGroupStatus(acc.statuses) }),
+          ruleIds: [...acc.ruleIds].slice(0, LOCATION_RULE_IDS_CAP),
+        }))
+        .sort(compareLocationOrder);
+      const rollup = fileRows.reduce(
+        (a, f) => ({
+          instanceCount: a.instanceCount + f.instanceCount,
+          maxSeverity: compareLocationOrder(f, a) < 0 ? f.maxSeverity : a.maxSeverity,
+          latestDetectedAt:
+            f.latestDetectedAt > a.latestDetectedAt ? f.latestDetectedAt : a.latestDetectedAt,
+        }),
+        {
+          instanceCount: 0,
+          maxSeverity: fileRows[0]?.maxSeverity ?? 'low',
+          latestDetectedAt: '',
+        },
+      );
+      const statuses = fileRows.map((f) => f.status);
+      const folded = foldGroupStatus(statuses);
+      return {
+        repo,
+        instanceCount: rollup.instanceCount,
+        maxSeverity: rollup.maxSeverity,
+        latestDetectedAt: rollup.latestDetectedAt,
+        ...(folded === undefined ? {} : { status: folded }),
+        files: fileRows,
+      };
+    });
+    repos.sort(compareLocationOrder);
+
+    return Promise.resolve({
+      totals: { findings: total, repos: repos.length, files: fileCount },
+      items: repos.slice(0, limit),
+      hasMore: repos.length > limit,
+    });
+  }
+
+  /**
+   * Every finding in scope as a FlatFindingRow, newest first, pulled in batches.
+   *
+   * A generator so a caller streams the scope without it ever being an array:
+   * the flat list counts and facets the whole filtered scope, which on a large
+   * store is far more rows than any page. Each batch advances the same keyset
+   * predicate the page read uses, so the scan is a sequence of bounded reads
+   * rather than one unbounded result set.
+   *
+   * The latest-resolution lookup is the CORRELATED form, not the derived table
+   * the grouped path joins: only `status` is needed, idx_finding_resolution_key
+   * makes it a point lookup per row, and the derived table would re-materialize
+   * a window over the whole resolution table once per batch.
+   *
+   * `scope` carries ONLY what no facet counts. A filter dimension narrowed here
+   * would be missing from its own facet, which is computed by excluding that
+   * dimension — see listFindingInstances.
+   */
+  private *scanFindingRows(scope: {
+    sessionId?: string | undefined;
+    from?: string | undefined;
+    after?: { startedAtMs: number; id: string } | undefined;
+  }): Generator<FlatFindingRow> {
+    const conditions = [`e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})`];
+    const params: SQLInputValue[] = [];
+
+    if (scope.sessionId !== undefined && scope.sessionId !== '') {
+      conditions.push('e.root_session_id = ?');
+      params.push(scope.sessionId);
+    }
+    if (scope.from !== undefined) {
+      conditions.push('e.started_at >= ?');
+      params.push(isoToEpochMillis(scope.from));
+    }
+
+    const sql = `SELECT f.id AS id, d.rule_id AS rule_id, d.category AS category,
+              d.severity AS severity, f.masked_match AS masked_match,
+              f.action_taken AS action_taken, f.confidence AS confidence,
+              e.started_at AS occurred_at,
+              json_extract(e.attributes, '$.source_tool') AS source_tool,
+              json_extract(e.attributes, '$.repo') AS repo,
+              json_extract(e.attributes, '$.file_path') AS file,
+              json_extract(e.attributes, '$.tool_name') AS tool_name,
+              f.audit_event_id AS event_id, e.root_session_id AS session_id,
+              e.event_type AS kind, f.finding_key AS finding_key,
+              ${latestResolutionStatusSql('f')} AS latest_status
+         FROM inspection_findings f
+         JOIN audit_events e ON e.id = f.audit_event_id
+         JOIN inspection_definitions d ON d.id = f.inspection_definition_id
+        WHERE ${conditions.join(' AND ')}
+          AND (e.started_at < ? OR (e.started_at = ? AND f.id < ?))
+        ORDER BY e.started_at DESC, f.id DESC
+        LIMIT ?`;
+
+    // The batch walks the same tuple the cursor does. It starts one past the
+    // newest possible row (or at the caller's cursor) and re-enters at the last
+    // row of the previous batch, so no row is read twice or skipped.
+    let after = scope.after ?? { startedAtMs: Number.MAX_SAFE_INTEGER, id: '￿' };
+    for (;;) {
+      const rows = allRows<FindingGroupRowJoined>(this.db.prepare(sql), [
+        ...params,
+        after.startedAtMs,
+        after.startedAtMs,
+        after.id,
+        SCAN_BATCH_ROWS,
+      ]);
+      for (const r of rows) {
+        yield {
+          id: r.id,
+          ruleId: r.rule_id,
+          category: r.category,
+          severity: r.severity,
+          maskedMatch: r.masked_match,
+          actionTaken: r.action_taken,
+          confidence: r.confidence,
+          occurredAt: epochMillisToIso(r.occurred_at),
+          sourceTool: r.source_tool,
+          repo: r.repo ?? '',
+          file: r.file ?? '',
+          ...(r.tool_name === null ? {} : { toolName: r.tool_name }),
+          eventId: r.event_id,
+          ...(r.session_id === null ? {} : { sessionId: r.session_id }),
+          status: deriveInstanceStatus(r),
+        };
+      }
+      if (rows.length < SCAN_BATCH_ROWS) return;
+      const lastRow = rows[rows.length - 1];
+      if (lastRow === undefined) return;
+      after = { startedAtMs: lastRow.occurred_at, id: lastRow.id };
+    }
+  }
+
   private groupAggregates(
     withSearchText: boolean,
-    scope: { predicate: string; params: Record<string, string> },
+    scope: { predicate: string; params: Record<string, string | number> },
   ): Map<string, FindingGroupAggregate> {
     // Tool names ride as their display label ("via Bash") to mirror
     // buildHaystack — see its doc for why the bare name is not searched.

--- a/packages/persistence/test/repositories/findings-flat.test.ts
+++ b/packages/persistence/test/repositories/findings-flat.test.ts
@@ -1,0 +1,547 @@
+import { randomUUID } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import type {
+  ActionTaken,
+  DetectedFinding,
+  DetectionCategory,
+  EventMetadata,
+  IngestEvent,
+  Severity,
+} from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openLocalDatabase } from '../../src/database.ts';
+import { captureId } from '../../src/ids.ts';
+
+// The instance-level reads: listFindingInstances (flat, keyset-paged) and
+// listFindingLocations (folded by repo → file). Both run against a real store,
+// like every other repository suite here.
+
+let dir: string;
+let db: ReturnType<typeof openLocalDatabase>;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'aka-findings-flat-'));
+  db = openLocalDatabase(dir);
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function record(opts: {
+  occurredAt: string;
+  sourceTool: IngestEvent['sourceTool'];
+  ruleId: string;
+  category?: DetectionCategory;
+  severity?: Severity;
+  actionTaken?: ActionTaken;
+  repo?: string;
+  filePath?: string;
+  toolName?: string;
+  sessionId?: string;
+  kind?: IngestEvent['kind'];
+}): string {
+  const id = randomUUID();
+  const contentHash = randomUUID();
+  const metadata: EventMetadata = {
+    ...(opts.repo === undefined ? {} : { repo: opts.repo }),
+    ...(opts.filePath === undefined ? {} : { filePath: opts.filePath }),
+    ...(opts.toolName === undefined ? {} : { toolName: opts.toolName }),
+    ...(opts.sessionId === undefined ? {} : { sessionId: opts.sessionId }),
+  };
+  const event: IngestEvent = {
+    id,
+    sourceTool: opts.sourceTool,
+    kind: opts.kind ?? 'prompt',
+    occurredAt: opts.occurredAt,
+    contentHash,
+    content: 'x',
+    metadata,
+  };
+  const finding: DetectedFinding = {
+    id: randomUUID(),
+    eventId: id,
+    ruleId: opts.ruleId,
+    category: opts.category ?? 'secret',
+    severity: opts.severity ?? 'critical',
+    span: { start: 0, end: 1 },
+    maskedMatch: 'masked',
+    actionTaken: opts.actionTaken ?? 'block',
+    confidence: 0.9,
+  };
+  db.recordCapture(event, [finding]);
+  // The store derives the audit-event id rather than taking the ingest id (see
+  // captureId), so a caller asserting on the linkage needs the derived one.
+  return captureId(opts.sessionId ?? null, contentHash, opts.filePath ?? null);
+}
+
+function seed(): void {
+  record({
+    occurredAt: '2026-01-03T00:00:00.000Z',
+    sourceTool: 'claude-code',
+    ruleId: 'aws-key',
+    severity: 'critical',
+    repo: 'acme/api',
+    filePath: 'a.ts',
+    toolName: 'Read',
+    sessionId: 's1',
+  });
+  record({
+    occurredAt: '2026-01-02T00:00:00.000Z',
+    sourceTool: 'cursor',
+    ruleId: 'aws-key',
+    severity: 'critical',
+    actionTaken: 'warn',
+    repo: 'acme/web',
+    filePath: 'b.ts',
+    toolName: 'Bash',
+  });
+  record({
+    occurredAt: '2026-01-01T00:00:00.000Z',
+    sourceTool: 'claude-code',
+    ruleId: 'email',
+    category: 'code_context',
+    severity: 'low',
+    actionTaken: 'redact',
+    repo: 'acme/api',
+    filePath: 'c.ts',
+  });
+}
+
+describe('SqliteFindingsRepository.listFindingInstances', () => {
+  it('returns one row per finding, newest first', async () => {
+    seed();
+    const res = await db.findings.listFindingInstances({});
+
+    expect(res.totals.findings).toBe(3);
+    expect(res.items.map((i) => i.detectedAt)).toEqual([
+      '2026-01-03T00:00:00.000Z',
+      '2026-01-02T00:00:00.000Z',
+      '2026-01-01T00:00:00.000Z',
+    ]);
+    // Where the grouped list would fold both aws-key rows into one group.
+    expect(res.items.map((i) => i.subtype)).toEqual(['aws-key', 'aws-key', 'email']);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('carries each row event and session linkage', async () => {
+    const eventId = record({
+      occurredAt: '2026-01-03T00:00:00.000Z',
+      sourceTool: 'claude-code',
+      ruleId: 'aws-key',
+      repo: 'acme/api',
+      sessionId: 'sess-1',
+    });
+    const res = await db.findings.listFindingInstances({});
+
+    expect(res.items[0]?.eventId).toBe(eventId);
+    expect(res.items[0]?.sessionId).toBe('sess-1');
+  });
+
+  it('omits sessionId for an event outside a session', async () => {
+    record({ occurredAt: '2026-01-03T00:00:00.000Z', sourceTool: 'claude-code', ruleId: 'r' });
+    const res = await db.findings.listFindingInstances({});
+
+    expect(res.items[0]?.eventId).toBeDefined();
+    expect(res.items[0]?.sessionId).toBeUndefined();
+  });
+
+  it('is empty with a null cursor on an empty store', async () => {
+    const res = await db.findings.listFindingInstances({});
+    expect(res.items).toEqual([]);
+    expect(res.totals.findings).toBe(0);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  describe('pagination', () => {
+    // More rows than one page, all sharing a timestamp for part of the run so
+    // the id tie-break in the keyset is actually exercised.
+    function seedMany(n: number): void {
+      for (let i = 0; i < n; i += 1) {
+        record({
+          // Two rows per millisecond: the (started_at, id) tuple is what
+          // separates them, not the timestamp alone.
+          occurredAt: new Date(Date.UTC(2026, 0, 1) + Math.floor(i / 2) * 1000).toISOString(),
+          sourceTool: 'claude-code',
+          ruleId: `rule-${String(i % 3)}`,
+          repo: 'acme/api',
+        });
+      }
+    }
+
+    it('walks every row exactly once across pages', async () => {
+      seedMany(25);
+      const seen: string[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page < 20; page += 1) {
+        const res: Awaited<ReturnType<typeof db.findings.listFindingInstances>> =
+          await db.findings.listFindingInstances({
+            limit: 10,
+            ...(cursor === undefined ? {} : { cursor }),
+          });
+        seen.push(...res.items.map((i) => i.id));
+        if (res.nextCursor === null) break;
+        cursor = res.nextCursor;
+      }
+
+      expect(seen).toHaveLength(25);
+      expect(new Set(seen).size).toBe(25);
+    });
+
+    it('reports totals and facets over the whole scope, not the page', async () => {
+      seedMany(25);
+      const first = await db.findings.listFindingInstances({ limit: 10 });
+      expect(first.items).toHaveLength(10);
+      expect(first.totals.findings).toBe(25);
+
+      const second = await db.findings.listFindingInstances({
+        limit: 10,
+        cursor: first.nextCursor ?? '',
+      });
+      // The numbers describe the query, so paging must not move them.
+      expect(second.totals).toEqual(first.totals);
+      expect(second.facets).toEqual(first.facets);
+    });
+
+    it('restarts from the top on an undecodable cursor', async () => {
+      seedMany(6);
+      const fresh = await db.findings.listFindingInstances({ limit: 3 });
+      const restarted = await db.findings.listFindingInstances({
+        limit: 3,
+        cursor: 'not-a-cursor',
+      });
+      expect(restarted.items.map((i) => i.id)).toEqual(fresh.items.map((i) => i.id));
+    });
+
+    it('keeps a filtered page full across scan batches', async () => {
+      // One rare match per 40 rows, so filling a page of 3 requires the scan to
+      // keep pulling batches rather than returning what the first one held.
+      for (let i = 0; i < 120; i += 1) {
+        record({
+          occurredAt: new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString(),
+          sourceTool: 'claude-code',
+          ruleId: i % 40 === 0 ? 'rare' : 'common',
+          repo: 'acme/api',
+        });
+      }
+      const res = await db.findings.listFindingInstances({ subtype: ['rare'], limit: 3 });
+      expect(res.items).toHaveLength(3);
+      expect(res.totals.findings).toBe(3);
+      expect(res.items.every((i) => i.subtype === 'rare')).toBe(true);
+    });
+
+    it('does not skip a match sitting past the page end', async () => {
+      seedMany(12);
+      const first = await db.findings.listFindingInstances({ limit: 5 });
+      expect(first.nextCursor).not.toBeNull();
+      const second = await db.findings.listFindingInstances({
+        limit: 5,
+        cursor: first.nextCursor ?? '',
+      });
+      const third = await db.findings.listFindingInstances({
+        limit: 5,
+        cursor: second.nextCursor ?? '',
+      });
+      const all = [...first.items, ...second.items, ...third.items].map((i) => i.id);
+      expect(new Set(all).size).toBe(12);
+    });
+  });
+
+  describe('filters', () => {
+    it('matches an instance own status, not its group fold', async () => {
+      seed();
+      // Every seeded row is in-flight, so each derives 'handled'.
+      const handled = await db.findings.listFindingInstances({ status: ['handled'] });
+      expect(handled.totals.findings).toBe(3);
+      const open = await db.findings.listFindingInstances({ status: ['open'] });
+      expect(open.totals.findings).toBe(0);
+    });
+
+    it('filters by exact tool name', async () => {
+      seed();
+      const res = await db.findings.listFindingInstances({ tool: ['Bash'] });
+      expect(res.totals.findings).toBe(1);
+      expect(res.items[0]?.toolName).toBe('Bash');
+    });
+
+    it('filters by exact repo and file', async () => {
+      seed();
+      const byRepo = await db.findings.listFindingInstances({ repo: 'acme/api' });
+      expect(byRepo.totals.findings).toBe(2);
+      const byFile = await db.findings.listFindingInstances({ file: 'a.ts' });
+      expect(byFile.totals.findings).toBe(1);
+    });
+
+    it('matches provider api as the unknown-tool catch-all', async () => {
+      // 'api' is what an unmapped source tool reads as, so it cannot be a SQL
+      // IN-list over known tools — this is the case that would return zero.
+      // 'unknown' is a real SourceTool that TOOL_TO_HARNESS does not name, so
+      // toApiProvider falls back to 'api' for it.
+      record({
+        occurredAt: '2026-01-04T00:00:00.000Z',
+        sourceTool: 'unknown',
+        ruleId: 'aws-key',
+        repo: 'acme/api',
+      });
+      seed();
+      const res = await db.findings.listFindingInstances({ provider: ['api'] });
+      expect(res.totals.findings).toBe(1);
+      expect(res.items[0]?.provider).toBe('api');
+    });
+
+    it('scopes to a session and to a time bound', async () => {
+      seed();
+      const bySession = await db.findings.listFindingInstances({ sessionId: 's1' });
+      expect(bySession.totals.findings).toBe(1);
+
+      const byFrom = await db.findings.listFindingInstances({
+        from: '2026-01-02T00:00:00.000Z',
+      });
+      expect(byFrom.totals.findings).toBe(2);
+    });
+
+    it('matches q against the rendered via-tool label', async () => {
+      seed();
+      const res = await db.findings.listFindingInstances({ q: 'via Bash' });
+      expect(res.totals.findings).toBe(1);
+      expect(res.items[0]?.toolName).toBe('Bash');
+    });
+  });
+
+  describe('facets', () => {
+    it('counts instances and excludes each dimension own filter', async () => {
+      seed();
+      const res = await db.findings.listFindingInstances({ severity: ['critical'] });
+
+      // Filtered: only the two critical rows.
+      expect(res.totals.findings).toBe(2);
+      // The severity facet excludes its own filter, so 'low' is still counted —
+      // that is what makes "how many if I also pick low?" answerable.
+      const low = res.facets.severity.find((f) => f.value === 'low');
+      expect(low?.count).toBe(1);
+      // Every other dimension DOES honor the severity filter.
+      const providers = Object.fromEntries(res.facets.provider.map((f) => [f.value, f.count]));
+      expect(providers).toEqual({ claudecode: 1, cursor: 1 });
+    });
+
+    it('counts tools, and counts no bucket for a row without one', async () => {
+      seed();
+      const res = await db.findings.listFindingInstances({});
+      const tools = Object.fromEntries((res.facets.tool ?? []).map((f) => [f.value, f.count]));
+      // Three rows, two of which carry a tool.
+      expect(tools).toEqual({ Read: 1, Bash: 1 });
+    });
+  });
+});
+
+describe('SqliteFindingsRepository.listFindingLocations', () => {
+  it('folds findings by repo then file', async () => {
+    seed();
+    const res = await db.findings.listFindingLocations({});
+
+    expect(res.totals).toEqual({ findings: 3, repos: 2, files: 3 });
+    // Worst severity first: acme/api holds the critical row.
+    expect(res.items.map((r) => r.repo)).toEqual(['acme/api', 'acme/web']);
+
+    const api = res.items[0];
+    expect(api?.instanceCount).toBe(2);
+    expect(api?.maxSeverity).toBe('critical');
+    expect(api?.files.map((f) => f.file)).toEqual(['a.ts', 'c.ts']);
+    expect(api?.files[0]?.ruleIds).toEqual(['aws-key']);
+  });
+
+  it('buckets a finding whose event recorded no repo or file under the empty key', async () => {
+    record({ occurredAt: '2026-01-03T00:00:00.000Z', sourceTool: 'claude-code', ruleId: 'r' });
+    const res = await db.findings.listFindingLocations({});
+
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]?.repo).toBe('');
+    expect(res.items[0]?.files[0]?.file).toBe('');
+  });
+
+  it('folds a location status from its instances', async () => {
+    seed();
+    const res = await db.findings.listFindingLocations({});
+    // Every seeded row is in-flight, so each location folds to 'handled'.
+    expect(res.items[0]?.status).toBe('handled');
+    expect(res.items[0]?.files[0]?.status).toBe('handled');
+  });
+
+  it('honors the same filters as the flat list', async () => {
+    seed();
+    const res = await db.findings.listFindingLocations({ severity: ['low'] });
+    expect(res.totals).toEqual({ findings: 1, repos: 1, files: 1 });
+    expect(res.items[0]?.files[0]?.file).toBe('c.ts');
+  });
+
+  it('reports hasMore when the limit truncates the repo list', async () => {
+    for (let i = 0; i < 5; i += 1) {
+      record({
+        occurredAt: new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString(),
+        sourceTool: 'claude-code',
+        ruleId: 'r',
+        repo: `acme/repo-${String(i)}`,
+      });
+    }
+    const res = await db.findings.listFindingLocations({ limit: 2 });
+    expect(res.items).toHaveLength(2);
+    expect(res.totals.repos).toBe(5);
+    expect(res.hasMore).toBe(true);
+  });
+
+  it('is empty on an empty store', async () => {
+    const res = await db.findings.listFindingLocations({});
+    expect(res.items).toEqual([]);
+    expect(res.totals).toEqual({ findings: 0, repos: 0, files: 0 });
+    expect(res.hasMore).toBe(false);
+  });
+});
+
+describe('SqliteFindingsRepository.listGroupedFindings pagination', () => {
+  // Distinct rules so each becomes its own group; the grouped list pages GROUPS.
+  function seedGroups(n: number): void {
+    for (let i = 0; i < n; i += 1) {
+      record({
+        occurredAt: new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString(),
+        sourceTool: 'claude-code',
+        ruleId: `rule-${String(i).padStart(3, '0')}`,
+        repo: 'acme/api',
+        filePath: `f${String(i)}.ts`,
+      });
+    }
+  }
+
+  it('walks every group exactly once across pages', async () => {
+    seedGroups(12);
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    for (let page = 0; page < 10; page += 1) {
+      const res: Awaited<ReturnType<typeof db.findings.listGroupedFindings>> =
+        await db.findings.listGroupedFindings({
+          limit: 5,
+          ...(cursor === undefined ? {} : { cursor }),
+        });
+      seen.push(...res.items.map((g) => g.id));
+      if (res.nextCursor === null) break;
+      cursor = res.nextCursor;
+    }
+
+    expect(seen).toHaveLength(12);
+    expect(new Set(seen).size).toBe(12);
+  });
+
+  it('reports a null cursor at exhaustion', async () => {
+    seedGroups(3);
+    const res = await db.findings.listGroupedFindings({ limit: 5 });
+    expect(res.items).toHaveLength(3);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('keeps totals and facets page-independent', async () => {
+    seedGroups(12);
+    const first = await db.findings.listGroupedFindings({ limit: 5 });
+    const second = await db.findings.listGroupedFindings({
+      limit: 5,
+      cursor: first.nextCursor ?? '',
+    });
+    expect(second.totals).toEqual(first.totals);
+    expect(second.facets).toEqual(first.facets);
+  });
+
+  it('restarts from the top on an undecodable cursor', async () => {
+    seedGroups(6);
+    const fresh = await db.findings.listGroupedFindings({ limit: 3 });
+    const restarted = await db.findings.listGroupedFindings({ limit: 3, cursor: 'garbage' });
+    expect(restarted.items.map((g) => g.id)).toEqual(fresh.items.map((g) => g.id));
+  });
+
+  it('restarts from the top on a decodable cursor carrying an unknown severity', async () => {
+    // Decodes fine but names no real severity. That ranks below every known one,
+    // so it sorts before the whole list and degrades to a restart rather than
+    // silently paging past rows.
+    seedGroups(6);
+    const bogus = Buffer.from(
+      JSON.stringify({ sev: 'not-a-severity', t: '2026-01-01T00:00:00.000Z', id: 'x' }),
+    ).toString('base64url');
+    const fresh = await db.findings.listGroupedFindings({ limit: 3 });
+    const restarted = await db.findings.listGroupedFindings({ limit: 3, cursor: bogus });
+    expect(restarted.items.map((g) => g.id)).toEqual(fresh.items.map((g) => g.id));
+  });
+
+  it('appends an includeId group that sorts past the page', async () => {
+    seedGroups(12);
+    const first = await db.findings.listGroupedFindings({ limit: 3 });
+    const onPage = new Set(first.items.map((g) => g.id));
+    const all = await db.findings.listGroupedFindings({ limit: 100 });
+    const offPage = all.items.find((g) => !onPage.has(g.id));
+    expect(offPage).toBeDefined();
+
+    const withDeepLink = await db.findings.listGroupedFindings({
+      limit: 3,
+      includeId: offPage?.id ?? '',
+    });
+    expect(withDeepLink.items).toHaveLength(4);
+    expect(withDeepLink.items.at(-1)?.id).toBe(offPage?.id);
+    // The append is presentation only: it must not shift the page boundary.
+    expect(withDeepLink.nextCursor).toBe(first.nextCursor);
+    expect(withDeepLink.totals).toEqual(first.totals);
+  });
+
+  it('does not duplicate an includeId group already on the page', async () => {
+    seedGroups(12);
+    const first = await db.findings.listGroupedFindings({ limit: 3 });
+    const onPageId = first.items[0]?.id ?? '';
+    const res = await db.findings.listGroupedFindings({ limit: 3, includeId: onPageId });
+    expect(res.items).toHaveLength(3);
+    expect(res.items.filter((g) => g.id === onPageId)).toHaveLength(1);
+  });
+
+  it('resolves an includeId naming an instance, not just a group', async () => {
+    seedGroups(12);
+    const all = await db.findings.listGroupedFindings({ limit: 100 });
+    const offPage = all.items.at(-1);
+    const instanceId = offPage?.instances[0]?.id ?? '';
+    expect(instanceId).not.toBe('');
+
+    const res = await db.findings.listGroupedFindings({ limit: 3, includeId: instanceId });
+    expect(res.items.at(-1)?.id).toBe(offPage?.id);
+  });
+
+  it('ignores an unknown includeId', async () => {
+    seedGroups(6);
+    const plain = await db.findings.listGroupedFindings({ limit: 3 });
+    const res = await db.findings.listGroupedFindings({ limit: 3, includeId: 'no-such-id' });
+    expect(res.items.map((g) => g.id)).toEqual(plain.items.map((g) => g.id));
+  });
+
+  it('scopes aggregates and previews to the from bound together', async () => {
+    seed();
+    const res = await db.findings.listGroupedFindings({ from: '2026-01-02T00:00:00.000Z' });
+
+    // The 2026-01-01 'email' row falls outside the window entirely.
+    expect(res.totals).toEqual({ findings: 2, groups: 1 });
+    const awsKey = res.items[0];
+    // instanceCount comes from the aggregate query and instances from the
+    // preview query — the bound has to reach both or they disagree.
+    expect(awsKey?.instanceCount).toBe(2);
+    expect(awsKey?.instances).toHaveLength(2);
+  });
+
+  it('carries event and session linkage on preview instances', async () => {
+    const eventId = record({
+      occurredAt: '2026-01-03T00:00:00.000Z',
+      sourceTool: 'claude-code',
+      ruleId: 'aws-key',
+      repo: 'acme/api',
+      sessionId: 'sess-9',
+    });
+    const res = await db.findings.listGroupedFindings({});
+    expect(res.items[0]?.instances[0]?.eventId).toBe(eventId);
+    expect(res.items[0]?.instances[0]?.sessionId).toBe('sess-9');
+  });
+});

--- a/packages/schema/drizzle/local-sqlite/0019_audit_started_at_index.sql
+++ b/packages/schema/drizzle/local-sqlite/0019_audit_started_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_audit_started_at` ON `audit_events` (`started_at`);

--- a/packages/schema/drizzle/local-sqlite/meta/0019_snapshot.json
+++ b/packages/schema/drizzle/local-sqlite/meta/0019_snapshot.json
@@ -1,0 +1,2586 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "90f14810-4928-4bdf-9963-cde6555bdcac",
+  "prevId": "1df4c7c9-b51d-4e16-95e3-edb69ba160d3",
+  "tables": {
+    "audit_events": {
+      "name": "audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_project_id": {
+          "name": "source_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.output_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_creation_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_read_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.model'))",
+            "type": "virtual"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.provider'))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_audit_parent": {
+          "name": "idx_audit_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session": {
+          "name": "idx_audit_session",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_harness_t": {
+          "name": "idx_audit_harness_t",
+          "columns": [
+            "harness_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_project_t": {
+          "name": "idx_audit_project_t",
+          "columns": [
+            "source_project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session_type": {
+          "name": "idx_audit_session_type",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false,
+          "where": "event_type = 'llm_call'"
+        },
+        "idx_audit_type_t": {
+          "name": "idx_audit_type_t",
+          "columns": [
+            "event_type",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_started_at": {
+          "name": "idx_audit_started_at",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_parent_id_audit_events_id_fk": {
+          "name": "audit_events_parent_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_root_session_id_audit_events_id_fk": {
+          "name": "audit_events_root_session_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "root_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_host_id_inventory_id_fk": {
+          "name": "audit_events_host_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_harness_id_inventory_id_fk": {
+          "name": "audit_events_harness_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_source_project_id_source_project_id_fk": {
+          "name": "audit_events_source_project_id_source_project_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "source_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "available_packs": {
+      "name": "available_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_available_packs_pack": {
+          "name": "uq_available_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classified_data": {
+      "name": "classified_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "egress_decision_override": {
+      "name": "egress_decision_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_egress_decision_override": {
+          "name": "uq_egress_decision_override",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": true
+        },
+        "uq_egress_decision_override_host": {
+          "name": "uq_egress_decision_override_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true,
+          "where": "`host` IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "egress_decision_override_destination_id_share_destination_id_fk": {
+          "name": "egress_decision_override_destination_id_share_destination_id_fk",
+          "tableFrom": "egress_decision_override",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_tool": {
+          "name": "source_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_occurred": {
+          "name": "idx_events_occurred",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_value": {
+          "name": "masked_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'suppress'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_exceptions_active": {
+          "name": "uq_exceptions_active",
+          "columns": [
+            "rule_id",
+            "value_fingerprint",
+            "key_version"
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_access_override": {
+      "name": "file_access_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_access_override_project": {
+          "name": "idx_file_access_override_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_file_access_override": {
+          "name": "uq_file_access_override",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_access_override_project_id_source_project_id_fk": {
+          "name": "file_access_override_project_id_source_project_id_fk",
+          "tableFrom": "file_access_override",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "finding_resolution": {
+      "name": "finding_resolution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_finding_resolution_key": {
+          "name": "idx_finding_resolution_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "findings": {
+      "name": "findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_findings_event": {
+          "name": "idx_findings_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_findings_key": {
+          "name": "uq_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "findings_event_id_events_id_fk": {
+          "name": "findings_event_id_events_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "harness_asset": {
+      "name": "harness_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_harness_asset_harness": {
+          "name": "idx_harness_asset_harness",
+          "columns": [
+            "harness_id"
+          ],
+          "isUnique": false
+        },
+        "uq_harness_asset": {
+          "name": "uq_harness_asset",
+          "columns": [
+            "harness_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "harness_asset_harness_id_inventory_id_fk": {
+          "name": "harness_asset_harness_id_inventory_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harness_asset_asset_id_inventory_asset_id_fk": {
+          "name": "harness_asset_asset_id_inventory_asset_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_definitions": {
+      "name": "inspection_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_findings": {
+      "name": "inspection_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_definition_id": {
+          "name": "inspection_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classified_data_id": {
+          "name": "classified_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_findings_event": {
+          "name": "idx_inspection_findings_event",
+          "columns": [
+            "audit_event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_inspection_findings_key": {
+          "name": "uq_inspection_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_findings_audit_event_id_audit_events_id_fk": {
+          "name": "inspection_findings_audit_event_id_audit_events_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "audit_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_inspection_definition_id_inspection_definitions_id_fk": {
+          "name": "inspection_findings_inspection_definition_id_inspection_definitions_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "inspection_definitions",
+          "columnsFrom": [
+            "inspection_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_classified_data_id_classified_data_id_fk": {
+          "name": "inspection_findings_classified_data_id_classified_data_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "classified_data",
+          "columnsFrom": [
+            "classified_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_packs": {
+      "name": "installed_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_installed_packs_pack": {
+          "name": "uq_installed_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory": {
+      "name": "inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.os_version'))",
+            "type": "virtual"
+          }
+        },
+        "harness_version": {
+          "name": "harness_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.harness_version'))",
+            "type": "virtual"
+          }
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_osver": {
+          "name": "idx_inventory_type_osver",
+          "columns": [
+            "object_type",
+            "os_version"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_harnessver": {
+          "name": "idx_inventory_type_harnessver",
+          "columns": [
+            "object_type",
+            "harness_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_host_id_inventory_id_fk": {
+          "name": "inventory_host_id_inventory_id_fk",
+          "tableFrom": "inventory",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_asset": {
+      "name": "inventory_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_asset_type": {
+          "name": "idx_inventory_asset_type",
+          "columns": [
+            "asset_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_override": {
+      "name": "mcp_trust_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_mcp_trust_override": {
+          "name": "uq_mcp_trust_override",
+          "columns": [
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pack_write_gate": {
+      "name": "_pack_write_gate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open": {
+          "name": "open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_pack_write_gate_single_row": {
+          "name": "ck_pack_write_gate_single_row",
+          "value": "\"_pack_write_gate\".\"id\" = 1"
+        }
+      }
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "custom_keywords": {
+          "name": "custom_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_policies_scope_target": {
+          "name": "uq_policies_scope_target",
+          "columns": [
+            "scope",
+            "target"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_file": {
+      "name": "project_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_access": {
+          "name": "default_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_file_project": {
+          "name": "idx_project_file_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_project_file": {
+          "name": "uq_project_file",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_source_project_id_fk": {
+          "name": "project_file_project_id_source_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault": {
+      "name": "secret_vault",
+      "columns": {
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_key_version": {
+          "name": "fingerprint_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format_version": {
+          "name": "format_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_value": {
+          "name": "uq_secret_vault_value",
+          "columns": [
+            "value_fingerprint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_deref": {
+      "name": "secret_vault_deref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pointer_count": {
+          "name": "pointer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_secret_vault_deref_pointer": {
+          "name": "idx_secret_vault_deref_pointer",
+          "columns": [
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_reason_at": {
+          "name": "idx_secret_vault_deref_reason_at",
+          "columns": [
+            "reason",
+            "at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_sighting": {
+      "name": "secret_vault_sighting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_sighting": {
+          "name": "uq_secret_vault_sighting",
+          "columns": [
+            "pointer_id",
+            "location"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_call_site": {
+      "name": "share_call_site",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "vendored": {
+          "name": "vendored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_call_site_endpoint": {
+          "name": "idx_share_call_site_endpoint",
+          "columns": [
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_call_site_project": {
+          "name": "idx_share_call_site_project",
+          "columns": [
+            "project_key",
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_call_site": {
+          "name": "uq_share_call_site",
+          "columns": [
+            "endpoint_id",
+            "project_key",
+            "file",
+            "line"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_call_site_endpoint_id_share_endpoint_id_fk": {
+          "name": "share_call_site_endpoint_id_share_endpoint_id_fk",
+          "tableFrom": "share_call_site",
+          "tableTo": "share_endpoint",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_destination": {
+      "name": "share_destination",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_json": {
+          "name": "network_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_destination_kind": {
+          "name": "idx_share_destination_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "uq_share_destination_host": {
+          "name": "uq_share_destination_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_endpoint": {
+      "name": "share_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "data_class": {
+          "name": "data_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_endpoint_dest": {
+          "name": "idx_share_endpoint_dest",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_endpoint": {
+          "name": "uq_share_endpoint",
+          "columns": [
+            "destination_id",
+            "method",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_endpoint_destination_id_share_destination_id_fk": {
+          "name": "share_endpoint_destination_id_share_destination_id_fk",
+          "tableFrom": "share_endpoint",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_project": {
+      "name": "source_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/schema/drizzle/local-sqlite/meta/_journal.json
+++ b/packages/schema/drizzle/local-sqlite/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1785351865257,
       "tag": "0018_serious_tana_nile",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1785759172956,
+      "tag": "0019_audit_started_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -376,6 +376,11 @@ export const auditEvents = sqliteTable(
     // a start/end window (e.g. the Activity timeline, token rollups by day)
     // without a full-table scan.
     index('idx_audit_type_t').on(t.eventType, t.startedAt),
+    // Serves the newest-first reads that span every event_type — the flat
+    // findings list walks (started_at DESC, id DESC) in keyset batches, which
+    // the composite indexes above cannot serve because none of them leads with
+    // started_at. Without it each batch sorts the whole remaining scope.
+    index('idx_audit_started_at').on(t.startedAt),
   ],
 );
 

--- a/packages/schema/src/drizzle/sqlite-ddl.ts
+++ b/packages/schema/src/drizzle/sqlite-ddl.ts
@@ -103,4 +103,8 @@ export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
     tag: '0018_serious_tana_nile',
     sql: 'ALTER TABLE `secret_vault` ADD `format_version` integer DEFAULT 2 NOT NULL;',
   },
+  {
+    tag: '0019_audit_started_at_index',
+    sql: 'CREATE INDEX `idx_audit_started_at` ON `audit_events` (`started_at`);',
+  },
 ];

--- a/packages/schema/src/zod/finding.ts
+++ b/packages/schema/src/zod/finding.ts
@@ -181,6 +181,15 @@ export const FindingInstance = z
     // Lifecycle status (see FindingStatus). Optional so legacy callers/rows
     // that predate the resolution feature stay valid.
     status: FindingStatus.optional(),
+    // The audit event this finding was captured from. Optional so callers that
+    // do not project it stay valid. An at-rest finding is content-addressed by
+    // finding_key and its row is upserted on re-detection, so this names the
+    // MOST RECENT detection event, not the first.
+    eventId: z.string().optional(),
+    // The session that event belongs to, when it has one — the seam a
+    // per-instance "view session" link needs. Absent for events captured
+    // outside a session.
+    sessionId: z.string().optional(),
   })
   .meta({ id: 'FindingInstance' });
 export type FindingInstance = z.infer<typeof FindingInstance>;
@@ -241,6 +250,10 @@ export const FindingFacets = z
     // group (possible only for callers whose rows carry no statuses) is
     // counted under no value.
     status: z.array(FindingFacetItem),
+    // Host tool (attributes.tool_name). Present only on the instance-level
+    // reads, which can filter by it; the grouped read omits the dimension
+    // because a group spans tools.
+    tool: z.array(FindingFacetItem).optional(),
   })
   .meta({ id: 'FindingFacets' });
 export type FindingFacets = z.infer<typeof FindingFacets>;
@@ -276,6 +289,16 @@ export const ListGroupedFindingsQuery = z.object({
   // Scope to findings whose event carries this session id (the Activity page's
   // session → findings drilldown). Findings without a session never match.
   sessionId: z.string().optional(),
+  // Inclusive lower bound on the parent event's timestamp, so a caller arriving
+  // from a time-scoped page (Activity's range) can carry that scope. Absent
+  // means all time — this list has no default window.
+  from: z.iso.datetime().optional(),
+  // A group or instance id that must appear in the page even when the cursor
+  // has already advanced past its sort position. This is what keeps the
+  // Findings page's one-shot ?finding= deep link resolving once the list
+  // paginates: the target group is appended out of sort order rather than
+  // scanning forward for it. Never affects totals, facets or the cursor.
+  includeId: z.string().optional(),
   groupBy: z.literal('type').optional(),
   limit: z.coerce.number().int().min(1).max(100).optional(),
   cursor: z.string().optional(),
@@ -340,3 +363,125 @@ export const FindingInstanceDetail = FindingInstance.extend({
   policy: FindingPolicyRef,
 }).meta({ id: 'FindingInstanceDetail' });
 export type FindingInstanceDetail = z.infer<typeof FindingInstanceDetail>;
+
+// ─── Instance-level (flat) findings list ─────────────────────────────────────
+
+// The grouped list answers "which rules are firing"; this one answers "what
+// happened most recently", newest first, one row per finding. It is a separate
+// contract rather than a mode of the grouped query because the two differ in
+// more than shape: `status` here matches each INSTANCE's derived status, while
+// the grouped query matches the group's folded status, and this response
+// paginates by a real keyset cursor where the grouped one pages a sorted array.
+//
+// Query schema — NO `.meta({ id })` (see ListGroupedFindingsQuery / api.ts
+// header). `limit` mirrors the legacy flat lists' 200 ceiling.
+export const DEFAULT_FLAT_FINDINGS_LIMIT = 50;
+
+export const ListFindingInstancesQuery = z.object({
+  severity: z.array(Severity).optional(),
+  // Rule ids, the same vocabulary the grouped list's `subtype` carries.
+  subtype: z.array(z.string()).optional(),
+  provider: z.array(FindingProvider).optional(),
+  action: z.array(FindingAction).optional(),
+  // Matches each instance's OWN derived status (deriveFindingStatus), unlike
+  // the grouped query's group-level fold.
+  status: z.array(FindingStatus).optional(),
+  // Exact host-tool names (attributes.tool_name, e.g. 'Bash'). A real filter,
+  // where the free-text `q` can only match the rendered "via Bash" label.
+  tool: z.array(z.string()).optional(),
+  // Exact repository / file-path matches, for the drill-down out of the
+  // locations view. A row whose event carries no repo/file matches neither.
+  repo: z.string().optional(),
+  file: z.string().optional(),
+  q: z.string().optional(),
+  sessionId: z.string().optional(),
+  from: z.iso.datetime().optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  cursor: z.string().optional(),
+});
+export type ListFindingInstancesQuery = z.infer<typeof ListFindingInstancesQuery>;
+
+export const ListFindingInstancesResponse = z
+  .object({
+    // Instances matching the filters across the whole scope, not just this
+    // page — cursor-independent, like the grouped list's totals.
+    totals: z.object({ findings: z.number().int().nonnegative() }),
+    // Counts in INSTANCES here, where the grouped response counts groups. Each
+    // dimension still excludes its own filter.
+    facets: FindingFacets,
+    items: z.array(FindingInstanceDetail),
+    nextCursor: z.string().nullable(),
+  })
+  .meta({ id: 'ListFindingInstancesResponse' });
+export type ListFindingInstancesResponse = z.infer<typeof ListFindingInstancesResponse>;
+
+// ─── Location-grouped findings list ──────────────────────────────────────────
+
+// Findings folded by where they live — repository, then file. The grouping keys
+// come from the capturing event's attributes (repo / file_path); there is no
+// finding↔inventory-asset relation in the local store to group by instead.
+
+export const FindingLocationFile = z
+  .object({
+    // Empty when the instances carried no file path (a prompt or a tool call
+    // with no file attribution).
+    file: z.string(),
+    instanceCount: z.number().int().nonnegative(),
+    maxSeverity: Severity,
+    latestDetectedAt: z.iso.datetime(),
+    // Folded from the instances' derived statuses with the same
+    // open-dominates precedence a group uses.
+    status: FindingStatus.optional(),
+    // Distinct rules seen at this location, capped — the row shows them as
+    // chips, and the count is what conveys scale.
+    ruleIds: z.array(z.string()),
+  })
+  .meta({ id: 'FindingLocationFile' });
+export type FindingLocationFile = z.infer<typeof FindingLocationFile>;
+
+export const FindingLocationRepo = z
+  .object({
+    /** Empty when the instances carried no repo attribute. */
+    repo: z.string(),
+    instanceCount: z.number().int().nonnegative(),
+    maxSeverity: Severity,
+    latestDetectedAt: z.iso.datetime(),
+    status: FindingStatus.optional(),
+    files: z.array(FindingLocationFile),
+  })
+  .meta({ id: 'FindingLocationRepo' });
+export type FindingLocationRepo = z.infer<typeof FindingLocationRepo>;
+
+// Query schema — NO `.meta({ id })` (see ListGroupedFindingsQuery / api.ts
+// header). `limit` caps the REPO rows returned; a repo's files are not
+// separately paged.
+export const ListFindingLocationsQuery = z.object({
+  severity: z.array(Severity).optional(),
+  subtype: z.array(z.string()).optional(),
+  provider: z.array(FindingProvider).optional(),
+  action: z.array(FindingAction).optional(),
+  // Per-instance, as in ListFindingInstancesQuery: a location keeps the
+  // instances that match, and folds its status from those.
+  status: z.array(FindingStatus).optional(),
+  tool: z.array(z.string()).optional(),
+  q: z.string().optional(),
+  sessionId: z.string().optional(),
+  from: z.iso.datetime().optional(),
+  limit: z.coerce.number().int().min(1).max(500).optional(),
+});
+export type ListFindingLocationsQuery = z.infer<typeof ListFindingLocationsQuery>;
+
+export const ListFindingLocationsResponse = z
+  .object({
+    totals: z.object({
+      findings: z.number().int().nonnegative(),
+      repos: z.number().int().nonnegative(),
+      files: z.number().int().nonnegative(),
+    }),
+    /** Sorted by max severity, then most recent. */
+    items: z.array(FindingLocationRepo),
+    /** Whether `limit` truncated the repo list. */
+    hasMore: z.boolean(),
+  })
+  .meta({ id: 'ListFindingLocationsResponse' });
+export type ListFindingLocationsResponse = z.infer<typeof ListFindingLocationsResponse>;

--- a/packages/schema/src/zod/findings-flat-build.ts
+++ b/packages/schema/src/zod/findings-flat-build.ts
@@ -1,0 +1,265 @@
+// Instance-level (flat) findings: the filtering, faceting and projection the
+// grouped path does per GROUP, done per FINDING instead.
+//
+// This is a sibling of findings-group-build.ts, not a replacement: the two
+// answer different questions and their filter semantics genuinely differ. A
+// status filter here matches the instance's own derived status, where the
+// grouped path matches the group's folded one; provider and action here match
+// the row, where the grouped path keeps a group if ANY instance matches. Every
+// DB→API translation still goes through the shared mappers, so no enum rule is
+// restated.
+
+import type {
+  FindingFacetItem,
+  FindingFacets,
+  FindingInstanceDetail,
+  FindingStatus,
+} from './finding.ts';
+import {
+  type GroupableFindingRow,
+  toApiAction,
+  toApiCategory,
+  toApiProvider,
+} from './findings-group-build.ts';
+
+/**
+ * A GroupableFindingRow that also carries its event linkage. The flat list
+ * projects one of these per finding; the grouped list's preview rows now carry
+ * the same two fields, so a store can produce either from one row shape.
+ */
+export interface FlatFindingRow extends GroupableFindingRow {
+  // Required here where the base leaves it optional: a flat row is always
+  // projected from the findings⋈events join, so it always has its event.
+  // `sessionId` stays optional — an event outside a session carries none.
+  eventId: string;
+}
+
+export interface InstanceFilterOptions {
+  // `| undefined` (not just optional) so callers may pass a field through
+  // explicitly as undefined under exactOptionalPropertyTypes — the same
+  // convention FindingFilterOptions follows.
+  severity?: string[] | undefined;
+  subtype?: string[] | undefined;
+  providers?: string[] | undefined;
+  actions?: string[] | undefined;
+  statuses?: string[] | undefined;
+  tools?: string[] | undefined;
+  repo?: string | undefined;
+  file?: string | undefined;
+  q?: string | undefined;
+}
+
+/** The filter dimensions, so a facet pass can name the one it excludes. */
+export type InstanceFilterDimension = keyof InstanceFilterOptions;
+
+/**
+ * The searchable text of one instance: rule id, category, masked value, repo,
+ * file, its tool as the rendered "via Bash" label, and its id. Mirrors the
+ * grouped path's haystack so the same `q` matches the same things in both
+ * views — a tool searched as the bare name would collide with file paths.
+ */
+function rowHaystack(row: FlatFindingRow): string {
+  return [
+    row.ruleId,
+    row.category,
+    row.maskedMatch,
+    row.repo,
+    row.file,
+    row.toolName ? `via ${row.toolName}` : '',
+    row.id,
+  ]
+    .join(' ')
+    .toLowerCase();
+}
+
+function matchesDimension(
+  row: FlatFindingRow,
+  opts: InstanceFilterOptions,
+  dimension: InstanceFilterDimension,
+): boolean {
+  switch (dimension) {
+    case 'severity':
+      return !opts.severity?.length || opts.severity.includes(row.severity);
+    case 'subtype':
+      return !opts.subtype?.length || opts.subtype.includes(row.ruleId);
+    case 'providers':
+      return !opts.providers?.length || opts.providers.includes(toApiProvider(row.sourceTool));
+    case 'actions':
+      return !opts.actions?.length || opts.actions.includes(toApiAction(row.actionTaken));
+    case 'statuses':
+      return (
+        !opts.statuses?.length || (row.status !== undefined && opts.statuses.includes(row.status))
+      );
+    case 'tools':
+      return (
+        !opts.tools?.length || (row.toolName !== undefined && opts.tools.includes(row.toolName))
+      );
+    case 'repo':
+      return opts.repo === undefined || opts.repo === '' || row.repo === opts.repo;
+    case 'file':
+      return opts.file === undefined || opts.file === '' || row.file === opts.file;
+    case 'q':
+      return !opts.q || rowHaystack(row).includes(opts.q.toLowerCase());
+  }
+}
+
+const DIMENSIONS: readonly InstanceFilterDimension[] = [
+  'severity',
+  'subtype',
+  'providers',
+  'actions',
+  'statuses',
+  'tools',
+  'repo',
+  'file',
+  'q',
+];
+
+/**
+ * Whether a row passes the filters, optionally ignoring one dimension — the
+ * `except` form is what lets a facet count answer "how many if I also pick X?"
+ * without re-filtering the whole scope per dimension.
+ */
+export function matchesInstanceFilters(
+  row: FlatFindingRow,
+  opts: InstanceFilterOptions,
+  except?: InstanceFilterDimension,
+): boolean {
+  for (const dimension of DIMENSIONS) {
+    if (dimension === except) continue;
+    if (!matchesDimension(row, opts, dimension)) return false;
+  }
+  return true;
+}
+
+function toItems(counts: Map<string, number>): FindingFacetItem[] {
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+}
+
+function bump(counts: Map<string, number>, value: string): void {
+  counts.set(value, (counts.get(value) ?? 0) + 1);
+}
+
+/**
+ * Per-dimension facet counts in INSTANCES, each excluding its own filter — the
+ * instance-level counterpart of computeFindingFacets.
+ *
+ * Streaming rather than array-based: the flat list scans its whole filtered
+ * scope to produce cursor-independent totals, and holding every row to run six
+ * more filter passes over them afterwards would make memory track the store.
+ * One `add` per row fills every dimension.
+ */
+export function createInstanceFacetAccumulator(opts: InstanceFilterOptions): {
+  add: (row: FlatFindingRow) => void;
+  facets: () => FindingFacets;
+} {
+  const severity = new Map<string, number>();
+  const subtype = new Map<string, number>();
+  const provider = new Map<string, number>();
+  const action = new Map<string, number>();
+  const status = new Map<string, number>();
+  const tool = new Map<string, number>();
+
+  return {
+    add(row) {
+      if (matchesInstanceFilters(row, opts, 'severity')) bump(severity, row.severity);
+      if (matchesInstanceFilters(row, opts, 'subtype')) bump(subtype, row.ruleId);
+      if (matchesInstanceFilters(row, opts, 'providers')) {
+        bump(provider, toApiProvider(row.sourceTool));
+      }
+      if (matchesInstanceFilters(row, opts, 'actions')) bump(action, toApiAction(row.actionTaken));
+      if (row.status !== undefined && matchesInstanceFilters(row, opts, 'statuses')) {
+        bump(status, row.status);
+      }
+      // A row with no tool contributes to no tool facet — the dimension counts
+      // tools, and "no tool" is not one.
+      if (row.toolName !== undefined && matchesInstanceFilters(row, opts, 'tools')) {
+        bump(tool, row.toolName);
+      }
+    },
+    facets: () => ({
+      severity: toItems(severity),
+      subtype: toItems(subtype),
+      provider: toItems(provider),
+      action: toItems(action),
+      status: toItems(status),
+      tool: toItems(tool),
+    }),
+  };
+}
+
+/**
+ * One row → the denormalized instance detail the flat list renders. The group
+ * context a row carries is its rule's, so `detection.name` is null and `policy`
+ * is synthesized from the category, exactly as the grouped path does for the
+ * local store.
+ */
+export function toInstanceDetail(row: FlatFindingRow): FindingInstanceDetail {
+  const category = toApiCategory(row.category);
+  return {
+    id: row.id,
+    provider: toApiProvider(row.sourceTool),
+    repo: row.repo,
+    file: row.file,
+    ...(row.toolName === undefined ? {} : { toolName: row.toolName }),
+    eventId: row.eventId,
+    ...(row.sessionId === undefined ? {} : { sessionId: row.sessionId }),
+    action: toApiAction(row.actionTaken),
+    detectedAt: row.occurredAt,
+    confidence: row.confidence,
+    ...(row.status === undefined ? {} : { status: row.status }),
+    groupId: row.ruleId,
+    category,
+    subtype: row.ruleId,
+    severity: row.severity as FindingInstanceDetail['severity'],
+    match: { maskedValue: row.maskedMatch, contextPrefix: '' },
+    detection: { id: row.ruleId, name: null },
+    policy: { id: `category:${category}`, name: category },
+  };
+}
+
+// ─── Location folding (repo → file) ──────────────────────────────────────────
+
+/** The running fold for one location, before it becomes a response row. */
+export interface LocationAccumulator {
+  instanceCount: number;
+  maxSeverityRank: number;
+  maxSeverity: string;
+  latestDetectedAt: string;
+  statuses: (FindingStatus | undefined)[];
+  ruleIds: Set<string>;
+}
+
+const SEVERITY_ORDER: Partial<Record<string, number>> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+export function newLocationAccumulator(): LocationAccumulator {
+  return {
+    instanceCount: 0,
+    // Sorts after every known severity, so the first row always wins the
+    // comparison below rather than an unknown value pinning the location.
+    maxSeverityRank: Number.MAX_SAFE_INTEGER,
+    maxSeverity: 'low',
+    latestDetectedAt: '',
+    statuses: [],
+    ruleIds: new Set(),
+  };
+}
+
+export function addToLocation(acc: LocationAccumulator, row: FlatFindingRow): void {
+  acc.instanceCount += 1;
+  const rank = SEVERITY_ORDER[row.severity] ?? Number.MAX_SAFE_INTEGER - 1;
+  if (rank < acc.maxSeverityRank) {
+    acc.maxSeverityRank = rank;
+    acc.maxSeverity = row.severity;
+  }
+  if (row.occurredAt > acc.latestDetectedAt) acc.latestDetectedAt = row.occurredAt;
+  acc.statuses.push(row.status);
+  acc.ruleIds.add(row.ruleId);
+}

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -145,6 +145,10 @@ export interface GroupableFindingRow {
   // see resolutions.ts). Optional/absent for legacy rows that predate the
   // resolution feature.
   status?: FindingStatus;
+  // The audit event the finding was captured from, and that event's session
+  // when it has one. Optional/absent for callers that do not project them.
+  eventId?: string;
+  sessionId?: string;
 }
 
 // Group-level status precedence: open dominates, then handled, then dismissed,
@@ -167,7 +171,7 @@ const STATUS_PRECEDENCE: readonly FindingStatus[] = ['open', 'handled', 'dismiss
  * are ignored; if NO instance carries a status, returns undefined (never
  * fabricates a status for legacy rows).
  */
-function foldGroupStatus(
+export function foldGroupStatus(
   instanceStatuses: (FindingStatus | undefined)[],
 ): FindingStatus | undefined {
   const statuses = new Set(instanceStatuses.filter((s): s is FindingStatus => s !== undefined));
@@ -319,6 +323,8 @@ export function buildFindingGroups(
         repo: r.repo,
         file: r.file,
         ...(r.toolName === undefined ? {} : { toolName: r.toolName }),
+        ...(r.eventId === undefined ? {} : { eventId: r.eventId }),
+        ...(r.sessionId === undefined ? {} : { sessionId: r.sessionId }),
         action: toApiAction(effectiveDbAction),
         detectedAt: r.occurredAt,
         confidence: r.confidence,
@@ -568,15 +574,34 @@ const SEVERITY_ORDER: Record<Severity, number> = { critical: 0, high: 1, medium:
 // -1) rather than a type-error-suppressed gap; keeps sort deterministic.
 const SEVERITY_RANK = SEVERITY_ORDER as Partial<Record<string, number>>;
 
+/**
+ * The findings list's sort order: severity rank, then most recent, then id.
+ *
+ * The id tie-break makes the order TOTAL. Two groups can legitimately share a
+ * severity and a latestDetectedAt, and without a third key their relative order
+ * is whatever the sort happened to produce — which a keyset cursor cannot
+ * resume from, because "everything after this group" is then ambiguous. Only
+ * groups tied on both other keys are affected.
+ *
+ * Takes the fields it compares rather than a whole FindingGroup so a cursor can
+ * be compared against the list without being inflated into one.
+ */
+export function compareFindingGroupOrder(
+  a: Pick<FindingGroup, 'severity' | 'latestDetectedAt' | 'id'>,
+  b: Pick<FindingGroup, 'severity' | 'latestDetectedAt' | 'id'>,
+): number {
+  const rankA = SEVERITY_RANK[a.severity] ?? -1;
+  const rankB = SEVERITY_RANK[b.severity] ?? -1;
+  const severityDiff = rankA - rankB;
+  if (severityDiff !== 0) return severityDiff;
+  // latestDetectedAt desc — ISO strings sort lexically.
+  const recencyDiff = b.latestDetectedAt.localeCompare(a.latestDetectedAt);
+  if (recencyDiff !== 0) return recencyDiff;
+  return a.id.localeCompare(b.id);
+}
+
 export function sortFindingGroups(groups: FindingGroup[]): FindingGroup[] {
-  return [...groups].sort((a, b) => {
-    const rankA = SEVERITY_RANK[a.severity] ?? -1;
-    const rankB = SEVERITY_RANK[b.severity] ?? -1;
-    const severityDiff = rankA - rankB;
-    if (severityDiff !== 0) return severityDiff;
-    // latestDetectedAt desc — ISO strings sort lexically.
-    return b.latestDetectedAt.localeCompare(a.latestDetectedAt);
-  });
+  return [...groups].sort(compareFindingGroupOrder);
 }
 
 // ─── Facets (per-filter-excluded counts) ─────────────────────────────────────

--- a/packages/schema/src/zod/index.ts
+++ b/packages/schema/src/zod/index.ts
@@ -7,6 +7,7 @@ export * from './egress-extraction.ts';
 export * from './event.ts';
 export * from './exception.ts';
 export * from './finding.ts';
+export * from './findings-flat-build.ts';
 export * from './findings-group-build.ts';
 export * from './harness-map.ts';
 export * from './installed-pack.ts';

--- a/packages/schema/test/zod/findings-flat-build.test.ts
+++ b/packages/schema/test/zod/findings-flat-build.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FindingGroup } from '../../src/zod/index.ts';
+import {
+  addToLocation,
+  compareFindingGroupOrder,
+  createInstanceFacetAccumulator,
+  type FlatFindingRow,
+  foldGroupStatus,
+  matchesInstanceFilters,
+  newLocationAccumulator,
+  sortFindingGroups,
+  toInstanceDetail,
+} from '../../src/zod/index.ts';
+
+function row(over: Partial<FlatFindingRow> = {}): FlatFindingRow {
+  return {
+    id: 'f1',
+    ruleId: 'aws-key',
+    category: 'secret',
+    severity: 'critical',
+    maskedMatch: 'AKIA****',
+    actionTaken: 'block',
+    confidence: 0.9,
+    occurredAt: '2026-01-02T00:00:00.000Z',
+    sourceTool: 'claude-code',
+    repo: 'acme/api',
+    file: 'a.ts',
+    eventId: 'e1',
+    status: 'handled',
+    ...over,
+  };
+}
+
+describe('matchesInstanceFilters', () => {
+  it('passes a row when no filter is set', () => {
+    expect(matchesInstanceFilters(row(), {})).toBe(true);
+  });
+
+  it('matches severity, subtype, action and status on the row itself', () => {
+    expect(matchesInstanceFilters(row(), { severity: ['critical'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { severity: ['low'] })).toBe(false);
+    expect(matchesInstanceFilters(row(), { subtype: ['aws-key'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { subtype: ['email'] })).toBe(false);
+    expect(matchesInstanceFilters(row(), { actions: ['blocked'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { actions: ['warned'] })).toBe(false);
+    expect(matchesInstanceFilters(row(), { statuses: ['handled'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { statuses: ['open'] })).toBe(false);
+  });
+
+  it('maps the source tool through the shared provider mapper', () => {
+    expect(matchesInstanceFilters(row(), { providers: ['claudecode'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { providers: ['cursor'] })).toBe(false);
+  });
+
+  it('treats provider api as the unknown-tool catch-all', () => {
+    // 'api' is what an unmapped tool reads as, so it cannot be expressed as a
+    // list of known tools — the case a SQL IN-predicate would get wrong.
+    const unknown = row({ sourceTool: 'some-unmapped-tool' });
+    expect(matchesInstanceFilters(unknown, { providers: ['api'] })).toBe(true);
+    expect(matchesInstanceFilters(row(), { providers: ['api'] })).toBe(false);
+  });
+
+  it('matches tool, repo and file exactly', () => {
+    const withTool = row({ toolName: 'Bash' });
+    expect(matchesInstanceFilters(withTool, { tools: ['Bash'] })).toBe(true);
+    expect(matchesInstanceFilters(withTool, { tools: ['Read'] })).toBe(false);
+    // A row with no tool matches no tool filter.
+    expect(matchesInstanceFilters(row(), { tools: ['Bash'] })).toBe(false);
+
+    expect(matchesInstanceFilters(row(), { repo: 'acme/api' })).toBe(true);
+    expect(matchesInstanceFilters(row(), { repo: 'acme/web' })).toBe(false);
+    expect(matchesInstanceFilters(row(), { file: 'a.ts' })).toBe(true);
+    expect(matchesInstanceFilters(row(), { file: 'b.ts' })).toBe(false);
+  });
+
+  it('treats an empty repo or file filter as unset', () => {
+    // The URL cannot tell an absent param from an empty one, so an empty value
+    // must not silently filter to the no-repo bucket.
+    expect(matchesInstanceFilters(row({ repo: 'acme/api' }), { repo: '' })).toBe(true);
+    expect(matchesInstanceFilters(row({ file: '' }), { file: '' })).toBe(true);
+  });
+
+  it('matches q over the rendered via-tool label, not the bare name', () => {
+    const withTool = row({ toolName: 'Bash' });
+    expect(matchesInstanceFilters(withTool, { q: 'via bash' })).toBe(true);
+    expect(matchesInstanceFilters(withTool, { q: 'AKIA' })).toBe(true);
+    expect(matchesInstanceFilters(withTool, { q: 'acme/api' })).toBe(true);
+    expect(matchesInstanceFilters(withTool, { q: 'nothing-here' })).toBe(false);
+  });
+
+  it('ignores the named dimension when one is excepted', () => {
+    const opts = { severity: ['low'], subtype: ['aws-key'] };
+    expect(matchesInstanceFilters(row(), opts)).toBe(false);
+    // Excepting the failing dimension passes, since the other still matches.
+    expect(matchesInstanceFilters(row(), opts, 'severity')).toBe(true);
+    // Excepting a different one does not rescue it.
+    expect(matchesInstanceFilters(row(), opts, 'subtype')).toBe(false);
+  });
+});
+
+describe('createInstanceFacetAccumulator', () => {
+  it('counts instances per dimension', () => {
+    const acc = createInstanceFacetAccumulator({});
+    acc.add(row({ id: 'a', severity: 'critical' }));
+    acc.add(row({ id: 'b', severity: 'low' }));
+    acc.add(row({ id: 'c', severity: 'low' }));
+
+    const facets = acc.facets();
+    expect(Object.fromEntries(facets.severity.map((f) => [f.value, f.count]))).toEqual({
+      critical: 1,
+      low: 2,
+    });
+  });
+
+  it('excludes each dimension own filter', () => {
+    const acc = createInstanceFacetAccumulator({ severity: ['critical'] });
+    acc.add(row({ id: 'a', severity: 'critical', sourceTool: 'claude-code' }));
+    acc.add(row({ id: 'b', severity: 'low', sourceTool: 'cursor' }));
+
+    const facets = acc.facets();
+    // Severity ignores its own filter, so the low row is still counted —
+    // that is what keeps "how many if I also pick low?" answerable.
+    expect(Object.fromEntries(facets.severity.map((f) => [f.value, f.count]))).toEqual({
+      critical: 1,
+      low: 1,
+    });
+    // Every other dimension honors it, so the low row's provider is not.
+    expect(Object.fromEntries(facets.provider.map((f) => [f.value, f.count]))).toEqual({
+      claudecode: 1,
+    });
+  });
+
+  it('counts no tool bucket for a row carrying none', () => {
+    const acc = createInstanceFacetAccumulator({});
+    acc.add(row({ id: 'a', toolName: 'Bash' }));
+    acc.add(row({ id: 'b' }));
+    expect(acc.facets().tool).toEqual([{ value: 'Bash', count: 1 }]);
+  });
+
+  it('orders each dimension by count, then value', () => {
+    const acc = createInstanceFacetAccumulator({});
+    acc.add(row({ id: 'a', ruleId: 'b-rule' }));
+    acc.add(row({ id: 'b', ruleId: 'a-rule' }));
+    acc.add(row({ id: 'c', ruleId: 'a-rule' }));
+    expect(acc.facets().subtype).toEqual([
+      { value: 'a-rule', count: 2 },
+      { value: 'b-rule', count: 1 },
+    ]);
+  });
+});
+
+describe('toInstanceDetail', () => {
+  it('translates DB values through the shared mappers', () => {
+    const detail = toInstanceDetail(row({ actionTaken: 'log', sourceTool: 'cursor' }));
+
+    expect(detail.action).toBe('monitored');
+    expect(detail.provider).toBe('cursor');
+    expect(detail.groupId).toBe('aws-key');
+    expect(detail.subtype).toBe('aws-key');
+    expect(detail.match).toEqual({ maskedValue: 'AKIA****', contextPrefix: '' });
+    // No pack names in the local store, and the policy is synthesized from the
+    // category — the same shape the grouped path produces.
+    expect(detail.detection).toEqual({ id: 'aws-key', name: null });
+    expect(detail.policy).toEqual({ id: 'category:secret', name: 'secret' });
+  });
+
+  it('carries the event linkage and omits an absent session', () => {
+    expect(toInstanceDetail(row({ sessionId: 's1' })).sessionId).toBe('s1');
+    expect(toInstanceDetail(row()).sessionId).toBeUndefined();
+    expect(toInstanceDetail(row()).eventId).toBe('e1');
+  });
+});
+
+describe('compareFindingGroupOrder', () => {
+  const group = (
+    over: Partial<FindingGroup>,
+  ): Pick<FindingGroup, 'severity' | 'latestDetectedAt' | 'id'> => ({
+    severity: 'critical',
+    latestDetectedAt: '2026-01-01T00:00:00.000Z',
+    id: 'a',
+    ...over,
+  });
+
+  it('orders by severity, then recency', () => {
+    expect(
+      compareFindingGroupOrder(group({ severity: 'critical' }), group({ severity: 'low' })),
+    ).toBeLessThan(0);
+    expect(
+      compareFindingGroupOrder(
+        group({ latestDetectedAt: '2026-01-02T00:00:00.000Z' }),
+        group({ latestDetectedAt: '2026-01-01T00:00:00.000Z' }),
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it('breaks a full tie on id, making the order total', () => {
+    // Without this a cursor cannot resume: "everything after this group" is
+    // ambiguous when two groups compare equal.
+    expect(compareFindingGroupOrder(group({ id: 'a' }), group({ id: 'b' }))).toBeLessThan(0);
+    expect(compareFindingGroupOrder(group({ id: 'b' }), group({ id: 'a' }))).toBeGreaterThan(0);
+    expect(compareFindingGroupOrder(group({ id: 'a' }), group({ id: 'a' }))).toBe(0);
+  });
+
+  it('ranks an unknown severity below every known one', () => {
+    // A garbage cursor decodes to this and therefore sorts before the list,
+    // degrading to a restart from the top rather than skipping rows.
+    expect(
+      compareFindingGroupOrder(
+        group({ severity: 'bogus' as FindingGroup['severity'] }),
+        group({ severity: 'low' }),
+      ),
+    ).toBeLessThan(0);
+  });
+
+  it('is the comparator sortFindingGroups uses', () => {
+    const groups = [
+      { severity: 'low', latestDetectedAt: '2026-01-03T00:00:00.000Z', id: 'x' },
+      { severity: 'critical', latestDetectedAt: '2026-01-01T00:00:00.000Z', id: 'z' },
+      { severity: 'critical', latestDetectedAt: '2026-01-01T00:00:00.000Z', id: 'y' },
+    ] as FindingGroup[];
+    expect(sortFindingGroups(groups).map((g) => g.id)).toEqual(['y', 'z', 'x']);
+  });
+});
+
+describe('location accumulator', () => {
+  it('folds count, worst severity, latest time and rule ids', () => {
+    const acc = newLocationAccumulator();
+    addToLocation(acc, row({ severity: 'low', occurredAt: '2026-01-01T00:00:00.000Z' }));
+    addToLocation(
+      acc,
+      row({ severity: 'critical', occurredAt: '2026-01-03T00:00:00.000Z', ruleId: 'email' }),
+    );
+
+    expect(acc.instanceCount).toBe(2);
+    expect(acc.maxSeverity).toBe('critical');
+    expect(acc.latestDetectedAt).toBe('2026-01-03T00:00:00.000Z');
+    expect([...acc.ruleIds]).toEqual(['aws-key', 'email']);
+  });
+
+  it('folds status with the same precedence a group uses', () => {
+    const acc = newLocationAccumulator();
+    addToLocation(acc, row({ status: 'resolved' }));
+    addToLocation(acc, row({ status: 'open' }));
+    // open dominates — see foldGroupStatus.
+    expect(foldGroupStatus(acc.statuses)).toBe('open');
+  });
+
+  it('does not let an unknown severity pin the location', () => {
+    const acc = newLocationAccumulator();
+    addToLocation(acc, row({ severity: 'not-a-severity' }));
+    addToLocation(acc, row({ severity: 'high' }));
+    expect(acc.maxSeverity).toBe('high');
+  });
+});


### PR DESCRIPTION
Groundwork for the flat and location-grouped findings views, and for real pagination. No UI in this PR — the views land next, on top of these contracts.

## What was missing

The findings list could only answer "which rules are firing". Findings were grouped by rule, capped at 50 groups, with no way to see the most recent ones, filter by where they landed, or page past the cap. `ListGroupedFindingsQuery` already carried `cursor` and the response `nextCursor`, but the repository ignored both — `nextCursor` was always `null`.

## Instance-level reads

A new `FindingInstancesView` port with two methods:

- **`listFindingInstances`** — the flat, newest-first list, keyset-paged, one row per finding. Filters include exact `tool`, `repo` and `file`. The tool filter is what lets the Activity page's tool chips stop relying on `?q=via Bash`, a text match against a rendered label.
- **`listFindingLocations`** — the same findings folded by repo, then file. That is what the store can group by: there is no finding-to-asset relation in the local model (`AssetDetail.finding` is always null), so the grouping keys come from the capturing event's attributes. A finding whose event recorded no repo or file folds into the empty-string bucket, which the view will render but not link, since no filter can name it.

Both reuse `FindingInstanceDetail`, which already existed and had no consumer.

### Where filters run, and why

**SQL owns scope; JS owns every filter dimension.** The session and the time bound are SQL predicates — nothing counts them, so narrowing by them changes no reported number. Severity, subtype, provider, action, status, tool, repo, file and `q` all stay in JS, because each has a facet and a facet is computed by excluding its own filter: a row the filter rejects still has to be counted, so pushing any of them into SQL silently empties that facet.

I had this wrong first, with `severity` and `subtype` as SQL predicates. The facet test caught it — the `low` bucket vanished from the severity facet under a `critical` filter.

Two of them could not be expressed in SQL regardless: status comes from `deriveFindingStatus`, the one shared classifier this repo deliberately never restates in SQL, and provider `api` means "a tool none of the mappers names" — an `IN` over known tools returns exactly the wrong set.

### Scan shape

`scanFindingRows` is a generator over keyset batches, so counting the whole scope for cursor-independent totals keeps memory flat rather than materializing every row. The latest-resolution lookup uses the **correlated** form, not the `LATEST_RESOLUTION_BY_KEY_SQL` derived table the grouped path joins: only `status` is needed, `idx_finding_resolution_key` makes it a point lookup, and the derived table would re-materialize a window over the whole resolution table once per batch.

## Grouped list changes

- **The cursor works.** Keyset over the sorted groups. `sortFindingGroups` now breaks a full tie on id via a new exported `compareFindingGroupOrder`, making the order total — two groups can legitimately share a severity and a `latestDetectedAt`, and a keyset cannot resume from an ambiguous position. A cursor that does not decode, or that decodes with an unknown severity, restarts from the top: an unknown severity ranks below every known one, so it sorts before the whole list. Both cases are pinned.
- **`includeId`** keeps the one-shot `?finding=` deep link resolving once the list pages. The named group (or the group holding the named instance) is appended out of sort order, *after* the cursor is minted from the real page end — minting from the appended group would skip everything in between — and it is status-narrowed like every other row.
- **`from`** applies to both the aggregate and the preview query, so `instanceCount` and `instances` cannot disagree about the window.
- **`eventId` / `sessionId`** on instances. The preview SQL already joined `audit_events`; this only adds columns to the SELECT.

Facets stay computed over the unfiltered group set and totals over the filtered one — both page-independent, both unchanged.

## Migration

`idx_audit_started_at` on `audit_events.started_at`. None of the existing composite indexes lead with `started_at`, so each batch of the newest-first scan would otherwise sort the whole remaining scope. It is a real migration (`0019_audit_started_at_index`), applied on open by every store-opening binary — including the plugin's fail-open hook path, where a large store pays a one-time `CREATE INDEX`.

## Testing

`packages/persistence/test/repositories/findings-flat.test.ts` (34 cases, real store) covers the keyset walk with no duplicate or skipped row, page-independent totals and facets, filtered pages filling across scan batches, undecodable and decodable-but-garbage cursors, the `api` catch-all, per-instance vs group-fold status, location folding including the empty bucket, and the grouped list's cursor, `includeId` and `from`.

`packages/schema/test/zod/findings-flat-build.test.ts` (21 cases) covers the pure helpers: per-dimension matching, the `except` form that facets depend on, the total order and its id tie-break, and the location fold.

Full workspace green: `pnpm lint`, `pnpm typecheck`, `pnpm test`. One flake seen in `detections`' `redos.test.ts` under the parallel full-suite run — a wall-clock budget test in a package this change does not touch; 115/115 in isolation.

## Release

Schema and persistence changed, so both `cli` **and** `plugins/claude-code` need a version bump (both bundle these packages), with `.claude-plugin/plugin.json` kept in sync. I have not touched any version — per CLAUDE.md that needs the release type from you first. No new dependencies.
