### PR TITLE
chore(release): 0.9.5

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Patch bump for the findings work. `cli` and `plugins/claude-code` both move 0.9.4 → 0.9.5, with `.claude-plugin/plugin.json` in sync — the same three files every release commit here touches.

## ⚠️ Merge this LAST

This must land **after** the three feature PRs, or the published artifacts carry a new version number without the changes that justify it:

1. [#188](https://github.com/akasecurity/ai-tc/pull/188) — route loading boundaries + navigation pending state
2. [#206](https://github.com/akasecurity/ai-tc/pull/206) — instance-level findings reads + grouped pagination
3. [#207](https://github.com/akasecurity/ai-tc/pull/207) — flat & location views + cursor pagination (stacked on #206)
4. **this one**

I branched it from `main` rather than stacking it on #207 because #188 is independent of the #206→#207 chain, so no single stack position sits above all three.

## Why both artifacts

Both are self-contained bundles (`noExternal: [/^@akasecurity\//]`), so a change to a bundled package changes the shipped output even when the app's own `src/` is untouched:

| Change | Bundled by | Bumps |
|---|---|---|
| #206 — `schema`, `persistence` | plugin **and** CLI | both |
| #207 — `ui-kit`, `dashboard-ui` | CLI (via the web-ui it ships) | `cli` |
| #188 — `web-ui` | CLI (spawned Next server) | `cli` |

`schema` and `persistence` in #206 are what pull the plugin along; the other two are CLI-only. The two normally move on one shared version line anyway.

## Checks

Version strings are identical across all three files, `pnpm install --frozen-lockfile` reports no drift, and `pnpm typecheck` passes. No dependency or code change — the diff is three version strings.

Note this is the npm/`cli-v*` line only. The binary `bin-v*` channel is independent and needs its own tag, which `release-binaries.yml` gates on matching `cli/package.json` — so if you cut binaries for this, the tag is `bin-v0.9.5`.