### PR TITLE
perf(detections): compile rule regexes once per rule, not per scan

### DIFF
--- a/packages/detections/src/engine.ts
+++ b/packages/detections/src/engine.ts
@@ -3,6 +3,7 @@ import type { Rule } from '@akasecurity/schema';
 import { escapeRegExp } from './escape-regexp.ts';
 import { KeywordMatcher } from './matchers/keyword.ts';
 import { RegexMatcher } from './matchers/regex.ts';
+import { memoizedRegExpList } from './regex-cache.ts';
 import type { MatchResult, RulePack } from './types.ts';
 import { isHighEntropy } from './validators/entropy.ts';
 import { luhnCheck } from './validators/luhn.ts';
@@ -111,13 +112,24 @@ function isCorroborated(candidate: Candidate, candidates: Candidate[], text: str
   const labels = req.labels;
   if (labels && labels.length > 0) {
     const haystack = text.slice(Math.max(0, winStart), winEnd);
-    for (const label of labels) {
-      const trimmed = label.trim();
-      if (trimmed.length === 0) continue;
-      // Boundaries = non-alphanumeric neighbours; robust for labels containing
-      // punctuation or spaces (e.g. "p.o. box") where \b is unreliable.
-      const re = new RegExp(`(?<![A-Za-z0-9])${escapeRegExp(trimmed)}(?![A-Za-z0-9])`, 'i');
-      if (re.test(haystack)) return true;
+    // Boundaries = non-alphanumeric neighbours; robust for labels containing
+    // punctuation or spaces (e.g. "p.o. box") where \b is unreliable.
+    //
+    // This was the densest construction site in the package: the loop runs per
+    // label per gated candidate, so a rule whose primitive matcher fires often
+    // and corroborates rarely (a 5-digit ZIP against a column of numbers)
+    // reached it once per candidate per label — and built the pattern string as
+    // well as the object each time. Compiling the set once per `requiresNearby`
+    // takes both off that product.
+    for (const re of memoizedRegExpList('label', req, () =>
+      labels.map((label) => {
+        const trimmed = label.trim();
+        return trimmed.length === 0
+          ? undefined
+          : new RegExp(`(?<![A-Za-z0-9])${escapeRegExp(trimmed)}(?![A-Za-z0-9])`, 'i');
+      }),
+    )) {
+      if (re?.test(haystack)) return true;
     }
   }
 

--- a/packages/detections/src/matchers/keyword.ts
+++ b/packages/detections/src/matchers/keyword.ts
@@ -1,6 +1,7 @@
 import type { Rule, Span } from '@akasecurity/schema';
 
 import { escapeRegExp } from '../escape-regexp.ts';
+import { memoizedRegExpList } from '../regex-cache.ts';
 import type { Matcher } from '../types.ts';
 import { MAX_MATCHES_PER_RULE } from './limits.ts';
 
@@ -10,29 +11,40 @@ export class KeywordMatcher implements Matcher {
     const { keywords, caseSensitive } = rule.matcher;
     const spans: Span[] = [];
 
-    for (const kw of keywords) {
-      // An empty keyword matches at every position without ever advancing
-      // `lastIndex`, so the walk below would not terminate. The schema rejects
-      // it; skipping keeps the matcher safe on its own if a rule bypasses that.
-      if (kw.length === 0) continue;
+    // One compiled pattern per keyword, built once per matcher rather than once
+    // per call, in the same order as `keywords` so the walk below can index
+    // straight into it. Every entry arrives with `lastIndex` at 0 — the ceiling
+    // below `break`s mid-input, so a keyword that hits it would otherwise leave
+    // the shared object pointing past the matches the next call has to find.
+    const compiled = memoizedRegExpList('keyword', rule.matcher, () =>
+      keywords.map((kw) => {
+        // An empty keyword matches at every position without ever advancing
+        // `lastIndex`, so the walk below would not terminate. The schema rejects
+        // it; compiling it to nothing keeps the matcher safe on its own if a rule
+        // bypasses that.
+        if (kw.length === 0) return undefined;
+        // `u` is safe and preferred here for two reasons: `escapeRegExp` only
+        // ever escapes SyntaxCharacters, so the pattern is always valid under
+        // `u` (which rejects stray identity escapes a lenient regex would
+        // accept); and `u` keeps case-folding parity with the old
+        // case-folded-copy matcher for characters like "ß"/"ẞ" (which a plain
+        // `i` regex stops folding). No bundled keyword is non-ASCII, so the
+        // folding only matters for custom rules — but the parity is free.
+        return new RegExp(escapeRegExp(kw), caseSensitive ? 'gu' : 'giu');
+      }),
+    );
+
+    // Match against the original `text` directly — a case-folded copy can differ
+    // in length from `text` (e.g. "İ".toLowerCase() is two code units), which
+    // would misalign every offset found in it.
+    for (const re of compiled) {
+      if (re === undefined) continue;
 
       // The per-rule ceiling is shared across all of a rule's keywords: a
       // 1-character keyword over a very large input would otherwise emit one
       // span per occurrence. Stop before scanning any further keyword.
       if (spans.length >= MAX_MATCHES_PER_RULE) break;
 
-      // Match against the original `text` directly — a case-folded copy can
-      // differ in length from `text` (e.g. "İ".toLowerCase() is two code
-      // units), which would misalign every offset found in it.
-      //
-      // `u` is safe and preferred here for two reasons: `escapeRegExp` only ever
-      // escapes SyntaxCharacters, so the pattern is always valid under `u`
-      // (which rejects stray identity escapes a lenient regex would accept); and
-      // `u` keeps case-folding parity with the old case-folded-copy matcher for
-      // characters like "ß"/"ẞ" (which a plain `i` regex stops folding). No
-      // bundled keyword is non-ASCII, so the folding only matters for custom
-      // rules — but the parity is free.
-      const re = new RegExp(escapeRegExp(kw), caseSensitive ? 'gu' : 'giu');
       let m: RegExpExecArray | null;
       // An escaped non-empty keyword only ever matches a non-empty run, so the
       // `g` flag always advances past it and the walk terminates.

--- a/packages/detections/src/matchers/regex.ts
+++ b/packages/detections/src/matchers/regex.ts
@@ -1,5 +1,6 @@
 import type { Rule, Span } from '@akasecurity/schema';
 
+import { memoizedRegExp } from '../regex-cache.ts';
 import type { Matcher } from '../types.ts';
 import { MAX_MATCHES_PER_RULE, MAX_REGEX_INPUT_LENGTH } from './limits.ts';
 
@@ -11,7 +12,16 @@ export class RegexMatcher implements Matcher {
     // the captured text inside the overall match (indexOf) would mislocate the
     // span whenever the captured value also occurs earlier in the match, and a
     // mislocated span makes redact() mask the wrong characters.
-    const re = new RegExp(pattern, flags.includes('d') ? flags : `${flags}d`);
+    //
+    // Compiled once per matcher rather than once per call, and shared across
+    // calls, so it arrives with `lastIndex` at 0. That reset is load-bearing
+    // rather than tidy: every `break` below leaves a global pattern's
+    // `lastIndex` mid-input, so without it the next call would resume from the
+    // previous call's offset and miss every match before it.
+    const re = memoizedRegExp(
+      rule.matcher,
+      () => new RegExp(pattern, flags.includes('d') ? flags : `${flags}d`),
+    );
     // Bound how much of `text` a single caller-supplied pattern is ever run
     // against — see MAX_REGEX_INPUT_LENGTH for why this matters for a
     // catastrophically-backtracking pattern. `scanText` is always a prefix of

--- a/packages/detections/src/regex-cache.ts
+++ b/packages/detections/src/regex-cache.ts
@@ -1,0 +1,127 @@
+// Compiled-`RegExp` cache shared by every per-scan construction site in this
+// package. Rule patterns, keywords and `requiresNearby` labels are all immutable
+// after `Rule.parse`, so the object built from one is reusable for the life of
+// the rule — but nothing reused it, and `scan()` rebuilt every one of them on
+// every call.
+//
+// KEYED ON THE OWNER OBJECT, NOT ON THE PATTERN TEXT. V8 keeps its own
+// compilation cache keyed on source and flags, so re-running `new RegExp` on a
+// pattern it has already seen does not recompile — it allocates a fresh wrapper
+// around compiled code it still holds. What that leaves to win is the wrapper,
+// and a cache keyed on the pattern text spends more than that to collect it:
+// the key has to be built and hashed on every lookup, and rule patterns run to
+// hundreds of characters. Looking up by the owner object skips both.
+//
+// The trade is that two distinct rules carrying identical patterns now compile
+// separately. That costs one wrapper object apiece around compiled code V8
+// already shares between them, which is the cheap half of what was being rebuilt.
+//
+// THE OWNER MUST NOT BE MUTATED AFTER FIRST USE. Identity is standing in for the
+// pattern text, so editing a matcher's `pattern`, `flags` or `keywords` in place
+// leaves this handing back the object compiled from the old text — a rule that
+// reads as updated and never matches, with nothing raised. Rules are built by
+// `Rule.parse` and treated as frozen from then on; a caller that needs a changed
+// pattern builds a new rule rather than editing one.
+//
+// THE RETURNED OBJECT IS SHARED AND MUTABLE. A `RegExp` carries exactly one
+// piece of mutable state, `lastIndex`, which `exec` advances and which a caller
+// that stops early (a match cap, a sticky pattern, a zero-length bump) leaves
+// pointing into the middle of the input it gave up on. A later caller reusing
+// that object starts its search from that offset and silently finds nothing.
+// Both accessors below therefore hand back objects whose `lastIndex` is already
+// 0, which is why acquisition goes through a function rather than a bare
+// `WeakMap.get`: a reset every caller has to remember is a reset somebody
+// eventually forgets.
+//
+// Use what you get synchronously and do not retain it — two live users of one
+// object would interleave their `lastIndex`. Every call site in this package
+// holds it for one loop over one input, which is what makes sharing safe here.
+//
+// BOUNDED BY LIVENESS. The maps are weak, so an entry lives exactly as long as
+// the rule it was built for and no size cap is needed: a ruleset that is dropped
+// takes its compiled patterns with it, and a caller that rebuilds its rules per
+// scan gets no benefit rather than an unbounded map. That last case is the one
+// to know about — the cache pays off only for a ruleset held across calls, which
+// is how every scanner in this workspace holds one.
+//
+// PER-THREAD BY CONSTRUCTION. An isolated scan runs this same engine on a worker
+// thread, and a worker gets a fresh module registry — so it evaluates this
+// module again and gets its own maps. The main thread and a worker therefore
+// never share a `lastIndex`, and that follows from module scoping rather than
+// from any locking, which is why there is none here. Keeping the compiled object
+// out of the rule itself is the other half: a ruleset reaches a worker by
+// structured clone, a `RegExp` is cloneable, and a cache hung on the rule would
+// hand the worker a copy carrying whatever `lastIndex` the parent left on it.
+
+// A `RegExp` reads and writes `lastIndex` only when it is global or sticky —
+// every other pattern ignores the field entirely, including the `test()` calls
+// the proximity labels use. Recording that per list at build time turns the
+// reset below into one branch for those, instead of a write per entry per
+// acquisition on the densest path in the engine.
+interface CompiledList {
+  readonly entries: readonly (RegExp | undefined)[];
+  readonly stateful: boolean;
+}
+
+// One map per kind of value rather than one shared by both. They are keyed by
+// different objects — a rule's `matcher` and its `requiresNearby` — and a single
+// keyspace would return a keyword list to a label lookup for any owner that ever
+// appeared in both positions.
+const singles = new WeakMap<object, RegExp>();
+const keywordLists = new WeakMap<object, CompiledList>();
+const labelLists = new WeakMap<object, CompiledList>();
+
+/** Which list cache a call is addressing. */
+export type ListKind = 'keyword' | 'label';
+
+function listCache(kind: ListKind): WeakMap<object, CompiledList> {
+  return kind === 'keyword' ? keywordLists : labelLists;
+}
+
+/**
+ * The compiled `RegExp` belonging to `owner`, built by `build` on first ask and
+ * handed back with `lastIndex` reset to 0.
+ *
+ * `owner` must be the immutable object the pattern is derived from — a rule's
+ * `matcher` — so that identity stands in for the pattern text.
+ */
+export function memoizedRegExp(owner: object, build: () => RegExp): RegExp {
+  const cached = singles.get(owner);
+  if (cached !== undefined) {
+    cached.lastIndex = 0;
+    return cached;
+  }
+  // A freshly constructed RegExp has lastIndex 0 already, so the miss path needs
+  // no reset of its own. Built before the store, so a pattern that fails to
+  // compile throws without recording anything.
+  const compiled = build();
+  singles.set(owner, compiled);
+  return compiled;
+}
+
+/**
+ * The compiled `RegExp`s belonging to `owner` in the `kind` cache — one per entry
+ * of whatever list it holds, `undefined` where that entry compiles to nothing —
+ * built by `build` on first ask and handed back with every stateful entry's
+ * `lastIndex` reset to 0.
+ */
+export function memoizedRegExpList(
+  kind: ListKind,
+  owner: object,
+  build: () => readonly (RegExp | undefined)[],
+): readonly (RegExp | undefined)[] {
+  const cache = listCache(kind);
+  const cached = cache.get(owner);
+  if (cached !== undefined) {
+    if (cached.stateful) {
+      for (const re of cached.entries) if (re !== undefined) re.lastIndex = 0;
+    }
+    return cached.entries;
+  }
+  const entries = build();
+  cache.set(owner, {
+    entries,
+    stateful: entries.some((re) => re !== undefined && (re.global || re.sticky)),
+  });
+  return entries;
+}

--- a/packages/detections/test/regex-cache.test.ts
+++ b/packages/detections/test/regex-cache.test.ts
@@ -1,0 +1,337 @@
+import type { Rule } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { scan } from '../src/engine.ts';
+import { KeywordMatcher } from '../src/matchers/keyword.ts';
+import { MAX_MATCHES_PER_RULE } from '../src/matchers/limits.ts';
+import { RegexMatcher } from '../src/matchers/regex.ts';
+import { memoizedRegExp, memoizedRegExpList } from '../src/regex-cache.ts';
+import { discoverBundledRuleFiles, loadRule } from './helpers/rules.ts';
+
+// Plain objects rather than Rule.parse(), matching the matcher suites: the cache
+// sits under the matchers and must behave for any pattern that reaches it,
+// including flag combinations the schema does not mint.
+function regexRule(pattern: string, flags: string): Rule {
+  return {
+    specVersion: 1,
+    id: 'test-pack/test-rule',
+    name: 'test',
+    category: 'custom',
+    severity: 'low',
+    matcher: { type: 'regex', pattern, flags },
+  };
+}
+
+function keywordRule(keywords: string[]): Rule {
+  return {
+    specVersion: 1,
+    id: 'test-pack/kw-rule',
+    name: 'test',
+    category: 'custom',
+    severity: 'low',
+    matcher: { type: 'keyword', keywords, caseSensitive: false },
+  };
+}
+
+describe('memoizedRegExp — identity keying', () => {
+  it('builds once per owner and returns the same object after', () => {
+    const owner = {};
+    let builds = 0;
+    const build = (): RegExp => {
+      builds++;
+      return new RegExp('memo-identity');
+    };
+    const first = memoizedRegExp(owner, build);
+    expect(memoizedRegExp(owner, build)).toBe(first);
+    expect(builds).toBe(1);
+  });
+
+  // Identity, not pattern text. Two rules carrying the same pattern compile
+  // separately — the trade that buys the lookup its speed, and the reason
+  // nothing here hashes a pattern string.
+  it('keeps separate entries for separate owners of an identical pattern', () => {
+    const a = memoizedRegExp({}, () => new RegExp('memo-same-text'));
+    const b = memoizedRegExp({}, () => new RegExp('memo-same-text'));
+    expect(b).not.toBe(a);
+    expect(b.source).toBe(a.source);
+  });
+
+  it('records nothing when the builder throws', () => {
+    const owner = {};
+    expect(() =>
+      memoizedRegExp(owner, () => {
+        throw new Error('bad pattern');
+      }),
+    ).toThrow('bad pattern');
+    // A recorded failure would make the retry return undefined instead of
+    // building, so a successful second attempt is what shows nothing was stored.
+    expect(memoizedRegExp(owner, () => new RegExp('memo-after-throw')).source).toBe(
+      'memo-after-throw',
+    );
+  });
+
+  it('builds a list once per owner', () => {
+    const owner = {};
+    let builds = 0;
+    const build = (): RegExp[] => {
+      builds++;
+      return [new RegExp('memo-list-a'), new RegExp('memo-list-b')];
+    };
+    const first = memoizedRegExpList('keyword', owner, build);
+    expect(memoizedRegExpList('keyword', owner, build)).toBe(first);
+    expect(builds).toBe(1);
+  });
+
+  // The two list caches are keyed by different objects — a rule's `matcher` and
+  // its `requiresNearby` — so one shared keyspace would hand a label lookup the
+  // keyword list belonging to the same owner, and corroborate against keyword
+  // patterns instead of labels.
+  it('keeps the keyword and label caches apart for one owner', () => {
+    const owner = {};
+    const keywords = memoizedRegExpList('keyword', owner, () => [new RegExp('memo-kw')]);
+    const labels = memoizedRegExpList('label', owner, () => [new RegExp('memo-label')]);
+    expect(labels).not.toBe(keywords);
+    expect(keywords[0]?.source).toBe('memo-kw');
+    expect(labels[0]?.source).toBe('memo-label');
+  });
+
+  // Identity stands in for the pattern text, so a matcher edited after first use
+  // keeps the object compiled from the old text. Nothing enforces that — rules
+  // are frozen by convention from `Rule.parse` onward — so the constraint is
+  // pinned here rather than left to the header comment alone.
+  it('does not notice a pattern edited in place after first use', () => {
+    const rule = regexRule('memo-stale-before', 'g');
+    expect(scan('memo-stale-before', [rule])).toHaveLength(1);
+
+    // Type-safe mutation of a field the engine treats as frozen.
+    (rule.matcher as { pattern: string }).pattern = 'memo-stale-after';
+    expect(scan('memo-stale-after', [rule])).toHaveLength(0);
+    expect(scan('memo-stale-before', [rule])).toHaveLength(1);
+  });
+});
+
+describe('memoizedRegExp — the bound', () => {
+  // The cache is bounded by liveness rather than by a size cap: entries are held
+  // weakly, so they last exactly as long as the rule they were built for.
+  //
+  // Weakness has no direct observation short of driving a collection, which is
+  // not something to assert on in a test suite. The refusal below is the one
+  // place it does surface — a WeakMap will not take a primitive key, while a
+  // plain Map takes it happily and then retains every entry for the life of the
+  // process. So this case is what separates the two containers, and swapping in
+  // a Map is what it exists to catch.
+  it('refuses a key that cannot be held weakly', () => {
+    expect(() => memoizedRegExp('a string' as unknown as object, () => /x/)).toThrow(TypeError);
+    expect(() => memoizedRegExpList('keyword', 7 as unknown as object, () => [/x/])).toThrow(
+      TypeError,
+    );
+  });
+});
+
+describe('cached regexes carry no state between calls', () => {
+  // Every early exit in RegexMatcher's walk leaves a global pattern's lastIndex
+  // pointing into the input it just gave up on. The cases below each drive one
+  // of those exits and then re-run on a DIFFERENT input, which is where a shared
+  // object without a reset silently returns nothing.
+
+  it('finds matches on a second scan after the first hit the per-rule cap', () => {
+    const rule = regexRule('a', 'g');
+    const capped = scan('a'.repeat(MAX_MATCHES_PER_RULE * 2), [rule]);
+    expect(capped).toHaveLength(MAX_MATCHES_PER_RULE);
+
+    // Far shorter than the offset the capped walk stopped at, so a carried
+    // lastIndex puts the search past the end of the input entirely.
+    const next = scan('aaa', [rule]);
+    expect(next.map((f) => f.span)).toEqual([
+      { start: 0, end: 1 },
+      { start: 1, end: 2 },
+      { start: 2, end: 3 },
+    ]);
+  });
+
+  it('finds matches on a second scan after a sticky pattern advanced lastIndex', () => {
+    // A sticky pattern honours lastIndex without the 'g' flag, so the walk's
+    // break-on-non-global exit leaves the object pointing at offset 1.
+    const rule = regexRule('a', 'y');
+    expect(scan('ab', [rule]).map((f) => f.span)).toEqual([{ start: 0, end: 1 }]);
+    expect(scan('ab', [rule]).map((f) => f.span)).toEqual([{ start: 0, end: 1 }]);
+  });
+
+  it('finds keyword matches on a second scan after the first hit the per-rule cap', () => {
+    const rule = keywordRule(['k']);
+    const capped = scan('k'.repeat(MAX_MATCHES_PER_RULE * 2), [rule]);
+    expect(capped).toHaveLength(MAX_MATCHES_PER_RULE);
+
+    const next = scan('kk', [rule]);
+    expect(next.map((f) => f.span)).toEqual([
+      { start: 0, end: 1 },
+      { start: 1, end: 2 },
+    ]);
+  });
+
+  it('resets every entry of a list, not only the first', () => {
+    // The cap is shared across a rule's keywords, so the walk can stop partway
+    // through the list — and the entry it stops on is not the one it started on.
+    // The fixture is built so the FIRST keyword finishes cleanly (one match,
+    // well under the cap) and the SECOND is the one that breaks mid-input: a
+    // reset covering only the head of the list leaves that second pattern
+    // pointing past the end of the next call's text, and this rule silently
+    // stops matching 'q' on every scan that follows.
+    const rule = keywordRule(['p', 'q']);
+    expect(scan(`p${'q'.repeat(MAX_MATCHES_PER_RULE * 2)}`, [rule])).toHaveLength(
+      MAX_MATCHES_PER_RULE,
+    );
+
+    const next = scan('qp', [rule]);
+    expect(next.map((f) => f.span).sort((a, b) => a.start - b.start)).toEqual([
+      { start: 0, end: 1 },
+      { start: 1, end: 2 },
+    ]);
+  });
+
+  it('is unaffected by a caller that leaves lastIndex dirty on the shared object', () => {
+    const matcher = new RegexMatcher();
+    const rule = regexRule('needle', 'g');
+    // Reach the very object the matcher will use and dirty it, which is what a
+    // second live user of a shared regex amounts to.
+    matcher.match('needle', rule);
+    memoizedRegExp(rule.matcher, () => {
+      throw new Error('already cached');
+    }).lastIndex = 4096;
+    expect(matcher.match('a needle here', rule)).toEqual([{ start: 2, end: 8 }]);
+  });
+
+  it('is unaffected by a dirty shared object in the keyword matcher', () => {
+    const matcher = new KeywordMatcher();
+    const rule = keywordRule(['token']);
+    matcher.match('token', rule);
+    const compiled = memoizedRegExpList('keyword', rule.matcher, () => {
+      throw new Error('already cached');
+    });
+    for (const re of compiled) if (re) re.lastIndex = 4096;
+    expect(matcher.match('a token here', rule)).toEqual([{ start: 2, end: 7 }]);
+  });
+});
+
+describe('compiled state never rides on a rule', () => {
+  // A ruleset crosses to the isolated scan's worker by structured clone, and a
+  // RegExp is cloneable — lastIndex and all. So a cache hung off the rule object
+  // would hand a worker a half-consumed pattern, which is the one way the main
+  // thread and a worker could come to share one. Keeping the compiled object in
+  // a module-scoped weak map is what rules that out, and a rule that comes back
+  // from a scan unchanged is how that stays true.
+  it('leaves a regex rule byte-identical after scanning', () => {
+    const rule = regexRule('\\d+', 'g');
+    const before = structuredClone(rule);
+    scan('1 22 333', [rule]);
+    expect(rule).toEqual(before);
+  });
+
+  it('leaves a keyword rule byte-identical after scanning', () => {
+    const rule = keywordRule(['alpha', 'beta']);
+    const before = structuredClone(rule);
+    scan('alpha and beta', [rule]);
+    expect(rule).toEqual(before);
+  });
+
+  it('leaves a corroborated rule byte-identical after scanning', () => {
+    const rule: Rule = {
+      ...regexRule('\\b[A-Z]\\d{8}\\b', 'g'),
+      requiresNearby: { labels: ['passport'], windowChars: 160 },
+    };
+    const before = structuredClone(rule);
+    scan('passport: A12345678', [rule]);
+    expect(rule).toEqual(before);
+  });
+
+  it('survives a rule that crosses a structured clone, as one reaching a worker does', () => {
+    const rule = regexRule('\\bcloned-\\d+\\b', 'g');
+    const arrived = structuredClone(rule);
+    // The clone is a different object, so it compiles its own copy — and starts
+    // from a clean lastIndex however hard the original was driven first.
+    scan('cloned-1 cloned-2', [rule]);
+    expect(scan('cloned-9', [arrived]).map((f) => f.span)).toEqual([{ start: 0, end: 8 }]);
+  });
+});
+
+describe('scan() stops recompiling its ruleset', () => {
+  // Counting constructions is the only way to see the cache from outside: the
+  // findings are identical either way, which is the point. RegExp is resolved
+  // from the global scope at each call site, so a global stand-in sees every
+  // construction the engine makes, in every module.
+  function countConstructions(run: () => void): number {
+    const Real = globalThis.RegExp;
+    let constructions = 0;
+    function Counting(this: unknown, ...args: [string, string?]): RegExp {
+      constructions++;
+      return new Real(...args);
+    }
+    Counting.prototype = Real.prototype;
+    Object.setPrototypeOf(Counting, Real);
+    globalThis.RegExp = Counting as unknown as RegExpConstructor;
+    try {
+      run();
+    } finally {
+      globalThis.RegExp = Real;
+    }
+    return constructions;
+  }
+
+  const bundled = (): Rule[] =>
+    discoverBundledRuleFiles().map(({ packDirAbs, ruleFile }) => loadRule(packDirAbs, ruleFile));
+
+  it('compiles nothing on a repeat scan of the same ruleset', () => {
+    const rules = bundled();
+    const text = 'the quick brown fox jumps over the lazy dog. '.repeat(48);
+
+    // The positive control: the first scan of a ruleset nothing has compiled yet
+    // must construct something, or the counter is measuring nothing and the
+    // assertion below holds for a reason that has nothing to do with the cache.
+    const first = countConstructions(() => void scan(text, rules));
+    expect(first).toBeGreaterThan(0);
+
+    const second = countConstructions(() => void scan(text, rules));
+    expect(second).toBe(0);
+  });
+
+  it('compiles per distinct label, not per gated candidate', () => {
+    // Proximity labels were compiled per label per gated candidate, so this is
+    // the densest construction site in the engine. Patterns unique to this case,
+    // so the first run below is genuinely cold whatever ran before it.
+    const rules: Rule[] = [
+      {
+        ...regexRule('\\b7\\d{4}\\b', 'g'),
+        requiresNearby: { labels: ['cachezip'], windowChars: 160 },
+      },
+    ];
+    const text = 'cachezip 71234 '.repeat(2000);
+
+    let findings = 0;
+    const first = countConstructions(() => {
+      findings = scan(text, rules).length;
+    });
+
+    // The scan visited the label loop once per candidate, and the count says so:
+    // every one of these findings reached it and corroborated there. Two
+    // constructions against that many visits is the whole claim — the same run
+    // built one object per visit before, and the assertion is on the ratio
+    // rather than on either number alone.
+    expect(findings).toBeGreaterThan(1000);
+    expect(first).toBeLessThan(10);
+
+    const second = countConstructions(() => void scan(text, rules));
+    expect(second).toBe(0);
+  });
+
+  it('compiles a fresh ruleset per call when the caller rebuilds its rules', () => {
+    // The cache is keyed on the rule's own matcher, so a caller that re-parses
+    // its ruleset every scan gets no reuse. That is the documented trade rather
+    // than a defect, and it is worth pinning: it is what keeps the weak map
+    // bounded by the rules a caller actually holds.
+    const text = 'the quick brown fox. '.repeat(8);
+    const first = countConstructions(() => void scan(text, bundled()));
+    const second = countConstructions(() => void scan(text, bundled()));
+    expect(first).toBeGreaterThan(0);
+    expect(second).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
`scan()` rebuilt every `RegExp` it used on every call. Rule patterns, keywords and
`requiresNearby` labels are all immutable after `Rule.parse`, so the compiled object is
reusable for the life of the rule — nothing reused one.

The densest site was proximity corroboration in `engine.ts`: the loop runs per label per
gated candidate, so a rule whose primitive matcher fires often and corroborates rarely (a
5-digit ZIP against a column of numbers) reached it once per candidate per label, building
the pattern *string* as well as the object each time.

## The keying decision

The issue proposed keying the cache on the pattern text. **That measured slower than doing
nothing**, so this ships identity keying instead.

V8 already keeps a compilation cache keyed on source and flags — re-running `new RegExp` on
a pattern it has seen does not recompile, it allocates a fresh wrapper around compiled code
it still holds. What is left to win is the wrapper, and a string-keyed cache spends more
than that to collect it: the key must be built and hashed on every lookup, and rule patterns
run to hundreds of characters. Keying on the owning object (a rule's `matcher`, or its
`requiresNearby`) skips both.

The trade is that two distinct rules carrying identical patterns now compile separately —
one wrapper object apiece around compiled code V8 already shares between them, which is the
cheap half of what was being rebuilt.

## Changes

**`src/regex-cache.ts` (new)** — two accessors over `WeakMap`s keyed on the owning object.

- **Every acquisition hands back `lastIndex` at 0.** This is the load-bearing part, not
  tidiness: each call site can `break` mid-input (a match cap, a zero-length bump), which
  leaves a global pattern's `lastIndex` pointing into the input it gave up on. A later
  caller reusing that object would resume from there and silently find nothing. Acquisition
  goes through a function rather than a bare `WeakMap.get` because a reset every caller has
  to remember is a reset somebody eventually forgets.
- **Keyword and label lists get separate keyspaces.** They are keyed by different objects
  (`matcher` vs `requiresNearby`); one shared map would serve a keyword list to a label
  lookup for any owner appearing in both positions.
- **The reset is gated on a precomputed `stateful` flag.** A `RegExp` reads or writes
  `lastIndex` only when global or sticky — the label `test()` calls are neither, so the
  reset loop was a write per entry per acquisition that could have no effect.
- **Weak by construction**, so entries live exactly as long as the rule and no size cap is
  needed. A caller that rebuilds its rules per scan gets no benefit rather than an unbounded
  map.
- **Per-thread by module scoping.** A worker gets a fresh module registry and so its own
  maps; keeping the compiled object out of the rule itself is the other half, since a
  ruleset reaches a worker by structured clone and a cache hung on the rule would hand the
  worker a copy carrying whatever `lastIndex` the parent left on it.

**`src/matchers/regex.ts`, `src/matchers/keyword.ts`, `src/engine.ts`** — routed through it.

## Measurements

**These came from a throwaway script written for this session, not from a command in the
repo** — the `vitest bench` harness is still open in #233 and is not on `main`. It builds
the bundled ruleset once and calls `scan()` in a loop, reporting the median and min over
n iterations; each variant ran in its own `node --experimental-strip-types` process, with
the two variants alternating inside each round to spread any drift across both.

Two shapes: a 2 KB prompt against the full bundled ruleset, and a 24 KB input against one
rule whose matcher fires on every line and corroborates on none (the shape that hits the
per-candidate-per-label loop hardest).

Raw output, 5 rounds — first pair of each round is `before`, second is `after`:

```
#### ROUND 1 ####
2 KB prompt (bundled ruleset)                median    0.1526 ms   min    0.1384 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.4830 ms   min    0.4493 ms   (n=40)
2 KB prompt (bundled ruleset)                median    0.1291 ms   min    0.1135 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.2202 ms   min    0.1936 ms   (n=40)
#### ROUND 2 ####
2 KB prompt (bundled ruleset)                median    0.1550 ms   min    0.1337 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.4983 ms   min    0.4255 ms   (n=40)
2 KB prompt (bundled ruleset)                median    0.1296 ms   min    0.1153 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.2141 ms   min    0.2041 ms   (n=40)
#### ROUND 3 ####
2 KB prompt (bundled ruleset)                median    0.1527 ms   min    0.1366 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.4827 ms   min    0.4365 ms   (n=40)
2 KB prompt (bundled ruleset)                median    0.1274 ms   min    0.1127 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.2201 ms   min    0.2143 ms   (n=40)
#### ROUND 4 ####
2 KB prompt (bundled ruleset)                median    0.1579 ms   min    0.1521 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.4999 ms   min    0.4689 ms   (n=40)
2 KB prompt (bundled ruleset)                median    0.1311 ms   min    0.1178 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.1858 ms   min    0.1713 ms   (n=40)
#### ROUND 5 ####
2 KB prompt (bundled ruleset)                median    0.1515 ms   min    0.1334 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.4921 ms   min    0.4508 ms   (n=40)
2 KB prompt (bundled ruleset)                median    0.1280 ms   min    0.1155 ms   (n=600)
24 KB corroboration-heavy (1 gated rule)     median    0.2131 ms   min    0.2011 ms   (n=40)
```

Median of the per-round medians:

| shape | before | after | change |
|---|---:|---:|---:|
| 2 KB prompt, bundled ruleset | 0.1527 ms | 0.1291 ms | −15.5% |
| 24 KB corroboration-heavy | 0.4921 ms | 0.2141 ms | −56.5% |

Every `after` round beats every `before` round in both shapes — the two distributions do not
overlap, so the direction does not rest on the medians alone. Single machine (arm64,
Node 24), so treat the magnitudes as indicative rather than a portable figure.

## Verification

`test/regex-cache.test.ts` (new, 20 cases) covers the reuse paths the existing matcher
suites cannot: every case in those builds a fresh rule per assertion, so under identity
keying they only ever exercise first-compile.

Each invariant was mutation-tested — the mutation applied, the named test confirmed red, the
tree restored, green re-confirmed:

| mutation | test that went red |
|---|---|
| `stateful: false` (reset never runs) | `finds keyword matches on a second scan after the first hit the per-rule cap`, + 2 |
| `listCache` returns one shared map | `keeps the keyword and label caches apart for one owner` |
| `memoizedRegExp` removed from `regex.ts` | `does not notice a pattern edited in place after first use`, + 3 |
| memoization removed from `engine.ts` | `compiles per distinct label, not per gated candidate` (`expected 2001 to be less than 10` — one compile per gated candidate per label) |

The mutate-after-first-use case pins the constraint identity keying implies — an in-place
edit to a matcher is *not* picked up — so the limitation is executable rather than only
asserted in a comment. Rules are built by `Rule.parse` and treated as frozen from then on.

Gates, all run on this branch: workspace `test` 38/38 (`--force`, 0 cached), `lint` 19/19,
`typecheck` 19/19, `format:check` clean. `@akasecurity/detections` is 1250 tests (was 1248).

## Known limitation

A rule whose matcher is mutated in place after first use keeps matching against the old
pattern, silently. Nothing in the tree enforces the immutability this relies on; it is
documented at the top of `regex-cache.ts` and pinned by the test named above.
