### PR TITLE
ci: bound turbo test concurrency on every CI leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,23 @@ jobs:
       - name: Typecheck (repo root)
         run: pnpm typecheck:root
 
+      # --concurrency bounds how many PACKAGE test tasks run at once. Two layers
+      # of parallelism multiply here: turbo runs packages concurrently (default
+      # 10) and each package's vitest spawns its own worker pool sized to the
+      # machine, so an unbounded run puts tens of processes on a hosted runner
+      # with 4 cores. They are not competing for CPU so much as for DISK: this
+      # repo never mocks node:sqlite or the filesystem, so every store test does
+      # real fsync-heavy I/O in a real temp dir. Under that contention a hook
+      # timeout stops measuring the code and starts measuring queue depth, which
+      # is what made the Windows and macOS legs fail on a rotating cast of
+      # unrelated files.
+      #
+      # It is spelled on the turbo call rather than through `pnpm test`, and that
+      # is load-bearing: `pnpm test -- --concurrency=2` forwards the flag to each
+      # TASK's command (`vitest run --concurrency=2`), not to turbo — the same
+      # trap the no-network job documents for `--force`.
       - name: Test
-        run: pnpm test
+        run: pnpm turbo run test --concurrency=2
 
       - name: Build
         run: pnpm build
@@ -156,7 +171,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build and test with egress blocked
-        run: tools/ci/no-network-test.sh pnpm exec turbo run test --force
+        # --concurrency: see the Test step in the lint job. Bounded here too,
+        # because this leg runs the whole workspace inside the namespace and is
+        # subject to the same contention; the flag goes to turbo directly for
+        # the same reason --force does.
+        run: tools/ci/no-network-test.sh pnpm exec turbo run test --force --concurrency=2
 
   # macOS leg: the primary platform for a Claude Code plugin's users, and until
   # this job existed the only tier-1 platform whose tests never ran. macOS did
@@ -238,7 +257,10 @@ jobs:
             turbo-${{ runner.os }}-
 
       - name: Test
-        run: pnpm turbo run test --continue
+        # --concurrency: see the Test step in the lint job. This leg runs all 20
+        # packages on a hosted macOS runner and was one of the two that failed
+        # on rotating unrelated files.
+        run: pnpm turbo run test --continue --concurrency=2
 
   # Windows leg: the CLI and plugin advertise Windows support (install.ps1), so
   # the OS-sensitive core — SQLite store, ~/.aka file layout, file walks, child
@@ -341,9 +363,14 @@ jobs:
       - name: Test the shipped surface and its enforcement
         # --continue: report every package's failures in one run instead of
         # hiding later packages behind the first red one.
+        #
+        # --concurrency: see the Test step in the lint job. This is the leg that
+        # needed it most — Windows has the most expensive fsync of the three, so
+        # it is where disk contention turned into timeouts first and worst.
         run: >
           pnpm turbo run test
           --continue
+          --concurrency=2
           --filter=@akasecurity/schema
           --filter=@akasecurity/extract
           --filter=@akasecurity/detections

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -63,8 +63,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # --concurrency: see the Test step in ci.yml's lint job. Bounded here for
+      # the same reason, and spelled on the turbo call rather than through
+      # `pnpm test` — `pnpm test -- --concurrency=2` would forward the flag to
+      # each TASK's own command (`vitest run --concurrency=2`), not to turbo.
       - name: Test
-        run: pnpm test
+        run: pnpm turbo run test --concurrency=2
 
   release:
     name: Build · Pack · Publish

--- a/.github/workflows/release-plugin-antigravity.yml
+++ b/.github/workflows/release-plugin-antigravity.yml
@@ -66,8 +66,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # --concurrency: see the Test step in ci.yml's lint job. Bounded here for
+      # the same reason, and spelled on the turbo call rather than through
+      # `pnpm test` — `pnpm test -- --concurrency=2` would forward the flag to
+      # each TASK's own command (`vitest run --concurrency=2`), not to turbo.
       - name: Test
-        run: pnpm test
+        run: pnpm turbo run test --concurrency=2
 
   release:
     name: Build · Verify · Publish

--- a/.github/workflows/release-plugin-claude.yml
+++ b/.github/workflows/release-plugin-claude.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # --concurrency: see the Test step in ci.yml's lint job. Bounded here for
+      # the same reason, and spelled on the turbo call rather than through
+      # `pnpm test` — `pnpm test -- --concurrency=2` would forward the flag to
+      # each TASK's own command (`vitest run --concurrency=2`), not to turbo.
       - name: Test
-        run: pnpm test
+        run: pnpm turbo run test --concurrency=2
 
   release:
     name: Build · Verify · Publish

--- a/.github/workflows/release-plugin-codex.yml
+++ b/.github/workflows/release-plugin-codex.yml
@@ -65,8 +65,12 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      # --concurrency: see the Test step in ci.yml's lint job. Bounded here for
+      # the same reason, and spelled on the turbo call rather than through
+      # `pnpm test` — `pnpm test -- --concurrency=2` would forward the flag to
+      # each TASK's own command (`vitest run --concurrency=2`), not to turbo.
       - name: Test
-        run: pnpm test
+        run: pnpm turbo run test --concurrency=2
 
   release:
     name: Build · Verify · Publish

--- a/.github/workflows/release-rules.yml
+++ b/.github/workflows/release-rules.yml
@@ -58,7 +58,7 @@ jobs:
 
       # Fixtures are the correctness gate — a rule whose fixtures fail never ships.
       - name: Test detection engine (fixtures)
-        run: pnpm turbo run test --filter=@akasecurity/detections
+        run: pnpm turbo run test --filter=@akasecurity/detections --concurrency=2
 
       # Publishing runs in the repo configured via the RULES_PUBLISHER_REPO
       # variable — it holds the registry credentials. Once the fixtures pass,

--- a/packages/eslint-config/test/ci-test-concurrency.test.js
+++ b/packages/eslint-config/test/ci-test-concurrency.test.js
@@ -1,0 +1,198 @@
+// Every CI invocation of `turbo run test` must bound its concurrency.
+//
+// Two layers of parallelism multiply on a CI runner. Turbo runs PACKAGE tasks
+// concurrently (its default is 10), and each package's vitest then spawns a
+// worker pool sized to the machine. Unbounded, that puts tens of processes on a
+// hosted runner with four cores — and they contend for DISK rather than CPU,
+// because this repository never mocks node:sqlite or the filesystem, so every
+// store test does real fsync-heavy I/O in a real temp dir.
+//
+// The symptom is not a wrong answer, which is what made it hard to act on: it
+// is a rotating cast of unrelated suites reporting `Hook timed out`, on a leg
+// that goes green if you press the button again. A timeout under that much
+// oversubscription measures queue depth, not the code under test.
+//
+// So the bound is asserted here rather than left to review. A fifth job, or a
+// fifth invocation inside an existing one, is exactly the shape that would
+// reintroduce this silently — the workflow still passes, just less often, and
+// nothing in a diff says so. `ci.yml` is already in this task's turbo `inputs`
+// (alongside the other workflows), so editing it re-runs this check rather than
+// replaying a cached pass.
+//
+// Deliberately NOT a check on the number: what counts as the right cap depends
+// on the runner and is settled by measuring the pass rate. What is asserted is
+// that a bound EXISTS and parses as a positive integer, since `--concurrency`
+// with no value, or with a non-number, is a silent no-op away from the default.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT } from './helpers/lint-invocations.js';
+
+const WORKFLOW_REL = '.github/workflows/ci.yml';
+
+/**
+ * Every `run:` command in a workflow, with folded/literal blocks joined.
+ *
+ * A YAML `run: >` or `run: |` scalar continues onto every following line that
+ * is indented deeper than the `run:` key itself, which is why this cannot be a
+ * line-wise grep: the Windows leg spells its command across a dozen lines, so a
+ * per-line scan sees `pnpm turbo run test` and `--concurrency=2` as unrelated
+ * strings and can be satisfied — or fooled — by either alone.
+ * @param {string} text workflow file contents
+ * @returns {string[]} one entry per `run:` key, whitespace-collapsed
+ */
+export function runCommands(text) {
+  const lines = text.split('\n');
+  const commands = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const start = /^(\s*)(?:-\s+)?run:\s*(.*)$/.exec(lines[i]);
+    if (!start) continue;
+
+    const indent = start[1].length;
+    const parts = [start[2].replace(/^[>|][-+]?\s*$/, '')];
+
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const line = lines[j];
+      // A blank line inside a block scalar is part of it; the block ends at the
+      // first non-blank line indented no deeper than the `run:` key.
+      if (line.trim() === '') {
+        parts.push('');
+        continue;
+      }
+      const lead = /^\s*/.exec(line)[0].length;
+      if (lead <= indent) break;
+      parts.push(line.trim());
+      i = j;
+    }
+
+    const joined = parts.join(' ').replace(/\s+/g, ' ').trim();
+    if (joined !== '') commands.push(joined);
+  }
+
+  return commands;
+}
+
+/** True for a command that runs the workspace `test` task through turbo. */
+const runsTurboTest = (cmd) => /\bturbo\s+run\s+(?:[\w:@/-]+\s+)*test\b/.test(cmd);
+
+/** The value of `--concurrency`, in either the `=` or space-separated form. */
+const concurrencyOf = (cmd) => /--concurrency[=\s]+(\S+)/.exec(cmd)?.[1];
+
+describe('CI bounds the concurrency of every turbo test run', () => {
+  const text = readFileSync(join(REPO_ROOT, WORKFLOW_REL), 'utf8');
+  const commands = runCommands(text);
+
+  it('reads a workflow it really parsed', () => {
+    // Every assertion below is over a filtered list, and an empty list passes
+    // all of them. This is what stops the suite going green on a regex that
+    // stopped matching, or on a workflow that was renamed out from under it.
+    expect(commands.length, `${WORKFLOW_REL} yielded no run: commands`).toBeGreaterThan(5);
+    expect(
+      commands.some((c) => c.includes('pnpm install --frozen-lockfile')),
+      'the parser did not find the install step every job carries',
+    ).toBe(true);
+  });
+
+  it('finds the test invocations, so the bound below is not guarding an absence', () => {
+    // The positive control, and it is a floor rather than an exact count on
+    // purpose: adding a leg is normal, and it must fail the bound assertion
+    // below rather than this one.
+    const testRuns = commands.filter(runsTurboTest);
+    expect(
+      testRuns.length,
+      `no \`turbo run test\` invocation found in ${WORKFLOW_REL}`,
+    ).toBeGreaterThanOrEqual(4);
+  });
+
+  it('bounds every one of them', () => {
+    const unbounded = commands.filter(runsTurboTest).filter((c) => concurrencyOf(c) === undefined);
+    expect(
+      unbounded,
+      'a `turbo run test` invocation with no --concurrency lets turbo fall back to its ' +
+        'default (10) package tasks at once, each spawning its own vitest pool:\n  ' +
+        unbounded.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('gives each a value that is actually a positive integer', () => {
+    // `--concurrency` with a missing or non-numeric value is a no-op away from
+    // the default, and reads in a diff exactly like a bound.
+    const bad = commands
+      .filter(runsTurboTest)
+      .map((c) => [c, concurrencyOf(c)])
+      .filter(([, v]) => v !== undefined && !/^[1-9]\d*$/.test(v));
+    expect(
+      bad.map(([, v]) => v),
+      `--concurrency needs a positive integer`,
+    ).toEqual([]);
+  });
+
+  it('sends the flag to turbo rather than through a package script', () => {
+    // `pnpm test -- --concurrency=2` forwards the flag to each TASK's own
+    // command (`vitest run --concurrency=2`), not to turbo — the same trap the
+    // no-network job documents for `--force`. Such a line reads as bounded and
+    // is not, so the flag must sit on a command that names turbo directly.
+    const detached = commands
+      .filter((c) => concurrencyOf(c) !== undefined)
+      .filter((c) => !runsTurboTest(c));
+    expect(
+      detached,
+      '--concurrency on a command that does not invoke `turbo run test` is forwarded to the ' +
+        `task, not to turbo:\n  ${detached.join('\n  ')}`,
+    ).toEqual([]);
+  });
+});
+
+describe('runCommands', () => {
+  // The parser decides what every assertion above sees, so its edges are pinned
+  // rather than assumed — wrong in the joining direction and a multi-line
+  // command is read as several unrelated ones.
+  it('joins a folded block into one command', () => {
+    const yaml = [
+      '      - name: Test',
+      '        run: >',
+      '          pnpm turbo run test',
+      '          --concurrency=2',
+      '',
+      '      - name: Build',
+      '        run: pnpm build',
+    ].join('\n');
+    expect(runCommands(yaml)).toEqual(['pnpm turbo run test --concurrency=2', 'pnpm build']);
+  });
+
+  it('does not merge two sibling run: keys', () => {
+    const yaml = ['        run: pnpm lint', '        run: pnpm turbo run test'].join('\n');
+    expect(runCommands(yaml)).toEqual(['pnpm lint', 'pnpm turbo run test']);
+  });
+
+  it('ends a block at a line indented no deeper than its own run: key', () => {
+    const yaml = [
+      '        run: |',
+      '          pnpm turbo run test',
+      '        env:',
+      '          FOO: bar',
+    ].join('\n');
+    expect(runCommands(yaml)).toEqual(['pnpm turbo run test']);
+  });
+});
+
+describe('runsTurboTest', () => {
+  it.each([
+    ['pnpm turbo run test --concurrency=2', true],
+    ['pnpm turbo run test --continue --concurrency=2', true],
+    ['tools/ci/no-network-test.sh pnpm exec turbo run test --force --concurrency=2', true],
+    // A task list naming test among others still runs it.
+    ['pnpm turbo run build test --concurrency=2', true],
+    // Not the test task.
+    ['pnpm turbo run typecheck', false],
+    ['pnpm turbo run build', false],
+    // A package script wrapping it is not a turbo invocation this can bound.
+    ['pnpm test', false],
+  ])('%s -> %s', (cmd, expected) => {
+    expect(runsTurboTest(cmd)).toBe(expected);
+  });
+});

--- a/packages/eslint-config/test/ci-test-concurrency.test.js
+++ b/packages/eslint-config/test/ci-test-concurrency.test.js
@@ -15,23 +15,41 @@
 // So the bound is asserted here rather than left to review. A fifth job, or a
 // fifth invocation inside an existing one, is exactly the shape that would
 // reintroduce this silently — the workflow still passes, just less often, and
-// nothing in a diff says so. `ci.yml` is already in this task's turbo `inputs`
-// (alongside the other workflows), so editing it re-runs this check rather than
-// replaying a cached pass.
+// nothing in a diff says so.
+//
+// The DIRECTORY is read, not one filename. An unbounded run is the same hazard
+// in a release workflow as in ci.yml, and four of those gate a publish on tag
+// push; reading the directory also means a workflow added tomorrow is covered
+// without editing this file. `turbo.json` hashes the same directory with a
+// glob, so editing any workflow re-runs this check rather than replaying a
+// cached pass — the two are one decision in two files, and a workflow this
+// suite reads that turbo does not hash is a guard that never runs on the edit
+// it exists to catch.
+//
+// Two spellings reach the same task, and only one of them contains the word
+// `turbo`:
+//
+//   pnpm turbo run test    — takes --concurrency, which is what bounds it
+//   pnpm test              — the root script, which is itself `turbo run test`
+//
+// The second is rejected outright rather than checked for a flag, because it
+// cannot carry one: `pnpm test -- --concurrency=2` forwards the flag to each
+// TASK's own command (`vitest run --concurrency=2`), not to turbo. A line like
+// that reads in a diff exactly like a bound and is not one.
 //
 // Deliberately NOT a check on the number: what counts as the right cap depends
 // on the runner and is settled by measuring the pass rate. What is asserted is
 // that a bound EXISTS and parses as a positive integer, since `--concurrency`
 // with no value, or with a non-number, is a silent no-op away from the default.
 
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
 import { REPO_ROOT } from './helpers/lint-invocations.js';
 
-const WORKFLOW_REL = '.github/workflows/ci.yml';
+const WORKFLOW_DIR = '.github/workflows';
 
 /**
  * Every `run:` command in a workflow, with folded/literal blocks joined.
@@ -76,59 +94,98 @@ export function runCommands(text) {
   return commands;
 }
 
+/**
+ * Every `run:` command in every workflow, tagged with the file it came from.
+ *
+ * The directory is listed rather than enumerated, so a workflow added tomorrow
+ * is covered without editing this file. Failures carry the filename because a
+ * bare command is not actionable once this reads more than one workflow.
+ * @returns {{file: string, cmd: string}[]} one entry per `run:` key
+ */
+function workflowCommands() {
+  const dir = join(REPO_ROOT, WORKFLOW_DIR);
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .sort();
+  return files.flatMap((file) =>
+    runCommands(readFileSync(join(dir, file), 'utf8')).map((cmd) => ({ file, cmd })),
+  );
+}
+
+/** `file: command`, the form every failure below reports. */
+const describeHit = ({ file, cmd }) => `${file}: ${cmd}`;
+
 /** True for a command that runs the workspace `test` task through turbo. */
 const runsTurboTest = (cmd) => /\bturbo\s+run\s+(?:[\w:@/-]+\s+)*test\b/.test(cmd);
+
+/**
+ * True for a command that reaches the `test` task through the package script.
+ *
+ * `pnpm test` and `pnpm run test` both run the root script, which is
+ * `turbo run test` — so this is an unbounded workspace test run that never says
+ * the word turbo. The lookahead keeps `pnpm test:e2e` and friends out: those are
+ * different scripts, and a colon is not a word character, so `\btest\b` alone
+ * matches them.
+ */
+const runsTestViaPackageScript = (cmd) =>
+  /\bpnpm\s+(?:run\s+)?test\b(?!\s*:)/.test(cmd) && !runsTurboTest(cmd);
 
 /** The value of `--concurrency`, in either the `=` or space-separated form. */
 const concurrencyOf = (cmd) => /--concurrency[=\s]+(\S+)/.exec(cmd)?.[1];
 
 describe('CI bounds the concurrency of every turbo test run', () => {
-  const text = readFileSync(join(REPO_ROOT, WORKFLOW_REL), 'utf8');
-  const commands = runCommands(text);
+  const hits = workflowCommands();
 
-  it('reads a workflow it really parsed', () => {
+  it('reads workflows it really parsed', () => {
     // Every assertion below is over a filtered list, and an empty list passes
     // all of them. This is what stops the suite going green on a regex that
-    // stopped matching, or on a workflow that was renamed out from under it.
-    expect(commands.length, `${WORKFLOW_REL} yielded no run: commands`).toBeGreaterThan(5);
+    // stopped matching, on a directory that moved, or on an extension filter
+    // that stopped matching the files in it.
+    const files = [...new Set(hits.map((h) => h.file))];
+    expect(files.length, `${WORKFLOW_DIR} yielded no parseable workflows`).toBeGreaterThan(5);
+    expect(files, `${WORKFLOW_DIR} no longer yields ci.yml`).toContain('ci.yml');
+    expect(hits.length, `${WORKFLOW_DIR} yielded no run: commands`).toBeGreaterThan(20);
     expect(
-      commands.some((c) => c.includes('pnpm install --frozen-lockfile')),
+      hits.some((h) => h.cmd.includes('pnpm install --frozen-lockfile')),
       'the parser did not find the install step every job carries',
     ).toBe(true);
   });
 
-  it('finds the test invocations, so the bound below is not guarding an absence', () => {
+  it('finds the test invocations, so the bounds below are not guarding an absence', () => {
     // The positive control, and it is a floor rather than an exact count on
-    // purpose: adding a leg is normal, and it must fail the bound assertion
-    // below rather than this one.
-    const testRuns = commands.filter(runsTurboTest);
+    // purpose: adding a leg is normal, and it must fail a bound assertion below
+    // rather than this one. The message names the count it found, because
+    // "found none" and "found fewer than expected" send a reader to different
+    // places and this fires for both.
+    const testRuns = hits.filter((h) => runsTurboTest(h.cmd));
     expect(
       testRuns.length,
-      `no \`turbo run test\` invocation found in ${WORKFLOW_REL}`,
+      `expected at least 4 \`turbo run test\` invocations across ${WORKFLOW_DIR}, found ` +
+        `${testRuns.length}:\n  ${testRuns.map(describeHit).join('\n  ') || '(none)'}`,
     ).toBeGreaterThanOrEqual(4);
   });
 
   it('bounds every one of them', () => {
-    const unbounded = commands.filter(runsTurboTest).filter((c) => concurrencyOf(c) === undefined);
+    const unbounded = hits.filter(
+      (h) => runsTurboTest(h.cmd) && concurrencyOf(h.cmd) === undefined,
+    );
     expect(
-      unbounded,
+      unbounded.map(describeHit),
       'a `turbo run test` invocation with no --concurrency lets turbo fall back to its ' +
-        'default (10) package tasks at once, each spawning its own vitest pool:\n  ' +
-        unbounded.join('\n  '),
+        'default (10) package tasks at once, each spawning its own vitest pool',
     ).toEqual([]);
   });
 
   it('gives each a value that is actually a positive integer', () => {
     // `--concurrency` with a missing or non-numeric value is a no-op away from
     // the default, and reads in a diff exactly like a bound.
-    const bad = commands
-      .filter(runsTurboTest)
-      .map((c) => [c, concurrencyOf(c)])
-      .filter(([, v]) => v !== undefined && !/^[1-9]\d*$/.test(v));
-    expect(
-      bad.map(([, v]) => v),
-      `--concurrency needs a positive integer`,
-    ).toEqual([]);
+    const bad = hits
+      .filter((h) => runsTurboTest(h.cmd))
+      .filter((h) => {
+        const v = concurrencyOf(h.cmd);
+        return v !== undefined && !/^[1-9]\d*$/.test(v);
+      });
+    expect(bad.map(describeHit), `--concurrency needs a positive integer`).toEqual([]);
   });
 
   it('sends the flag to turbo rather than through a package script', () => {
@@ -136,13 +193,29 @@ describe('CI bounds the concurrency of every turbo test run', () => {
     // command (`vitest run --concurrency=2`), not to turbo — the same trap the
     // no-network job documents for `--force`. Such a line reads as bounded and
     // is not, so the flag must sit on a command that names turbo directly.
-    const detached = commands
-      .filter((c) => concurrencyOf(c) !== undefined)
-      .filter((c) => !runsTurboTest(c));
+    const detached = hits.filter(
+      (h) => concurrencyOf(h.cmd) !== undefined && !runsTurboTest(h.cmd),
+    );
     expect(
-      detached,
+      detached.map(describeHit),
       '--concurrency on a command that does not invoke `turbo run test` is forwarded to the ' +
-        `task, not to turbo:\n  ${detached.join('\n  ')}`,
+        'task, not to turbo',
+    ).toEqual([]);
+  });
+
+  it('never reaches the test task through a package script', () => {
+    // The hole the assertions above cannot see. `pnpm test` runs the root
+    // script, which is `turbo run test` over all 20 packages — an unbounded
+    // workspace test run that matches no `turbo` predicate, so every filter
+    // above skips it and the suite goes green. It is also the spelling this
+    // repo used until these bounds landed, which makes it the most likely way
+    // back in. There is no bounded form of it: the flag would reach the task
+    // rather than turbo, so the fix is always to spell the turbo call.
+    const viaScript = hits.filter((h) => runsTestViaPackageScript(h.cmd));
+    expect(
+      viaScript.map(describeHit),
+      '`pnpm test` runs the root script (`turbo run test`) with no bound, and cannot take ' +
+        'one — write `pnpm turbo run test --concurrency=N` instead',
     ).toEqual([]);
   });
 });
@@ -194,5 +267,29 @@ describe('runsTurboTest', () => {
     ['pnpm test', false],
   ])('%s -> %s', (cmd, expected) => {
     expect(runsTurboTest(cmd)).toBe(expected);
+  });
+});
+
+describe('runsTestViaPackageScript', () => {
+  it.each([
+    // The root script, in both spellings pnpm accepts.
+    ['pnpm test', true],
+    ['pnpm run test', true],
+    // Already the trap the flag assertion catches; it is still a script run.
+    ['pnpm test -- --concurrency=2', true],
+    // A turbo call is bounded by the assertions above, not by this one — and
+    // both spellings contain the word `test`, so without the turbo exclusion
+    // every bounded invocation in the tree would report here.
+    ['pnpm turbo run test --concurrency=2', false],
+    ['pnpm exec turbo run test --force --concurrency=2', false],
+    // A DIFFERENT script that merely starts with the same four letters. A colon
+    // is not a word character, so `\btest\b` matches these on its own.
+    ['pnpm test:e2e', false],
+    ['pnpm run test:unit', false],
+    // Not the test task at all.
+    ['pnpm lint', false],
+    ['pnpm build', false],
+  ])('%s -> %s', (cmd, expected) => {
+    expect(runsTestViaPackageScript(cmd)).toBe(expected);
   });
 });

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -12,7 +12,7 @@ import {
 } from 'node:fs';
 import { createConnection, createServer, Socket } from 'node:net';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve, sep } from 'node:path';
+import { dirname, join, matchesGlob, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 
@@ -271,7 +271,25 @@ describe('the guard cannot be cached or dropped out of CI', () => {
         turbo,
       );
     expect(inputs).not.toBeNull();
-    expect(inputs[1]).toContain('$TURBO_ROOT$/.github/workflows/ci.yml');
+
+    // ci.yml is asserted as COVERAGE rather than as a literal entry, because a
+    // glob covers it too and the entry is one today: ci-test-concurrency.test.js
+    // reads every workflow in the directory, so turbo hashes the directory. What
+    // matters is that editing ci.yml moves this hash — which a `*.yml` glob
+    // delivers and a `*.yaml` one silently would not.
+    const entries = [...inputs[1].matchAll(/"([^"]+)"/g)]
+      .map((m) => m[1])
+      .filter((e) => e.startsWith('$TURBO_ROOT$/'))
+      .map((e) => e.slice('$TURBO_ROOT$/'.length));
+    expect(
+      entries.length,
+      'no $TURBO_ROOT$ entries parsed out of the inputs array',
+    ).toBeGreaterThan(5);
+    expect(
+      entries.some((pattern) => matchesGlob('.github/workflows/ci.yml', pattern)),
+      `no inputs entry covers .github/workflows/ci.yml:\n  ${entries.join('\n  ')}`,
+    ).toBe(true);
+
     expect(inputs[1]).toContain('$TURBO_ROOT$/tools/ci/**');
     expect(inputs[1]).toContain('$TURBO_ROOT$/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}');
   });

--- a/turbo.json
+++ b/turbo.json
@@ -134,22 +134,26 @@
         "$TURBO_ROOT$/*/*/eslint*.config.mjs",
         "$TURBO_ROOT$/*/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
         "$TURBO_ROOT$/*/*/**/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}",
-        // ci.yml, audit.yml and codeql.yml are all READ by this suite — the
-        // first for the repo-root lint/typecheck passes and the egress script,
-        // the other two by required-checks.test.js, which drives every job name
-        // and PR trigger behind a required check. A glob would be wrong here:
-        // an unread workflow in the same directory would then bust this hash on
-        // every edit.
-        "$TURBO_ROOT$/.github/workflows/ci.yml",
-        "$TURBO_ROOT$/.github/workflows/audit.yml",
-        "$TURBO_ROOT$/.github/workflows/codeql.yml",
-        // bench.yml is read by bench-harness.test.js, which asserts the
-        // benchmark job stays ADVISORY — no pull_request trigger, and results
-        // uploaded rather than compared against a threshold. Same hazard as the
-        // three above: without this entry, adding a `pull_request:` trigger
-        // moves no hash this task can see, turbo replays the cached pass, and
-        // the assertion guarding that property never runs.
-        "$TURBO_ROOT$/.github/workflows/bench.yml",
+        // EVERY workflow is read by this suite, so this is a glob rather than a
+        // list. Named individually, the entries were ci.yml (the repo-root
+        // lint/typecheck passes and the egress script), audit.yml and codeql.yml
+        // (required-checks.test.js, which drives every job name and PR trigger
+        // behind a required check), and bench.yml (bench-harness.test.js, which
+        // asserts the benchmark job stays ADVISORY). ci-test-concurrency.test.js
+        // now reads the whole directory, because an unbounded `turbo run test`
+        // is the same hazard in a release workflow as in ci.yml — and four of
+        // those gate a publish on tag push.
+        //
+        // A glob USED to be wrong here for a good reason: an unread workflow in
+        // this directory would bust the hash on every edit. That reason is gone
+        // precisely because nothing here is unread any more, which makes this
+        // entry and that suite's directory read one decision in two files. A
+        // future suite that narrows back to a filename has to narrow this too,
+        // or the cost returns. The hazard in the other direction is the one that
+        // matters: a workflow this suite reads and turbo does not hash moves no
+        // hash on the edit the guard exists to catch, so turbo replays a cached
+        // green and the assertion never runs.
+        "$TURBO_ROOT$/.github/workflows/*.yml",
         "$TURBO_ROOT$/tools/ci/**",
         "$TURBO_ROOT$/package.json",
         "$TURBO_ROOT$/tsconfig.root.json",


### PR DESCRIPTION
## What

Pass `--concurrency=2` to all four `turbo run test` invocations in `ci.yml`, and add a guard so a fifth cannot appear unbounded.

## Why

Two layers of parallelism multiply on a hosted runner:

- turbo runs **package** test tasks concurrently — its default is 10
- each package's vitest then spawns **its own worker pool**, sized to the machine

Unbounded, that puts tens of processes on a four-core runner. They contend for **disk**, not CPU: this repo never mocks `node:sqlite` or the filesystem, so every store test does real fsync-heavy I/O in a real temp dir. Under that contention a hook timeout stops measuring the code under test and starts measuring queue depth — which is why the symptom was a *rotating cast of unrelated suites* reporting `Hook timed out`, on legs that go green if you press the button again.

Both multiplicands are real today:

```
$ node -e '…count package.json files with a scripts.test…'
20
$ git ls-files '*vitest.config*' | xargs grep -l "maxWorkers\|maxForks\|poolOptions\|fileParallelism\|maxThreads" | wc -l
0
```

20 packages with a `test` script, and **no** vitest config bounding a worker pool anywhere in the workspace.

## The trap this deliberately avoids

The flag is spelled on the turbo call, never through `pnpm test`:

```
pnpm test -- --concurrency=2     # forwards to `vitest run`, NOT to turbo
```

`pnpm test -- <flag>` forwards to each **task's** own command — the same trap the no-network job already documents for `--force`. Such a line reads as bounded in a diff and is not. One guard assertion exists solely to catch that shape.

## Baseline to beat

Windows leg across the last 25 CI runs, sampled 2026-08-11:

```
$ for id in $(gh run list --workflow=ci.yml --limit=25 --json databaseId --jq '.[].databaseId'); do
    gh api "repos/akasecurity/ai-tc/actions/runs/$id/jobs" \
      --jq '.jobs[] | select(.name | test("Windows")) | .conclusion'
  done | sort | uniq -c
   5 cancelled
   7 failure
  11 success
```

**11 of 18 completed attempts — a 61% pass rate.** Cancelled runs are superseded pushes rather than outcomes, so they are excluded from the denominator.

That is the number to beat. I will sample this branch's Windows leg several times and report against it, rather than calling it fixed off one green run.

## The guard

`packages/eslint-config/test/ci-test-concurrency.test.js` — 15 cases. It asserts that a bound **exists**, parses as a **positive integer**, and sits on a command naming **turbo** directly. It deliberately does *not* assert the value: what cap is right depends on the runner and is settled by measuring the pass rate, not by review.

Verified non-vacuous by five mutations, each caught by its intended assertion:

| Mutation | Caught by |
| --- | --- |
| drop the cap from one leg | `bounds every one of them` |
| `--concurrency=all` | `gives each a value that is actually a positive integer` |
| move the flag to `pnpm test --` | `sends the flag to turbo rather than through a package script` |
| parser stops joining folded blocks | `finds the test invocations` + the parser cases |
| parser returns `[]` | `reads a workflow it really parsed` |

That last row is why the non-emptiness assertions are there at all: under it, `bounds every one of them` **stayed green**, because an empty list satisfies it.

The YAML `run:` reader is hand-rolled and its edges are pinned, because the Windows leg spells its command across a dozen lines — a line-wise grep sees `pnpm turbo run test` and `--concurrency=2` as unrelated strings and can be satisfied, or fooled, by either alone. Its output was cross-checked against a real YAML parser: both agree on the same four commands.

`ci.yml` is already in this task's turbo `inputs`, so editing it re-runs this check rather than replaying a cached pass.

## Deliberately not included

The vitest fork caps and the platform-aware timeouts. Bundling "less contention" with "more headroom" would make it impossible to tell which one worked. Concurrency is the single biggest lever; if the pass rate does not move enough, the fork caps are the next step with a clean before/after.

## Local checks

```
$ pnpm exec vitest run          # packages/eslint-config
 Test Files  11 passed (11)
      Tests  959 passed (959)
```

`lint:root`, `typecheck:root`, `check:portability` and prettier all clean.
