### PR TITLE
feat(persistence): give the exceptions repository an injectable clock

### DIFF
--- a/packages/persistence/src/repositories/exceptions.ts
+++ b/packages/persistence/src/repositories/exceptions.ts
@@ -141,8 +141,12 @@ const ACTIVE_PREDICATE = `revoked_at IS NULL
  *
  * Exported as the single definition of "authorizes a reveal right now": the
  * vault inventory's badge subquery interpolates this same string (binding
- * `:now`), so the dashboard can never call a value revealable where the
- * crossing itself would refuse.
+ * `:now`), so the dashboard cannot call a value revealable where the crossing
+ * itself would refuse — while both bind the same instant. They do wherever
+ * this repository is built with its default clock, which is every product
+ * path. A caller that supplies a clock of its own moves only the crossing:
+ * SqliteSecretVaultRepository takes no clock, so its badge stays on the wall
+ * clock and the two can then disagree.
  */
 export const ACTIVE_REVEAL_GRANT_PREDICATE = `capability = 'reveal_to_model'
      AND conditions IS NULL
@@ -163,7 +167,14 @@ export class SqliteExceptionsRepository {
   private readonly insertBlockedStmt: StatementSync;
   private readonly sweepBlockedStmt: StatementSync;
 
-  constructor(private readonly db: DatabaseSync) {
+  constructor(
+    private readonly db: DatabaseSync,
+    // Every time-dependent decision here — expiry, both sweeps, and the
+    // terminal-collider supersede — reads this and nothing else, so a test can
+    // drive the boundary instead of racing the wall clock. The use budget is
+    // not among them: `use_count < max_uses` binds no instant.
+    private readonly now: () => number = () => Date.now(),
+  ) {
     // The fail-secure primitive: one-time semantics ride a single conditional
     // UPDATE (SQLite serializes writers, so this is race-free on one machine).
     // changes === 1 → the grant applies; 0 rows or any error → enforce as usual.
@@ -215,7 +226,7 @@ export class SqliteExceptionsRepository {
       );
     }
     const id = randomUUID();
-    const now = Date.now();
+    const now = this.now();
     try {
       this.insertExceptionRow(id, input, now);
     } catch (err) {
@@ -306,7 +317,7 @@ export class SqliteExceptionsRepository {
     const where = opts?.includeTerminal ? '' : `WHERE ${ACTIVE_PREDICATE}`;
     const rows = allRows<ExceptionRow>(
       this.db.prepare(`SELECT * FROM exceptions ${where} ORDER BY created_at DESC, rowid DESC`),
-      opts?.includeTerminal ? {} : { now: Date.now() },
+      opts?.includeTerminal ? {} : { now: this.now() },
     );
     const exceptions = mapRowsTolerant(rows, parseExceptionRow);
     return Promise.resolve(exceptions);
@@ -350,7 +361,7 @@ export class SqliteExceptionsRepository {
    * already revoked.
    */
   revoke(id: string, revokedBy: string, reason?: string): Promise<boolean> {
-    const now = Date.now();
+    const now = this.now();
     const result = this.db
       .prepare(
         `UPDATE exceptions
@@ -367,7 +378,7 @@ export class SqliteExceptionsRepository {
    * callers must treat identically — means it does not and the detection is
    * enforced as usual. Deliberately NOT wrapped in try/catch.
    */
-  consume(id: string, now = Date.now()): Promise<boolean> {
+  consume(id: string, now = this.now()): Promise<boolean> {
     const result = this.consumeStmt.run({ id, now });
     return Promise.resolve(Number(result.changes) === 1);
   }
@@ -377,7 +388,7 @@ export class SqliteExceptionsRepository {
    * version — what rides the policy bundle to the hook. Grants written under
    * a different (rotated-away) key never match, so they are excluded at read.
    */
-  activeBundleEntries(keyVersion: number, now = Date.now()): Promise<ExceptionBundleEntryType[]> {
+  activeBundleEntries(keyVersion: number, now = this.now()): Promise<ExceptionBundleEntryType[]> {
     const rows = allRows<ExceptionRow>(
       this.db.prepare(
         `SELECT * FROM exceptions
@@ -410,7 +421,7 @@ export class SqliteExceptionsRepository {
    * than the retention window on every write, so the ledger self-limits.
    */
   recordBlocked(entry: BlockedDetectionInput): Promise<void> {
-    const now = Date.now();
+    const now = this.now();
     this.sweepBlockedStmt.run({ cutoff: now - BLOCKED_DETECTIONS_RETENTION_MS });
     this.insertBlockedStmt.run({
       reference: entry.reference,
@@ -434,7 +445,7 @@ export class SqliteExceptionsRepository {
           WHERE blocked_at > :cutoff
           ORDER BY blocked_at DESC, rowid DESC`,
       ),
-      { cutoff: Date.now() - windowMs },
+      { cutoff: this.now() - windowMs },
     );
     return Promise.resolve(
       rows.map((row) => ({
@@ -467,9 +478,14 @@ export class SqliteExceptionsRepository {
     ruleId: string,
     valueFingerprint: string,
     keyVersion: number,
-    now = Date.now(),
+    now?: number,
   ): Promise<{ id: string } | null> {
     try {
+      // Read the clock INSIDE the try rather than as a default-parameter
+      // initializer: an initializer runs before the body, so a clock that
+      // threw would escape this method synchronously — past the guard that
+      // exists to make every failure here a rejection.
+      const at = now ?? this.now();
       const row = getRow<{ id: string }>(
         this.db.prepare(
           `SELECT id FROM exceptions
@@ -478,7 +494,7 @@ export class SqliteExceptionsRepository {
               AND ${ACTIVE_REVEAL_GRANT_PREDICATE}
             LIMIT 1`,
         ),
-        { ruleId, valueFingerprint, keyVersion, now },
+        { ruleId, valueFingerprint, keyVersion, now: at },
       );
       return Promise.resolve(row ?? null);
     } catch (err) {
@@ -493,7 +509,7 @@ export class SqliteExceptionsRepository {
    * predicate, so correctness never depends on this sweep; it only bounds how
    * long the audit evidence is kept locally. Returns the deleted count.
    */
-  sweepTerminal(retentionMs: number, now = Date.now()): Promise<number> {
+  sweepTerminal(retentionMs: number, now = this.now()): Promise<number> {
     const result = this.db
       .prepare(
         `DELETE FROM exceptions

--- a/packages/persistence/test/repositories/exceptions-clock.test.ts
+++ b/packages/persistence/test/repositories/exceptions-clock.test.ts
@@ -1,0 +1,391 @@
+import { DatabaseSync } from 'node:sqlite';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { applyMigrations } from '../../src/migrations.ts';
+import type {
+  BlockedDetectionInput,
+  CreateExceptionInput,
+} from '../../src/repositories/exceptions.ts';
+import {
+  BLOCKED_DETECTIONS_RETENTION_MS,
+  BLOCKED_DETECTIONS_TTL_MS,
+  DuplicateActiveExceptionError,
+  SqliteExceptionsRepository,
+} from '../../src/repositories/exceptions.ts';
+import { useTempStore } from '../helpers/temp-store.ts';
+
+// The time-dependent half of the grant mechanism: expiry, both sweeps, and the
+// terminal-collider supersede. Most cases here assert a boundary to the
+// MILLISECOND, which is the whole reason the repository takes an injectable
+// clock — on the wall clock those decisions can only be approached from far
+// enough away that the one-millisecond discrimination (active collider vs.
+// terminal collider; inside the window vs. outside) is unreachable, and the
+// sibling suite has to fabricate raw row timestamps with UPDATE to get near
+// them at all. The rest pin the stamping itself, and the last describe pins
+// that the DEFAULT is still the wall clock.
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+// A retention window for the sweep cases, and deliberately a local value that
+// claims no link to the one plugin-runtime passes in production. `sweepTerminal`
+// takes the window as an argument, so every assertion below drives BOTH that
+// argument and the clock advance from this constant and would hold for any
+// value — naming it after the production constant would promise a coupling
+// nothing here can check.
+const RETENTION_MS = 30 * DAY_MS;
+
+// A named instant, not `Date.now()`. A run-dependent origin makes a boundary
+// failure irreproducible, and it also stops the assertions below from
+// discriminating: they pin the exact stamp, which is only decisive when the
+// injected instant cannot be confused with the wall clock.
+const T0 = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+let db: DatabaseSync;
+let repo: SqliteExceptionsRepository;
+let clock: number;
+let fingerprintSeq = 0;
+
+/** Move the injected clock to an absolute instant. */
+function at(instant: number): void {
+  clock = instant;
+}
+
+function iso(instant: number): string {
+  return new Date(instant).toISOString();
+}
+
+beforeEach(() => {
+  db = new DatabaseSync(':memory:');
+  applyMigrations(db);
+  clock = T0;
+  repo = new SqliteExceptionsRepository(db, () => clock);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function input(overrides: Partial<CreateExceptionInput> = {}): CreateExceptionInput {
+  fingerprintSeq += 1;
+  return {
+    ruleId: 'aws-access-key-id',
+    category: 'secret',
+    // Unique per call so a test only collides on the index when it means to.
+    valueFingerprint: fingerprintSeq.toString(16).padStart(64, '0'),
+    keyVersion: 1,
+    maskedValue: 'AKIA******Q',
+    scope: 'temporary',
+    // An hour past the INJECTED clock, so a grant built with the default is
+    // active for the cases below. The wall-clock describe builds its own input
+    // instead — this default would be months stale against real time.
+    expiresAt: iso(clock + HOUR_MS),
+    maxUses: null,
+    justification: 'temp deploy creds, rotating after infra apply',
+    conditions: null,
+    createdBy: 'alice',
+    createdVia: 'cli-approve',
+    ...overrides,
+  };
+}
+
+function blockedInput(overrides: Partial<BlockedDetectionInput> = {}): BlockedDetectionInput {
+  fingerprintSeq += 1;
+  return {
+    reference: `ref-${String(fingerprintSeq)}`,
+    ruleId: 'aws-access-key-id',
+    category: 'secret',
+    valueFingerprint: fingerprintSeq.toString(16).padStart(64, '0'),
+    keyVersion: 1,
+    maskedValue: 'AKIA******Q',
+    sessionId: 'session-1',
+    repo: 'github.com/acme/api',
+    ...overrides,
+  };
+}
+
+/** Rows in storage, which is not the same question as rows a read returns. */
+function rawBlockedCount(): number {
+  return (db.prepare('SELECT count(*) AS c FROM blocked_detections').get() as { c: number }).c;
+}
+
+describe('SqliteExceptionsRepository — injected clock', () => {
+  it('stamps every write from the injected clock, not the wall clock', async () => {
+    const created = await repo.create(input({ expiresAt: iso(T0 + HOUR_MS) }));
+
+    expect(created.createdAt).toBe(iso(T0));
+    expect(created.updatedAt).toBe(iso(T0));
+    expect(created.expiresAt).toBe(iso(T0 + HOUR_MS));
+
+    // `revoke` stamps inline too. Before the injection a test could only assert
+    // this was non-null; the exact instant is the new assertion.
+    at(T0 + 5 * 60 * 1000);
+    expect(await repo.revoke(created.id, 'alice', 'rotated early')).toBe(true);
+
+    const revoked = await repo.getByIdPrefix(created.id);
+    expect(revoked?.revokedAt).toBe(iso(T0 + 5 * 60 * 1000));
+    expect(revoked?.updatedAt).toBe(iso(T0 + 5 * 60 * 1000));
+  });
+
+  it('defaults `consume` to the injected clock', async () => {
+    const grant = await repo.create(input());
+
+    at(T0 + 42);
+    expect(await repo.consume(grant.id)).toBe(true);
+
+    expect((await repo.getByIdPrefix(grant.id))?.lastUsedAt).toBe(iso(T0 + 42));
+  });
+
+  describe('expiry', () => {
+    it('drops a grant from list() at the exact millisecond it expires', async () => {
+      const expiry = T0 + HOUR_MS;
+      const grant = await repo.create(input({ expiresAt: iso(expiry) }));
+
+      at(expiry - 1);
+      expect((await repo.list()).map((e) => e.id)).toEqual([grant.id]);
+
+      // ACTIVE_PREDICATE is `expires_at > :now` — strictly future, so the grant
+      // is terminal AT its expiry, not one millisecond after it.
+      at(expiry);
+      expect(await repo.list()).toEqual([]);
+
+      // Terminal, not deleted: the row is retained as audit evidence.
+      expect((await repo.list({ includeTerminal: true })).map((e) => e.id)).toEqual([grant.id]);
+    });
+
+    it('drops a grant from the bundle at the same boundary, with no explicit now', async () => {
+      const expiry = T0 + HOUR_MS;
+      await repo.create(input({ keyVersion: 7, expiresAt: iso(expiry) }));
+
+      at(expiry - 1);
+      expect(await repo.activeBundleEntries(7)).toHaveLength(1);
+
+      at(expiry);
+      expect(await repo.activeBundleEntries(7)).toEqual([]);
+    });
+  });
+
+  describe('reveal grants', () => {
+    // The stakes the suppression case does not carry: a reveal grant authorizes
+    // decrypting a vaulted value, so an expiry that does not fire is the
+    // difference between a time-boxed reveal and a permanent one.
+    const REVEAL_FP = 'ab'.repeat(32);
+
+    async function revealGrant(expiresAt: number) {
+      return repo.create(
+        input({
+          capability: 'reveal_to_model',
+          valueFingerprint: REVEAL_FP,
+          expiresAt: iso(expiresAt),
+        }),
+      );
+    }
+
+    it('stops authorizing a reveal at the exact millisecond the grant expires', async () => {
+      const expiry = T0 + HOUR_MS;
+      const grant = await revealGrant(expiry);
+
+      at(expiry - 1);
+      expect(await repo.activeRevealGrant('aws-access-key-id', REVEAL_FP, 1)).toEqual({
+        id: grant.id,
+      });
+
+      at(expiry);
+      expect(await repo.activeRevealGrant('aws-access-key-id', REVEAL_FP, 1)).toBeNull();
+    });
+
+    it('stops authorizing a reveal the moment the grant is revoked', async () => {
+      const grant = await revealGrant(T0 + DAY_MS);
+
+      // Well inside the grant's life, so revocation — not expiry — is the only
+      // thing that can change the answer below.
+      at(T0 + 60_000);
+      expect(await repo.activeRevealGrant('aws-access-key-id', REVEAL_FP, 1)).toEqual({
+        id: grant.id,
+      });
+
+      expect(await repo.revoke(grant.id, 'alice')).toBe(true);
+      expect(await repo.activeRevealGrant('aws-access-key-id', REVEAL_FP, 1)).toBeNull();
+    });
+  });
+
+  describe('blocked-detections ledger', () => {
+    it('ends the recentBlocked window exactly BLOCKED_DETECTIONS_TTL_MS after the write', async () => {
+      const entry = blockedInput();
+      await repo.recordBlocked(entry);
+
+      // `blocked_at > :cutoff`, cutoff = now - windowMs: the row is in-window
+      // while now < blockedAt + window.
+      at(T0 + BLOCKED_DETECTIONS_TTL_MS - 1);
+      expect((await repo.recentBlocked()).map((e) => e.reference)).toEqual([entry.reference]);
+
+      at(T0 + BLOCKED_DETECTIONS_TTL_MS);
+      expect(await repo.recentBlocked()).toEqual([]);
+
+      // Out of the READ window is not out of storage — the wider lookback the
+      // dashboard uses still reaches it, which is the distinction the retention
+      // sweep below actually acts on.
+      expect((await repo.recentBlocked(DAY_MS)).map((e) => e.reference)).toEqual([entry.reference]);
+    });
+
+    it('sweeps on write at exactly BLOCKED_DETECTIONS_RETENTION_MS, and not a millisecond earlier', async () => {
+      await repo.recordBlocked(blockedInput());
+      expect(rawBlockedCount()).toBe(1);
+
+      // `blocked_at <= :cutoff`, cutoff = now - retention: one millisecond short
+      // of the window, the row survives the write's sweep.
+      at(T0 + BLOCKED_DETECTIONS_RETENTION_MS - 1);
+      await repo.recordBlocked(blockedInput());
+      expect(rawBlockedCount()).toBe(2);
+
+      // At the boundary the first row is deleted from STORAGE. Counting raw
+      // rows is load-bearing: read through `recentBlocked` and a swept row and
+      // a merely out-of-window row look identical.
+      at(T0 + BLOCKED_DETECTIONS_RETENTION_MS);
+      await repo.recordBlocked(blockedInput());
+      expect(rawBlockedCount()).toBe(2);
+    });
+  });
+
+  describe('sweepTerminal', () => {
+    it('holds the strict retention boundary, with no explicit now', async () => {
+      const grant = await repo.create(input());
+      await repo.revoke(grant.id, 'alice');
+
+      // `updated_at < :cutoff`, cutoff = now - retention: at exactly one
+      // retention window the row is NOT yet old enough.
+      at(T0 + RETENTION_MS);
+      expect(await repo.sweepTerminal(RETENTION_MS)).toBe(0);
+      expect((await repo.list({ includeTerminal: true })).map((e) => e.id)).toEqual([grant.id]);
+
+      at(T0 + RETENTION_MS + 1);
+      expect(await repo.sweepTerminal(RETENTION_MS)).toBe(1);
+    });
+
+    it('sweeps a grant that went terminal only by expiring, never an active one', async () => {
+      // Expires inside the window; nothing ever revokes or consumes it, so
+      // `expires_at <= :now` is the only thing that can make it terminal.
+      await repo.create(input({ expiresAt: iso(T0 + HOUR_MS) }));
+      const permanent = await repo.create(input({ scope: 'permanent', expiresAt: null }));
+
+      at(T0 + RETENTION_MS + 1);
+      expect(await repo.sweepTerminal(RETENTION_MS)).toBe(1);
+
+      // The exact surviving set, which is what says the sweep took the expired
+      // row and only that one.
+      const remaining = await repo.list({ includeTerminal: true });
+      expect(remaining.map((e) => e.id)).toEqual([permanent.id]);
+    });
+
+    it('never sweeps an active grant, however far the clock advances', async () => {
+      const grant = await repo.create(input({ scope: 'permanent', expiresAt: null }));
+
+      at(T0 + 10 * 365 * DAY_MS);
+      expect(await repo.sweepTerminal(RETENTION_MS)).toBe(0);
+      expect((await repo.list()).map((e) => e.id)).toEqual([grant.id]);
+    });
+  });
+
+  describe('terminal-collider supersede', () => {
+    // Same triple, so the second insert always hits `uq_exceptions_active`.
+    // Which branch it takes is decided purely by the clock.
+    const TRIPLE = {
+      ruleId: 'aws-access-key-id',
+      valueFingerprint: 'cd'.repeat(32),
+      keyVersion: 1,
+    } as const;
+
+    it('supersedes a collider that expires at exactly the injected instant', async () => {
+      const expiry = T0 + HOUR_MS;
+      const first = await repo.create(input({ ...TRIPLE, expiresAt: iso(expiry) }));
+
+      // The supersede UPDATE matches `expires_at <= :now`.
+      at(expiry);
+      const second = await repo.create(input({ ...TRIPLE, expiresAt: iso(expiry + HOUR_MS) }));
+
+      // The slot is the assertion: createSync mints a fresh UUID whichever
+      // branch it took, so only the surviving active set says the supersede
+      // fired.
+      expect((await repo.list()).map((e) => e.id)).toEqual([second.id]);
+
+      const superseded = await repo.getByIdPrefix(first.id);
+      expect(superseded?.revokedAt).toBe(iso(expiry));
+      expect(superseded?.revokeReason).toMatch(/superseded/);
+    });
+
+    it('refuses a collider one millisecond short of expiry — it is genuinely active', async () => {
+      const expiry = T0 + HOUR_MS;
+      const first = await repo.create(input({ ...TRIPLE, expiresAt: iso(expiry) }));
+
+      at(expiry - 1);
+      await expect(
+        repo.create(input({ ...TRIPLE, expiresAt: iso(expiry + HOUR_MS) })),
+      ).rejects.toThrow(DuplicateActiveExceptionError);
+
+      // The refusal left the collider untouched — not revoked as superseded.
+      const untouched = await repo.getByIdPrefix(first.id);
+      expect(untouched?.revokedAt).toBeNull();
+      expect((await repo.list()).map((e) => e.id)).toEqual([first.id]);
+    });
+  });
+});
+
+describe('SqliteExceptionsRepository — default clock', () => {
+  // The injection must not have moved the product off the wall clock. Two
+  // separate properties, and neither is asserted as an elapsed time: a
+  // millisecond bracket sampled around the write is a flake on a loaded runner
+  // (Date.now() is not guaranteed monotonic) and it cannot see the failure that
+  // matters anyway.
+  //
+  // That failure is a clock read ONCE and reused — `((t) => () => t)(Date.now())`
+  // — which a window bracketing its own construction satisfies by definition.
+  // web-ui/app/lib/db.ts memoizes LocalDatabase on globalThis.__akaDb across
+  // every request, so a repository built once and reused for hours is the
+  // product's normal shape: a frozen clock there stops list() ever expiring a
+  // grant and leaves activeRevealGrant authorizing model reveals past expiry.
+  // Only a second read at a later instant separates the two.
+  const store = useTempStore('aka-exceptions-clock-');
+
+  // Anchored to real time, not to `clock` — these repositories never see the
+  // injected timeline, and a T0-anchored expiry would be months stale.
+  function wallInput(): CreateExceptionInput {
+    return input({ expiresAt: new Date(Date.now() + HOUR_MS).toISOString() });
+  }
+
+  /** Spin until the wall clock strictly advances — sub-millisecond in practice. */
+  function tick(): void {
+    const start = Date.now();
+    while (Date.now() <= start) {
+      /* the shortest wait that guarantees the next read is a different ms */
+    }
+  }
+
+  /** Two creates through one repository, separated by a real millisecond. */
+  async function stamps(repo: SqliteExceptionsRepository): Promise<[number, number]> {
+    const first = await repo.create(wallInput());
+    tick();
+    const second = await repo.create(wallInput());
+    return [Date.parse(first.createdAt), Date.parse(second.createdAt)];
+  }
+
+  it('reads the wall clock, freshly, when constructed without one', async () => {
+    // Constructed OUTSIDE any measurement, so a clock frozen at construction
+    // gets no free pass from a window it was built inside.
+    const [first, second] = await stamps(new SqliteExceptionsRepository(db));
+
+    // Months of margin instead of a millisecond bracket: this separates real
+    // time from T0 decisively and cannot be moved by scheduler jitter.
+    expect(first).toBeGreaterThan(T0 + 30 * DAY_MS);
+    // Read per call, not once at construction. `not.toBe` rather than a
+    // comparison, so a clock that steps BACKWARDS still reads as live.
+    expect(second).not.toBe(first);
+  });
+
+  it('reads the wall clock, freshly, through openLocalDatabase', async () => {
+    const [first, second] = await stamps(store.open().exceptions);
+
+    expect(first).toBeGreaterThan(T0 + 30 * DAY_MS);
+    expect(second).not.toBe(first);
+  });
+});


### PR DESCRIPTION
## Summary

`SqliteExceptionsRepository` read `Date.now()` inline at nine sites, so every time-dependent
decision it makes — expiry, both sweeps, and the terminal-collider supersede — could only be
tested by fabricating raw row timestamps or moving the wall clock. Four sibling repositories
(`activity`, `detections`, `resolutions`, `security`) already take an injectable clock; this
brings exceptions in line.

Product behaviour is unchanged: `openLocalDatabase` constructs the repository with no clock,
exactly as it does the other four, so the default `() => Date.now()` applies on every product path.

## Changes

**`packages/persistence/src/repositories/exceptions.ts`**

- Second constructor parameter `now: () => number = () => Date.now()`, character-identical to the
  four siblings. All nine reads route through it.
- `activeRevealGrant` reads the clock inside its `try` rather than as a default-parameter
  initializer. An initializer runs before the body, so a caller-supplied clock that threw would
  escape synchronously past the guard that exists to make every failure there a rejection.
- `ACTIVE_REVEAL_GRANT_PREDICATE`'s doc comment now scopes its guarantee to a shared instant: the
  vault inventory's badge subquery interpolates the same predicate string but binds its own `now`
  and takes no clock, so the two can disagree once a clock is supplied.

**`packages/persistence/test/repositories/exceptions-clock.test.ts`** (new, 15 cases)

- Expiry pinned to the millisecond through `list()` and the policy bundle.
- Reveal-grant expiry and revocation — where a miss is the difference between a time-boxed reveal
  and a permanent one.
- The blocked-detections read window, and the sweep-on-every-write asserted against raw storage so
  a swept row is distinguished from a merely out-of-window one.
- The retention sweep's strict boundary, and that an active grant is never swept however far the
  clock advances.
- The terminal-collider supersede: a collider expiring at exactly the injected instant is
  superseded and the slot re-claimed; one millisecond short it is genuinely active and the insert
  is refused.
- Two cases pinning that the default is still read fresh from the wall clock.

## Verification

- `pnpm turbo run test --force` — 29/29 tasks, `Cached: 0`.
- `pnpm lint` (incl. `lint:root`) and `pnpm turbo run typecheck --force` — green, `Cached: 0`.
- `packages/persistence` — 60 files, 884 passed, 1 skipped.
- The existing `exceptions.test.ts` is byte-unchanged; its 27 cases pass as-is.

### Mutation testing

Every new assertion was checked for its ability to fail:

| Mutation | Tests reddened |
| --- | --- |
| Revert the injection (`this.now()` → `Date.now()`) | 12 — the existing 27 stay green |
| `expires_at > :now` → `>=` | 3 |
| `blocked_at > :cutoff` → `>=` | 1 |
| `blocked_at <= :cutoff` → `<` | 1 |
| `updated_at < :cutoff` → `<=` | 1 |
| Supersede `expires_at <= :now` → `<` | 1 |
| Sweep terminal condition → `1=1` | 2 |
| Default clock frozen at construction | 2, on 6 of 6 runs |

The last row is why the default-clock cases compare two stamps taken a millisecond apart instead
of bracketing a single write: an earlier draft bracketed a write around its own construction,
which a clock read once at construction satisfies by definition — it escaped that mutation 1 run
in 5. Both cases now also avoid asserting an elapsed time, which this package's testing
conventions rule out as a flake on slower runners.
