### PR TITLE
test(persistence): pin exception state agreement, budget and the window values

### DIFF
--- a/packages/persistence/src/repositories/exceptions.ts
+++ b/packages/persistence/src/repositories/exceptions.ts
@@ -129,6 +129,12 @@ interface BlockedDetectionRow {
 // a second source of truth that a crashed sweep could leave stale. This
 // predicate is the single definition of "active"; correctness never depends on
 // a cleanup sweep.
+//
+// Its COMPLEMENT is derived from neither: `create()`'s supersede clause and
+// `sweepTerminal` each spell "terminal" out longhand instead of negating this
+// string. One boundary, three statements — they must move together. The two
+// longhand copies decide whether a spent grant frees its index slot and
+// whether it is ever deleted, so a one-sided edit is not visible from here.
 const ACTIVE_PREDICATE = `revoked_at IS NULL
      AND (expires_at IS NULL OR expires_at > :now)
      AND (max_uses IS NULL OR use_count < max_uses)`;

--- a/packages/persistence/test/repositories/exceptions-clock.test.ts
+++ b/packages/persistence/test/repositories/exceptions-clock.test.ts
@@ -285,6 +285,55 @@ describe('SqliteExceptionsRepository — injected clock', () => {
       expect(await repo.sweepTerminal(RETENTION_MS)).toBe(0);
       expect((await repo.list()).map((e) => e.id)).toEqual([grant.id]);
     });
+
+    /**
+     * The cases above reach the expiry arm from far outside it — the clock
+     * lands a whole retention window past the stamp, where `expires_at <= :now`
+     * and `expires_at < :now` are the same question. So nothing pinned THIS
+     * copy of the boundary: the supersede clause has a millisecond-exact pair
+     * below, and the sweep had no counterpart.
+     *
+     * That matters because `sweepTerminal` does not read `ACTIVE_PREDICATE`; it
+     * restates the complement longhand. This case asserts the two agree at the
+     * one instant that can tell them apart — terminal per the sweep and inert
+     * on all four readers of the predicate, at the same millisecond. A sweep
+     * that drifted to `<` would leave a row every active surface has already
+     * disowned.
+     */
+    it('sweeps at exactly the millisecond of expiry, agreeing with all four active surfaces', async () => {
+      // Expiry a retention window past T0, so the row is ALREADY old enough
+      // when the clock reaches the stamp. Nearer than that and `updated_at <
+      // :cutoff` is what decides the case, leaving the expiry comparison
+      // unreached — which is exactly how the boundary went unpinned above.
+      const expiry = T0 + RETENTION_MS + 1;
+      const SWEEP_FP = 'ef'.repeat(32);
+      const expiring = await repo.create(
+        input({
+          // So the reveal surface is askable of this same row; the other three
+          // do not filter on capability.
+          capability: 'reveal_to_model',
+          valueFingerprint: SWEEP_FP,
+          expiresAt: iso(expiry),
+        }),
+      );
+      // The control: equally old, never expires. Without it a sweep deleting
+      // every row past the cutoff passes this test.
+      const permanent = await repo.create(input({ scope: 'permanent', expiresAt: null }));
+
+      at(expiry);
+
+      // Inert on all four readers of the predicate. `consume` is asked BEFORE
+      // the sweep: once the row is deleted it returns false whatever the
+      // predicate says, and the assertion would hold vacuously.
+      expect((await repo.list()).map((e) => e.id)).toEqual([permanent.id]);
+      expect((await repo.activeBundleEntries(1)).map((e) => e.id)).toEqual([permanent.id]);
+      expect(await repo.activeRevealGrant('aws-access-key-id', SWEEP_FP, 1)).toBeNull();
+      expect(await repo.consume(expiring.id)).toBe(false);
+
+      // ...and terminal per the sweep, at that same instant.
+      expect(await repo.sweepTerminal(RETENTION_MS)).toBe(1);
+      expect((await repo.list({ includeTerminal: true })).map((e) => e.id)).toEqual([permanent.id]);
+    });
   });
 
   describe('terminal-collider supersede', () => {

--- a/packages/persistence/test/repositories/exceptions.test.ts
+++ b/packages/persistence/test/repositories/exceptions.test.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from 'node:sqlite';
 
+import type { DetectionException } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { applyMigrations } from '../../src/migrations.ts';
@@ -9,18 +10,36 @@ import type {
 } from '../../src/repositories/exceptions.ts';
 import {
   AmbiguousExceptionIdError,
+  BLOCKED_DETECTIONS_RETENTION_MS,
+  BLOCKED_DETECTIONS_TTL_MS,
   DuplicateActiveExceptionError,
   SqliteExceptionsRepository,
 } from '../../src/repositories/exceptions.ts';
+import { errorFrom } from '../helpers/errors.ts';
+import { lockStore, primaryCode, SQLITE_BUSY } from '../helpers/fault-injection.ts';
+import { withTempStore } from '../helpers/temp-store.ts';
+import { assertNoOpenTransaction } from '../helpers/transactions.ts';
+import { withTwoWriters, withWriters } from '../helpers/with-two-writers.ts';
 
 let db: DatabaseSync;
 let repo: SqliteExceptionsRepository;
 let fingerprintSeq = 0;
 
+// The repository's clock. Every "is this grant still active" question is a
+// comparison against it, so a test that moves it can reach the far side of a
+// 30-minute, 24-hour or 90-day window without fabricating a raw row timestamp
+// — which is what fabricating one costs: the row stops having been written by
+// the code under test, and the window it lands in stops being evidence about
+// the write path. It starts at the wall clock and only the tests that mean to
+// move time touch it, so a test that says nothing about time behaves exactly as
+// it did before the seam existed.
+let clock = 0;
+
 beforeEach(() => {
   db = new DatabaseSync(':memory:');
   applyMigrations(db);
-  repo = new SqliteExceptionsRepository(db);
+  clock = Date.now();
+  repo = new SqliteExceptionsRepository(db, () => clock);
 });
 
 afterEach(() => {
@@ -39,7 +58,7 @@ function input(overrides: Partial<CreateExceptionInput> = {}): CreateExceptionIn
     keyVersion: 1,
     maskedValue: 'AKIA******Q',
     scope: 'temporary',
-    expiresAt: new Date(Date.now() + HOUR_MS).toISOString(),
+    expiresAt: new Date(clock + HOUR_MS).toISOString(),
     maxUses: null,
     justification: 'temp deploy creds, rotating after infra apply',
     conditions: null,
@@ -47,6 +66,11 @@ function input(overrides: Partial<CreateExceptionInput> = {}): CreateExceptionIn
     createdVia: 'cli-approve',
     ...overrides,
   };
+}
+
+/** An ISO stamp `ms` from the repository's current clock. */
+function at(ms: number): string {
+  return new Date(clock + ms).toISOString();
 }
 
 // Insert a row with a caller-controlled id (create() mints random UUIDs, so
@@ -167,6 +191,229 @@ describe('SqliteExceptionsRepository', () => {
     it('returns false for an unknown id', async () => {
       expect(await repo.consume('no-such-id')).toBe(false);
     });
+  });
+
+  /**
+   * "Active" is DERIVED — `ACTIVE_PREDICATE` is its single definition, and no
+   * column stores it — but FOUR surfaces ask the question independently:
+   * `list()`, `activeBundleEntries()` (what rides the policy bundle to the
+   * hook), `activeRevealGrant()` (what authorizes decrypting a vaulted value
+   * for the model) and `consume()` (the claim itself). A predicate that drifts
+   * on any one of them is a grant that goes on applying somewhere after the
+   * user believed it was spent — silently, because every surface returns a
+   * well-formed answer either way.
+   *
+   * So each case here asks all four OF ONE GRANT and asserts them together: a
+   * per-surface test can be individually correct while the set disagrees, and
+   * the disagreement is the bug. Every grant is minted `reveal_to_model` with
+   * no conditions purely so the reveal surface is askable of the same row as
+   * the other three — the capability and condition gates are separate
+   * properties, pinned in their own block below.
+   *
+   * `consume()` is asked LAST because it is the one that mutates: it claims a
+   * use, so probing it first would change the state the other three report on.
+   */
+  describe('the active-state predicate, on every surface that asks', () => {
+    interface Surfaces {
+      listed: boolean;
+      inBundle: boolean;
+      revealable: boolean;
+      consumable: boolean;
+    }
+
+    const ACTIVE: Surfaces = {
+      listed: true,
+      inBundle: true,
+      revealable: true,
+      consumable: true,
+    };
+    const INERT: Surfaces = {
+      listed: false,
+      inBundle: false,
+      revealable: false,
+      consumable: false,
+    };
+
+    function revealGrant(
+      overrides: Partial<CreateExceptionInput> = {},
+    ): Promise<DetectionException> {
+      return repo.create(input({ capability: 'reveal_to_model', ...overrides }));
+    }
+
+    async function probe(grant: DetectionException): Promise<Surfaces> {
+      const listed = (await repo.list()).some((e) => e.id === grant.id);
+      const inBundle = (await repo.activeBundleEntries(grant.keyVersion)).some(
+        (e) => e.id === grant.id,
+      );
+      const reveal = await repo.activeRevealGrant(
+        grant.ruleId,
+        grant.valueFingerprint,
+        grant.keyVersion,
+      );
+      return {
+        listed,
+        inBundle,
+        revealable: reveal?.id === grant.id,
+        consumable: await repo.consume(grant.id),
+      };
+    }
+
+    it('an unexpired grant under its budget is active on all four', async () => {
+      expect(await probe(await revealGrant())).toEqual(ACTIVE);
+    });
+
+    it('an expired grant is inert on all four', async () => {
+      const grant = await revealGrant({ expiresAt: at(HOUR_MS) });
+      clock += HOUR_MS;
+      expect(await probe(grant)).toEqual(INERT);
+    });
+
+    it('expiry is exclusive: active through the last millisecond, inert at the stamp', async () => {
+      const grant = await revealGrant({ expiresAt: at(HOUR_MS) });
+
+      clock += HOUR_MS - 1;
+      expect(await probe(grant)).toEqual(ACTIVE);
+
+      // The probe above claimed a use, but `maxUses` is null here, so the only
+      // thing that can have changed between these two assertions is the clock.
+      clock += 1;
+      expect(await probe(grant)).toEqual(INERT);
+    });
+
+    it('a budget-exhausted grant is inert on all four', async () => {
+      const grant = await revealGrant({ scope: 'once', maxUses: 1 });
+      expect(await repo.consume(grant.id)).toBe(true); // 1 of 1 spent
+      expect(await probe(grant)).toEqual(INERT);
+    });
+
+    it('the budget is exclusive too: the last use inside it still applies', async () => {
+      const grant = await revealGrant({ maxUses: 2 });
+      expect(await probe(grant)).toEqual(ACTIVE); // useCount 0 -> 1
+      expect(await probe(grant)).toEqual(ACTIVE); // useCount 1 -> 2
+      expect(await probe(grant)).toEqual(INERT); // 2 >= 2
+    });
+
+    it('maxUses null is unlimited — the budget clause is skipped, never defaulted', async () => {
+      const grant = await revealGrant({ maxUses: null });
+
+      expect(await probe(grant)).toEqual(ACTIVE);
+      expect(await probe(grant)).toEqual(ACTIVE);
+      expect(await probe(grant)).toEqual(ACTIVE);
+
+      // Uses are still COUNTED without a budget; what is absent is the ceiling.
+      expect((await repo.getByIdPrefix(grant.id))?.useCount).toBe(3);
+    });
+
+    it('a revoked grant is inert on all four', async () => {
+      const grant = await revealGrant();
+      expect(await repo.revoke(grant.id, 'alice')).toBe(true);
+      expect(await probe(grant)).toEqual(INERT);
+    });
+  });
+
+  /**
+   * The bundle entry carries `useCount`, and the hook pre-filters on it before
+   * asking the store. That number is a SNAPSHOT taken when the bundle was
+   * built: the hook, the CLI and the dashboard each hold their own connection
+   * to one `aka.db`, so by the time the hook acts on it another process may
+   * have spent the budget. The pre-filter is an optimization; `consume` is the
+   * authority.
+   */
+  describe('the bundle useCount is a snapshot, not the authority', () => {
+    it('a stale snapshot still reads under budget after the store has refused', async () => {
+      const grant = await repo.create(input({ scope: 'once', maxUses: 1 }));
+      const [snapshot] = await repo.activeBundleEntries(grant.keyVersion);
+      expect(snapshot).toMatchObject({ id: grant.id, maxUses: 1, useCount: 0 });
+
+      // Another crossing spends the single use.
+      expect(await repo.consume(grant.id)).toBe(true);
+
+      // The entry in hand is a value, not a view, so it still reads as
+      // applicable — a pre-filter trusting it would apply this grant twice...
+      expect(snapshot?.useCount).toBe(0);
+      // ...and the store is what refuses.
+      expect(await repo.consume(grant.id)).toBe(false);
+      // A bundle rebuilt now no longer carries it at all.
+      expect(await repo.activeBundleEntries(grant.keyVersion)).toEqual([]);
+    });
+  });
+
+  /**
+   * `consume` is the fail-secure primitive: the budget check and the claim ride
+   * ONE conditional UPDATE, so no window exists between them. What that buys is
+   * a budget that holds across the processes the product actually runs in — a
+   * hook, the CLI and the dashboard each open their own handle on one `aka.db`,
+   * with WAL and `busy_timeout` between them and nothing else.
+   *
+   * `node:sqlite` is synchronous, so handles on one thread interleave rather
+   * than collide. These cases pin that N independent claimants share ONE
+   * budget, which is the property the product depends on. They do NOT
+   * demonstrate a read/read/write/write interleaving — that is unreachable from
+   * one thread and would need a seam inside `consume` — so do not read them as
+   * proof of that.
+   */
+  describe('consume across independent handles', () => {
+    it('two handles, one use: exactly one of them claims it', () =>
+      withTwoWriters(async (a, b) => {
+        const grant = await a.exceptions.create(input({ scope: 'once', maxUses: 1 }));
+
+        const claims = [await a.exceptions.consume(grant.id), await b.exceptions.consume(grant.id)];
+
+        expect(claims).toEqual([true, false]);
+        // Read back through the OTHER handle: one claim, counted once.
+        expect((await b.exceptions.getByIdPrefix(grant.id))?.useCount).toBe(1);
+      }));
+
+    it('four handles share one budget of two', () =>
+      withWriters(4, async (writers) => {
+        const [w0, w1, w2, w3] = writers;
+        if (!w0 || !w1 || !w2 || !w3) throw new Error('expected four handles');
+        const grant = await w0.exceptions.create(input({ maxUses: 2 }));
+
+        const claims = [
+          await w0.exceptions.consume(grant.id),
+          await w1.exceptions.consume(grant.id),
+          await w2.exceptions.consume(grant.id),
+          await w3.exceptions.consume(grant.id),
+        ];
+
+        expect(claims).toEqual([true, true, false, false]);
+        expect((await w3.exceptions.getByIdPrefix(grant.id))?.useCount).toBe(2);
+      }));
+
+    it('a contended claim refuses by throwing, and spends nothing', () =>
+      withTempStore(async (store) => {
+        const seed = store.open();
+        const grant = await seed.exceptions.create(input({ scope: 'once', maxUses: 1 }));
+
+        // A repository over a handle the TEST owns: `LocalDatabase` exposes no
+        // accessor for the connection it opened, and the connection that meets
+        // the contention is the one the assertions below have to inspect.
+        // Both handles are taken BEFORE the lock — opening one while the write
+        // lock is held fails, because opening writes on the way in.
+        const raw = store.openRaw();
+        const contended = new SqliteExceptionsRepository(raw);
+
+        // Hold the write lock from a worker; a handle on this thread would
+        // interleave rather than contend.
+        const lock = lockStore(store.dbFile, { onCleanup: store.onCleanup });
+        // `consume` is deliberately NOT wrapped in try/catch, so contention
+        // surfaces as a throw. Captured outside its own catch — inside one, a
+        // `consume` that stopped throwing would satisfy the assertion below.
+        const err = errorFrom(() => contended.consume(grant.id));
+        lock.release();
+
+        expect(primaryCode(err)).toBe(SQLITE_BUSY);
+        // The refusal cost nothing: the use is unspent...
+        expect((await seed.exceptions.getByIdPrefix(grant.id))?.useCount).toBe(0);
+        // ...which is what makes the throw a refusal rather than a loss — the
+        // one use is still there to claim once the lock is gone.
+        expect(await contended.consume(grant.id)).toBe(true);
+        // A forward guard rather than a live one: `consume` is a single
+        // autocommit statement, so there is no envelope to strand today. It
+        // goes live the moment one is added around it.
+        assertNoOpenTransaction(raw);
+      }));
   });
 
   describe('revoke', () => {
@@ -309,6 +556,53 @@ describe('SqliteExceptionsRepository', () => {
       expect(all[0]?.maxUses).toBe(1);
     });
 
+    // The expiry stamp itself — where `ACTIVE_PREDICATE`'s `expires_at > :now`
+    // and the supersede clause's `expires_at <= :now` must stay complements —
+    // is pinned in exceptions-clock.test.ts, which drives both sides of that
+    // millisecond off the injected clock.
+
+    /**
+     * The supersede and the re-insert run inside ONE transaction so "two
+     * concurrent creates cannot both claim the freed slot". This is that
+     * invariant seen from outside: the second arrival meets an ACTIVE collider
+     * — the grant the first one just made — and is refused, rather than finding
+     * a half-freed slot and superseding a live grant.
+     *
+     * What it does NOT do is distinguish `IMMEDIATE` from `DEFERRED`. Nothing
+     * reachable from a test can, in this code shape: the first statement inside
+     * the transaction is already a write, so both modes take the write lock at
+     * the same moment, both surface contention as `SQLITE_BUSY`, and
+     * `withTransaction` rolls back either way. Swap the mode and this file stays
+     * green — knowingly. The mode is a belt-and-braces choice about WHEN the
+     * lock is taken, and the invariant it protects is what is asserted here.
+     */
+    it('two handles cannot both claim the slot a terminal collider frees', () =>
+      withTwoWriters(async (a, b) => {
+        const first = input({ scope: 'once', maxUses: 1 });
+        const created = await a.exceptions.create(first);
+        expect(await a.exceptions.consume(created.id)).toBe(true); // terminal: 1/1 spent
+
+        const collider = (): CreateExceptionInput =>
+          input({
+            ruleId: first.ruleId,
+            valueFingerprint: first.valueFingerprint,
+            keyVersion: first.keyVersion,
+            scope: 'once',
+            maxUses: 1,
+          });
+
+        // The first arrival supersedes the spent grant and takes the slot.
+        const claimed = await a.exceptions.create(collider());
+        // The second finds it occupied by a live grant, not freed.
+        await expect(b.exceptions.create(collider())).rejects.toThrow(
+          DuplicateActiveExceptionError,
+        );
+
+        // Read back through the other handle: one active grant, one supersede.
+        expect((await b.exceptions.list()).map((e) => e.id)).toEqual([claimed.id]);
+        expect(await b.exceptions.list({ includeTerminal: true })).toHaveLength(2);
+      }));
+
     it('rejects a provider condition (no capture fact carries one yet)', async () => {
       await expect(repo.create(input({ conditions: { provider: 'anthropic' } }))).rejects.toThrow(
         /provider conditions are not supported/,
@@ -377,6 +671,75 @@ describe('SqliteExceptionsRepository', () => {
     });
   });
 
+  /**
+   * Rotation is invalidation — for suppression. `activeBundleEntries` is
+   * `WHERE key_version = :keyVersion` and the hook asks it with the CURRENT
+   * key, so a grant written under a rotated-away epoch stops riding the bundle.
+   *
+   * Reveal grants are deliberately EXEMPT, and the exemption reads like a bug
+   * unless it is written down. `activeRevealGrant` takes the key version as an
+   * ARGUMENT, and its caller passes the vault row's own — the triple the
+   * pointer was minted under, not whatever is current now. So the very grant
+   * the bundle has dropped still authorizes the reveal it was granted for.
+   * That is correct: the row's fingerprint was never recomputed under the new
+   * key, so refusing on the current key would refuse a grant that does enforce.
+   *
+   * Both halves are asserted of ONE grant, because the asymmetry is the point.
+   * Split across two tests, each half reads like an oversight in the other.
+   */
+  describe('key-version scoping, and the reveal grant exempt from it', () => {
+    const ROTATED_AWAY = 1;
+    const CURRENT = 2;
+
+    it('the bundle drops a rotated-away grant that activeRevealGrant still honours', async () => {
+      const grant = await repo.create(
+        input({ keyVersion: ROTATED_AWAY, capability: 'reveal_to_model' }),
+      );
+
+      // The hook builds its bundle under the current key: the grant is gone.
+      expect(await repo.activeBundleEntries(CURRENT)).toEqual([]);
+      // Its own epoch still carries it — the predicate SCOPES, it does not expire.
+      expect((await repo.activeBundleEntries(ROTATED_AWAY)).map((e) => e.id)).toEqual([grant.id]);
+
+      // The crossing asks with the vault row's own triple, and is answered.
+      expect(
+        await repo.activeRevealGrant(grant.ruleId, grant.valueFingerprint, ROTATED_AWAY),
+      ).toEqual({ id: grant.id });
+      // Asked under the current key it matches nothing, so this is scoping too
+      // — an exemption from what the CURRENT key is, not from the key at all.
+      expect(
+        await repo.activeRevealGrant(grant.ruleId, grant.valueFingerprint, CURRENT),
+      ).toBeNull();
+    });
+
+    it('a suppression grant never authorizes a reveal, even on its own key version', async () => {
+      const grant = await repo.create(input({ capability: 'suppress' }));
+
+      expect((await repo.activeBundleEntries(grant.keyVersion)).map((e) => e.id)).toEqual([
+        grant.id,
+      ]);
+      expect(
+        await repo.activeRevealGrant(grant.ruleId, grant.valueFingerprint, grant.keyVersion),
+      ).toBeNull();
+    });
+
+    it('a conditioned reveal grant fails closed — the reveal path evaluates no conditions', async () => {
+      const grant = await repo.create(
+        input({ capability: 'reveal_to_model', conditions: { repo: 'acme/api' } }),
+      );
+
+      // It still rides the suppression bundle, which DOES evaluate conditions...
+      expect((await repo.activeBundleEntries(grant.keyVersion)).map((e) => e.id)).toEqual([
+        grant.id,
+      ]);
+      // ...but the reveal crossing, which ignores them, refuses rather than
+      // honouring a narrowed grant as though it had been granted unconditionally.
+      expect(
+        await repo.activeRevealGrant(grant.ruleId, grant.valueFingerprint, grant.keyVersion),
+      ).toBeNull();
+    });
+  });
+
   describe('blocked-detections ledger', () => {
     function rawBlockedCount(): number {
       return (db.prepare('SELECT count(*) AS c FROM blocked_detections').get() as { c: number }).c;
@@ -388,6 +751,54 @@ describe('SqliteExceptionsRepository', () => {
          VALUES (:reference, 'r', 'secret', 'fp', 1, 'x***y', NULL, NULL, :blockedAt)`,
       ).run({ reference, blockedAt });
     }
+
+    function rawReferences(): string[] {
+      return (
+        db.prepare('SELECT reference FROM blocked_detections').all() as { reference: string }[]
+      )
+        .map((r) => r.reference)
+        .sort();
+    }
+
+    /**
+     * Both windows are product decisions about how long evidence lives, and
+     * both are reachable only by moving the clock. The VALUE pin and the
+     * BOUNDARY case below are different guards and neither implies the other:
+     * a boundary case derived from the constant follows it wherever it goes, so
+     * it proves the window the code applies is the window the constant names
+     * while saying nothing about what that number should be. Shrink the
+     * constant with only the boundary case in place and every assertion moves
+     * with it, green the whole way.
+     */
+    it('the ledger windows are 30 minutes and 24 hours', () => {
+      expect(BLOCKED_DETECTIONS_TTL_MS).toBe(30 * 60 * 1000);
+      expect(BLOCKED_DETECTIONS_RETENTION_MS).toBe(24 * 60 * 60 * 1000);
+      // The read window has to be the narrower of the two, or the picker offers
+      // rows the sweep may already have taken.
+      expect(BLOCKED_DETECTIONS_TTL_MS).toBeLessThan(BLOCKED_DETECTIONS_RETENTION_MS);
+    });
+
+    // Both window EDGES — `blocked_at > :cutoff` for the read and
+    // `blocked_at <= :cutoff` for the sweep — are pinned off the injected clock
+    // in exceptions-clock.test.ts. What is left here is the pair of properties
+    // that file does not reach: the constants' own values, and the fact that
+    // only a write collects.
+
+    it('the sweep runs on EVERY write, not on a read', async () => {
+      const stale = blockedInput();
+      await repo.recordBlocked(stale);
+      clock += BLOCKED_DETECTIONS_RETENTION_MS;
+
+      // Reading past the retention window hides the row without removing it:
+      // nothing on the read path deletes.
+      expect(await repo.recentBlocked(BLOCKED_DETECTIONS_RETENTION_MS * 2)).toHaveLength(1);
+      expect(rawReferences()).toEqual([stale.reference]);
+
+      // The next write is what collects it.
+      const fresh = blockedInput();
+      await repo.recordBlocked(fresh);
+      expect(rawReferences()).toEqual([fresh.reference]);
+    });
 
     it('round-trips recordBlocked → recentBlocked, newest-first with ISO blockedAt', async () => {
       const older = blockedInput();
@@ -479,6 +890,29 @@ describe('SqliteExceptionsRepository', () => {
       await repo.create(input());
       expect(await repo.sweepTerminal(90 * DAY_MS)).toBe(0);
       expect(await repo.list()).toHaveLength(1);
+    });
+
+    // The `updated_at < :cutoff` edge, and the grant that goes terminal by
+    // EXPIRY alone, are pinned off the injected clock in
+    // exceptions-clock.test.ts. The third way a grant goes terminal without
+    // anyone revoking it — spending its budget — is only reachable here,
+    // because it needs a consume rather than a clock move.
+    it('sweeps a grant that went terminal by budget alone', async () => {
+      const spent = await repo.create(input({ scope: 'once', maxUses: 1 }));
+      expect(await repo.consume(spent.id)).toBe(true);
+      // The control: equally old, never spent, and it must survive. Without it
+      // a sweep that deletes every row past the cutoff passes this test.
+      const permanent = await repo.create(input({ scope: 'permanent', expiresAt: null }));
+
+      clock += 1;
+      // Terminal by the budget alone — `revoked_at` is still null, which is the
+      // case a sweep keyed only on revocation would leave behind forever.
+      expect((await repo.getByIdPrefix(spent.id))?.revokedAt).toBeNull();
+
+      expect(await repo.sweepTerminal(0)).toBe(1);
+      // The exact surviving set, which is what says the sweep took the spent
+      // grant and only it.
+      expect((await repo.list({ includeTerminal: true })).map((e) => e.id)).toEqual([permanent.id]);
     });
   });
 });

--- a/packages/persistence/test/repositories/exceptions.test.ts
+++ b/packages/persistence/test/repositories/exceptions.test.ts
@@ -400,6 +400,14 @@ describe('SqliteExceptionsRepository', () => {
         // `consume` is deliberately NOT wrapped in try/catch, so contention
         // surfaces as a throw. Captured outside its own catch — inside one, a
         // `consume` that stopped throwing would satisfy the assertion below.
+        //
+        // `errorFrom` is a SYNCHRONOUS try/catch, and it reaches this throw
+        // only because `consume` returns `Promise.resolve(...)` rather than
+        // being `async`: the statement runs on the calling stack, before any
+        // promise exists. Marking it `async` — a refactor its return type
+        // invites — turns the throw into a rejection this cannot see, and the
+        // assertion below then fails on `undefined` with an unhandled
+        // rejection beside it.
         const err = errorFrom(() => contended.consume(grant.id));
         lock.release();
 

--- a/packages/plugin-runtime/test/handle-session-start.test.ts
+++ b/packages/plugin-runtime/test/handle-session-start.test.ts
@@ -7,7 +7,7 @@ import { openLocalDatabase } from '@akasecurity/persistence';
 import { bundledDetections, type PluginConfig } from '@akasecurity/plugin-sdk';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { handleSessionStart } from '../src/handle-session-start.ts';
+import { EXCEPTION_RETENTION_MS, handleSessionStart } from '../src/handle-session-start.ts';
 import { StandaloneDataGateway } from '../src/standalone-gateway.ts';
 
 let dir: string; // the ~/.aka data dir
@@ -188,9 +188,20 @@ describe('handleSessionStart (standalone)', () => {
     db.close();
   });
 
+  // How long a terminal grant is kept is a product decision about how long the
+  // audit evidence for a revoked or spent exception lives. Pinning the VALUE
+  // and pinning the BOUNDARY are different guards and neither implies the
+  // other: the boundary case below derives its offsets from the constant, so it
+  // follows the constant wherever it goes and proves only that the sweep
+  // applies the window it is handed. Shrink the constant with just that case in
+  // place and every offset shrinks with it, green the whole way.
+  it('terminal exception rows are retained for 90 days', () => {
+    expect(EXCEPTION_RETENTION_MS).toBe(90 * 24 * 60 * 60 * 1000);
+  });
+
   it('sweeps terminal exception rows past retention, never active grants', async () => {
-    // Seed the store, then plant one long-terminal (revoked) grant and one
-    // active grant before a fresh session starts.
+    // Seed the store, then plant grants straddling the retention boundary
+    // before a fresh session starts.
     await handleSessionStart({ sessionId: 's1', cwd, tool: 'claude-code' }, config(dir));
     const seed = open();
     const insert = seed.prepare(
@@ -201,21 +212,34 @@ describe('handleSessionStart (standalone)', () => {
        ) VALUES (?, 'r', 'secret', ?, 1, 'm', 'permanent', NULL, NULL, 0, 'j',
          'u', 'cli-add', ?, ?, ?, ?)`,
     );
-    const old = Date.now() - 100 * 24 * 60 * 60 * 1000; // 100 days ago
-    insert.run('terminal-old', 'fp-a', old, old, old, 'u');
-    insert.run('still-active', 'fp-b', old, old, null, null);
+    // Straddle the window rather than sit on it. The sweep compares
+    // `updated_at < now - retentionMs` against a `now` that SessionStart
+    // resolves after these rows are written, so an exact-millisecond boundary
+    // here is a race against however long the session takes — which on a loaded
+    // Windows runner is not a millisecond. The hour of margin makes the
+    // straddle decide the outcome instead of the elapsed time; the exact
+    // inclusive/exclusive edge is pinned where it can be, on the repository's
+    // own injectable clock, in persistence's exceptions.test.ts.
+    const now = Date.now();
+    const MARGIN_MS = 60 * 60 * 1000;
+    const past = now - EXCEPTION_RETENTION_MS - MARGIN_MS;
+    const inside = now - EXCEPTION_RETENTION_MS + MARGIN_MS;
+    insert.run('terminal-past-retention', 'fp-a', past, past, past, 'u');
+    insert.run('terminal-inside-retention', 'fp-b', inside, inside, inside, 'u');
+    insert.run('active-equally-old', 'fp-c', past, past, null, null);
     seed.close();
 
     await handleSessionStart({ sessionId: 's2', cwd, tool: 'claude-code' }, config(dir));
 
     const db = open();
-    const ids = (db.prepare('SELECT id FROM exceptions').all() as { id: string }[]).map(
+    const ids = (db.prepare('SELECT id FROM exceptions ORDER BY id').all() as { id: string }[]).map(
       (r) => r.id,
     );
     db.close();
-    // The revoked row aged past the 90-day retention is purged; the active
-    // grant — equally old — is untouched (the sweep is terminal-only).
-    expect(ids).toEqual(['still-active']);
+    // Only the revoked row aged PAST retention is purged. The revoked row still
+    // inside the window survives, and so does the active grant — equally old,
+    // but the sweep is terminal-only and correctness never depends on it.
+    expect(ids).toEqual(['active-equally-old', 'terminal-inside-retention']);
   });
 
   it('no-ops without a session id (returns before even opening the store)', async () => {


### PR DESCRIPTION
Rebased onto main now that the injectable clock has landed. This branch is
**tests only** — the clock seam it originally carried was the same change, so
that commit is dropped and main's version (which is better: it moves
`activeRevealGrant`'s clock read inside the `try`, and corrects the predicate
doc about the vault badge) stands.

## What

An exception grant is how a user says "this flagged value is fine, stop blocking it." It stops applying when it expires, when its use budget runs out, or when it is revoked. That state is **derived** from the row every time, never stored — and four surfaces derive it independently:

| Surface | What it decides |
| --- | --- |
| `list()` | what the dashboard and CLI show |
| `activeBundleEntries()` | what rides to the hook and decides enforcement |
| `activeRevealGrant()` | what authorizes decrypting a vaulted value for the model |
| `consume()` | the claim that spends a use |

If one drifts, a grant keeps applying somewhere after the user believed it was spent — silently, because every surface returns a well-formed answer either way.

## What this adds, on top of `exceptions-clock.test.ts`

That file (already on main) pins each window **edge** off the injected clock. This one pins the properties an edge case cannot reach:

- **The four surfaces agree.** Asked of **one** grant and asserted together — a per-surface test can be individually correct while the set disagrees, and the disagreement is the bug. No number of per-surface cases expresses this.
- **The bundle's `useCount` is a snapshot, not the authority** — a stale entry still reads as applicable after the store has already refused.
- **`consume()` across independent handles** — N claimants share one budget, and a contended claim refuses by throwing without spending the use.
- **Key-version scoping, and the reveal grant deliberately exempt from it.** A grant under a rotated-away key is dropped from the bundle yet still honoured by `activeRevealGrant`, which matches on the vault row's own triple. Pinned as intended, so a later "fix" that matches the newest key instead goes red.
- **The window constants' values**, and that only a *write* sweeps.
- **A grant that goes terminal by spending its budget** — needs a consume rather than a clock move — with a control row that must survive.

Five boundary cases that duplicated `exceptions-clock.test.ts` were dropped in the rebase rather than kept alongside it.

## Why the value pins are separate from the edge cases

A boundary case derived from a constant follows that constant wherever it goes, so it proves only that the code applies the window it is *handed*. Shrinking `BLOCKED_DETECTIONS_TTL_MS` 30 min → 5 min, its retention 24 h → 2 h, or `EXCEPTION_RETENTION_MS` 90 d → 9 d each left the suite green. The value pins are what catch that; neither guard implies the other.

Every gap here was demonstrated by mutation before being closed. The one that mattered most: dropping expiry **and** budget from the bundle query let an expired grant ride to the hook with **869 tests green**.

## Deliberately not pinned

Stated in the tests rather than left looking covered:

- **`IMMEDIATE` vs `DEFERRED`** on the supersede transaction — the first statement inside the envelope is already a write, so both take the lock at the same moment, both surface contention as `SQLITE_BUSY`, and both roll back. The invariant the mode protects is asserted instead.
- **`consume()` as one conditional UPDATE vs read-then-write** — behaviour-preserving while `node:sqlite` is synchronous. What the tests do catch is predicate **drift between surfaces**: a one-boundary drift reddens 9 tests.

## Verification

Rebased, reinstalled, and re-run against the new main: **62/62 turbo tasks with the cache forced off**, plus `lint:root`, `typecheck:root` and `format:check`. Both exception suites run together at 60 tests.
