### PR TITLE
feat(web-ui): reclaim activity screen real estate

### DIFF
--- a/packages/dashboard-ui/src/activity/ActivitySummaryStripView.tsx
+++ b/packages/dashboard-ui/src/activity/ActivitySummaryStripView.tsx
@@ -15,17 +15,21 @@ export interface SummaryStatItem {
   fill: string;
 }
 
+// One stat. The value and its label sit on a single baseline rather than stacked:
+// the strip is chrome above the session list, so its height is space the list
+// does not get, and a label long enough to wrap is truncated with the full text
+// on hover rather than growing the row.
 function SummaryStat({ icon: Icon, value, label, text, fill }: SummaryStatItem) {
   return (
-    <div className="flex flex-1 items-center gap-2.5 px-5">
-      <span className={cn('grid size-8 shrink-0 place-items-center rounded-lg', fill, text)}>
-        <Icon aria-hidden focusable={false} className="size-4" />
+    <div className="flex min-w-0 flex-1 items-center gap-2 px-4">
+      <span className={cn('grid size-7 shrink-0 place-items-center rounded-lg', fill, text)}>
+        <Icon aria-hidden focusable={false} className="size-3.5" />
       </span>
-      <div className="min-w-0">
-        <div className="font-display text-xl font-semibold leading-none tabular-nums text-text">
+      <div className="flex min-w-0 items-baseline gap-1.5" title={`${String(value)} ${label}`}>
+        <span className="font-display text-lg font-semibold leading-none tabular-nums text-text">
           {value}
-        </div>
-        <div className="mt-0.5 text-xs text-text-3">{label}</div>
+        </span>
+        <span className="truncate text-xs text-text-3">{label}</span>
       </div>
     </div>
   );
@@ -41,7 +45,7 @@ export function ActivitySummaryStripView({
   error: string | null;
 }) {
   return (
-    <Card className="mb-3.5 flex shrink-0 items-stretch py-3.5 shadow-sm" aria-busy={isLoading}>
+    <Card className="mb-3 flex shrink-0 items-stretch py-2.5 shadow-sm" aria-busy={isLoading}>
       {error ? (
         <div className="px-5">
           <WidgetError message={error} />
@@ -50,12 +54,9 @@ export function ActivitySummaryStripView({
         Array.from({ length: 5 }, (_, i) => (
           <Fragment key={i}>
             {i > 0 && <span className="w-px shrink-0 self-stretch bg-text/6" />}
-            <div className="flex flex-1 items-center gap-2.5 px-5">
-              <Skeleton className="size-8 shrink-0 rounded-lg" />
-              <div className="min-w-0 flex-1">
-                <Skeleton className="h-5 w-10" />
-                <Skeleton className="mt-1 h-3 w-20" />
-              </div>
+            <div className="flex flex-1 items-center gap-2 px-4">
+              <Skeleton className="size-7 shrink-0 rounded-lg" />
+              <Skeleton className="h-4 w-24" />
             </div>
           </Fragment>
         ))

--- a/packages/dashboard-ui/src/activity/ActivityTokenUsageView.tsx
+++ b/packages/dashboard-ui/src/activity/ActivityTokenUsageView.tsx
@@ -1,15 +1,24 @@
 'use client';
-// The Activity page's token-usage panel: a collapsible Card that folds the token
-// report (the plugin's `/aka:tokens` view) into the Activity surface instead of
-// giving it its own page. Collapsed, it's a one-line glance — sessions, total
-// tokens, estimated cost. Expanded, it's the per-(provider, model) breakdown.
-// Props-driven off the shared @akasecurity/schema `TokenUsageSummary`
-// (built by `aggregateTokenUsage`), so token counts are exact truth and cost is a
+// The Activity page's token-usage control: a compact chip that sits in the page's
+// filter bar beside the range picker and opens the per-(provider, model)
+// breakdown in a slide-over. It reads as a glance — total tokens + estimated
+// cost — and costs one row of the filter bar rather than a full-width card, so
+// the session list/detail below it keeps the viewport.
+//
+// It opens SIDEWAYS rather than expanding down on purpose: an inline expansion
+// pushes the master/detail panes off-screen, which is the space the panel exists
+// to summarise.
+//
+// Props-driven off the shared @akasecurity/schema `TokenUsageSummary` (built by
+// `aggregateTokenUsage`), so token counts are exact truth and cost is a
 // read-time estimate (`~$X`, or `≥ $X` when some calls have unknown pricing).
 import type { TokenUsageSummary } from '@akasecurity/schema';
 import {
-  Card,
-  cn,
+  Button,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
   Skeleton,
   Table,
   TableBody,
@@ -20,19 +29,11 @@ import {
 } from '@akasecurity/ui-kit';
 import { useState } from 'react';
 
-import { AnalyticsIcon, ChevronDownIcon } from '../shared/icons.tsx';
-import { WidgetError } from '../shared/widget-state.tsx';
+import { AnalyticsIcon } from '../shared/icons.tsx';
+import { WidgetEmpty, WidgetError } from '../shared/widget-state.tsx';
 import { formatCostTotal, formatUsd, tokenLabel } from './format.ts';
 
-function HeaderIcon() {
-  return (
-    <span className="grid size-8 shrink-0 place-items-center rounded-lg bg-primary-tint text-primary">
-      <AnalyticsIcon aria-hidden focusable={false} className="size-4" />
-    </span>
-  );
-}
-
-/** Per-model rows table — the expanded body. Token counts are compact; a model
+/** Per-model rows table — the slide-over body. Token counts are compact; a model
  * with no known price shows `—` in the cost column. */
 function ModelTable({ summary }: { summary: TokenUsageSummary }) {
   return (
@@ -52,7 +53,9 @@ function ModelTable({ summary }: { summary: TokenUsageSummary }) {
         {summary.models.map((m) => (
           <TableRow key={`${m.provider} ${m.model}`}>
             <TableCell className="text-text-2">{m.provider}</TableCell>
-            <TableCell className="font-mono text-text">{m.model}</TableCell>
+            <TableCell className="max-w-40 truncate font-mono text-text" title={m.model}>
+              {m.model}
+            </TableCell>
             <TableCell className="text-right tabular-nums text-text-2">
               {tokenLabel(m.inputTokens)}
             </TableCell>
@@ -89,88 +92,98 @@ export function ActivityTokenUsageView({
 }) {
   const [open, setOpen] = useState(false);
 
-  if (error) {
-    return (
-      <Card className="mb-3.5 shrink-0 px-5 py-3.5 shadow-sm">
-        <WidgetError message={error} />
-      </Card>
-    );
-  }
-
   if (isLoading && !summary) {
-    return (
-      <Card className="mb-3.5 flex shrink-0 items-center gap-2.5 px-5 py-3.5 shadow-sm" aria-busy>
-        <Skeleton className="size-8 shrink-0 rounded-lg" />
-        <Skeleton className="h-5 w-64" />
-      </Card>
-    );
+    return <Skeleton className="h-9 w-44 rounded-lg" aria-busy />;
   }
 
   const hasUsage = summary !== null && summary.models.length > 0;
 
-  if (!hasUsage) {
-    return (
-      <Card className="mb-3.5 flex shrink-0 items-center gap-2.5 px-5 py-3.5 shadow-sm">
-        <HeaderIcon />
-        <div className="min-w-0">
-          <div className="text-ui font-semibold text-text">Token usage</div>
-          <div className="text-xs text-text-3">
-            No token usage recorded yet — sessions are reconciled as you work.
-          </div>
-        </div>
-      </Card>
-    );
-  }
+  // The chip renders on every state so the control never moves; which of the
+  // three bodies the slide-over shows is what varies.
+  const chipLabel = error
+    ? 'Token usage'
+    : hasUsage
+      ? `${tokenLabel(summary.totalTokens)} tokens · ${formatCostTotal(summary.estimatedCostUsd, summary.costIsPartial)}`
+      : 'No token usage';
 
-  const sessions = `${String(summary.sessionCount)} session${summary.sessionCount === 1 ? '' : 's'}`;
-  const cost = formatCostTotal(summary.estimatedCostUsd, summary.costIsPartial);
+  const chipTitle = error
+    ? `Token usage could not be read — ${error}`
+    : hasUsage
+      ? `Token usage${rangeLabel ? ` · ${rangeLabel}` : ''} — ${String(summary.sessionCount)} session${summary.sessionCount === 1 ? '' : 's'}. Open the per-model breakdown.`
+      : 'No token usage recorded yet — open for details';
 
   return (
-    <Card className="mb-3.5 shrink-0 overflow-hidden shadow-sm">
-      <button
-        type="button"
+    <>
+      <Button
+        variant="outline"
+        size="md"
+        title={chipTitle}
+        aria-label="Token usage — open the per-model breakdown"
         onClick={() => {
-          setOpen((v) => !v);
+          setOpen(true);
         }}
-        aria-expanded={open}
-        aria-controls="activity-token-usage-body"
-        className="flex w-full cursor-pointer items-center gap-2.5 px-5 py-3.5 text-left transition-colors hover:bg-surface-2"
       >
-        <HeaderIcon />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-            <span className="text-ui font-semibold text-text">Token usage</span>
-            {rangeLabel && <span className="text-xs text-text-3">· {rangeLabel}</span>}
-          </div>
-          <div className="mt-0.5 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-xs text-text-3">
-            <span>{sessions}</span>
-            <span className="text-text-3">·</span>
-            <span className="font-semibold tabular-nums text-text-2">
-              {tokenLabel(summary.totalTokens)} tokens
-            </span>
-            <span className="text-text-3">·</span>
-            <span className="font-semibold tabular-nums text-text-2">{cost}</span>
-          </div>
-        </div>
-        <ChevronDownIcon
+        <AnalyticsIcon
           aria-hidden
           focusable={false}
-          className={cn('size-4 shrink-0 text-text-3 transition-transform', open && 'rotate-180')}
+          className={error ? 'size-4 text-sev-critical-ink' : 'size-4 text-primary'}
         />
-      </button>
-      {open && (
-        <div
-          id="activity-token-usage-body"
-          className="max-h-64 overflow-y-auto border-t border-border px-2 py-2"
+        <span className="max-w-56 truncate tabular-nums">{chipLabel}</span>
+      </Button>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        {/* No description in this panel — opt out of Radix's aria-describedby. */}
+        <SheetContent
+          className="w-200 max-w-[94%] gap-0 overflow-hidden p-0"
+          aria-describedby={undefined}
         >
-          <ModelTable summary={summary} />
-          {summary.costIsPartial && (
-            <p className="px-3 pb-1 pt-2 text-xs text-text-3">
-              — = unknown pricing (a local or non-Anthropic model); the cost total is a lower bound.
-            </p>
-          )}
-        </div>
-      )}
-    </Card>
+          <SheetHeader className="shrink-0 border-b border-border px-5 py-4">
+            <SheetTitle className="flex items-center gap-2">
+              <AnalyticsIcon aria-hidden focusable={false} className="size-4 text-primary" />
+              Token usage
+              {rangeLabel && (
+                <span className="text-ui font-normal text-text-3">· {rangeLabel}</span>
+              )}
+            </SheetTitle>
+            {hasUsage && (
+              <div className="mt-1 flex flex-wrap items-center gap-x-2.5 gap-y-0.5 text-xs text-text-3">
+                <span>
+                  {summary.sessionCount} session{summary.sessionCount === 1 ? '' : 's'}
+                </span>
+                <span>·</span>
+                <span className="font-semibold tabular-nums text-text-2">
+                  {tokenLabel(summary.totalTokens)} tokens
+                </span>
+                <span>·</span>
+                <span className="font-semibold tabular-nums text-text-2">
+                  {formatCostTotal(summary.estimatedCostUsd, summary.costIsPartial)}
+                </span>
+              </div>
+            )}
+          </SheetHeader>
+          <div className="min-h-0 flex-1 overflow-auto px-2 py-2">
+            {error ? (
+              <div className="p-3">
+                <WidgetError message={error} />
+              </div>
+            ) : hasUsage ? (
+              <>
+                <ModelTable summary={summary} />
+                {summary.costIsPartial && (
+                  <p className="px-3 pb-1 pt-2 text-xs text-text-3">
+                    — = unknown pricing (a local or non-Anthropic model); the cost total is a lower
+                    bound.
+                  </p>
+                )}
+              </>
+            ) : (
+              <div className="p-3">
+                <WidgetEmpty message="No token usage recorded yet — sessions are reconciled as you work." />
+              </div>
+            )}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
   );
 }

--- a/packages/dashboard-ui/src/activity/SessionDetailView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionDetailView.tsx
@@ -5,7 +5,7 @@
 // one behaviour. Token figures + time labels are derived from the semantic
 // @akasecurity/schema `ActivitySession` (raw counts + ISO timestamps).
 import type { ActivitySession, SessionTokenReport } from '@akasecurity/schema';
-import { Button, Skeleton } from '@akasecurity/ui-kit';
+import { Button, cn, Skeleton } from '@akasecurity/ui-kit';
 import { useState } from 'react';
 
 import { MetaItem } from '../shared/DetailFields.tsx';
@@ -15,6 +15,7 @@ import {
   ArrowUpRightIcon,
   BoltIcon,
   DownloadIcon,
+  ExpandIcon,
   ListIcon,
   TerminalIcon,
 } from '../shared/icons.tsx';
@@ -49,18 +50,39 @@ function downloadSession(session: ActivitySession): void {
   URL.revokeObjectURL(url);
 }
 
+/**
+ * A single-line meta value: truncated to its column with the whole string on
+ * hover (and exposed to assistive tech through the same `title`).
+ *
+ * Meta values here are unbounded — a working dir, a branch name, a session id —
+ * and letting one wrap costs the pane several rows of height that the audit
+ * timeline below would otherwise get. `text` is the hover/tooltip string, which
+ * is the full value even when `children` renders it decorated.
+ */
+function MetaLine({ text, mono = false }: { text: string; mono?: boolean }) {
+  return (
+    <span className={cn('block truncate', mono && 'font-mono')} title={text}>
+      {text}
+    </span>
+  );
+}
+
 function DetailBody({
   session,
   tokenReport,
   liveFindings,
   linkHref,
   toolHref,
+  onExpand,
+  overlayClose = false,
 }: {
   session: ActivitySession;
   tokenReport?: SessionTokenReport | null;
   liveFindings?: { count: number; href: string } | null;
   linkHref?: BuildActivityLinkHref;
   toolHref?: (toolName: string) => string;
+  onExpand?: () => void;
+  overlayClose?: boolean;
 }) {
   const harness = PROVIDERS[session.harness];
   const tools = toolEntries(session.tools);
@@ -69,22 +91,44 @@ function DetailBody({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {/* Header + meta grid */}
-      <div className="shrink-0 border-b border-border px-5 py-4">
+      {/* Header + meta grid. In a slide-over the host paints its own close
+          control over the top-right corner, so the action row yields that space
+          rather than sitting under it. */}
+      <div className={cn('shrink-0 border-b border-border px-5 py-4', overlayClose && 'pr-14')}>
         <div className="flex items-start gap-3.5">
           <Provider id={session.harness} size={40} />
           <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2.5">
-              <span className="font-display text-lg font-semibold text-text">{session.title}</span>
+            <div className="flex items-center gap-2.5">
+              <span
+                className="min-w-0 truncate font-display text-lg font-semibold text-text"
+                title={session.title}
+              >
+                {session.title}
+              </span>
               <SessionStatusBadge status={session.status} />
             </div>
-            <div className="mt-1 flex flex-wrap items-center gap-2 text-ui text-text-3">
-              {harness.label} · {HARNESS_KIND[session.harness]}
-              <span className="text-text-3">·</span>
-              <span className="font-mono">{session.id}</span>
+            <div className="mt-1 flex items-center gap-2 text-ui text-text-3">
+              <span className="shrink-0 whitespace-nowrap">
+                {harness.label} · {HARNESS_KIND[session.harness]}
+              </span>
+              <span className="shrink-0 text-text-3">·</span>
+              <span className="min-w-0 truncate font-mono" title={session.id}>
+                {session.id}
+              </span>
             </div>
           </div>
-          <div className="flex gap-1">
+          <div className="flex shrink-0 gap-1">
+            {onExpand && (
+              <Button
+                variant="ghost"
+                size="sm"
+                title="Open this session in the full-width inspector"
+                aria-label="Open this session in the full-width inspector"
+                onClick={onExpand}
+              >
+                <ExpandIcon aria-hidden focusable={false} className="size-4" />
+              </Button>
+            )}
             <Button
               variant="ghost"
               size="sm"
@@ -98,39 +142,48 @@ function DetailBody({
             </Button>
           </div>
         </div>
-        <div className="mt-4 grid 2xl:grid-cols-4 grid-cols-3 gap-x-4 gap-y-3.5 max-h-44 overflow-y-auto">
+        {/* Every cell is one line high and truncates — the full value is on hover.
+            A wrapped working dir or branch used to cost the pane rows of height
+            that the timeline below needs, and `min-w-0` on the cells is what
+            lets a grid column shrink below its content at all. */}
+        <div className="mt-3.5 grid 2xl:grid-cols-4 grid-cols-3 gap-x-4 gap-y-3 [&>*]:min-w-0">
           <MetaItem label="Working dir">
-            <span className="font-mono break-all">{session.cwd}</span>
+            <MetaLine text={session.cwd} mono />
           </MetaItem>
           <MetaItem label="Branch">
-            <MetaChips items={session.branches} mono />
+            <MetaChips items={session.branches} mono nowrap />
           </MetaItem>
           <MetaItem label="Model">
-            <MetaChips items={session.models} mono />
+            <MetaChips items={session.models} mono nowrap />
           </MetaItem>
           <MetaItem label="Started">
-            {startLabel(session.startedAt)} · {dayLabel(session.startedAt)}
+            <MetaLine text={`${startLabel(session.startedAt)} · ${dayLabel(session.startedAt)}`} />
           </MetaItem>
           <MetaItem label="Duration">
-            {durationLabel(session.startedAt, session.endedAt, session.status)}
+            <MetaLine text={durationLabel(session.startedAt, session.endedAt, session.status)} />
           </MetaItem>
           <MetaItem label="Turns">{session.turns}</MetaItem>
+          {/* In the Findings cell the tally is what yields when the column is
+              narrow — the "enforced live" link is the actionable half and stays
+              whole. */}
           <MetaItem label="Findings">
             {session.findings > 0 || liveFindings ? (
-              <span className="inline-flex flex-wrap items-center gap-x-1.5">
+              <span className="flex items-center gap-x-1.5 overflow-hidden whitespace-nowrap">
                 {session.findings > 0 && (
                   <span
-                    className="font-semibold text-sev-critical-ink"
-                    title="Detection firings across this session's transcript — the same value fires once per event it appears in"
+                    className="min-w-0 shrink truncate font-semibold text-sev-critical-ink"
+                    title={`${String(session.findings)} triggered — detection firings across this session's transcript; the same value fires once per event it appears in`}
                   >
                     {session.findings} triggered
                   </span>
                 )}
-                {session.findings > 0 && liveFindings && <span className="text-text-3">·</span>}
+                {session.findings > 0 && liveFindings && (
+                  <span className="shrink-0 text-text-3">·</span>
+                )}
                 {liveFindings && (
                   <a
                     href={liveFindings.href}
-                    className="inline-flex items-center gap-0.5 font-semibold text-sev-critical-ink underline-offset-2 hover:underline"
+                    className="inline-flex shrink-0 items-center gap-0.5 font-semibold text-sev-critical-ink underline-offset-2 hover:underline"
                     title="Unique findings recorded by live enforcement — open in Findings"
                   >
                     {liveFindings.count} enforced live
@@ -269,6 +322,8 @@ export function SessionDetailView({
   liveFindings,
   linkHref,
   toolHref,
+  onExpand,
+  overlayClose,
 }: {
   session: ActivitySession | null;
   isLoading: boolean;
@@ -289,6 +344,12 @@ export function SessionDetailView({
   /** Href for a tool chip (e.g. the findings page filtered to that tool).
    * Optional: omitted, the chips render as plain text. */
   toolHref?: (toolName: string) => string;
+  /** Opens this session in the host's full-width inspector. Omitted (and in the
+   * inspector itself, which is already expanded) hides the expand control. */
+  onExpand?: () => void;
+  /** The host paints a close control over this view's top-right corner (a
+   * slide-over does) — reserve room for it in the header's action row. */
+  overlayClose?: boolean;
 }) {
   if (error) {
     return (
@@ -321,6 +382,8 @@ export function SessionDetailView({
       liveFindings={liveFindings ?? null}
       {...(linkHref ? { linkHref } : {})}
       {...(toolHref ? { toolHref } : {})}
+      {...(onExpand ? { onExpand } : {})}
+      {...(overlayClose ? { overlayClose } : {})}
     />
   );
 }

--- a/packages/dashboard-ui/src/activity/atoms.tsx
+++ b/packages/dashboard-ui/src/activity/atoms.tsx
@@ -67,16 +67,31 @@ export function ToolChip({ name, n, href }: { name: string; n: number; href?: st
   return <span className={className}>{content}</span>;
 }
 
-/** A wrap of small chips for a multi-valued meta field (branches, models). */
-export function MetaChips({ items, mono = false }: { items: string[]; mono?: boolean }) {
+/** A row of small chips for a multi-valued meta field (branches, models).
+ *
+ * `nowrap` keeps the row one line high — each chip truncates and carries its own
+ * `title`, so a long branch name is readable on hover instead of wrapping the
+ * meta grid onto extra rows. Wrapping stays the default for callers with the
+ * vertical space to spend. */
+export function MetaChips({
+  items,
+  mono = false,
+  nowrap = false,
+}: {
+  items: string[];
+  mono?: boolean;
+  nowrap?: boolean;
+}) {
   return (
-    <div className="flex flex-wrap gap-1.5">
+    <div className={cn('flex gap-1.5', nowrap ? 'min-w-0 overflow-hidden' : 'flex-wrap')}>
       {items.map((item) => (
         <span
           key={item}
+          title={item}
           className={cn(
             'rounded-md border border-border bg-surface-2 px-1.5 py-0.5 text-xs text-text',
             mono && 'font-mono',
+            nowrap && 'min-w-0 truncate',
           )}
         >
           {item}

--- a/packages/dashboard-ui/src/shared/icons.tsx
+++ b/packages/dashboard-ui/src/shared/icons.tsx
@@ -478,6 +478,12 @@ export const DownloadIcon: IconComponent = (props) => (
   </svg>
 );
 
+export const ExpandIcon: IconComponent = (props) => (
+  <svg {...base} {...props}>
+    <path d="M14 4h6v6M20 4l-7 7M10 20H4v-6M4 20l7-7" />
+  </svg>
+);
+
 // ─── Operations dashboard chrome ─────────────────────────────────────────────
 
 export const FlowIcon: IconComponent = (props) => (

--- a/web-ui/app/(app)/activity/ActivityClient.tsx
+++ b/web-ui/app/(app)/activity/ActivityClient.tsx
@@ -64,7 +64,7 @@ export function ActivityClient({
   expanded: boolean;
 }) {
   const pathname = usePathname();
-  const { isPending, push: pushUrl } = useNavigationTransition();
+  const { isPending, push: pushUrl, replace: replaceUrl } = useNavigationTransition();
 
   // Timeline deep links: a detection event opens the findings page scoped to
   // this session (narrowed to the event's finding when the event carries one);
@@ -124,13 +124,23 @@ export function ActivityClient({
     [onNavigate, pushUrl, buildUrl],
   );
 
-  // Opening and closing the inspector are both real navigations, so the drill-down
-  // is in history (Back closes it) and the open state survives a copied URL.
+  // Push to open, replace to close.
+  //
+  // Opening is a real drill-down, so it earns a history entry: Back closes the
+  // inspector and the open state survives a copied URL. Closing is the reverse of
+  // that entry rather than a place of its own — pushing it would leave the panel
+  // the reader just dismissed sitting on the Back path (and open/close/open would
+  // stack a run of them), so the close overwrites the entry the open added.
   const setExpanded = useCallback(
     (next: boolean) => {
-      push({ q: query, harness, range, id: selectedId, showEmpty, expanded: next });
+      const url = buildUrl({ q: query, harness, range, id: selectedId, showEmpty, expanded: next });
+      // Settle the search debounce on both paths: it holds a URL built from the
+      // pre-navigation state, so closing mid-typing would otherwise let the timer
+      // fire a URL that predates the close and re-open the panel.
+      onNavigate(query);
+      (next ? pushUrl : replaceUrl)(url);
     },
-    [push, query, harness, range, selectedId, showEmpty],
+    [buildUrl, onNavigate, pushUrl, replaceUrl, query, harness, range, selectedId, showEmpty],
   );
 
   // Shared by the docked pane and the inspector — one session, two frames, so
@@ -201,7 +211,13 @@ export function ActivityClient({
 
       {/* The full-width inspector. Same view, more room: the docked pane shares
           the viewport with the session list, so a long timeline is read here.
-          Open state is the URL's, not this component's — see setExpanded. */}
+          Open state is the URL's, not this component's — see setExpanded.
+
+          `detail !== null` is a second guard, and it is the one that survives a
+          hand-typed URL. parseExpanded already refuses `?view=full` with no ?id,
+          but an id naming a session the store does not have parses as open and
+          arrives here with nothing to render — so the panel stays shut on the
+          session itself, not merely on the param that claims one. */}
       <Sheet
         open={expanded && detail !== null}
         onOpenChange={(open) => {

--- a/web-ui/app/(app)/activity/ActivityClient.tsx
+++ b/web-ui/app/(app)/activity/ActivityClient.tsx
@@ -12,7 +12,7 @@ import type {
   Harness,
   SessionTokenReport,
 } from '@akasecurity/schema';
-import { Card, cn } from '@akasecurity/ui-kit';
+import { Card, cn, Sheet, SheetContent, SheetTitle } from '@akasecurity/ui-kit';
 import { usePathname } from 'next/navigation';
 import { useCallback } from 'react';
 
@@ -40,6 +40,7 @@ export function ActivityClient({
   hasMore,
   emptyCount,
   showEmpty,
+  expanded,
 }: {
   sessions: ActivitySessionSummary[];
   detail: ActivitySession | null;
@@ -59,6 +60,8 @@ export function ActivityClient({
   emptyCount: number;
   /** Whether zero-activity sessions are currently listed (?empty=1). */
   showEmpty: boolean;
+  /** Whether the full-width session inspector is open (?view=full). */
+  expanded: boolean;
 }) {
   const pathname = usePathname();
   const { isPending, push: pushUrl } = useNavigationTransition();
@@ -91,6 +94,7 @@ export function ActivityClient({
       range: TimeRange;
       id?: string;
       showEmpty?: boolean;
+      expanded?: boolean;
     }) => {
       const qs = buildActivityParams(opts).toString();
       return qs ? `${pathname}?${qs}` : pathname;
@@ -112,12 +116,47 @@ export function ActivityClient({
       range: TimeRange;
       id?: string;
       showEmpty?: boolean;
+      expanded?: boolean;
     }) => {
       onNavigate(opts.q);
       pushUrl(buildUrl(opts));
     },
     [onNavigate, pushUrl, buildUrl],
   );
+
+  // Opening and closing the inspector are both real navigations, so the drill-down
+  // is in history (Back closes it) and the open state survives a copied URL.
+  const setExpanded = useCallback(
+    (next: boolean) => {
+      push({ q: query, harness, range, id: selectedId, showEmpty, expanded: next });
+    },
+    [push, query, harness, range, selectedId, showEmpty],
+  );
+
+  // Shared by the docked pane and the inspector — one session, two frames, so
+  // the deep links and figures must not drift between them.
+  const detailProps = {
+    session: detail,
+    tokenReport,
+    liveFindings,
+    linkHref,
+    isLoading: false,
+    error: null,
+    // Tool chips deep-link to the flat findings view filtered to that
+    // tool. `?tool=` is a real filter on the capturing event's recorded
+    // tool name, where the previous `?q=via Bash` was a text match
+    // against a rendered label — it matched any finding whose search
+    // text happened to contain the phrase, and missed nothing only by
+    // luck. The session scope rides along so the link stays about this
+    // session.
+    toolHref: (toolName: string) => {
+      const params = new URLSearchParams();
+      params.set('view', 'flat');
+      if (sessionId) params.set('session', sessionId);
+      params.append('tool', toolName);
+      return `/findings?${params.toString()}`;
+    },
+  };
 
   return (
     <div
@@ -153,28 +192,35 @@ export function ActivityClient({
       </Card>
       <Card className="flex min-w-0 flex-1 flex-col overflow-hidden shadow-sm">
         <SessionDetailView
-          session={detail}
-          tokenReport={tokenReport}
-          liveFindings={liveFindings}
-          linkHref={linkHref}
-          isLoading={false}
-          error={null}
-          // Tool chips deep-link to the flat findings view filtered to that
-          // tool. `?tool=` is a real filter on the capturing event's recorded
-          // tool name, where the previous `?q=via Bash` was a text match
-          // against a rendered label — it matched any finding whose search
-          // text happened to contain the phrase, and missed nothing only by
-          // luck. The session scope rides along so the link stays about this
-          // session.
-          toolHref={(toolName) => {
-            const params = new URLSearchParams();
-            params.set('view', 'flat');
-            if (sessionId) params.set('session', sessionId);
-            params.append('tool', toolName);
-            return `/findings?${params.toString()}`;
+          {...detailProps}
+          onExpand={() => {
+            setExpanded(true);
           }}
         />
       </Card>
+
+      {/* The full-width inspector. Same view, more room: the docked pane shares
+          the viewport with the session list, so a long timeline is read here.
+          Open state is the URL's, not this component's — see setExpanded. */}
+      <Sheet
+        open={expanded && detail !== null}
+        onOpenChange={(open) => {
+          if (!open) setExpanded(false);
+        }}
+      >
+        {/* No description in this panel — opt out of Radix's aria-describedby. */}
+        <SheetContent
+          className="w-320 max-w-[96%] gap-0 overflow-hidden p-0"
+          aria-describedby={undefined}
+        >
+          {/* The view renders its own visible heading; this is the accessible
+              name Radix requires on the dialog. */}
+          <SheetTitle className="sr-only">
+            {detail ? `Session ${detail.title}` : 'Session'}
+          </SheetTitle>
+          <SessionDetailView {...detailProps} overlayClose />
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/web-ui/app/(app)/activity/filters.ts
+++ b/web-ui/app/(app)/activity/filters.ts
@@ -51,15 +51,20 @@ export function parseShowEmpty(sp: ActivitySearchParams): boolean {
 }
 
 /**
- * Whether the full-width session inspector is open (`?view=full`).
+ * Whether the full-width session inspector is open (`?view=full&id=<session>`).
  *
  * It lives in the URL rather than in component state so the drill-down is a real
  * navigation: it gets a history entry (Back closes it) and the link is
  * shareable — `?id=<session>&view=full` opens straight into that session's
  * inspector. Any other value reads as closed, so a crafted `?view=` is inert.
+ *
+ * The `?id` is required here, not just when building: the serializer constrains
+ * only the URLs this app writes, and a hand-typed `/activity?view=full` reaches
+ * the parser having gone nowhere near it. The panel is a view OF a session, so
+ * the pairing is a property of the state itself and belongs on both sides.
  */
 export function parseExpanded(sp: ActivitySearchParams): boolean {
-  return one(sp.view) === 'full';
+  return one(sp.view) === 'full' && parseSelectedId(sp) !== '';
 }
 
 /**

--- a/web-ui/app/(app)/activity/filters.ts
+++ b/web-ui/app/(app)/activity/filters.ts
@@ -6,7 +6,7 @@ import {
 } from '@akasecurity/dashboard-ui';
 import { Harness, type ListActivitySessionsQuery } from '@akasecurity/schema';
 
-// The Activity list state rides in the URL (?q=&harness=&harness=&range=&id=&empty=1)
+// The Activity list state rides in the URL (?q=&harness=&harness=&range=&id=&empty=1&view=full)
 // so the Server Component re-queries the local store on every change — the same
 // mechanism as the findings/detections pages. These pure helpers convert between
 // the URL params and the persistence query; shared by the page (parse) and the
@@ -51,6 +51,18 @@ export function parseShowEmpty(sp: ActivitySearchParams): boolean {
 }
 
 /**
+ * Whether the full-width session inspector is open (`?view=full`).
+ *
+ * It lives in the URL rather than in component state so the drill-down is a real
+ * navigation: it gets a history entry (Back closes it) and the link is
+ * shareable — `?id=<session>&view=full` opens straight into that session's
+ * inspector. Any other value reads as closed, so a crafted `?view=` is inert.
+ */
+export function parseExpanded(sp: ActivitySearchParams): boolean {
+  return one(sp.view) === 'full';
+}
+
+/**
  * Search + harness + range → the persistence session-list query. The range maps
  * to a `from` lower bound (`now − N days`); `limit: 100` is the schema max (the
  * list shows a truncation notice past it rather than paginating). `nowMs` is
@@ -80,6 +92,7 @@ export function buildActivityParams(opts: {
   range: TimeRange;
   id?: string;
   showEmpty?: boolean;
+  expanded?: boolean;
 }): URLSearchParams {
   const sp = new URLSearchParams();
   const q = opts.q.trim();
@@ -91,5 +104,8 @@ export function buildActivityParams(opts: {
   if (opts.range !== DEFAULT_TIME_RANGE) sp.set('range', opts.range);
   if (opts.id) sp.set('id', opts.id);
   if (opts.showEmpty) sp.set('empty', '1');
+  // The inspector is scoped to one session, so it is only ever written next to
+  // the ?id that names it — `?view=full` alone would open a panel over nothing.
+  if (opts.expanded && opts.id) sp.set('view', 'full');
   return sp;
 }

--- a/web-ui/app/(app)/activity/page.tsx
+++ b/web-ui/app/(app)/activity/page.tsx
@@ -21,6 +21,7 @@ import { ActivityClient } from './ActivityClient';
 import {
   type ActivitySearchParams,
   parseActivityRange,
+  parseExpanded,
   parseHarness,
   parseQuery,
   parseSelectedId,
@@ -50,6 +51,7 @@ export default async function ActivityPage({
   const range = parseActivityRange(sp);
   const requestedId = parseSelectedId(sp);
   const showEmpty = parseShowEmpty(sp);
+  const expanded = parseExpanded(sp);
 
   const activity = db().activity;
 
@@ -132,20 +134,26 @@ export default async function ActivityPage({
 
   return (
     <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+      {/* Token usage sits in the filter bar beside the range picker rather than
+          in a card of its own: it is a per-range summary like the range itself,
+          and the vertical band it used to occupy is the session list's. */}
       <PageHead
         title="Activity"
         sub="Your local harness sessions, reconstructed from the audit log"
-        actions={<RangeSelect value={range} />}
+        actions={
+          <>
+            <ActivityTokenUsageView
+              summary={tokenUsage}
+              isLoading={false}
+              error={null}
+              rangeLabel={label}
+            />
+            <RangeSelect value={range} />
+          </>
+        }
       />
 
       <ActivitySummaryStripView items={items} isLoading={false} error={null} />
-
-      <ActivityTokenUsageView
-        summary={tokenUsage}
-        isLoading={false}
-        error={null}
-        rangeLabel={label}
-      />
 
       <ActivityClient
         sessions={list.items}
@@ -160,6 +168,7 @@ export default async function ActivityPage({
         hasMore={Boolean(list.nextCursor)}
         emptyCount={list.emptyCount}
         showEmpty={showEmpty}
+        expanded={expanded}
       />
     </div>
   );

--- a/web-ui/app/components/NavigationTransition.tsx
+++ b/web-ui/app/components/NavigationTransition.tsx
@@ -36,6 +36,13 @@ import {
 interface NavigationTransition {
   isPending: boolean;
   push: (url: string) => void;
+  /**
+   * Same transition, but overwriting the current history entry instead of adding
+   * one. For a state change that undoes the entry it is reverting — dismissing a
+   * panel a push opened — where a second entry would put the dismissed state on
+   * the Back path and re-open it.
+   */
+  replace: (url: string) => void;
 }
 
 const NavigationTransitionContext = createContext<NavigationTransition | null>(null);
@@ -53,7 +60,16 @@ export function NavigationTransitionProvider({ children }: { children: ReactNode
     [router],
   );
 
-  const value = useMemo(() => ({ isPending, push }), [isPending, push]);
+  const replace = useCallback(
+    (url: string) => {
+      startTransition(() => {
+        router.replace(url);
+      });
+    },
+    [router],
+  );
+
+  const value = useMemo(() => ({ isPending, push, replace }), [isPending, push, replace]);
 
   return (
     <NavigationTransitionContext.Provider value={value}>

--- a/web-ui/test/pages/activity-filters.test.ts
+++ b/web-ui/test/pages/activity-filters.test.ts
@@ -1,0 +1,99 @@
+import type { TimeRange } from '@akasecurity/dashboard-ui';
+import type { Harness } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildActivityParams,
+  parseExpanded,
+  parseSelectedId,
+} from '../../app/(app)/activity/filters';
+
+// The full-width session inspector is URL state (`?view=full`) rather than
+// component state, which is what makes the drill-down shareable and puts it in
+// the browser's history. These pin the round trip — parse ∘ build — plus the two
+// ways the param can arrive without a session behind it.
+
+describe('parseExpanded', () => {
+  it('reads ?view=full as open', () => {
+    expect(parseExpanded({ view: 'full' })).toBe(true);
+  });
+
+  it('reads a missing ?view as closed', () => {
+    expect(parseExpanded({})).toBe(false);
+  });
+
+  it('reads any other ?view value as closed', () => {
+    // `view` is a shared param name across pages (findings uses `view=flat`), so
+    // a value this page does not own must be inert rather than truthy.
+    for (const view of ['', 'flat', '1', 'true', 'FULL']) {
+      expect(parseExpanded({ view })).toBe(false);
+    }
+  });
+
+  it('reads the first value when the param repeats', () => {
+    expect(parseExpanded({ view: ['full', 'flat'] })).toBe(true);
+    expect(parseExpanded({ view: ['flat', 'full'] })).toBe(false);
+  });
+});
+
+describe('buildActivityParams — the inspector', () => {
+  const base: { q: string; harness: Harness[]; range: TimeRange } = {
+    q: '',
+    harness: [],
+    range: '7d',
+  };
+
+  it('writes view=full next to the id it drills into', () => {
+    const sp = buildActivityParams({ ...base, id: 'sess-1', expanded: true });
+    expect(sp.get('view')).toBe('full');
+    expect(sp.get('id')).toBe('sess-1');
+  });
+
+  it('omits view=full with no session pinned', () => {
+    // An inspector over nothing: the panel is scoped to one session, so the
+    // param is only ever written beside the ?id that names it.
+    const sp = buildActivityParams({ ...base, expanded: true });
+    expect(sp.get('view')).toBeNull();
+    expect(sp.get('id')).toBeNull();
+  });
+
+  it('omits view when not expanded', () => {
+    const sp = buildActivityParams({ ...base, id: 'sess-1', expanded: false });
+    expect(sp.get('view')).toBeNull();
+  });
+
+  it('round-trips through the parsers', () => {
+    const sp = buildActivityParams({
+      ...base,
+      q: 'deploy',
+      id: 'sess-2',
+      showEmpty: true,
+      expanded: true,
+    });
+    const sm = Object.fromEntries(sp.entries());
+    expect(parseExpanded(sm)).toBe(true);
+    expect(parseSelectedId(sm)).toBe('sess-2');
+  });
+
+  it('leaves the rest of the list state alone', () => {
+    // The inspector is a view of the current selection, not a filter — opening
+    // it must not disturb the search/range/empty state the list is showing.
+    const withPanel = buildActivityParams({
+      q: 'deploy',
+      harness: [],
+      range: '30d',
+      id: 'sess-3',
+      showEmpty: true,
+      expanded: true,
+    });
+    const withoutPanel = buildActivityParams({
+      q: 'deploy',
+      harness: [],
+      range: '30d',
+      id: 'sess-3',
+      showEmpty: true,
+    });
+    withPanel.delete('view');
+    expect(withPanel.toString()).toBe(withoutPanel.toString());
+  });
+});

--- a/web-ui/test/pages/activity-filters.test.ts
+++ b/web-ui/test/pages/activity-filters.test.ts
@@ -8,31 +8,44 @@ import {
   parseSelectedId,
 } from '../../app/(app)/activity/filters';
 
-// The full-width session inspector is URL state (`?view=full`) rather than
-// component state, which is what makes the drill-down shareable and puts it in
-// the browser's history. These pin the round trip — parse ∘ build — plus the two
-// ways the param can arrive without a session behind it.
+// The full-width session inspector is URL state (`?view=full&id=<session>`)
+// rather than component state, which is what makes the drill-down shareable and
+// puts it in the browser's history. These pin the round trip — parse ∘ build —
+// plus the ways the param can arrive without a session behind it, on BOTH sides:
+// the serializer never writes that pairing, and the parser refuses it when
+// something else wrote the URL.
 
 describe('parseExpanded', () => {
-  it('reads ?view=full as open', () => {
-    expect(parseExpanded({ view: 'full' })).toBe(true);
+  it('reads ?view=full beside an ?id as open', () => {
+    expect(parseExpanded({ view: 'full', id: 'sess-1' })).toBe(true);
   });
 
   it('reads a missing ?view as closed', () => {
-    expect(parseExpanded({})).toBe(false);
+    expect(parseExpanded({ id: 'sess-1' })).toBe(false);
   });
 
   it('reads any other ?view value as closed', () => {
     // `view` is a shared param name across pages (findings uses `view=flat`), so
     // a value this page does not own must be inert rather than truthy.
     for (const view of ['', 'flat', '1', 'true', 'FULL']) {
-      expect(parseExpanded({ view })).toBe(false);
+      expect(parseExpanded({ view, id: 'sess-1' })).toBe(false);
     }
   });
 
   it('reads the first value when the param repeats', () => {
-    expect(parseExpanded({ view: ['full', 'flat'] })).toBe(true);
-    expect(parseExpanded({ view: ['flat', 'full'] })).toBe(false);
+    expect(parseExpanded({ view: ['full', 'flat'], id: 'sess-1' })).toBe(true);
+    expect(parseExpanded({ view: ['flat', 'full'], id: 'sess-1' })).toBe(false);
+  });
+
+  it('reads ?view=full with no session behind it as closed', () => {
+    // buildActivityParams never writes this pairing, but it only constrains the
+    // URLs this app writes — a hand-typed /activity?view=full reaches the parser
+    // having gone nowhere near the serializer, and a panel is a view OF a
+    // session. Blank and whitespace-only ids are the same case as a missing one.
+    expect(parseExpanded({ view: 'full' })).toBe(false);
+    expect(parseExpanded({ view: 'full', id: '' })).toBe(false);
+    expect(parseExpanded({ view: 'full', id: '   ' })).toBe(false);
+    expect(parseExpanded({ view: 'full', id: [] })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

The activity page spent most of a 900px viewport on chrome sitting above the session master/detail — a two-line summary strip, then a full-width token-usage card that expanded **downward**, pushing the sessions further off screen. Long values (working dir, session id, model) wrapped to multiple lines and took more of what was left.

## What changed

**Token usage moves into the filter bar.** It's now a chip beside the range picker (`1.1B tokens · ≥ $131.31`) that opens the per-model table in a right-hand slide-over. Opening sideways rather than expanding down is the point: an inline expansion pushes away exactly the region the summary was there to describe.

**Every text field is one line, full value on hover.** Working dir, session id, title, started and duration truncate with a `title`; branch/model chips gained a `nowrap` mode that truncates per chip. The summary strip is single-baseline (`4 Sessions today` rather than stacked) and tighter.

Measured against a real store: the master/detail region goes from **~526px to ~634px on a 900px viewport** — ~70% of the screen, +21%.

**Full-width session inspector, linkable.** An expand button in the detail header opens the same view in a wide slide-over. State lives in the URL as `?id=<session>&view=full`, so browser Back closes it and `/activity?id=<session>&view=full` opens straight into that session.

Two invariants in `filters.ts`, both covered:

- `view=full` is only ever serialized alongside an `?id` — a panel over no session isn't reachable by URL.
- Any other `view` value reads as closed. `view=flat` already exists on the findings page, so a permissive parse would have made a stray param open the inspector.

## Testing

- New `web-ui/test/pages/activity-filters.test.ts` — 9 cases over parse/serialize round-tripping and both invariants above.
- Full suites green: 186 `dashboard-ui`, 443 `web-ui`; lint and typecheck clean on a forced (uncached) run.
- Guards mutation-checked: dropping the `&& opts.id` condition and loosening `parseExpanded` to `!== ''` each turn the relevant cases red.
- Verified in the browser against a real `~/.aka` store in light and dark at 1600px and 1280px, including that Back closes the inspector and drops `view=full`.

## Note

There's a **pre-existing** hydration error on this page, unrelated to these changes: `durationLabel` reads `Date.now()` for live sessions, so server and client render different minute counts. `SessionListView` suppresses it for relative time but not for duration, and the detail pane suppresses neither. Left alone here — it touches both call sites and belongs in its own change.