### PR TITLE
fix(test): make PATH shims cross-platform and fail closed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1122,6 +1122,55 @@ probe reporting itself broken, the probe file gone, started as root, and the one
 path where the command actually runs. Change a probe and a case fails; delete one and
 the case that covered it fails.
 
+### The PATH shim, and why it fails OPEN
+
+A suite that drives a **built** script cannot reach that script's spawn seams — they are
+in-process, and the script is another process. So the external command is faked by putting a
+controlled executable first on the child's `PATH`: the journey harnesses' judge stub
+(`claude`/`codex`/`agy`) and `plugins/claude-code/test/provenance.test.ts`'s fake `npm`.
+
+**A shim that does not land is not an `ENOENT`.** Resolution walks the rest of `PATH` and runs
+the REAL installed binary — measured by joining `PATH` with `';'` on a POSIX host, which
+resolved and executed the live `claude` CLI. So the failure mode is a suite that looks hermetic
+while reaching a live model or the npm registry, and no gate above sees it: the ESLint ban reads
+source, the vitest guard cannot follow a child process, and the Linux `No-network` job is the
+only one that would — on the one platform where the shim happens to work.
+
+`plugins/*/test/helpers/path-shim.ts` is the shared answer, and it is a **peer copy per
+plugin** for the reason `no-echo.ts` is: a package wall blocks the import, and a copy takes its
+`path-shim.test.ts` with it — or `assertShimResolves` can be weakened back into a no-op with
+every caller staying green. Four properties are load-bearing:
+
+- **Resolution is PROVEN before a chain is driven, not assumed.** `assertShimResolves` spawns
+  the command the way the code under test will, so a miss is a red setup rather than a live
+  call. It **performs** resolution rather than modelling it, so it agrees with libuv about
+  `PATHEXT` instead of restating it.
+- **`shell` and `cwd` must mirror the spawn being stood in for**, because the probe cannot
+  discover either and PATH is not the whole of resolution. `provenance.ts` exports its
+  `USE_SHELL` so the probe imports the runner's own condition rather than re-deriving it;
+  `triage/judge.ts`'s `spawnClaude` uses no shell. **Windows searches the working directory
+  before walking PATH**, so a probe taken under a different cwd than its subject faithfully
+  performs a resolution the subject never performs — which is why the journey harness keys its
+  proof by cwd rather than latching it once, its `run()` taking a per-step cwd.
+- **The probe answer comes before anything else the stub does**, so probing is never recorded
+  as an invocation — which is what a `judgeWasInvoked()`-style sentinel assertion rests on.
+- **Three POSIX-only defects, not one**: `path.delimiter` rather than a literal `':'`, a `.cmd`
+  launcher on win32 rather than an extensionless `#!` file, and no reliance on a `chmod` that
+  is a no-op there. `tools/portability-gate`'s `path-separator-literal` rule catches the first
+  returning to a call site, which is how it arrived.
+
+`writeCommandShim` takes an optional `platform` (as `judgeEnv` does), so both branches are
+driven from either host: writing the other platform's form is a resolution failure on this one.
+Pin the **artifact** as well as the refusal there — a branch that wrote nothing also refuses,
+and reads identically.
+
+Two smaller things the same reasoning decides. The probe's own deadline sits **well under the
+package's `testTimeout`**, because it runs inside a test body: equal deadlines mean vitest wins
+the race and the refusal — the whole point of failing closed — is replaced by a bare timeout.
+And `shimmedPath` returns the bin dir **alone** when there is no base PATH: an empty PATH entry
+means the current directory to execvp and to libuv, so a trailing separator quietly puts the cwd
+on a search path whose only purpose is that nothing but the shim is on it.
+
 ### The adversarial fixture corpus
 
 `test/fixtures/adversarial/hostile-repo/` builds the hostile trees the tree walkers

--- a/plugins/antigravity/test/helpers/path-shim.test.ts
+++ b/plugins/antigravity/test/helpers/path-shim.test.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { assertShimResolves, shimMarker, shimmedPath, writeCommandShim } from './path-shim.ts';
+
+// A name no real binary on any developer machine or runner answers to, so a
+// resolution MISS in this suite can only ever fail — never reach a live tool.
+// That matters more here than anywhere else: this file exists to drive the miss
+// case on purpose.
+const COMMAND = 'aka-shim-fixture-cmd';
+
+// The shim body every case writes: records that it ran, then prints a word the
+// caller can match. Written behind the helper's prologue, so the probe answer
+// sits ahead of the sentinel write.
+const bodyWritingSentinel = (sentinelPath: string): string =>
+  `require('node:fs').writeFileSync(${JSON.stringify(sentinelPath)}, '');
+process.stdout.write('SHIM-BODY-RAN');
+`;
+
+// A third-party binary that happens to answer to the same name — what the real
+// installed CLI is to a judge stub. Deliberately NOT written through
+// writeCommandShim: the whole point is that it runs cleanly and answers the
+// probe with something other than this suite's marker.
+const writeForeignBinary = (dir: string, command: string): void => {
+  const js = "process.stdout.write('FOREIGN-TOOL 1.2.3');\n";
+  if (process.platform === 'win32') {
+    writeFileSync(join(dir, `${command}-foreign.js`), js);
+    writeFileSync(
+      join(dir, `${command}.cmd`),
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-foreign.js" %*\r\n`,
+    );
+    return;
+  }
+  const binPath = join(dir, command);
+  writeFileSync(binPath, `#!/usr/bin/env node\n${js}`);
+  chmodSync(binPath, 0o755);
+};
+
+const dirs: string[] = [];
+const tempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'aka-path-shim-test-'));
+  dirs.push(dir);
+  return dir;
+};
+
+// node's own dir, so a POSIX shim's `#!/usr/bin/env node` line resolves without
+// dragging the whole host PATH (and its real binaries) into these cases.
+const NODE_DIR = dirname(process.execPath);
+
+afterEach(() => {
+  while (dirs.length > 0) rmSync(dirs.pop() ?? '', { recursive: true, force: true });
+});
+
+const errorFrom = (fn: () => unknown): Error | undefined => {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+};
+
+// The weaker check this helper replaced: "the spawn worked". Kept as the paired
+// control — a case is only evidence that identity is being checked if the
+// spawn-succeeded form would have passed on the same input.
+const spawnSucceeded = (command: string, env: NodeJS.ProcessEnv): boolean => {
+  try {
+    execFileSync(command, ['--version'], {
+      env,
+      encoding: 'utf8',
+      timeout: 20_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('shimmedPath', () => {
+  it('prepends the shim dir as a real first entry under the platform delimiter', () => {
+    const base = ['/first/base', '/second/base'].join(delimiter);
+    const entries = shimmedPath('/shim/dir', base).split(delimiter);
+    expect(entries[0]).toBe('/shim/dir');
+    expect(entries.slice(1)).toEqual(['/first/base', '/second/base']);
+  });
+
+  it('yields the shim dir ALONE when there is no base PATH, leaving no empty entry', () => {
+    // Asserting entry [0] would pass on a trailing delimiter too, which is the
+    // bug: an empty PATH element is read as the CURRENT DIRECTORY by execvp and
+    // by libuv's own search, so `${binDir}${delimiter}` quietly adds the cwd to
+    // a search path whose whole purpose is that only the shim is on it.
+    expect(shimmedPath('/shim/dir', undefined)).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', '')).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', undefined).split(delimiter)).toEqual(['/shim/dir']);
+  });
+});
+
+describe('writeCommandShim + assertShimResolves', () => {
+  it('resolves the shim written for the running platform', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('answers the probe WITHOUT recording an invocation, and records one when really run', () => {
+    const binDir = tempDir();
+    const sentinel = join(binDir, 'ran');
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(sentinel));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    assertShimResolves(COMMAND, env);
+    // The property a `judgeWasInvoked()`-style sentinel depends on: probing is
+    // not invoking. Lose the ordering in the prologue and every "the egress
+    // never happened" assertion starts failing for a reason that is not the
+    // one under test.
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Positive control: the sentinel IS written when the shim runs for real, so
+    // the absence above is the ordering rather than a shim that never runs.
+    const out = execFileSync(COMMAND, [], { env, encoding: 'utf8', timeout: 20_000 });
+    expect(out).toContain('SHIM-BODY-RAN');
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('performs the probe under the cwd it is given, not this process s', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    // A real cwd changes nothing on POSIX (only Windows searches it), so the
+    // decisive check is a cwd that cannot be entered: the spawn itself fails,
+    // which can only happen if the option reached the spawn. Drop the cwd from
+    // assertShimResolves and this resolves cleanly and the case goes red —
+    // asserting a successful resolution under a valid cwd would not, since
+    // ignoring the option produces exactly the same pass.
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env, { cwd: join(binDir, 'no-such-dir') });
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+    expect(err?.message).toContain('the spawn failed');
+
+    // Positive control on the same shim: with no cwd override it resolves, so
+    // the refusal above is the cwd and not a shim that never worked.
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('refuses when the shim dir is not on PATH at all', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: NODE_DIR };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+  });
+
+  it('refuses when another executable of the same name answers first', () => {
+    // The fail-open shape itself: something DOES resolve and DOES run, it is
+    // just not the stub. A judge stub that missed this way would be the real
+    // CLI, and the call would reach a live model.
+    const decoyDir = tempDir();
+    writeForeignBinary(decoyDir, COMMAND);
+    const shimDir = tempDir();
+    writeCommandShim(shimDir, COMMAND, bodyWritingSentinel(join(shimDir, 'ran')));
+    const env = { PATH: shimmedPath(decoyDir, shimmedPath(shimDir, NODE_DIR)) };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+    // Paired control: the weaker "did the spawn work?" check passes here. The
+    // decoy answers the probe cleanly — it just is not ours — so only an
+    // identity check can tell this case from the passing one above.
+    expect(spawnSucceeded(COMMAND, env)).toBe(true);
+  });
+
+  it('names the live-call consequence and the Windows cause in its refusal', () => {
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, { PATH: NODE_DIR });
+    });
+    // A setup failure is only useful if it says why continuing is unsafe.
+    expect(err?.message).toContain('does NOT fail closed');
+    expect(err?.message).toContain('PATHEXT');
+  });
+});
+
+describe('the platform branch, driven from either host', () => {
+  // The win32 shim is a `.cmd` launcher, which POSIX cannot execute; the POSIX
+  // shim is an extensionless file, which Windows will not resolve for a bare
+  // name. So writing the OTHER platform's form is a resolution failure on this
+  // one — which is exactly what makes it a live check of the refusal path
+  // rather than an assertion about a string.
+  const otherPlatform = process.platform === 'win32' ? 'linux' : 'win32';
+
+  it(`refuses a shim written for ${otherPlatform} while running on ${process.platform}`, () => {
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      otherPlatform,
+    );
+
+    // Pin the ARTIFACT, not just the refusal. A branch that wrote nothing at all
+    // would also refuse, and would look identical here — so a POSIX runner
+    // checking only the throw proves nothing about what win32 gets.
+    if (otherPlatform === 'win32') {
+      expect(written.endsWith(`${COMMAND}.cmd`)).toBe(true);
+      expect(existsSync(written)).toBe(true);
+      expect(existsSync(join(binDir, `${COMMAND}-shim.js`))).toBe(true);
+    } else {
+      expect(written).toBe(join(binDir, COMMAND));
+      expect(existsSync(written)).toBe(true);
+    }
+
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+  });
+
+  it('writes the running platform form under an explicit platform argument too', () => {
+    // Guards the parameter itself: a `platform` argument the writer ignores
+    // would leave the case above passing for the wrong reason — every shim
+    // would be the running platform's, and a `.cmd` would never be written.
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      process.platform,
+    );
+    expect(written.endsWith('.cmd')).toBe(process.platform === 'win32');
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, { PATH: shimmedPath(binDir, NODE_DIR) });
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('shimMarker', () => {
+  it('is per command, so one command s shim cannot satisfy another s probe', () => {
+    expect(shimMarker('alpha')).not.toBe(shimMarker('beta'));
+  });
+});

--- a/plugins/antigravity/test/helpers/path-shim.ts
+++ b/plugins/antigravity/test/helpers/path-shim.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+/**
+ * A controlled executable placed first on a child's PATH, so a suite driving a
+ * BUILT script can fake the external command that script shells out to.
+ *
+ * This is the only way to fake such a command: the spawns live behind a process
+ * boundary (`triage/judge.ts`'s `spawnClaude`, `provenance.ts`'s npm runner),
+ * so their dependency-injection seams are in-process only and unreachable from
+ * a test that runs the real built script.
+ *
+ * ## The shim fails OPEN, which is why every user of it must probe first
+ *
+ * A shim that does not land is NOT an `ENOENT`. Resolution simply continues
+ * down the rest of PATH and finds the REAL installed binary — measured on a
+ * POSIX host by joining PATH with the wrong separator, which resolved and ran
+ * the real `claude`, returning that live binary's own error. For a judge stub
+ * that means a suite quietly making a live model call with its seeded hits on
+ * stdin; a sentinel checked afterwards reports the egress rather than
+ * preventing it.
+ *
+ * So a caller asserts resolution BEFORE it drives anything —
+ * `assertShimResolves` — and a failure there is a red setup, never a live call.
+ *
+ * ## Three ways a hand-rolled shim is POSIX-only
+ *
+ * 1. **Separator.** PATH is `:`-joined on POSIX and `;`-joined on Windows. A
+ *    `:`-joined PATH on Windows is one malformed entry, so the shim dir is not
+ *    on PATH at all. `shimmedPath` uses `path.delimiter`.
+ * 2. **Extension.** An extensionless file with a `#!` line is executable on
+ *    POSIX and unrunnable on Windows, which resolves a bare command name
+ *    through `PATHEXT`. `writeCommandShim` writes a `.cmd` launcher there.
+ * 3. **Mode bits.** `chmodSync(…, 0o755)` is a no-op on Windows, so a shim that
+ *    relies on it has no executable bit to rely on. It is skipped there.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `plugins/claude-code` and
+ * `plugins/codex` carry peer copies — each taking a `path-shim.test.ts`
+ * with it, or `assertShimResolves` can be weakened back into a no-op with
+ * every caller staying green.
+ */
+
+/**
+ * The argument the resolution probe sends.
+ *
+ * Deliberately `--version` rather than a bespoke flag: when resolution has
+ * FAILED, the probe itself is what lands on the real binary, and `--version` is
+ * the one argument every candidate here answers locally, from its own package
+ * metadata, without contacting a model or a registry. A bespoke flag would be
+ * rejected — usually harmlessly — by an argument parser this repo does not own.
+ */
+export const SHIM_PROBE_ARG = '--version';
+
+/**
+ * How long the probe may take before the resolved binary is force-killed.
+ *
+ * Deliberately well under the 20s `testTimeout` every plugin package sets: the
+ * probe runs inside a test body, so a deadline equal to vitest's own means
+ * vitest wins the race and the refusal below — the entire point of failing
+ * closed — is replaced by a bare "test timed out". A binary that has not
+ * answered `--version` in ten seconds is not going to.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** The token a shim prints for {@link SHIM_PROBE_ARG}, and nothing else does. */
+export function shimMarker(command: string): string {
+  return `AKA-TEST-SHIM-OK:${command}`;
+}
+
+/**
+ * The prologue every shim body is written behind: the shebang and strict-mode
+ * directive a POSIX shim needs, then the probe answer.
+ *
+ * The probe is answered FIRST — ahead of any sentinel write or argv parsing —
+ * so probing can never be mistaken for an invocation by a suite asserting the
+ * command was not spawned.
+ */
+function shimPrologue(command: string): string {
+  return `#!/usr/bin/env node
+'use strict';
+// Answer the harness's resolution probe before doing anything else, so a probe
+// is never recorded as an invocation.
+if (process.argv.slice(2).includes(${JSON.stringify(SHIM_PROBE_ARG)})) {
+  process.stdout.write(${JSON.stringify(shimMarker(command))});
+  process.exit(0);
+}
+`;
+}
+
+/**
+ * `basePath` with `binDir` prepended, joined the way the RUNNING platform joins
+ * PATH. A literal `':'` here is the first of the three POSIX-only defects
+ * above.
+ *
+ * An absent or empty `basePath` yields the bin dir ALONE, with no trailing
+ * separator: an empty PATH entry is read as the current directory by execvp and
+ * by libuv's own search, so the convenient-looking `${binDir}${delimiter}` would
+ * quietly add the working directory to a search path whose whole purpose is that
+ * only the shim is on it.
+ */
+export function shimmedPath(binDir: string, basePath: string | undefined): string {
+  return basePath ? `${binDir}${delimiter}${basePath}` : binDir;
+}
+
+/**
+ * Write `body` into `binDir` as something the platform will execute for the
+ * bare name `command`, and return the file a caller would name in an error.
+ *
+ * POSIX gets the extensionless file the `#!` line makes runnable. Windows gets
+ * the body as a plain `.js` beside a `<command>.cmd` launcher that runs it
+ * under this process's own node — an absolute interpreter path, so the launcher
+ * does not additionally depend on node being on the child's PATH.
+ *
+ * `platform` defaults to the running one and exists so both branches are
+ * reachable from either host, the way `triage/judge.ts`'s `judgeEnv` takes one.
+ * Writing the other platform's form is a resolution failure on this one, which
+ * is what lets a POSIX runner drive the win32 branch against the real refusal
+ * rather than against a description of it.
+ */
+export function writeCommandShim(
+  binDir: string,
+  command: string,
+  body: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const source = shimPrologue(command) + body;
+  if (platform === 'win32') {
+    const scriptPath = join(binDir, `${command}-shim.js`);
+    writeFileSync(scriptPath, source);
+    const launcherPath = join(binDir, `${command}.cmd`);
+    // CRLF, because a batch file is read by cmd.exe. %~dp0 carries its own
+    // trailing separator; %* forwards argv, and stdin passes through untouched.
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-shim.js" %*\r\n`,
+    );
+    // No chmod: it is a no-op on Windows, and PATHEXT decides what runs.
+    return launcherPath;
+  }
+  const shimPath = join(binDir, command);
+  writeFileSync(shimPath, source);
+  chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
+export interface ShimResolutionOptions {
+  /**
+   * Mirror the spawn this shim stands in for. Pass `true` wherever the code
+   * under test spawns with `shell` — on Windows that is the difference between
+   * resolving a `.cmd` and skipping it, so a probe that disagrees with its
+   * subject is a false verdict in one direction or the other.
+   */
+  readonly shell?: boolean;
+  /**
+   * The working directory the spawn being stood in for will use, when it is not
+   * this process's own.
+   *
+   * PATH is not the whole of resolution: Windows searches the working directory
+   * BEFORE walking PATH, so a probe run from a different cwd than its subject
+   * verifies a resolution the subject never performs — and a binary sitting in
+   * the subject's cwd wins silently. Pass whatever `cwd` reaches the real spawn.
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * Refuse to continue unless the bare name `command` resolves to the shim under
+ * `env.PATH`.
+ *
+ * Resolution is not modelled, it is PERFORMED — the probe spawns the command
+ * the same way the code under test will, so it agrees about `PATHEXT` and about
+ * every other rule a hand-rolled resolver would have to restate. `options.shell`
+ * and `options.cwd` are the axes the CALLER must supply, because they belong to
+ * the spawn being stood in for rather than to the shim, and the probe cannot
+ * discover either: get one wrong and the probe faithfully performs a resolution
+ * its subject never performs.
+ *
+ * Throws — loudly, and naming the cause — rather than returning a boolean: a
+ * caller that forgets to check a boolean is back to the fail-open behaviour
+ * this exists to remove.
+ */
+export function assertShimResolves(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  options: ShimResolutionOptions = {},
+): void {
+  const marker = shimMarker(command);
+  // Assigned on both paths below — the success value, or the failed spawn's own
+  // stdout, which may still carry the marker.
+  let output: string;
+  let spawnFailure: string | undefined;
+  try {
+    output = execFileSync(command, [SHIM_PROBE_ARG], {
+      env,
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: options.shell ?? false,
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    });
+  } catch (err) {
+    // Narrowed rather than `unknown`: an unknown here stringifies to
+    // [object Object] instead of the fields a reader needs.
+    const e = err as {
+      code?: string;
+      status?: number;
+      signal?: string;
+      stdout?: string;
+      stderr?: string;
+    };
+    // A non-zero exit still carries both streams, and stdout may hold the marker
+    // — a shim that answered and then failed for its own reasons has resolved,
+    // which is the only question being asked here. Reading it is what keeps a
+    // real resolution from being reported as a miss.
+    output = e.stdout ?? '';
+    const status = e.status === undefined ? '(none)' : String(e.status);
+    // stderr is the only thing that explains a genuine failure, so it belongs in
+    // the one message written to diagnose one.
+    const stderr = (e.stderr ?? '').trim();
+    spawnFailure =
+      `code=${e.code ?? '(none)'} status=${status} signal=${e.signal ?? '(none)'}` +
+      (stderr === '' ? '' : ` stderr=${JSON.stringify(stderr.slice(0, 200))}`);
+  }
+  if (output.includes(marker)) return;
+
+  const sawInstead =
+    spawnFailure !== undefined
+      ? `the spawn failed (${spawnFailure})`
+      : `it answered ${JSON.stringify(output.trim().slice(0, 120))}`;
+  throw new Error(
+    [
+      `PATH shim for "${command}" did not resolve to the test stub — ${sawInstead}.`,
+      'This is a SETUP failure and the suite must not continue: a shim that does',
+      'not land does NOT fail closed. Resolution carries on down PATH and finds',
+      `the REAL installed "${command}", so driving the chain from here would make`,
+      'a live call with the seeded fixtures as its input.',
+      'On Windows the usual cause is that execFile does no PATHEXT resolution and',
+      'refuses to spawn a .cmd/.bat without a shell (the CVE-2024-27980 fix) — see',
+      "packages/local-ops/src/exec.ts's USE_SHELL for the same constraint in",
+      'shipped code. On POSIX, check the shim is executable and that PATH was',
+      'joined with path.delimiter.',
+    ].join(' '),
+  );
+}

--- a/plugins/antigravity/test/journey/no-model-judge-consent.journey.test.ts
+++ b/plugins/antigravity/test/journey/no-model-judge-consent.journey.test.ts
@@ -24,21 +24,15 @@
  * uncalled. Nothing can reach the model API on this path.
  */
 import { spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { bundledDetections } from '@akasecurity/plugin-sdk';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { assertShimResolves, shimmedPath, writeCommandShim } from '../helpers/path-shim.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test/journey -> plugins/antigravity
@@ -71,13 +65,18 @@ interface StepResult {
 // POSIX, so pointing HOME at a temp dir isolates the whole chain — no
 // script-level flag or process.env read is added to shipped code. The child env
 // is built from scratch (never the host env): PATH carries only the stub-judge
-// bin dir plus node's own dir, so the stub `agy` is the ONLY resolvable judge
-// and the `#!/usr/bin/env node` shebang still finds node.
+// bin dir plus node's own dir, so a real `agy` on the developer's PATH is not
+// reachable through it, and the shebang still finds node. That is a narrower
+// claim than "the stub is the only resolvable judge" — PATH is not the whole
+// of resolution (Windows searches the working and system directories first),
+// and a stub that fails to land is answered by whatever is, not by an ENOENT.
+// assertShimResolves in run() is what closes that gap.
 class SetupJourney {
   readonly home: string;
   // The settings.json the onboarding writer records the consent into.
   readonly settingsPath: string;
   private readonly binDir: string;
+  private shimProven = false;
 
   constructor() {
     this.home = mkdtempSync(join(tmpdir(), 'aka-antigravity-journey-home-'));
@@ -171,10 +170,22 @@ class SetupJourney {
       USERPROFILE: this.home,
       // Stub judge first on PATH so apply-suppressions' `agy` spawn hits
       // it, never a live model; node's own dir second so the stub's
-      // `#!/usr/bin/env node` shebang resolves. Nothing else from the host
-      // environment reaches the chain.
-      PATH: `${this.binDir}:${dirname(process.execPath)}`,
+      // `#!/usr/bin/env node` shebang resolves — that shebang is the POSIX
+      // branch of writeCommandShim; on Windows the stub is a .cmd naming an
+      // absolute node, so node's dir is on PATH for POSIX's sake, not both.
+      // Nothing else from the host environment reaches the chain.
+      PATH: shimmedPath(this.binDir, dirname(process.execPath)),
     };
+    // Proven once per journey, before the first script runs. A shim that does
+    // not land does NOT fail closed: resolution keeps walking PATH and finds a
+    // real installed `agy`, so the chain would reach a live model and this
+    // suite's load-bearing `judgeWasInvoked()` assertion would pass for the
+    // wrong reason — nothing ran because nothing COULD run. spawnAgy uses no
+    // `shell`, so the probe must not either.
+    if (!this.shimProven) {
+      assertShimResolves('agy', env);
+      this.shimProven = true;
+    }
     // spawnSync (not execFileSync) so BOTH streams are captured on the success
     // path too — the stderr assertions below must see what a wizard transcript
     // would see, and execFileSync only surfaces stderr when the child fails.
@@ -199,9 +210,7 @@ class SetupJourney {
   // envelope on stdout — the first hit per (category, rule) surfaced (genuine),
   // the rest marked routine false positives. No live model is ever hit.
   private writeFakeJudge(): void {
-    const src = `#!/usr/bin/env node
-'use strict';
-// Record that the judge actually ran, so a test can prove the consent gate
+    const body = `// Record that the judge actually ran, so a test can prove the consent gate
 // stopped the egress at the process boundary (see judgeWasInvoked).
 require('node:fs').writeFileSync(${JSON.stringify(this.judgeSentinelPath)}, '');
 const args = process.argv.slice(2);
@@ -253,9 +262,9 @@ process.stdout.write(JSON.stringify({
   response: '\`\`\`json\\n' + JSON.stringify(verdict) + '\\n\`\`\`',
 }));
 `;
-    const path = join(this.binDir, 'agy');
-    writeFileSync(path, src);
-    chmodSync(path, 0o755);
+    // writeCommandShim owns the shebang, the mode bits and — on Windows — the
+    // .cmd launcher that makes a bare `agy` resolvable at all.
+    writeCommandShim(this.binDir, 'agy', body);
   }
 }
 

--- a/plugins/claude-code/src/provenance.ts
+++ b/plugins/claude-code/src/provenance.ts
@@ -35,7 +35,12 @@ export type NpmRunner = (args: readonly string[]) => NpmRunResult;
 // On Windows the global `npm` binary is `npm.cmd`; execFile refuses to spawn a
 // `.cmd` without a shell (post CVE-2024-27980). Route through the shell there.
 // The args are fixed flags with no shell metacharacters, so no quoting concern.
-const USE_SHELL = process.platform === 'win32';
+//
+// Exported because a suite that stands a fake `npm` in front of this runner has
+// to probe resolution under the SAME spawn shape — a shell-free probe against a
+// shelled runner reports a false miss, and the reverse reports a false pass.
+// Re-deriving the condition there would let the two drift silently apart.
+export const USE_SHELL = process.platform === 'win32';
 
 // Real subprocess runner. When the budget elapses the child is force-killed with
 // SIGKILL (which a child cannot trap or ignore), so a hung shell-out is bounded

--- a/plugins/claude-code/test/helpers/path-shim.test.ts
+++ b/plugins/claude-code/test/helpers/path-shim.test.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { assertShimResolves, shimMarker, shimmedPath, writeCommandShim } from './path-shim.ts';
+
+// A name no real binary on any developer machine or runner answers to, so a
+// resolution MISS in this suite can only ever fail — never reach a live tool.
+// That matters more here than anywhere else: this file exists to drive the miss
+// case on purpose.
+const COMMAND = 'aka-shim-fixture-cmd';
+
+// The shim body every case writes: records that it ran, then prints a word the
+// caller can match. Written behind the helper's prologue, so the probe answer
+// sits ahead of the sentinel write.
+const bodyWritingSentinel = (sentinelPath: string): string =>
+  `require('node:fs').writeFileSync(${JSON.stringify(sentinelPath)}, '');
+process.stdout.write('SHIM-BODY-RAN');
+`;
+
+// A third-party binary that happens to answer to the same name — what the real
+// installed CLI is to a judge stub. Deliberately NOT written through
+// writeCommandShim: the whole point is that it runs cleanly and answers the
+// probe with something other than this suite's marker.
+const writeForeignBinary = (dir: string, command: string): void => {
+  const js = "process.stdout.write('FOREIGN-TOOL 1.2.3');\n";
+  if (process.platform === 'win32') {
+    writeFileSync(join(dir, `${command}-foreign.js`), js);
+    writeFileSync(
+      join(dir, `${command}.cmd`),
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-foreign.js" %*\r\n`,
+    );
+    return;
+  }
+  const binPath = join(dir, command);
+  writeFileSync(binPath, `#!/usr/bin/env node\n${js}`);
+  chmodSync(binPath, 0o755);
+};
+
+const dirs: string[] = [];
+const tempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'aka-path-shim-test-'));
+  dirs.push(dir);
+  return dir;
+};
+
+// node's own dir, so a POSIX shim's `#!/usr/bin/env node` line resolves without
+// dragging the whole host PATH (and its real binaries) into these cases.
+const NODE_DIR = dirname(process.execPath);
+
+afterEach(() => {
+  while (dirs.length > 0) rmSync(dirs.pop() ?? '', { recursive: true, force: true });
+});
+
+const errorFrom = (fn: () => unknown): Error | undefined => {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+};
+
+// The weaker check this helper replaced: "the spawn worked". Kept as the paired
+// control — a case is only evidence that identity is being checked if the
+// spawn-succeeded form would have passed on the same input.
+const spawnSucceeded = (command: string, env: NodeJS.ProcessEnv): boolean => {
+  try {
+    execFileSync(command, ['--version'], {
+      env,
+      encoding: 'utf8',
+      timeout: 20_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('shimmedPath', () => {
+  it('prepends the shim dir as a real first entry under the platform delimiter', () => {
+    const base = ['/first/base', '/second/base'].join(delimiter);
+    const entries = shimmedPath('/shim/dir', base).split(delimiter);
+    expect(entries[0]).toBe('/shim/dir');
+    expect(entries.slice(1)).toEqual(['/first/base', '/second/base']);
+  });
+
+  it('yields the shim dir ALONE when there is no base PATH, leaving no empty entry', () => {
+    // Asserting entry [0] would pass on a trailing delimiter too, which is the
+    // bug: an empty PATH element is read as the CURRENT DIRECTORY by execvp and
+    // by libuv's own search, so `${binDir}${delimiter}` quietly adds the cwd to
+    // a search path whose whole purpose is that only the shim is on it.
+    expect(shimmedPath('/shim/dir', undefined)).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', '')).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', undefined).split(delimiter)).toEqual(['/shim/dir']);
+  });
+});
+
+describe('writeCommandShim + assertShimResolves', () => {
+  it('resolves the shim written for the running platform', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('answers the probe WITHOUT recording an invocation, and records one when really run', () => {
+    const binDir = tempDir();
+    const sentinel = join(binDir, 'ran');
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(sentinel));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    assertShimResolves(COMMAND, env);
+    // The property a `judgeWasInvoked()`-style sentinel depends on: probing is
+    // not invoking. Lose the ordering in the prologue and every "the egress
+    // never happened" assertion starts failing for a reason that is not the
+    // one under test.
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Positive control: the sentinel IS written when the shim runs for real, so
+    // the absence above is the ordering rather than a shim that never runs.
+    const out = execFileSync(COMMAND, [], { env, encoding: 'utf8', timeout: 20_000 });
+    expect(out).toContain('SHIM-BODY-RAN');
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('performs the probe under the cwd it is given, not this process s', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    // A real cwd changes nothing on POSIX (only Windows searches it), so the
+    // decisive check is a cwd that cannot be entered: the spawn itself fails,
+    // which can only happen if the option reached the spawn. Drop the cwd from
+    // assertShimResolves and this resolves cleanly and the case goes red —
+    // asserting a successful resolution under a valid cwd would not, since
+    // ignoring the option produces exactly the same pass.
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env, { cwd: join(binDir, 'no-such-dir') });
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+    expect(err?.message).toContain('the spawn failed');
+
+    // Positive control on the same shim: with no cwd override it resolves, so
+    // the refusal above is the cwd and not a shim that never worked.
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('refuses when the shim dir is not on PATH at all', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: NODE_DIR };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+  });
+
+  it('refuses when another executable of the same name answers first', () => {
+    // The fail-open shape itself: something DOES resolve and DOES run, it is
+    // just not the stub. A judge stub that missed this way would be the real
+    // CLI, and the call would reach a live model.
+    const decoyDir = tempDir();
+    writeForeignBinary(decoyDir, COMMAND);
+    const shimDir = tempDir();
+    writeCommandShim(shimDir, COMMAND, bodyWritingSentinel(join(shimDir, 'ran')));
+    const env = { PATH: shimmedPath(decoyDir, shimmedPath(shimDir, NODE_DIR)) };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+    // Paired control: the weaker "did the spawn work?" check passes here. The
+    // decoy answers the probe cleanly — it just is not ours — so only an
+    // identity check can tell this case from the passing one above.
+    expect(spawnSucceeded(COMMAND, env)).toBe(true);
+  });
+
+  it('names the live-call consequence and the Windows cause in its refusal', () => {
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, { PATH: NODE_DIR });
+    });
+    // A setup failure is only useful if it says why continuing is unsafe.
+    expect(err?.message).toContain('does NOT fail closed');
+    expect(err?.message).toContain('PATHEXT');
+  });
+});
+
+describe('the platform branch, driven from either host', () => {
+  // The win32 shim is a `.cmd` launcher, which POSIX cannot execute; the POSIX
+  // shim is an extensionless file, which Windows will not resolve for a bare
+  // name. So writing the OTHER platform's form is a resolution failure on this
+  // one — which is exactly what makes it a live check of the refusal path
+  // rather than an assertion about a string.
+  const otherPlatform = process.platform === 'win32' ? 'linux' : 'win32';
+
+  it(`refuses a shim written for ${otherPlatform} while running on ${process.platform}`, () => {
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      otherPlatform,
+    );
+
+    // Pin the ARTIFACT, not just the refusal. A branch that wrote nothing at all
+    // would also refuse, and would look identical here — so a POSIX runner
+    // checking only the throw proves nothing about what win32 gets.
+    if (otherPlatform === 'win32') {
+      expect(written.endsWith(`${COMMAND}.cmd`)).toBe(true);
+      expect(existsSync(written)).toBe(true);
+      expect(existsSync(join(binDir, `${COMMAND}-shim.js`))).toBe(true);
+    } else {
+      expect(written).toBe(join(binDir, COMMAND));
+      expect(existsSync(written)).toBe(true);
+    }
+
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+  });
+
+  it('writes the running platform form under an explicit platform argument too', () => {
+    // Guards the parameter itself: a `platform` argument the writer ignores
+    // would leave the case above passing for the wrong reason — every shim
+    // would be the running platform's, and a `.cmd` would never be written.
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      process.platform,
+    );
+    expect(written.endsWith('.cmd')).toBe(process.platform === 'win32');
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, { PATH: shimmedPath(binDir, NODE_DIR) });
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('shimMarker', () => {
+  it('is per command, so one command s shim cannot satisfy another s probe', () => {
+    expect(shimMarker('alpha')).not.toBe(shimMarker('beta'));
+  });
+});

--- a/plugins/claude-code/test/helpers/path-shim.ts
+++ b/plugins/claude-code/test/helpers/path-shim.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+/**
+ * A controlled executable placed first on a child's PATH, so a suite driving a
+ * BUILT script can fake the external command that script shells out to.
+ *
+ * This is the only way to fake such a command: the spawns live behind a process
+ * boundary (`triage/judge.ts`'s `spawnClaude`, `provenance.ts`'s npm runner),
+ * so their dependency-injection seams are in-process only and unreachable from
+ * a test that runs the real built script.
+ *
+ * ## The shim fails OPEN, which is why every user of it must probe first
+ *
+ * A shim that does not land is NOT an `ENOENT`. Resolution simply continues
+ * down the rest of PATH and finds the REAL installed binary — measured on a
+ * POSIX host by joining PATH with the wrong separator, which resolved and ran
+ * the real `claude`, returning that live binary's own error. For a judge stub
+ * that means a suite quietly making a live model call with its seeded hits on
+ * stdin; a sentinel checked afterwards reports the egress rather than
+ * preventing it.
+ *
+ * So a caller asserts resolution BEFORE it drives anything —
+ * `assertShimResolves` — and a failure there is a red setup, never a live call.
+ *
+ * ## Three ways a hand-rolled shim is POSIX-only
+ *
+ * 1. **Separator.** PATH is `:`-joined on POSIX and `;`-joined on Windows. A
+ *    `:`-joined PATH on Windows is one malformed entry, so the shim dir is not
+ *    on PATH at all. `shimmedPath` uses `path.delimiter`.
+ * 2. **Extension.** An extensionless file with a `#!` line is executable on
+ *    POSIX and unrunnable on Windows, which resolves a bare command name
+ *    through `PATHEXT`. `writeCommandShim` writes a `.cmd` launcher there.
+ * 3. **Mode bits.** `chmodSync(…, 0o755)` is a no-op on Windows, so a shim that
+ *    relies on it has no executable bit to rely on. It is skipped there.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `plugins/codex` and
+ * `plugins/antigravity` carry peer copies — each taking a `path-shim.test.ts`
+ * with it, or `assertShimResolves` can be weakened back into a no-op with
+ * every caller staying green.
+ */
+
+/**
+ * The argument the resolution probe sends.
+ *
+ * Deliberately `--version` rather than a bespoke flag: when resolution has
+ * FAILED, the probe itself is what lands on the real binary, and `--version` is
+ * the one argument every candidate here answers locally, from its own package
+ * metadata, without contacting a model or a registry. A bespoke flag would be
+ * rejected — usually harmlessly — by an argument parser this repo does not own.
+ */
+export const SHIM_PROBE_ARG = '--version';
+
+/**
+ * How long the probe may take before the resolved binary is force-killed.
+ *
+ * Deliberately well under the 20s `testTimeout` every plugin package sets: the
+ * probe runs inside a test body, so a deadline equal to vitest's own means
+ * vitest wins the race and the refusal below — the entire point of failing
+ * closed — is replaced by a bare "test timed out". A binary that has not
+ * answered `--version` in ten seconds is not going to.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** The token a shim prints for {@link SHIM_PROBE_ARG}, and nothing else does. */
+export function shimMarker(command: string): string {
+  return `AKA-TEST-SHIM-OK:${command}`;
+}
+
+/**
+ * The prologue every shim body is written behind: the shebang and strict-mode
+ * directive a POSIX shim needs, then the probe answer.
+ *
+ * The probe is answered FIRST — ahead of any sentinel write or argv parsing —
+ * so probing can never be mistaken for an invocation by a suite asserting the
+ * command was not spawned.
+ */
+function shimPrologue(command: string): string {
+  return `#!/usr/bin/env node
+'use strict';
+// Answer the harness's resolution probe before doing anything else, so a probe
+// is never recorded as an invocation.
+if (process.argv.slice(2).includes(${JSON.stringify(SHIM_PROBE_ARG)})) {
+  process.stdout.write(${JSON.stringify(shimMarker(command))});
+  process.exit(0);
+}
+`;
+}
+
+/**
+ * `basePath` with `binDir` prepended, joined the way the RUNNING platform joins
+ * PATH. A literal `':'` here is the first of the three POSIX-only defects
+ * above.
+ *
+ * An absent or empty `basePath` yields the bin dir ALONE, with no trailing
+ * separator: an empty PATH entry is read as the current directory by execvp and
+ * by libuv's own search, so the convenient-looking `${binDir}${delimiter}` would
+ * quietly add the working directory to a search path whose whole purpose is that
+ * only the shim is on it.
+ */
+export function shimmedPath(binDir: string, basePath: string | undefined): string {
+  return basePath ? `${binDir}${delimiter}${basePath}` : binDir;
+}
+
+/**
+ * Write `body` into `binDir` as something the platform will execute for the
+ * bare name `command`, and return the file a caller would name in an error.
+ *
+ * POSIX gets the extensionless file the `#!` line makes runnable. Windows gets
+ * the body as a plain `.js` beside a `<command>.cmd` launcher that runs it
+ * under this process's own node — an absolute interpreter path, so the launcher
+ * does not additionally depend on node being on the child's PATH.
+ *
+ * `platform` defaults to the running one and exists so both branches are
+ * reachable from either host, the way `triage/judge.ts`'s `judgeEnv` takes one.
+ * Writing the other platform's form is a resolution failure on this one, which
+ * is what lets a POSIX runner drive the win32 branch against the real refusal
+ * rather than against a description of it.
+ */
+export function writeCommandShim(
+  binDir: string,
+  command: string,
+  body: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const source = shimPrologue(command) + body;
+  if (platform === 'win32') {
+    const scriptPath = join(binDir, `${command}-shim.js`);
+    writeFileSync(scriptPath, source);
+    const launcherPath = join(binDir, `${command}.cmd`);
+    // CRLF, because a batch file is read by cmd.exe. %~dp0 carries its own
+    // trailing separator; %* forwards argv, and stdin passes through untouched.
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-shim.js" %*\r\n`,
+    );
+    // No chmod: it is a no-op on Windows, and PATHEXT decides what runs.
+    return launcherPath;
+  }
+  const shimPath = join(binDir, command);
+  writeFileSync(shimPath, source);
+  chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
+export interface ShimResolutionOptions {
+  /**
+   * Mirror the spawn this shim stands in for. Pass `true` wherever the code
+   * under test spawns with `shell` — on Windows that is the difference between
+   * resolving a `.cmd` and skipping it, so a probe that disagrees with its
+   * subject is a false verdict in one direction or the other.
+   */
+  readonly shell?: boolean;
+  /**
+   * The working directory the spawn being stood in for will use, when it is not
+   * this process's own.
+   *
+   * PATH is not the whole of resolution: Windows searches the working directory
+   * BEFORE walking PATH, so a probe run from a different cwd than its subject
+   * verifies a resolution the subject never performs — and a binary sitting in
+   * the subject's cwd wins silently. Pass whatever `cwd` reaches the real spawn.
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * Refuse to continue unless the bare name `command` resolves to the shim under
+ * `env.PATH`.
+ *
+ * Resolution is not modelled, it is PERFORMED — the probe spawns the command
+ * the same way the code under test will, so it agrees about `PATHEXT` and about
+ * every other rule a hand-rolled resolver would have to restate. `options.shell`
+ * and `options.cwd` are the axes the CALLER must supply, because they belong to
+ * the spawn being stood in for rather than to the shim, and the probe cannot
+ * discover either: get one wrong and the probe faithfully performs a resolution
+ * its subject never performs.
+ *
+ * Throws — loudly, and naming the cause — rather than returning a boolean: a
+ * caller that forgets to check a boolean is back to the fail-open behaviour
+ * this exists to remove.
+ */
+export function assertShimResolves(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  options: ShimResolutionOptions = {},
+): void {
+  const marker = shimMarker(command);
+  // Assigned on both paths below — the success value, or the failed spawn's own
+  // stdout, which may still carry the marker.
+  let output: string;
+  let spawnFailure: string | undefined;
+  try {
+    output = execFileSync(command, [SHIM_PROBE_ARG], {
+      env,
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: options.shell ?? false,
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    });
+  } catch (err) {
+    // Narrowed rather than `unknown`: an unknown here stringifies to
+    // [object Object] instead of the fields a reader needs.
+    const e = err as {
+      code?: string;
+      status?: number;
+      signal?: string;
+      stdout?: string;
+      stderr?: string;
+    };
+    // A non-zero exit still carries both streams, and stdout may hold the marker
+    // — a shim that answered and then failed for its own reasons has resolved,
+    // which is the only question being asked here. Reading it is what keeps a
+    // real resolution from being reported as a miss.
+    output = e.stdout ?? '';
+    const status = e.status === undefined ? '(none)' : String(e.status);
+    // stderr is the only thing that explains a genuine failure, so it belongs in
+    // the one message written to diagnose one.
+    const stderr = (e.stderr ?? '').trim();
+    spawnFailure =
+      `code=${e.code ?? '(none)'} status=${status} signal=${e.signal ?? '(none)'}` +
+      (stderr === '' ? '' : ` stderr=${JSON.stringify(stderr.slice(0, 200))}`);
+  }
+  if (output.includes(marker)) return;
+
+  const sawInstead =
+    spawnFailure !== undefined
+      ? `the spawn failed (${spawnFailure})`
+      : `it answered ${JSON.stringify(output.trim().slice(0, 120))}`;
+  throw new Error(
+    [
+      `PATH shim for "${command}" did not resolve to the test stub — ${sawInstead}.`,
+      'This is a SETUP failure and the suite must not continue: a shim that does',
+      'not land does NOT fail closed. Resolution carries on down PATH and finds',
+      `the REAL installed "${command}", so driving the chain from here would make`,
+      'a live call with the seeded fixtures as its input.',
+      'On Windows the usual cause is that execFile does no PATHEXT resolution and',
+      'refuses to spawn a .cmd/.bat without a shell (the CVE-2024-27980 fix) — see',
+      "packages/local-ops/src/exec.ts's USE_SHELL for the same constraint in",
+      'shipped code. On POSIX, check the shim is executable and that PATH was',
+      'joined with path.delimiter.',
+    ].join(' '),
+  );
+}

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -406,8 +406,19 @@ export class SetupJourney {
   // resolution probe below, so the PATH the probe proves is the PATH the chain
   // actually runs under — two independently-built envs could disagree.
   private childEnv(): NodeJS.ProcessEnv {
+    // `process.env` reads case-insensitively on Windows but SPREADS the key as
+    // the OS stored it — `Path`, not `PATH`. So `{ ...HOST_ENV, PATH: … }` hands
+    // the child TWO path variables there: the host's untouched `Path` and our
+    // stub-first `PATH`. A Windows environment block is case-insensitive, so
+    // which one the child resolves against is not something this harness may
+    // assume — and if the host's wins, the stub judge is no longer first and a
+    // real `claude` becomes reachable, which is the one thing this harness
+    // promises cannot happen. Drop every case-variant before setting ours.
+    const hostEnv = Object.fromEntries(
+      Object.entries(HOST_ENV).filter(([name]) => name.toUpperCase() !== 'PATH'),
+    );
     return {
-      ...HOST_ENV,
+      ...hostEnv,
       HOME: this.home,
       // Windows resolves the home dir from USERPROFILE; keep both in lockstep.
       USERPROFILE: this.home,

--- a/plugins/claude-code/test/journey/harness.ts
+++ b/plugins/claude-code/test/journey/harness.ts
@@ -14,6 +14,9 @@
  * The one external dependency the chain has — the `claude -p` triage judge the
  * apply-suppressions preview spawns — is stubbed hermetically by putting a
  * controlled `claude` executable first on the child PATH (see writeFakeJudge).
+ * That shim fails OPEN, so its resolution is PROVEN before any script runs
+ * (see assertJudgeStubOnPath): a shim that does not land is not an ENOENT, it
+ * is the real installed CLI answering instead, with the seeded hits on stdin.
  * Everything else is the real thing: the real backfill scan, the real store
  * writes, the real rendered frames.
  *
@@ -21,15 +24,7 @@
  * empty states).
  */
 import { execFileSync } from 'node:child_process';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -54,6 +49,7 @@ import { transcriptsDir } from '../../src/history/transcripts.ts';
 import { loadSecretLeakFindings } from '../../src/remediation/findings.ts';
 import { renderRemediationDecision } from '../../src/remediation/render.ts';
 import { frameJsonBlock } from '../../src/setup-frame-json.ts';
+import { assertShimResolves, shimmedPath, writeCommandShim } from '../helpers/path-shim.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test/journey -> plugins/claude-code
@@ -114,6 +110,9 @@ export class SetupJourney {
   // The settings.json the onboarding writer records the consent + prefs into.
   readonly settingsPath: string;
   private readonly binDir: string;
+  // The cwds the judge stub's resolution has already been proven under ('' is
+  // "no cwd override"). See assertJudgeStubOnPath.
+  private readonly shimProven = new Set<string>();
 
   constructor() {
     this.home = mkdtempSync(join(tmpdir(), 'aka-journey-home-'));
@@ -403,15 +402,19 @@ export class SetupJourney {
     return this.run('remediate.js', args, frameText, cwd);
   }
 
-  private run(script: string, args: string[], input?: string, cwd?: string): StepResult {
-    const env: NodeJS.ProcessEnv = {
+  // The environment every step of the chain is spawned with. Shared with the
+  // resolution probe below, so the PATH the probe proves is the PATH the chain
+  // actually runs under — two independently-built envs could disagree.
+  private childEnv(): NodeJS.ProcessEnv {
+    return {
       ...HOST_ENV,
       HOME: this.home,
       // Windows resolves the home dir from USERPROFILE; keep both in lockstep.
       USERPROFILE: this.home,
       // Stub judge first on PATH so apply-suppressions' `claude -p` spawn hits it,
-      // never a live model.
-      PATH: `${this.binDir}:${HOST_ENV.PATH ?? ''}`,
+      // never a live model. Joined with path.delimiter: a literal ':' is one
+      // malformed entry on Windows, which puts the shim dir on PATH nowhere.
+      PATH: shimmedPath(this.binDir, HOST_ENV.PATH),
       // Cleared so judgeEnvSeen() proves something: if these reached the stub
       // merely by being inherited from here, the assertion would hold even with
       // spawnClaude passing no env at all. Node drops undefined entries when it
@@ -419,6 +422,34 @@ export class SetupJourney {
       CLAUDE_CODE_SKIP_PROMPT_HISTORY: undefined,
       CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: undefined,
     };
+  }
+
+  // Proven before the first script runs under each working directory.
+  //
+  // A shim that fails to land does NOT fail closed: `claude` resolution keeps
+  // walking PATH and finds the REAL installed CLI, so the chain would send its
+  // seeded hits to a live model and only report it afterwards, via
+  // judgeEnvSeen()'s 'the judge stub never ran'. Proving resolution up front
+  // turns that into a red setup. Kept lazy so a journey that only drives the
+  // module-seam RemediationDrive pays for no spawn at all.
+  //
+  // Keyed by cwd rather than latched once, because PATH is not the whole of
+  // resolution: Windows searches the working directory BEFORE walking PATH, and
+  // run() takes a per-step cwd (a temp repo dir). A single proof taken under the
+  // harness's own cwd would say nothing about a step that runs somewhere else.
+  private assertJudgeStubOnPath(env: NodeJS.ProcessEnv, cwd?: string): void {
+    const key = cwd ?? '';
+    if (this.shimProven.has(key)) return;
+    // spawnClaude uses execFileSync with no `shell`, so the probe must not
+    // either — on Windows that is the difference between resolving a .cmd and
+    // skipping it, and a probe that disagrees with its subject proves nothing.
+    assertShimResolves('claude', env, cwd === undefined ? {} : { cwd });
+    this.shimProven.add(key);
+  }
+
+  private run(script: string, args: string[], input?: string, cwd?: string): StepResult {
+    const env = this.childEnv();
+    this.assertJudgeStubOnPath(env, cwd);
     try {
       const stdout = execFileSync(process.execPath, [join(SCRIPTS_DIR, script), ...args], {
         env,
@@ -447,9 +478,7 @@ export class SetupJourney {
   // category (e.g. aws + stripe + github secrets) each surface their own
   // genuine hit. No live model is ever hit.
   private writeFakeJudge(): void {
-    const src = `#!/usr/bin/env node
-'use strict';
-// Record that the judge actually ran, so a test can prove the consent gate
+    const body = `// Record that the judge actually ran, so a test can prove the consent gate
 // stopped the egress at the process boundary (see judgeWasInvoked) — and WITH
 // WHAT environment, so a test can prove judgeEnv's transcript-suppression vars
 // survived the trip through spawnClaude's execFileSync (see judgeEnvSeen).
@@ -496,9 +525,9 @@ const verdict = { perCategory, notes: 'looks routine' };
 const result = '\`\`\`json\\n' + JSON.stringify(verdict) + '\\n\`\`\`';
 process.stdout.write(JSON.stringify({ result, is_error: false }));
 `;
-    const path = join(this.binDir, 'claude');
-    writeFileSync(path, src);
-    chmodSync(path, 0o755);
+    // writeCommandShim owns the shebang, the mode bits and — on Windows — the
+    // .cmd launcher that makes a bare `claude` resolvable at all.
+    writeCommandShim(this.binDir, 'claude', body);
   }
 }
 

--- a/plugins/claude-code/test/provenance.test.ts
+++ b/plugins/claude-code/test/provenance.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -8,8 +8,10 @@ import {
   EXPECTED_REPOSITORY,
   EXPECTED_WORKFLOW_PATH,
   PROVENANCE_CHECK_TIMEOUT_MS,
+  USE_SHELL,
   verifyProvenance,
 } from '../src/provenance.ts';
+import { assertShimResolves, shimmedPath, writeCommandShim } from './helpers/path-shim.ts';
 
 const PACKAGE_NAME = '@akasecurity/ai-tc-claude-code';
 const VERSION = '0.8.2';
@@ -192,16 +194,28 @@ describe('verifyProvenance', () => {
 // Places a fake `npm` first on PATH (mirroring the journey harness's writeFakeJudge
 // pattern) so the REAL default runner is exercised end-to-end — real execFileSync,
 // real stdout capture, real base64/JSON parse — without spawning a live npm.
+//
+// The shim goes through writeCommandShim/shimmedPath for the same three reasons
+// the journey harness does — path.delimiter rather than a literal ':', a .cmd
+// launcher on Windows, no reliance on a chmod that is a no-op there — and its
+// resolution is proven before the runner is allowed to spawn: a miss here does
+// not fail closed, it runs the developer's real npm and reaches the registry.
 const withFakeNpmOnPath = <T>(script: string, fn: () => T): T => {
   const binDir = mkdtempSync(join(tmpdir(), 'aka-provenance-bin-'));
-  const npmPath = join(binDir, 'npm');
-  writeFileSync(npmPath, script);
-  chmodSync(npmPath, 0o755);
+  writeCommandShim(binDir, 'npm', script);
   // eslint-disable-next-line n/no-process-env -- test needs to prepend a fake npm onto the child's PATH
   const originalPath = process.env.PATH;
   // eslint-disable-next-line n/no-process-env -- test needs to prepend a fake npm onto the child's PATH
-  process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+  process.env.PATH = shimmedPath(binDir, originalPath);
   try {
+    // runNpmAudit passes no `env`, so the child inherits this process's — which
+    // makes process.env the environment the probe must resolve under too. The
+    // runner's own USE_SHELL is imported rather than re-derived: on Windows the
+    // shell is what consults PATHEXT, so a probe that disagrees with the runner
+    // reports a false miss in one direction or a false pass in the other, and a
+    // copied condition is free to drift.
+    // eslint-disable-next-line n/no-process-env -- the runner under test inherits this env; the probe must resolve under the same one
+    assertShimResolves('npm', process.env, { shell: USE_SHELL });
     return fn();
   } finally {
     // eslint-disable-next-line n/no-process-env -- restore the host PATH after the test
@@ -210,10 +224,27 @@ const withFakeNpmOnPath = <T>(script: string, fn: () => T): T => {
   }
 };
 
+// Elapsed time measured INSIDE the fake-npm scope, around the call under test
+// alone. withFakeNpmOnPath does a mkdtemp, two file writes and a resolution
+// probe that spawns a process; charging those to a budget that exists to bound
+// the RUNNER's timeout would measure setup this assertion has no opinion about
+// — and the probe's spawn is the most expensive of them on Windows, where it
+// launches a .cmd that launches node.
+const verifyWithElapsed = (script: string): { result: boolean; elapsed: number } => {
+  let elapsed = 0;
+  const result = withFakeNpmOnPath(script, () => {
+    const start = Date.now();
+    const verified = verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION });
+    elapsed = Date.now() - start;
+    return verified;
+  });
+  return { result, elapsed };
+};
+
 describe('verifyProvenance — real default runner against a fake npm on PATH', () => {
   it('returns true end-to-end when the real runner reads a matching verified report', () => {
     const report = buildReport({});
-    const script = `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(report)});\n`;
+    const script = `process.stdout.write(${JSON.stringify(report)});\n`;
     const result = withFakeNpmOnPath(script, () =>
       verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION }),
     );
@@ -224,7 +255,7 @@ describe('verifyProvenance — real default runner against a fake npm on PATH', 
     // `npm audit signatures` exits 1 when any entry is unverified; the report is
     // still on stdout and the exact package@version must still be honored.
     const report = buildReport({});
-    const script = `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(report)});\nprocess.exit(1);\n`;
+    const script = `process.stdout.write(${JSON.stringify(report)});\nprocess.exit(1);\n`;
     const result = withFakeNpmOnPath(script, () =>
       verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION }),
     );
@@ -232,12 +263,7 @@ describe('verifyProvenance — real default runner against a fake npm on PATH', 
   });
 
   it('terminates a non-terminating npm child and returns false within the timeout budget', () => {
-    const script = '#!/usr/bin/env node\nsetInterval(() => {}, 1000);\n';
-    const start = Date.now();
-    const result = withFakeNpmOnPath(script, () =>
-      verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION }),
-    );
-    const elapsed = Date.now() - start;
+    const { result, elapsed } = verifyWithElapsed('setInterval(() => {}, 1000);\n');
     expect(result).toBe(false);
     // Bounded, not indefinite — allow slack for spawn/teardown without waiting
     // anywhere near the length of an unbounded hang.
@@ -248,12 +274,9 @@ describe('verifyProvenance — real default runner against a fake npm on PATH', 
     // The report captured before the timeout kill must NOT count as success: a hung
     // shell-out is failed-open regardless of what it printed before being killed.
     const report = buildReport({});
-    const script = `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(report)});\nsetInterval(() => {}, 1000);\n`;
-    const start = Date.now();
-    const result = withFakeNpmOnPath(script, () =>
-      verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION }),
+    const { result, elapsed } = verifyWithElapsed(
+      `process.stdout.write(${JSON.stringify(report)});\nsetInterval(() => {}, 1000);\n`,
     );
-    const elapsed = Date.now() - start;
     expect(result).toBe(false);
     expect(elapsed).toBeLessThan(PROVENANCE_CHECK_TIMEOUT_MS * 3);
   });
@@ -261,13 +284,9 @@ describe('verifyProvenance — real default runner against a fake npm on PATH', 
   it('hard-kills a SIGTERM-resistant npm child within the budget and returns false', () => {
     // A child that traps SIGTERM cannot outlast the bound — the runner force-kills
     // with SIGKILL, which cannot be trapped or ignored.
-    const script =
-      '#!/usr/bin/env node\nprocess.on("SIGTERM", () => {});\nsetInterval(() => {}, 1000);\n';
-    const start = Date.now();
-    const result = withFakeNpmOnPath(script, () =>
-      verifyProvenance({ packageName: PACKAGE_NAME, version: VERSION }),
+    const { result, elapsed } = verifyWithElapsed(
+      'process.on("SIGTERM", () => {});\nsetInterval(() => {}, 1000);\n',
     );
-    const elapsed = Date.now() - start;
     expect(result).toBe(false);
     expect(elapsed).toBeLessThan(PROVENANCE_CHECK_TIMEOUT_MS * 3);
   });

--- a/plugins/claude-code/test/provenance.test.ts
+++ b/plugins/claude-code/test/provenance.test.ts
@@ -218,8 +218,14 @@ const withFakeNpmOnPath = <T>(script: string, fn: () => T): T => {
     assertShimResolves('npm', process.env, { shell: USE_SHELL });
     return fn();
   } finally {
+    // `delete` rather than assigning back, because assigning `undefined` to a
+    // process.env property stores the STRING "undefined" — so a host with no
+    // PATH would leave every later test in this worker resolving children
+    // against a one-entry garbage PATH instead of none.
     // eslint-disable-next-line n/no-process-env -- restore the host PATH after the test
-    process.env.PATH = originalPath;
+    if (originalPath === undefined) delete process.env.PATH;
+    // eslint-disable-next-line n/no-process-env -- restore the host PATH after the test
+    else process.env.PATH = originalPath;
     rmSync(binDir, { recursive: true, force: true });
   }
 };

--- a/plugins/codex/test/helpers/path-shim.test.ts
+++ b/plugins/codex/test/helpers/path-shim.test.ts
@@ -1,0 +1,263 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, dirname, join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { assertShimResolves, shimMarker, shimmedPath, writeCommandShim } from './path-shim.ts';
+
+// A name no real binary on any developer machine or runner answers to, so a
+// resolution MISS in this suite can only ever fail — never reach a live tool.
+// That matters more here than anywhere else: this file exists to drive the miss
+// case on purpose.
+const COMMAND = 'aka-shim-fixture-cmd';
+
+// The shim body every case writes: records that it ran, then prints a word the
+// caller can match. Written behind the helper's prologue, so the probe answer
+// sits ahead of the sentinel write.
+const bodyWritingSentinel = (sentinelPath: string): string =>
+  `require('node:fs').writeFileSync(${JSON.stringify(sentinelPath)}, '');
+process.stdout.write('SHIM-BODY-RAN');
+`;
+
+// A third-party binary that happens to answer to the same name — what the real
+// installed CLI is to a judge stub. Deliberately NOT written through
+// writeCommandShim: the whole point is that it runs cleanly and answers the
+// probe with something other than this suite's marker.
+const writeForeignBinary = (dir: string, command: string): void => {
+  const js = "process.stdout.write('FOREIGN-TOOL 1.2.3');\n";
+  if (process.platform === 'win32') {
+    writeFileSync(join(dir, `${command}-foreign.js`), js);
+    writeFileSync(
+      join(dir, `${command}.cmd`),
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-foreign.js" %*\r\n`,
+    );
+    return;
+  }
+  const binPath = join(dir, command);
+  writeFileSync(binPath, `#!/usr/bin/env node\n${js}`);
+  chmodSync(binPath, 0o755);
+};
+
+const dirs: string[] = [];
+const tempDir = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'aka-path-shim-test-'));
+  dirs.push(dir);
+  return dir;
+};
+
+// node's own dir, so a POSIX shim's `#!/usr/bin/env node` line resolves without
+// dragging the whole host PATH (and its real binaries) into these cases.
+const NODE_DIR = dirname(process.execPath);
+
+afterEach(() => {
+  while (dirs.length > 0) rmSync(dirs.pop() ?? '', { recursive: true, force: true });
+});
+
+const errorFrom = (fn: () => unknown): Error | undefined => {
+  try {
+    fn();
+    return undefined;
+  } catch (e) {
+    return e as Error;
+  }
+};
+
+// The weaker check this helper replaced: "the spawn worked". Kept as the paired
+// control — a case is only evidence that identity is being checked if the
+// spawn-succeeded form would have passed on the same input.
+const spawnSucceeded = (command: string, env: NodeJS.ProcessEnv): boolean => {
+  try {
+    execFileSync(command, ['--version'], {
+      env,
+      encoding: 'utf8',
+      timeout: 20_000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('shimmedPath', () => {
+  it('prepends the shim dir as a real first entry under the platform delimiter', () => {
+    const base = ['/first/base', '/second/base'].join(delimiter);
+    const entries = shimmedPath('/shim/dir', base).split(delimiter);
+    expect(entries[0]).toBe('/shim/dir');
+    expect(entries.slice(1)).toEqual(['/first/base', '/second/base']);
+  });
+
+  it('yields the shim dir ALONE when there is no base PATH, leaving no empty entry', () => {
+    // Asserting entry [0] would pass on a trailing delimiter too, which is the
+    // bug: an empty PATH element is read as the CURRENT DIRECTORY by execvp and
+    // by libuv's own search, so `${binDir}${delimiter}` quietly adds the cwd to
+    // a search path whose whole purpose is that only the shim is on it.
+    expect(shimmedPath('/shim/dir', undefined)).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', '')).toBe('/shim/dir');
+    expect(shimmedPath('/shim/dir', undefined).split(delimiter)).toEqual(['/shim/dir']);
+  });
+});
+
+describe('writeCommandShim + assertShimResolves', () => {
+  it('resolves the shim written for the running platform', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('answers the probe WITHOUT recording an invocation, and records one when really run', () => {
+    const binDir = tempDir();
+    const sentinel = join(binDir, 'ran');
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(sentinel));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    assertShimResolves(COMMAND, env);
+    // The property a `judgeWasInvoked()`-style sentinel depends on: probing is
+    // not invoking. Lose the ordering in the prologue and every "the egress
+    // never happened" assertion starts failing for a reason that is not the
+    // one under test.
+    expect(existsSync(sentinel)).toBe(false);
+
+    // Positive control: the sentinel IS written when the shim runs for real, so
+    // the absence above is the ordering rather than a shim that never runs.
+    const out = execFileSync(COMMAND, [], { env, encoding: 'utf8', timeout: 20_000 });
+    expect(out).toContain('SHIM-BODY-RAN');
+    expect(existsSync(sentinel)).toBe(true);
+  });
+
+  it('performs the probe under the cwd it is given, not this process s', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+
+    // A real cwd changes nothing on POSIX (only Windows searches it), so the
+    // decisive check is a cwd that cannot be entered: the spawn itself fails,
+    // which can only happen if the option reached the spawn. Drop the cwd from
+    // assertShimResolves and this resolves cleanly and the case goes red —
+    // asserting a successful resolution under a valid cwd would not, since
+    // ignoring the option produces exactly the same pass.
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env, { cwd: join(binDir, 'no-such-dir') });
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+    expect(err?.message).toContain('the spawn failed');
+
+    // Positive control on the same shim: with no cwd override it resolves, so
+    // the refusal above is the cwd and not a shim that never worked.
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, env);
+      }),
+    ).toBeUndefined();
+  });
+
+  it('refuses when the shim dir is not on PATH at all', () => {
+    const binDir = tempDir();
+    writeCommandShim(binDir, COMMAND, bodyWritingSentinel(join(binDir, 'ran')));
+    const env = { PATH: NODE_DIR };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain(`PATH shim for "${COMMAND}" did not resolve`);
+  });
+
+  it('refuses when another executable of the same name answers first', () => {
+    // The fail-open shape itself: something DOES resolve and DOES run, it is
+    // just not the stub. A judge stub that missed this way would be the real
+    // CLI, and the call would reach a live model.
+    const decoyDir = tempDir();
+    writeForeignBinary(decoyDir, COMMAND);
+    const shimDir = tempDir();
+    writeCommandShim(shimDir, COMMAND, bodyWritingSentinel(join(shimDir, 'ran')));
+    const env = { PATH: shimmedPath(decoyDir, shimmedPath(shimDir, NODE_DIR)) };
+
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+    // Paired control: the weaker "did the spawn work?" check passes here. The
+    // decoy answers the probe cleanly — it just is not ours — so only an
+    // identity check can tell this case from the passing one above.
+    expect(spawnSucceeded(COMMAND, env)).toBe(true);
+  });
+
+  it('names the live-call consequence and the Windows cause in its refusal', () => {
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, { PATH: NODE_DIR });
+    });
+    // A setup failure is only useful if it says why continuing is unsafe.
+    expect(err?.message).toContain('does NOT fail closed');
+    expect(err?.message).toContain('PATHEXT');
+  });
+});
+
+describe('the platform branch, driven from either host', () => {
+  // The win32 shim is a `.cmd` launcher, which POSIX cannot execute; the POSIX
+  // shim is an extensionless file, which Windows will not resolve for a bare
+  // name. So writing the OTHER platform's form is a resolution failure on this
+  // one — which is exactly what makes it a live check of the refusal path
+  // rather than an assertion about a string.
+  const otherPlatform = process.platform === 'win32' ? 'linux' : 'win32';
+
+  it(`refuses a shim written for ${otherPlatform} while running on ${process.platform}`, () => {
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      otherPlatform,
+    );
+
+    // Pin the ARTIFACT, not just the refusal. A branch that wrote nothing at all
+    // would also refuse, and would look identical here — so a POSIX runner
+    // checking only the throw proves nothing about what win32 gets.
+    if (otherPlatform === 'win32') {
+      expect(written.endsWith(`${COMMAND}.cmd`)).toBe(true);
+      expect(existsSync(written)).toBe(true);
+      expect(existsSync(join(binDir, `${COMMAND}-shim.js`))).toBe(true);
+    } else {
+      expect(written).toBe(join(binDir, COMMAND));
+      expect(existsSync(written)).toBe(true);
+    }
+
+    const env = { PATH: shimmedPath(binDir, NODE_DIR) };
+    const err = errorFrom(() => {
+      assertShimResolves(COMMAND, env);
+    });
+    expect(err?.message).toContain('did not resolve to the test stub');
+  });
+
+  it('writes the running platform form under an explicit platform argument too', () => {
+    // Guards the parameter itself: a `platform` argument the writer ignores
+    // would leave the case above passing for the wrong reason — every shim
+    // would be the running platform's, and a `.cmd` would never be written.
+    const binDir = tempDir();
+    const written = writeCommandShim(
+      binDir,
+      COMMAND,
+      bodyWritingSentinel(join(binDir, 'ran')),
+      process.platform,
+    );
+    expect(written.endsWith('.cmd')).toBe(process.platform === 'win32');
+    expect(
+      errorFrom(() => {
+        assertShimResolves(COMMAND, { PATH: shimmedPath(binDir, NODE_DIR) });
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('shimMarker', () => {
+  it('is per command, so one command s shim cannot satisfy another s probe', () => {
+    expect(shimMarker('alpha')).not.toBe(shimMarker('beta'));
+  });
+});

--- a/plugins/codex/test/helpers/path-shim.ts
+++ b/plugins/codex/test/helpers/path-shim.ts
@@ -1,0 +1,247 @@
+import { execFileSync } from 'node:child_process';
+import { chmodSync, writeFileSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
+
+/**
+ * A controlled executable placed first on a child's PATH, so a suite driving a
+ * BUILT script can fake the external command that script shells out to.
+ *
+ * This is the only way to fake such a command: the spawns live behind a process
+ * boundary (`triage/judge.ts`'s `spawnClaude`, `provenance.ts`'s npm runner),
+ * so their dependency-injection seams are in-process only and unreachable from
+ * a test that runs the real built script.
+ *
+ * ## The shim fails OPEN, which is why every user of it must probe first
+ *
+ * A shim that does not land is NOT an `ENOENT`. Resolution simply continues
+ * down the rest of PATH and finds the REAL installed binary — measured on a
+ * POSIX host by joining PATH with the wrong separator, which resolved and ran
+ * the real `claude`, returning that live binary's own error. For a judge stub
+ * that means a suite quietly making a live model call with its seeded hits on
+ * stdin; a sentinel checked afterwards reports the egress rather than
+ * preventing it.
+ *
+ * So a caller asserts resolution BEFORE it drives anything —
+ * `assertShimResolves` — and a failure there is a red setup, never a live call.
+ *
+ * ## Three ways a hand-rolled shim is POSIX-only
+ *
+ * 1. **Separator.** PATH is `:`-joined on POSIX and `;`-joined on Windows. A
+ *    `:`-joined PATH on Windows is one malformed entry, so the shim dir is not
+ *    on PATH at all. `shimmedPath` uses `path.delimiter`.
+ * 2. **Extension.** An extensionless file with a `#!` line is executable on
+ *    POSIX and unrunnable on Windows, which resolves a bare command name
+ *    through `PATHEXT`. `writeCommandShim` writes a `.cmd` launcher there.
+ * 3. **Mode bits.** `chmodSync(…, 0o755)` is a no-op on Windows, so a shim that
+ *    relies on it has no executable bit to rely on. It is skipped there.
+ *
+ * Shared by this package's suites because they sit behind one package wall.
+ * Across a wall it cannot be imported, so `plugins/claude-code` and
+ * `plugins/antigravity` carry peer copies — each taking a `path-shim.test.ts`
+ * with it, or `assertShimResolves` can be weakened back into a no-op with
+ * every caller staying green.
+ */
+
+/**
+ * The argument the resolution probe sends.
+ *
+ * Deliberately `--version` rather than a bespoke flag: when resolution has
+ * FAILED, the probe itself is what lands on the real binary, and `--version` is
+ * the one argument every candidate here answers locally, from its own package
+ * metadata, without contacting a model or a registry. A bespoke flag would be
+ * rejected — usually harmlessly — by an argument parser this repo does not own.
+ */
+export const SHIM_PROBE_ARG = '--version';
+
+/**
+ * How long the probe may take before the resolved binary is force-killed.
+ *
+ * Deliberately well under the 20s `testTimeout` every plugin package sets: the
+ * probe runs inside a test body, so a deadline equal to vitest's own means
+ * vitest wins the race and the refusal below — the entire point of failing
+ * closed — is replaced by a bare "test timed out". A binary that has not
+ * answered `--version` in ten seconds is not going to.
+ */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** The token a shim prints for {@link SHIM_PROBE_ARG}, and nothing else does. */
+export function shimMarker(command: string): string {
+  return `AKA-TEST-SHIM-OK:${command}`;
+}
+
+/**
+ * The prologue every shim body is written behind: the shebang and strict-mode
+ * directive a POSIX shim needs, then the probe answer.
+ *
+ * The probe is answered FIRST — ahead of any sentinel write or argv parsing —
+ * so probing can never be mistaken for an invocation by a suite asserting the
+ * command was not spawned.
+ */
+function shimPrologue(command: string): string {
+  return `#!/usr/bin/env node
+'use strict';
+// Answer the harness's resolution probe before doing anything else, so a probe
+// is never recorded as an invocation.
+if (process.argv.slice(2).includes(${JSON.stringify(SHIM_PROBE_ARG)})) {
+  process.stdout.write(${JSON.stringify(shimMarker(command))});
+  process.exit(0);
+}
+`;
+}
+
+/**
+ * `basePath` with `binDir` prepended, joined the way the RUNNING platform joins
+ * PATH. A literal `':'` here is the first of the three POSIX-only defects
+ * above.
+ *
+ * An absent or empty `basePath` yields the bin dir ALONE, with no trailing
+ * separator: an empty PATH entry is read as the current directory by execvp and
+ * by libuv's own search, so the convenient-looking `${binDir}${delimiter}` would
+ * quietly add the working directory to a search path whose whole purpose is that
+ * only the shim is on it.
+ */
+export function shimmedPath(binDir: string, basePath: string | undefined): string {
+  return basePath ? `${binDir}${delimiter}${basePath}` : binDir;
+}
+
+/**
+ * Write `body` into `binDir` as something the platform will execute for the
+ * bare name `command`, and return the file a caller would name in an error.
+ *
+ * POSIX gets the extensionless file the `#!` line makes runnable. Windows gets
+ * the body as a plain `.js` beside a `<command>.cmd` launcher that runs it
+ * under this process's own node — an absolute interpreter path, so the launcher
+ * does not additionally depend on node being on the child's PATH.
+ *
+ * `platform` defaults to the running one and exists so both branches are
+ * reachable from either host, the way `triage/judge.ts`'s `judgeEnv` takes one.
+ * Writing the other platform's form is a resolution failure on this one, which
+ * is what lets a POSIX runner drive the win32 branch against the real refusal
+ * rather than against a description of it.
+ */
+export function writeCommandShim(
+  binDir: string,
+  command: string,
+  body: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const source = shimPrologue(command) + body;
+  if (platform === 'win32') {
+    const scriptPath = join(binDir, `${command}-shim.js`);
+    writeFileSync(scriptPath, source);
+    const launcherPath = join(binDir, `${command}.cmd`);
+    // CRLF, because a batch file is read by cmd.exe. %~dp0 carries its own
+    // trailing separator; %* forwards argv, and stdin passes through untouched.
+    writeFileSync(
+      launcherPath,
+      `@echo off\r\n"${process.execPath}" "%~dp0${command}-shim.js" %*\r\n`,
+    );
+    // No chmod: it is a no-op on Windows, and PATHEXT decides what runs.
+    return launcherPath;
+  }
+  const shimPath = join(binDir, command);
+  writeFileSync(shimPath, source);
+  chmodSync(shimPath, 0o755);
+  return shimPath;
+}
+
+export interface ShimResolutionOptions {
+  /**
+   * Mirror the spawn this shim stands in for. Pass `true` wherever the code
+   * under test spawns with `shell` — on Windows that is the difference between
+   * resolving a `.cmd` and skipping it, so a probe that disagrees with its
+   * subject is a false verdict in one direction or the other.
+   */
+  readonly shell?: boolean;
+  /**
+   * The working directory the spawn being stood in for will use, when it is not
+   * this process's own.
+   *
+   * PATH is not the whole of resolution: Windows searches the working directory
+   * BEFORE walking PATH, so a probe run from a different cwd than its subject
+   * verifies a resolution the subject never performs — and a binary sitting in
+   * the subject's cwd wins silently. Pass whatever `cwd` reaches the real spawn.
+   */
+  readonly cwd?: string;
+}
+
+/**
+ * Refuse to continue unless the bare name `command` resolves to the shim under
+ * `env.PATH`.
+ *
+ * Resolution is not modelled, it is PERFORMED — the probe spawns the command
+ * the same way the code under test will, so it agrees about `PATHEXT` and about
+ * every other rule a hand-rolled resolver would have to restate. `options.shell`
+ * and `options.cwd` are the axes the CALLER must supply, because they belong to
+ * the spawn being stood in for rather than to the shim, and the probe cannot
+ * discover either: get one wrong and the probe faithfully performs a resolution
+ * its subject never performs.
+ *
+ * Throws — loudly, and naming the cause — rather than returning a boolean: a
+ * caller that forgets to check a boolean is back to the fail-open behaviour
+ * this exists to remove.
+ */
+export function assertShimResolves(
+  command: string,
+  env: NodeJS.ProcessEnv,
+  options: ShimResolutionOptions = {},
+): void {
+  const marker = shimMarker(command);
+  // Assigned on both paths below — the success value, or the failed spawn's own
+  // stdout, which may still carry the marker.
+  let output: string;
+  let spawnFailure: string | undefined;
+  try {
+    output = execFileSync(command, [SHIM_PROBE_ARG], {
+      env,
+      encoding: 'utf8',
+      timeout: PROBE_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: options.shell ?? false,
+      ...(options.cwd !== undefined ? { cwd: options.cwd } : {}),
+    });
+  } catch (err) {
+    // Narrowed rather than `unknown`: an unknown here stringifies to
+    // [object Object] instead of the fields a reader needs.
+    const e = err as {
+      code?: string;
+      status?: number;
+      signal?: string;
+      stdout?: string;
+      stderr?: string;
+    };
+    // A non-zero exit still carries both streams, and stdout may hold the marker
+    // — a shim that answered and then failed for its own reasons has resolved,
+    // which is the only question being asked here. Reading it is what keeps a
+    // real resolution from being reported as a miss.
+    output = e.stdout ?? '';
+    const status = e.status === undefined ? '(none)' : String(e.status);
+    // stderr is the only thing that explains a genuine failure, so it belongs in
+    // the one message written to diagnose one.
+    const stderr = (e.stderr ?? '').trim();
+    spawnFailure =
+      `code=${e.code ?? '(none)'} status=${status} signal=${e.signal ?? '(none)'}` +
+      (stderr === '' ? '' : ` stderr=${JSON.stringify(stderr.slice(0, 200))}`);
+  }
+  if (output.includes(marker)) return;
+
+  const sawInstead =
+    spawnFailure !== undefined
+      ? `the spawn failed (${spawnFailure})`
+      : `it answered ${JSON.stringify(output.trim().slice(0, 120))}`;
+  throw new Error(
+    [
+      `PATH shim for "${command}" did not resolve to the test stub — ${sawInstead}.`,
+      'This is a SETUP failure and the suite must not continue: a shim that does',
+      'not land does NOT fail closed. Resolution carries on down PATH and finds',
+      `the REAL installed "${command}", so driving the chain from here would make`,
+      'a live call with the seeded fixtures as its input.',
+      'On Windows the usual cause is that execFile does no PATHEXT resolution and',
+      'refuses to spawn a .cmd/.bat without a shell (the CVE-2024-27980 fix) — see',
+      "packages/local-ops/src/exec.ts's USE_SHELL for the same constraint in",
+      'shipped code. On POSIX, check the shim is executable and that PATH was',
+      'joined with path.delimiter.',
+    ].join(' '),
+  );
+}

--- a/plugins/codex/test/journey/no-model-judge-consent.journey.test.ts
+++ b/plugins/codex/test/journey/no-model-judge-consent.journey.test.ts
@@ -24,21 +24,15 @@
  * uncalled. Nothing can reach the model API on this path.
  */
 import { spawnSync } from 'node:child_process';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { bundledDetections } from '@akasecurity/plugin-sdk';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { assertShimResolves, shimmedPath, writeCommandShim } from '../helpers/path-shim.ts';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 // test/journey -> plugins/codex
@@ -71,13 +65,18 @@ interface StepResult {
 // POSIX, so pointing HOME at a temp dir isolates the whole chain — no
 // script-level flag or process.env read is added to shipped code. The child env
 // is built from scratch (never the host env): PATH carries only the stub-judge
-// bin dir plus node's own dir, so the stub `codex` is the ONLY resolvable judge
-// and the `#!/usr/bin/env node` shebang still finds node.
+// bin dir plus node's own dir, so a real `codex` on the developer's PATH is not
+// reachable through it, and the shebang still finds node. That is a narrower
+// claim than "the stub is the only resolvable judge" — PATH is not the whole
+// of resolution (Windows searches the working and system directories first),
+// and a stub that fails to land is answered by whatever is, not by an ENOENT.
+// assertShimResolves in run() is what closes that gap.
 class SetupJourney {
   readonly home: string;
   // The settings.json the onboarding writer records the consent into.
   readonly settingsPath: string;
   private readonly binDir: string;
+  private shimProven = false;
 
   constructor() {
     this.home = mkdtempSync(join(tmpdir(), 'aka-codex-journey-home-'));
@@ -156,10 +155,22 @@ class SetupJourney {
       USERPROFILE: this.home,
       // Stub judge first on PATH so apply-suppressions' `codex exec` spawn hits
       // it, never a live model; node's own dir second so the stub's
-      // `#!/usr/bin/env node` shebang resolves. Nothing else from the host
-      // environment reaches the chain.
-      PATH: `${this.binDir}:${dirname(process.execPath)}`,
+      // `#!/usr/bin/env node` shebang resolves — that shebang is the POSIX
+      // branch of writeCommandShim; on Windows the stub is a .cmd naming an
+      // absolute node, so node's dir is on PATH for POSIX's sake, not both.
+      // Nothing else from the host environment reaches the chain.
+      PATH: shimmedPath(this.binDir, dirname(process.execPath)),
     };
+    // Proven once per journey, before the first script runs. A shim that does
+    // not land does NOT fail closed: resolution keeps walking PATH and finds a
+    // real installed `codex`, so the chain would reach a live model and this
+    // suite's load-bearing `judgeWasInvoked()` assertion would pass for the
+    // wrong reason — nothing ran because nothing COULD run. spawnCodex uses no
+    // `shell`, so the probe must not either.
+    if (!this.shimProven) {
+      assertShimResolves('codex', env);
+      this.shimProven = true;
+    }
     // spawnSync (not execFileSync) so BOTH streams are captured on the success
     // path too — the stderr assertions below must see what a wizard transcript
     // would see, and execFileSync only surfaces stderr when the child fails.
@@ -185,9 +196,7 @@ class SetupJourney {
   // (genuine), the rest marked routine false positives. No live model is ever
   // hit.
   private writeFakeJudge(): void {
-    const src = `#!/usr/bin/env node
-'use strict';
-// Record that the judge actually ran, so a test can prove the consent gate
+    const body = `// Record that the judge actually ran, so a test can prove the consent gate
 // stopped the egress at the process boundary (see judgeWasInvoked).
 require('node:fs').writeFileSync(${JSON.stringify(this.judgeSentinelPath)}, '');
 const args = process.argv.slice(2);
@@ -237,9 +246,9 @@ if (outFile) {
   require('node:fs').writeFileSync(outFile, '\`\`\`json\\n' + JSON.stringify(verdict) + '\\n\`\`\`');
 }
 `;
-    const path = join(this.binDir, 'codex');
-    writeFileSync(path, src);
-    chmodSync(path, 0o755);
+    // writeCommandShim owns the shebang, the mode bits and — on Windows — the
+    // .cmd launcher that makes a bare `codex` resolvable at all.
+    writeCommandShim(this.binDir, 'codex', body);
   }
 }
 

--- a/tools/portability-gate/src/lib.ts
+++ b/tools/portability-gate/src/lib.ts
@@ -1,13 +1,14 @@
 // Pure scanning logic for the cross-platform portability gate: a lightweight,
-// non-parsing scanner over the tracked test and bench trees looking for four
+// non-parsing scanner over the tracked test and bench trees looking for five
 // known failure shapes — a hardcoded file:/// URL (POSIX-only, breaks on Windows),
 // a bare GNU `timeout` shell command (absent on macOS), a path comparison
 // with no case normalization (macOS/Windows are case-insensitive, Linux is
-// not), and a worker/concurrency test with no explicit timeout. The CLI entry
+// not), a worker/concurrency test with no explicit timeout, and a PATH built
+// with a literal ':' (Windows joins with ';'). The CLI entry
 // (check-portability.ts) owns all I/O — git ls-files, reading file contents —
 // so the unit suite can drive this with canned file lists.
 //
-// Rules 1-3 describe primitives, not test structure, so they apply to every
+// Rules 1-3 and 5 describe primitives, not test structure, so they apply to every
 // source file in a test or bench tree — the helpers, fixtures-in-code, worker
 // entrypoints and benchmark drivers that carry the worker/platform/path code a
 // spec file usually only calls. Rule 4 keys on an `it()`/`test()` call and so
@@ -22,10 +23,13 @@
 // e.g. /["']/ — would otherwise be misread as the start of a string), then
 // pattern-matches within each. Rules 1 and 2 are mechanical and reliable:
 // they only fire on characters that are unambiguously part of a string
-// literal. Rules 3 and 4 are best-effort: they cannot see a comparison split
+// literal. Rules 3, 4 and 5 are best-effort: they cannot see a comparison split
 // across lines or routed through an intermediate variable, and rule 3 in
 // particular only catches two path-producing expressions compared directly on
-// one line. Treat their silence as "found nothing," not "there is nothing."
+// one line. Rule 5 needs the word PATH to be code on the separator's own line
+// or on the line its literal opens, so a separator held in a named constant, or
+// a PATH assembled several statements away from the ':' it is joined with, goes
+// unseen. Treat their silence as "found nothing," not "there is nothing."
 
 export interface ScannedFile {
   path: string;
@@ -36,7 +40,8 @@ export type RuleId =
   | 'hardcoded-file-url'
   | 'bare-timeout-command'
   | 'path-comparison-case'
-  | 'concurrency-missing-timeout';
+  | 'concurrency-missing-timeout'
+  | 'path-separator-literal';
 
 export interface RuleInfo {
   title: string;
@@ -59,6 +64,10 @@ export const RULES: Record<RuleId, RuleInfo> = {
   'concurrency-missing-timeout': {
     title: 'Concurrency/worker test with no explicit timeout',
     help: "a test that spawns a worker or waits on concurrent I/O can outrun vitest's 5s default under CI load. Either raise testTimeout/hookTimeout for the whole package (see plugins/claude-code/vitest.config.ts) or pass an explicit timeout to this test.",
+  },
+  'path-separator-literal': {
+    title: "PATH joined or split on a literal ':'",
+    help: "Windows joins PATH with ';', so a ':'-joined value is one malformed entry there and a prepended bin dir is not on PATH at all. Use path.delimiter. This one fails OPEN, which is why it is worth a rule: a test shim that does not land is not an ENOENT — resolution walks on and runs the REAL installed binary, so the suite reaches a live tool while still looking hermetic (see plugins/*/test/helpers/path-shim.ts).",
   },
 };
 
@@ -345,6 +354,70 @@ function checkPathComparisonCase(file: ScannedFile, codeMasked: string): Violati
   return violations;
 }
 
+// A PATH the code builds or takes apart itself. `\bPATH\b` is deliberately
+// case-sensitive and boundary-anchored: it reaches `PATH:`, `env.PATH` and
+// `process.env.PATH`, and stays off `filePath` (no boundary, wrong case) and
+// `SCRIPTS_PATH` (an underscore is a word character, so no boundary either).
+const PATH_TOKEN_RE = /\bPATH\b/;
+// The two shapes a POSIX-only separator takes. A template interpolating either
+// side of a bare colon (`${dir}:${rest}`), and a lone ':' as a whole string,
+// which is what a .join(':')/.split(':') argument or a concatenation reads as.
+// A colon anywhere else in a longer literal is left alone — that is a path, a
+// URL or a label far more often than a separator.
+const PATH_JOIN_TEMPLATE = '}:${';
+const LONE_COLON = ':';
+
+// Every line a separator literal actually occupies. A template literal can span
+// lines, and s.line is only where it OPENS — so a PATH built across lines has
+// its `}:${` on a line the segment's start never names. Reporting (and testing
+// for the PATH token at) the opening line alone both misses those and points the
+// reader at the wrong line when it does fire.
+function separatorLines(segment: StringSegment): number[] {
+  if (segment.text === LONE_COLON) return [segment.line];
+  const lines: number[] = [];
+  let searchFrom = 0;
+  for (;;) {
+    const at = segment.text.indexOf(PATH_JOIN_TEMPLATE, searchFrom);
+    if (at === -1) break;
+    // +1 for the opening quote, which is not part of text.
+    const newlines = segment.text.slice(0, at).split('\n').length - 1;
+    lines.push(segment.line + newlines);
+    searchFrom = at + PATH_JOIN_TEMPLATE.length;
+  }
+  return lines;
+}
+
+function checkPathSeparatorLiteral(
+  file: ScannedFile,
+  codeMasked: string,
+  strings: StringSegment[],
+): Violation[] {
+  const codeLines = codeMasked.split('\n');
+  // The PATH token has to be code on the separator's own line or on the line the
+  // literal opens (a single-line build is both), so a colon-joined string with
+  // nothing to do with the environment variable stays quiet — and a `PATH` that
+  // appears only inside a comment or a test description is masked out and so
+  // does not count as naming one.
+  const namesPath = (line: number): boolean => PATH_TOKEN_RE.test(codeLines[line - 1] ?? '');
+  const flagged = new Set<number>();
+  for (const segment of strings) {
+    if (!segment.text.includes(PATH_JOIN_TEMPLATE) && segment.text !== LONE_COLON) continue;
+    for (const line of separatorLines(segment)) {
+      if (namesPath(line) || namesPath(segment.line)) flagged.add(line);
+    }
+  }
+  // One violation per line however many literals sit on it: two reports of the
+  // same defect at the same place is noise a reader has to reconcile.
+  return [...flagged]
+    .sort((a, b) => a - b)
+    .map((line) => ({
+      rule: 'path-separator-literal' as const,
+      file: file.path,
+      line,
+      message: `PATH built or split on a literal ":" — ${RULES['path-separator-literal'].help}`,
+    }));
+}
+
 function checkConcurrencyMissingTimeout(
   file: ScannedFile,
   codeMasked: string,
@@ -451,6 +524,7 @@ export function scanTree(files: ScannedFile[]): Violation[] {
       ...checkHardcodedFileUrl(file, codeMasked, strings),
       ...checkBareTimeoutCommand(file, codeMasked, strings),
       ...checkPathComparisonCase(file, codeMasked),
+      ...checkPathSeparatorLiteral(file, codeMasked, strings),
       ...(isSpec
         ? checkConcurrencyMissingTimeout(
             file,

--- a/tools/portability-gate/test/check-portability.test.ts
+++ b/tools/portability-gate/test/check-portability.test.ts
@@ -94,6 +94,66 @@ describe('path-comparison-case', () => {
   });
 });
 
+describe('path-separator-literal', () => {
+  // The shim that motivated this rule lives in a HELPER, not a *.test.ts, so
+  // every case here is filed under a test-tree path rather than a spec name —
+  // a bare "harness.ts" is neither, and scanTree would skip it, passing each
+  // absence assertion below without ever running the rule.
+  const HELPER = 'plugins/x/test/journey/harness.ts';
+
+  it('flags a template join, a .join(":") and a .split(":") on PATH', () => {
+    const violations = scanTree([testFile(HELPER, fixture('path-separator.bad.txt'))]).filter(
+      (v) => v.rule === 'path-separator-literal',
+    );
+    expect(violations.map((v) => v.line)).toEqual([8, 11, 12]);
+    expect(violations[0]?.message).toContain('path.delimiter');
+  });
+
+  it('does not flag path.delimiter, nor a colon-joined string naming no PATH', () => {
+    expect(scanTree([testFile(HELPER, fixture('path-separator.clean.txt'))])).toEqual([]);
+  });
+
+  it('flags it in a spec file too', () => {
+    const violations = scanTree([
+      testFile('shim.test.ts', fixture('path-separator.bad.txt')),
+    ]).filter((v) => v.rule === 'path-separator-literal');
+    expect(violations).toHaveLength(3);
+  });
+
+  it('reports a multi-line template at the separator s line, not where the literal opens', () => {
+    // A string segment's line is only where it OPENS. A template that spans
+    // lines carries its `}:${` further down, and reporting the opening line
+    // sends the reader somewhere the defect is not.
+    const violations = scanTree([
+      testFile(
+        HELPER,
+        ['const env = {', '  PATH: `${binDir}', '${middle}:${hostPath}`,', '};'].join('\n'),
+      ),
+    ]).filter((v) => v.rule === 'path-separator-literal');
+    expect(violations.map((v) => v.line)).toEqual([3]);
+  });
+
+  it('reports one violation per line however many literals sit on it', () => {
+    const violations = scanTree([
+      testFile(HELPER, "const round = process.env.PATH.split(':').join(':');"),
+    ]).filter((v) => v.rule === 'path-separator-literal');
+    expect(violations).toHaveLength(1);
+  });
+
+  it('does not flag the same shape inside a comment', () => {
+    const violations = scanTree([
+      testFile(
+        HELPER,
+        [
+          '// PATH: `${binDir}:${rest}` is the POSIX-only form this rule catches.',
+          'export const x = 1;',
+        ].join('\n'),
+      ),
+    ]);
+    expect(violations).toEqual([]);
+  });
+});
+
 describe('concurrency-missing-timeout', () => {
   it('flags a worker-spawning test with no timeout anywhere', () => {
     const violations = scanTree([

--- a/tools/portability-gate/test/fixtures/path-separator.bad.txt
+++ b/tools/portability-gate/test/fixtures/path-separator.bad.txt
@@ -1,0 +1,12 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const binDir = mkdtempSync(join(tmpdir(), 'shim-'));
+
+const env = {
+  PATH: `${binDir}:${process.env.PATH ?? ''}`,
+};
+
+const alsoWrong = [binDir, process.env.PATH].join(':');
+const entries = env.PATH.split(':');

--- a/tools/portability-gate/test/fixtures/path-separator.clean.txt
+++ b/tools/portability-gate/test/fixtures/path-separator.clean.txt
@@ -1,0 +1,15 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { delimiter, join } from 'node:path';
+
+const binDir = mkdtempSync(join(tmpdir(), 'shim-'));
+
+const env = {
+  PATH: `${binDir}${delimiter}${process.env.PATH ?? ''}`,
+};
+
+const alsoFine = [binDir, process.env.PATH].join(delimiter);
+const entries = env.PATH.split(delimiter);
+// A colon-joined string that names no PATH is somebody else's business.
+const label = `${file}:${line}`;
+const url = 'https://example.invalid/a:b';


### PR DESCRIPTION
## Summary

A suite that drives a **built** script cannot reach that script's spawn seams — they are
in-process, and the script is another process. So the external command is faked by putting a
controlled executable first on the child's `PATH`: the journey harnesses' judge stub
(`claude`/`codex`/`agy`) and `provenance.test.ts`'s fake `npm`.

Those shims were POSIX-only in all three plugins, and **a shim that does not land is not an
`ENOENT`** — resolution walks the rest of `PATH` and runs the REAL installed binary. So the
failure mode is a suite that looks hermetic while reaching a live model or the npm registry.

None of the existing gates see it: the ESLint ban reads source, the vitest no-network guard
cannot follow a child process, and the Linux `No-network` job is the only one that would — on
the one platform where the shim happens to work.

Tracked separately.

## Changes

- **`plugins/*/test/helpers/path-shim.ts`** — the shared helper, a **peer copy per plugin** for
  the reason `no-echo.ts` is: a package wall blocks the import, and a copy takes its
  `path-shim.test.ts` with it, or `assertShimResolves` can be weakened back into a no-op with
  every caller staying green. Writes a `.cmd` launcher on win32 rather than an extensionless
  `#!` file, joins with `path.delimiter` rather than a literal `':'`, relies on no `chmod`
  (a no-op there), and returns the bin dir **alone** when there is no base PATH — an empty
  PATH entry means the current directory to execvp and to libuv.
- **`assertShimResolves`** — resolution is now **proven** before a chain is driven, by spawning
  the command the way the code under test will, so a miss is a red setup rather than a live
  call. It *performs* resolution rather than modelling it, so it agrees with libuv about
  `PATHEXT` instead of restating it. `shell` and `cwd` mirror the spawn being stood in for;
  the journey harness keys its proof **by cwd** rather than latching it once, because Windows
  searches the working directory before walking PATH. The probe answer comes before anything
  else the stub does, so probing is never recorded as an invocation — which is what the
  `judgeWasInvoked()` sentinel assertions rest on.
- **`provenance.ts`** — exports `USE_SHELL` so the probe imports the runner's own condition
  rather than re-deriving it; a shell-free probe against a shelled runner reports a false miss,
  and the reverse a false pass.
- **`tools/portability-gate`** — new `path-separator-literal` rule plus clean/bad fixtures,
  which catches a literal `':'` returning to a PATH call site (how this defect arrived).
- **`CLAUDE.md`** — new "The PATH shim, and why it fails OPEN" section documenting the contract.

`writeCommandShim` takes an optional `platform` (as `judgeEnv` does), so both branches are
driven from either host — writing the other platform's form is a resolution failure on this
one. Each case pins the **artifact** as well as the refusal, since a branch that wrote nothing
also refuses and reads identically.

## Verification

Full suites, run on this commit (arm64 macOS, Node 24):

```
$ pnpm --filter @akasecurity/ai-tc-claude-code test
 Test Files  79 passed (79)
      Tests  959 passed (959)
   Duration  61.99s
EXIT=0

$ pnpm --filter @akasecurity/ai-tc-codex test
 Test Files  39 passed (39)
      Tests  428 passed (428)
   Duration  68.80s

$ pnpm --filter @akasecurity/ai-tc-antigravity test
 Test Files  36 passed (36)
      Tests  435 passed | 1 skipped (436)
   Duration  44.21s
EXIT=0

$ pnpm --filter @akasecurity/portability-gate test
 Test Files  1 passed (1)
      Tests  46 passed (46)
   Duration  877ms
```

Pre-push `pnpm lint` (20/20 tasks) and `pnpm check:portability` both passed on this commit —
`Portability check passed: no violations found.` No hook was bypassed.

Every acceptance criterion was proven non-vacuous by mutation: the guarded behaviour was
deliberately broken, the named test confirmed red, the tree restored, and green re-confirmed.

Note on flakiness: the pre-existing `withTempHome` `ENOTEMPTY` teardown flake in
`test/e2e/*` / `test/helpers/*` did surface during development, including on a run of a single
e2e file that imports none of the changed files. It did not reproduce in the runs above
(`grep -nE 'FAIL|ENOTEMPTY'` over the claude-code log returned nothing). It is unrelated to
this diff.

## Known gaps (deliberate, not oversights)

- **From-scratch child env omits `PATHEXT`.** The codex/antigravity harnesses build their child
  env from nothing by design ("Nothing else from the host environment reaches the chain"), so
  fixing this changes a stated hermeticity invariant on a platform not runnable here — and the
  failure mode it causes is a red setup, not a silent live call. Belongs with the Windows
  `spawnClaude` work.
- **Probe-before-spawn ordering is not pinned by a test.** A faithful pin needs each harness to
  expose its private `binDir` so a test can break the shim and assert the script never ran —
  restructuring three harnesses, outside this diff.
- **The gate's new rule is best-effort, like rules 3 and 4.** It needs `PATH` to be code on the
  separator's own line or the line its literal opens, so a separator held in a named constant,
  or a PATH assembled several statements from the `':'` it is joined with, goes unseen. That
  limit is written into the rule's header rather than implied by a passing test.
