### PR TITLE
fix(persistence): serialize settings.json writes behind a file lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,63 @@ Two `scan()` calls inside the SDK are not exposure: `mask.ts` and `tokenize.ts`'
 
 What remains uncovered is the packaged artifact: nothing installs the published CLI and drives its dashboard's folder scan under a hostile pack, so the chain above is proven link by link rather than end to end.
 
+### 6. Every writer of `settings.json` takes its lock
+
+`writeOwnerOnlyFileSync`'s tmp+rename makes each PUBLISH indivisible. It does not make a
+**read-modify-write** indivisible, and that is the shape every settings write has: read the file,
+merge answers over it, rename the result. The plugin, the CLI and the dashboard are three separate
+processes over one home, so two of them read the same bytes and the second rename discards the
+first one's answers — with both reporting success, because neither ever learns the other existed.
+
+`withFileLock` (`packages/persistence/src/file-lock.ts`) is the section around that pair. It is the
+existence of a sibling `<file>.lock`, taken with an exclusive create — `flock` has no Windows
+equivalent, and an fd-held lock is lost by any writer that opens the file a second time. Four
+properties are load-bearing:
+
+- **It is ADVISORY, and it is scoped to one file.** A writer that skips it is not excluded by the
+  ones that take it, so the guarantee is only as wide as the set of writers holding it. Two
+  writers hold it today: `applyOnboarding` (which the `/aka:setup` wizard and the dashboard's
+  Settings action both go through) and `aka init`'s create-if-absent. A third that writes
+  `settings.json` directly reopens the hole for both. **Other `~/.aka` files are NOT covered** —
+  `fingerprint.ts`'s key mint and `local-ops`' `update-cache.ts` are unlocked read-modify-writes
+  with the same shape, and each is its own outstanding fix. Do not read this section as a
+  property the store has; it is a property `settings.json` has.
+- **Anything derived from the current file is derived INSIDE it.** `applyOnboarding` takes an
+  updater function for exactly this: a caller that reads first and passes a plain object has put
+  its read outside the lock and kept the lost update, one frame further out. The dashboard's
+  vault-consent carry-forward is the worked example — read outside, it writes a grant back over a
+  concurrent revoke.
+- **It fails loudly rather than writing unlocked.** The fields at stake include the vault and
+  model-judge consent grants, so the write that goes missing can be a REVOCATION. A refused save
+  the user retries beats a silent one they never learn about.
+- **A killed holder must not wedge the file, and a slow one must not be evicted.** Taking an
+  abandoned lock needs BOTH that its own recorded acquire clock is older than the stale window and
+  that the pid it names is gone. Age alone evicts a holder that is merely suspended or throttled,
+  which puts two writers in the section — the defect, reintroduced by its own recovery. The clock
+  is read from the lock BODY, never from mtime, which on a network home is the file server's clock
+  and drifts a fresh lock straight into staleness. `FileLockError.reason` separates `timeout`
+  (contention) from `unavailable` (a directory that will never hold a lock); `aka init` branches on
+  it, swallowing the first — another writer is already creating the file — and propagating the
+  second, which is the fault its pre-lock write raised too.
+- **A release must prove it still owns the lock.** Each acquisition writes a token and removes the
+  file only while that token is still there — an unreadable body counts as somebody else's, since
+  a lock exists for an instant between its exclusive create and its body write. Unlinking by path
+  alone means a holder that was stolen from deletes its successor's lock, and the section is
+  unguarded while that successor is mid-write, every writer reporting success.
+- **Recovering an abandoned lock is itself a critical section**, held by a second exclusive file.
+  Several waiters meet the same dead lock at once; unserialised they all judge it stale, one
+  removes it and takes a fresh lock, and the next one's removal lands on THAT. Neither a rename
+  nor a re-read closes it — every check is separated from its removal by a window another waiter
+  acts in, and a rename that has to be undone clobbers whatever took the path meanwhile. Measured
+  at 5 of 12 trials losing an update with eight waiters over one abandoned lock; zero once the
+  judging and the removal became one section.
+
+`packages/persistence/test/concurrency/settings-race.test.ts` is what holds this: real child
+processes, released together on a readiness handshake, asserting no answer is lost and no
+revocation is resurrected. It uses processes rather than worker threads deliberately — a worker
+shares `process.pid`, and the atomic write's tmp path is per-process, so two threads meet a
+collision two processes never can, which is the wrong axis.
+
 ## Dependency advisories
 
 CI gates every PR (and a daily run) on two audits via `tools/audit-gate`: `pnpm audit`

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -10,9 +10,11 @@ import {
   pluginRef,
 } from '@akasecurity/local-ops';
 import {
+  FileLockError,
   keysDir,
   openLocalDatabase,
   tightenFile,
+  withFileLock,
   writeOwnerOnlyFileSync,
 } from '@akasecurity/persistence';
 import {
@@ -281,15 +283,41 @@ export async function runInit(argv: string[]): Promise<void> {
   // Don't clobber an existing settings.json — a re-run must preserve the user's
   // onboarding choices (runMode/policy/historicalAccess). Only write defaults on
   // first init.
-  const settingsCreated = !existsSync(settingsFile);
-  if (settingsCreated) {
-    // Owner-only atomic write (tmp + rename), matching every other writer under
-    // ~/.aka — a crash mid-write must never leave a truncated or group-readable
-    // settings.json, and a pre-existing loose `.tmp` isn't carried through.
-    writeOwnerOnlyFileSync(
-      settingsFile,
-      `${JSON.stringify(defaultWorkspaceSettings(), null, 2)}\n`,
-    );
+  //
+  // Under the same lock the wizard and the dashboard take, and the existence
+  // check is re-run INSIDE it: this is the third writer of one file, and an
+  // unlocked check-then-write can see no file, have the wizard's answers land
+  // while it decides, and then replace them with defaults.
+  //
+  // The lock is taken only when there is a write to make. A settings.json that
+  // is already there needs neither the lock nor the write, and taking one anyway
+  // would make `aka init` fail on a store whose settings dir refuses new files —
+  // the broken state this command exists to repair, and one it used to walk
+  // through untouched.
+  //
+  // A `timeout` is swallowed because the only writer that can hold this lock is
+  // one writing this same file: it is creating what init would have created, so
+  // there is nothing left to do. An `unavailable` directory is a real fault and
+  // propagates, exactly as the failed write did before there was a lock.
+  let settingsCreated = false;
+  if (!existsSync(settingsFile)) {
+    try {
+      settingsCreated = withFileLock(settingsFile, () => {
+        // Re-checked INSIDE the lock: the wizard's answers can land between the
+        // check above and this one, and defaults must never replace them.
+        if (existsSync(settingsFile)) return false;
+        // Owner-only atomic write (tmp + rename), matching every other writer under
+        // ~/.aka — a crash mid-write must never leave a truncated or group-readable
+        // settings.json, and a pre-existing loose `.tmp` isn't carried through.
+        writeOwnerOnlyFileSync(
+          settingsFile,
+          `${JSON.stringify(defaultWorkspaceSettings(), null, 2)}\n`,
+        );
+        return true;
+      });
+    } catch (err) {
+      if (!(err instanceof FileLockError) || err.reason !== 'timeout') throw err;
+    }
   }
   // Re-tighten whether or not we just wrote it: a re-run of `aka init` over a
   // settings.json a prior release left loose (the leftover-`.tmp` bug) must
@@ -319,7 +347,12 @@ export async function runInit(argv: string[]): Promise<void> {
   const symlinked = symlinkedStorePaths(home);
   process.stdout.write(
     `✓ Initialized AKA at ${home}\n` +
-      `  settings: ${settingsFile}${settingsCreated ? '' : ' (kept existing)'}\n` +
+      // "kept existing" is a claim about a file that is there. The one path that
+      // reaches here with nothing on disk is a write skipped because another
+      // process held the lock, and saying "kept existing" about a file that does
+      // not exist would make the case where init did not do its job read exactly
+      // like the case where it had nothing to do.
+      `  settings: ${settingsFile}${settingsCreated ? '' : existsSync(settingsFile) ? ' (kept existing)' : ' (not written — another process was writing it)'}\n` +
       `  database: ${dbPath(home)}\n` +
       `  seeded ${String(policyCount)} default policies, ${String(packCount)} detection pack(s)\n` +
       (updatesAvailable > 0

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
+import { once } from 'node:events';
 import {
   chmodSync,
   existsSync,
@@ -19,6 +20,7 @@ import { dirname, join } from 'node:path';
 import type * as LocalOps from '@akasecurity/local-ops';
 import { cachePath, writeCache } from '@akasecurity/local-ops';
 import { dataDir, dbPath, settingsDir } from '@akasecurity/plugin-sdk';
+import { defaultWorkspaceSettings } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -237,6 +239,48 @@ describe('runInit contract', () => {
 
     // A re-run re-applies no migration and must not overwrite the user's answers.
     expect(readFileSync(file, 'utf8')).toBe(first);
+    const out = stdout.mock.calls.map((c) => String(c[0])).join('');
+    expect(out).toContain('(kept existing)');
+  });
+
+  it('preserves answers another writer publishes while init waits for the lock', async () => {
+    // init is the THIRD writer of settings.json, behind the wizard and the
+    // dashboard. Checking for the file outside the write lock lets it find none,
+    // have the wizard's answers land while it decides, and then replace them
+    // with defaults — the same silent loss the lock exists to remove, from the
+    // one writer whose payload is "no answers at all".
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    mkdirSync(settingsDir(dir), { recursive: true });
+    const file = join(settingsDir(dir), 'settings.json');
+    const answers = `${JSON.stringify({ ...defaultWorkspaceSettings(), policy: 'warn' }, null, 2)}\n`;
+
+    const holder = spawn(
+      process.execPath,
+      [join(import.meta.dirname, '..', 'helpers', 'settings-lock-holder.ts'), file, answers, '600'],
+      { stdio: ['ignore', 'pipe', 'inherit'] },
+    );
+    // Bound to the event BEFORE anything is awaited. `close` fires once, so a
+    // listener attached in the `finally` waits for a second emission that never
+    // comes — the test would hang to its own timeout whenever init outlasts the
+    // hold, which is the ordinary case.
+    const holderClosed = once(holder, 'close');
+    try {
+      // Start init only once the lock is really held, so this is not a race that
+      // happens to resolve one way. From here the ordering is the lock's to
+      // enforce: the holder writes the file before releasing, and a live holder
+      // is never stolen from, so an init that waits for the section always
+      // finds it.
+      await once(holder.stdout, 'data');
+      await runInit(['--home', dir]);
+    } finally {
+      await holderClosed;
+    }
+
+    expect(JSON.parse(readFileSync(file, 'utf8'))).toMatchObject({ policy: 'warn' });
+    // The observable difference. Unlocked, init writes its defaults before the
+    // holder ever publishes — the answers still end up on disk (the holder
+    // renames last), but init reports having CREATED the file, which is only
+    // true if it clobbered somebody.
     const out = stdout.mock.calls.map((c) => String(c[0])).join('');
     expect(out).toContain('(kept existing)');
   });

--- a/cli/test/helpers/settings-lock-holder.ts
+++ b/cli/test/helpers/settings-lock-holder.ts
@@ -1,0 +1,59 @@
+/**
+ * Holds the settings.json write lock from a process of its own, then writes the
+ * file and releases — so `aka init` can meet a real, live lock rather than a
+ * planted one.
+ *
+ * Ordering here is a guarantee, not a timing hope: the file is written BEFORE
+ * the lock is released, and a waiter cannot enter the section until it is. So an
+ * init that takes the lock always finds the file, however slow the runner. The
+ * hold only has to outlast an init that DOESN'T take it, which is what makes the
+ * difference observable.
+ *
+ * The lock protocol is the existence of `<file>.lock` (see
+ * packages/persistence/src/file-lock.ts) — created exclusively, removed on
+ * release — so this holds one by creating the file, with nothing imported.
+ *
+ * Loaded by Node directly, outside the test runner's transform, so it stays on
+ * node: builtins and plain erasable type annotations.
+ */
+import { closeSync, openSync, rmSync, writeFileSync } from 'node:fs';
+
+const [settingsFile, contents, holdMsRaw] = process.argv.slice(2);
+if (settingsFile === undefined || contents === undefined || holdMsRaw === undefined) {
+  throw new Error('settings-lock-holder: expected <settingsFile> <contents> <holdMs>');
+}
+
+// `Atomics.wait` reads a NaN timeout as Infinity, so a non-numeric hold would
+// park here forever still holding the lock — the parent's init would time out,
+// and its wait for this process to close would never settle. Refuse it loudly.
+const holdMs = Number(holdMsRaw);
+if (!Number.isFinite(holdMs) || holdMs < 0) {
+  throw new Error(`settings-lock-holder: holdMs must be a non-negative number, got "${holdMsRaw}"`);
+}
+
+// The lock protocol is the existence of `<file>.lock` carrying the holder's pid,
+// its own acquire clock and an ownership token (see
+// packages/persistence/src/file-lock.ts). The body matters: a waiter reads the
+// pid to check the holder is alive before ever considering the lock abandoned,
+// so a body-less lock would exercise the truncated-lock fallback instead of the
+// live-holder path this test is about.
+const lock = `${settingsFile}.lock`;
+const fd = openSync(lock, 'wx', 0o600);
+writeFileSync(
+  fd,
+  `${JSON.stringify({ pid: process.pid, token: 'lock-holder', at: Date.now() })}\n`,
+);
+closeSync(fd);
+
+// Tell the parent the lock is up, so it starts init knowing the section is
+// already taken rather than guessing.
+process.stdout.write('locked\n');
+
+// Slept, not spun: a hot loop would hold a core for the whole hold and slow
+// whatever else the suite is running in parallel.
+const PARK = new Int32Array(new SharedArrayBuffer(4));
+Atomics.wait(PARK, 0, 0, holdMs);
+
+writeFileSync(settingsFile, contents, { mode: 0o600 });
+rmSync(lock, { force: true });
+process.stdout.write('released\n');

--- a/packages/persistence/src/file-lock.ts
+++ b/packages/persistence/src/file-lock.ts
@@ -1,0 +1,455 @@
+import { randomUUID } from 'node:crypto';
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { hostname } from 'node:os';
+
+import { DATA_FILE_MODE } from './paths.ts';
+
+// Cross-process mutual exclusion around one file under ~/.aka.
+//
+// The plugin, the CLI and the dashboard are three independent processes over
+// one home, and an atomic write is not enough on its own: tmp+rename makes each
+// PUBLISH indivisible, but a read-modify-write spans two of them, so two writers
+// can read the same bytes and the second rename silently discards the first
+// one's change. `busy_timeout` covers none of this — settings.json and the key
+// files are outside SQLite entirely.
+//
+// The lock is the EXISTENCE of a sibling `<file>.lock`, taken with an exclusive
+// create. That is the one primitive every platform this ships to agrees on:
+// `flock` has no Windows equivalent, and an advisory lock held on an fd is lost
+// by any writer that opens the file a second time.
+
+// A sibling of the file it guards, so it inherits the directory's 0700 and
+// needs no layout of its own.
+const LOCK_SUFFIX = '.lock';
+
+// How long a writer waits for its turn. A legitimate hold is a single small
+// read plus a write — sub-millisecond — so this is a ceiling on a queue that
+// should never form, not a budget anything is expected to spend. It is not on
+// any hook path: readWorkspaceSettings takes no lock, and the writers are the
+// /aka:setup wizard, `aka init` and the dashboard's Settings save.
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+// How old a lock must be before a waiter considers taking it. Reaching this
+// alone is not enough — the recorded pid must also be gone (see breakIfStale),
+// so a holder that is merely slow is waited for rather than evicted.
+//
+// Deliberately BELOW the acquire timeout: a waiter must be able to recover a
+// dead holder's lock within its own call, rather than failing and leaving the
+// next caller to meet the same lock.
+const DEFAULT_STALE_MS = 2_000;
+
+// Poll interval while another writer holds the lock. Short enough that a handoff
+// is not the dominant cost of a write, long enough not to spin a core.
+const RETRY_INTERVAL_MS = 5;
+
+// Errnos that mean "try again", not "this can never work". EEXIST is a held
+// lock. The rest are Windows: a deleted name stays in a delete-pending state
+// until every handle closes and answers ERROR_ACCESS_DENIED (EACCES/EPERM), and
+// a scanner or indexer holding the file answers ERROR_SHARING_VIOLATION (EBUSY)
+// — all three transient, all three raised by an ordinary handoff. Whether one is
+// contention or a directory that will never hold a lock is then decided by
+// whether the lock path EXISTS, not by the errno.
+const RETRYABLE_CREATE_ERRNOS = new Set(['EEXIST', 'EACCES', 'EPERM', 'EBUSY']);
+
+// A block of shared memory nothing ever notifies, so `Atomics.wait` on it always
+// runs to its timeout — the one way to sleep without yielding to the event loop.
+// The callers here are synchronous top to bottom (the whole store API is), so
+// an async sleep would mean making every writer async up to its entry point.
+const PARK = new Int32Array(new SharedArrayBuffer(4));
+
+function sleepSync(ms: number): void {
+  Atomics.wait(PARK, 0, 0, ms);
+}
+
+export interface FileLockOptions {
+  /** How long to wait for the lock before failing. */
+  timeoutMs?: number;
+  /** How old a lock must be, with its holder gone, before a waiter takes it. */
+  staleMs?: number;
+}
+
+/**
+ * Why the lock could not be taken.
+ *
+ * `timeout` is contention — somebody holds it and did not let go in time.
+ * `unavailable` is the directory refusing to hold a lock at all (read-only,
+ * unwritable, immutable), which no amount of waiting resolves.
+ *
+ * They are separated because reporting one as the other misleads in the
+ * direction a user acts on: a permissions fault announced as "timed out waiting"
+ * sends someone looking for a process that does not exist. `aka init` branches
+ * on it — it repairs stores in the second state, while a contended lock means
+ * another writer is mid-write and there is nothing for it to do.
+ */
+export type FileLockFailure = 'timeout' | 'unavailable';
+
+/**
+ * Raised when the lock could not be taken — a loud failure in place of the
+ * silent overwrite this exists to prevent.
+ *
+ * Carries the holder's pid on a `timeout` when the lock file could be read, so a
+ * writer wedged for seconds can be told apart from a lock file nothing owns.
+ */
+export class FileLockError extends Error {
+  readonly reason: FileLockFailure;
+  readonly file: string;
+  readonly holderPid: number | undefined;
+  constructor(
+    reason: FileLockFailure,
+    file: string,
+    detail: string,
+    holderPid?: number,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `cannot lock ${file} for writing: ${detail}` +
+        (holderPid === undefined ? '' : ` (held by pid ${String(holderPid)})`),
+      options,
+    );
+    this.name = 'FileLockError';
+    this.reason = reason;
+    this.file = file;
+    this.holderPid = holderPid;
+  }
+}
+
+// What a holder records in its lock file.
+//
+// `at` is the acquiring process's own clock, and staleness is measured from it
+// rather than from the file's mtime. An mtime comes from whichever clock owns
+// the filesystem — a server's, on the network homes this store already ships to
+// — so a client running a couple of seconds ahead reads every lock as born
+// stale and mutual exclusion silently disappears, while one running behind never
+// recovers an abandoned lock at all. Coarse mtime granularity (2s on FAT/exFAT,
+// 1s on ext3/HFS+) pushes the same way for free.
+//
+// `token` is what makes a release safe — see release().
+//
+// `host` is what makes the pid meaningful. A `~/.aka` on a network home is
+// shared between machines, where a pid names a process in someone else's table:
+// asking about it locally answers about an unrelated program, so a lock from
+// another host is judged on age alone.
+interface LockBody {
+  pid: number;
+  token: string;
+  at: number;
+  host: string;
+}
+
+function lockPathFor(file: string): string {
+  return `${file}${LOCK_SUFFIX}`;
+}
+
+// The body of the lock currently at `lock`. Null covers both "no file" and "not
+// a body this understands" — a truncated write, or a file another tool left at
+// the path — which the callers treat differently, so neither may be mistaken for
+// a readable body.
+function readLockBody(lock: string): LockBody | null {
+  let raw: string;
+  try {
+    raw = readFileSync(lock, 'utf8');
+  } catch {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const { pid, token, at, host } = parsed as Partial<LockBody>;
+    if (typeof pid !== 'number' || typeof token !== 'string' || typeof at !== 'number') return null;
+    return { pid, token, at, host: typeof host === 'string' ? host : '' };
+  } catch {
+    return null;
+  }
+}
+
+// Whether the process that recorded the lock is still running here. `kill(pid, 0)`
+// sends no signal, it only asks; EPERM means the process exists under another
+// user, which is still alive.
+//
+// Answers `true` when it cannot tell, because the safe direction is to leave a
+// lock alone: waiting costs a timeout the caller reports, where stealing from a
+// live holder puts two writers in the section — the defect this module exists to
+// remove.
+function holderIsAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+// Take the lock, returning the token that proves this call owns it, or null if
+// somebody else holds it.
+//
+// `wx` is O_CREAT|O_EXCL: it succeeds for exactly one caller, and it REFUSES to
+// follow a symlink, so a link planted at the lock path can never be written
+// through — the same property the tmp write in paths.ts relies on.
+//
+// A create that fails for a retryable reason is contention only if a lock is
+// actually there. With no file at the path the fault is the directory's, and no
+// amount of waiting fixes a read-only or immutable one, so it is raised at once
+// rather than spending the whole timeout to report contention that never was.
+function tryAcquire(lock: string, file: string): string | null {
+  const token = randomUUID();
+  let fd: number;
+  try {
+    fd = openSync(lock, 'wx', DATA_FILE_MODE);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code ?? '';
+    // EEXIST is unambiguous — the file was there — and needs no second opinion.
+    // Asking `existsSync` about it as well would call a normal handoff
+    // permanent: the holder can release between the two calls, leaving a
+    // released lock reported as a directory that will never hold one, with an
+    // EEXIST message attached. That fires on an ordinary two-writer handoff.
+    if (code === 'EEXIST') return null;
+    // The rest arrive from Windows for both reasons, so the path itself decides:
+    // a lock that is there is contention, and one that is not means the
+    // directory refused the create.
+    if (RETRYABLE_CREATE_ERRNOS.has(code) && existsSync(lock)) return null;
+    throw new FileLockError(
+      'unavailable',
+      file,
+      err instanceof Error ? err.message : String(err),
+      undefined,
+      { cause: err },
+    );
+  }
+  const body: LockBody = { pid: process.pid, token, at: Date.now(), host: hostname() };
+  try {
+    writeFileSync(fd, `${JSON.stringify(body)}\n`);
+  } catch {
+    // The body is what a waiter reads to decide staleness and ownership, so a
+    // lock without one can never be identified as abandoned. Drop it rather than
+    // leave behind one that nothing can recover.
+    try {
+      closeSync(fd);
+    } catch {
+      // fall through to the unlink; the file is what matters, not the handle
+    }
+    rmSync(lock, { force: true });
+    return null;
+  }
+  try {
+    closeSync(fd);
+  } catch {
+    // The fd is not the lock; the file is. Nothing here can un-take it.
+  }
+  return token;
+}
+
+// Whether a lock is abandoned: older than `staleMs` by its OWN recorded clock,
+// and written by a process that is gone. Age alone evicts a holder that is
+// merely slow — a suspended laptop, a throttled container, a network home — and
+// puts two writers in the section.
+function isAbandoned(body: LockBody | null, lock: string, staleMs: number): boolean {
+  if (!body) {
+    // A lock with no readable body records neither a clock nor a pid — a
+    // truncated write, or a file another tool left at this path. Fall back to the
+    // filesystem's mtime so it can still be recovered rather than wedging the
+    // file forever; there is no pid to ask about.
+    try {
+      return Date.now() - statSync(lock).mtimeMs >= staleMs;
+    } catch {
+      return false;
+    }
+  }
+  if (Date.now() - body.at < staleMs) return false;
+  // A pid is only answerable on the host that recorded it. On a shared network
+  // home it names a process in another machine's table, where a local answer is
+  // about an unrelated program, so those are judged on age alone.
+  if (body.host !== hostname() || !holderIsAlive(body.pid)) return true;
+  // Past the abandon window a still-resolving pid is read as recycled: a dead
+  // holder's number gets reused, and an unrelated process wearing it would
+  // otherwise keep the lock alive forever — the permanent wedge the stale path
+  // exists to prevent, reintroduced by its own liveness check.
+  return Date.now() - body.at >= abandonWindow(staleMs);
+}
+
+// Hand a waiter the lock of a process that died holding it.
+//
+// The judging and the removal are ONE critical section, held against the other
+// waiters by a second exclusive file. That is what makes the removal safe rather
+// than merely likely: several waiters meet the same abandoned lock at once, and
+// unserialised they all judge it stale, then one removes it and takes a fresh
+// lock while the next one's removal lands on THAT — so two of them end up inside
+// the section, which is the defect the lock exists to remove. Neither a rename
+// nor a re-read closes it, because every check is separated from its removal by
+// a window another waiter can act in.
+//
+// Serialised, the second waiter re-reads the path inside the breaker and finds
+// the first one's fresh, live lock instead of the abandoned one, so it simply
+// waits.
+function breakIfStale(lock: string, staleMs: number): boolean {
+  const breaker = `${lock}.break`;
+  let fd: number;
+  try {
+    fd = openSync(breaker, 'wx', DATA_FILE_MODE);
+  } catch {
+    // Another waiter is judging right now — its outcome is the one that counts,
+    // so this call just waits. A breaker left behind by a killed waiter is reaped
+    // rather than blocking every future recovery.
+    reapAbandonedBreaker(breaker);
+    return false;
+  }
+  try {
+    closeSync(fd);
+  } catch {
+    // The fd is not the breaker; the file is.
+  }
+  try {
+    // Re-read INSIDE the section. The lock this call meant to judge may already
+    // have been recovered, and what sits at the path now can be a live holder.
+    if (!existsSync(lock) || !isAbandoned(readLockBody(lock), lock, staleMs)) return false;
+    // Safe to remove by path: the lock is here, so nobody can be acquiring; its
+    // holder is gone, so nobody is releasing; and no other waiter can be
+    // removing, because this call holds the breaker.
+    rmSync(lock, { force: true });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      rmSync(breaker, { force: true });
+    } catch {
+      // Left behind, and reaped by the next waiter that meets it.
+    }
+  }
+}
+
+// A breaker is held for the length of one read and one unlink, so anything that
+// has sat around is a waiter that died mid-judgement. Reaped on mtime alone —
+// there is no body and no holder to ask about, and leaving it would disable
+// recovery for the file permanently.
+const BREAKER_ABANDONED_MS = 10_000;
+
+function reapAbandonedBreaker(breaker: string): void {
+  try {
+    if (Date.now() - statSync(breaker).mtimeMs >= BREAKER_ABANDONED_MS) {
+      rmSync(breaker, { force: true });
+    }
+  } catch {
+    // Gone already, or unreadable — the next waiter tries again.
+  }
+}
+
+// How long past `staleMs` a lock whose pid still resolves is tolerated before it
+// is taken anyway. Generous, because inside it a genuinely slow holder is safe;
+// past it the likeliest explanation is a recycled pid, and the alternative is a
+// file no writer can ever have again.
+function abandonWindow(staleMs: number): number {
+  return Math.max(staleMs * 30, 60_000);
+}
+
+// Drop the lock, but ONLY while the file still carries this call's token.
+//
+// A holder that was stolen from must not delete the lock the thief now holds.
+// Unlinking by path alone does exactly that, and it cascades: the thief's
+// successor is let in while the thief is still writing, which is the lost update
+// the lock exists to prevent, now with every writer reporting success.
+//
+// Best-effort and deliberately never throwing: a release that failed must not
+// mask the outcome of the work it guarded. A lock left behind is recovered by
+// the stale path above rather than wedging the file.
+// A body that cannot be read is NOT this call's lock either. Falling through to
+// an unlink there defeats the whole guard in the one window a successor is most
+// exposed: a fresh lock exists for an instant between its exclusive create and
+// its body write, so a departing predecessor would find no body and delete it.
+// A lock this call does not own is left for the stale path to recover.
+function release(lock: string, token: string): void {
+  try {
+    if (readLockBody(lock)?.token !== token) return;
+    rmSync(lock, { force: true });
+  } catch {
+    // see above
+  }
+}
+
+/**
+ * Run `fn` as the only writer of `file` on this machine.
+ *
+ * Guards a read-modify-write, which tmp+rename cannot: rename makes each publish
+ * indivisible, but two writers that both read before either renames still lose
+ * one side's change. Every writer of a given file must take this lock — it is
+ * advisory, so a writer that skips it is not excluded by the ones that do.
+ *
+ * The caller must have created the parent directory (ensureDataDirSync): the
+ * lock is a sibling of `file`.
+ *
+ * NOT re-entrant. A nested call on the same file waits out its own timeout and
+ * throws, because the outer hold belongs to a live process this one cannot tell
+ * apart from any other holder — and must not, or it would steal from itself.
+ *
+ * `fn` must be SYNCHRONOUS. The lock is released when `fn` returns, so an async
+ * body would drop it at the first await with the write still to come; that is
+ * refused rather than left silently unguarded.
+ *
+ * Throws {@link FileLockError} rather than proceeding unlocked when the lock
+ * cannot be taken. Losing a write loudly is recoverable — the user is told and
+ * retries — where losing it silently is not, and the fields at stake include the
+ * consent grants a user can revoke.
+ */
+export function withFileLock<T>(file: string, fn: () => T, options: FileLockOptions = {}): T {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const staleMs = options.staleMs ?? DEFAULT_STALE_MS;
+  const lock = lockPathFor(file);
+  const deadline = Date.now() + timeoutMs;
+
+  let token = tryAcquire(lock, file);
+  while (token === null) {
+    // A successful steal is retried at once rather than slept on, and BEFORE the
+    // deadline is consulted: the lock is gone, so failing here would report a
+    // timeout for a section this call had just cleared for itself.
+    if (breakIfStale(lock, staleMs)) {
+      token = tryAcquire(lock, file);
+      continue;
+    }
+    if (Date.now() >= deadline) {
+      throw new FileLockError(
+        'timeout',
+        file,
+        `still held after ${String(timeoutMs)}ms`,
+        readLockBody(lock)?.pid,
+      );
+    }
+    sleepSync(RETRY_INTERVAL_MS);
+    token = tryAcquire(lock, file);
+  }
+
+  try {
+    const result = fn();
+    if (isThenable(result)) {
+      // The body has already started; nothing here can call it back. Adopt its
+      // rejection so a failure inside it cannot become an unhandled rejection —
+      // which under Node's default policy takes the whole process down, and the
+      // processes reachable here include the dashboard server.
+      void (result as PromiseLike<unknown>).then(
+        () => undefined,
+        () => undefined,
+      );
+      throw new TypeError(
+        `withFileLock(${file}) was given an async body; the lock is released as soon as it ` +
+          'returns, so the awaited work would run unguarded. Pass a synchronous function.',
+      );
+    }
+    return result;
+  } finally {
+    release(lock, token);
+  }
+}
+
+function isThenable(value: unknown): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === 'function'
+  );
+}

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -2,6 +2,8 @@ export type { InventoryContext, LocalDatabase, ResolvedInventory } from './datab
 export { openLocalDatabase } from './database.ts';
 export type { ExceptionPolicyProvider, RevealDecision } from './exception-policy.ts';
 export { UserGrantPolicyProvider } from './exception-policy.ts';
+export type { FileLockFailure, FileLockOptions } from './file-lock.ts';
+export { FileLockError, withFileLock } from './file-lock.ts';
 export type { FindingKeyInput } from './finding-key.ts';
 export { computeFindingKey } from './finding-key.ts';
 export type { FingerprintKey } from './fingerprint.ts';
@@ -103,6 +105,7 @@ export {
 } from './repositories/shares.ts';
 export { SqliteSourceProjectRepository } from './repositories/source-project.ts';
 export { compareBinaryVersions } from './semver.ts';
+export type { OnboardingAnswers } from './settings.ts';
 export { applyOnboarding, readWorkspaceSettings, SETTINGS_FILENAME } from './settings.ts';
 export {
   base32Decode,

--- a/packages/persistence/src/settings.ts
+++ b/packages/persistence/src/settings.ts
@@ -7,6 +7,7 @@ import {
   WorkspaceSettings as WorkspaceSettingsSchema,
 } from '@akasecurity/schema';
 
+import { withFileLock } from './file-lock.ts';
 import { parseJsonObject } from './internal/json.ts';
 import { defaultDataDir, settingsDir } from './local-layout.ts';
 import { ensureDataDirSync, writeOwnerOnlyFileSync } from './paths.ts';
@@ -41,6 +42,17 @@ export function readWorkspaceSettings(base: string = defaultDataDir()): Workspac
 }
 
 /**
+ * The answers to apply, either directly or derived from what is already on
+ * disk. The function form is the one to reach for whenever an answer depends on
+ * a current value — it runs INSIDE the write lock, so the settings it is handed
+ * are the ones the merge is about to be applied to. Reading first and passing a
+ * plain object puts that read outside the lock, which is the lost update this
+ * writer exists to prevent, one caller further out.
+ */
+export type OnboardingAnswers =
+  Partial<WorkspaceSettings> | ((current: WorkspaceSettings) => Partial<WorkspaceSettings>);
+
+/**
  * Persist onboarding answers to settings.json (the /aka:setup writer, and the
  * web-ui settings page). Merges over the existing file so each edit is
  * additive, re-validates through the versioned schema, and stamps onboardedAt
@@ -48,23 +60,42 @@ export function readWorkspaceSettings(base: string = defaultDataDir()): Workspac
  * rename), so a settings.json (or a leftover `.tmp` from an earlier crash) that
  * pre-existed with looser permissions ends 0600 rather than carrying its mode
  * through the rename — see writeOwnerOnlyFileSync.
+ *
+ * The read, the merge and the write are ONE critical section, held against
+ * every other process on the machine (see withFileLock). tmp+rename alone makes
+ * each publish indivisible but leaves the pair of them interleavable: the
+ * wizard and the dashboard's Settings page are separate processes over one
+ * file, and without the lock both read the same bytes and the second rename
+ * discards the first one's answers with nothing raised at either end. The
+ * fields at stake include the vault and model-judge consent grants, where the
+ * lost write can be a REVOCATION — silently reinstating an egress the user
+ * just withdrew.
+ *
+ * Throws rather than writing unlocked if the lock cannot be taken (see
+ * FileLockError). Both callers surface that: the wizard exits non-zero with the
+ * message, and the Settings action renders a save failure.
  */
 export function applyOnboarding(
-  answers: Partial<WorkspaceSettings>,
+  answers: OnboardingAnswers,
   base: string = defaultDataDir(),
 ): WorkspaceSettings {
   const dir = settingsDir(base);
-  const current = readWorkspaceSettings(base);
-  const merged = WorkspaceSettingsSchema.parse({
-    ...current,
-    ...answers,
-    // First setup stamps the time; later edits keep the original completion mark.
-    onboardedAt: answers.onboardedAt ?? current.onboardedAt ?? new Date().toISOString(),
-  });
+  // Ahead of the lock, not inside it: the lock file is a sibling of
+  // settings.json, so the directory has to exist before one can be taken.
   ensureDataDirSync(dir);
   const file = join(dir, SETTINGS_FILENAME);
-  writeOwnerOnlyFileSync(file, `${JSON.stringify(merged, null, 2)}\n`);
-  return merged;
+  return withFileLock(file, () => {
+    const current = readWorkspaceSettings(base);
+    const applied = typeof answers === 'function' ? answers(current) : answers;
+    const merged = WorkspaceSettingsSchema.parse({
+      ...current,
+      ...applied,
+      // First setup stamps the time; later edits keep the original completion mark.
+      onboardedAt: applied.onboardedAt ?? current.onboardedAt ?? new Date().toISOString(),
+    });
+    writeOwnerOnlyFileSync(file, `${JSON.stringify(merged, null, 2)}\n`);
+    return merged;
+  });
 }
 
 function readJson(file: string): Record<string, unknown> | null {

--- a/packages/persistence/test/concurrency/settings-race.test.ts
+++ b/packages/persistence/test/concurrency/settings-race.test.ts
@@ -1,0 +1,176 @@
+/**
+ * settings.json under real concurrent writers.
+ *
+ * The wizard, `aka init` and the dashboard server are separate processes over
+ * one ~/.aka. `applyOnboarding` is a read-modify-write, and an atomic
+ * tmp+rename bounds only the write half: without a lock two writers read the
+ * same bytes and the second rename discards the first one's answers, with
+ * BOTH reporting success. That is the failure these tests exist to make
+ * impossible — silent, and on fields that include the consent grants a user
+ * can revoke.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { applyOnboarding, readWorkspaceSettings, SETTINGS_FILENAME } from '../../src/settings.ts';
+import type { WriterJob } from '../helpers/settings-writers.ts';
+import { allReleasedTogether, runConcurrentSettingsWriters } from '../helpers/settings-writers.ts';
+
+let base: string;
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'aka-settings-race-'));
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+function settingsFile(): string {
+  return join(base, 'settings', SETTINGS_FILENAME);
+}
+
+// One writer per field, each setting a value that differs from that field's
+// default — so a field back at its default is a lost answer and not a value
+// some other writer happened to write too.
+const DISTINCT_ANSWERS: { field: string; job: WriterJob; expected: unknown }[] = [
+  { field: 'policy', job: { set: { policy: 'warn' } }, expected: 'warn' },
+  { field: 'historicalAccess', job: { set: { historicalAccess: 'full' } }, expected: 'full' },
+  { field: 'dataSharesInPlace', job: { set: { dataSharesInPlace: false } }, expected: false },
+  { field: 'vaultInlineReveal', job: { set: { vaultInlineReveal: 'full' } }, expected: 'full' },
+  { field: 'vaultKeyCustody', job: { set: { vaultKeyCustody: 'keychain' } }, expected: 'keychain' },
+  {
+    field: 'modelJudgeConsent',
+    job: {
+      set: {
+        modelJudgeConsent: { acknowledgedAt: '2026-01-01T00:00:00.000Z', payloadVersion: 1 },
+      },
+    },
+    expected: { acknowledgedAt: '2026-01-01T00:00:00.000Z', payloadVersion: 1 },
+  },
+  {
+    field: 'vaultConsent',
+    job: { set: { vaultConsent: { acknowledgedAt: '2026-01-01T00:00:00.000Z', version: 1 } } },
+    expected: { acknowledgedAt: '2026-01-01T00:00:00.000Z', version: 1 },
+  },
+];
+
+describe('concurrent applyOnboarding', () => {
+  it('keeps every writer’s answer when all of them write at once', async () => {
+    const run = await runConcurrentSettingsWriters(
+      base,
+      DISTINCT_ANSWERS.map((w) => w.job),
+    );
+
+    // Positive control on the barrier itself. Writers that ran one after
+    // another would satisfy every assertion below without a race ever having
+    // happened, so the contention is asserted before its consequences are.
+    expect(allReleasedTogether(run)).toBe(true);
+    expect(run.outcomes.filter((o) => !o.ok).map((o) => o.error)).toEqual([]);
+
+    const settings = readWorkspaceSettings(base);
+    const lost = DISTINCT_ANSWERS.filter(
+      (w) =>
+        JSON.stringify((settings as unknown as Record<string, unknown>)[w.field]) !==
+        JSON.stringify(w.expected),
+    ).map((w) => w.field);
+    expect(lost).toEqual([]);
+  });
+
+  it('does not resurrect a consent that a concurrent writer revoked', async () => {
+    // A grant already on file, as it would be after the wizard's Yes path.
+    applyOnboarding(
+      { modelJudgeConsent: { acknowledgedAt: '2026-01-01T00:00:00.000Z', payloadVersion: 1 } },
+      base,
+    );
+    expect(readWorkspaceSettings(base).modelJudgeConsent).toBeDefined();
+
+    // The revoke races writers that carry no opinion about the consent at all.
+    // Unlocked, any of them can have read the granted state before the revoke
+    // landed and then rename its own merge — carrying the grant back — which
+    // silently reinstates an egress the user just withdrew. Whichever order the
+    // lock imposes, none of them can: the revoke either has not happened yet, or
+    // is already in the bytes they merge over.
+    const run = await runConcurrentSettingsWriters(base, [
+      { clear: ['modelJudgeConsent'] },
+      { set: { policy: 'warn' } },
+      { set: { historicalAccess: 'full' } },
+      { set: { dataSharesInPlace: false } },
+      { set: { vaultInlineReveal: 'off' } },
+    ]);
+
+    expect(allReleasedTogether(run)).toBe(true);
+    expect(run.outcomes.filter((o) => !o.ok).map((o) => o.error)).toEqual([]);
+    expect(readWorkspaceSettings(base).modelJudgeConsent).toBeUndefined();
+    // The revoke is the only answer under test; the rest must still be there,
+    // or "consent absent" could just be a settings.json nobody wrote.
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+    expect(readWorkspaceSettings(base).historicalAccess).toBe('full');
+  });
+
+  it('leaves settings.json owner-only, with no tmp or lock file behind', async (ctx) => {
+    await runConcurrentSettingsWriters(
+      base,
+      DISTINCT_ANSWERS.map((w) => w.job),
+    );
+
+    const dir = join(base, 'settings');
+    // The atomic write and the lock both work through sibling files; a storm
+    // that leaves either behind has either failed to publish or failed to
+    // release, and a leftover lock costs every later writer its stale wait.
+    expect(readdirSync(dir)).toEqual([SETTINGS_FILENAME]);
+
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes are a no-op on Windows');
+      return;
+    }
+    expect(statSync(settingsFile()).mode & 0o777).toBe(0o600);
+  });
+
+  it('recovers a lock abandoned by a killed writer instead of wedging the file', () => {
+    // A writer killed mid-section leaves its lock behind. Nothing releases it,
+    // so without a stale path settings.json would be unwritable for the rest of
+    // the machine's life — the lock's own availability risk, and the reason the
+    // stale window sits BELOW the acquire timeout: one call has to recover it.
+    const dir = join(base, 'settings');
+    mkdirSync(dir, { recursive: true });
+    const lock = `${settingsFile()}.lock`;
+    // A lock as a killed writer leaves it: its own recorded acquire clock well
+    // outside the stale window, and a pid no process here holds. Both are
+    // required — age alone never evicts a holder that is merely slow.
+    writeFileSync(
+      lock,
+      `${JSON.stringify({ pid: 0x7ffffffe, token: 'killed-writer', at: Date.now() - 60_000 })}\n`,
+    );
+
+    expect(applyOnboarding({ policy: 'warn' }, base).policy).toBe('warn');
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('merges over a file another writer published, rather than over its own read', async () => {
+    // Two writers, one field each, run at once and then read back through the
+    // file rather than the return value: the second one's merge has to be built
+    // on bytes that already carry the first one's answer.
+    const run = await runConcurrentSettingsWriters(base, [
+      { set: { policy: 'warn' } },
+      { set: { historicalAccess: 'full' } },
+    ]);
+    expect(allReleasedTogether(run)).toBe(true);
+
+    const raw: unknown = JSON.parse(readFileSync(settingsFile(), 'utf8'));
+    expect(raw).toMatchObject({ policy: 'warn', historicalAccess: 'full' });
+  });
+});

--- a/packages/persistence/test/file-lock.test.ts
+++ b/packages/persistence/test/file-lock.test.ts
@@ -1,0 +1,378 @@
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { hostname, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { FileLockError, withFileLock } from '../src/file-lock.ts';
+
+let dir: string;
+let file: string;
+let lock: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'aka-file-lock-'));
+  file = join(dir, 'settings.json');
+  lock = `${file}.lock`;
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// A held lock, without a second process. `pid` decides whether a waiter sees a
+// LIVE holder or an abandoned one: this process is alive by definition, so it
+// stands in for a real holder, while an unused pid stands in for one that died.
+// `ageMs` backdates the lock's own recorded clock, which is what staleness is
+// measured from — not the file's mtime.
+function plantHeldLock({
+  pid = process.pid,
+  ageMs = 0,
+  token = 'planted',
+  host = hostname(),
+} = {}): void {
+  writeFileSync(lock, `${JSON.stringify({ pid, token, at: Date.now() - ageMs, host })}\n`);
+}
+
+// A pid no process on this machine holds, so `kill(pid, 0)` reports ESRCH.
+// Above the platform maximum rather than merely unused, which a fresh fork could
+// otherwise claim mid-test.
+const DEAD_PID = 0x7ffffffe;
+
+function backdate(path: string, ms: number): void {
+  const when = new Date(Date.now() - ms);
+  utimesSync(path, when, when);
+}
+
+// Long enough that nothing under test can age into staleness mid-run, so a case
+// about exclusion is never quietly answered by the stale path instead.
+const NEVER_STALE = { timeoutMs: 50, staleMs: 600_000 };
+
+describe('withFileLock', () => {
+  it('runs the body and returns its value', () => {
+    expect(withFileLock(file, () => 'written')).toBe('written');
+  });
+
+  it('releases the lock once the body returns', () => {
+    withFileLock(file, () => 'entered');
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('releases the lock when the body throws, and raises the body’s error', () => {
+    const err = new Error('write failed');
+    expect(() =>
+      withFileLock(file, () => {
+        throw err;
+      }),
+    ).toThrow(err);
+    // A lock held by a failed write is the same wedge as one held by a killed
+    // process, and this one is reachable without anybody dying.
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('excludes a second holder while the lock is held, even with no stale window', () => {
+    let inner: unknown;
+    withFileLock(file, () => {
+      inner = (() => {
+        try {
+          // Not re-entrant, deliberately: the lock is held against every writer
+          // on the machine, and this process is not a privileged one.
+          //
+          // `staleMs: 1` so the age test is satisfied instantly and the ONLY
+          // thing that can refuse the steal is the holder-still-alive check.
+          // Pinned with NEVER_STALE instead, this passes while a nested call
+          // quietly steals its own live lock and leaves the outer section
+          // running unguarded.
+          return withFileLock(file, () => 'entered', { timeoutMs: 200, staleMs: 1 });
+        } catch (err) {
+          return err;
+        }
+      })();
+    });
+    expect(inner).toBeInstanceOf(FileLockError);
+  });
+
+  it('never runs the body when the lock cannot be taken', () => {
+    plantHeldLock();
+    let ran = false;
+    expect(() => {
+      withFileLock(
+        file,
+        () => {
+          ran = true;
+        },
+        NEVER_STALE,
+      );
+    }).toThrow(FileLockError);
+    // The whole point of failing loudly: the write does not happen anyway.
+    expect(ran).toBe(false);
+  });
+
+  it('names the file and the holding pid on timeout', () => {
+    plantHeldLock({ pid: 31337 });
+    const err = errorFrom(() => withFileLock(file, () => 'entered', NEVER_STALE));
+    expect(err).toBeInstanceOf(FileLockError);
+    expect((err as FileLockError).reason).toBe('timeout');
+    expect((err as FileLockError).file).toBe(file);
+    expect((err as FileLockError).holderPid).toBe(31337);
+    expect(err?.message).toContain('31337');
+  });
+
+  it('still reports a timeout when the lock body is unreadable', () => {
+    // The pid decorates the message; it must never be what decides whether the
+    // refusal happens.
+    writeFileSync(lock, 'not json at all');
+    const err = errorFrom(() => withFileLock(file, () => 'entered', NEVER_STALE));
+    expect(err).toBeInstanceOf(FileLockError);
+    expect((err as FileLockError).reason).toBe('timeout');
+    expect((err as FileLockError).holderPid).toBeUndefined();
+  });
+
+  it('reports a directory that cannot hold a lock at all as unavailable', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX directory modes are what make the lock uncreatable here');
+      return;
+    }
+    if (process.getuid?.() === 0) {
+      ctx.skip('root bypasses directory mode bits, so the chmod below denies nothing');
+      return;
+    }
+    // A read-only or unwritable directory is not contention, and waiting out the
+    // full timeout to announce one as the other sends a reader looking for a
+    // process that does not exist. It also blocks `aka init`, whose whole job is
+    // repairing a store in exactly this state.
+    const frozen = join(dir, 'frozen');
+    mkdirSync(frozen);
+    const target = join(frozen, 'settings.json');
+    chmodSync(frozen, 0o500);
+    try {
+      const err = errorFrom(() =>
+        withFileLock(target, () => 'entered', { timeoutMs: 30_000, staleMs: 30_000 }),
+      );
+      expect(err).toBeInstanceOf(FileLockError);
+      expect((err as FileLockError).reason).toBe('unavailable');
+      expect(err?.message).toContain(target);
+    } finally {
+      chmodSync(frozen, 0o700);
+    }
+  });
+
+  it('takes a lock whose holder is gone and whose window has passed', () => {
+    plantHeldLock({ pid: DEAD_PID, ageMs: 5_000 });
+    expect(withFileLock(file, () => 'entered', { timeoutMs: 1_000, staleMs: 1_000 })).toBe(
+      'entered',
+    );
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('never takes a lock whose holder is still alive, well past the stale window', () => {
+    // Age alone must not evict anybody. A holder can outlive the window without
+    // being dead — a suspended laptop, a throttled container, a slow network
+    // home — and stealing from one puts two writers in the section, which is the
+    // defect the lock exists to remove, reintroduced by its own recovery.
+    // `staleMs: 1` leaves the liveness check as the only thing that can refuse.
+    plantHeldLock({ pid: process.pid, ageMs: 5_000 });
+    const err = errorFrom(() => withFileLock(file, () => 'entered', { timeoutMs: 50, staleMs: 1 }));
+    expect(err).toBeInstanceOf(FileLockError);
+    expect((err as FileLockError).reason).toBe('timeout');
+    expect(existsSync(lock)).toBe(true);
+  });
+
+  it('takes a lock whose pid still resolves once it is far past any plausible hold', () => {
+    // The liveness check's own failure mode: a dead holder's pid gets recycled by
+    // an unrelated process, and a lock kept alive by that coincidence would never
+    // be recoverable — the permanent wedge the stale path exists to prevent. Past
+    // the abandon window the recycled-pid reading wins over the still-running one.
+    plantHeldLock({ pid: process.pid, ageMs: 10 * 60_000 });
+    expect(withFileLock(file, () => 'entered', { timeoutMs: 1_000, staleMs: 1_000 })).toBe(
+      'entered',
+    );
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('judges a lock from another host on age alone, since its pid is not ours to ask about', () => {
+    // A ~/.aka on a shared network home carries locks from other machines, where
+    // a pid names a process in someone else's table. Asking locally answers about
+    // an unrelated program — so that answer must not be what keeps the lock.
+    plantHeldLock({ pid: process.pid, ageMs: 5_000, host: 'some-other-machine' });
+    expect(withFileLock(file, () => 'entered', { timeoutMs: 1_000, staleMs: 1_000 })).toBe(
+      'entered',
+    );
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('lets only one waiter recover a given abandoned lock', () => {
+    // Several waiters meet one abandoned lock at the same moment. Unserialised
+    // they all judge it stale, one removes it and takes a fresh lock, and the
+    // next one's removal lands on THAT — two writers inside at once, which is
+    // the defect the lock exists to remove. The recovery is serialised by its
+    // own exclusive file so the second waiter re-reads the path and finds the
+    // first one's live lock instead of the abandoned one.
+    plantHeldLock({ pid: DEAD_PID, ageMs: 60_000 });
+
+    // Stand in for the winner: hold the section, and from inside it let another
+    // waiter judge the same lock this call already recovered.
+    let inner: unknown;
+    const outer = withFileLock(
+      file,
+      () => {
+        inner = errorFrom(() =>
+          withFileLock(file, () => 'second-in', { timeoutMs: 60, staleMs: 1 }),
+        );
+        return 'first-in';
+      },
+      { timeoutMs: 1_000, staleMs: 1_000 },
+    );
+
+    expect(outer).toBe('first-in');
+    // The second waiter must be refused, not handed the section: the lock it
+    // meets is the winner's live one, however stale the one it set out to break.
+    expect(inner).toBeInstanceOf(FileLockError);
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('leaves no breaker file behind', () => {
+    plantHeldLock({ pid: DEAD_PID, ageMs: 60_000 });
+    withFileLock(file, () => 'entered', { timeoutMs: 1_000, staleMs: 1_000 });
+    // A breaker left behind stalls every later recovery until it ages out.
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it('does not delete a lock that was taken away from it', () => {
+    // The cascade this guards: a holder that was stolen from must not remove the
+    // lock its successor now holds. Unlinking by path alone does exactly that,
+    // and the successor's successor then walks in while the successor is still
+    // writing — every writer reporting success.
+    let observed: string | undefined;
+    withFileLock(file, () => {
+      // Stand in for the thief: replace the lock with somebody else's while this
+      // call is inside the section.
+      writeFileSync(
+        lock,
+        `${JSON.stringify({ pid: process.pid, token: 'thief', at: Date.now() })}\n`,
+      );
+      observed = 'held';
+    });
+    expect(observed).toBe('held');
+    // The thief's lock survives its predecessor's release.
+    expect(existsSync(lock)).toBe(true);
+    expect(JSON.parse(readFileSync(lock, 'utf8'))).toMatchObject({ token: 'thief' });
+  });
+
+  it('refuses an async body rather than releasing the lock before it finishes', async () => {
+    // The lock is dropped when `fn` returns, so an async body would hand it back
+    // at the first await with the write still to come — silently unguarded, and
+    // type-checking clean. Refused instead.
+    let settled: Promise<string> | undefined;
+    expect(() =>
+      withFileLock(file, () => {
+        settled = Promise.resolve('done');
+        return settled;
+      }),
+    ).toThrow(TypeError);
+    await settled;
+    // And the refusal still releases, rather than wedging the file.
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('measures staleness from the lock body, not the file mtime', () => {
+    // An mtime comes from whichever clock owns the filesystem. On a network home
+    // that is the server's, so a client a few seconds ahead would read every
+    // fresh lock as already abandoned and exclusion would silently disappear.
+    plantHeldLock({ pid: DEAD_PID, ageMs: 0 });
+    backdate(lock, 10 * 60_000); // an mtime far outside any stale window
+    const err = errorFrom(() =>
+      withFileLock(file, () => 'entered', { timeoutMs: 50, staleMs: 2_000 }),
+    );
+    expect(err).toBeInstanceOf(FileLockError);
+    expect(existsSync(lock)).toBe(true);
+  });
+
+  it('recovers a lock with an unreadable body, which records no clock or pid', () => {
+    // A truncated write leaves a lock nothing can identify. Falling back to mtime
+    // is what stops it wedging the file forever.
+    writeFileSync(lock, 'not json at all');
+    backdate(lock, 10_000);
+    expect(withFileLock(file, () => 'entered', { timeoutMs: 1_000, staleMs: 1_000 })).toBe(
+      'entered',
+    );
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it('does not take a lock younger than the stale window', () => {
+    plantHeldLock({ pid: DEAD_PID, ageMs: 1_000 });
+    // The stale path is a last resort for a dead holder. If it fired on a live
+    // one it would hand the section to two writers at once — the exact defect
+    // the lock exists to remove, reintroduced by its own recovery.
+    expect(() => withFileLock(file, () => 'entered', { timeoutMs: 50, staleMs: 30_000 })).toThrow(
+      FileLockError,
+    );
+    expect(existsSync(lock)).toBe(true);
+  });
+
+  it('creates the lock owner-only', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes are a no-op on Windows');
+      return;
+    }
+    let mode = 0;
+    withFileLock(file, () => {
+      mode = statSync(lock).mode & 0o777;
+    });
+    expect(mode).toBe(0o600);
+  });
+
+  it('refuses to write through a symlink planted at the lock path', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('symlink creation needs a privilege this runner may not have');
+      return;
+    }
+    // The lock sits in ~/.aka beside the file it guards, so in the loose-store
+    // state this package exists to repair its path is as plantable as the tmp
+    // path. The exclusive create is what refuses to follow the link — the same
+    // property the atomic write depends on.
+    const victimDir = join(dir, 'victim');
+    mkdirSync(victimDir);
+    const victim = join(victimDir, 'precious');
+    writeFileSync(victim, 'untouched');
+    symlinkSync(victim, lock);
+
+    expect(() => withFileLock(file, () => 'entered', NEVER_STALE)).toThrow(FileLockError);
+    expect(readFileSync(victim, 'utf8')).toBe('untouched');
+    expect(lstatSync(lock).isSymbolicLink()).toBe(true);
+  });
+
+  it('serialises callers that arrive one after another', () => {
+    // Not a race — a plain check that an ordinary sequence of writers still
+    // makes progress, so a lock that never released would show up here rather
+    // than only under contention.
+    const order: number[] = [];
+    for (let i = 0; i < 5; i++) withFileLock(file, () => order.push(i));
+    expect(order).toEqual([0, 1, 2, 3, 4]);
+  });
+});
+
+// Capture OUTSIDE the catch: a `try { …; throw new Error('expected') } catch`
+// shape asserts on the test's own guard error, and stays green when the call
+// under test stops throwing altogether.
+function errorFrom(fn: () => unknown): Error | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/packages/persistence/test/helpers/settings-writer-child.ts
+++ b/packages/persistence/test/helpers/settings-writer-child.ts
@@ -1,0 +1,71 @@
+/**
+ * One settings writer, as a process of its own — the shape the product runs in.
+ *
+ * The wizard, `aka init` and the dashboard server are three separate processes
+ * over one ~/.aka, and the race between them is a FILE race, so neither
+ * `withTwoWriters` (independent handles on one store, in one thread) nor a
+ * worker thread models it. A worker would in fact model the wrong thing: it
+ * shares `process.pid`, and the tmp path the atomic write builds is per-process,
+ * so two threads meet a collision that two processes never can.
+ *
+ * Reports on stdout as one JSON line rather than by exit code, because the
+ * interesting failure is a writer that reported success and lost its answer
+ * anyway. The timestamps bracket the applyOnboarding call so a test can show the
+ * writers really did overlap — a barrier that quietly serialised them would make
+ * every no-loss assertion pass for the wrong reason.
+ *
+ * Loaded by Node directly, outside the test runner's transform, so it stays on
+ * node: builtins and plain erasable type annotations.
+ */
+import { existsSync, writeFileSync } from 'node:fs';
+
+import { applyOnboarding } from '../../src/settings.ts';
+
+const [base, jobJson, readyFile, goFile] = process.argv.slice(2);
+if (
+  base === undefined ||
+  jobJson === undefined ||
+  readyFile === undefined ||
+  goFile === undefined
+) {
+  throw new Error('settings-writer-child: expected <base> <jobJson> <readyFile> <goFile>');
+}
+
+const job = JSON.parse(jobJson) as { set?: Record<string, unknown>; clear?: string[] };
+
+// `clear` is a list of names rather than keys set to undefined, because
+// JSON.stringify DROPS an undefined value: a revoke written the natural way
+// crosses as `{}` and the child writes nothing at all. Silently — the writer
+// still reports success, so a test asserting the revoke stuck fails looking like
+// a product defect, and one asserting the grant survived passes for no reason.
+const answers: Record<string, unknown> = { ...job.set };
+for (const field of job.clear ?? []) answers[field] = undefined;
+
+// A handshake, not a clock. Announce that this process is loaded and ready, then
+// wait until the parent releases everyone. A deadline-based barrier instead ties
+// the contention to how long Node takes to boot and load the schema — which
+// under a full parallel suite can outlast the deadline, leaving the writers to
+// run one after another and every no-loss assertion true for want of a race.
+//
+// Polled with a sleep rather than a bare spin: several of these run at once,
+// and a hot loop each would take a core apiece off the rest of the suite —
+// enough to push a timing-sensitive test elsewhere over its threshold. The
+// extra millisecond of release latency costs nothing here, since the barrier's
+// assertion tolerates a late start (see allReleasedTogether).
+const PARK = new Int32Array(new SharedArrayBuffer(4));
+const readyAt = Date.now();
+writeFileSync(readyFile, '');
+while (!existsSync(goFile)) {
+  Atomics.wait(PARK, 0, 0, 1);
+}
+
+const startedAt = Date.now();
+let ok = false;
+let error: string | undefined;
+try {
+  applyOnboarding(answers, base);
+  ok = true;
+} catch (err) {
+  error = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+process.stdout.write(`${JSON.stringify({ ok, error, readyAt, startedAt, endedAt: Date.now() })}\n`);

--- a/packages/persistence/test/helpers/settings-writers.test.ts
+++ b/packages/persistence/test/helpers/settings-writers.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The concurrent-writer harness's own suite.
+ *
+ * Every no-loss assertion in concurrency/settings-race.test.ts rests on this
+ * helper doing two things: actually running the writers, and actually releasing
+ * them together. Both fail silently if left unguarded — a child that never ran
+ * writes nothing to lose, and a barrier that serialised them removes the race
+ * the assertions are about.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { readWorkspaceSettings } from '../../src/settings.ts';
+import type { ConcurrentRun, WriterJob } from './settings-writers.ts';
+import { allReleasedTogether, runConcurrentSettingsWriters } from './settings-writers.ts';
+
+let base: string;
+
+beforeEach(() => {
+  base = mkdtempSync(join(tmpdir(), 'aka-writers-helper-'));
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+function run(releasedAt: number, readies: number[]): ConcurrentRun {
+  return {
+    releasedAt,
+    outcomes: readies.map((readyAt) => ({
+      ok: true,
+      readyAt,
+      // Every writer starts after the release; that is true by construction and
+      // is precisely why the barrier check reads readyAt instead.
+      startedAt: releasedAt + 1,
+      endedAt: releasedAt + 11,
+    })),
+  };
+}
+
+describe('runConcurrentSettingsWriters', () => {
+  it('runs a writer, and it really writes', async () => {
+    // Deliberately ONE writer: an outcome saying `ok` while the store stayed
+    // empty would let every downstream assertion pass on nothing, and that is a
+    // property of the harness. Asserting it across concurrent writers instead
+    // would make this suite go red whenever the PRODUCT lost an update — a
+    // harness failure reported for a defect somewhere else.
+    const result = await runConcurrentSettingsWriters(base, [{ set: { policy: 'warn' } }]);
+    expect(result.outcomes).toHaveLength(1);
+    expect(result.outcomes[0]?.ok).toBe(true);
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+  });
+
+  it('runs one writer per job and reports each one', async () => {
+    const result = await runConcurrentSettingsWriters(base, [
+      { set: { policy: 'warn' } },
+      { set: { historicalAccess: 'full' } },
+      { set: { dataSharesInPlace: false } },
+    ]);
+    expect(result.outcomes).toHaveLength(3);
+    expect(result.outcomes.every((o) => o.ok)).toBe(true);
+  });
+
+  it('holds every writer at the line until all of them are ready', async () => {
+    const result = await runConcurrentSettingsWriters(base, [
+      { set: { policy: 'warn' } },
+      { set: { historicalAccess: 'full' } },
+      { set: { dataSharesInPlace: false } },
+    ]);
+    expect(allReleasedTogether(result)).toBe(true);
+  });
+
+  it('carries a revoke across the process boundary', async () => {
+    // JSON.stringify drops an undefined value, so a job that cleared a field by
+    // setting it to undefined would cross as `{}` — the writer applies nothing
+    // and still reports success, and a test asserting the revoke stuck fails
+    // looking like a product defect. `clear` names the field instead.
+    await runConcurrentSettingsWriters(base, [
+      {
+        set: {
+          modelJudgeConsent: { acknowledgedAt: '2026-01-01T00:00:00.000Z', payloadVersion: 1 },
+        },
+      },
+    ]);
+    expect(readWorkspaceSettings(base).modelJudgeConsent).toBeDefined();
+
+    await runConcurrentSettingsWriters(base, [{ clear: ['modelJudgeConsent'] }]);
+    expect(readWorkspaceSettings(base).modelJudgeConsent).toBeUndefined();
+  });
+
+  it('throws when a writer dies instead of folding it into a result', async () => {
+    // A child that cannot even parse its arguments exits non-zero having written
+    // nothing. Reported as a plain `ok: false` it would read as "this writer
+    // lost the race", which is a legitimate outcome — so it has to be a failure
+    // of the run instead.
+    await expect(
+      runConcurrentSettingsWriters(base, [undefined as unknown as WriterJob]),
+    ).rejects.toThrow(/settings writer 0/);
+  });
+});
+
+describe('allReleasedTogether', () => {
+  it('is true when every writer was parked before the release', () => {
+    expect(allReleasedTogether(run(100, [20, 60, 100]))).toBe(true);
+  });
+
+  it('is false when a writer was still loading at the release', () => {
+    // The failure mode it exists to catch: a barrier that stopped holding, so
+    // the writers ran as each finished booting, one after another — under which
+    // "no answer was lost" is trivially true.
+    expect(allReleasedTogether(run(100, [20, 140]))).toBe(false);
+  });
+
+  it('tolerates a writer scheduled late AFTER the release, which is not a defect', () => {
+    // A released child can sit unscheduled for longer than another writer's
+    // whole call on a loaded runner. Only readiness is the barrier's business,
+    // so that must not read as a broken barrier — otherwise the suite fails on
+    // machine load rather than on the product.
+    const late = run(100, [20, 60]);
+    const scheduledLate = late.outcomes.map((o, i) =>
+      i === 1 ? { ...o, startedAt: 9_000, endedAt: 9_010 } : o,
+    );
+    expect(allReleasedTogether({ ...late, outcomes: scheduledLate })).toBe(true);
+  });
+
+  it('is false for no writers at all', () => {
+    expect(allReleasedTogether(run(100, []))).toBe(false);
+  });
+});

--- a/packages/persistence/test/helpers/settings-writers.ts
+++ b/packages/persistence/test/helpers/settings-writers.ts
@@ -1,0 +1,193 @@
+/**
+ * N concurrent settings writers, each in its own process, released together.
+ *
+ * `withTwoWriters` deliberately does not cover this: it hands out independent
+ * SQLite handles in ONE thread, and `node:sqlite` is synchronous, so those
+ * interleave rather than collide. settings.json is outside SQLite entirely —
+ * no WAL, no `busy_timeout` — and its writers are separate processes, so the
+ * contention has to be real.
+ */
+import type { ChildProcess } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const CHILD = fileURLToPath(new URL('./settings-writer-child.ts', import.meta.url));
+
+/** How long to wait for every writer to report itself loaded and ready. */
+const READY_TIMEOUT_MS = 30_000;
+
+/** What one writer applies. */
+export interface WriterJob {
+  /** Fields to set, with the values to set them to. */
+  set?: Record<string, unknown>;
+  /**
+   * Fields to clear — a revoke.
+   *
+   * Named rather than passed as `undefined` values because JSON.stringify drops
+   * an undefined, so a revoke would cross the process boundary as an empty
+   * answer set and the writer would apply nothing while still reporting success.
+   */
+  clear?: string[];
+}
+
+/** One writer's own account of its write. */
+export interface WriterOutcome {
+  /** Whether applyOnboarding returned. */
+  ok: boolean;
+  /** `Name: message` when it threw; absent when it returned. */
+  error?: string;
+  /** When this writer finished loading and parked at the barrier. */
+  readyAt: number;
+  startedAt: number;
+  endedAt: number;
+}
+
+/** One concurrent run: what each writer reported, and when they were released. */
+export interface ConcurrentRun {
+  outcomes: WriterOutcome[];
+  /** The instant the parent released every parked writer. */
+  releasedAt: number;
+}
+
+interface Writer {
+  child: ChildProcess;
+  done: Promise<ChildResult>;
+}
+
+interface ChildResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function spawnWriter(base: string, job: WriterJob, readyFile: string, goFile: string): Writer {
+  const child = spawn(process.execPath, [CHILD, base, JSON.stringify(job), readyFile, goFile], {
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const done = new Promise<ChildResult>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ code, stdout, stderr });
+    });
+  });
+  return { child, done };
+}
+
+// Poll until every writer has announced itself, or give up loudly.
+//
+// A silent give-up would release the ones that are ready and leave the rest to
+// arrive afterwards — the serialised run this handshake exists to rule out. A
+// writer that DIED is the other way to wait forever, so an exited child ends the
+// wait at once rather than at the timeout: its readiness is never coming, and
+// the caller has a real failure to report.
+async function waitForAllReady(writers: Writer[], readyFiles: string[]): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (!readyFiles.every((f) => existsSync(f))) {
+    if (writers.some((w) => w.child.exitCode !== null || w.child.signalCode !== null)) return;
+    if (Date.now() >= deadline) {
+      const missing = readyFiles.filter((f) => !existsSync(f)).length;
+      throw new Error(
+        `${String(missing)} of ${String(readyFiles.length)} settings writers never reported ready`,
+      );
+    }
+    await delay(5);
+  }
+}
+
+/**
+ * Run one writer per job, all released at the same instant, and return what each
+ * one reported.
+ *
+ * THROWS on a child that died or printed nothing parseable, rather than folding
+ * it into a `false`. A crashed writer wrote nothing, so every "no answer was
+ * lost" assertion downstream would pass on a run where most of the writers never
+ * ran — the failure this helper exists to make visible, arriving as a green
+ * test. The child's stderr is carried into the message, because a module that
+ * failed to load says so there and nowhere else.
+ */
+export async function runConcurrentSettingsWriters(
+  base: string,
+  jobs: WriterJob[],
+): Promise<ConcurrentRun> {
+  const sync = mkdtempSync(join(tmpdir(), 'aka-writer-sync-'));
+  const goFile = join(sync, 'go');
+  const readyFiles = jobs.map((_, i) => join(sync, `ready-${String(i)}`));
+  // Declared outside the try so the cleanup can reach them. A writer parks by
+  // polling for `goFile`, so a throw that removed the sync dir without killing
+  // the children would leave them waiting on a path that can never appear —
+  // orphans polling for the life of the CI job.
+  const writers = jobs.map((job, i) => spawnWriter(base, job, readyFiles[i] ?? '', goFile));
+  let results: ChildResult[];
+  let releasedAt: number;
+  try {
+    await waitForAllReady(writers, readyFiles);
+    // Released only once every writer is loaded and waiting. Timing the barrier
+    // instead ties the contention to Node's boot time, which under a full
+    // parallel suite can outrun any deadline — and a barrier that expired early
+    // does not fail, it just serialises the writers, leaving every no-loss
+    // assertion downstream true for want of a race.
+    releasedAt = Date.now();
+    writeFileSync(goFile, '');
+    results = await Promise.all(writers.map((w) => w.done));
+  } catch (err) {
+    for (const w of writers) w.child.kill('SIGKILL');
+    await Promise.allSettled(writers.map((w) => w.done));
+    throw err;
+  } finally {
+    rmSync(sync, { recursive: true, force: true });
+  }
+  const outcomes = results.map((result, index) => {
+    if (result.code !== 0) {
+      throw new Error(
+        `settings writer ${String(index)} exited ${String(result.code)}: ${result.stderr.trim()}`,
+      );
+    }
+    const line = result.stdout.trim();
+    try {
+      return JSON.parse(line) as WriterOutcome;
+    } catch {
+      throw new Error(
+        `settings writer ${String(index)} printed no outcome (stdout: ${JSON.stringify(line)}, stderr: ${result.stderr.trim()})`,
+      );
+    }
+  });
+  return { outcomes, releasedAt };
+}
+
+/**
+ * Whether every writer was already parked at the barrier before ANY of them was
+ * released — the barrier's own positive control.
+ *
+ * The point of a barrier is contention, and one that quietly stopped working
+ * would let each writer run as it finished booting, one after another. Every
+ * no-loss assertion downstream then holds for want of a race, silently.
+ *
+ * It compares `readyAt` — stamped by each child as it parks — against the
+ * instant the parent released them. Comparing `startedAt` instead cannot fail:
+ * a child stamps that only after it observes the release, so `startedAt >=
+ * releasedAt` is true by construction and stays true with the handshake deleted.
+ * `readyAt` is the one of the two the barrier actually decides.
+ *
+ * What it deliberately does NOT assert is that the calls overlapped in wall
+ * clock. A released child can be descheduled — on a runner with more test
+ * processes than cores, for longer than another writer's whole call — so an
+ * overlap check fails on a scheduling artifact rather than on a defect.
+ */
+export function allReleasedTogether(run: ConcurrentRun): boolean {
+  if (run.outcomes.length === 0) return false;
+  return run.outcomes.every((o) => o.readyAt <= run.releasedAt);
+}

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -16,6 +16,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'DuplicateActiveExceptionError',
   'EXCEPTION_KEY_FILENAME',
   'FileKeyProvider',
+  'FileLockError',
   'KeychainKeyProvider',
   'MAX_EGRESS_CALL_SITES_PER_PROJECT',
   'SETTINGS_FILENAME',
@@ -90,6 +91,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'tightenPerms',
   'toolCallId',
   'verifyPointerTag',
+  'withFileLock',
   'writeOwnerOnlyFileSync',
 ];
 

--- a/packages/persistence/test/settings.test.ts
+++ b/packages/persistence/test/settings.test.ts
@@ -1,7 +1,16 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import type { SimpleDetectionPolicy } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { applyOnboarding, readWorkspaceSettings } from '../src/settings.ts';
@@ -136,5 +145,69 @@ describe('applyOnboarding', () => {
     expect(second.policy).toBe('warn'); // preserved from the first call
     expect(second.historicalAccess).toBe('full'); // newly applied
     expect(second.onboardedAt).toBe(first.onboardedAt); // stable across edits
+  });
+
+  it('leaves no lock file behind', () => {
+    applyOnboarding({ policy: 'warn' }, base);
+    // The write lock is a sibling of settings.json. One left behind costs every
+    // later writer its full stale wait before it can proceed.
+    expect(readdirSync(join(base, 'settings'))).toEqual(['settings.json']);
+  });
+});
+
+describe('applyOnboarding (derived answers)', () => {
+  it('hands the updater the settings already on disk', () => {
+    applyOnboarding({ policy: 'warn' }, base);
+
+    let seen: SimpleDetectionPolicy | undefined;
+    applyOnboarding((current) => {
+      seen = current.policy;
+      return { historicalAccess: 'full' };
+    }, base);
+
+    expect(seen).toBe('warn');
+    expect(readWorkspaceSettings(base).historicalAccess).toBe('full');
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+  });
+
+  it('merges what the updater returns, exactly as a plain answer object would', () => {
+    const saved = applyOnboarding(() => ({ policy: 'warn' }), base);
+    expect(saved.policy).toBe('warn');
+    expect(saved.onboardedAt).toBeDefined();
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+  });
+
+  it('lets an updater carry a value forward from the current settings', () => {
+    // The dashboard's shape: a consent grant that survives an unrelated edit is
+    // read on the far side of the lock, so it is the grant still on file rather
+    // than one a concurrent revoke has since cleared.
+    const granted = { acknowledgedAt: '2026-01-01T00:00:00.000Z', version: 1 };
+    applyOnboarding({ vaultConsent: granted }, base);
+
+    applyOnboarding((current) => ({ policy: 'warn', vaultConsent: current.vaultConsent }), base);
+
+    expect(readWorkspaceSettings(base).vaultConsent).toEqual(granted);
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+  });
+
+  it('drops a field the updater returns as undefined', () => {
+    applyOnboarding(
+      { modelJudgeConsent: { acknowledgedAt: '2026-01-01T00:00:00.000Z', payloadVersion: 1 } },
+      base,
+    );
+    applyOnboarding(() => ({ modelJudgeConsent: undefined }), base);
+    expect(readWorkspaceSettings(base).modelJudgeConsent).toBeUndefined();
+  });
+
+  it('does not write when the updater throws', () => {
+    applyOnboarding({ policy: 'warn' }, base);
+    expect(() =>
+      applyOnboarding(() => {
+        throw new Error('derivation failed');
+      }, base),
+    ).toThrow('derivation failed');
+    expect(readWorkspaceSettings(base).policy).toBe('warn');
+    // And the lock is released, so the next writer is not left waiting it out.
+    expect(applyOnboarding({ historicalAccess: 'full' }, base).historicalAccess).toBe('full');
   });
 });

--- a/web-ui/app/(app)/settings/actions.ts
+++ b/web-ui/app/(app)/settings/actions.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { applyOnboarding, readWorkspaceSettings } from '@akasecurity/persistence';
+import { applyOnboarding } from '@akasecurity/persistence';
 import {
   HistoricalAccess,
   isVaultConsentValid,
@@ -51,21 +51,13 @@ export async function saveSettings(input: {
   // verbatim; modelJudgeConsent needs no equivalent parse because only its
   // truthiness survives — the record written below is built entirely here.
   try {
-    // The vault grant is stamped HERE, never accepted from the client — the
-    // input is only the choice string, so a caller-supplied acknowledgedAt or
-    // version has no path in. 'on' records the current time at the current
-    // consent version; if a still-valid grant is already on file it is kept
-    // as-is so its acknowledgedAt survives unrelated edits. 'off' clears the
-    // field entirely: future vaulting stops, but entries already stored remain
-    // until the vault is purged.
-    const current = readWorkspaceSettings();
-    const vaultConsent =
-      vaultChoice === 'off'
-        ? undefined
-        : isVaultConsentValid(current.vaultConsent)
-          ? current.vaultConsent
-          : { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION };
-    applyOnboarding({
+    // Derived inside applyOnboarding's write lock, not before it: `current` is
+    // read back on the far side of the merge that is about to happen, so a
+    // grant this page keeps is one that is still on file. Reading it out here
+    // instead would carry a stale grant across a concurrent revoke — from the
+    // wizard, or from a second tab — and write it back, silently reinstating
+    // consent the user had just withdrawn.
+    applyOnboarding((current) => ({
       policy: policy.data,
       historicalAccess: historicalAccess.data,
       // Grant records fresh consent at the current payload version; revoke
@@ -73,9 +65,21 @@ export async function saveSettings(input: {
       modelJudgeConsent: input.modelJudgeConsent
         ? { acknowledgedAt: new Date().toISOString(), payloadVersion: MODEL_JUDGE_PAYLOAD_VERSION }
         : undefined,
-      vaultConsent,
+      // The vault grant is stamped HERE, never accepted from the client — the
+      // input is only the choice string, so a caller-supplied acknowledgedAt or
+      // version has no path in. 'on' records the current time at the current
+      // consent version; if a still-valid grant is already on file it is kept
+      // as-is so its acknowledgedAt survives unrelated edits. 'off' clears the
+      // field entirely: future vaulting stops, but entries already stored remain
+      // until the vault is purged.
+      vaultConsent:
+        vaultChoice === 'off'
+          ? undefined
+          : isVaultConsentValid(current.vaultConsent)
+            ? current.vaultConsent
+            : { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },
       vaultInlineReveal: inlineReveal.data,
-    });
+    }));
   } catch {
     return { ok: false, error: 'Could not write settings.json.' };
   }


### PR DESCRIPTION
`~/.aka/settings/settings.json` is written by three separate processes — the `/aka:setup` wizard, `aka init`, and the dashboard's Settings page. Saving a setting is a read-modify-write, and nothing coordinated them: two writers read the same bytes, each merged its own change onto that stale copy, and whichever renamed last published a file missing the other's answer. Both reported success, so the loss was silent.

The file holds **consent** records (`modelJudgeConsent`, `vaultConsent`), so the write that goes missing can be a **revocation** — a permission the user just switched off, silently switched back on.

Reproduced before fixing, with 7 concurrent processes each setting a different field:

```
=== 10/10 rounds lost at least one answer; 0/10 had a writer fail ===
```

Six of seven answers lost every round, with zero writers reporting failure.

## Changes

- **`withFileLock`** (`packages/persistence/src/file-lock.ts`) — cross-process mutual exclusion via an exclusive sibling `<file>.lock`. Chosen over `flock` (no Windows equivalent) and over an fd-held lock (lost when a writer reopens the file).
- **`applyOnboarding`** holds it across the whole read-merge-write, and gains an updater form so a value derived from the current settings is derived *inside* the lock. The dashboard's vault-consent carry-forward uses it — read outside, it writes a stale grant back over a concurrent revoke.
- **`aka init`** re-checks for the file inside the lock, so it can't see none, have the wizard's answers land while it decides, then replace them with defaults.

Four properties are load-bearing and each is pinned by a test:

- A **release proves it still owns the lock** (ownership token). Unlinking by path means a holder that was stolen from deletes its *successor's* lock — the section unguarded while that successor is mid-write.
- **Recovering an abandoned lock is a critical section of its own.** Unserialised, several waiters judge the same dead lock stale, one removes it and takes a fresh lock, and the next one's removal lands on that. Measured at 5/12 trials losing an update with eight waiters; 0/14 after.
- **Staleness needs both an elapsed window and a holder that is gone.** Age alone evicts a merely slow holder (suspended laptop, throttled container). The clock is read from the lock body, never mtime — on a network home that is the file server's clock.
- **It fails loudly rather than writing unlocked.** `FileLockError.reason` separates contention from a directory that will never hold a lock; `aka init` branches on it, so it stays the repair path for a broken `~/.aka`.

## Verification

- The reproduction above: **0/8 rounds** lose an answer after the fix.
- Eight waiters contending over one abandoned lock: **0/14 trials** lose an update.
- Mutation-tested — removing the lock reddens 4 concurrency tests; a no-op release, an ignored stale window, an ignored liveness check, and hoisting `aka init`'s check out of the lock each redden their own cases.
- `turbo run test lint typecheck --force` → **47/47, `Cached: 0`**, twice; persistence suite green over 6 consecutive runs.

The concurrency suite drives **real child processes** released on a readiness handshake, not worker threads: a worker shares `process.pid`, and the atomic write's tmp path is per-process, so threads meet a collision two processes never can.

## Notes

- The lock is **advisory and scoped to this one file**. `fingerprint.ts`'s key mint and `local-ops`' `update-cache.ts` are unlocked read-modify-writes of the same shape and are **not** covered here — `CLAUDE.md` §6 says so explicitly rather than implying the store has the property.
- `@akasecurity/persistence` is bundled into both the CLI and the plugin, so both artifacts change. **No versions bumped** — that's a release decision.
