### PR TITLE
test(persistence): reach the fail-open closures with a connection-scoped fault

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -771,18 +771,37 @@ cleanup dance; it is not reachable across a package wall, so store tests in `cli
   must gate**: `if (!readOnly.effective) ctx.skip(reason)`. Pass the store's `onCleanup` to
   any injector that has to be undone before the tree can be removed, and the store itself
   to any that needs no live connection.
-  `fillStore` is in the same file and reaches **most** of what the other three do, but not
-  all of it: the page cap is connection-scoped, so it bounds only the handle it is given.
-  A repository constructed over a raw handle takes it (`SqliteAuditEventsRepository(raw)`,
-  the `activity.test.ts` pattern), and so does `applyMigrations` — but only with a cap
-  sized against a real migration: the default headroom on an empty file stops the ledger's
-  own `CREATE TABLE`, so the applier's loop never runs and every claim about a partial
+  `fillStore` is in the same file and its page cap is connection-scoped, so it bounds only
+  the handle it is given — which is what decides where it can be aimed. A repository
+  constructed over a raw handle takes it (`SqliteAuditEventsRepository(raw)`, the
+  `activity.test.ts` pattern), and so does `applyMigrations` — but only with a cap sized
+  against a real migration: the default headroom on an empty file stops the ledger's own
+  `CREATE TABLE`, so the applier's loop never runs and every claim about a partial
   migration then holds vacuously. The blanket fail-open sites in `database.ts`
   (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`, and
-  `reconcileWorktreeProjects`, which reaches `withTransaction` directly) stay out of
-  reach: they are closures over the connection `openLocalDatabase` opened, and
-  `LocalDatabase` exposes no accessor for it. Aiming a connection-scoped fault at those
-  waits on a raw-handle seam.
+  `reconcileWorktreeProjects`, which reaches `withTransaction` directly) are closures over
+  the connection `openLocalDatabase` opened, so they are reached by capping **that**
+  connection — `db[UNSAFE_TEST_ONLY_RAW_HANDLE]`, below. Handing `fillStore` a second
+  handle on the same file instead is the mistake to avoid: it carries none of the cap, the
+  facade writes on undisturbed, and every "the write was dropped" assertion then passes
+  because nothing was ever refused.
+- **`UNSAFE_TEST_ONLY_RAW_HANDLE`** — not a helper but the seam a connection-scoped
+  injector aims at, so it is listed here: the `DatabaseSync` a `LocalDatabase` writes
+  through, exported from `src/database.ts`, and the only test-only seam in shipped
+  source. It is
+  symbol-keyed and **not** re-exported from `src/index.ts`, and the package's `exports` map
+  is `"." -> "./src/index.ts"` alone, so no other package can reach the module that defines
+  it. Two properties are load-bearing and easy to break: it is a plain **enumerable data
+  property**, because the helpers hand out `{ ...db, close }` wrappers and spread copies own
+  enumerable symbols — a getter or a non-enumerable definition loses it silently; and it is
+  the **real** connection, so `close()` reaches it.
+  `packages/eslint-config/test/test-only-seam.test.js` is what keeps "test-only" true: it
+  walks the tracked tree and fails if any file naming the seam is neither its one definition
+  site nor a test. That is a derived rule, not a list — a new fault test needs no edit there,
+  a product caller anywhere in the workspace fails CI. It lives in that package rather than
+  in `persistence` because only that task's turbo `inputs` hash the whole workspace; the
+  same check inside `persistence` would replay a cached green while a caller appeared in
+  `cli/src`.
 - `assertNoOpenTransaction(db)` — a fault that leaves a transaction open is worse than the
   fault; assert this after injecting one. It reads `db.isTransaction` rather than probing
   with a transaction of its own, so it cannot disturb the handle it is inspecting.

--- a/packages/eslint-config/test/test-only-seam.test.js
+++ b/packages/eslint-config/test/test-only-seam.test.js
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import { join, posix } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { lintableTrackedFiles, REPO_ROOT, trackedFiles } from './helpers/lint-invocations.js';
+
+// `@akasecurity/persistence` ships one deliberately test-only seam:
+// UNSAFE_TEST_ONLY_RAW_HANDLE, a symbol-keyed property on `LocalDatabase`
+// holding the `DatabaseSync` the facade writes through. The fault suite needs it
+// because `PRAGMA max_page_count` — the only way to raise a real SQLITE_FULL in
+// CI — binds to a CONNECTION, and the store's blanket fail-open closures write
+// through one nothing else could reach.
+//
+// A raw handle on a shipped, bundled package is worth exactly one guarantee: no
+// product code reads it. Nothing else here can check that. The network and
+// process.env audits in this package are about MODULES and DIRECTIVES; neither
+// looks at an identifier, and the persistence package's own suite cannot see
+// past its package wall to `cli/src` or `web-ui/app`. So the check lives here,
+// beside the tree-wide walk and the turbo inputs that already hash the whole
+// workspace — a guard scoped to one package would go on passing while a caller
+// appeared in another.
+//
+// The rule is derived, not listed. A file naming the seam is either its one
+// definition site or a test, so a new fault test needs no edit here while a
+// `cli/src/*.ts` reaching for it fails — which is the property, stated directly.
+
+/** The seam this suite exists for. */
+const SEAM = 'UNSAFE_TEST_ONLY_RAW_HANDLE';
+
+/** The only shipped-source file allowed to name it: where it is defined. */
+const DEFINITION = 'packages/persistence/src/database.ts';
+
+/** The package whose entry point must not re-export it. */
+const ENTRY = 'packages/persistence/src/index.ts';
+const MANIFEST = 'packages/persistence/package.json';
+
+/**
+ * True for a path the workspace treats as test code.
+ *
+ * A `test`/`tests` path segment or a `.test.`/`.spec.` basename — the two
+ * layouts the tree actually uses. Anything else counts as shipped source, which
+ * is the safe direction to be wrong in: a test file this misses is reported as a
+ * product caller and someone looks, where a product file it wrongly excused
+ * would ship unguarded.
+ * @param {string} file repo-relative posix path
+ */
+function isTestFile(file) {
+  const segments = file.split('/');
+  return (
+    segments.slice(0, -1).some((s) => s === 'test' || s === 'tests') ||
+    /\.(test|spec)\./.test(posix.basename(file))
+  );
+}
+
+/** Every tracked lintable file whose text names the seam. */
+function filesNamingSeam() {
+  return lintableTrackedFiles().filter((file) => {
+    // A tracked path can still be unreadable — a submodule gitlink, a symlink
+    // to nowhere. Skipping one silently would drop a file out of the audit
+    // without anyone noticing, so this throws instead.
+    let text;
+    try {
+      text = readFileSync(join(REPO_ROOT, file), 'utf8');
+    } catch (cause) {
+      throw new Error(`Could not read tracked file ${file} while auditing ${SEAM}.`, { cause });
+    }
+    return text.includes(SEAM);
+  });
+}
+
+describe(`the ${SEAM} test-only seam`, () => {
+  it('is named by exactly one shipped source file — the one that defines it', () => {
+    const shipped = filesNamingSeam()
+      .filter((file) => !isTestFile(file))
+      .sort();
+
+    // An exact set of one, not a floor. "The definition is still there" would
+    // stay green with a second, product caller beside it, and the second caller
+    // is the entire failure mode.
+    expect(shipped).toEqual([DEFINITION]);
+  });
+
+  it('is used by the fault tests, so this suite is not guarding an absence', () => {
+    const tests = filesNamingSeam().filter(isTestFile);
+
+    // The positive control. Delete the seam and its consumers and every
+    // assertion above holds perfectly — on a workspace where the thing being
+    // guarded does not exist. This is the case that goes red for that.
+    expect(tests.length).toBeGreaterThan(0);
+    expect(tests).toContain('packages/persistence/test/faults/disk-full.test.ts');
+  });
+
+  it('is not re-exported from the package entry point', () => {
+    const entry = readFileSync(join(REPO_ROOT, ENTRY), 'utf8');
+
+    // What makes "test-only" structural rather than a request. The manifest
+    // below exposes `.` alone, so `src/database.ts` is unreachable from another
+    // package — re-export the symbol here and every consumer of
+    // `@akasecurity/persistence` can name it, at which point the rule above is
+    // the only thing left and it is a rule about this repo, not about a
+    // published surface.
+    expect(entry).not.toContain(SEAM);
+  });
+
+  it('is unreachable from outside the package: no exports subpath resolves to its module', () => {
+    const { exports: map } = JSON.parse(readFileSync(join(REPO_ROOT, MANIFEST), 'utf8'));
+    const entries = Object.entries(map);
+
+    expect(entries.length).toBeGreaterThan(0);
+    for (const [subpath, target] of entries) {
+      // A wildcard subpath (`"./*": "./src/*"`) would expose every module in
+      // the package, this one included, without ever naming it.
+      expect(subpath).not.toContain('*');
+      expect(JSON.stringify(target)).not.toContain('*');
+      expect(JSON.stringify(target)).not.toContain('database.ts');
+    }
+  });
+
+  it('reads a tree it really walked', () => {
+    // `trackedFiles()` returning nothing would make every assertion above pass
+    // by describing an empty workspace — the failure mode a git-backed walk has
+    // and a hardcoded list does not.
+    expect(trackedFiles()).toContain(DEFINITION);
+    expect(lintableTrackedFiles()).toContain(DEFINITION);
+  });
+});
+
+describe('isTestFile', () => {
+  // The classifier decides which side of the rule a file lands on, so its own
+  // edges are pinned rather than assumed. Wrong in the excusing direction and a
+  // product caller is reported as a test.
+  it.each([
+    ['packages/persistence/test/faults/disk-full.test.ts', true],
+    ['packages/persistence/test/helpers/temp-store.ts', true],
+    ['cli/test/commands/exception.test.ts', true],
+    ['packages/plugin-sdk/src/scan.test.ts', true],
+    ['packages/persistence/src/database.ts', false],
+    ['cli/src/commands/exception.ts', false],
+    // A directory whose name merely starts with `test` is not a test directory.
+    ['packages/testkit/src/index.ts', false],
+    // The last segment is the file, never a directory — a source file called
+    // `test.ts` is source.
+    ['packages/persistence/src/test.ts', false],
+  ])('%s -> %s', (file, expected) => {
+    expect(isTestFile(file)).toBe(expected);
+  });
+});

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -65,6 +65,38 @@ import { purgeSampleData } from './sample-purge.ts';
 export type { InventoryContext, InventoryFacets, ResolvedInventory } from '@akasecurity/schema';
 
 /**
+ * TEST-ONLY. The `DatabaseSync` this facade writes through.
+ *
+ * A connection-scoped fault — `PRAGMA max_page_count`, the only way to raise a
+ * genuine `SQLITE_FULL` without a real full disk — binds to one connection, not
+ * to the file. Without this the store's blanket fail-open closures
+ * (`recordCapture` and friends, below) could not be faulted at all: they close
+ * over the connection opened here, a second handle on the same file carries none
+ * of the cap, and those closures are the whole reason the fault tests exist.
+ *
+ * Three properties are load-bearing:
+ *
+ * - **Symbol-keyed and NOT re-exported from `src/index.ts`.** The package's
+ *   `exports` map is `"." -> "./src/index.ts"` and nothing else, so no other
+ *   package can reach `database.ts` to name this. Test-only is structural here,
+ *   not a request.
+ * - **A plain enumerable data property, never a getter.** Test helpers hand out
+ *   `{ ...db, close }` wrappers (`test/helpers/temp-store.ts`), and object
+ *   spread copies own enumerable properties — symbol keys included. Make it
+ *   non-enumerable and every wrapped handle silently loses the seam instead of
+ *   failing.
+ * - **It grants nothing the process did not already have.** Any code running
+ *   here can open the store file directly with `node:sqlite`; the store's
+ *   protection is the 0600 file mode, not the reachability of a handle.
+ *
+ * The handle is closed by `close()` like any other reference to it — a caller
+ * holding this after that holds a closed connection.
+ */
+export const UNSAFE_TEST_ONLY_RAW_HANDLE: unique symbol = Symbol(
+  'aka.persistence.unsafeTestOnlyRawHandle',
+);
+
+/**
  * The local SQLite store under <dir>/aka.db — the writer of events/findings
  * for the plugin/CLI. Uses the Node 24+ builtin node:sqlite (no native dep,
  * tsup-bundleable), applies the canonical schema from @akasecurity/schema on
@@ -178,6 +210,12 @@ export interface LocalDatabase {
   // call this from inside another transaction.
   transaction<T>(fn: () => Promise<T> | T): Promise<T>;
   close(): void;
+  /**
+   * TEST-ONLY — see UNSAFE_TEST_ONLY_RAW_HANDLE. No product code reads this;
+   * `packages/eslint-config/test/test-only-seam.test.js` fails the workspace if
+   * any does.
+   */
+  readonly [UNSAFE_TEST_ONLY_RAW_HANDLE]: DatabaseSync;
 }
 
 // Attach the resolved host id to a harness/account descriptor — the
@@ -668,5 +706,7 @@ export function openLocalDatabase(dir: string): LocalDatabase {
     close: () => {
       db.close();
     },
+    // Last, and a plain value rather than a getter, so `{ ...db }` carries it.
+    [UNSAFE_TEST_ONLY_RAW_HANDLE]: db,
   };
 }

--- a/packages/persistence/test/faults/disk-full.test.ts
+++ b/packages/persistence/test/faults/disk-full.test.ts
@@ -8,24 +8,35 @@
  * that reads as healthy while telling a lie.
  *
  * `fillStore` caps growth on the connection it is handed, so these drive the
- * real repositories and the real shared envelopes over a raw handle. That is
- * as far as the fault reaches today: `openLocalDatabase` opens a connection of
- * its own and exposes no accessor for it, so the four blanket fail-open
- * closures in `database.ts` cannot be capped from a test. They take the same
- * `failOpenTransaction` path pinned below.
+ * real repositories and the real shared envelopes over a raw handle — and, via
+ * `UNSAFE_TEST_ONLY_RAW_HANDLE`, the facade's own connection, which is what
+ * reaches the blanket fail-open closures in `database.ts`. Those closures are
+ * the sites the store's fail-open policy is really made of: every one of them
+ * turns a full disk, a locked file and a caller bug into the same discarded
+ * `false`, so they are where "the write vanished and nothing said so" has to be
+ * pinned as the actual behaviour.
  */
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
-import type { AuditEventInput } from '@akasecurity/schema';
+import type {
+  AuditEventInput,
+  ConfigScanRecord,
+  InventoryContext,
+  ProjectFilesScan,
+} from '@akasecurity/schema';
 import { SQLITE_MIGRATIONS } from '@akasecurity/schema';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import type { LocalDatabase } from '../../src/database.ts';
+import { UNSAFE_TEST_ONLY_RAW_HANDLE } from '../../src/database.ts';
 import { failOpenTransaction } from '../../src/internal/transactions.ts';
 import { applyMigrations } from '../../src/migrations.ts';
 import { SqliteAuditEventsRepository } from '../../src/repositories/audit-events.ts';
+import { captureEvent, captureFinding } from '../helpers/capture-fixtures.ts';
 import { errorFrom } from '../helpers/errors.ts';
+import type { FilledStore } from '../helpers/fault-injection.ts';
 import { fillStore, primaryCode, SQLITE_FULL } from '../helpers/fault-injection.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 import { assertNoOpenTransaction } from '../helpers/transactions.ts';
@@ -48,6 +59,10 @@ function auditEvent(): AuditEventInput {
 
 function countAuditEvents(db: DatabaseSync): number {
   return (db.prepare('SELECT COUNT(*) AS n FROM audit_events').get() as { n: number }).n;
+}
+
+function countRows(db: DatabaseSync, table: string): number {
+  return (db.prepare(`SELECT COUNT(*) AS n FROM ${table}`).get() as { n: number }).n;
 }
 
 function integrityOf(db: DatabaseSync): string | undefined {
@@ -291,5 +306,311 @@ describe('running out of room mid-migration', () => {
     } finally {
       reopened.close();
     }
+  });
+});
+
+/**
+ * The five blanket fail-open closures in `database.ts`, faulted on the
+ * connection they actually write through.
+ *
+ * These are the class-blind sites: each wraps its work in `failOpenTransaction`
+ * (or, for `reconcileWorktreeProjects`, a bare `catch {}`) and discards the
+ * outcome, so a full disk arrives at the caller as exactly nothing. Every case
+ * below documents that as the ACTUAL behaviour rather than the desirable one.
+ * There is no dropped-write counter and no marker, so none is asserted — a test
+ * demanding a signal the product does not emit would be a feature request in
+ * assertion form. What IS asserted is the silence itself, on the one channel
+ * that could plausibly change: nothing reaches stderr.
+ *
+ * They reach the closures through `UNSAFE_TEST_ONLY_RAW_HANDLE`. A second handle
+ * on the same file carries none of the cap, which is why this needed a seam
+ * rather than another `openRaw()`.
+ */
+describe('the facade’s fail-open closures with no room left', () => {
+  /** Bound on the fill loop — a backstop, not the expected count. */
+  const MAX_CAPTURES_TO_FILL = 128;
+  /**
+   * Bigger than the slack `fillToRefusal` can leave behind.
+   *
+   * That helper stops when a PAGE_HUNGRY capture is refused, which leaves up to
+   * a page of room inside the pages the store already has — enough for a small
+   * write to land. A closure whose payload is sized like this cannot fit in it
+   * whatever the page size, so its refusal is a property rather than an
+   * arithmetic coincidence that holds on one runner. `ensureInventory` proved
+   * that the hard way: at 4 KiB it committed, and every assertion about a
+   * dropped write passed against a write that had simply fit.
+   */
+  const OVERSIZE_CONTENT = 'x'.repeat(64 * 1024);
+
+  function capture(db: LocalDatabase): void {
+    const event = captureEvent({ content: PAGE_HUNGRY_CONTENT });
+    db.recordCapture(event, [captureFinding(event.id)]);
+  }
+
+  /**
+   * Run `fn` and report what it threw and what it said on stderr.
+   *
+   * "The caller is told nothing" is two claims, and only one of them is worth a
+   * test. The return value is `void` in the signature, so asserting it comes
+   * back `undefined` asserts TypeScript rather than the store. Stderr is the
+   * half that could change: `akaWarn` is the package's one loud channel, it
+   * already writes on three other paths, and none of these closures uses it —
+   * so a warning added here goes red, and the silence stops being an accident
+   * nobody wrote down.
+   */
+  function outcomeOf(fn: () => void): { err: Error | undefined; stderr: string[] } {
+    const stderr: string[] = [];
+    const write = vi.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+      stderr.push(String(chunk));
+      return true;
+    });
+    try {
+      return { err: errorFrom(fn), stderr };
+    } finally {
+      write.mockRestore();
+    }
+  }
+
+  /**
+   * Cap the facade's own connection, then spend the free space the store still
+   * had, so the next write is refused rather than absorbed.
+   *
+   * The cap is on pages, not rows: a fresh store carries free space inside the
+   * pages it already has, and the first captures land in it. Every case here
+   * asserts that something did NOT happen, so a store still holding room would
+   * satisfy all of them without refusing anything — which is why the refusal is
+   * REACHED and then checked, never assumed.
+   */
+  function fillToRefusal(db: LocalDatabase): FilledStore {
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const filled = fillStore(raw, { headroomPages: 0 });
+    let previous = -1;
+    for (let i = 0; i < MAX_CAPTURES_TO_FILL && countAuditEvents(raw) !== previous; i += 1) {
+      previous = countAuditEvents(raw);
+      capture(db);
+    }
+    const before = countAuditEvents(raw);
+    capture(db);
+    expect(countAuditEvents(raw)).toBe(before);
+    // And the fault is named, not inferred. The closures swallow the error, so
+    // nothing downstream can say WHICH failure it was — without this the whole
+    // block would rest on "a write did not land", which a dedup, a validation
+    // reject or a silent no-op satisfies just as well as a full store.
+    const probe = errorFrom(() => {
+      new SqliteAuditEventsRepository(raw).insertAuditEvent(auditEvent());
+    });
+    expect(primaryCode(probe)).toBe(SQLITE_FULL);
+    return filled;
+  }
+
+  it('recordCapture fails open and tells the caller nothing', () => {
+    const db = store.open();
+    const filled = fillToRefusal(db);
+
+    const event = captureEvent({ content: PAGE_HUNGRY_CONTENT });
+    const { err, stderr } = outcomeOf(() => {
+      db.recordCapture(event, [captureFinding(event.id)]);
+    });
+    filled.restore();
+
+    // Fail-open is the store's first principle: a throw here travels up into
+    // the hook that called it, which is the one outcome the product forbids.
+    expect(err).toBeUndefined();
+    // And the drop is silent. Nothing is returned (the signature is `void`) and
+    // nothing is said — so a full disk, a locked file and a caller bug are the
+    // same non-event to everything downstream. Documented, not asserted away.
+    expect(stderr).toEqual([]);
+  });
+
+  it('recordCapture leaves no partial rows — not the event, not its findings', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const filled = fillToRefusal(db);
+    const events = countAuditEvents(raw);
+    const findings = countRows(raw, 'inspection_findings');
+
+    const event = captureEvent({ content: PAGE_HUNGRY_CONTENT });
+    db.recordCapture(event, [captureFinding(event.id), captureFinding(event.id)]);
+    filled.restore();
+
+    // The claim that matters more than fail-open. An audit event whose findings
+    // did not land, or findings pointing at an event that is not there, reads
+    // as a healthy store on every surface while telling a lie.
+    expect(countAuditEvents(raw)).toBe(events);
+    expect(countRows(raw, 'inspection_findings')).toBe(findings);
+  });
+
+  it('recordCapture corrupts nothing and leaves no transaction open', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const filled = fillToRefusal(db);
+
+    const event = captureEvent({ content: PAGE_HUNGRY_CONTENT });
+    db.recordCapture(event, [captureFinding(event.id)]);
+
+    expect(integrityOf(raw)).toBe('ok');
+    // A transaction left behind by the fault is worse than the fault: the
+    // connection keeps its locks and every later write on it silently joins a
+    // transaction nobody started. This connection is the one the whole process
+    // shares, so that would outlive the fault by the life of the handle.
+    assertNoOpenTransaction(raw);
+
+    filled.restore();
+
+    // The positive control, and the criterion's "store still openable": the
+    // refusals were the cap, not damage. Without it every assertion above holds
+    // just as well on a store this fault had broken for good.
+    capture(db);
+    expect(countAuditEvents(raw)).toBeGreaterThan(0);
+    expect(integrityOf(raw)).toBe('ok');
+  });
+
+  it('ensureInventory fails open to an empty resolution', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const filled = fillToRefusal(db);
+    const inventory = countRows(raw, 'inventory');
+    const projects = countRows(raw, 'source_project');
+
+    const ctx: InventoryContext = {
+      host: {
+        objectType: 'host',
+        identityKey: `machine-${randomUUID()}`,
+        title: 'a-laptop',
+        attributes: { padding: OVERSIZE_CONTENT },
+      },
+      project: { url: `https://example.invalid/${randomUUID()}.git`, name: 'repo', attributes: {} },
+    };
+    // `unset` rather than `undefined`, so "resolved to nothing" and "never ran"
+    // stay distinguishable — a throw would leave the latter.
+    let resolved: unknown = 'unset';
+    const { err, stderr } = outcomeOf(() => {
+      resolved = db.ensureInventory(ctx);
+    });
+    filled.restore();
+
+    expect(err).toBeUndefined();
+    expect(stderr).toEqual([]);
+    // The one closure with a return value, and it says only "nothing resolved".
+    // A caller cannot tell that apart from a context carrying no dimensions.
+    expect(resolved).toEqual({});
+    expect(countRows(raw, 'inventory')).toBe(inventory);
+    expect(countRows(raw, 'source_project')).toBe(projects);
+    assertNoOpenTransaction(raw);
+  });
+
+  it('recordConfigScan fails open and writes no part of the scan', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const filled = fillToRefusal(db);
+    const events = countAuditEvents(raw);
+    const inventory = countRows(raw, 'inventory');
+
+    const record: ConfigScanRecord = {
+      items: [
+        {
+          objectType: 'skill',
+          identityKey: `skill-${randomUUID()}`,
+          title: 'a-skill',
+          attributes: { padding: OVERSIZE_CONTENT },
+        },
+      ],
+      scanEvent: {
+        id: randomUUID(),
+        eventType: 'config_scan',
+        startedAt: new Date().toISOString(),
+        content: OVERSIZE_CONTENT,
+      },
+    };
+    const { err, stderr } = outcomeOf(() => {
+      db.recordConfigScan(record);
+    });
+    filled.restore();
+
+    expect(err).toBeUndefined();
+    expect(stderr).toEqual([]);
+    // One transaction covers the inventory upserts AND the scan event, so a
+    // torn scan is the failure to rule out: inventory rows recorded as seen by
+    // a scan whose own event never landed.
+    expect(countAuditEvents(raw)).toBe(events);
+    expect(countRows(raw, 'inventory')).toBe(inventory);
+    assertNoOpenTransaction(raw);
+  });
+
+  it('recordProjectFiles fails open and leaves the stored tree untouched', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    // Seeded before the cap: the interesting claim is that a failed scan does
+    // not PRUNE, and an empty tree could not show that.
+    const projectId = db.sourceProject.upsert(
+      { url: `https://example.invalid/${randomUUID()}.git`, name: 'repo', attributes: {} },
+      Date.now(),
+    );
+    db.recordProjectFiles(projectId, {
+      files: [{ path: 'src/app.ts', name: 'app.ts', origin: 'source', defaultAccess: 'approved' }],
+      truncated: false,
+      scannedAt: new Date().toISOString(),
+    });
+    const seeded = countRows(raw, 'project_file');
+    expect(seeded).toBe(1);
+
+    const filled = fillToRefusal(db);
+    // Padded names, for the same reason as OVERSIZE_CONTENT: 64 short paths are
+    // a few kilobytes and could land in the slack the fill leaves.
+    const scan: ProjectFilesScan = {
+      files: Array.from({ length: 256 }, (_, i) => {
+        const name = `${'f'.repeat(200)}${String(i)}.ts`;
+        return {
+          path: `src/generated/${name}`,
+          name,
+          origin: 'source' as const,
+          defaultAccess: 'approved' as const,
+        };
+      }),
+      truncated: false,
+      scannedAt: new Date().toISOString(),
+    };
+    const { err, stderr } = outcomeOf(() => {
+      db.recordProjectFiles(projectId, scan);
+    });
+    filled.restore();
+
+    expect(err).toBeUndefined();
+    expect(stderr).toEqual([]);
+    // The whole replace-and-prune pass rolls back together: the new files are
+    // absent AND the pre-existing row survives. Pruning without inserting would
+    // be the torn outcome here, and it would look like an empty project.
+    expect(countRows(raw, 'project_file')).toBe(seeded);
+  });
+
+  it('reconcileWorktreeProjects fails open on a store with no room', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+    const headRoot = '/repos/payments';
+    const canonicalId = db.sourceProject.upsert(
+      { url: 'https://example.invalid/payments.git', name: 'payments', attributes: {} },
+      Date.now(),
+    );
+    const worktreeRoot = `${headRoot}/.claude/worktrees/wt-${randomUUID()}`;
+    db.sourceProject.upsert({ url: worktreeRoot, name: 'payments', attributes: {} }, Date.now());
+
+    const filled = fillToRefusal(db);
+    const { err, stderr } = outcomeOf(() => {
+      db.reconcileWorktreeProjects(canonicalId, headRoot, worktreeRoot);
+    });
+    filled.restore();
+
+    // Only the fail-open claim, deliberately. This closure DELETES rows, so
+    // whether a capped store refuses it depends on whether the rollback journal
+    // needs a page it cannot get — the row count is not a property that holds
+    // either way, and asserting one would pin the page arithmetic instead of
+    // the behaviour.
+    expect(err).toBeUndefined();
+    // Its fail-open is a bare `catch {}` rather than `failOpenTransaction`, and
+    // it is the one site here that sits next to a real `akaWarn` caller
+    // (the source-project reconcile failure) — so the silence is worth pinning.
+    expect(stderr).toEqual([]);
+    assertNoOpenTransaction(raw);
+    expect(integrityOf(raw)).toBe('ok');
   });
 });

--- a/packages/persistence/test/helpers/fault-injection.ts
+++ b/packages/persistence/test/helpers/fault-injection.ts
@@ -498,15 +498,19 @@ export interface FilledStore {
  * store is unaffected, so this fills the store for the handle passed in and
  * that handle only. A genuinely full filesystem stays out of reach in CI.
  *
- * That connection scope is what decides its reach. A repository constructed
- * over a raw handle takes the cap (`SqliteAuditEventsRepository(raw)`, the
- * `activity.test.ts` pattern), and so does `applyMigrations` — `test/faults/
- * disk-full.test.ts` drives both. What stays out of reach is the four blanket
- * fail-open sites in `database.ts` (`recordCapture`, `ensureInventory`,
- * `recordConfigScan`, `recordProjectFiles`) and `reconcileWorktreeProjects`:
- * all of them close over the connection `openLocalDatabase` opened, and
- * `LocalDatabase` exposes no accessor for it. Aiming a connection-scoped fault
- * at those needs a raw-handle seam.
+ * That connection scope is what decides its reach, and every product write path
+ * is now inside it. A repository constructed over a raw handle takes the cap
+ * (`SqliteAuditEventsRepository(raw)`, the `activity.test.ts` pattern), and so
+ * does `applyMigrations`. The blanket fail-open closures in `database.ts`
+ * (`recordCapture`, `ensureInventory`, `recordConfigScan`, `recordProjectFiles`,
+ * `reconcileWorktreeProjects`) close over the connection `openLocalDatabase`
+ * opened, so they are reached by capping THAT connection —
+ * `db[UNSAFE_TEST_ONLY_RAW_HANDLE]`, the test-only seam on `LocalDatabase`.
+ * `test/faults/disk-full.test.ts` drives all three shapes.
+ *
+ * Passing a second handle on the same file instead is the mistake to avoid: it
+ * carries none of the cap, so the facade writes on undisturbed and every
+ * "the write was dropped" assertion holds because nothing was ever refused.
  */
 export function fillStore(db: DatabaseSync, opts: { headroomPages?: number } = {}): FilledStore {
   const readPragma = (name: string): number => {

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -116,6 +116,13 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
       // accessors, nothing `this`-bound, nothing lazily got. Turn that into a
       // class instance or add a getter and every handle handed out here goes
       // quietly wrong instead of failing.
+      //
+      // It also carries UNSAFE_TEST_ONLY_RAW_HANDLE, which spread copies because
+      // that property is an enumerable own symbol. A fault test capping the
+      // connection reads it off the wrapper handed back here, so a handle that
+      // lost it would leave the cap pointed at nothing and every fault
+      // assertion downstream passing vacuously. `raw-handle-seam.test.ts` pins
+      // the spread itself rather than leave that to this comment.
       let closed = false;
       const tracked: LocalDatabase = {
         ...db,

--- a/packages/persistence/test/raw-handle-seam.test.ts
+++ b/packages/persistence/test/raw-handle-seam.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The test-only raw-handle seam on `LocalDatabase`.
+ *
+ * Everything in `test/faults/` that faults the facade rests on one claim: the
+ * handle behind `UNSAFE_TEST_ONLY_RAW_HANDLE` is the connection the facade
+ * really writes through, not a second one on the same file. A seam pointing at
+ * a sibling connection would leave every connection-scoped fault landing on a
+ * handle nothing uses — and since those faults assert that a write did NOT
+ * happen, the whole suite would pass while injecting nothing at all.
+ *
+ * So the identity claim is pinned here, on its own, in the one form that can
+ * fail: a cap set through the seam must change what the FACADE does.
+ *
+ * The workspace-wide half — that no product code reads the seam — is a
+ * different question and lives in
+ * `packages/eslint-config/test/test-only-seam.test.js`, which is where the
+ * tree-wide walk and its turbo inputs already are.
+ */
+import { realpathSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, expect, it } from 'vitest';
+
+import type { LocalDatabase } from '../src/database.ts';
+import { UNSAFE_TEST_ONLY_RAW_HANDLE } from '../src/database.ts';
+import { captureEvent, captureFinding } from './helpers/capture-fixtures.ts';
+import { fillStore } from './helpers/fault-injection.ts';
+import { useTempStore } from './helpers/temp-store.ts';
+
+const store = useTempStore('aka-raw-seam-');
+
+/** Big enough that a capture needs a new page, not free space in an old one. */
+const PAGE_HUNGRY_CONTENT = 'x'.repeat(4096);
+/** More captures than a zero-headroom cap can take, so the fault bounds the run. */
+const MORE_CAPTURES_THAN_FIT = 64;
+
+function countAuditEvents(db: DatabaseSync): number {
+  return (db.prepare('SELECT COUNT(*) AS n FROM audit_events').get() as { n: number }).n;
+}
+
+function capture(db: LocalDatabase): void {
+  const event = captureEvent({ content: PAGE_HUNGRY_CONTENT });
+  db.recordCapture(event, [captureFinding(event.id)]);
+}
+
+describe('UNSAFE_TEST_ONLY_RAW_HANDLE', () => {
+  it('is a live DatabaseSync on the store the facade opened', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+
+    expect(raw).toBeInstanceOf(DatabaseSync);
+    expect(raw.isOpen).toBe(true);
+    // Same file, not merely the same shape. Both sides go through realpath:
+    // macOS resolves the temp root through a /var -> /private/var symlink, and
+    // only one of the two readings has been through it.
+    expect(realpathSync(raw.location() ?? '')).toBe(realpathSync(store.dbFile));
+  });
+
+  it('is the connection the facade writes through, not a sibling on the same file', () => {
+    const db = store.open();
+    const sibling = store.openRaw();
+
+    const filled = fillStore(db[UNSAFE_TEST_ONLY_RAW_HANDLE], { headroomPages: 0 });
+    // The cap is on pages, not on rows, so the first few captures still fit in
+    // free space the store already had. What the cap decides is where that
+    // stops — so the measurement is the stall, not the first refusal.
+    for (let i = 0; i < MORE_CAPTURES_THAN_FIT; i += 1) capture(db);
+    const stalled = countAuditEvents(sibling);
+    for (let i = 0; i < MORE_CAPTURES_THAN_FIT; i += 1) capture(db);
+
+    // The two discriminating readings. Capping a SIBLING connection — the state
+    // before this seam existed — leaves the facade untouched, so `stalled`
+    // would be the whole first batch and the second batch would land on top of
+    // it. Neither reading can be satisfied by a seam wired to the wrong handle.
+    expect(stalled).toBeLessThan(MORE_CAPTURES_THAN_FIT);
+    expect(countAuditEvents(sibling)).toBe(stalled);
+
+    filled.restore();
+
+    // Positive control: the refusals were the cap, not something this fault did
+    // permanently to the store — and not `capture()` having quietly stopped
+    // writing anything at all, which would satisfy both assertions above.
+    capture(db);
+    expect(countAuditEvents(sibling)).toBe(stalled + 1);
+  });
+
+  it('travels with the `{ ...db }` wrappers the test helpers hand out', () => {
+    // `temp-store.ts` returns a spread copy so it can track `close()`, and
+    // fault tests take the seam off THAT object. Spread copies own enumerable
+    // properties, symbol keys included; make this one non-enumerable or a
+    // getter and the copy silently loses it.
+    const db = store.open();
+
+    expect(Object.getOwnPropertySymbols(db)).toContain(UNSAFE_TEST_ONLY_RAW_HANDLE);
+    const wrapped: LocalDatabase = { ...db };
+    expect(wrapped[UNSAFE_TEST_ONLY_RAW_HANDLE]).toBe(db[UNSAFE_TEST_ONLY_RAW_HANDLE]);
+  });
+
+  it('closes with the facade rather than outliving it', () => {
+    const db = store.open();
+    const raw = db[UNSAFE_TEST_ONLY_RAW_HANDLE];
+
+    db.close();
+
+    // The seam hands out the real connection, so `close()` reaches it. A seam
+    // that stayed open would leak a handle per store a test opens — and on
+    // Windows keep the temp tree undeletable.
+    expect(raw.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

The store fails open: when a write fails, it vanishes and the caller is told nothing.
Five closures in `packages/persistence/src/database.ts` do this — `recordCapture`,
`ensureInventory`, `recordConfigScan`, `recordProjectFiles` and
`reconcileWorktreeProjects` — and none of them could be tested under a full store.

The only way to raise a genuine `SQLITE_FULL` in CI is `PRAGMA max_page_count`, and that
pragma binds to **one open connection**, not to the file. Those five closures write
through the connection `openLocalDatabase` opens and keeps private, and `LocalDatabase`
exposed no way to reach it — so a second handle on the same file carried none of the cap
and the fault reached nothing. Measured before the change: capping a sibling handle at
zero headroom left `recordCapture` returning normally with its row committed.

## What changed

- **`UNSAFE_TEST_ONLY_RAW_HANDLE`** — a `unique symbol` on `LocalDatabase` carrying the
  `DatabaseSync` the facade writes through. Symbol-keyed and deliberately **not**
  re-exported from `src/index.ts`; the package's `exports` map is `"." -> "./src/index.ts"`
  alone, so no other package can reach the defining module. Test-only is structural, not a
  convention.
- **Six fault cases** over the five closures under `SQLITE_FULL`: each fails open, writes
  nothing to stderr, and leaves no partial rows, no corruption (`PRAGMA integrity_check`)
  and no open transaction. They document the *actual* behaviour — there is no
  dropped-write counter, so none is asserted.
- **A tree-wide audit** (`packages/eslint-config/test/test-only-seam.test.js`): every
  tracked file naming the seam must be its one definition site or a test. A derived rule,
  not an allowlist — a new fault test needs no edit, a `cli/src` caller fails CI. It lives
  in that package because only that task's turbo `inputs` hash the whole workspace.
- `fillStore`'s reach caveat and the matching CLAUDE.md paragraph, which no longer hold.

## Notes on the seam

A `WeakMap` side table was the obvious alternative and is wrong here: the test helpers
hand out `{ ...db, close }` wrappers, and a spread creates a new object no `WeakMap`
knows. Object spread *does* copy own enumerable symbols, so a plain data property
survives — a getter or a non-enumerable definition would lose it silently, which is why
the spread itself is pinned by a test.

The seam grants nothing a process did not already have: any code running in-process can
open the store file directly with `node:sqlite`. The store's protection is the 0600 file
mode, not the reachability of a handle.

## Verification

Full workspace `test lint typecheck --force`: **47 tasks successful, `Cached: 0`**.
Persistence 880 passed / 1 skipped across 60 files; eslint-config 776 passed.

Each claim was mutation-tested rather than only run green:

| Mutation | Result |
| --- | --- |
| Seam points at a sibling connection | 2 red (identity + close) |
| `fillStore` injects nothing | 16 of 19 red |
| `failOpenTransaction` rethrows | 8 red |
| Planted caller in `cli/src` | audit red, names the file |
| Re-export from `index.ts` | 2 red |
| Seam absent from the tree | 2 red |

Two traps found while writing these, both now recorded in the test comments: a page cap
bites **late** (the first several writes land in free space inside existing pages), and
the resulting stall still leaves slack a *small* write fits — `ensureInventory` committed
at a 4 KiB payload while every "dropped write" assertion passed vacuously.
