### PR TITLE
fix(persistence): retry a Windows lock handoff instead of calling it unavailable

### DIFF
--- a/packages/persistence/src/file-lock.ts
+++ b/packages/persistence/src/file-lock.ts
@@ -187,6 +187,34 @@ function holderIsAlive(pid: number): boolean {
   }
 }
 
+// Whether the lock's own directory will accept a create at all.
+//
+// Asked only when a retryable errno arrived and the lock path looks absent —
+// the one case where "contention" and "this directory can never hold a lock"
+// are otherwise indistinguishable. A unique name, so it can never collide with
+// the lock, another waiter's probe, or a delete-pending entry of its own.
+//
+// Answers `false` when it cannot tell, which is the safe direction here: a
+// wrong `false` raises a loud FileLockError the caller surfaces, where a wrong
+// `true` spends the whole timeout to report contention that never existed.
+function directoryAcceptsCreates(lock: string): boolean {
+  const probe = `${lock}.probe-${randomUUID()}`;
+  try {
+    closeSync(openSync(probe, 'wx', DATA_FILE_MODE));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    // `force` so the failure path — where nothing was created — is not an error
+    // of its own. A probe left behind would be swept by nothing.
+    try {
+      rmSync(probe, { force: true });
+    } catch {
+      // Best effort; a stray probe blocks no lock, since the name is unique.
+    }
+  }
+}
+
 // Take the lock, returning the token that proves this call owns it, or null if
 // somebody else holds it.
 //
@@ -195,9 +223,10 @@ function holderIsAlive(pid: number): boolean {
 // through — the same property the tmp write in paths.ts relies on.
 //
 // A create that fails for a retryable reason is contention only if a lock is
-// actually there. With no file at the path the fault is the directory's, and no
-// amount of waiting fixes a read-only or immutable one, so it is raised at once
-// rather than spending the whole timeout to report contention that never was.
+// actually there, OR if the directory would still take one. With neither, the
+// fault is the directory's, and no amount of waiting fixes a read-only or
+// immutable one, so it is raised at once rather than spending the whole timeout
+// to report contention that never was.
 function tryAcquire(lock: string, file: string): string | null {
   const token = randomUUID();
   let fd: number;
@@ -211,10 +240,20 @@ function tryAcquire(lock: string, file: string): string | null {
     // released lock reported as a directory that will never hold one, with an
     // EEXIST message attached. That fires on an ordinary two-writer handoff.
     if (code === 'EEXIST') return null;
-    // The rest arrive from Windows for both reasons, so the path itself decides:
-    // a lock that is there is contention, and one that is not means the
-    // directory refused the create.
-    if (RETRYABLE_CREATE_ERRNOS.has(code) && existsSync(lock)) return null;
+    // The rest arrive from Windows for both reasons, so something has to decide
+    // which. `existsSync` alone cannot: an unlinked name stays DELETE-PENDING
+    // until every handle on it closes, and in that window a create answers
+    // ERROR_ACCESS_DENIED (EPERM/EACCES) while `existsSync` already reports
+    // false — an ordinary handoff, reported as a directory that will never hold
+    // a lock. That is the same mistake the EEXIST note above refuses to make,
+    // and it is what `applyOnboarding` surfaced as a hard save failure.
+    //
+    // So the visible lock is the fast answer and the directory is the fallback:
+    // if it still takes a create, the lock path is transient and this is
+    // contention; if it does not, the directory really is the fault.
+    if (RETRYABLE_CREATE_ERRNOS.has(code) && (existsSync(lock) || directoryAcceptsCreates(lock))) {
+      return null;
+    }
     throw new FileLockError(
       'unavailable',
       file,

--- a/packages/persistence/test/file-lock.test.ts
+++ b/packages/persistence/test/file-lock.test.ts
@@ -154,6 +154,13 @@ describe('withFileLock', () => {
     // full timeout to announce one as the other sends a reader looking for a
     // process that does not exist. It also blocks `aka init`, whose whole job is
     // repairing a store in exactly this state.
+    //
+    // The generous timeout is the assertion, not a cushion: this refusal has to
+    // be IMMEDIATE. A retryable errno now falls back to probing the directory
+    // when the lock path looks absent, so a probe that wrongly answered "this
+    // directory takes creates" would turn this case into a 30s wait ending in
+    // `timeout` — which `aka init` swallows, silently declining to write the
+    // settings file it exists to create.
     const frozen = join(dir, 'frozen');
     mkdirSync(frozen);
     const target = join(frozen, 'settings.json');
@@ -169,6 +176,19 @@ describe('withFileLock', () => {
       chmodSync(frozen, 0o700);
     }
   });
+
+  // No case here drives the directory probe, and that is a statement rather
+  // than an omission. The probe runs only where a retryable errno meets a lock
+  // path that looks absent — Windows' delete-pending window — and POSIX has no
+  // way to produce that combination: every route to EACCES/EPERM on the lock
+  // also denies the probe and the `unavailable` case above already covers it,
+  // while a dangling symlink answers EEXIST and never reaches the branch. A
+  // case constructed here would create no probe at all and assert its absence
+  // vacuously.
+  //
+  // What proves the fix is `test/concurrency/settings-race.test.ts` on the
+  // Windows CI leg — the suite that caught the bug, where a concurrent handoff
+  // was reported as a permanently unavailable directory.
 
   it('takes a lock whose holder is gone and whose window has passed', () => {
     plantHeldLock({ pid: DEAD_PID, ageMs: 5_000 });


### PR DESCRIPTION
Found while merging #188, whose Windows leg went red on a test that has nothing to do with it. Not a flake — a real race-dependent defect from #212, already on `main`.

## The failure

`packages/persistence/test/concurrency/settings-race.test.ts` → `concurrent applyOnboarding > keeps every writer's answer when all of them write at once`, on [run 30960481614](https://github.com/akasecurity/ai-tc/actions/runs/30960481614):

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ "FileLockError: cannot lock ...settings.json for writing:
   EPERM: operation not permitted, open '...settings.json.lock'"
```

## The bug

`tryAcquire` decides whether a retryable errno is contention by asking whether the lock is still there:

```ts
if (code === 'EEXIST') return null;
if (RETRYABLE_CREATE_ERRNOS.has(code) && existsSync(lock)) return null;   // <-
throw new FileLockError('unavailable', ...);
```

On Windows `existsSync` frequently cannot see it. An unlinked name stays **delete-pending** until every handle on it closes, and a create in that window answers `ERROR_ACCESS_DENIED` (EPERM/EACCES) while `existsSync` already reports `false`. So an ordinary two-writer handoff falls through to `unavailable` — *a directory that will never hold a lock*.

The certain part, independent of the OS mechanism: **EPERM was raised with `existsSync(lock) === false` during a normal concurrent handoff.**

This is the same mistake the `EEXIST` branch immediately above it exists to refuse, and its comment says so — *"the holder can release between the two calls … That fires on an ordinary two-writer handoff."* The reasoning was applied to one branch and not the next.

**User impact.** `applyOnboarding` is the writer, so the dashboard's Settings save and the `/aka:setup` wizard can hard-fail on Windows under concurrency. It fails loudly rather than writing unlocked, so it is a false *refusal* rather than a lost write — the safe direction, but wrong.

**Why it got through.** It needs a real race. #212's own Windows check passed, and so did main's post-merge run; it surfaced on an unrelated PR.

## The fix

The visible lock stays the fast answer; the directory becomes the fallback. On a retryable errno with the lock path apparently absent, probe whether the directory still accepts a create at a unique name — succeeds → the lock path is transient, retry; fails → the directory really is the fault.

Retrying unconditionally instead would have been simpler and wrong: a genuinely unusable directory would then report `timeout`, and `aka init` *swallows* `timeout` while propagating `unavailable`, so it would silently decline to write the settings file it exists to create.

## On coverage, plainly

**No test here drives the probe, and that is stated in the file rather than papered over.** POSIX cannot produce the combination the branch needs — every route to EACCES/EPERM on the lock path also denies the probe (already covered by the `unavailable` case), and a dangling symlink answers EEXIST and never reaches the branch. I wrote a case for it, found it created no probe at all and asserted its absence vacuously, and deleted it rather than ship a green test that proves nothing.

What proves the fix is `settings-race.test.ts` on the Windows leg — the suite that caught it.

What guards *this change's own risk* is the existing `reports a directory that cannot hold a lock at all as unavailable`, which grants 30s precisely so an immediate refusal is the assertion. Mutation-verified: forcing the probe to always answer "writable" turns that case into a **30.94s** run ending in `timeout`, and it goes red.

## Verified

`persistence` 976 passed / 1 skipped · `cli` 194 · `web-ui` 278 · typecheck, lint, `format:check` clean.

Windows is the platform that matters here and I cannot run it locally, so the CI leg on this PR is the real check.
