### PR TITLE
docs(eslint-config): state the ignore-flag rule for lint:root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,6 +494,16 @@ tools/                repo tooling: installer one-liners + the audit-gate worksp
    suites are covered by the ordinary per-package check and nothing about them is
    special any more.
 
+   **Naming a target is not enough here either.** The rule the package paragraph
+   above draws applies to `lint:root` unchanged: an `--ignore-pattern` cancels a
+   target it matches, and an `--ignore-path` cancels the whole invocation, so the
+   script reads as covering a repo-root file that ESLint then skips. Either way the
+   file counts as **uncovered** and the failure names it, and the fix is to drop the
+   flag rather than the target. This is enforced rather than remembered — the
+   derived check below reads each invocation's ignore flags next to its own targets,
+   so an ignore that takes a root file back out fails exactly as a missing target
+   does.
+
    Anything new outside every package belongs in those passes — and a **file** at
    the root is named explicitly, not folded into a directory glob (the same rule
    step 5 draws inside a package). `*.config.*` is the standing lint target for root

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -18,6 +18,7 @@ import {
 } from './helpers/claude-md.js';
 import {
   eslintInvocations,
+  IGNORE_VALUE_FLAGS,
   lintableTrackedFiles,
   LINTABLE_EXT,
   packageLintInvocations,
@@ -1008,6 +1009,98 @@ describe('every file outside every workspace package is linted by a repo-root pa
             `tooling config, anything else is named explicitly:\n  ${uncovered.join('\n  ')}`
         : undefined,
     ).toEqual([]);
+  });
+});
+
+describe(`the root pass states the ignore-flag rule (${CONVENTIONS_DOC} step 5)`, () => {
+  // The ignore rule is enforced for the ROOT pass by nonPackageFilesNotWired, and
+  // stated for a PACKAGE by the paragraph earlier in step 5. Prose sitting beside
+  // an enforced property inherits none of its guard, so a reader who takes the
+  // package paragraph as the general rule has nothing telling them it also binds
+  // `lint:root` — and a reader who does not is one flag away from a repo-root file
+  // that reads as covered and is never linted.
+  //
+  // Anchored on the boundary between the two halves rather than on the claim
+  // itself. An anchor that IS the claim disappears with it, and a slice that
+  // cannot find its anchor reports a missing anchor rather than a missing rule —
+  // the deletion this guard exists to catch would read as a broken guard.
+  const ROOT_HALF_ANCHOR = 'Files **outside every package**';
+  const STEP_5_SECTION = '## Adding a new workspace package';
+
+  /** Step 5's text from the repo-root half onward. Throws rather than returning ''. */
+  function rootHalf() {
+    const section = sectionOf(readConventions(), STEP_5_SECTION);
+    const at = section.indexOf(ROOT_HALF_ANCHOR);
+    if (at === -1) {
+      throw new Error(
+        `${CONVENTIONS_DOC} ${STEP_5_SECTION}: no ${JSON.stringify(ROOT_HALF_ANCHOR)} — the guard ` +
+          'cannot tell where the repo-root half begins, so it would assert against the package ' +
+          'paragraph and pass on prose that says nothing about `lint:root`.',
+      );
+    }
+    if (section.indexOf(ROOT_HALF_ANCHOR, at + 1) !== -1) {
+      throw new Error(
+        `${CONVENTIONS_DOC}: ${JSON.stringify(ROOT_HALF_ANCHOR)} occurs more than once, so this ` +
+          'slice starts at whichever came first rather than at the root half.',
+      );
+    }
+    return section.slice(at);
+  }
+
+  // A flag named in prose, normalized: `--ignore-pattern=<glob>` is the same flag
+  // as `--ignore-pattern`, and comparing the spellings rather than the flags would
+  // fail on a rewording that changed nothing.
+  const ignoreFlagsNamedIn = (text) =>
+    [
+      ...new Set(
+        codeSpansOf(text)
+          .map((span) => span.split('=')[0].trim())
+          .filter((span) => span.startsWith('--ignore')),
+      ),
+    ].sort();
+
+  it('names every ignore flag the coverage check models, and no other', () => {
+    // Both directions. A doc that drops one leaves contributors told about half
+    // the rule; a doc that names one the parser does not model promises an
+    // enforcement that is not there. Compared against the modelled set rather
+    // than a literal pair, so adding a third flag to IGNORE_VALUE_FLAGS fails
+    // here until the prose catches up.
+    expect(
+      ignoreFlagsNamedIn(rootHalf()),
+      `${CONVENTIONS_DOC} step 5's repo-root half must state the ignore-flag rule for ` +
+        '`lint:root`, naming each flag the coverage check subtracts by. The package paragraph ' +
+        'above it states the same rule; a reader has no way to know it also binds the root pass ' +
+        'unless this half says so.',
+    ).toEqual([...IGNORE_VALUE_FLAGS].sort());
+  });
+
+  it('states a rule the root walk really applies (each flag, with the control)', () => {
+    // The prose assertion above is only worth its green while the behaviour it
+    // describes is real. Drive the ROOT walk — not the per-package one — with each
+    // flag the doc names, through the same rootLintInvocations the live check uses.
+    const FILE = 'commitlint.config.mjs';
+    const targets = 'eslint -c eslint.root.config.mjs *.config.*';
+    const walk = (lintRoot) =>
+      nonPackageFilesNotWired(
+        [FILE],
+        rootLintInvocations({ lint: 'pnpm lint:root', 'lint:root': lintRoot }),
+      );
+
+    // The control, in the same case: without a flag the root pass reaches the
+    // file. Without this half, a predicate that reported EVERYTHING would satisfy
+    // every expectation below and the rule would look enforced while nothing was.
+    expect(
+      walk(targets),
+      `${targets} does not reach ${FILE}, so the flagged runs prove nothing`,
+    ).toEqual([]);
+
+    for (const flag of IGNORE_VALUE_FLAGS) {
+      expect(
+        walk(`${targets} ${flag} ${FILE}`),
+        `${flag} does not take ${FILE} back out of the root pass, so ${CONVENTIONS_DOC}'s claim ` +
+          'that it counts as uncovered is false',
+      ).toEqual([FILE]);
+    }
   });
 });
 


### PR DESCRIPTION
## What

Step 5 of `CLAUDE.md` told a contributor that **naming a target is not enough if the same
invocation hands it back** — and said it in the paragraph about a package `lint` script.
The very next paragraph introduced `pnpm lint:root` and said nothing of the kind, so the
rule read as general while the only place it was written down was the half it did not
apply to.

The coverage check has enforced it for the root pass all along: `nonPackageFilesNotWired`
reads each invocation's ignore flags next to that invocation's own targets. Nothing said so.

## Why the paragraph comes with a test

Prose sitting beside an enforced property inherits none of its guard. Adding the sentence
on its own would leave a claim nothing checks — the same shape as the gap it describes. So
`effective-config.test.js` gains two assertions:

- **Doc → reality.** The ignore flags the root half names must **equal** `IGNORE_VALUE_FLAGS`,
  the set the parser actually subtracts by. Both directions fail: dropping one leaves
  contributors told half the rule, and naming one the parser does not model promises an
  enforcement that is not there.
- **Reality → doc.** Each named flag is driven through `rootLintInvocations` to show it
  really does take a repo-root file back out — with the unflagged run asserted **in the same
  case** as the control, without which a predicate that reported everything would satisfy
  the rest.

Anchored on the boundary between the package and root halves rather than on the claim
itself. An anchor that *is* the claim disappears with it, and a slice that cannot find its
anchor reports a missing anchor rather than a missing rule — the deletion the guard exists
to catch would read as a broken guard.

## Mutation evidence

A new guard's green means nothing until it has been made red for its own reason:

| Mutation | Result |
| --- | --- |
| Delete the whole new paragraph | Red on the **flags assertion**, not an anchor error — `expected [] to deeply equal ['--ignore-path','--ignore-pattern']` |
| Doc names only `--ignore-pattern` | Red — `expected ['--ignore-pattern'] to deeply equal ['--ignore-path','--ignore-pattern']` |
| `invocationExcludes` stops honouring `--ignore-path` | Red on the **behavioural** half — "`--ignore-path` does not take `commitlint.config.mjs` back out of the root pass" |
| Neutralise the control's targets | Red on the **control** — "does not reach `commitlint.config.mjs`, so the flagged runs prove nothing" |

## Verification

- `pnpm lint` → EXIT=0
- `pnpm format:check` → EXIT=0
- `pnpm typecheck:root` → EXIT=0
- `@akasecurity/eslint-config` suite → **750 passed** (was 748)
- `pnpm exec turbo run test --force --concurrency=2` → **29/29, Cached: 0**

Docs and tests only; no shipped source changes.
