### PR TITLE
fix(cli): ship the dashboard's runtime deps in the SEA archive

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -63,11 +63,15 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # build:sea (ESM bundle) → bundle:web-ui (standalone sidecar) → bundle:extension → package:sea
-      # (binary + self-verify via --version) → archive:sea (tarball/zip + sha256).
+      # (binary + self-verify via --version) → smoke:dashboard → archive:sea (tarball/zip + sha256).
       - run: pnpm --filter @akasecurity/cli build:sea
       - run: pnpm --filter @akasecurity/cli bundle:web-ui
       - run: pnpm --filter @akasecurity/cli bundle:extension
       - run: pnpm --filter @akasecurity/cli package:sea
+      # Boot the packaged binary's dashboard from a copy of the archive outside the repo and
+      # assert HTTP 200. build-binaries.yml runs this on PRs; releasing without it is what let
+      # a binary ship whose `aka dashboard` could not resolve `next` on any user's machine.
+      - run: pnpm --filter @akasecurity/cli smoke:dashboard
       - run: pnpm --filter @akasecurity/cli archive:sea
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -63,11 +63,15 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       # build:sea (ESM bundle) → bundle:web-ui (standalone sidecar) → bundle:extension → package:sea
-      # (binary + self-verify via --version) → smoke:dashboard → archive:sea (tarball/zip + sha256).
+      # (binary + self-verify via --version) → smoke:sea → smoke:dashboard → archive:sea
+      # (tarball/zip + sha256).
       - run: pnpm --filter @akasecurity/cli build:sea
       - run: pnpm --filter @akasecurity/cli bundle:web-ui
       - run: pnpm --filter @akasecurity/cli bundle:extension
       - run: pnpm --filter @akasecurity/cli package:sea
+      # build-binaries.yml runs both smokes on PRs; this workflow ran neither, which is how a
+      # binary shipped whose `aka dashboard` could not resolve `next` on any user's machine.
+      - run: pnpm --filter @akasecurity/cli smoke:sea
       # Boot the packaged binary's dashboard from a copy of the archive outside the repo and
       # assert HTTP 200. build-binaries.yml runs this on PRs; releasing without it is what let
       # a binary ship whose `aka dashboard` could not resolve `next` on any user's machine.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,8 +214,12 @@ registry: `.github/workflows/audit.yml` (via `tools/audit-gate`) runs `pnpm audi
 PR and daily, sending the workspace dependency graph — package names and versions,
 including the `@akasecurity/*` workspace importers — to the registry's audit endpoint; it
 also resolves and audits the published CLI's runtime dependency ranges with `npm` in a
-temp dir, sending that (public-package) graph the same way. That is repository tooling,
-not a product path; nothing a user installs performs it.
+temp dir, sending that (public-package) graph the same way. The binary channel's packaging
+is the second such path: `cli/scripts/package-sea.mjs` shells out to `npm install` to place
+the Next standalone server's runtime dependencies (`next`, `react`, `react-dom` and their
+transitive graph) inside the archive, so `release-binaries.yml` and `build-binaries.yml`
+both reach the registry — and `pnpm package:sea` does not run offline. Both are repository
+tooling, not product paths; nothing a user installs performs either.
 
 **Three gates enforce this, and they cover different things.** Losing track of which is
 which is how "enforced by ESLint and CI" becomes a claim nobody has checked:

--- a/cli/scripts/package-sea.mjs
+++ b/cli/scripts/package-sea.mjs
@@ -1,7 +1,8 @@
 // Package the CLI as a Node Single Executable Application for the current OS/arch.
 // Prereqs (run first): `build:sea` (dist-sea/cli.mjs) and `bundle:web-ui` (cli/web-ui).
 // Produces sea-dist/aka-<platform>-<arch>/ containing the `aka` binary plus its sidecars:
-//   boot.cjs, cli.mjs, package.json (for cliVersion), web-ui/ (the Next standalone).
+//   boot.cjs, cli.mjs, package.json (for cliVersion), web-ui/ (the Next standalone plus
+//   the node_modules that standalone needs — see step 1b).
 // The binary embeds Node + entry.cjs; entry.cjs requires boot.cjs, which imports cli.mjs.
 import { execFileSync } from 'node:child_process';
 import {
@@ -10,11 +11,13 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -48,6 +51,67 @@ writeFileSync(
   `${JSON.stringify({ name: pkg.name, version: pkg.version, private: true }, null, 2)}\n`,
 );
 cpSync(webUiSrc, join(outDir, 'web-ui'), { recursive: true });
+
+// 1b. Install the standalone server's runtime dependencies INTO the staged web-ui.
+//
+// bundle-web-ui strips node_modules out of the Next standalone copy on purpose, and the
+// npm channel re-supplies them a different way: `@akasecurity/cli` declares next/react/
+// react-dom as runtime deps, so `npm i -g` puts them ABOVE web-ui/web-ui/server.js and
+// Node's upward node_modules walk finds them from there.
+//
+// A SEA has no npm install anywhere and nothing above the extracted archive, so that walk
+// finds nothing — `aka dashboard` dies with "Cannot find module 'next'" on every binary
+// install. Nothing in-repo notices, because the build tree answers the same walk: from
+// cli/sea-dist/aka-<triple>/web-ui/web-ui/ it climbs to cli/node_modules/next, which the
+// workspace install already put there. That is why smoke-dashboard runs from a copy
+// outside this tree — a smoke rooted here passes on an archive that cannot work anywhere
+// else.
+//
+// Installed at the standalone ROOT (web-ui/), which is both where Next expects them and
+// the first node_modules the walk from web-ui/web-ui/server.js reaches.
+const seaWebUi = join(outDir, 'web-ui');
+// Pin to the versions the workspace lockfile already resolved, so the binary channel
+// serves the same Next the npm channel does instead of whatever the range floats to.
+const runtimeDeps = ['next', 'react', 'react-dom'].map((name) => {
+  const manifest = join(cliDir, 'node_modules', name, 'package.json');
+  if (!existsSync(manifest)) {
+    throw new Error(`cannot pin ${name} for the web-ui sidecar — missing ${manifest}`);
+  }
+  return `${name}@${JSON.parse(readFileSync(manifest, 'utf8')).version}`;
+});
+// Into a temp prefix, then copied in: installing directly over the staged web-ui would
+// have npm rewrite its package.json — which is the REPO ROOT manifest that Next's
+// outputFileTracingRoot puts there, devDependencies and all — rather than a manifest this
+// step owns. `--ignore-scripts` keeps release packaging free of dependency install hooks;
+// the deps here ship prebuilt binaries via optional deps and need no build step.
+const depStage = mkdtempSync(join(tmpdir(), 'aka-sea-deps-'));
+try {
+  execFileSync(
+    'npm',
+    [
+      'install',
+      '--prefix',
+      depStage,
+      '--no-package-lock',
+      '--no-audit',
+      '--no-fund',
+      '--omit=dev',
+      '--ignore-scripts',
+      ...runtimeDeps,
+    ],
+    // `shell` on Windows: npm is npm.cmd there, and Node refuses to execFile a .cmd
+    // without a shell. No-op elsewhere. (Same reason bundle-web-ui.mjs does it for pnpm.)
+    { stdio: 'inherit', shell: isWin },
+  );
+  cpSync(join(depStage, 'node_modules'), join(seaWebUi, 'node_modules'), { recursive: true });
+} finally {
+  rmSync(depStage, { recursive: true, force: true });
+}
+// Assert the module whose absence is the whole failure mode actually landed. `npm install`
+// exits 0 on plenty of outcomes that leave a tree the server cannot boot from.
+if (!existsSync(join(seaWebUi, 'node_modules', 'next', 'package.json'))) {
+  throw new Error(`next missing from the staged web-ui at ${join(seaWebUi, 'node_modules')}`);
+}
 
 // The browser extension + its native-messaging host, staged next to the binary
 // the same way (aka extension install resolves them via dirname(process.execPath)

--- a/cli/scripts/package-sea.mjs
+++ b/cli/scripts/package-sea.mjs
@@ -4,6 +4,9 @@
 //   boot.cjs, cli.mjs, package.json (for cliVersion), web-ui/ (the Next standalone plus
 //   the node_modules that standalone needs — see step 1b).
 // The binary embeds Node + entry.cjs; entry.cjs requires boot.cjs, which imports cli.mjs.
+//
+// NEEDS THE NETWORK: step 1b shells out to `npm install` against the registry, so this script
+// does not run offline or behind a blocked proxy. It is release tooling, never a product path.
 import { execFileSync } from 'node:child_process';
 import {
   chmodSync,
@@ -70,9 +73,17 @@ cpSync(webUiSrc, join(outDir, 'web-ui'), { recursive: true });
 // Installed at the standalone ROOT (web-ui/), which is both where Next expects them and
 // the first node_modules the walk from web-ui/web-ui/server.js reaches.
 const seaWebUi = join(outDir, 'web-ui');
-// Pin to the versions the workspace lockfile already resolved, so the binary channel
-// serves the same Next the npm channel does instead of whatever the range floats to.
-const runtimeDeps = ['next', 'react', 'react-dom'].map((name) => {
+// Pin the three TOP-LEVEL versions to what the workspace lockfile already resolved, so the
+// binary channel serves the same Next the npm channel does rather than whatever the range
+// floats to that day. The pin reaches exactly one level: there is no lockfile here, so every
+// TRANSITIVE dependency (styled-jsx, @swc/helpers, caniuse-lite, scheduler, …) resolves by
+// range at package time, and two builds of one bin-v tag can embed different bytes. Parity
+// with the npm channel survives that — an end user's `npm i -g` re-resolves those same ranges,
+// since a published package ships no lockfile for its own dependencies — but bit-for-bit
+// reproducibility does not, and the SHA256SUMS the installers verify are per-build, not
+// per-tag. Closing that needs a checked-in lockfile and `npm ci`, not a stronger comment.
+const RUNTIME_DEP_NAMES = ['next', 'react', 'react-dom'];
+const runtimeDeps = RUNTIME_DEP_NAMES.map((name) => {
   const manifest = join(cliDir, 'node_modules', name, 'package.json');
   if (!existsSync(manifest)) {
     throw new Error(`cannot pin ${name} for the web-ui sidecar — missing ${manifest}`);
@@ -95,7 +106,6 @@ try {
       '--no-package-lock',
       '--no-audit',
       '--no-fund',
-      '--omit=dev',
       '--ignore-scripts',
       ...runtimeDeps,
     ],
@@ -107,10 +117,17 @@ try {
 } finally {
   rmSync(depStage, { recursive: true, force: true });
 }
-// Assert the module whose absence is the whole failure mode actually landed. `npm install`
-// exits 0 on plenty of outcomes that leave a tree the server cannot boot from.
-if (!existsSync(join(seaWebUi, 'node_modules', 'next', 'package.json'))) {
-  throw new Error(`next missing from the staged web-ui at ${join(seaWebUi, 'node_modules')}`);
+// Assert every module whose absence is the failure mode actually landed. `npm install` exits
+// 0 on plenty of outcomes that leave a tree the server cannot boot from.
+//
+// existsSync rather than createRequire(...).resolve(name): a resolve walks UP from this
+// script, so running in-repo it climbs to cli/node_modules and reports success for precisely
+// the archive this step exists to fix — the same trap that made the old smoke pass on a
+// broken tree. Check the path that has to hold, not the one Node would search.
+for (const name of RUNTIME_DEP_NAMES) {
+  if (!existsSync(join(seaWebUi, 'node_modules', name, 'package.json'))) {
+    throw new Error(`${name} missing from the staged web-ui at ${join(seaWebUi, 'node_modules')}`);
+  }
 }
 
 // The browser extension + its native-messaging host, staged next to the binary

--- a/cli/scripts/package-sea.mjs
+++ b/cli/scripts/package-sea.mjs
@@ -93,8 +93,15 @@ const runtimeDeps = RUNTIME_DEP_NAMES.map((name) => {
 // Into a temp prefix, then copied in: installing directly over the staged web-ui would
 // have npm rewrite its package.json — which is the REPO ROOT manifest that Next's
 // outputFileTracingRoot puts there, devDependencies and all — rather than a manifest this
-// step owns. `--ignore-scripts` keeps release packaging free of dependency install hooks;
-// the deps here ship prebuilt binaries via optional deps and need no build step.
+// step owns. `--ignore-scripts` keeps release packaging free of dependency install hooks.
+//
+// `--omit=optional` sheds ~140M of a ~308M tree, nearly all of it `@next/swc-<host>`. A
+// standalone Next server is prebuilt and compiles nothing while serving, so swc is not on the
+// serve path — smoke-dashboard is what holds that claim rather than this comment, by booting
+// the PACKAGED binary and rendering two Server Component pages through middleware. The flag
+// also drops `sharp`, which only `next/image` would load: the dashboard has no `next/image`
+// usage at all, which `.github/audit-waivers.json` already relies on for its sharp waiver.
+// Adding a `next/image` anywhere in web-ui means dropping this flag (or re-adding `sharp`).
 const depStage = mkdtempSync(join(tmpdir(), 'aka-sea-deps-'));
 try {
   execFileSync(
@@ -106,6 +113,7 @@ try {
       '--no-package-lock',
       '--no-audit',
       '--no-fund',
+      '--omit=optional',
       '--ignore-scripts',
       ...runtimeDeps,
     ],

--- a/cli/scripts/smoke-dashboard.mjs
+++ b/cli/scripts/smoke-dashboard.mjs
@@ -17,8 +17,12 @@
 // Copying to a temp dir removes the workspace from the walk; assertNoAncestorNodeModules
 // then proves it, because a smoke that silently regained an ancestor node_modules would
 // go back to passing on a broken archive without changing a line of this file.
+//
+// It also drives TWO routes. `/security` alone shows the server boots; a second Server
+// Component page shows it renders, which is the claim that actually covers the runtime
+// module graph rather than just its entrypoint.
 import { execFileSync, spawn } from 'node:child_process';
-import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -36,16 +40,32 @@ if (!existsSync(join(stagedDir, 'web-ui', 'web-ui', 'server.js')))
 const PORT = 41847;
 const HOST = '127.0.0.1';
 
-// Every node_modules on the walk from `startDir` to the filesystem root. The archive's
-// own (web-ui/node_modules) sits BELOW the root passed in and is deliberately not counted
-// — it is the thing under test.
-const ancestorNodeModules = (startDir) => {
+// Two routes, not one. The first proves the server BOOTS; the second proves a Server
+// Component page RENDERS, which is what actually walks the runtime module graph rather than
+// just its entrypoint. Both go through web-ui/middleware.ts.
+const ROUTES = ['/security', '/findings'];
+
+// Throw if any node_modules sits on the walk from `startDir` to the filesystem root. The
+// archive's own (web-ui/node_modules) sits BELOW the root passed in and is deliberately not
+// counted — it is the thing under test.
+//
+// Walks the REAL path: Node resolves a module's realpath before starting its upward walk, so
+// on macOS — where tmpdir() is /var/…, a symlink to /private/var — the resolver's chain
+// includes /private/node_modules and a walk over the symlinked path never looks there.
+const assertNoAncestorNodeModules = (startDir) => {
   const hits = [];
-  for (let dir = startDir; ;) {
+  for (let dir = realpathSync(startDir); ;) {
     if (existsSync(join(dir, 'node_modules'))) hits.push(join(dir, 'node_modules'));
     const parent = dirname(dir);
-    if (parent === dir) return hits;
+    if (parent === dir) break;
     dir = parent;
+  }
+  if (hits.length > 0) {
+    throw new Error(
+      `the smoke root ${startDir} has node_modules above it (${hits.join(', ')}) — server.js ` +
+        `would resolve \`next\` from there, so this check could not tell a self-contained ` +
+        `archive from a broken one`,
+    );
   }
 };
 
@@ -72,14 +92,7 @@ try {
   const runDir = join(stage, `aka-${platform}-${arch}`);
   cpSync(stagedDir, runDir, { recursive: true });
 
-  const leaks = ancestorNodeModules(stage);
-  if (leaks.length > 0) {
-    throw new Error(
-      `the smoke root ${stage} has node_modules above it (${leaks.join(', ')}) — server.js ` +
-        `would resolve \`next\` from there, so this check could not tell a self-contained ` +
-        `archive from a broken one`,
-    );
-  }
+  assertNoAncestorNodeModules(stage);
 
   const exe = join(runDir, exeName);
   const serverJs = join(runDir, 'web-ui', 'web-ui', 'server.js');
@@ -97,14 +110,25 @@ try {
     process.exitCode = 1;
   });
 
+  // The retry loop is the BOOT probe and belongs to the first route only. Retrying the rest
+  // would let a route that never renders read as merely slow.
   let status = null;
   for (let i = 0; i < 120 && child.exitCode === null; i++) {
-    status = await get('/security');
+    status = await get(ROUTES[0]);
     if (status) break;
     await new Promise((r) => setTimeout(r, 500));
   }
-  if (status !== 200) throw new Error(`dashboard /security returned ${status ?? 'no response'}`);
-  process.stdout.write(`sea-dashboard-smoke: OK (/security -> ${status})\n`);
+  if (status !== 200) {
+    throw new Error(`dashboard ${ROUTES[0]} returned ${status ?? 'no response'}`);
+  }
+
+  const served = [`${ROUTES[0]} -> ${status}`];
+  for (const route of ROUTES.slice(1)) {
+    const code = await get(route);
+    if (code !== 200) throw new Error(`dashboard ${route} returned ${code ?? 'no response'}`);
+    served.push(`${route} -> ${code}`);
+  }
+  process.stdout.write(`sea-dashboard-smoke: OK (${served.join(', ')})\n`);
 } catch (err) {
   process.stderr.write(
     `sea-dashboard-smoke: FAIL — ${err instanceof Error ? err.message : String(err)}\n`,

--- a/cli/scripts/smoke-dashboard.mjs
+++ b/cli/scripts/smoke-dashboard.mjs
@@ -4,8 +4,21 @@
 // only evaluates the module graph — it never starts the server — so this drives the
 // PACKAGED binary through that subcommand against its own web-ui sidecar and asserts the
 // dashboard actually serves HTTP 200. Run after `package:sea`.
+//
+// It runs the binary from a COPY of the staged archive placed outside this repo, which is
+// the only reason the check means anything. server.js does `require('next')`, resolved by
+// Node's upward node_modules walk — so run in place, from cli/sea-dist/aka-<triple>/, that
+// walk climbs out of the archive into the workspace's own cli/node_modules and finds the
+// `next` the CLI declares as a runtime dep. An archive shipping no node_modules at all
+// therefore serves 200 here and dies with "Cannot find module 'next'" the moment a user
+// extracts it anywhere else. That is not hypothetical: it is what shipped, green, until
+// package-sea grew the step that installs those deps into the staged web-ui.
+//
+// Copying to a temp dir removes the workspace from the walk; assertNoAncestorNodeModules
+// then proves it, because a smoke that silently regained an ancestor node_modules would
+// go back to passing on a broken archive without changing a line of this file.
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { cpSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
 import http from 'node:http';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -13,20 +26,28 @@ import { fileURLToPath } from 'node:url';
 
 const cliDir = join(dirname(fileURLToPath(import.meta.url)), '..');
 const { platform, arch } = process;
-const outDir = join(cliDir, 'sea-dist', `aka-${platform}-${arch}`);
-const exe = join(outDir, platform === 'win32' ? 'aka.exe' : 'aka');
-const serverJs = join(outDir, 'web-ui', 'web-ui', 'server.js');
-if (!existsSync(exe)) throw new Error(`missing ${exe} — run \`pnpm package:sea\` first`);
-if (!existsSync(serverJs))
-  throw new Error(`missing ${serverJs} — run \`pnpm bundle:web-ui\` then \`package:sea\``);
+const exeName = platform === 'win32' ? 'aka.exe' : 'aka';
+const stagedDir = join(cliDir, 'sea-dist', `aka-${platform}-${arch}`);
+if (!existsSync(join(stagedDir, exeName)))
+  throw new Error(`missing ${join(stagedDir, exeName)} — run \`pnpm package:sea\` first`);
+if (!existsSync(join(stagedDir, 'web-ui', 'web-ui', 'server.js')))
+  throw new Error(`missing the web-ui sidecar — run \`pnpm bundle:web-ui\` then \`package:sea\``);
 
 const PORT = 41847;
 const HOST = '127.0.0.1';
 
-// Isolate the ~/.aka store in a temp home so the smoke never touches a real one and
-// runs deterministically on a clean CI runner. homedir() honors HOME / USERPROFILE.
-const home = mkdtempSync(join(tmpdir(), 'aka-dash-smoke-'));
-const env = { ...process.env, HOME: home, USERPROFILE: home, PORT: String(PORT), HOSTNAME: HOST };
+// Every node_modules on the walk from `startDir` to the filesystem root. The archive's
+// own (web-ui/node_modules) sits BELOW the root passed in and is deliberately not counted
+// — it is the thing under test.
+const ancestorNodeModules = (startDir) => {
+  const hits = [];
+  for (let dir = startDir; ;) {
+    if (existsSync(join(dir, 'node_modules'))) hits.push(join(dir, 'node_modules'));
+    const parent = dirname(dir);
+    if (parent === dir) return hits;
+    dir = parent;
+  }
+};
 
 const get = (path) =>
   new Promise((resolve) => {
@@ -37,8 +58,32 @@ const get = (path) =>
     req.on('error', () => resolve(null));
   });
 
+// Isolate the ~/.aka store in a temp home so the smoke never touches a real one and
+// runs deterministically on a clean CI runner. homedir() honors HOME / USERPROFILE.
+const home = mkdtempSync(join(tmpdir(), 'aka-dash-smoke-'));
+const stage = mkdtempSync(join(tmpdir(), 'aka-dash-stage-'));
+const env = { ...process.env, HOME: home, USERPROFILE: home, PORT: String(PORT), HOSTNAME: HOST };
+
 let child;
 try {
+  // Run from a copy outside the repo — see the header. cpSync preserves modes, so the
+  // binary stays executable and its ad-hoc macOS signature (embedded in the Mach-O)
+  // survives.
+  const runDir = join(stage, `aka-${platform}-${arch}`);
+  cpSync(stagedDir, runDir, { recursive: true });
+
+  const leaks = ancestorNodeModules(stage);
+  if (leaks.length > 0) {
+    throw new Error(
+      `the smoke root ${stage} has node_modules above it (${leaks.join(', ')}) — server.js ` +
+        `would resolve \`next\` from there, so this check could not tell a self-contained ` +
+        `archive from a broken one`,
+    );
+  }
+
+  const exe = join(runDir, exeName);
+  const serverJs = join(runDir, 'web-ui', 'web-ui', 'server.js');
+
   // Seed the store the dashboard reads (init resolves the same homedir()/.aka).
   execFileSync(exe, ['init', '--yes'], { env, stdio: 'ignore' });
 
@@ -70,9 +115,11 @@ try {
   // Best-effort teardown: on Windows the just-killed server can still hold handles
   // on the temp store for a moment, so retry — and never let a cleanup EPERM mask the
   // smoke result (the OS temp dir is reclaimed by the runner regardless).
-  try {
-    rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
-  } catch {
-    // ignore — temp dir, reclaimed by the OS/runner
+  for (const dir of [home, stage]) {
+    try {
+      rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+    } catch {
+      // ignore — temp dir, reclaimed by the OS/runner
+    }
   }
 }


### PR DESCRIPTION
`aka dashboard` fails on **every** binary (SEA) install:

```
Starting the AKA dashboard at http://localhost:4319/security
aka: Cannot find module 'next'
Require stack:
- ~/.local/share/aka/0.9.4/aka-darwin-arm64/web-ui/web-ui/server.js
```

## Why

`bundle-web-ui` strips `node_modules` out of the Next standalone copy on purpose, and the
npm channel re-supplies it a different way: `@akasecurity/cli` declares `next`/`react`/
`react-dom` as runtime deps, so `npm i -g` puts them **above** `web-ui/web-ui/server.js`
and Node's upward `node_modules` walk finds them from there.

A SEA has no npm install anywhere and nothing above the extracted archive — `package-sea`
copies that same `node_modules`-free `cli/web-ui` next to the binary, and `install.sh` only
extracts. So the walk finds nothing, on every binary install, since the channel existed.

## Why nothing caught it

`smoke-dashboard.mjs` is exactly this gate — it boots the packaged binary's
`__dashboard-server` and asserts HTTP 200. It missed it twice over:

1. **It ran from inside the repo.** From `cli/sea-dist/aka-<triple>/web-ui/web-ui/`, the
   resolution walk climbs out of the archive into the workspace's own `cli/node_modules`
   and finds the `next` the CLI declares as a runtime dep. The build tree supplied what the
   archive lacked, so an archive that cannot work anywhere else served 200 here.
2. **The release workflow never ran it.** It was wired into `build-binaries.yml` only;
   `release-binaries.yml` went `build:sea → bundle:web-ui → bundle:extension → package:sea →
   archive:sea` and skipped it.

## Changes

- **`cli/scripts/package-sea.mjs`** — new step 1b installs `next`/`react`/`react-dom` into
  the staged `web-ui/` (the standalone root, and the first `node_modules` the walk from
  `server.js` reaches). Versions are read from the workspace's own resolved copies, so the
  binary channel serves the same Next the lockfile gave the npm channel rather than whatever
  the range floats to. It installs into a temp prefix and copies in — installing over the
  staged tree directly would have npm rewrite the repo-root manifest that
  `outputFileTracingRoot` parks there — then asserts `next` actually landed, since
  `npm install` exits 0 on plenty of outcomes that don't boot.
- **`cli/scripts/smoke-dashboard.mjs`** — runs the binary from a copy **outside the repo**,
  plus `assertNoAncestorNodeModules`, which fails loudly if the smoke root ever regains an
  ancestor `node_modules`. Without that second check the guard could silently return to
  passing on a broken archive without a line of this file changing.
- **`.github/workflows/release-binaries.yml`** — `smoke:dashboard` now runs between
  `package:sea` and `archive:sea`.

## Verification

Built and packaged locally (`darwin-arm64`), then deleted the `node_modules` step 1b
installs — reproducing the archive exactly as it shipped — and ran both smoke forms against
the same bytes:

| Smoke form | Result on the broken archive |
| --- | --- |
| Old (in place, `cli/sea-dist/…`) | **HTTP 200 — reports OK** |
| New (copy outside the repo) | **exit 1**, `Cannot find module 'next'` |

The ancestor guard was mutation-checked the same way: planting a `node_modules` in the temp
root makes the smoke refuse to run rather than pass vacuously, naming the offending path.

Restored, re-run: exit 0. `cli` 194 tests pass, `@akasecurity/eslint-config` 873 pass,
`pnpm lint` clean.

## Cost

**The `darwin-arm64` archive goes 44M → 78M.** An earlier revision of this branch landed at
124M; `--omit=optional` on the sidecar install takes it back down, and the numbers below are
measured end-to-end (`package:sea` → `smoke:dashboard` → `archive:sea`, all exit 0), not estimated.

| | before this PR | first revision | **now** |
| --- | --- | --- | --- |
| staged `node_modules` | — | 308M | **168M** |
| `aka-0.9.4-darwin-arm64.tar.gz` | 44M | 124M | **78M** |

`--omit=optional` drops `@next/swc-darwin-arm64` (124M), `@img` (16M), `sharp` (596K),
`detect-libc`, `semver`. A standalone Next server is prebuilt and compiles nothing while
serving, so swc is not on the serve path.

**An earlier version of this description claimed the flag would cost `next/image` optimization
and so recreate the npm-vs-binary divergence. That was wrong.** There is no `next/image`
import, no `<Image>`, and no `images` config anywhere in the tree — and
`.github/audit-waivers.json:21` already records it as repo policy: *"the dashboard has no
next/image usage, so sharp is never loaded at runtime."* The trade did not exist; the feature
is unused on both channels. Thanks @pmontiel-git for catching it.

What holds the swc claim is the smoke, not a comment: it boots the **packaged** binary from a
copy outside the repo and now renders **two** Server Component pages (`/security`, `/findings`)
through `middleware.ts` — so it asserts the server *renders*, not just that it boots.
`build-binaries.yml` runs that same smoke on all four targets, so a platform where swc is
actually reachable fails the PR rather than shipping.

## Windows archiving — resolved

Settled by this PR's own CI, which I had missed: `build-binaries.yml` runs on `cli/**`, so the
Windows leg already exercised both paths on the fat tree. `archive:sea` 19s → 2m11s,
`Expand-Archive` verify 2s → 10s, whole job 2m56s → 7m35s. Slower, comfortably within budget.
`ZipFile::CreateFromDirectory` is not needed and `Compress-Archive` stays.

**`--omit=optional` does not speed that up, though it might look like it should.** Measured
on the win32-x64 leg across both commits: `archive:sea` 165s → 166s, whole job 7m52s → 7m51s
— unchanged, while the artifact went 124.9 MB → 71.8 MB. `Compress-Archive` is bound by file
COUNT, not bytes, and the flag removes 113 files of 8,878 (1.3%) while removing 45% of the
bytes: `@next/swc` is 124M in **7 files**. So the size win is real on every platform and the
Windows-runtime win is not. The ~30k files that made that job slow are next's own JS, which
this flag does not touch.

`smoke:sea` is now wired into `release-binaries.yml` alongside `smoke:dashboard` — it was the
same class of gap this PR is about, so it belonged in scope after all.

