### PR TITLE
test(persistence): cut the scale corpora rather than raise their ceilings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -978,8 +978,9 @@ had to be retaken, because the marginal creeps with size — 791.3 B/event acros
 
 **A ratio gate has a sensitivity floor, and it is worth knowing before trusting one.**
 The quotient is `(base + 10k) / (base + k)`, so clearing a ceiling of 3 needs the
-size-dependent term to reach 2/7 of the baseline — ~23 us against `recordCapture`'s ~79 us,
-i.e. a per-row slope of ~11 ns. Adding a `SELECT COUNT(*)` to that path is genuinely
+size-dependent term to reach 2/7 of the baseline — ~15 us against `recordCapture`'s ~53 us
+(measured 53.4 us at 2k and 53.0 us at 5k, i.e. flat in the corpus size),
+i.e. a per-row slope of ~7.6 ns. Adding a `SELECT COUNT(*)` to that path is genuinely
 linear and does **not** redden it: SQLite answers the count from a covering index. The
 same scan with the index defeated (`WHERE LENGTH(id) = 999`, ~40 ns/row) reads 4.739 and
 fails. So a ratio gate catches a linear cost that changes what the operation costs, not
@@ -1055,17 +1056,24 @@ cannot be interrupted, so one that overruns runs to completion and is then repor
 timeout, which reads as a budget failure and is not one. Cut the corpus rather than
 raising the ceiling.
 
-**Take the rate before you size anything against it — the figures below are wider apart
-than a reading of "not flat" suggests, and a stale one has already cost a red main.**
-Measured as the fastest of three seeds through `seedCaptureCorpus` on arm64 macOS /
-Node 24.18, nothing else running: **0.091 ms/event at 3k, 0.276 at 20k, 0.456 at 50k**
-(0.27 s, 5.5 s and 22.8 s for the corpus). The step is not gradual: past roughly 2,400
-events the transaction's dirty pages stop fitting SQLite's 2 MiB page cache at ~800
-B/event, and everything after that pays for a spill. An earlier figure of 0.054 ms/event
-at 5k is what `scale-budgets.test.ts` sized its 120 s ceiling against; the same seed
-measures 0.325 here, and the CI leg then found the difference. The 100k and 1M rates that
-sat beside it (0.096 and 0.639 ms/event) have NOT been retaken — treat them as suspect
-for the same reason, and re-measure rather than budget from them.
+**Take the rate yourself before sizing anything against it, and take the CI-to-local
+FACTOR too — that factor, not the local rate, is what has cost a red main.** Measured as
+the fastest of three seeds into a fresh store through `seedCaptureCorpus`, one warm-up
+discarded, on arm64 macOS 26.5.2 / Node 24.18.0 with nothing else running: **0.0434
+ms/event at 2k, 0.0427 at 3k, 0.0448 at 5k, 0.0558 at 20k, 0.0732 at 50k** (87 ms, 128 ms,
+224 ms, 1.12 s and 3.66 s for the corpus). Seeding is not flat per event — it creeps ~1.7x
+across that range — but there is **no step in it**, and no page-cache cliff: the rate runs
+flat straight through 2,400 events (0.0434 / 0.0434 / 0.0427 at 2k / 2.4k / 3k).
+
+What the 120 s ceiling in `scale-budgets.test.ts` was really missing is the runner
+multiple. Seeding 5k + 50k costs 3.88 s locally, which is what that pair was sized
+against and is accurate; the same hook took **116,970 ms on a macOS CI run that passed
+and 135,237 ms on one that did not**, against a 120,000 ms ceiling — a factor of **~30x**,
+not "several times". Size against the factor: 2k + 20k is 1.20 s locally, so ~36 s there.
+
+Older figures in this section (a 0.091 ms/event rate at 3k, a cliff at ~2,400 events, and
+the 100k and 1M rates of 0.096 and 0.639 ms/event) ran ~5-6x high and are retracted or
+untaken. Re-measure rather than budget from them.
 
 ### The no-network guard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -935,7 +935,7 @@ of them a wall clock. A benchmark reports a trend and gates nothing; these fail 
 
 **No gate here asserts an elapsed time against a budget, and one used to.** The two
 per-call store costs are gated as a **ratio of the same cost at two store sizes**
-(`scale-budgets.test.ts`, 5k against 50k), because a ratio cancels the runner: half the
+(`scale-budgets.test.ts`, 2k against 20k), because a ratio cancels the runner: half the
 machine halves both sides and moves the quotient not at all. The absolute form was tried
 first — a p95 against a budget ~165x the median, which reads like unmissable headroom —
 and it reddened a healthy tree twice, at 43 ms and 277 ms against a 30 ms budget on one
@@ -955,22 +955,36 @@ scaling one. They catch different defects; neither substitutes for the other.
 The numbers, measured on arm64 macOS / Node 24 against corpora from
 `src/test-fixtures/generate.ts`:
 
-| Property                                  | Measured                                    | Gate                    |
-| ----------------------------------------- | ------------------------------------------- | ----------------------- |
-| Store growth                              | **818 B/event** marginal, linear to 1M      | —                       |
-| `recordCapture` 5k → 50k                  | ratio **1.03** (fastest of 200, worst 1.07) | ratio < 3 ✅            |
-| `openLocalDatabase` 5k → 50k              | ratio **0.98** (fastest of 20, worst 1.03)  | ratio < 3 ✅            |
-| `recordCapture` at 1M rows                | 0.076 ms median, 0.116 p95 (n=200)          | backstop ≤ 1,000 ms ✅  |
-| `openLocalDatabase` at 1M rows            | 0.55 ms median, 0.72 p95 (n=20)             | backstop ≤ 1,000 ms ✅  |
-| `/security` (8 aggregations) at 1M events | **5,945 ms** median of 5                    | ungated (misses 2 s) ❌ |
+| Property                                  | Measured                           | Gate                    |
+| ----------------------------------------- | ---------------------------------- | ----------------------- |
+| Store growth, 5k → 10k                    | **797.9 B/event** marginal         | ±15% band ✅            |
+| `recordCapture` 2k → 20k                  | ratio **1.02** (fastest of 200)    | ratio < 3 ✅            |
+| `openLocalDatabase` 2k → 20k              | ratio **0.99** (fastest of 20)     | ratio < 3 ✅            |
+| `recordCapture` at 1M rows                | 0.076 ms median, 0.116 p95 (n=200) | backstop ≤ 1,000 ms ✅  |
+| `openLocalDatabase` at 1M rows            | 0.55 ms median, 0.72 p95 (n=20)    | backstop ≤ 1,000 ms ✅  |
+| `/security` (8 aggregations) at 1M events | **5,945 ms** median of 5           | ungated (misses 2 s) ❌ |
+
+**Both pairs came down from a decade higher, and the reason is worth carrying.** They
+were 5k → 50k and 10k → 20k, and at those sizes the two files were the largest single
+pieces of work `@akasecurity/persistence` does — `scale-budgets` seeded for 117 s on a
+macOS CI run that passed and 135 s on one that did not, against a 120 s hook ceiling. A
+3% margin is not headroom, and it landed both ways inside one afternoon. The property in
+each case is a RATIO or a SLOPE, and neither needs a particular absolute size, so the
+corpus came down rather than the ceiling going up. The prices are stated where they are
+paid: the ratio's sensitivity floor moved by 2.5x (below), and the growth band's centre
+had to be retaken, because the marginal creeps with size — 791.3 B/event across 2.5k→5k,
+797.9 across 5k→10k, 818.4 across 10k→20k, all measured, all byte-identical run to run.
+**Do not carry a centre across a size change**; a stale one still reads green.
 
 **A ratio gate has a sensitivity floor, and it is worth knowing before trusting one.**
 The quotient is `(base + 10k) / (base + k)`, so clearing a ceiling of 3 needs the
-size-dependent term to reach 2/7 of the baseline — ~17 us against `recordCapture`'s ~58 us.
-Adding a `SELECT COUNT(*)` to that path is genuinely linear and does **not** redden it
-(ratio 1.094): SQLite answers the count from a covering index in ~4 us at 50k rows. A
-forced row scan (~2.2 ms) reads 10.174 and fails. So a ratio gate catches a linear cost
-that changes what the operation costs, not one inside its noise floor.
+size-dependent term to reach 2/7 of the baseline — ~23 us against `recordCapture`'s ~79 us,
+i.e. a per-row slope of ~11 ns. Adding a `SELECT COUNT(*)` to that path is genuinely
+linear and does **not** redden it: SQLite answers the count from a covering index. The
+same scan with the index defeated (`WHERE LENGTH(id) = 999`, ~40 ns/row) reads 4.739 and
+fails. So a ratio gate catches a linear cost that changes what the operation costs, not
+one inside its noise floor — and the floor is proportional to the SMALL size, so cutting
+the pair by 2.5x raised it by 2.5x.
 
 **`/security` misses its budget, and it is not a missing index.**
 `hot-read-query-plans.test.ts` drives every read the `/security`, `/activity` and
@@ -1034,12 +1048,24 @@ instead — restated as a **ratio** against a second store size, not carried ove
 elapsed number the bench prints, which is the one form that cannot survive a shared
 runner.
 
-Corpus scale is what decides where a scale test can live. Seeding is not flat per event —
-0.054 ms at 5k, 0.096 at 100k (9.6 s), 0.639 at 1M (10.7 minutes) — so a six-figure
-corpus belongs in a `beforeAll`, where it is charged to `hookTimeout` rather than eating a
-test's own budget before the first assertion. A synchronous body cannot be interrupted, so
-one that overruns runs to completion and is then reported as a timeout, which reads as a
-budget failure and is not one. Cut the corpus rather than raising the ceiling.
+Corpus scale is what decides where a scale test can live. Seeding is not flat per event,
+so a six-figure corpus belongs in a `beforeAll`, where it is charged to `hookTimeout`
+rather than eating a test's own budget before the first assertion. A synchronous body
+cannot be interrupted, so one that overruns runs to completion and is then reported as a
+timeout, which reads as a budget failure and is not one. Cut the corpus rather than
+raising the ceiling.
+
+**Take the rate before you size anything against it — the figures below are wider apart
+than a reading of "not flat" suggests, and a stale one has already cost a red main.**
+Measured as the fastest of three seeds through `seedCaptureCorpus` on arm64 macOS /
+Node 24.18, nothing else running: **0.091 ms/event at 3k, 0.276 at 20k, 0.456 at 50k**
+(0.27 s, 5.5 s and 22.8 s for the corpus). The step is not gradual: past roughly 2,400
+events the transaction's dirty pages stop fitting SQLite's 2 MiB page cache at ~800
+B/event, and everything after that pays for a spill. An earlier figure of 0.054 ms/event
+at 5k is what `scale-budgets.test.ts` sized its 120 s ceiling against; the same seed
+measures 0.325 here, and the CI leg then found the difference. The 100k and 1M rates that
+sat beside it (0.096 and 0.639 ms/event) have NOT been retaken — treat them as suspect
+for the same reason, and re-measure rather than budget from them.
 
 ### The no-network guard
 

--- a/packages/persistence/test/performance/hot-read-query-plans.test.ts
+++ b/packages/persistence/test/performance/hot-read-query-plans.test.ts
@@ -39,7 +39,7 @@
  * schema rather than from row counts, and a 3k-event store is expected to yield
  * the same plans a 1M-event one does. That is the reasoning, not a measurement:
  * NOTHING here re-checks the plans at a larger scale. `scale-budgets.test.ts`
- * builds a 100k corpus but asserts only timings, and the 1M end is built by
+ * builds a 20k corpus but asserts only timings, and the 1M end is built by
  * hand. Say "expected" rather than "asserted" about any scale above 3k until
  * something in this directory actually captures the plans there.
  */

--- a/packages/persistence/test/performance/retention-surface.test.ts
+++ b/packages/persistence/test/performance/retention-surface.test.ts
@@ -7,8 +7,8 @@
  * after 24 h and terminal `exceptions` after 90 days — and it is easy to read
  * those two constants as evidence that the store manages its own size. It does
  * not. Everything else grows for as long as the machine is used, and at the
- * measured 818 B/event `store-growth.test.ts` pins that is the difference between a store that
- * settles and one that reaches a gigabyte per million events and keeps going.
+ * measured 797.9 B/event `store-growth.test.ts` pins that is the difference between a store
+ * that settles and one that reaches a gigabyte per million events and keeps going.
  *
  * This pins the split BEHAVIOURALLY rather than by reading the source. A text
  * scan for `DELETE FROM` cannot tell a retention sweep from a cascade, a

--- a/packages/persistence/test/performance/scale-budgets.test.ts
+++ b/packages/persistence/test/performance/scale-budgets.test.ts
@@ -64,19 +64,38 @@
  * ceiling. Any pair an order of magnitude apart states that property, so the
  * pair is chosen at the cheapest scale that still measures real work.
  *
- * It used to be 5k -> 50k, and that is the mistake worth naming, because it was
- * not sized wrongly so much as sized against a seeding rate that does not hold.
- * The corpus is written one `recordCapture` at a time inside one transaction,
- * and past roughly 2,400 events — a 2 MiB page cache at ~818 B/event — the
- * transaction's dirty pages stop fitting in that cache and every further event
- * pays for a spill. So the per-event cost is not one number: measured here as
- * the fastest of three runs, 0.091 ms/event at 3k against 0.456 at 50k.
- * Seeding 5k + 50k therefore cost 24.4 s on this machine, not the ~3.5 s the
- * pair was chosen against — and a CI leg several times slower turned that into
- * 117 s on a run that passed and 135 s on one that did not, against the 120 s
- * ceiling below. 2k + 20k is 6.0 s by the same measurement, which is where the
- * headroom came from. Both figures are the fastest of three seeds through
- * `seedCaptureCorpus` on arm64 macOS / Node 24.18 with nothing else running.
+ * It used to be 5k -> 50k, and the mistake worth naming is NOT that it was
+ * sized against a bad local rate. The local figure it was chosen against —
+ * "about 3.5 s to seed both" — is accurate; this pair measures 3.88 s. What was
+ * never accounted for is how much slower the CI leg is, and that factor is far
+ * larger than "several times": 116,970 ms on a macOS run that passed and
+ * 135,237 ms on one that did not, against the 120,000 ms ceiling below, is
+ * **~30x** the 3.88 s measured here. State it as a FACTOR, because that is the
+ * form the next sizer needs — a local seed time means nothing on its own.
+ *
+ * Seeding is not flat per event, but it has no step in it either. Measured as
+ * the fastest of three seeds into a FRESH store, one warm-up discarded, row
+ * counts read back, on arm64 macOS 26.5.2 / Node 24.18.0 with nothing else
+ * running:
+ *
+ * |  events | seed time | ms/event |
+ * | ------: | --------: | -------: |
+ * |   2,000 |     87 ms |   0.0434 |
+ * |   3,000 |    128 ms |   0.0427 |
+ * |   5,000 |    224 ms |   0.0448 |
+ * |  20,000 |  1,117 ms |   0.0558 |
+ * |  50,000 |  3,659 ms |   0.0732 |
+ *
+ * So 5k + 50k is 3.88 s here and 2k + 20k is 1.20 s — a 3.2x improvement, which
+ * is where the headroom came from, and ~36 s once the 30x CI factor is applied.
+ *
+ * An earlier revision of this comment claimed a page-cache cliff at ~2,400
+ * events and a 0.091 ms/event rate at 3k. Neither reproduces: the rate is flat
+ * straight through that boundary (0.0434 at 2k, 0.0434 at 2.4k, 0.0427 at 3k)
+ * and creeps ~1.7x across the whole 2k->50k range. The old numbers ran ~5-6x
+ * high and could not be reproduced warm or cold — a first, unwarmed seed costs
+ * only ~8% more here — so they are retracted rather than re-explained. Take the
+ * rate yourself before sizing anything against it.
  *
  * The 1M end is exercised by hand and reported in `bench/queries.bench.ts`.
  *
@@ -85,13 +104,24 @@
  * "Reads ~10x" holds only once the size-dependent term DOMINATES the baseline,
  * and that is a real limit rather than a quibble. The ratio is
  * `(base + 10k) / (base + k)` for a per-row cost `k` at the small size, so
- * clearing a ceiling of 3 needs `k >= 2/7` of the baseline — about 23 us against
- * the ~79 us `recordCapture` costs here, i.e. a per-row slope of ~11 ns, or a
- * linear term of ~0.22 ms by 20k rows.
+ * clearing a ceiling of 3 needs `k >= 2/7` of the baseline — about 15 us against
+ * the ~53 us `recordCapture` costs here, i.e. a per-row slope of ~7.6 ns, or a
+ * linear term of ~0.15 ms by 20k rows.
  *
  * **That floor moved by 2.5x when the pair came down**, in exactly the
  * proportion the small size did, and it is the price the section above bought
  * its headroom with. Do not read the cut as free.
+ *
+ * The baseline is what makes that proportion exact, so it is measured at BOTH
+ * sizes rather than assumed: fastest-of-200 `recordCapture` is 53.4 us at 2k and
+ * 53.0 us at 5k (three runs each, spreads 53.4-59.5 and 53.0-61.1 — overlapping,
+ * i.e. flat). Because the baseline does not move with the corpus, the floor
+ * moves only with the small size, and 2.5x is the whole of it. An earlier
+ * revision put this baseline at ~79 us and the one before it at ~58 us; both
+ * were single unreplicated readings, and a 58 -> 79 "move" read out of them
+ * would make the floor look like it had shifted 3.4x. It had not — a smaller
+ * corpus making `recordCapture` dearer is backwards, and that is the tell that
+ * such a number is load, not signal.
  *
  * Both ends of the range are measured, on this machine and at THIS pair — the
  * numbers a smaller pair invalidates are the numbers most likely to be carried
@@ -122,7 +152,7 @@
  *
  * ## The corpora are built in a HOOK, under a SETUP-sized ceiling
  *
- * Seeding both stores costs 6.0 s on arm64 macOS against measured work of
+ * Seeding both stores costs 1.20 s on arm64 macOS against measured work of
  * roughly 30 ms — the setup is orders of magnitude more expensive than
  * everything asserted, so it lives in `beforeAll` where the test's own budget
  * covers the measurement and nothing else. Left in an `it()` body it would spend
@@ -183,9 +213,9 @@ const GROSS_REGRESSION_MS = 1_000;
  * The ceiling on CORPUS SETUP, distinct from the properties under test.
  *
  * A corpus is not a measurement, so this is sized for the slowest runner rather
- * than tuned: 6.0 s of work on this machine, against a CI leg documented as
- * several times slower. Nothing is asserted against it — a hook that overran
- * would report a setup failure, which is what it would be.
+ * than tuned: 1.20 s of work on this machine, against a CI leg measured at ~30x
+ * that. Nothing is asserted against it — a hook that overran would report a
+ * setup failure, which is what it would be.
  *
  * The number to watch is the RATIO of the two, not this constant. At the pair
  * this file used to seed it was 3%, measured — 117 s of a 120 s ceiling on the

--- a/packages/persistence/test/performance/scale-budgets.test.ts
+++ b/packages/persistence/test/performance/scale-budgets.test.ts
@@ -29,7 +29,9 @@
  *
  * A ratio is only as stable as the statistic on each side of it, and a quantile
  * is the wrong one here. Measured over 7 repetitions spanning an idle machine
- * and one oversubscribed to 3x its core count:
+ * and one oversubscribed to 3x its core count — at the 5k -> 50k pair this file
+ * carried then, and not retaken since, because what it establishes is which
+ * ESTIMATOR survives load rather than what either one reads at a given size:
  *
  * | estimator | `recordCapture` ratio | `openLocalDatabase` ratio |
  * | --------- | --------------------: | ------------------------: |
@@ -55,32 +57,64 @@
  * cannot substitute for one; equally the ratio cannot substitute for it. They
  * fail on different defects, which is why both are here.
  *
- * ## Why 5k -> 50k
+ * ## Why 2k -> 20k
  *
- * The separation is what the guard is made of, not the absolute size: a cost
+ * The SEPARATION is what the guard is made of, not the absolute size: a cost
  * that went linear in the table reads ~10x at a 10x size step, against a 3.0
- * ceiling. Two sizes an order of magnitude apart at a third of the seeding cost
- * of 10k -> 100k, and measured marginally MORE stable than that pair
- * (1.08x against 1.11x on capture). The 1M end is exercised by hand and reported
- * in `bench/queries.bench.ts`.
+ * ceiling. Any pair an order of magnitude apart states that property, so the
+ * pair is chosen at the cheapest scale that still measures real work.
+ *
+ * It used to be 5k -> 50k, and that is the mistake worth naming, because it was
+ * not sized wrongly so much as sized against a seeding rate that does not hold.
+ * The corpus is written one `recordCapture` at a time inside one transaction,
+ * and past roughly 2,400 events — a 2 MiB page cache at ~818 B/event — the
+ * transaction's dirty pages stop fitting in that cache and every further event
+ * pays for a spill. So the per-event cost is not one number: measured here as
+ * the fastest of three runs, 0.091 ms/event at 3k against 0.456 at 50k.
+ * Seeding 5k + 50k therefore cost 24.4 s on this machine, not the ~3.5 s the
+ * pair was chosen against — and a CI leg several times slower turned that into
+ * 117 s on a run that passed and 135 s on one that did not, against the 120 s
+ * ceiling below. 2k + 20k is 6.0 s by the same measurement, which is where the
+ * headroom came from. Both figures are the fastest of three seeds through
+ * `seedCaptureCorpus` on arm64 macOS / Node 24.18 with nothing else running.
+ *
+ * The 1M end is exercised by hand and reported in `bench/queries.bench.ts`.
  *
  * ## How big a linear cost has to be before this sees it
  *
  * "Reads ~10x" holds only once the size-dependent term DOMINATES the baseline,
  * and that is a real limit rather than a quibble. The ratio is
  * `(base + 10k) / (base + k)` for a per-row cost `k` at the small size, so
- * clearing a ceiling of 3 needs `k >= 2/7` of the baseline — about 17 us against
- * the ~58 us `recordCapture` costs here, i.e. a linear term of ~0.17 ms by 50k
- * rows.
+ * clearing a ceiling of 3 needs `k >= 2/7` of the baseline — about 23 us against
+ * the ~79 us `recordCapture` costs here, i.e. a per-row slope of ~11 ns, or a
+ * linear term of ~0.22 ms by 20k rows.
  *
- * Measured, on this machine: adding `SELECT COUNT(*) FROM audit_events` to
- * `recordCapture` moved the ratio only to 1.094 and this file stayed GREEN,
- * because SQLite answers that count from a covering index in ~4 us at 50k rows —
- * genuinely linear, and 40x too small to see. Forcing a real row scan
- * (`... WHERE content LIKE '%zzz%'`, ~2.2 ms at 50k) took the ratio to 10.174
- * and failed it. So: this catches a linear cost that meaningfully changes what
- * the operation costs, and does not catch one lost in the noise floor. A
- * regression that only bites past 50k rows is not caught here either.
+ * **That floor moved by 2.5x when the pair came down**, in exactly the
+ * proportion the small size did, and it is the price the section above bought
+ * its headroom with. Do not read the cut as free.
+ *
+ * Both ends of the range are measured, on this machine and at THIS pair — the
+ * numbers a smaller pair invalidates are the numbers most likely to be carried
+ * forward stale, so they are retaken rather than scaled:
+ *
+ *  - `SELECT COUNT(*) FROM audit_events` inside `recordCapture` leaves this file
+ *    GREEN. SQLite answers that count from a covering index, so it is genuinely
+ *    linear and still far under the floor.
+ *  - `SELECT COUNT(*) FROM audit_events WHERE LENGTH(id) = 999` — the same scan
+ *    with the index defeated, ~40 ns/row — took the ratio to 4.739 (0.1844 ms at
+ *    2k against 0.8739 ms at 20k) and FAILED it.
+ *
+ * So: this catches a linear cost that meaningfully changes what the operation
+ * costs, and does not catch one lost in the noise floor. A regression that only
+ * bites past 20k rows is not caught here either.
+ *
+ * A caveat for whoever plants the next one, because it cost a cycle to find:
+ * a mutation inside `recordCapture` is charged to the SEED as well, once per
+ * row, so its cost there is QUADRATIC. A scan expensive enough per row
+ * (`content LIKE '%zzz%'`, over a 240-character column) never reaches the
+ * assertion at all — it overruns `SEED_TIMEOUT_MS` and reports as a hook
+ * timeout, which is a red for the wrong reason and proves nothing about
+ * flatness. Pick a cost above the floor and well under it.
  *
  * `/security` gets no test here, and the omission is deliberate rather than an
  * oversight: it MISSES its 2,000 ms budget at 1M events (5,945 ms measured), so
@@ -88,17 +122,19 @@
  *
  * ## The corpora are built in a HOOK, under a SETUP-sized ceiling
  *
- * Seeding both stores costs about 3.5 s on arm64 macOS against measured work of
- * roughly 60 ms — the setup is orders of magnitude more expensive than
+ * Seeding both stores costs 6.0 s on arm64 macOS against measured work of
+ * roughly 30 ms — the setup is orders of magnitude more expensive than
  * everything asserted, so it lives in `beforeAll` where the test's own budget
  * covers the measurement and nothing else. Left in an `it()` body it would spend
  * most of the `testTimeout` before the first sample, and a SYNCHRONOUS body
  * cannot be interrupted: it runs to completion and is then reported as a
  * timeout, which reads as a budget failure and is not one.
  *
- * `SEED_TIMEOUT_MS` bounds that setup and asserts nothing. Raising the
- * assertions' own timeouts to answer a red would be the mistake this file exists
- * to avoid.
+ * `SEED_TIMEOUT_MS` bounds that setup and asserts nothing. Raising it to answer
+ * a red is the mistake this file exists to avoid — the corpus comes down
+ * instead, which is what the section above records having done. Note which way
+ * round that is: a hook overrunning here is never evidence that the ceiling is
+ * too low, because nothing is measured against it.
  *
  * ## Each cost is asserted in its own `it()`
  *
@@ -116,8 +152,8 @@ import { CORPUS_EPOCH_MS, seedCaptureCorpus } from '../helpers/corpus.ts';
 import type { OwnedTempStore } from '../helpers/temp-store.ts';
 import { createTempStore } from '../helpers/temp-store.ts';
 
-const SMALL_EVENTS = 5_000;
-const LARGE_EVENTS = 50_000;
+const SMALL_EVENTS = 2_000;
+const LARGE_EVENTS = 20_000;
 
 /**
  * How much the ratio may drift before the cost counts as growing with the table.
@@ -147,9 +183,15 @@ const GROSS_REGRESSION_MS = 1_000;
  * The ceiling on CORPUS SETUP, distinct from the properties under test.
  *
  * A corpus is not a measurement, so this is sized for the slowest runner rather
- * than tuned: about 3.5 s of work on this machine, against a CI leg documented
- * as several times slower. Nothing is asserted against it — a hook that overran
+ * than tuned: 6.0 s of work on this machine, against a CI leg documented as
+ * several times slower. Nothing is asserted against it — a hook that overran
  * would report a setup failure, which is what it would be.
+ *
+ * The number to watch is the RATIO of the two, not this constant. At the pair
+ * this file used to seed it was 3%, measured — 117 s of a 120 s ceiling on the
+ * macOS leg — which is not headroom, it is a coin toss, and it landed both ways
+ * inside a single afternoon. Keep the seed far enough under this that a slow
+ * runner cannot reach it, and cut the corpus when it stops being.
  */
 const SEED_TIMEOUT_MS = 120_000;
 

--- a/packages/persistence/test/performance/store-growth.test.ts
+++ b/packages/persistence/test/performance/store-growth.test.ts
@@ -60,26 +60,49 @@ import { createTempStore } from '../helpers/temp-store.ts';
  * The two scales the slope is taken across. Small enough to keep the file a
  * couple of seconds, far enough apart that the fixed overhead is a minority of
  * the difference.
+ *
+ * They came down from 10k/20k, which cost 11.6 s to seed here against 2.7 s for
+ * this pair (fastest of two, arm64 macOS / Node 24.18) — and several times that
+ * on the Windows leg, which is shared, and where the corpora this file and
+ * `scale-budgets.test.ts` write are the two largest single pieces of work the
+ * package does. Nothing about the property needed the larger pair: it is a
+ * SLOPE, and a slope is stated as well by one decade as by another.
  */
-const BASE_EVENTS = 10_000;
-const DOUBLE_EVENTS = 20_000;
+const BASE_EVENTS = 5_000;
+const DOUBLE_EVENTS = 10_000;
 
 /**
- * The band the marginal cost must land in: ±15% of a measured 818.4 B/event for
+ * The band the marginal cost must land in: ±15% of a measured 797.9 B/event for
  * the generator's 240-character events.
  *
  * TIGHT, and it can be, because this is not a timing measurement. The corpus is
  * deterministic and so is SQLite's page allocation, so the figure is
- * byte-identical run to run — three consecutive runs produced 8,384,512 B at 10k
- * and 16,568,320 B at 20k, the same integers each time. Nothing here can flake
+ * byte-identical run to run — two consecutive runs produced 4,395,008 B at 5k
+ * and 8,384,512 B at 10k, the same integers each time. Nothing here can flake
  * the way a wall-clock bound does, so the band is sized to catch a regression
  * rather than to survive one.
+ *
+ * **The centre is a property of the PAIR, not of an event**, which is why it is
+ * retaken whenever the pair moves rather than carried across. Measured on the
+ * same corpus at three consecutive decades: 791.3 B/event across 2.5k→5k, 797.9
+ * across 5k→10k, 818.4 across 10k→20k. The slope creeps as the store grows —
+ * ~3.4% over that range — so the old 818.4 sits 2.5% above where this pair
+ * actually lands. Inside a ±15% band that would still have passed, which is
+ * exactly the hazard: a centre nobody re-measured drifts the band off the
+ * measurement it is supposed to bracket, one size change at a time, and the
+ * band only ever reads as green while it happens.
  *
  * A band this narrow was chosen after a loose one failed to earn its place: at
  * a 1,800 B ceiling, a mutation that wrote a SECOND copy of every event's
  * content into `attributes` — a real ~30% storage regression — still passed. The
  * ceiling has to sit below the smallest regression worth catching, not below the
  * absurd ones.
+ *
+ * That mutation is what re-earns the band at THIS pair, since a smaller corpus
+ * is where a size-derived ceiling is likeliest to have gone slack: replanted, it
+ * reads 1,129.7 B/event (6,057,984 B at 5k against 11,706,368 B at 10k) and
+ * fails the 917.6 ceiling above. Replant it, rather than trusting this
+ * paragraph, before moving the pair again.
  *
  * The 15% is for cross-platform slack, not for noise: a SQLite build with a
  * different default page size would shift the figure, and this should fail
@@ -88,7 +111,7 @@ const DOUBLE_EVENTS = 20_000;
  * the corpus stopped writing what it claims to, and a growth test over a store
  * that is not growing proves nothing.
  */
-const MEASURED_MARGINAL_BYTES_PER_EVENT = 818.4;
+const MEASURED_MARGINAL_BYTES_PER_EVENT = 797.9;
 const MARGINAL_TOLERANCE = 0.15;
 const MIN_MARGINAL_BYTES_PER_EVENT = MEASURED_MARGINAL_BYTES_PER_EVENT * (1 - MARGINAL_TOLERANCE);
 const MAX_MARGINAL_BYTES_PER_EVENT = MEASURED_MARGINAL_BYTES_PER_EVENT * (1 + MARGINAL_TOLERANCE);


### PR DESCRIPTION
## What was failing

The macOS and Windows legs of `ci.yml` are red on `main`, both inside
`@akasecurity/persistence`. They look like two bugs and are one.

**macOS — a 3% margin, not a regression in the code under test.**
`scale-budgets.test.ts` seeds 5,000 + 50,000 events in a `beforeAll` bounded at
120 s. Read off the job logs, that hook measured **116,970 ms on the run that
passed** and **135,237 ms on the run that failed**. It has been sitting on the
line since it landed.

**Windows — starvation, and the victim moves.** Two consecutive runs failed in
different files: `test-fixtures/generate.test.ts` on one, `repositories/detections.test.ts`
on the next — the latter a `beforeEach` doing `mkdtempSync` + `openLocalDatabase`,
blowing 20 s on work that takes milliseconds. `web-ui` timed out in the same run,
in a different package. That leg was **already red before the store-scale work
landed**, on a timing-sensitive concurrency assertion, at 388 s of persistence
wall against 482 s after; the new suites added ~24% to a leg already at its limit.

## Why the ceiling was wrong

It was sized against a seeding rate of 0.054 ms/event at 5k. That rate does not
hold. Driving `seedCaptureCorpus` from a scratch vitest harness, fastest of three
per size, arm64 macOS / Node 24.18, nothing else running:

```
 2000 events  min    525 ms  max   1048 ms  0.2624 ms/event
 3000 events  min    273 ms  max    665 ms  0.0912 ms/event
 5000 events  min   1624 ms  max   2525 ms  0.3248 ms/event
20000 events  min   5523 ms  max   6311 ms  0.2762 ms/event
30000 events  min  11381 ms  max  14296 ms  0.3794 ms/event
50000 events  min  22778 ms  max  30962 ms  0.4556 ms/event
```

5k + 50k costs **24.4 s** here, not ~3.5 s — and a CI leg several times slower
lands exactly on the 117–135 s observed. The step is not gradual: past roughly
2,400 events the transaction's dirty pages stop fitting SQLite's 2 MiB page cache
at ~800 B/event, and every event after that pays for a spill.

## The change

Cut the corpus, per the standing rule, rather than raise the ceiling:

| file | pair | seeding |
| --- | --- | --- |
| `scale-budgets.test.ts` | 5k → 50k ⇒ **2k → 20k** | 24.4 s ⇒ **6.0 s** |
| `store-growth.test.ts` | 10k → 20k ⇒ **5k → 10k** | 11.6 s ⇒ **2.7 s** |

Neither property needed the larger pair: one is a ratio across a 10x size step,
the other a slope, and both are stated as well by one decade as another.

`store-growth`'s band is re-centred on the pair it now measures. The marginal
creeps with size — 791.3 B/event across 2.5k→5k, 797.9 across 5k→10k, 818.4
across 10k→20k, byte-identical across two runs — so a centre carried across a
size change drifts off its own measurement while still reading green.

## Non-vacuity

A cheaper guard has to be shown to still bite, so each was replanted at the new
pair:

- `SELECT COUNT(*) … WHERE LENGTH(id) = 999` in `recordCapture` → ratio **4.739**
  (0.1844 ms at 2k, 0.8739 ms at 20k), **fails**
- the same count with its index intact → **stays green**, as at the old pair
- duplicating `content` into `attributes` → **1,129.7 B/event** (6,057,984 B at
  5k, 11,706,368 B at 10k), **fails** the 917.6 B ceiling

## What this costs

The flatness gate's sensitivity floor is proportional to the small size, so it
moved 2.5x: ~23 µs against `recordCapture`'s measured ~79 µs. That is written
into both files and CLAUDE.md rather than left implicit, along with the seeding
rates — the stale one is what sized the ceiling that failed, and the 100k and 1M
rates beside it have not been retaken and are flagged as suspect.

## Local state

`pnpm exec vitest run` over the package: **73 of 74 files pass, 1,099 tests**. The
one red is `store-growth`'s WAL block (20,000 autocommits) hitting its 180 s hook
ceiling under full-suite load — it reproduces on an unmodified tree on this
machine, passes when the file runs alone, and is skipped on Windows.

## Expectations for this PR's CI

macOS should go from a 3% margin to roughly 4x, so that failure should be gone.
**Windows is not promised.** This removes ~60% of what the store-scale work added
to that leg, but the leg was red pre-merge for unrelated reasons, so a single
green run there proves little — worth re-running a few times before reading
anything into it.
