### PR TITLE
chore(release): rename claude-code plugin release tag to plugin-claude-v*

### DIFF
--- a/.github/workflows/release-plugin-claude.yml
+++ b/.github/workflows/release-plugin-claude.yml
@@ -1,4 +1,4 @@
-name: Release plugin
+name: Release plugin (Claude Code)
 
 # Publishes the Claude Code plugin package to the public npm registry AND to the
 # repo's GitHub Packages registry, and attaches the packed tarball to a GitHub
@@ -9,12 +9,12 @@ name: Release plugin
 # even for public reads, so it is a secondary artifact, not the marketplace source).
 #
 # Release flow: bump version in package.json + .claude-plugin/plugin.json, then
-# push a tag `plugin-v<version>` (e.g. plugin-v0.1.0).
+# push a tag `plugin-claude-v<version>` (e.g. plugin-claude-v0.1.0).
 
 on:
   push:
     tags:
-      - 'plugin-v*'
+      - 'plugin-claude-v*'
   workflow_dispatch:
     inputs:
       publish:
@@ -97,12 +97,12 @@ jobs:
       - name: Verify tag matches manifest versions
         if: github.event_name == 'push'
         run: |
-          tag="${GITHUB_REF_NAME#plugin-v}"
+          tag="${GITHUB_REF_NAME#plugin-claude-v}"
           pkg=$(node -p "require('./plugins/claude-code/package.json').version")
           manifest=$(node -p "require('./plugins/claude-code/.claude-plugin/plugin.json').version")
           echo "tag=$tag  package.json=$pkg  plugin.json=$manifest"
           if [ "$tag" != "$pkg" ] || [ "$tag" != "$manifest" ]; then
-            echo "::error::Version mismatch — tag plugin-v$tag must equal package.json ($pkg) and plugin.json ($manifest)"
+            echo "::error::Version mismatch — tag plugin-claude-v$tag must equal package.json ($pkg) and plugin.json ($manifest)"
             exit 1
           fi
 
@@ -144,7 +144,7 @@ jobs:
         with:
           files: ${{ runner.temp }}/*.tgz
           generate_release_notes: true
-          prerelease: ${{ startsWith(github.ref_name, 'plugin-v0.') }}
+          prerelease: ${{ startsWith(github.ref_name, 'plugin-claude-v0.') }}
 
   # Publish the same package to the repo's GitHub Packages registry (requirement:
   # packages land in the org's GitHub registry). Kept a separate job so its GitHub

--- a/plugins/claude-code/src/provenance.ts
+++ b/plugins/claude-code/src/provenance.ts
@@ -12,7 +12,7 @@ import { execFileSync } from 'node:child_process';
 // plugin must bind to. An attestation missing either, or bound to any other
 // value, is a failed check.
 export const EXPECTED_REPOSITORY = 'https://github.com/akasecurity/ai-tc';
-export const EXPECTED_WORKFLOW_PATH = '.github/workflows/release-plugin.yml';
+export const EXPECTED_WORKFLOW_PATH = '.github/workflows/release-plugin-claude.yml';
 
 // The SLSA provenance predicate type carried by an npm build-provenance
 // attestation; its buildDefinition names the GitHub Actions workflow identity.


### PR DESCRIPTION
## Summary
- Renames the Claude Code plugin release tag from `plugin-vX.Y.Z` to `plugin-claude-vX.Y.Z`, matching `plugin-codex-vX.Y.Z` / `plugin-antigravity-vX.Y.Z`.
- Renames `.github/workflows/release-plugin.yml` -> `release-plugin-claude.yml` and its display name to "Release plugin (Claude Code)", for the same consistency.
- Updates `plugins/claude-code/src/provenance.ts`'s `EXPECTED_WORKFLOW_PATH` to the new workflow path — the plugin's own npm build-provenance self-check binds to this exact path, so leaving it stale would fail every future genuine release's verification silently (fail-open, so no crash, just a missing "verified" badge).

Existing `plugin-v0.9.0`..`plugin-v0.9.4` tags are untouched history; only releases from here forward use `plugin-claude-v*`. The release runbook (`akasecurity/engineering`) will be updated to match once this merges.

## Test plan
- [x] `pnpm --filter @akasecurity/ai-tc-claude-code test` — 947/947 passing, including `provenance.test.ts` and `identity-consistency.test.ts` (both import the constant rather than hardcoding the path, so they track the rename automatically)
- [x] `pnpm --filter @akasecurity/ai-tc-claude-code lint` / `typecheck` — clean
- [x] `pnpm lint` (workspace) — clean
- [x] Grepped the tracked tree for any remaining `plugin-v*` / `release-plugin.yml` reference — none found outside this diff