### PR TITLE
fix(deps): raise js-yaml security floor to ^4.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "brace-expansion@5": "^5.0.9",
       "esbuild": "^0.28.1",
       "fast-uri": "^3.1.5",
-      "js-yaml": "^4.3.0",
+      "js-yaml": "^4.3.1",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   brace-expansion@5: ^5.0.9
   esbuild: ^0.28.1
   fast-uri: ^3.1.5
-  js-yaml: ^4.3.0
+  js-yaml: ^4.3.1
   postcss: ^8.5.18
   sharp: ^0.35.0
 
@@ -3503,8 +3503,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@27.4.0:
@@ -5091,7 +5091,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6458,7 +6458,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -7246,7 +7246,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What

Raises the `js-yaml` floor in the root `pnpm.overrides` from `^4.3.0` to `^4.3.1`, and re-locks.

## Why

`main`'s own daily dependency audit is red, and every open PR is inheriting it:

```
[workspace] high advisory GHSA-5p4m-2wfm-xmqj in js-yaml
JS-YAML: Quadratic CPU consumption in !!omap resolution
```

**Nothing in the tree changed — the advisory was published under us.** It went public at `2026-08-06T20:27:32Z`, after the last green audit run. The evidence:

- `js-yaml@4.3.0` has been in the lock since `9178c036` (2026-07-27) — itself a security-floor raise.
- `e3ed4fb3`, the first sha to fail, touches **zero** js-yaml lines (it is the SEA dashboard fix, #227).
- The only other red audit run on main, at 15:48Z on 2026-08-06, was **cancelled**, not failed — so this is main's first genuine audit failure, not a second symptom.

## The trap in this advisory

The summary text says the fix was **not** backported to 3.x and 4.x. Its version data says otherwise:

```
vulnerable: >= 4.0.0, < 4.3.1   first_patched: 4.3.1
vulnerable: >= 3.0.0, < 3.15.1  first_patched: 3.15.1
```

Read only the CI error line and the conclusion is that we need js-yaml **5.x** — a major bump across eslint and cosmiconfig. The structured data is what is true here: a **patch** bump clears it, which is what this PR does.

The existing `^4.3.0` floor already permitted 4.3.1. It did not move on its own, because a caret does not re-resolve a pinned lockfile — so the floor is raised explicitly, matching the pattern in `9178c036`.

## Verification

`tools/audit-gate/src/audit-dependencies.ts`, run on this branch before and after the change:

```
before   exit 1   Dependency audit (workspace) failed: 1 blocking advisory
after    exit 0   Dependency audit (workspace) passed: 0 waived, 1 below the gate
```

Artifact audit unaffected — `passed: 3 waived, 2 below the gate` both before and after (overrides do not reach a consumer's re-resolution, so this was expected and is confirmed rather than assumed).

## Blast radius

One package. The re-resolve moves `js-yaml@4.3.0` → `4.3.1` and nothing else:

```
+  js-yaml@4.3.1
-  js-yaml@4.3.0
```

Consumers are `@eslint/eslintrc` and `cosmiconfig`, both dev-time.

One note for whoever reviews: `pnpm install` prints `unmet peer eslint@^10.0.0: found 9.39.4` for `@eslint/js@10.0.1`. That is **pre-existing and unrelated** — this diff touches no eslint lines, and both versions were already in the lock. It only appears now because a real re-resolve prints warnings where an up-to-date no-op install prints none.
