### PR TITLE
ci: lint on Windows and guard both Windows legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,13 +288,18 @@ jobs:
   # two cases declared with `it.each` (which passes no TestContext) threw instead
   # of skipping, on the only platform that reaches the skip.
   #
-  # It runs its whole `test` script — all four suites, 604 assertions — and
-  # depends on no workspace package, so turbo schedules nothing upstream of it.
+  # It runs its whole `test` script — every suite in the package — and depends on
+  # no workspace package, so turbo schedules nothing upstream of it.
   #
-  # Cost, over three Windows runs (identical 604-test workload each time): the
-  # package's task 33s / 54s / 57s, effective-config.test.js 32s / 53s / 55s of
-  # that, against ~4.7s on a developer machine. Size a new case against the
-  # slower end — roughly a 10x factor, not the 3-5x the store suites see.
+  # Cost, over three Windows runs: the package's task 33s / 54s / 57s,
+  # effective-config.test.js 32s / 53s / 55s of that, against ~4.7s on a
+  # developer machine. Size a new case against the slower end — roughly a 10x
+  # factor, not the 3-5x the store suites see. Treat those figures as a FLOOR
+  # rather than the workload today: they were taken over an identical 604-test
+  # run, and the package has grown well past that since (measure the current
+  # figure with `pnpm --filter @akasecurity/eslint-config exec vitest run
+  # --reporter=json` and read `numTotalTests` — do not trust a count written
+  # here, which is what went stale last time).
   #
   # It is NOT on the critical path, and that is the number to reason about
   # rather than the job's wall clock. `@akasecurity/persistence` is the tail in
@@ -355,3 +360,89 @@ jobs:
           --filter=@akasecurity/local-ops
           --filter=@akasecurity/web-ui
           --filter=@akasecurity/eslint-config
+
+  # Windows lint leg: every `lint` script in this workspace carries a GLOB — all
+  # twenty packages target `*.config.*`, and so does the repo-root `lint:root`,
+  # which is the twenty-first invocation rather than a twenty-first package —
+  # and WHO EXPANDS IT is decided by the platform, not by the script. On POSIX
+  # the shell expands the pattern and hands eslint concrete filenames; `cmd.exe`
+  # does not glob at all, so eslint receives the literal pattern and runs its
+  # own expansion. Both should work. Until this job existed neither was
+  # observed on Windows, because `pnpm lint` ran on ubuntu-latest alone.
+  #
+  # It is load-bearing because `*.config.*` is the ONLY target that reaches each
+  # package's root config files (CLAUDE.md, "Adding a new workspace package",
+  # step 5). A pattern resolving to nothing there would take every ban off those
+  # files on this platform, while the guard that audits coverage went on
+  # reporting them covered — effective-config.test.js MODELS the expansion with
+  # `path.posix.matchesGlob` rather than running it, so it answers from the
+  # model on every platform and cannot see a real one that came back empty.
+  #
+  # A green run here is a real observation rather than a vacuous one, and that
+  # rests on a measured detail: eslint fails an unmatched pattern PER PATTERN,
+  # not only when every pattern is empty. Measured on eslint 9.39.4 —
+  # `eslint src 'zzz*.config.*'` exits 2 with `No files matching the pattern
+  # "zzz*.config.*" were found` even though `src` matches; the same command with
+  # the real pattern exits 0. So an expansion that silently came back empty
+  # reddens this job. It cannot pass quietly.
+  #
+  # Unfiltered, deliberately. Every lint script in the workspace carries the
+  # glob, and `pnpm lint` chains `lint:root`, whose own `*.config.*` is the only
+  # pass covering repo-root files that belong to no package.
+  #
+  # What this leg CANNOT exercise, so that nobody adds a case expecting it to:
+  # the CRLF normalization in parseWorkspaceGlobs. `.gitattributes` sets
+  # `* text=auto eol=lf`, so a Windows checkout gets LF like every other, and no
+  # `\r` ever reaches that parser here. It is covered instead by a synthetic
+  # case in effective-config.test.js that runs on every platform, which is the
+  # only place it can be covered. What this leg DOES uniquely exercise is the
+  # separator half: `globSync` yields native paths while `git ls-files` yields
+  # posix, and on Windows alone those two disagree.
+  #
+  # DELIBERATELY NO TURBO CACHE, for the same reason the no-network job has
+  # none. Turbo's hash covers file contents, dependencies and env — not the
+  # runner image, the shell, or the Node build, which are exactly the inputs
+  # this leg exists to exercise. A restored cache would let turbo replay a green
+  # `lint` task that expanded no glob on this runner at all, and the job would
+  # report success having observed nothing.
+  #
+  # Lint is the cheapest of the four task types, which is what makes a cold run
+  # affordable where a cold `test` would not be — but size the budget off the
+  # Windows factor, not off the figure below. Measured on an M-series Mac at
+  # `Cached: 0`: 72s for all twenty packages, plus 6.5s for lint:root and 0.6s
+  # for check:portability. At the ~10x factor the test leg above documents for
+  # this runner that is on the order of 13 minutes before `pnpm install`, which
+  # is the margin `timeout-minutes: 25` actually has. No Windows measurement
+  # exists yet; take one from the first green run and replace this paragraph
+  # with it rather than reasoning from the Mac number twice.
+  #
+  # It is a SEPARATE job rather than a step on the Windows test leg above, for
+  # two reasons. It runs in parallel, so it adds nothing to the critical path of
+  # what is already the slowest job here. And folding it in would make that
+  # job's NAME wrong — and that name is a required check (CONTRIBUTING.md,
+  # "Checks that gate `main`"), so renaming it stops branch protection matching
+  # anything and blocks every merge until a repo admin re-points it.
+  windows-lint:
+    name: Windows · Lint
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 10.30.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # `pnpm lint`, not `turbo run lint`: the root script chains `lint:root`
+      # and `check:portability` after it, and the first of those is the pass
+      # that covers the repo root. Going to turbo directly would drop both.
+      - name: Lint
+        run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,14 +407,18 @@ jobs:
   # report success having observed nothing.
   #
   # Lint is the cheapest of the four task types, which is what makes a cold run
-  # affordable where a cold `test` would not be — but size the budget off the
-  # Windows factor, not off the figure below. Measured on an M-series Mac at
-  # `Cached: 0`: 72s for all twenty packages, plus 6.5s for lint:root and 0.6s
-  # for check:portability. At the ~10x factor the test leg above documents for
-  # this runner that is on the order of 13 minutes before `pnpm install`, which
-  # is the margin `timeout-minutes: 25` actually has. No Windows measurement
-  # exists yet; take one from the first green run and replace this paragraph
-  # with it rather than reasoning from the Mac number twice.
+  # affordable where a cold `test` would not be. Measured on THIS runner rather
+  # than extrapolated (`gh run view 31536100993 --repo akasecurity/ai-tc`): the
+  # Lint step 1m49s, the whole job 2m41s. The same `pnpm lint` at `Cached: 0` on
+  # an M-series Mac is 72s for all twenty packages plus 6.5s for lint:root and
+  # 0.6s for check:portability.
+  #
+  # So the ~10x factor the test leg above documents does NOT transfer to lint —
+  # here it is about 1.5x. Size a lint budget off a lint measurement; the factor
+  # is a property of the task type, not of the runner. That leaves
+  # `timeout-minutes: 25` roughly 9x headroom, not the ~2x an estimate carried
+  # over from the test leg predicts. One run is not a stable figure — re-take it
+  # with the command above rather than trusting this line indefinitely.
   #
   # It is a SEPARATE job rather than a step on the Windows test leg above, for
   # two reasons. It runs in parallel, so it adds nothing to the critical path of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,7 @@ a name in it no longer belongs to a real job.
 | `No-network · Full suite, egress blocked` | `ci.yml`     |
 | `macOS · Full suite`                      | `ci.yml`     |
 | `Windows · Unit tests (shipped surface)`  | `ci.yml`     |
+| `Windows · Lint`                          | `ci.yml`     |
 | `Dependency audit`                        | `audit.yml`  |
 | `CodeQL (javascript-typescript)`          | `codeql.yml` |
 | `CodeQL (actions)`                        | `codeql.yml` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,19 @@ knowing since the branch-protection REST endpoint 404s to non-admins and reads l
 gh api graphql -f query='{repository(owner:"akasecurity",name:"ai-tc"){pullRequest(number:PR){commits(last:1){nodes{commit{statusCheckRollup{contexts(first:50){nodes{... on CheckRun{name isRequired(pullRequestNumber:PR)}}}}}}}}}}'
 ```
 
+**Measured 2026-08-12: only two of the eight are actually required** —
+`Lint · Typecheck · Test · Build` and `Windows · Unit tests (shipped surface)`. The other
+six run on every PR and block nothing. Two of those six are asserted as enforced
+elsewhere in this repository: CLAUDE.md presents `No-network · Full suite, egress blocked`
+as one of the three gates gating the no-network guarantee, and describes `Dependency
+audit` as the reason a high or critical advisory "will not merge". Neither holds until an
+admin marks them required — a PR that reaches the network on a shell-out, or that carries
+a critical advisory, goes red there and stays mergeable.
+
+This paragraph is a hand-recorded observation, not something the tree derives, so it goes
+stale in the safe direction only until someone fixes the setting. Re-run the query above
+rather than trusting it.
+
 By contributing you agree that your contributions are licensed under the
 repository's [LICENSE](LICENSE). Please also read our
 [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -15,6 +15,8 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
+import { rootScripts, workspaceLintScripts } from './helpers/lint-invocations.js';
+
 const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url));
 const WORKFLOWS = join(REPO_ROOT, '.github', 'workflows');
 
@@ -72,6 +74,17 @@ function jobBlock(source, key) {
   return body;
 }
 
+// The windows-lint step, which must be `pnpm lint` and nothing else. The
+// boundary is `(?![\w:])` rather than `\b` because `:` is a NON-word character,
+// so `pnpm lint\b` also matches `pnpm lint:root` — and that is not a hypothetical
+// spelling, it is a script this repo really has. Swapping the step to it drops
+// `turbo run lint` (all twenty packages) and `check:portability`, leaving only
+// the repo-root pass, while every assertion below goes on passing. The negative
+// class deliberately excludes a SPACE, so an argument appended after the script
+// name still matches: that is what lets this double as the positive control for
+// the absence checks, which is the property the comments below turn on.
+const LINT_STEP = /run: pnpm lint(?![\w:])/;
+
 // Every Turbo cache key a job declares — the `key:` and each line under
 // `restore-keys:`, which are bare values rather than `key: `-prefixed.
 // `[^\S\n]+` rather than `\s+`: this is one line's indentation, and `\s` would
@@ -118,10 +131,10 @@ describe('the required-check table in CONTRIBUTING.md', () => {
   const rows = requiredChecks();
 
   // A table that parsed to nothing would satisfy every per-row assertion below
-  // without checking anything, so pin the count first. The four CI jobs, the
+  // without checking anything, so pin the count first. The five CI jobs, the
   // audit, and CodeQL's two matrix legs.
   it('parses, and covers every gate the table is supposed to list', () => {
-    expect(rows).toHaveLength(7);
+    expect(rows).toHaveLength(8);
     expect(rows.map((row) => row.file)).toEqual(
       expect.arrayContaining(['ci.yml', 'audit.yml', 'codeql.yml']),
     );
@@ -235,6 +248,100 @@ describe('the macOS leg', () => {
   });
 });
 
+// The two Windows legs. Between them they are the only place three things are
+// ever executed on this platform, and each is invisible in a diff once dropped:
+// the guard package's own path handling, and the glob expansion every `lint`
+// script depends on.
+describe('the Windows legs', () => {
+  const ci = readWorkflow('ci.yml');
+
+  // Read here, but BLOCKED inside each `it` — jobBlock asserts, and an assertion
+  // in a describe body is a collection error that reports the whole FILE as
+  // `(0 test)`, silently taking the gate-table rows with it. Reading the file is
+  // safe out here; resolving a block is not.
+
+  it('runs the shipped-surface tests on a Windows runner', () => {
+    expect(jobBlock(ci, 'windows')).toMatch(/^ {4}runs-on: windows-latest$/m);
+  });
+
+  // @akasecurity/eslint-config is the one filter entry that ships nothing —
+  // `private: true`, bundled by no artifact — so it is the first thing anyone
+  // trimming this list back to "the shipped surface" would strike, and the job's
+  // NAME invites exactly that. It is also the only place the guard's own
+  // Windows path handling ever runs: globSync yields native separators while
+  // `git ls-files` yields posix, and the two are compared against each other
+  // throughout effective-config.test.js. Drop this entry and those normalizations
+  // go back to being a hypothesis no runner checks, with nothing red to show it.
+  it('tests the enforcement package, not just the shipped surface', () => {
+    const block = jobBlock(ci, 'windows');
+    expect(block).toMatch(/turbo run test/);
+    // `(?![\w-])` rather than `\b`: a hyphen is a non-word character, so `\b`
+    // would also accept `--filter=@akasecurity/eslint-config-legacy`, i.e. a
+    // rename or split that repoints the filter at a sibling and takes this
+    // package's Windows coverage away while the test stays green.
+    expect(block).toMatch(/--filter=@akasecurity\/eslint-config(?![\w-])/);
+  });
+
+  it('runs lint on a Windows runner', () => {
+    expect(jobBlock(ci, 'windows-lint')).toMatch(/^ {4}runs-on: windows-latest$/m);
+  });
+
+  // `pnpm lint`, not `turbo run lint`: the root script chains `lint:root` after
+  // it, which is the only pass covering the repo-root files that belong to no
+  // package. Going to turbo directly drops that half while still reading as a
+  // lint pass.
+  it('runs the root lint script, so the repo-root pass runs too', () => {
+    expect(jobBlock(ci, 'windows-lint')).toMatch(LINT_STEP);
+  });
+
+  // Unfiltered is the whole point: every lint script in the workspace targets
+  // `*.config.*`, so a filter narrows what expansion is observed while leaving a
+  // green check that reads as covering all of it. Absence-only, so it is paired
+  // with the positive control above — without a `pnpm lint` in the same body
+  // this passes on a block that captured no run step at all.
+  //
+  // That control stops at a boundary rather than end-of-line, and the difference
+  // is the whole value of the pair. Anchored with `$`, appending `--filter=…` to
+  // the step breaks the CONTROL, so this test goes red for the wrong reason and
+  // its own assertion — the one naming the property — is never reached. The
+  // absence check has to be the thing that fires on the mutation it describes, or
+  // it is unproven however green the suite is. See LINT_STEP for why that
+  // boundary is not `\b`.
+  it('lints the whole workspace rather than a filtered subset', () => {
+    const block = jobBlock(ci, 'windows-lint');
+    expect(block).toMatch(LINT_STEP);
+    expect(block).not.toMatch(/--filter/);
+  });
+
+  // Same reasoning as the macOS leg: a job-level `if:` does not save a PR the
+  // wait, because GitHub reports a skipped job as PENDING for a required check.
+  it.each(['windows', 'windows-lint'])('%s carries no condition that could skip it', (job) => {
+    expect(jobBlock(ci, job)).not.toMatch(/^ {4}if:/m);
+  });
+
+  // The windows-lint job's whole justification is that a `lint` script carries a
+  // glob whose expansion is decided by the platform. That premise is a claim
+  // about the tree, so derive it rather than asserting it in a comment: a package
+  // whose lint script drops `*.config.*` takes its root config files out of every
+  // lint pass on every platform, and this job would stay green throughout —
+  // twenty other scripts still expand, so nothing here reddens.
+  //
+  // The count is pinned first for the usual reason: an empty list satisfies a
+  // `for` loop over it without checking anything. It is a floor AND a ceiling, so
+  // a package added without a lint script is caught by the same assertion.
+  it('every lint script carries the glob this job exists to observe', () => {
+    const scripts = workspaceLintScripts();
+    expect(scripts).toHaveLength(20);
+    for (const { dir, lintScript } of scripts) {
+      expect(lintScript, `${dir} declares no lint script`).not.toBe('');
+      expect(lintScript, `${dir}'s lint script targets no *.config.* glob`).toContain('*.config.*');
+    }
+    // And the repo-root pass, which is the twenty-first invocation rather than a
+    // twenty-first package — it is the only one covering files no package owns.
+    expect(rootScripts()['lint:root']).toContain('*.config.*');
+  });
+});
+
 // Turbo's task hash covers file contents, dependencies and env — not the
 // platform. Two jobs now restore .turbo/cache on two different OSes, so a key
 // that did not separate them would let macOS restore Linux's entry, hash-match,
@@ -268,6 +375,23 @@ describe('the Turbo caches in ci.yml', () => {
   it('leaves the no-network job uncached', () => {
     const block = jobBlock(ci, 'no-network');
     expect(block).toMatch(/no-network-test\.sh/);
+    expect(block).not.toMatch(/uses: actions\/cache@/);
+  });
+
+  // And the Windows lint leg, for the same reason one step further out. What it
+  // exists to observe is who expands `*.config.*` on this platform — a property
+  // of the runner image, the shell and the Node build, none of which turbo
+  // hashes. So a restored cache is not merely stale here, it is the failure:
+  // turbo replays a green `lint` task that expanded no glob on this runner at
+  // all, and the check reports success having observed nothing. `runner.os` in
+  // the key does not help — the replay it would license is a WINDOWS entry from
+  // an earlier commit, which is exactly the run being skipped.
+  //
+  // Paired with the lint step for the same reason as above: the assertion is an
+  // absence, and an absence passes on a body that captured nothing.
+  it('leaves the Windows lint job uncached', () => {
+    const block = jobBlock(ci, 'windows-lint');
+    expect(block).toMatch(LINT_STEP);
     expect(block).not.toMatch(/uses: actions\/cache@/);
   });
 });


### PR DESCRIPTION
## Summary

Every `lint` script in this workspace carries a `*.config.*` glob, and **who expands it is decided by the platform, not the script**. On POSIX the shell expands it and hands eslint concrete filenames; `cmd.exe` does not glob at all, so eslint receives the literal pattern and runs its own expansion. Until now `pnpm lint` only ever ran on `ubuntu-latest`, so neither path was observed on Windows.

That glob is load-bearing: it is the only target reaching each package's root config files, so a pattern resolving to nothing there would silently take every lint ban off those files on that platform — while the guard that audits coverage went on reporting them covered, because it *models* the expansion with `path.posix.matchesGlob` rather than running it.

## Changes

- **New `Windows · Lint` job** — unfiltered `pnpm lint` on `windows-latest`, deliberately uncached. Turbo's hash covers file contents, dependencies and env, not the runner image or shell, so a restored cache would replay a green `lint` that expanded no glob on that runner at all.
- **Both Windows legs guarded** in `required-checks.test.js`: the runner, the `@akasecurity/eslint-config` filter entry, the root lint chain, unfiltered, no `if:`, no turbo cache — each absence check paired with a positive control so none is vacuous.
- **The premise is now derived from the tree** rather than asserted in a comment: a test walks every package's lint script and fails if one drops the glob.
- Corrected two stale counts in the ci.yml commentary, citing the command to re-measure instead of a written number.

## Verification

The `--filter=@akasecurity/eslint-config` half was already true but unguarded; it is now pinned. Its suite passes on Windows today — from `gh run view 31514799252` on `0d0c421e`:

```
@akasecurity/eslint-config:test  D:\a\ai-tc\ai-tc\packages\eslint-config
 Test Files  10 passed (10)
      Tests  935 passed | 9 skipped (944)
```

Every new guard is mutation-proven, not merely green (`pnpm exec vitest run test/required-checks.test.js`):

| mutation | result |
|---|---|
| step → `pnpm lint:root` | 3 failed \| 29 passed |
| drop `*.config.*` from a package's lint script | 1 failed \| 31 passed, naming the package |
| remove the `--filter` entry | red on the filter assertion |

The first is why the step matcher is `(?![\w:])` rather than `\b`: `:` is a non-word character, so `pnpm lint\b` also matches `pnpm lint:root` — which drops `turbo run lint` across all 20 packages and `check:portability` while leaving the guard green.

Local: `Test Files 10 passed (10)`, `Tests 954 passed (954)`. Pre-push `pnpm lint` green at `Cached: 0`.

## Notes for review

- **`Windows · Lint` needs adding to branch protection.** CONTRIBUTING.md now lists it as a check that gates `main`, but that table is documentation — the setting lives in repo settings and nothing in the tree can verify it. Until an admin adds it, the row overstates what is enforced.
- **The Windows and macOS checks on this PR will be red for a pre-existing reason.** Both legs went red on `main` at `0d0c421e`, in `@akasecurity/persistence` (`generate.test.ts` times out at 20000ms on Windows; `scale-budgets.test.ts` hook times out at 120000ms on macOS). `2ebb61f8` was green on both. That is a different package and is being fixed separately — read this job's own result rather than the leg's overall conclusion.
- No Windows timing measurement exists for the new job yet; the comment says so and asks for one from the first green run rather than reasoning twice from the Mac figure.