### PR TITLE
test(detections): bound the probe-tier ratio against a contended runner

### DIFF
--- a/packages/detections/test/security/redos-probe.test.ts
+++ b/packages/detections/test/security/redos-probe.test.ts
@@ -15,6 +15,51 @@ function regexRule(pattern: string): Rule {
   });
 }
 
+// A fixed CPU-bound workload used only to ask whether this machine ran at the
+// same speed either side of a measurement. It touches no Rule and calls no
+// scan(): running the rule under test even once before `worstProbeMs` would tier
+// its pattern up, and the interpreted reading — the property the ratio case
+// exists to check — only exists on the first run.
+//
+// `sink` escapes the loop so the whole thing cannot be optimised away.
+//
+// The ITERATION COUNT and the sample count are both load-bearing, and getting
+// them wrong fails silently in the dangerous direction. This reading is a proxy
+// for what contention does to the native loop below, so it has to be about as
+// susceptible to contention AS that loop — same order of duration, same min-of-N
+// shape. Sized at ~4ms against a ~18ms scan it is strictly HARDER to disturb,
+// because `min` finds a quiet slot inside a short workload far more easily than
+// inside a long one: driven with load arriving on the native loop, a 4ms probe
+// moved 1.44x while the thing it was standing in for moved 5.3x, so the guard
+// sat under its budget and the false failure went through anyway. Keep this
+// it near the native scan's own duration, and re-check it if either moves.
+let sink = 0;
+function calibrationMs(samples = 5): number {
+  let ms = Infinity;
+  for (let i = 0; i < samples; i++) {
+    const start = performance.now();
+    let acc = 0;
+    for (let j = 0; j < 9_000_000; j++) acc = (acc + j) % 9973;
+    sink = (sink + acc) % 2_147_483_647;
+    ms = Math.min(ms, performance.now() - start);
+  }
+  // Reading `sink` is what makes the accumulation above observable. Written and
+  // never read, the whole loop is dead code — free for V8 to drop and for the
+  // unused-var rule to flag — and a calibration that measures an empty loop
+  // reports a machine that is never busy, so the guard below would never fire.
+  if (!Number.isFinite(sink)) throw new Error('calibration workload collapsed');
+  return ms;
+}
+
+// How far the two calibration readings may diverge before the ratio below is
+// treated as unmeasurable rather than failed. Contention that is present for the
+// WHOLE test is the safe direction and does not trip this: it inflates the
+// ~135ms numerator and the ~18ms denominator alike, and the ratio rises. What
+// this catches is contention that differs ACROSS the two windows — the numerator
+// is timed inside `worstProbeMs`, the denominator ~135ms later — because that is
+// the only thing that can inflate the denominator alone.
+const MAX_CALIBRATION_DRIFT = 1.5;
+
 describe('checkRuleTiming', () => {
   it('flags a catastrophic pattern as unsafe', () => {
     const result = checkRuleTiming(regexRule('^(a+)+$'));
@@ -72,7 +117,10 @@ describe('worstProbeMs attributes a probe to its interpreted tier', () => {
   // measured on the machine running them, so hardware speed and CPU contention
   // move them together and cancel — the same reason `backtrackRatio` and
   // CATASTROPHIC_RATIO exist rather than a fixed ms bound.
-  it('reports the first probe at its interpreted cost, not its native cost', () => {
+  it('reports the first probe at its interpreted cost, not its native cost', (ctx) => {
+    // Read the machine's speed before anything is measured against it, and again
+    // after. Neither reading touches `rule`.
+    const calibrationBefore = calibrationMs();
     const rule = regexRule('^(a+)+bd');
     const result = worstProbeMs(rule);
 
@@ -94,16 +142,82 @@ describe('worstProbeMs attributes a probe to its interpreted tier', () => {
     // same probe now measures the native tier, so a correct gate reports
     // several times what this second sample costs; a gate that kept a second
     // sample reports the same thing twice, and the ratio collapses to ~1.
-    const start = performance.now();
-    scan(result.probe, [rule]);
-    const nativeMs = performance.now() - start;
+    //
+    // The two sides are sampled differently ON PURPOSE, and the asymmetry is
+    // the point rather than an inconsistency. `result.ms` is probe #0 timed
+    // exactly once — that lone sample IS the property under test, so it must
+    // stay unreplicated. The denominator is the opposite case: it only has to
+    // name this probe's native-tier floor, and a single sample of a ~18ms scan
+    // is dominated by any scheduler preemption that lands inside it. Because
+    // contention can only push a sample above the floor, never below it, `min`
+    // recovers the tier while a lone sample tracks the noise — the same reason
+    // benignBaselineMs takes a min over several samples.
+    //
+    // Be precise about what that does and does not buy, because the obvious
+    // reading of it is wrong. Contention present for the WHOLE test does not
+    // collapse this ratio; it RAISES it, and uniformly more load is uniformly
+    // safer. Measured on a 10-core box: 7.05-8.15x idle, 9.69-19.79x at 2x
+    // oversubscription, 6.97-17.83x at 8x. The reason is that the numerator is
+    // one sample of a ~135ms scan and absorbs the contention in full, while the
+    // denominator is a min over seven ~18ms scans and recovers whenever any one
+    // of the seven catches a quiet slot.
+    //
+    // So `min` widens the margin against the common case, and the single sample
+    // it replaced was the weaker estimator there (4.21x worst against min-of-7's
+    // 6.97x, at 8x oversubscription). What neither form survives is load that
+    // differs ACROSS the two windows: the numerator is timed inside
+    // `worstProbeMs`, the denominator ~135ms later, so a burst arriving in that
+    // gap inflates the denominator alone and nothing cancels. Driven that way
+    // this ratio reaches 0.84x with the gate working perfectly. `min` cannot fix
+    // that — it needs a quiet slot to find, and there is none — which is why the
+    // drift guard below exists rather than a wider threshold.
+    let nativeMs = Infinity;
+    for (let i = 0; i < 7; i++) {
+      const start = performance.now();
+      scan(result.probe, [rule]);
+      nativeMs = Math.min(nativeMs, performance.now() - start);
+    }
     const ratio = result.ms / nativeMs;
+
+    // `min` bounds noise only where a quiet slot exists to be found. Sustained
+    // load arriving between the two windows leaves all seven samples inflated,
+    // and then the ratio reports the machine rather than the tier — measured
+    // down to 0.84x that way, on a gate that was working perfectly. That is
+    // unmeasurable, not failed, so abstain rather than reporting either verdict.
+    // `ctx.skip` and not an early return, which reports as a pass.
+    //
+    // This is what lets the threshold below stay a regression detector and stop
+    // doubling as the flake tolerance: the two duties now sit in different
+    // places, and neither has to be loosened to buy room for the other.
+    //
+    // The probe-length assertion above has already run, and it is the robust
+    // half — scale-free because it compares probes against each other inside one
+    // process, so contention hits every candidate alike and cancels exactly. It
+    // held across every load condition measured. Skipping here therefore gives
+    // up the backstop, never the primary detector.
+    const calibrationAfter = calibrationMs();
+    const drift =
+      Math.max(calibrationBefore, calibrationAfter) / Math.min(calibrationBefore, calibrationAfter);
+    if (drift > MAX_CALIBRATION_DRIFT) {
+      ctx.skip(
+        `machine speed moved ${drift.toFixed(2)}x across the measurement ` +
+          `(${calibrationBefore.toFixed(1)}ms before, ${calibrationAfter.toFixed(1)}ms after, ` +
+          `budget ${String(MAX_CALIBRATION_DRIFT)}x), so the ${ratio.toFixed(2)}x ratio times the ` +
+          `runner rather than the tier. The probe-length verdict above still ran.`,
+      );
+    }
+
     expect(
       ratio,
-      `gate reported ${result.ms.toFixed(1)}ms for a probe that re-scans in ${nativeMs.toFixed(1)}ms ` +
-        `(ratio ${ratio.toFixed(2)}x). Measured 6.9-7.7x when each probe is timed once and ` +
-        `0.95-1.16x with a lower-of-two-samples bypass in place, so a ratio near 1 means the ` +
-        `interpreted tier is no longer what the gate reports.`,
+      `gate reported ${result.ms.toFixed(1)}ms interpreted against a min-of-7 native floor of ` +
+        `${nativeMs.toFixed(1)}ms (ratio ${ratio.toFixed(2)}x), with machine speed steady to ` +
+        `${drift.toFixed(2)}x across the measurement. Measured 7.05-8.15x idle, 9.69-19.79x at 2x ` +
+        `CPU oversubscription and 6.97-17.83x at 8x — uniform load RAISES this ratio, so a low one ` +
+        `is not a busy runner. A ratio near 1 means the interpreted tier is no longer what the gate ` +
+        `reports. Note an actual lower-of-two-samples bypass trips the probe-length assertion above ` +
+        `before reaching this one — discarding probe #0's interpreted cost hands the title to the ` +
+        `25-char probe. This assertion is the backstop for a bypass that leaves the length verdict ` +
+        `intact, so read it as "which tier", not "which probe".`,
     ).toBeGreaterThan(3);
   });
 });


### PR DESCRIPTION
Split out of #188 at review request — that branch is web-ui work and this file rode along on it unmentioned. #188 no longer contains it.

## The flake

`worstProbeMs attributes a probe to its interpreted tier` fails on CI while **the same commit passes it concurrently in another job**. On [run 30940567564](https://github.com/akasecurity/ai-tc/actions/runs/30940567564):

```
gate reported 1218.1ms for a probe that re-scans in 914.5ms (ratio 1.33x)
  expected 1.3320779602624229 to be greater than 3
```

The No-network job on that same commit ran the same test 30s earlier and passed it (`✓ … 1712ms`). 17 PRs are open against this test today.

## The reasoning that looked right and is backwards

The original fix took the native floor as a min over 7 samples instead of one. The stated justification — a contended runner inflates the small denominator more than the large numerator, so the noise does not cancel — is **not** what the data shows, and it matters because it points at the wrong lever.

Contention present for the *whole* test does not collapse this ratio. It **raises** it, and more of it is safer. Measured on a 10-core box, one measurement per fresh process (V8 tiers the pattern up, so the interpreted reading exists once per process):

| condition | interpreted | native min-of-7 | ratio_single | ratio_min7 |
|---|---|---|---|---|
| idle (n=10) | 130–144ms | 17.3–19.7ms | 6.82–8.07x | **7.05–8.15x** |
| 2x oversubscription (n=10) | 434–663ms | 28–47ms | 5.70–13.77x | **9.69–19.79x** |
| 8x oversubscription (n=8) | 1262–1645ms | 82–183ms | 4.21–9.98x | **6.97–17.83x** |

Uniform load multiplies both sides by roughly the same factor, so it cancels — that is the scale-free property, and it genuinely holds. What tips it in min-of-7's favour is that the numerator is one sample of a ~135ms scan and absorbs contention in full, while the denominator is a min over seven ~18ms scans and recovers whenever one catches a quiet slot.

So min-of-7 is the better estimator (4.21x → 6.97x worst case at 8x oversubscription) — but it **reduces the flake without bounding it**.

## What actually breaks it

The numerator is timed inside `worstProbeMs`; the denominator ~135ms later. A burst arriving *in that gap* inflates the denominator alone and nothing cancels. Driven that way the ratio reaches **0.68x with the gate working perfectly**. `min` cannot help — it needs a quiet slot to find, and under sustained saturation there is none.

That is what the CI failure looks like: interpreted 8.7x its ~140ms norm, native **45x** its ~18ms norm. Uniform load would have moved both alike.

## The fix

The flake tolerance moves **out of the threshold and into an explicit contention guard**. A fixed CPU-bound workload — touching no `Rule`, so it cannot tier the pattern up — is timed before and after. If the readings disagree by more than 1.5x, the machine changed speed mid-measurement, the ratio times the runner rather than the tier, and the case abstains with `ctx.skip` rather than reporting a verdict it cannot support.

The probe-length assertion runs first and is **never** skipped. It is the robust half — scale-free because it compares probes against each other inside one process, so contention hits every candidate alike — and it held in 56/56 runs across every load condition. Skipping gives up the backstop, never the primary detector.

**`>3` is unchanged.** It now does one job instead of two, and against the worst uniform observation (6.97x) it keeps 2.3x headroom. The bypass it exists to catch collapses the ratio to ~1.

## One trap worth flagging

Sizing the guard's workload fails **silently, in the dangerous direction**. At ~4ms against an ~18ms scan the probe is strictly *harder* to disturb, because `min` finds a quiet slot in a short workload far more easily than in a long one. Measured that way it moved 1.44x while the thing it stands in for moved 5.3x — so it sat under its budget and let the false failure through anyway. It is sized to the scan it proxies, and that is the first thing to re-check if either moves.

## Verified

Each condition driven directly, load injected inside the test so it lands in the intended window:

| condition | drift | ratio | verdict |
|---|---|---|---|
| idle | 1.00 | 7.76 | pass |
| uniform load (40 spinners) | 1.09 | 18.75 | pass |
| load on the native loop | 9.55 | 0.68 | **skip**, not a false failure |
| `Math.min(e1, e2)` bypass in `worstProbeMs` | — | — | **fail** |

The last row is the one that matters for whether this weakened anything: with a real lower-of-two-samples bypass in the source, the case still fails.

Full `@akasecurity/detections` suite: 1230 passed.

## Where it abstains, and what that costs

On this PR's own CI the ratio case **skipped on both Linux jobs** (`Lint · Typecheck · Test · Build`, `No-network`) and **ran on Windows** (`✓ reports the first probe at its interpreted cost … 3511ms`). That is the guard working as designed rather than a surprise — GitHub's Linux runners are small and shared, vitest runs files concurrently on them, and the machine really does change speed across the measurement. Abstaining is the honest reading of that.

But it should be stated plainly rather than counted as a win: **the backstop now provides little coverage on the Linux jobs.** What still runs everywhere is the probe-length assertion, which is the primary detector and the one that catches an actual lower-of-two-samples bypass; the ratio case is the secondary check for a bypass that leaves the length verdict intact.

Two things a maintainer may want to weigh, neither of which I would decide as a rider on a flake fix:

- Giving this file a quiet machine (its own non-parallel run) would let the ratio case execute on Linux *and* keep the measurement trustworthy — better than loosening the budget, which just readmits the false failures.
- Vitest's default reporter does not print skip reasons, so the drift numbers are invisible in CI logs. If the abstention rate matters, that message needs somewhere to go.
