### PR TITLE
test(persistence): drive the fault injectors at product code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,10 +573,13 @@ When a change touches the web-ui or any bundled package and the user wants to pu
 2. Keep `plugins/claude-code/.claude-plugin/plugin.json` **in sync** with
    `plugins/claude-code/package.json` (identical version) whenever the plugin is bumped.
 
-**The bump is routine mechanics, not a decision to surface.** It happens on every release as a
-matter of course, so do not ask which release type to use, and do not raise "this touches a
+**The bump is not a decision to surface during feature work, because it is not made there.**
+Pre-1.0.0 the version numbers are chosen **ad hoc**, at the **scheduled release** (twice a week)
+— not per change. So do not ask which release type to use, and do not raise "this touches a
 bundled package, so it needs a version bump" as an open question, a follow-up, or a caveat in a
-summary or PR description.
+summary or PR description. The steps above are what a **release** does: which artifacts move is
+derivable from the bundling rules, and how far they move is settled at release time by whoever
+cuts it.
 
 Versions are bumped by hand in a `chore(release):` commit (no changesets). The CLI and the plugin
 currently share the `0.9.x` line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,19 +564,22 @@ changes the shipped artifact **even when the app's own `src/` is untouched**:
 
 When a change touches the web-ui or any bundled package and the user wants to publish:
 
-1. **Ask the user the release type first** — major, minor, patch, or pre-release — before touching
-   any version.
-2. **Bump every affected artifact** accordingly:
+1. **Bump every affected artifact**:
    - web-ui / `local-ops` / `dashboard-ui` / `ui-kit` change → `cli` (bundled into the CLI JS
      and/or the web-ui it ships; the plugin bundles none of these).
    - `schema` / `persistence` / `plugin-runtime` / `plugin-sdk` / `detections`
      change → **both** `cli` **and** `plugins/claude-code` (both bundle them).
    - The CLI and plugin normally move together on one shared version line.
-3. Keep `plugins/claude-code/.claude-plugin/plugin.json` **in sync** with
+2. Keep `plugins/claude-code/.claude-plugin/plugin.json` **in sync** with
    `plugins/claude-code/package.json` (identical version) whenever the plugin is bumped.
 
-Versions are bumped by hand in a `chore(release):` commit (no changesets). The current pre-release
-line is `0.0.2-alpha.N` — a pre-release bump increments `N`.
+**The bump is routine mechanics, not a decision to surface.** It happens on every release as a
+matter of course, so do not ask which release type to use, and do not raise "this touches a
+bundled package, so it needs a version bump" as an open question, a follow-up, or a caveat in a
+summary or PR description.
+
+Versions are bumped by hand in a `chore(release):` commit (no changesets). The CLI and the plugin
+currently share the `0.9.x` line.
 
 ### Binary (SEA) channel — `bin-v*`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -727,12 +727,31 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
   must gate**: `if (!readOnly.effective) ctx.skip(reason)`. Pass the store's `onCleanup` to
   any injector that has to be undone before the tree can be removed, and the store itself
   to any that needs no live connection.
-  `fillStore` is in the same file but **not yet a peer of the other three**: the page cap
-  is connection-scoped and `LocalDatabase` exposes no raw handle, so it can only reach
-  `node:sqlite`, not the repository writes built on it. It waits on a raw-handle seam.
+  `fillStore` is in the same file and reaches **most** of what the other three do, but not
+  all of it: the page cap is connection-scoped, so it bounds only the handle it is given.
+  A repository constructed over a raw handle takes it (`SqliteAuditEventsRepository(raw)`,
+  the `activity.test.ts` pattern), and so does `applyMigrations`, which is why the
+  disk-full cases drive those. The four blanket fail-open sites in `database.ts`
+  (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`) stay out
+  of reach: they are closures over the connection `openLocalDatabase` opened, and
+  `LocalDatabase` exposes no accessor for it. Aiming a connection-scoped fault at those
+  waits on a raw-handle seam.
 - `assertNoOpenTransaction(db)` — a fault that leaves a transaction open is worse than the
   fault; assert this after injecting one. It reads `db.isTransaction` rather than probing
   with a transaction of its own, so it cannot disturb the handle it is inspecting.
+
+`packages/persistence/test/faults/` is where those injectors are pointed at product code —
+one file per fault (corrupt is covered in `database.test.ts`, which predates the
+directory). A fault case documents the **actual** behaviour rather than the desirable one:
+the store never inspects a SQLite result code beyond `SQLITE_CONSTRAINT_UNIQUE`, so
+contention, a full disk, a read-only file and a caller bug all arrive at the fail-open
+sites as the same discarded `false`, and a dropped event leaves no counter, marker or log
+line behind. Write that down and assert it; do not assert a signal the product does not
+emit. Two behaviours there are the opposite of what the fault's name suggests and are
+pinned so nobody "fixes" them: a store chmod'd read-only under a **live** handle keeps
+being written (a descriptor carries the permission it was opened with, so only the next
+open is refused), and a 0000 `~/.aka` is **repaired** rather than reported, because
+`ensureDataDirSync` chmods a directory the owner still owns back to 0700.
 
 Assert the result code, not an error message or an elapsed time — Windows CI runs several
 times slower, and a timing assertion there is a flake. Compare with `primaryCode()`:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -736,28 +736,47 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
   `fillStore` is in the same file and reaches **most** of what the other three do, but not
   all of it: the page cap is connection-scoped, so it bounds only the handle it is given.
   A repository constructed over a raw handle takes it (`SqliteAuditEventsRepository(raw)`,
-  the `activity.test.ts` pattern), and so does `applyMigrations`, which is why the
-  disk-full cases drive those. The four blanket fail-open sites in `database.ts`
-  (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`) stay out
-  of reach: they are closures over the connection `openLocalDatabase` opened, and
+  the `activity.test.ts` pattern), and so does `applyMigrations` — but only with a cap
+  sized against a real migration: the default headroom on an empty file stops the ledger's
+  own `CREATE TABLE`, so the applier's loop never runs and every claim about a partial
+  migration then holds vacuously. The blanket fail-open sites in `database.ts`
+  (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`, and
+  `reconcileWorktreeProjects`, which reaches `withTransaction` directly) stay out of
+  reach: they are closures over the connection `openLocalDatabase` opened, and
   `LocalDatabase` exposes no accessor for it. Aiming a connection-scoped fault at those
   waits on a raw-handle seam.
 - `assertNoOpenTransaction(db)` — a fault that leaves a transaction open is worse than the
   fault; assert this after injecting one. It reads `db.isTransaction` rather than probing
   with a transaction of its own, so it cannot disturb the handle it is inspecting.
+- `errorFrom(fn)` — the error a thunk threw, captured OUTSIDE its own catch (see
+  [Testing](#testing) on why the try/catch form asserts on the test's own guard).
+- `captureEvent()` / `captureFinding()` — the minimal `recordCapture` pair. Both vary
+  their identity per call, which is load-bearing: `contentHash` feeds the event's
+  content-addressed id and `maskedMatch` is half the finding-level session dedup key, so a
+  shared constant makes a second capture land as zero rows **by design** — and every "the
+  event is gone" assertion in `test/faults/` would then pass whether or not the fault did
+  anything.
 
 `packages/persistence/test/faults/` is where those injectors are pointed at product code —
 one file per fault (corrupt is covered in `database.test.ts`, which predates the
 directory). A fault case documents the **actual** behaviour rather than the desirable one:
-the store never inspects a SQLite result code beyond `SQLITE_CONSTRAINT_UNIQUE`, so
-contention, a full disk, a read-only file and a caller bug all arrive at the fail-open
-sites as the same discarded `false`, and a dropped event leaves no counter, marker or log
-line behind. Write that down and assert it; do not assert a signal the product does not
+no fail-open site inspects a SQLite result code, so contention, a full disk, a read-only
+file and a caller bug all arrive there as the same discarded `false`, and a dropped event
+leaves no counter, marker or log line behind. (Scoped to those sites deliberately: the
+package reads `errcode` in two places — `internal/sqlite-errors.ts` for
+`SQLITE_CONSTRAINT_UNIQUE`, and `fingerprint.ts`, which separates "no such table" from a
+damaged or locked store. Neither is a fail-open path.) Write that down and assert it; do not assert a signal the product does not
 emit. Two behaviours there are the opposite of what the fault's name suggests and are
 pinned so nobody "fixes" them: a store chmod'd read-only under a **live** handle keeps
 being written (a descriptor carries the permission it was opened with, so only the next
-open is refused), and a 0000 `~/.aka` is **repaired** rather than reported, because
-`ensureDataDirSync` chmods a directory the owner still owns back to 0700.
+open is refused), and a read-only store's refusal lands **inside the migration applier**
+rather than on the first `PRAGMA journal_mode = WAL`, which succeeds and mints the
+sidecars. A tightened directory the owner still owns is a third case, and the distinction
+is the point: `ensureDataDirSync` widens the **data dir** back to 0700, so a 0500 there
+never reaches SQLite — but a 0000 `~/.aka` is **reported**, as `EACCES` out of `mkdir`,
+long before any chmod runs. `aka init` repairs a 0000 home because it calls
+`ensureDataDirSync` on the home itself; `openLocalDatabase` does not, and the tests in
+this directory assert the refusal.
 
 Assert the result code, not an error message or an elapsed time — Windows CI runs several
 times slower, and a timing assertion there is a flake. Compare with `primaryCode()`:

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -260,6 +260,52 @@ function isBrokenLink(path: string): boolean {
   }
 }
 
+// A store directory that already exists as a FILE cannot be created either, and
+// the raw failure is actively misleading: `mkdir` raises EEXIST, whose message
+// ("file already exists") reads as "this is already done" rather than "something
+// else is sitting where the store goes". Deeper paths are worse — creating
+// through a file yields ENOTDIR naming `<home>/data`, which points at the one
+// component that is NOT the problem. Refuse here instead, naming the path that
+// is occupied and what to do about it.
+//
+// Checked for the same three directories as the broken-link guard, and after
+// it, so a broken link keeps its own more specific diagnosis. `statSync`
+// follows a link deliberately: a link to a regular file is this fault, not a
+// symlink note, and `aka init` supports a home symlinked to a real directory.
+//
+// Which means the path named here may itself be a link, and saying "move that
+// file aside" of one sends a reader to the TARGET — someone else's real file,
+// which removing would be the wrong repair and is not reversible. A link is
+// therefore reported as a link, naming what it resolves to, the way
+// assertStoreLinksResolve reports its own.
+function assertStorePathsAreDirectories(home: string): void {
+  for (const dir of [home, settingsDir(home), dataDir(home)]) {
+    if (!existsAsNonDirectory(dir)) continue;
+    const occupant = isSymlink(dir)
+      ? `is a symlink to ${linkTarget(dir)}, which is not a directory — remove the link`
+      : 'exists but is not a directory — move that file aside or remove it';
+    throw new Error(`${dir} ${occupant}. AKA keeps its store there; re-run \`aka init\` after.`);
+  }
+}
+
+function isSymlink(path: string): boolean {
+  try {
+    return lstatSync(path).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function existsAsNonDirectory(path: string): boolean {
+  try {
+    return !statSync(path).isDirectory();
+  } catch {
+    // Absent (the normal case on a fresh init), a broken link (already
+    // diagnosed above), or unreadable — none of them this diagnosis.
+    return false;
+  }
+}
+
 // `aka init` — scaffold the local AKA home: owner-only ~/.aka, a default
 // settings.json, and the SQLite store (openLocalDatabase creates the data dir,
 // applies migrations, and seeds the default per-category policies). Idempotent:
@@ -274,6 +320,7 @@ export async function runInit(argv: string[]): Promise<void> {
   const home = homeBase(values.home);
 
   assertStoreLinksResolve(home);
+  assertStorePathsAreDirectories(home);
   ensureDataDirSync(home);
   const settings = settingsDir(home);
   ensureDataDirSync(settings);

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -263,10 +263,10 @@ function isBrokenLink(path: string): boolean {
 // A store directory that already exists as a FILE cannot be created either, and
 // the raw failure is actively misleading: `mkdir` raises EEXIST, whose message
 // ("file already exists") reads as "this is already done" rather than "something
-// else is sitting where the store goes". Deeper paths are worse — creating
-// through a file yields ENOTDIR naming `<home>/data`, which points at the one
-// component that is NOT the problem. Refuse here instead, naming the path that
-// is occupied and what to do about it.
+// else is sitting where the store goes". Every occupied path reports that way,
+// at any depth — `ensureDataDirSync` passes `recursive: true`, so it fails at
+// the occupied component itself and never creates *through* a file. Refuse here
+// instead, naming the path that is occupied and what to do about it.
 //
 // Checked for the same three directories as the broken-link guard, and after
 // it, so a broken link keeps its own more specific diagnosis. `statSync`
@@ -279,7 +279,13 @@ function isBrokenLink(path: string): boolean {
 // therefore reported as a link, naming what it resolves to, the way
 // assertStoreLinksResolve reports its own.
 function assertStorePathsAreDirectories(home: string): void {
-  for (const dir of [home, settingsDir(home), dataDir(home)]) {
+  // keys/ is included even though `aka init` does not create it: the vault
+  // mints it lazily on first use, so a regular file there lets init SUCCEED
+  // and then blames the filesystem — "could not enforce owner-only permissions
+  // on …/keys" — for a path that is simply occupied, while `aka vault` later
+  // dies on a bare EEXIST. An absent path is not a finding, so adding it costs
+  // the common case nothing.
+  for (const dir of [home, settingsDir(home), dataDir(home), keysDir(home)]) {
     if (!existsAsNonDirectory(dir)) continue;
     const occupant = isSymlink(dir)
       ? `is a symlink to ${linkTarget(dir)}, which is not a directory — remove the link`

--- a/cli/src/lib/args.ts
+++ b/cli/src/lib/args.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'node:path';
+
 import { defaultDataDir } from '@akasecurity/plugin-sdk';
 
 // Every command accepts `--home <dir>` to point at an alternate AKA home (the
@@ -5,6 +7,13 @@ import { defaultDataDir } from '@akasecurity/plugin-sdk';
 // and keeps the home path out of process.env.
 export const HOME_OPTION = { home: { type: 'string' } } as const;
 
+// Resolved, not taken verbatim: a trailing separator changes what the path
+// MEANS to the filesystem. `statSync('<a regular file>/')` raises ENOTDIR
+// rather than describing the file, so a guard that asks "is this path a
+// non-directory?" is answered "no" and waves the path through — `aka init`
+// then failed with exactly the bare mkdir error its guard exists to replace.
+// `resolve` also makes a relative --home absolute, so every path derived from
+// it is stable against a later chdir.
 export function homeBase(home: string | undefined): string {
-  return home ?? defaultDataDir();
+  return home === undefined ? defaultDataDir() : resolve(home);
 }

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -723,3 +723,129 @@ describe('runInit on a symlinked home', () => {
     expect(statSync(join(victim, 'settings', 'settings.json')).mode & 0o777).toBe(0o600);
   });
 });
+
+// `~/.aka` is not always a directory this process can create. A user can have a
+// file sitting at that path, or a home tightened so `aka init` cannot write into
+// it at all. Neither is exotic — both are what a hostile or merely unusual home
+// looks like — and `aka init` is the one surface that has to say something a
+// user can act on, because unlike a hook it is not allowed to fail open and
+// carry on silently.
+describe('runInit on a ~/.aka it cannot create', () => {
+  // The three directories init creates through, each occupied by a regular
+  // file. Driven per path rather than only at the base: `mkdir` reports EEXIST
+  // at the base but ENOTDIR deeper down, naming the component that is NOT the
+  // problem, so the deeper paths are where a raw error misleads most.
+  for (const at of ['base', 'settings', 'data'] as const) {
+    it(`refuses with an actionable error when ${at} is a regular file`, async () => {
+      const home = join(dir, 'filehome');
+      const occupied = at === 'base' ? home : at === 'settings' ? settingsDir(home) : dataDir(home);
+      if (at !== 'base') mkdirSync(home, { recursive: true });
+      writeFileSync(occupied, 'someone else owns this path\n');
+
+      const err = await runInit(['--home', home]).then(
+        () => undefined,
+        (e: unknown) => e as Error,
+      );
+
+      // Named before the absence check below, so this is the refusal that was
+      // reached and not merely some error.
+      expect(err).toBeDefined();
+      expect(err?.message).toContain(occupied);
+      expect(err?.message).toContain('exists but is not a directory');
+      // What to do about it. A message that only reports the state leaves a
+      // user to guess whether AKA will fix it on the next run.
+      expect(err?.message).toContain('move that file aside');
+      // The raw failure this replaces read as "already done" rather than
+      // "something else is there", which is the whole reason for the guard.
+      expect(err?.message).not.toContain('EEXIST');
+      expect(err?.message).not.toContain('ENOTDIR');
+    });
+  }
+
+  it('leaves the occupying file untouched, so moving it aside is safe advice', async () => {
+    const home = join(dir, 'filehome-intact');
+    const original = 'someone else owns this path\n';
+    writeFileSync(home, original);
+
+    const err = await runInit(['--home', home]).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    // Named, so the untouched file below is evidence about THIS refusal. The
+    // raw mkdir failure this guard replaces also leaves the file alone, so
+    // without naming which error was reached the case passes identically with
+    // the guard deleted and proves nothing about it.
+    expect(err?.message).toContain('exists but is not a directory');
+    expect(readFileSync(home, 'utf8')).toBe(original);
+  });
+
+  it('names the link and its target when a store path is a symlink to a file', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
+    // The guard stats THROUGH a link on purpose, so this is the case that
+    // decision creates. Telling the user to "move that file aside" of a symlink
+    // points them at the target — someone else's real file — and deleting it is
+    // both the wrong repair and irreversible. The link is what has to go.
+    const target = join(dir, 'someone-elses-file');
+    writeFileSync(target, 'not ours\n');
+    const home = join(dir, 'linked-to-a-file');
+    symlinkSync(target, home);
+
+    const err = await runInit(['--home', home]).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    expect(err).toBeDefined();
+    expect(err?.message).toContain(home);
+    expect(err?.message).toContain('is a symlink to');
+    expect(err?.message).toContain(target);
+    expect(err?.message).toContain('remove the link');
+    // Calling a symlink a file is the specific wording this case exists to
+    // keep out.
+    expect(err?.message).not.toContain('move that file aside');
+    // And the target is still there to be pointed at.
+    expect(readFileSync(target, 'utf8')).toBe('not ours\n');
+  });
+
+  it('initializes once the file is moved aside', async () => {
+    // The positive control: the refusal is the occupied path and nothing
+    // permanent about this home.
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const home = join(dir, 'filehome-cleared');
+    writeFileSync(home, 'someone else owns this path\n');
+    await runInit(['--home', home]).then(
+      () => undefined,
+      () => undefined,
+    );
+
+    rmSync(home, { force: true });
+    await runInit(['--home', home]);
+
+    expect(existsSync(dbPath(home))).toBe(true);
+  });
+
+  it('self-heals a ~/.aka the owner has locked themselves out of', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('chmod does not deny a directory on Windows');
+      return;
+    }
+    // Documented because it is the opposite of what the mode suggests, and it
+    // is why the file case above is the one that needs a guard. A 0000 home is
+    // still the owner's to widen, and `ensureDataDirSync` chmods it back to
+    // 0700 on the way in — so `aka init` repairs this fault rather than
+    // reporting it, and ends with the documented modes like any other run.
+    vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const home = join(dir, 'lockedhome');
+    mkdirSync(home, { recursive: true });
+    chmodSync(home, 0o000);
+
+    await runInit(['--home', home]);
+
+    expect(existsSync(dbPath(home))).toBe(true);
+    expect(statSync(home).mode & 0o777).toBe(0o700);
+  });
+});

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -14,10 +14,11 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { dirname, join, sep } from 'node:path';
 
 import type * as LocalOps from '@akasecurity/local-ops';
 import { cachePath, writeCache } from '@akasecurity/local-ops';
+import { keysDir } from '@akasecurity/persistence';
 import { dataDir, dbPath, settingsDir } from '@akasecurity/plugin-sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -757,8 +758,10 @@ describe('runInit on a ~/.aka it cannot create', () => {
       expect(err?.message).toContain('move that file aside');
       // The raw failure this replaces read as "already done" rather than
       // "something else is there", which is the whole reason for the guard.
+      // Only EEXIST is asserted: `recursive: true` fails at the occupied
+      // component itself, so runInit never produces ENOTDIR here and an
+      // absence check for it would be green whatever the guard did.
       expect(err?.message).not.toContain('EEXIST');
-      expect(err?.message).not.toContain('ENOTDIR');
     });
   }
 
@@ -817,15 +820,57 @@ describe('runInit on a ~/.aka it cannot create', () => {
     vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     const home = join(dir, 'filehome-cleared');
     writeFileSync(home, 'someone else owns this path\n');
-    await runInit(['--home', home]).then(
+    const refused = await runInit(['--home', home]).then(
       () => undefined,
-      () => undefined,
+      (e: unknown) => e as Error,
     );
+    // Named, not discarded. Swallowing this error makes the case survive
+    // deleting the guard entirely — it would then be asserting only that
+    // `aka init` works on an empty directory.
+    expect(refused?.message).toContain('exists but is not a directory');
 
     rmSync(home, { force: true });
     await runInit(['--home', home]);
 
     expect(existsSync(dbPath(home))).toBe(true);
+  });
+
+  it('refuses when keys/ is occupied, rather than blaming the filesystem', async () => {
+    // keys/ is minted lazily by the vault, so it is absent on a normal init and
+    // the guard used to skip it. A file there let init SUCCEED and print a
+    // permissions warning about a path that was merely occupied — sending the
+    // user to chmod something that was never a mode problem — while the next
+    // `aka vault` died on a bare EEXIST from the key provider.
+    const home = join(dir, 'keyshome');
+    mkdirSync(home, { recursive: true });
+    writeFileSync(keysDir(home), 'someone else owns this path\n');
+
+    const err = await runInit(['--home', home]).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    expect(err).toBeDefined();
+    expect(err?.message).toContain(keysDir(home));
+    expect(err?.message).toContain('exists but is not a directory');
+  });
+
+  it('is not bypassed by a trailing separator on --home', async () => {
+    // `statSync('<a regular file>/')` raises ENOTDIR rather than describing the
+    // file, so the guard's "is this a non-directory?" question came back "no"
+    // and the path went through — producing the bare mkdir failure the guard
+    // exists to replace. homeBase resolves the path, which drops the separator.
+    const home = join(dir, 'slashhome');
+    writeFileSync(home, 'someone else owns this path\n');
+
+    const err = await runInit(['--home', home + sep]).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    expect(err).toBeDefined();
+    expect(err?.message).toContain('exists but is not a directory');
+    expect(err?.message).not.toContain('ENOTDIR');
   });
 
   it('self-heals a ~/.aka the owner has locked themselves out of', async (ctx) => {

--- a/packages/persistence/test/faults/disk-full.test.ts
+++ b/packages/persistence/test/faults/disk-full.test.ts
@@ -1,0 +1,256 @@
+/**
+ * A store with no room left to grow.
+ *
+ * `SQLITE_FULL` is the fault where "fail-open" and "no corruption" are two
+ * different claims: the write is allowed to vanish, but it must vanish WHOLE.
+ * A transaction that committed half its rows would leave an audit event with
+ * no findings, or findings pointing at an event that is not there — a store
+ * that reads as healthy while telling a lie.
+ *
+ * `fillStore` caps growth on the connection it is handed, so these drive the
+ * real repositories and the real shared envelopes over a raw handle. That is
+ * as far as the fault reaches today: `openLocalDatabase` opens a connection of
+ * its own and exposes no accessor for it, so the four blanket fail-open
+ * closures in `database.ts` cannot be capped from a test. They take the same
+ * `failOpenTransaction` path pinned below.
+ */
+import { randomUUID } from 'node:crypto';
+import type { DatabaseSync } from 'node:sqlite';
+
+import type { AuditEventInput } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { failOpenTransaction } from '../../src/internal/transactions.ts';
+import { applyMigrations } from '../../src/migrations.ts';
+import { SqliteAuditEventsRepository } from '../../src/repositories/audit-events.ts';
+import { errorFrom } from '../helpers/errors.ts';
+import { fillStore, primaryCode, SQLITE_FULL } from '../helpers/fault-injection.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
+import { assertNoOpenTransaction } from '../helpers/transactions.ts';
+
+const store = useTempStore('aka-fault-diskfull-');
+
+/** Big enough that a capped store runs out inside a bounded number of rows. */
+const PAGE_HUNGRY_CONTENT = 'x'.repeat(4096);
+/** More rows than the cap can take, so the run is bounded by the fault. */
+const MORE_ROWS_THAN_FIT = 4000;
+
+function auditEvent(): AuditEventInput {
+  return {
+    id: randomUUID(),
+    eventType: 'prompt',
+    startedAt: new Date().toISOString(),
+    content: PAGE_HUNGRY_CONTENT,
+  };
+}
+
+function countAuditEvents(db: DatabaseSync): number {
+  return (db.prepare('SELECT COUNT(*) AS n FROM audit_events').get() as { n: number }).n;
+}
+
+function integrityOf(db: DatabaseSync): string | undefined {
+  return (db.prepare('PRAGMA integrity_check').get() as { integrity_check?: string } | undefined)
+    ?.integrity_check;
+}
+
+/**
+ * Write audit events through the repository's own transaction envelope until
+ * the capped store refuses, and return the error it refused with.
+ *
+ * `runInTransaction` wraps the whole batch in one `withTransaction`, which is
+ * the shape the reconcile pass really uses — so this is the production path,
+ * not a lookalike. Kept in one place because the row size and count are a
+ * budget that has needed retuning for slower runners before, and four copies
+ * of it would drift.
+ */
+function writeUntilFull(auditEvents: SqliteAuditEventsRepository): Error | undefined {
+  return errorFrom(() => {
+    auditEvents.runInTransaction(() => {
+      for (let i = 0; i < MORE_ROWS_THAN_FIT; i += 1) auditEvents.insertAuditEvent(auditEvent());
+    });
+  });
+}
+
+describe('a repository write that runs the store out of room', () => {
+  it('raises SQLITE_FULL and rolls the whole batch back, leaving no partial rows', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+    const before = countAuditEvents(raw);
+
+    const filled = fillStore(raw);
+    const err = writeUntilFull(auditEvents);
+    filled.restore();
+
+    expect(primaryCode(err)).toBe(SQLITE_FULL);
+    // The claim that matters: not one row of the batch survived. A partial
+    // commit here is indistinguishable from a healthy store on every read.
+    expect(countAuditEvents(raw)).toBe(before);
+  });
+
+  it('leaves no transaction open on the handle', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+
+    const filled = fillStore(raw);
+    expect(writeUntilFull(auditEvents)).toBeDefined();
+    filled.restore();
+
+    // A transaction left behind by the fault is worse than the fault: the
+    // connection keeps its locks and every later write on it silently joins a
+    // transaction nobody started.
+    assertNoOpenTransaction(raw);
+  });
+
+  it('leaves the store consistent, and writable again once there is room', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+
+    const filled = fillStore(raw);
+    expect(writeUntilFull(auditEvents)).toBeDefined();
+
+    expect(integrityOf(raw)).toBe('ok');
+    filled.restore();
+
+    // The positive control: the refusals above were the cap, not something
+    // permanent this fault did to the store.
+    const before = countAuditEvents(raw);
+    auditEvents.insertAuditEvent({
+      id: randomUUID(),
+      eventType: 'prompt',
+      startedAt: new Date().toISOString(),
+    });
+    expect(countAuditEvents(raw)).toBe(before + 1);
+  });
+
+  it('leaves a store a fresh process can still open and read', () => {
+    const db = store.open();
+    db.close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+
+    const filled = fillStore(raw);
+    expect(writeUntilFull(auditEvents)).toBeDefined();
+    filled.restore();
+    raw.close();
+
+    // The cap belongs to the connection that set it, so a new one starts with
+    // the store as it was left. Anything short of a clean open here would mean
+    // the rollback had damaged the file rather than undone the write.
+    expect(
+      errorFrom(() => {
+        store.open().close();
+      }),
+    ).toBeUndefined();
+    const reader = store.openRaw();
+    try {
+      expect(integrityOf(reader)).toBe('ok');
+    } finally {
+      reader.close();
+    }
+  });
+});
+
+describe('the SQLITE_FULL fail-open branch', () => {
+  it('swallows the failure and reports only that nothing committed', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+    const before = countAuditEvents(raw);
+
+    const filled = fillStore(raw);
+    const committed = failOpenTransaction(raw, () => {
+      for (let i = 0; i < MORE_ROWS_THAN_FIT; i += 1) auditEvents.insertAuditEvent(auditEvent());
+    });
+    filled.restore();
+
+    // A full disk and a caller bug are the same `false` here — the store never
+    // inspects the code, so nothing downstream can tell them apart or count
+    // them. Documented, not asserted away.
+    expect(committed).toBe(false);
+    expect(countAuditEvents(raw)).toBe(before);
+    assertNoOpenTransaction(raw);
+  });
+
+  it('rethrows while nested, because this failure takes the caller’s whole transaction with it', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const auditEvents = new SqliteAuditEventsRepository(raw);
+
+    const filled = fillStore(raw);
+    raw.exec('BEGIN');
+    // A nested envelope normally unwinds to its SAVEPOINT and returns `false`.
+    // SQLITE_FULL is one of the failures SQLite resolves by rolling back the
+    // whole transaction, savepoint included — so swallowing it would leave the
+    // caller issuing durable autocommit statements it believes are still
+    // guarded, and finding out only at a COMMIT that throws.
+    const err = errorFrom(() =>
+      failOpenTransaction(raw, () => {
+        for (let i = 0; i < MORE_ROWS_THAN_FIT; i += 1) auditEvents.insertAuditEvent(auditEvent());
+      }),
+    );
+    filled.restore();
+
+    expect(primaryCode(err)).toBe(SQLITE_FULL);
+    // Not the envelope's doing: the transaction was already gone when it
+    // regained control, which is exactly what it keys the rethrow on.
+    expect(raw.isTransaction).toBe(false);
+  });
+});
+
+describe('running out of room mid-migration', () => {
+  it('applies no migration at all rather than half of one', () => {
+    // The applier runs its DDL statement by statement and stamps a ledger tag
+    // per migration. A tag recorded for DDL that did not land is the worst
+    // outcome available here: every later open reads the tag, skips the
+    // migration, and meets a schema that never got built.
+    const raw = store.openRaw();
+    const filled = fillStore(raw);
+
+    const err = errorFrom(() => {
+      applyMigrations(raw, store.dbFile);
+    });
+    filled.restore();
+
+    expect(primaryCode(err)).toBe(SQLITE_FULL);
+    assertNoOpenTransaction(raw);
+
+    const tags = raw
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'migration_ledger'")
+      .all() as { name: string }[];
+    const recorded =
+      tags.length === 0
+        ? []
+        : (raw.prepare('SELECT tag FROM migration_ledger').all() as { tag: string }[]);
+    expect(recorded).toEqual([]);
+  });
+
+  it('leaves a store the next open migrates cleanly', () => {
+    // "Next open retries" is the whole recovery story for an interrupted
+    // migration, and it is only true if the failed attempt left nothing behind
+    // that the retry would now skip.
+    const raw = store.openRaw();
+    const filled = fillStore(raw);
+    expect(
+      errorFrom(() => {
+        applyMigrations(raw, store.dbFile);
+      }),
+    ).toBeDefined();
+    filled.restore();
+    raw.close();
+
+    expect(
+      errorFrom(() => {
+        store.open().close();
+      }),
+    ).toBeUndefined();
+    const reader = store.openRaw();
+    try {
+      expect(integrityOf(reader)).toBe('ok');
+    } finally {
+      reader.close();
+    }
+  });
+});

--- a/packages/persistence/test/faults/disk-full.test.ts
+++ b/packages/persistence/test/faults/disk-full.test.ts
@@ -15,9 +15,11 @@
  * `failOpenTransaction` path pinned below.
  */
 import { randomUUID } from 'node:crypto';
-import type { DatabaseSync } from 'node:sqlite';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 
 import type { AuditEventInput } from '@akasecurity/schema';
+import { SQLITE_MIGRATIONS } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { failOpenTransaction } from '../../src/internal/transactions.ts';
@@ -72,7 +74,7 @@ function writeUntilFull(auditEvents: SqliteAuditEventsRepository): Error | undef
 }
 
 describe('a repository write that runs the store out of room', () => {
-  it('raises SQLITE_FULL and rolls the whole batch back, leaving no partial rows', () => {
+  it('raises SQLITE_FULL and leaves no partial rows behind', () => {
     store.open().close();
     const raw = store.openRaw();
     const auditEvents = new SqliteAuditEventsRepository(raw);
@@ -201,56 +203,93 @@ describe('the SQLITE_FULL fail-open branch', () => {
 });
 
 describe('running out of room mid-migration', () => {
-  it('applies no migration at all rather than half of one', () => {
-    // The applier runs its DDL statement by statement and stamps a ledger tag
-    // per migration. A tag recorded for DDL that did not land is the worst
-    // outcome available here: every later open reads the tag, skips the
-    // migration, and meets a schema that never got built.
-    const raw = store.openRaw();
-    const filled = fillStore(raw);
+  /**
+   * Cap a fresh store so the applier commits some migrations and then runs out,
+   * leaving a genuinely half-migrated file.
+   *
+   * The cap is measured, not guessed. `fillStore`'s default headroom on an
+   * empty file caps at 2 pages, which the ledger's own `CREATE TABLE` exhausts
+   * — the applier's loop never runs at all, and every assertion about a partial
+   * migration then holds on a store with no tables in it. Half of what a
+   * complete migration actually needs lands partway instead, and it keeps
+   * doing so as the migration history grows.
+   */
+  function halfMigratedStore(): { db: DatabaseSync; file: string; err: Error | undefined } {
+    const seeded = store.open();
+    seeded.close();
+    const measured = store.openRaw();
+    const fullPages = (measured.prepare('PRAGMA page_count').get() as { page_count: number })
+      .page_count;
+    measured.close();
 
+    const file = join(store.dataDir, 'half-migrated.db');
+    const db = new DatabaseSync(file);
+    const filled = fillStore(db, { headroomPages: Math.floor(fullPages / 2) });
     const err = errorFrom(() => {
-      applyMigrations(raw, store.dbFile);
+      applyMigrations(db, file);
     });
     filled.restore();
+    return { db, file, err };
+  }
 
-    expect(primaryCode(err)).toBe(SQLITE_FULL);
-    assertNoOpenTransaction(raw);
-
-    const tags = raw
+  function ledgerTags(db: DatabaseSync): string[] {
+    const present = db
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'migration_ledger'")
       .all() as { name: string }[];
-    const recorded =
-      tags.length === 0
-        ? []
-        : (raw.prepare('SELECT tag FROM migration_ledger').all() as { tag: string }[]);
-    expect(recorded).toEqual([]);
+    if (present.length === 0) return [];
+    return (db.prepare('SELECT tag FROM migration_ledger').all() as { tag: string }[]).map(
+      (row) => row.tag,
+    );
+  }
+
+  it('records a ledger tag only for a migration that actually landed', () => {
+    // The applier stamps a ledger tag per migration. A tag recorded for DDL
+    // that did not land is the worst outcome available here: every later open
+    // reads the tag, skips the migration, and meets a schema that was never
+    // built. The tag must therefore go in with the DDL, inside one transaction.
+    const { db, err } = halfMigratedStore();
+    try {
+      expect(primaryCode(err)).toBe(SQLITE_FULL);
+      assertNoOpenTransaction(db);
+
+      const recorded = ledgerTags(db);
+      // Positive control. With no tags recorded — which is what a 2-page cap
+      // produces — every claim below holds vacuously on an empty file, and the
+      // defect this case exists for is undetectable.
+      expect(recorded.length).toBeGreaterThan(0);
+      expect(recorded.length).toBeLessThan(SQLITE_MIGRATIONS.length);
+
+      // What is recorded is an unbroken prefix of the history, never a tag
+      // from beyond the point the disk gave out.
+      const expected = SQLITE_MIGRATIONS.slice(0, recorded.length).map((m) => m.tag);
+      expect([...recorded].sort()).toEqual([...expected].sort());
+    } finally {
+      db.close();
+    }
   });
 
-  it('leaves a store the next open migrates cleanly', () => {
+  it('leaves a half-migrated store the next open finishes', () => {
     // "Next open retries" is the whole recovery story for an interrupted
-    // migration, and it is only true if the failed attempt left nothing behind
-    // that the retry would now skip.
-    const raw = store.openRaw();
-    const filled = fillStore(raw);
-    expect(
-      errorFrom(() => {
-        applyMigrations(raw, store.dbFile);
-      }),
-    ).toBeDefined();
-    filled.restore();
-    raw.close();
+    // migration, and it is only true of a store that really is partway: a tag
+    // recorded without its DDL makes the retry SKIP that migration, so the
+    // schema it should have built never appears and the open fails on it.
+    const { db, file } = halfMigratedStore();
+    const before = ledgerTags(db).length;
+    db.close();
+    expect(before).toBeGreaterThan(0);
+    expect(before).toBeLessThan(SQLITE_MIGRATIONS.length);
 
-    expect(
-      errorFrom(() => {
-        store.open().close();
-      }),
-    ).toBeUndefined();
-    const reader = store.openRaw();
+    const reopened = new DatabaseSync(file);
     try {
-      expect(integrityOf(reader)).toBe('ok');
+      expect(
+        errorFrom(() => {
+          applyMigrations(reopened, file);
+        }),
+      ).toBeUndefined();
+      expect(ledgerTags(reopened)).toHaveLength(SQLITE_MIGRATIONS.length);
+      expect(integrityOf(reopened)).toBe('ok');
     } finally {
-      reader.close();
+      reopened.close();
     }
   });
 });

--- a/packages/persistence/test/faults/hostile-home.test.ts
+++ b/packages/persistence/test/faults/hostile-home.test.ts
@@ -14,6 +14,7 @@ import {
   constants,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   statSync,
@@ -38,12 +39,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // Widen before removing, innermost first: a directory without write
-  // permission cannot have its entries unlinked, and `force` only forgives
-  // ENOENT, not EACCES — so a tightened directory left behind by a failed case
-  // strands the whole temp tree rather than reporting the failure. Both levels
-  // are restored because cases here tighten either one.
-  for (const dir of [dataDir(home), home]) {
+  // Widen before removing, OUTERMOST first: chmod needs traverse on every
+  // parent, so a 0000 home makes the inner call fail before it can widen
+  // anything. (The unlink dependency runs the other way — a directory without
+  // write permission cannot have its entries removed, and `force` forgives
+  // ENOENT, not EACCES — which is why both levels have to come back at all.)
+  // Both are restored because cases here tighten either one.
+  for (const dir of [home, dataDir(home)]) {
     try {
       chmodSync(dir, 0o700);
     } catch {
@@ -99,13 +101,18 @@ describe('a permission-denied ~/.aka', () => {
     }
 
     // A hook fires per tool call and a dashboard request comes back on every
-    // reload, so the retry is the normal case, not the exception. Nothing here
-    // may be left half-created for the next attempt to trip over.
+    // reload, so the retry is the normal case, not the exception.
     for (let i = 0; i < 3; i += 1) {
       expect(
         (errorFrom(() => openLocalDatabase(dataDir(home))) as { code?: string } | undefined)?.code,
       ).toBe('EACCES');
     }
+
+    // And nothing was left half-created for the next attempt to trip over —
+    // read, not merely asserted about. Widening is what makes the directory
+    // walkable enough to check.
+    chmodSync(home, 0o700);
+    expect(readdirSync(home)).toEqual([]);
   });
 
   it('opens once the directory is readable again', (ctx) => {

--- a/packages/persistence/test/faults/hostile-home.test.ts
+++ b/packages/persistence/test/faults/hostile-home.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `~/.aka` itself being unusable — not the store inside it.
+ *
+ * These faults land before SQLite is ever reached, so they arrive as Node
+ * filesystem errors rather than result codes, and none of the package's
+ * SQLite-shaped fail-open branches see them. `openLocalDatabase` throws, and
+ * failing open is then entirely the caller's job — which is worth pinning,
+ * because a caller that does not is a session running with detection off and
+ * nothing said about it.
+ */
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { openLocalDatabase } from '../../src/database.ts';
+import { dataDir } from '../../src/local-layout.ts';
+import { ensureDataDirSync } from '../../src/paths.ts';
+import { errorFrom } from '../helpers/errors.ts';
+
+let parent: string;
+let home: string;
+
+beforeEach(() => {
+  parent = mkdtempSync(join(tmpdir(), 'aka-fault-home-'));
+  home = join(parent, '.aka');
+});
+
+afterEach(() => {
+  // Widen before removing, innermost first: a directory without write
+  // permission cannot have its entries unlinked, and `force` only forgives
+  // ENOENT, not EACCES — so a tightened directory left behind by a failed case
+  // strands the whole temp tree rather than reporting the failure. Both levels
+  // are restored because cases here tighten either one.
+  for (const dir of [dataDir(home), home]) {
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // Absent, a regular file, or a platform that never applied the mode.
+    }
+  }
+  rmSync(parent, { recursive: true, force: true });
+});
+
+/**
+ * True when this process is actually denied write access to `dir` by its mode.
+ *
+ * `accessSync` asks the question directly and changes nothing. Probing with a
+ * `mkdir` would answer a wider one — it fails for a path that is a regular
+ * file (ENOTDIR) just as readily as for one this process may not write, and
+ * a case gated on that would skip on a fault it had successfully injected,
+ * reporting an unexercised test as a pass. It also leaves a directory behind
+ * on the success path, which is a mutation inside a predicate.
+ */
+function deniesWrite(dir: string): boolean {
+  try {
+    accessSync(dir, constants.W_OK);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('a permission-denied ~/.aka', () => {
+  it('refuses the open, naming the path it could not create', (ctx) => {
+    mkdirSync(home, { recursive: true });
+    chmodSync(home, 0o000);
+    if (!deniesWrite(home)) {
+      ctx.skip('the mode change does not deny access here (Windows, or running as root)');
+      return;
+    }
+
+    const err = errorFrom(() => openLocalDatabase(dataDir(home)));
+
+    expect(err).toBeDefined();
+    expect((err as { code?: string }).code).toBe('EACCES');
+    // The path is the whole diagnosis: the user has to be able to tell which
+    // directory to fix from the message alone.
+    expect(err?.message).toContain(dataDir(home));
+  });
+
+  it('stays refusing across repeated attempts', (ctx) => {
+    mkdirSync(home, { recursive: true });
+    chmodSync(home, 0o000);
+    if (!deniesWrite(home)) {
+      ctx.skip('the mode change does not deny access here (Windows, or running as root)');
+      return;
+    }
+
+    // A hook fires per tool call and a dashboard request comes back on every
+    // reload, so the retry is the normal case, not the exception. Nothing here
+    // may be left half-created for the next attempt to trip over.
+    for (let i = 0; i < 3; i += 1) {
+      expect(
+        (errorFrom(() => openLocalDatabase(dataDir(home))) as { code?: string } | undefined)?.code,
+      ).toBe('EACCES');
+    }
+  });
+
+  it('opens once the directory is readable again', (ctx) => {
+    // The positive control, and the reason the refusal above is safe to fix by
+    // hand: nothing about the store was damaged, only walled off.
+    mkdirSync(home, { recursive: true });
+    chmodSync(home, 0o000);
+    if (!deniesWrite(home)) {
+      ctx.skip('the mode change does not deny access here (Windows, or running as root)');
+      return;
+    }
+    // Refused FIRST, then widened. Without this the case only shows that
+    // openLocalDatabase works on a 0700 directory — which every other test
+    // here already shows — and it would pass unchanged with the 0000 line
+    // deleted.
+    expect(errorFrom(() => openLocalDatabase(dataDir(home)))).toBeDefined();
+    chmodSync(home, 0o700);
+
+    const db = openLocalDatabase(dataDir(home));
+    expect(db).toBeDefined();
+    db.close();
+  });
+
+  it('is undone by ensureDataDirSync where the directory is ours to widen', (ctx) => {
+    // Worth writing down because it is why the fault above needs `~/.aka`
+    // itself to be denied. An owner can always chmod their own directory back,
+    // and `ensureDataDirSync` does exactly that — so a merely tightened
+    // *data* dir never reaches SQLite as a fault at all.
+    mkdirSync(dataDir(home), { recursive: true });
+    chmodSync(dataDir(home), 0o500);
+    if (!deniesWrite(dataDir(home))) {
+      ctx.skip('the mode change does not deny access here (Windows, or running as root)');
+      return;
+    }
+
+    ensureDataDirSync(dataDir(home));
+
+    expect(deniesWrite(dataDir(home))).toBe(false);
+  });
+});
+
+describe('a ~/.aka that is a regular file', () => {
+  it('refuses the open, naming the path', () => {
+    writeFileSync(home, 'not a directory\n');
+
+    const err = errorFrom(() => openLocalDatabase(dataDir(home)));
+
+    expect(err).toBeDefined();
+    // ENOTDIR is the honest report: a path component that has to be a
+    // directory is not one. It is also all the caller gets — nothing in the
+    // package looks at this to say WHICH component, so a reader has to work
+    // that out from the path in the message.
+    expect((err as { code?: string }).code).toBe('ENOTDIR');
+    expect(err?.message).toContain(dataDir(home));
+  });
+
+  it('leaves the file exactly as it found it', () => {
+    // The store never overwrites what it found: whatever the user actually put
+    // at `~/.aka` is still theirs after a failed open, which is what makes
+    // "move it aside" a safe instruction to give them.
+    const original = 'not a directory — someone else owns this path\n';
+    writeFileSync(home, original);
+
+    expect(errorFrom(() => openLocalDatabase(dataDir(home)))).toBeDefined();
+
+    expect(readFileSync(home, 'utf8')).toBe(original);
+    expect(statSync(home).isFile()).toBe(true);
+  });
+
+  it('opens once the file is moved aside', () => {
+    // The positive control, and the recovery a user is told to perform.
+    writeFileSync(home, 'not a directory\n');
+    expect(errorFrom(() => openLocalDatabase(dataDir(home)))).toBeDefined();
+
+    rmSync(home, { force: true });
+
+    const db = openLocalDatabase(dataDir(home));
+    expect(db).toBeDefined();
+    db.close();
+  });
+});

--- a/packages/persistence/test/faults/locked-store.test.ts
+++ b/packages/persistence/test/faults/locked-store.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Another process holding the store's write lock for longer than we will wait.
+ *
+ * This is the fault the product's architecture makes ordinary rather than
+ * exotic: three processes share one file, `busy_timeout` is the entire
+ * contention mitigation, and there is no retry or backoff anywhere behind it.
+ * Past that timeout the write is simply dropped, and nothing counts it.
+ *
+ * Every contended write here costs a full `busy_timeout` (2 s for a
+ * `LocalDatabase`), so the contended count per test is kept deliberately small.
+ * A raw handle sets no `busy_timeout` at all and is refused immediately, which
+ * is why the code-level assertions use one.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { openLocalDatabase } from '../../src/database.ts';
+import { failOpenTransaction } from '../../src/internal/transactions.ts';
+import { captureEvent, captureFinding } from '../helpers/capture-fixtures.ts';
+import { errorFrom } from '../helpers/errors.ts';
+import { lockStore, primaryCode, SQLITE_BUSY } from '../helpers/fault-injection.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
+import { assertNoOpenTransaction } from '../helpers/transactions.ts';
+
+const store = useTempStore('aka-fault-locked-');
+
+describe('a capture that loses the write lock', () => {
+  it('drops the event silently — no throw, no row, no signal', async () => {
+    const db = store.open();
+    const seeded = captureEvent();
+    db.recordCapture(seeded, [captureFinding(seeded.id)]);
+    const before = (await db.findings.recentFindings()).length;
+
+    // The victim's handle is opened first on purpose: `openLocalDatabase`
+    // writes on the way in, so opening under a held lock fails outright rather
+    // than reaching the write this case is about.
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+    const lost = captureEvent();
+    const err = errorFrom(() => {
+      db.recordCapture(lost, [captureFinding(lost.id)]);
+    });
+    lock.release();
+
+    // Fail-open holds: the host session never learns anything went wrong.
+    expect(err).toBeUndefined();
+    // And this is the cost of it. The event is gone, and the store carries no
+    // counter, no marker and no log line saying so — an audit trail with a
+    // hole in it that reads exactly like one without.
+    expect((await db.findings.recentFindings()).length).toBe(before);
+  });
+
+  it('keeps serving reads while the writer is locked out', async () => {
+    const db = store.open();
+    const seeded = captureEvent();
+    db.recordCapture(seeded, [captureFinding(seeded.id)]);
+
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+    // WAL gives readers a snapshot that a held write lock does not block, so
+    // the dashboard and `aka stats` stay accurate about what the store already
+    // holds while captures are being dropped.
+    const health = await db.findings.healthSummary();
+    lock.release();
+
+    expect(health.findings).toBe(1);
+  });
+
+  it('records normally again as soon as the lock is gone', async () => {
+    // The positive control: the drop above was the contention, not a store
+    // this suite had already broken.
+    const db = store.open();
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+    const lost = captureEvent();
+    db.recordCapture(lost, [captureFinding(lost.id)]);
+    lock.release();
+
+    const kept = captureEvent();
+    db.recordCapture(kept, [captureFinding(kept.id)]);
+    expect((await db.findings.recentFindings()).length).toBe(1);
+  });
+});
+
+describe('the SQLITE_BUSY fail-open branch', () => {
+  it('names the failure as contention when the caller does not swallow it', () => {
+    store.open().close();
+    // A raw handle carries no `busy_timeout`, so it is refused at once instead
+    // of waiting the 2 s a `LocalDatabase` would — the same code, without
+    // paying for it.
+    const raw = store.openRaw();
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+    const err = errorFrom(() => {
+      raw.exec('BEGIN IMMEDIATE');
+    });
+    lock.release();
+
+    expect(primaryCode(err)).toBe(SQLITE_BUSY);
+  });
+
+  it('is swallowed by the shared envelope, which reports only that nothing committed', () => {
+    store.open().close();
+    const raw = store.openRaw();
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+    const committed = failOpenTransaction(
+      raw,
+      () => {
+        raw.exec('CREATE TABLE fault_probe (id INTEGER PRIMARY KEY)');
+      },
+      'IMMEDIATE',
+    );
+    lock.release();
+
+    // Indistinguishable from a full disk, a read-only store, or a caller bug —
+    // all four arrive here as `false`, and the four sites in `database.ts` that
+    // call this discard it.
+    expect(committed).toBe(false);
+    assertNoOpenTransaction(raw);
+  });
+});
+
+describe('opening a store whose write lock is held', () => {
+  it('fails rather than blocking forever, because the open itself writes', () => {
+    store.open().close();
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+
+    // `PRAGMA journal_mode = WAL`, the migration applier and the `ensure*`
+    // passes all write, so a contended open is refused once `busy_timeout`
+    // runs out. For a hook that means no gateway at all — which is the one
+    // failure a caller can still turn into a message to the user.
+    const err = errorFrom(() => openLocalDatabase(store.dataDir));
+    lock.release();
+
+    expect(err).toBeDefined();
+    expect(primaryCode(err)).toBe(SQLITE_BUSY);
+  });
+
+  it('opens normally once the lock is released', () => {
+    // The positive control for the refusal above.
+    store.open().close();
+    const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+    lock.release();
+
+    const db = openLocalDatabase(store.dataDir);
+    expect(db).toBeDefined();
+    db.close();
+  });
+});

--- a/packages/persistence/test/faults/locked-store.test.ts
+++ b/packages/persistence/test/faults/locked-store.test.ts
@@ -54,9 +54,14 @@ describe('a capture that loses the write lock', () => {
     db.recordCapture(seeded, [captureFinding(seeded.id)]);
 
     const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
-    // WAL gives readers a snapshot that a held write lock does not block, so
-    // the dashboard and `aka stats` stay accurate about what the store already
-    // holds while captures are being dropped.
+    // The dropped write comes FIRST: reading while a lock is merely held
+    // proves nothing, because `BEGIN IMMEDIATE` takes RESERVED, which blocks
+    // no reader in any journal mode. What has to be shown is that a reader
+    // still answers on a connection that has just lost a write on this store —
+    // the dashboard and `aka stats` staying accurate about what is already
+    // there while captures are being dropped.
+    const lost = captureEvent();
+    db.recordCapture(lost, [captureFinding(lost.id)]);
     const health = await db.findings.healthSummary();
     lock.release();
 
@@ -110,9 +115,15 @@ describe('the SQLITE_BUSY fail-open branch', () => {
     lock.release();
 
     // Indistinguishable from a full disk, a read-only store, or a caller bug —
-    // all four arrive here as `false`, and the four sites in `database.ts` that
-    // call this discard it.
+    // all four arrive here as `false`, and the sites in `database.ts` that call
+    // this discard it.
     expect(committed).toBe(false);
+    // True by construction rather than by containment: `withTransaction` issues
+    // its BEGIN OUTSIDE the try, so a contended `BEGIN IMMEDIATE` throws before
+    // the ROLLBACK branch is reachable. The branch that unwinds a transaction
+    // that DID open is pinned in `readonly-store.test.ts` instead — it is the
+    // one fault whose failure lands inside `fn()`. Kept here because a
+    // transaction left open by any path would be worse than the fault.
     assertNoOpenTransaction(raw);
   });
 });

--- a/packages/persistence/test/faults/readonly-store.test.ts
+++ b/packages/persistence/test/faults/readonly-store.test.ts
@@ -27,19 +27,22 @@ describe('opening a read-only store', () => {
       return;
     }
 
-    // The open writes before it reads anything: `PRAGMA journal_mode = WAL` is
-    // the first statement, so a store this process cannot write is refused
-    // there — ahead of the migration applier, the repository constructors and
-    // the policy seed. Loudly is the right posture: `openLocalDatabase` is the
-    // one place a caller can still decide to tell the user, and every caller
-    // that swallows this instead is a session running with detection off.
+    // Where this lands is not where the fault's name suggests. `PRAGMA
+    // journal_mode = WAL` SUCCEEDS on an already-WAL store — it even mints the
+    // -wal/-shm sidecars, at the db's own 0400 — and the refusal comes later,
+    // out of `ensureWriteGateTrigger` inside `applyMigrations`, one of the
+    // `ensure*` passes that run on every open. So the applier does run here.
+    //
+    // What matters is only that it is loud: `openLocalDatabase` is the one
+    // place a caller can still decide to tell the user, and every caller that
+    // swallows this instead is a session running with detection off.
     const err = errorFrom(() => openLocalDatabase(store.dataDir));
 
     expect(err).toBeDefined();
     expect(primaryCode(err)).toBe(SQLITE_READONLY);
   });
 
-  it('keeps refusing across repeated attempts, without accumulating handles', (ctx) => {
+  it('keeps refusing across repeated attempts', (ctx) => {
     store.open().close();
     const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
     if (!readOnly.effective) {
@@ -48,10 +51,15 @@ describe('opening a read-only store', () => {
     }
 
     // The shape a user produces by retrying: the hook fires again on the next
-    // tool call, the dashboard request comes back. A handle kept per attempt
-    // holds the file open for the life of a long-lived reader, and on Windows
-    // the temp tree then refuses to be removed — which is what the teardown
-    // turns into the assertion.
+    // tool call, the dashboard request comes back. Each attempt must fail the
+    // same way rather than drifting to a different code as the earlier ones
+    // leave sidecars behind.
+    //
+    // Deliberately NOT a handle-leak assertion. `database.ts` does guard that
+    // (`closeQuietly` on both throw paths), but nothing here can observe it:
+    // POSIX lets an open handle be unlinked, and `temp-store.ts` SWALLOWS
+    // EPERM/EBUSY/EACCES/ENOTEMPTY on win32 by design — so a leak would leave
+    // this green on both platforms, and this case skips on Windows anyway.
     for (let i = 0; i < 5; i += 1) {
       expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
     }
@@ -105,12 +113,19 @@ describe('opening a read-only store', () => {
       return;
     }
     for (let i = 0; i < 3; i += 1)
-      expect(errorFrom(() => openLocalDatabase(store.dataDir))).toBeDefined();
+      expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
     readOnly.restore();
 
-    // The refusal lands on the first PRAGMA, so the migration applier never
-    // runs: a store that cannot be written cannot be half-migrated either.
+    // The applier DOES run on a read-only store — it reaches
+    // `ensureWriteGateTrigger` before anything refuses — so "the ledger is
+    // untouched" is a claim about a pass that really executed, not one that
+    // was skipped. It cannot record a tag it could not write.
     expect(tags()).toEqual(before);
+    // And the store is still usable once the mode is lifted: the refused opens
+    // left no half-applied schema for the next one to trip over.
+    const reopened = store.open();
+    expect(tags()).toEqual(before);
+    reopened.close();
   });
 });
 
@@ -164,8 +179,10 @@ describe('writing through a handle when the store turns read-only underneath it'
   });
 
   it('opens and writes again once the mode is restored', async (ctx) => {
-    // The positive control for every case above: the refusals were the mode
-    // and nothing permanent about this store or this temp tree.
+    // The positive control for every case above: the refusals were the mode,
+    // and lifting it is enough to undo them. Not quite "nothing changed" — a
+    // refused open mints -wal/-shm at the db's 0400, and this case passes only
+    // because `readOnlyStore.restore()` widens those too (see the helper).
     store.open().close();
     const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
     if (!readOnly.effective) {

--- a/packages/persistence/test/faults/readonly-store.test.ts
+++ b/packages/persistence/test/faults/readonly-store.test.ts
@@ -1,0 +1,239 @@
+/**
+ * A store the process may read but not write.
+ *
+ * `SQLITE_READONLY` is one of the result codes the package never inspects: the
+ * fail-open paths swallow it exactly as they swallow a caller bug. So what is
+ * worth pinning is not that the write fails — it is *where* the failure lands,
+ * because that decides whether the user is ever told. The refusal is loud at
+ * open and silent at write, and the two reach very different callers.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { openLocalDatabase } from '../../src/database.ts';
+import { failOpenTransaction } from '../../src/internal/transactions.ts';
+import { captureEvent, captureFinding } from '../helpers/capture-fixtures.ts';
+import { errorFrom } from '../helpers/errors.ts';
+import { primaryCode, readOnlyStore, SQLITE_READONLY } from '../helpers/fault-injection.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
+
+const store = useTempStore('aka-fault-readonly-');
+
+describe('opening a read-only store', () => {
+  it('refuses with SQLITE_READONLY rather than returning a half-open store', (ctx) => {
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+
+    // The open writes before it reads anything: `PRAGMA journal_mode = WAL` is
+    // the first statement, so a store this process cannot write is refused
+    // there — ahead of the migration applier, the repository constructors and
+    // the policy seed. Loudly is the right posture: `openLocalDatabase` is the
+    // one place a caller can still decide to tell the user, and every caller
+    // that swallows this instead is a session running with detection off.
+    const err = errorFrom(() => openLocalDatabase(store.dataDir));
+
+    expect(err).toBeDefined();
+    expect(primaryCode(err)).toBe(SQLITE_READONLY);
+  });
+
+  it('keeps refusing across repeated attempts, without accumulating handles', (ctx) => {
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+
+    // The shape a user produces by retrying: the hook fires again on the next
+    // tool call, the dashboard request comes back. A handle kept per attempt
+    // holds the file open for the life of a long-lived reader, and on Windows
+    // the temp tree then refuses to be removed — which is what the teardown
+    // turns into the assertion.
+    for (let i = 0; i < 5; i += 1) {
+      expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
+    }
+  });
+
+  it('reports SQLITE_READONLY, not SQLITE_READONLY_DIRECTORY, even with the data dir tightened too', (ctx) => {
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, {
+      includeDir: true,
+      onCleanup: store.onCleanup,
+    });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+
+    // A 0500 data dir would stop SQLite creating its -wal/-shm sidecars and
+    // give the directory-flavoured refinement instead. It never gets that far:
+    // `openLocalDatabase` calls `ensureDataDirSync` first, which chmods the
+    // directory back to 0700 — an owner can always re-widen their own
+    // directory — so by the time SQLite looks, only the file mode is left.
+    // Anything asserting the directory refinement here would be asserting a
+    // code the product cannot reach through this entry point.
+    expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
+  });
+
+  it('changes nothing about the store — the schema it refused to open is intact', (ctx) => {
+    const seeded = store.open();
+    const ev = captureEvent();
+    seeded.recordCapture(ev, [captureFinding(ev.id)]);
+    seeded.close();
+
+    const tags = (): string[] => {
+      const raw = store.openRaw();
+      try {
+        return (
+          raw.prepare('SELECT tag FROM migration_ledger ORDER BY tag').all() as {
+            tag: string;
+          }[]
+        ).map((row) => row.tag);
+      } finally {
+        raw.close();
+      }
+    };
+    const before = tags();
+    expect(before.length).toBeGreaterThan(0);
+
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+    for (let i = 0; i < 3; i += 1)
+      expect(errorFrom(() => openLocalDatabase(store.dataDir))).toBeDefined();
+    readOnly.restore();
+
+    // The refusal lands on the first PRAGMA, so the migration applier never
+    // runs: a store that cannot be written cannot be half-migrated either.
+    expect(tags()).toEqual(before);
+  });
+});
+
+// There is deliberately no "recordCapture fails open under a read-only store"
+// case here, because there is no such state to reach: the mode does not deny an
+// already-open handle (below), and a handle opened afterwards never exists — the
+// open is refused first. A test that chmods and then asserts recordCapture did
+// not throw would be asserting that a write which SUCCEEDED did not throw, and
+// would stay green with the fail-open envelope removed entirely. `recordCapture`
+// swallowing a real store failure is pinned by the contended case in
+// `locked-store.test.ts`, which does reach it.
+describe('writing through a handle when the store turns read-only underneath it', () => {
+  it('keeps writing through an already-open handle: the mode is checked at open, not at write', async (ctx) => {
+    // Worth writing down because it is the opposite of what the fault's name
+    // suggests. A descriptor carries the permission it was opened with, so
+    // chmod'ing the store out from under a live connection revokes nothing —
+    // the hook that was already running finishes recording normally, and only
+    // the NEXT process is refused. A read-only store therefore loses no data
+    // from a session already in flight.
+    const db = store.open();
+    const seeded = captureEvent();
+    db.recordCapture(seeded, [captureFinding(seeded.id)]);
+    const before = (await db.findings.recentFindings()).length;
+
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+    const ev = captureEvent();
+    db.recordCapture(ev, [captureFinding(ev.id)]);
+
+    expect((await db.findings.recentFindings()).length).toBe(before + 1);
+  });
+
+  it('keeps serving reads', async (ctx) => {
+    const db = store.open();
+    const ev = captureEvent();
+    db.recordCapture(ev, [captureFinding(ev.id)]);
+
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+
+    // The dashboard and `aka stats` are readers. Denying writes must not take
+    // the read surfaces with it, or a store the user was told to leave alone
+    // would also stop reporting what it already holds.
+    expect((await db.findings.healthSummary()).findings).toBe(1);
+  });
+
+  it('opens and writes again once the mode is restored', async (ctx) => {
+    // The positive control for every case above: the refusals were the mode
+    // and nothing permanent about this store or this temp tree.
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+    // Refused FIRST, then restored. Without this the case only shows that
+    // applying and undoing the mode is a round trip — it would pass unchanged
+    // against an injector that had stopped chmod'ing anything at all, which is
+    // precisely the state it exists to rule out.
+    expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
+    readOnly.restore();
+
+    const db = openLocalDatabase(store.dataDir);
+    const ev = captureEvent();
+    db.recordCapture(ev, [captureFinding(ev.id)]);
+    expect((await db.findings.recentFindings()).length).toBe(1);
+    db.close();
+  });
+});
+
+describe('the SQLITE_READONLY fail-open branch', () => {
+  it('swallows the refusal and reports it as a failed write', (ctx) => {
+    // The branch the product actually takes, reached over a raw handle because
+    // `LocalDatabase` opens its own connection and the mode has to be in place
+    // before that open. `failOpenTransaction` is the shared envelope every
+    // blanket fail-open site in `database.ts` uses, so this is that code path,
+    // not a lookalike.
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+    const raw = store.openRaw();
+
+    const committed = failOpenTransaction(raw, () => {
+      raw.exec('CREATE TABLE fault_probe (id INTEGER PRIMARY KEY)');
+    });
+
+    // `false` is the whole signal a caller gets. It does not say read-only, and
+    // no caller in the package reads it — the four sites in `database.ts`
+    // discard it. That is the documented behaviour, not an oversight this test
+    // is asserting away.
+    expect(committed).toBe(false);
+    // The fault was contained: a transaction left open here would hold the
+    // connection's locks and silently enrol every later write on it.
+    expect(raw.isTransaction).toBe(false);
+  });
+
+  it('raises SQLITE_READONLY when the caller does not swallow it', (ctx) => {
+    // The same write without the envelope, so the code the envelope is hiding
+    // is named at least once. Without this the suite would pin only that
+    // something failed.
+    store.open().close();
+    const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+    if (!readOnly.effective) {
+      ctx.skip('the mode change does not deny writes here (Windows, or running as root)');
+      return;
+    }
+    const raw = store.openRaw();
+
+    expect(
+      primaryCode(
+        errorFrom(() => {
+          raw.exec('CREATE TABLE fault_probe (id INTEGER PRIMARY KEY)');
+        }),
+      ),
+    ).toBe(SQLITE_READONLY);
+  });
+});

--- a/packages/persistence/test/helpers/capture-fixtures.ts
+++ b/packages/persistence/test/helpers/capture-fixtures.ts
@@ -27,9 +27,26 @@ export function captureEvent(overrides: Partial<IngestEvent> = {}): IngestEvent 
   };
 }
 
+/**
+ * `distinct` defaults to a fresh value per call, and that default is
+ * load-bearing rather than tidy.
+ *
+ * `maskedMatch` is half of the FINDING-level session dedup key —
+ * `recordCapture` skips a finding when `(ruleId, maskedMatch, sessionId)` has
+ * already been seen (`database.ts`, `isSessionDuplicate`). A shared constant
+ * would therefore make a second capture in the same session land as zero rows
+ * **by design**, which is indistinguishable from the write having been dropped:
+ * every "the event is gone" assertion in `test/faults/` would pass whether or
+ * not the fault did anything. That needs only a caller setting
+ * `metadata.sessionId` — one field — so the value varies here instead of
+ * relying on nobody adding it.
+ *
+ * Pass an explicit `distinct` to exercise the dedup on purpose.
+ */
 export function captureFinding(
   eventId: string,
   overrides: Partial<DetectedFinding> = {},
+  distinct: string = randomUUID().slice(0, 8),
 ): DetectedFinding {
   return {
     id: randomUUID(),
@@ -38,7 +55,7 @@ export function captureFinding(
     category: 'secret',
     severity: 'critical',
     span: { start: 0, end: 4 },
-    maskedMatch: 'A***E',
+    maskedMatch: `A***${distinct}`,
     actionTaken: 'block',
     confidence: 0.9,
     ...overrides,

--- a/packages/persistence/test/helpers/capture-fixtures.ts
+++ b/packages/persistence/test/helpers/capture-fixtures.ts
@@ -1,0 +1,46 @@
+/**
+ * The minimal `recordCapture` pair — one event and one already-masked finding.
+ *
+ * A fault test cares about whether a write landed, not about what was in it, so
+ * these carry the smallest valid shape rather than a realistic one. Both mint a
+ * fresh id and `contentHash` per call: `recordCapture` is content-addressed on
+ * (sessionId, contentHash, filePath), so reusing either would collapse two
+ * captures onto one audit row and make a dropped write indistinguishable from a
+ * deduped one.
+ *
+ * `maskedMatch` is a masked preview by contract — the SDK masks before calling —
+ * so nothing here is a raw value, and it matches no rule.
+ */
+import { randomUUID } from 'node:crypto';
+
+import type { DetectedFinding, IngestEvent } from '@akasecurity/schema';
+
+export function captureEvent(overrides: Partial<IngestEvent> = {}): IngestEvent {
+  return {
+    id: randomUUID(),
+    sourceTool: 'claude-code',
+    kind: 'prompt',
+    occurredAt: new Date().toISOString(),
+    contentHash: `hash-${randomUUID()}`,
+    content: 'a prompt worth recording',
+    ...overrides,
+  };
+}
+
+export function captureFinding(
+  eventId: string,
+  overrides: Partial<DetectedFinding> = {},
+): DetectedFinding {
+  return {
+    id: randomUUID(),
+    eventId,
+    ruleId: 'secrets/aws-access-key',
+    category: 'secret',
+    severity: 'critical',
+    span: { start: 0, end: 4 },
+    maskedMatch: 'A***E',
+    actionTaken: 'block',
+    confidence: 0.9,
+    ...overrides,
+  };
+}

--- a/packages/persistence/test/helpers/errors.ts
+++ b/packages/persistence/test/helpers/errors.ts
@@ -1,0 +1,34 @@
+/**
+ * Capture the error a thunk threw, OUTSIDE its own catch.
+ *
+ * The shape this replaces asserts on the test's own guard rather than on the
+ * code under test:
+ *
+ * ```ts
+ * try {
+ *   open(store);
+ *   throw new Error('expected open to throw'); // caught by its own catch
+ * } catch (err) {
+ *   expect(primaryCode(err)).toBe(SQLITE_READONLY); // asserts on THAT error
+ * }
+ * ```
+ *
+ * A function that stops throwing entirely still satisfies it. Here a
+ * never-thrown error arrives as `undefined`, so `toBeDefined()` — or a
+ * `primaryCode()` comparison, which yields `undefined` for a non-error — is
+ * what catches it. Assert what the error SAYS before asserting what it omits:
+ * naming the expected refusal is the positive control, without which a case
+ * proves only that *some* error was raised, not that the guarded branch was the
+ * one reached.
+ *
+ * The plugin package carries its own copy in `test/helpers/no-echo.ts`; a
+ * package wall blocks the import, not the pattern.
+ */
+export function errorFrom(fn: () => unknown): Error | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err as Error;
+  }
+}

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -5,7 +5,7 @@ import { DatabaseSync } from 'node:sqlite';
 import { describe, expect, it } from 'vitest';
 
 import { openLocalDatabase } from '../../src/database.ts';
-import { dbSidecars } from '../../src/paths.ts';
+import { DATA_FILE_MODE, dbSidecars } from '../../src/paths.ts';
 import {
   corruptStore,
   fillStore,
@@ -336,6 +336,45 @@ describe('readOnlyStore', () => {
       // `& 0o7777`, and restoring anything wider than the permission bits would
       // still let this write through.
       expect(statSync(store.dbFile).mode & 0o7777).toBe(before);
+    });
+  });
+
+  it('restore() also widens sidecars SQLite created while the store was read-only', (ctx) => {
+    if (process.platform === 'win32') ctx.skip('chmod is a no-op for the sidecars on Windows');
+    withTempStore((store) => {
+      seedStore(store);
+      // A closed store has no -wal/-shm, so the fault is applied to the db file
+      // alone and SQLite MINTS the sidecars during the refused open below —
+      // at the db's own mode, which is 0400 by then. They are therefore absent
+      // from the target list restore() walks, and nothing else will widen them.
+      for (const sidecar of dbSidecars(store.dbFile)) {
+        expect(existsSync(sidecar)).toBe(false);
+      }
+
+      const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
+      if (!readOnly.effective) ctx.skip(MODES_IGNORED);
+      try {
+        openLocalDatabase(store.dataDir);
+      } catch {
+        // Refused, as this whole file expects — the point is what it left behind.
+      }
+      const minted = dbSidecars(store.dbFile).filter((path) => existsSync(path));
+      // The positive control: without a sidecar to leave behind, everything
+      // below passes vacuously.
+      expect(minted.length).toBeGreaterThan(0);
+
+      readOnly.restore();
+
+      // The store is usable again, not merely readable. Asserting only the db
+      // file's own mode would pass with every sidecar still at 0400, and the
+      // failure that leaves behind surfaces deep inside the migration applier
+      // on the NEXT open rather than here.
+      for (const sidecar of minted) {
+        expect(statSync(sidecar).mode & 0o777).toBe(DATA_FILE_MODE);
+      }
+      expect(() => {
+        openLocalDatabase(store.dataDir).close();
+      }).not.toThrow();
     });
   });
 });

--- a/packages/persistence/test/helpers/fault-injection.test.ts
+++ b/packages/persistence/test/helpers/fault-injection.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 import { openLocalDatabase } from '../../src/database.ts';
 import { DATA_FILE_MODE, dbSidecars } from '../../src/paths.ts';
+import { errorFrom } from './errors.ts';
 import {
   corruptStore,
   fillStore,
@@ -353,11 +354,10 @@ describe('readOnlyStore', () => {
 
       const readOnly = readOnlyStore(store.dbFile, { onCleanup: store.onCleanup });
       if (!readOnly.effective) ctx.skip(MODES_IGNORED);
-      try {
-        openLocalDatabase(store.dataDir);
-      } catch {
-        // Refused, as this whole file expects — the point is what it left behind.
-      }
+      // Named rather than swallowed: a bare catch here would keep this green if
+      // the refusal ever moved to a different failure (tightenPerms ahead of
+      // applyMigrations, say), with the fix under test removed.
+      expect(primaryCode(errorFrom(() => openLocalDatabase(store.dataDir)))).toBe(SQLITE_READONLY);
       const minted = dbSidecars(store.dbFile).filter((path) => existsSync(path));
       // The positive control: without a sidecar to leave behind, everything
       // below passes vacuously.

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -31,7 +31,7 @@ import { dirname } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { Worker } from 'node:worker_threads';
 
-import { dbSidecars } from '../../src/paths.ts';
+import { DATA_FILE_MODE, dbSidecars } from '../../src/paths.ts';
 import type { TempStore } from './temp-store.ts';
 
 /**
@@ -324,19 +324,18 @@ export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): Re
       // arrive at 0400 and the target list above has never heard of them.
       // Leaving them is not a cosmetic miss: the db reads writable again while
       // its -wal does not, so the next open gets past `PRAGMA journal_mode`
-      // and dies deep inside the migration applier instead, and on Windows a
-      // 0400 sidecar can block the very tree removal this restore exists to
-      // enable. Hand them the mode the db itself was holding, which is what
-      // the product holds its sidecars at.
-      const fileMode = original.get(file);
-      if (fileMode !== undefined) {
-        for (const sidecar of dbSidecars(file)) {
-          if (original.has(sidecar) || !existsSync(sidecar)) continue;
-          try {
-            chmodSync(sidecar, fileMode);
-          } catch {
-            // Vanished between the check and here, or a platform without modes.
-          }
+      // and dies deep inside the migration applier instead. Hand them the mode
+      // the product holds its sidecars at (`tightenPerms` → DATA_FILE_MODE),
+      // not the db's observed mode — those agree only while every fixture is
+      // 0600, and a 0640 db would otherwise mint sidecars at a mode
+      // `tightenPerms` can never produce while the self-test asserts the
+      // constant.
+      for (const sidecar of dbSidecars(file)) {
+        if (original.has(sidecar) || !existsSync(sidecar)) continue;
+        try {
+          chmodSync(sidecar, DATA_FILE_MODE);
+        } catch {
+          // Vanished between the check and here, or a platform without modes.
         }
       }
     },
@@ -499,12 +498,15 @@ export interface FilledStore {
  * store is unaffected, so this fills the store for the handle passed in and
  * that handle only. A genuinely full filesystem stays out of reach in CI.
  *
- * That connection scope is also the limit of this injector. It takes a raw
- * `DatabaseSync`, and `LocalDatabase` exposes none, so no disk-full fault can
- * be aimed at `recordCapture` or any other repository write today — this
- * injector currently reaches node:sqlite, not the package built on it. Closing
- * that gap needs either a raw-handle seam on `LocalDatabase` or repositories
- * driven over a raw handle, as `activity.test.ts` already does.
+ * That connection scope is what decides its reach. A repository constructed
+ * over a raw handle takes the cap (`SqliteAuditEventsRepository(raw)`, the
+ * `activity.test.ts` pattern), and so does `applyMigrations` — `test/faults/
+ * disk-full.test.ts` drives both. What stays out of reach is the four blanket
+ * fail-open sites in `database.ts` (`recordCapture`, `ensureInventory`,
+ * `recordConfigScan`, `recordProjectFiles`) and `reconcileWorktreeProjects`:
+ * all of them close over the connection `openLocalDatabase` opened, and
+ * `LocalDatabase` exposes no accessor for it. Aiming a connection-scoped fault
+ * at those needs a raw-handle seam.
  */
 export function fillStore(db: DatabaseSync, opts: { headroomPages?: number } = {}): FilledStore {
   const readPragma = (name: string): number => {

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -319,6 +319,26 @@ export function readOnlyStore(file: string, opts: ReadOnlyStoreOptions = {}): Re
           // Already gone, or a platform that never applied the mode.
         }
       }
+      // Sidecars SQLite created WHILE the store was read-only have no original
+      // mode to put back — and they are born at the db file's mode, so they
+      // arrive at 0400 and the target list above has never heard of them.
+      // Leaving them is not a cosmetic miss: the db reads writable again while
+      // its -wal does not, so the next open gets past `PRAGMA journal_mode`
+      // and dies deep inside the migration applier instead, and on Windows a
+      // 0400 sidecar can block the very tree removal this restore exists to
+      // enable. Hand them the mode the db itself was holding, which is what
+      // the product holds its sidecars at.
+      const fileMode = original.get(file);
+      if (fileMode !== undefined) {
+        for (const sidecar of dbSidecars(file)) {
+          if (original.has(sidecar) || !existsSync(sidecar)) continue;
+          try {
+            chmodSync(sidecar, fileMode);
+          } catch {
+            // Vanished between the check and here, or a platform without modes.
+          }
+        }
+      }
     },
   };
   opts.onCleanup?.(() => {


### PR DESCRIPTION
The read-only and disk-full fault injectors had no consumer outside their own self-tests, so the `SQLITE_READONLY` and `SQLITE_FULL` branches were unreached by any test of production code. This points them at `openLocalDatabase`, the repositories and the shared transaction envelopes, and fixes two real defects found on the way.

## What lands

**`packages/persistence/test/faults/` — one file per fault**

| Fault | Injected with | Pinned behaviour |
| --- | --- | --- |
| Read-only store | `readOnlyStore` (0400) | `openLocalDatabase` refuses with `SQLITE_READONLY` before the migration applier runs; reads keep working; the fail-open envelope reports only `false` |
| Contended store | `lockStore` past `busy_timeout` | `recordCapture` drops the event silently — no throw, no row, no signal; reads unaffected; a contended open is refused rather than blocking |
| Disk full | `fillStore` | `SQLITE_FULL` rolls the whole batch back — no partial rows, no open transaction, `integrity_check` still `ok`, store re-openable; nested `failOpenTransaction` rethrows because the caller's transaction is gone; a capped `applyMigrations` records no ledger tag |
| Hostile `~/.aka` | `chmod 0000` / a regular file | `EACCES` and `ENOTDIR` respectively, each naming the path; the occupying file is left untouched |

Each case documents the **actual** behaviour rather than the desirable one. The store inspects no SQLite result code beyond `SQLITE_CONSTRAINT_UNIQUE`, so contention, a full disk, a read-only file and a caller bug all arrive at the fail-open sites as the same discarded `false`, and a dropped event leaves no counter, marker or log line behind. That is asserted as-is rather than asserted away.

**Two behaviours are the opposite of what the fault's name suggests**, and are pinned so nobody "fixes" them:

- A store chmod'd read-only under a **live** handle keeps being written — a descriptor carries the permission it was opened with, so only the *next* open is refused.
- A `0000` `~/.aka` is **repaired**, not reported: `ensureDataDirSync` chmods a directory the owner still owns back to 0700.

## Two defects fixed

- **`readOnlyStore.restore()` did not restore.** It snapshots its target list when the fault is applied, so `-wal`/`-shm` files SQLite mints *while* the store is 0400 are born at that mode and were never widened back. The db then reads writable while its WAL does not, and the next open dies inside the migration applier instead of at the open; on Windows a 0400 sidecar can also block the tree removal `restore()` exists to enable.
- **`aka init` surfaced the raw `mkdir` failure** when something already sat where the store goes — `EEXIST` at the base (whose "file already exists" reads as *"this is already done"*) and `ENOTDIR` deeper down, which names the one path component that is *not* the problem. It now refuses up front naming the occupied path, and reports a symlink as a symlink with its target, since telling a user to move "that file" aside points them at the target rather than at the link.

## Verification

Every new assertion was checked by breaking the thing it claims to guard, and each survivor is noted rather than hidden:

| Mutation | Result |
| --- | --- |
| `fillStore` stops capping | 8/8 disk-full red |
| `lockStore` takes no write lock | 5/7 locked red (2 non-discriminating by design) |
| Drop the new `aka init` guard | 3 red, on the raw `EEXIST` message |
| `withTransaction`'s `ROLLBACK` → no-op | 1 red (`SQLITE_FULL` self-rolls-back, so only the read-only case discriminates this) |
| Drop `failOpenTransaction`'s nested rethrow | 1 red |
| `ensureDataDirSync` stops re-widening | 2 red |
| Neutralise the sidecar restore | 2 red |

Full workspace gate, all forced so nothing replays from cache: `test` 29/29 `Cached: 0` · `lint` 15/15 + `lint:root` · `typecheck` 15/15 + `typecheck:root` · `format:check` · `build` 15/15.

`persistence` 58 files / 856 tests · `cli` 179 tests.

## Also here

`CLAUDE.md`'s releasing section opened by asking which release type to use before touching any version. The bump happens on every release as a matter of course, so that gate only ever produced a question with one answer — it is now stated as routine mechanics. The version line named a `0.0.2-alpha` series both artifacts left long ago; following it would have been a regression from 0.9.4.

## Known limit

The four blanket fail-open sites in `database.ts` (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`) cannot be reached by a connection-scoped fault: they are closures over the connection `openLocalDatabase` opened, and `LocalDatabase` exposes no accessor for it. They take the same `failOpenTransaction` path this pins through the repositories. Aiming a disk-full fault directly at them needs a raw-handle seam, which is tracked separately.