### PR TITLE
test: skip rather than return on a platform guard, and gate the shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1358,9 +1358,29 @@ times slower, and a timing assertion there is a flake. Compare with `primaryCode
 
 Where a platform or a privilege makes an assertion meaningless, use `ctx.skip(reason)`.
 An early `return` reports as a pass, which is the failure mode the store harness exists
-to remove. Some older suites in this package still use
-`if (process.platform === 'win32') return;` — leave them be unless you are already
-changing that test for another reason, and do not convert a neighbour in passing.
+to remove — and it is worse than a missing test, because a green tick is read as
+coverage. The macOS-only `O_EXCL` case in `paths.test.ts` is the one that shows the cost:
+it is the only thing anywhere pinning `flag: 'wx'`, so while it returned, deleting that
+flag left every other leg green.
+
+**Which of the two shapes to write is decided by what the test still asserts on the
+guarded platform, not by taste.** A guard that ends the body before any assertion runs
+must `ctx.skip(reason)`, because a pass there is a claim the run never checked. A guard
+that only gates a subset — the test still verifies something real on that platform — is
+written as a positive conditional, `if (process.platform !== 'win32') expect(…)`, and
+**must not** become a skip: `ctx.skip` throws, so a skip at the tail discards a result
+that genuinely held and reports the case as uncovered where it was not. Both shapes are
+the same edit to make, and neither leaves an `if (process.platform …) return;` behind.
+
+That last part is enforced rather than asked: `tools/portability-gate`'s
+`platform-guard-early-return` (rule 6, spec files only) fails `pnpm lint` on the shape.
+Three older suites predate it — `settings.test.ts`, `fingerprint.test.ts` and
+`plugin-sdk`'s `config.test.ts` — and are exempt through `GRANDFATHERED_PLATFORM_GUARDS`,
+which records the exact count each may keep. Leave them be unless you are already changing
+that test for another reason, and do not convert a neighbour in passing; the allowance is a
+ratchet, so converting one means lowering its number in the same commit, and a file that
+reaches zero leaves the map. All three carry the top-of-body shape, so each is a real
+`ctx.skip` still owed.
 
 ### Testing a web-ui Server Action
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1379,8 +1379,10 @@ Three older suites predate it — `settings.test.ts`, `fingerprint.test.ts` and
 which records the exact count each may keep. Leave them be unless you are already changing
 that test for another reason, and do not convert a neighbour in passing; the allowance is a
 ratchet, so converting one means lowering its number in the same commit, and a file that
-reaches zero leaves the map. All three carry the top-of-body shape, so each is a real
-`ctx.skip` still owed.
+reaches zero leaves the map. The ratchet is on the COUNT, though, not on which guards make
+it up: converting one and adding another in the same commit holds the number and passes
+both rules, so the gate cannot tell that pairing from an honest conversion. All three carry
+the top-of-body shape, so each is a real `ctx.skip` still owed.
 
 ### Testing a web-ui Server Action
 

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -396,13 +396,17 @@ describe('looseStorePaths', () => {
     expect(looseStorePaths(dir)).toEqual([]);
   });
 
-  it('makes `aka init` print a warning when a mode could not be applied', async () => {
+  it('makes `aka init` print a warning when a mode could not be applied', async (ctx) => {
     // macOS-only fault injection: chflags freezes the settings dir so init's
     // tighten of settings.json fails, and init must surface that (data/ stays
     // writable, so the store still initializes). Runs on the `macOS · Full
-    // suite` leg in ci.yml — the only leg it executes on, since the early return
-    // below reports a pass everywhere else.
-    if (process.platform !== 'darwin') return;
+    // suite` leg in ci.yml — the only leg it executes on, which is why the
+    // guard below skips rather than returning: this case reaches no assertion
+    // elsewhere, and a bare `return` reports that as a pass.
+    if (process.platform !== 'darwin') {
+      ctx.skip('needs chflags to freeze the settings dir, which is macOS-only');
+      return;
+    }
     const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     const settings = settingsDir(dir);
     mkdirSync(settings, { recursive: true });

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -91,22 +91,28 @@ describe('openLocalDatabase — open / migrate / seed', () => {
     expect(policies.every((p) => p.enabled)).toBe(true);
   });
 
-  it('writes the db file owner-only (0600) where POSIX modes apply', () => {
+  it('writes the db file owner-only (0600) where POSIX modes apply', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const db = openLocalDatabase(dir);
     db.close();
-    if (process.platform === 'win32') return;
     const mode = statSync(join(dir, 'aka.db')).mode & 0o777;
     expect(mode).toBe(0o600);
   });
 
-  it('writes the -wal/-shm sidecars owner-only (0600) while the store is open', () => {
+  it('writes the -wal/-shm sidecars owner-only (0600) while the store is open', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // The sidecars hold prompt/file content just like the main db, so they must
     // carry the same 0600 mode. They exist only while a WAL-mode handle is open
     // (a clean close checkpoints and removes them), so assert before closing.
     const db = openLocalDatabase(dir);
     const dbFile = join(dir, 'aka.db');
     try {
-      if (process.platform === 'win32') return;
       // WAL mode creates exactly the -wal/-shm pair (no rollback -journal).
       for (const sidecar of [`${dbFile}-wal`, `${dbFile}-shm`]) {
         expect(existsSync(sidecar)).toBe(true);
@@ -117,18 +123,24 @@ describe('openLocalDatabase — open / migrate / seed', () => {
     }
   });
 
-  it('re-tightens the db and its recreated -wal/-shm sidecars to 0600 on reopen (steady-state)', () => {
+  it('re-tightens the db and its recreated -wal/-shm sidecars to 0600 on reopen (steady-state)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // Every hook after the first init reopens an already-migrated store. The
     // sidecars are removed on close and recreated by the reopen's writes; SQLite
     // gives a new sidecar the main db's mode, so a store loosened out of band
     // must be re-tightened on open — not only at first creation.
     openLocalDatabase(dir).close();
     const file = join(dir, 'aka.db');
-    if (process.platform !== 'win32') chmodSync(file, 0o644); // simulate a loosened store
+    // Unguarded because the ctx.skip at the top of this body already returned on
+    // Windows, where chmod is a no-op; narrowing that skip means restoring a
+    // platform guard here.
+    chmodSync(file, 0o644); // simulate a loosened store
 
     const db = openLocalDatabase(dir);
     try {
-      if (process.platform === 'win32') return;
       expect(statSync(file).mode & 0o777).toBe(0o600);
       for (const sidecar of [`${file}-wal`, `${file}-shm`]) {
         expect(existsSync(sidecar)).toBe(true);
@@ -289,8 +301,7 @@ describe('openLocalDatabase — open / migrate / seed', () => {
     raw.close();
 
     expect(existsSync(backup)).toBe(true);
-    if (process.platform === 'win32') return;
-    expect(statSync(backup).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') expect(statSync(backup).mode & 0o777).toBe(0o600);
   });
 });
 

--- a/packages/persistence/test/local-layout.test.ts
+++ b/packages/persistence/test/local-layout.test.ts
@@ -44,22 +44,28 @@ describe('ensureLayoutDirSync', () => {
     const dir = dataDir(base);
     ensureLayoutDirSync(dir);
     expect(existsSync(dir)).toBe(true);
-    if (process.platform === 'win32') return;
-    expect(statSync(dir).mode & 0o777).toBe(0o700);
+    if (process.platform !== 'win32') expect(statSync(dir).mode & 0o777).toBe(0o700);
   });
 
-  it('tightens an existing loose base directory to 0700', () => {
+  it('tightens an existing loose base directory to 0700', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // An ~/.aka created by an older release (or the user) with looser
     // permissions must be tightened, not left as it was found.
     const home = join(base, 'loose-home');
     mkdirSync(home);
     chmodSync(home, 0o755);
     ensureLayoutDirSync(home);
-    if (process.platform === 'win32') return;
     expect(statSync(home).mode & 0o777).toBe(0o700);
   });
 
-  it('leaves the whole ~/.aka layout owner-only (0700 base, settings/, data/) — the `aka init` shape', () => {
+  it('leaves the whole ~/.aka layout owner-only (0700 base, settings/, data/) — the `aka init` shape', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // Mirrors what `aka init` composes: ensure the base, then settings/, then
     // data/ (the last via openLocalDatabase). All three are the store's only
     // at-rest control and must all end 0700.
@@ -67,7 +73,6 @@ describe('ensureLayoutDirSync', () => {
     ensureLayoutDirSync(home);
     ensureLayoutDirSync(settingsDir(home));
     ensureLayoutDirSync(dataDir(home));
-    if (process.platform === 'win32') return;
     expect(statSync(home).mode & 0o777).toBe(0o700);
     expect(statSync(settingsDir(home)).mode & 0o777).toBe(0o700);
     expect(statSync(dataDir(home)).mode & 0o777).toBe(0o700);
@@ -105,8 +110,7 @@ describe('migrateLegacyLayout', () => {
     migrateLegacyLayout(base);
 
     expect(existsSync(join(settingsDir(base), 'config.json'))).toBe(true);
-    if (process.platform === 'win32') return;
-    expect(statSync(settingsDir(base)).mode & 0o777).toBe(0o700);
+    if (process.platform !== 'win32') expect(statSync(settingsDir(base)).mode & 0o777).toBe(0o700);
   });
 
   it('tightens a moved legacy config.json to 0600 (it can carry a token)', () => {
@@ -121,7 +125,6 @@ describe('migrateLegacyLayout', () => {
 
     const moved = join(settingsDir(base), 'config.json');
     expect(existsSync(moved)).toBe(true);
-    if (process.platform === 'win32') return;
-    expect(statSync(moved).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') expect(statSync(moved).mode & 0o777).toBe(0o600);
   });
 });

--- a/packages/persistence/test/paths.test.ts
+++ b/packages/persistence/test/paths.test.ts
@@ -63,21 +63,23 @@ describe('ensureDataDirSync', () => {
     const dir = join(base, 'data');
     ensureDataDirSync(dir);
     expect(existsSync(dir)).toBe(true);
-    if (process.platform === 'win32') return;
-    expect(mode(dir)).toBe(DATA_DIR_MODE);
+    if (process.platform !== 'win32') expect(mode(dir)).toBe(DATA_DIR_MODE);
   });
 
-  it('tightens an existing loose directory to 0700 (chmods after mkdir)', () => {
+  it('tightens an existing loose directory to 0700 (chmods after mkdir)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const dir = join(base, 'data');
     mkdirSync(dir);
     chmodSync(dir, 0o777);
-    if (process.platform !== 'win32') {
-      expect(mode(dir)).toBe(0o777); // precondition: genuinely loose
-    }
+    // Unguarded because the ctx.skip at the top of this body already returned on
+    // Windows; narrowing that skip means restoring a platform guard here.
+    expect(mode(dir)).toBe(0o777); // precondition: genuinely loose
 
     ensureDataDirSync(dir);
 
-    if (process.platform === 'win32') return;
     expect(mode(dir)).toBe(DATA_DIR_MODE);
   });
 
@@ -89,8 +91,7 @@ describe('ensureDataDirSync', () => {
     expect(() => {
       ensureDataDirSync(dir);
     }).not.toThrow();
-    if (process.platform === 'win32') return;
-    expect(mode(dir)).toBe(DATA_DIR_MODE);
+    if (process.platform !== 'win32') expect(mode(dir)).toBe(DATA_DIR_MODE);
   });
 
   it('holds every level it creates at 0700, not just the leaf it tightens', (ctx) => {
@@ -230,7 +231,11 @@ describe('dbSidecars', () => {
 });
 
 describe('tightenPerms', () => {
-  it('sets 0600 on the db file and all of its sidecars', () => {
+  it('sets 0600 on the db file and all of its sidecars', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const file = join(base, 'aka.db');
     // Create the set with deliberately loose modes so the chmod is observable.
     for (const p of [file, ...dbSidecars(file)]) {
@@ -240,7 +245,6 @@ describe('tightenPerms', () => {
 
     tightenPerms(file);
 
-    if (process.platform === 'win32') return;
     for (const p of [file, ...dbSidecars(file)]) {
       expect(mode(p)).toBe(DATA_FILE_MODE);
     }
@@ -255,8 +259,7 @@ describe('tightenPerms', () => {
     expect(() => {
       tightenPerms(file);
     }).not.toThrow();
-    if (process.platform === 'win32') return;
-    expect(mode(file)).toBe(DATA_FILE_MODE);
+    if (process.platform !== 'win32') expect(mode(file)).toBe(DATA_FILE_MODE);
   });
 
   it('never chmods THROUGH a symlink planted at a sidecar path', (ctx) => {
@@ -282,14 +285,17 @@ describe('tightenPerms', () => {
 });
 
 describe('tightenFile', () => {
-  it('sets 0600 on a single file (a backup copy, the exception key)', () => {
+  it('sets 0600 on a single file (a backup copy, the exception key)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const file = join(base, 'aka.db.legacy.bak');
     writeFileSync(file, 'corpus copy');
     chmodSync(file, 0o644); // as VACUUM INTO / a mode-preserving rename would leave it
 
     tightenFile(file);
 
-    if (process.platform === 'win32') return;
     expect(mode(file)).toBe(DATA_FILE_MODE);
   });
 
@@ -299,8 +305,11 @@ describe('tightenFile', () => {
     }).not.toThrow();
   });
 
-  it('never chmods THROUGH a symlink (self-heal must not tighten an arbitrary target)', () => {
-    if (process.platform === 'win32') return;
+  it('never chmods THROUGH a symlink (self-heal must not tighten an arbitrary target)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
     // Fault injection: settings.json (or the exception key) is a planted symlink
     // to a victim the attacker can read. tightenFile must skip it, not follow the
     // link and chmod the victim.
@@ -322,8 +331,7 @@ describe('writeOwnerOnlyFileSync', () => {
     const file = join(base, 'settings.json');
     writeOwnerOnlyFileSync(file, 'hello\n');
     expect(readFileSync(file, 'utf8')).toBe('hello\n');
-    if (process.platform === 'win32') return;
-    expect(mode(file)).toBe(DATA_FILE_MODE);
+    if (process.platform !== 'win32') expect(mode(file)).toBe(DATA_FILE_MODE);
   });
 
   it('clears a stale same-pid tmp from an earlier crash and still lands 0600', () => {
@@ -338,8 +346,7 @@ describe('writeOwnerOnlyFileSync', () => {
     writeOwnerOnlyFileSync(file, 'fresh\n');
 
     expect(readFileSync(file, 'utf8')).toBe('fresh\n');
-    if (process.platform === 'win32') return;
-    expect(mode(file)).toBe(DATA_FILE_MODE);
+    if (process.platform !== 'win32') expect(mode(file)).toBe(DATA_FILE_MODE);
   });
 
   it('replaces an existing loose target and ends 0600', () => {
@@ -350,12 +357,14 @@ describe('writeOwnerOnlyFileSync', () => {
     writeOwnerOnlyFileSync(file, 'new\n');
 
     expect(readFileSync(file, 'utf8')).toBe('new\n');
-    if (process.platform === 'win32') return;
-    expect(mode(file)).toBe(DATA_FILE_MODE);
+    if (process.platform !== 'win32') expect(mode(file)).toBe(DATA_FILE_MODE);
   });
 
-  it('never writes through or installs a symlink planted at the tmp path', () => {
-    if (process.platform === 'win32') return;
+  it('never writes through or installs a symlink planted at the tmp path', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
     // Fault injection: an attacker with write access to the (loose) dir plants a
     // symlink at our tmp path pointing at a victim file. The write must not follow
     // it (no arbitrary overwrite) and must not install it as `file`.
@@ -389,7 +398,7 @@ describe('writeOwnerOnlyFileSync', () => {
     expect(readdirSync(base).filter((f) => f.includes('.tmp'))).toEqual([]);
   });
 
-  it('refuses to follow a planted tmp symlink the unlink could not clear (O_EXCL, not the rm)', () => {
+  it('refuses to follow a planted tmp symlink the unlink could not clear (O_EXCL, not the rm)', (ctx) => {
     // Isolates `wx`: chflags makes the dir immutable so the leading rmSync can't
     // remove the planted symlink, so ONLY the exclusive create can prevent the
     // write from following it. Without `flag: 'wx'` the write overwrites the
@@ -397,9 +406,16 @@ describe('writeOwnerOnlyFileSync', () => {
     // CI leg that executes it is `macOS · Full suite` in ci.yml (a local run on a
     // Mac executes it too, and is the quickest way to reproduce a failure here).
     // That leg runs the WHOLE workspace for this reason among others; filtering
-    // `persistence` out of it silently returns this case to the state below,
-    // where it reports a pass on every runner without reaching an assertion.
-    if (process.platform !== 'darwin') return;
+    // `persistence` out of it leaves nothing anywhere exercising `wx`.
+    //
+    // The skip is what makes that legible. This case reaches no assertion off
+    // macOS, and an early `return` there is reported as a PASS — so every other
+    // leg would read as having covered the one property only this case pins,
+    // and deleting `flag: 'wx'` would keep them all green.
+    if (process.platform !== 'darwin') {
+      ctx.skip('needs chflags to fail the unlink, which is macOS-only');
+      return;
+    }
     const file = join(base, 'settings.json');
     const victim = join(base, 'victim');
     writeFileSync(victim, 'SECRET');

--- a/tools/portability-gate/src/check-portability.ts
+++ b/tools/portability-gate/src/check-portability.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-// Local pre-push / lint gate for four cross-platform test bugs: a hardcoded
+// Local pre-push / lint gate for six cross-platform test bugs: a hardcoded
 // file:/// URL, a bare GNU `timeout` inside a shell command string, a path
-// comparison with no case normalization, and a worker/concurrency test with
-// no explicit timeout. Scans the git-tracked test tree only — see lib.ts's
-// header for what each rule can and cannot see.
+// comparison with no case normalization, a worker/concurrency test with no
+// explicit timeout, a PATH joined on a literal ':', and a platform guard that
+// ends a test body with a bare `return`. Scans the git-tracked test tree only —
+// see lib.ts's header for what each rule can and cannot see.
 //
 // Exit codes:
 //   0 — no violations

--- a/tools/portability-gate/src/lib.ts
+++ b/tools/portability-gate/src/lib.ts
@@ -96,11 +96,18 @@ export const RULES: Record<RuleId, RuleInfo> = {
 // rule exempts them rather than reporting a backlog nobody is going to clear in
 // one go.
 //
-// An allowance is a RATCHET, not a floor. Exceeding it is a violation, so a new
-// guard cannot hide inside an exempt file; falling below it is a violation too
-// (`platform-guard-stale-allowance`), so converting one guard means lowering the
-// number in the same commit and the exemption can only ever shrink. A file that
-// reaches zero leaves the map entirely.
+// An allowance is an exact COUNT, pinned in both directions: exceeding it is a
+// violation, and falling below it is one too (`platform-guard-stale-allowance`),
+// so converting a guard means lowering the number in the same commit. A file
+// that reaches zero leaves the map entirely.
+//
+// That makes the NUMBER a ratchet, never the set of guards behind it. A commit
+// converting one guard and adding another holds the count at the allowance and
+// passes both rules, so a new guard CAN land in an exempt file when it arrives
+// paired with a conversion. Closing that needs guard identity — either a line
+// number, which shifts on any unrelated edit, or the enclosing test name — so
+// the count stands and the limit is written down instead. The exposure is the
+// map: a file with no allowance reports every guard in it.
 //
 // An allowance is keyed by PATH, so a rename leaves it behind: the entry then
 // covers nothing and the file arrives with an allowance of zero, which reports

--- a/tools/portability-gate/src/lib.ts
+++ b/tools/portability-gate/src/lib.ts
@@ -1,18 +1,20 @@
 // Pure scanning logic for the cross-platform portability gate: a lightweight,
-// non-parsing scanner over the tracked test and bench trees looking for five
+// non-parsing scanner over the tracked test and bench trees looking for six
 // known failure shapes — a hardcoded file:/// URL (POSIX-only, breaks on Windows),
 // a bare GNU `timeout` shell command (absent on macOS), a path comparison
 // with no case normalization (macOS/Windows are case-insensitive, Linux is
-// not), a worker/concurrency test with no explicit timeout, and a PATH built
-// with a literal ':' (Windows joins with ';'). The CLI entry
-// (check-portability.ts) owns all I/O — git ls-files, reading file contents —
-// so the unit suite can drive this with canned file lists.
+// not), a worker/concurrency test with no explicit timeout, a PATH built
+// with a literal ':' (Windows joins with ';'), and a platform guard that ends a
+// test body with a bare `return` (reported as a PASS on every platform that
+// cannot run it). The CLI entry (check-portability.ts) owns all I/O — git
+// ls-files, reading file contents — so the unit suite can drive this with
+// canned file lists.
 //
 // Rules 1-3 and 5 describe primitives, not test structure, so they apply to every
 // source file in a test or bench tree — the helpers, fixtures-in-code, worker
 // entrypoints and benchmark drivers that carry the worker/platform/path code a
-// spec file usually only calls. Rule 4 keys on an `it()`/`test()` call and so
-// stays scoped to spec files, which a `.bench.ts` is not. isRelevantPath is
+// spec file usually only calls. Rules 4 and 6 are about what a TEST reports, so
+// both stay scoped to spec files, which a `.bench.ts` is not. isRelevantPath is
 // the single definition of what the scan reaches; the CLI entry imports it
 // rather than keeping a second copy, since a filter that pre-selects paths and
 // a filter that scans them are one decision.
@@ -23,13 +25,20 @@
 // e.g. /["']/ — would otherwise be misread as the start of a string), then
 // pattern-matches within each. Rules 1 and 2 are mechanical and reliable:
 // they only fire on characters that are unambiguously part of a string
-// literal. Rules 3, 4 and 5 are best-effort: they cannot see a comparison split
+// literal. Rules 3, 4, 5 and 6 are best-effort: they cannot see a comparison split
 // across lines or routed through an intermediate variable, and rule 3 in
 // particular only catches two path-producing expressions compared directly on
 // one line. Rule 5 needs the word PATH to be code on the separator's own line
 // or on the line its literal opens, so a separator held in a named constant, or
 // a PATH assembled several statements away from the ':' it is joined with, goes
-// unseen. Treat their silence as "found nothing," not "there is nothing."
+// unseen. Rule 6 locates its guard on the masked text, so a comment between the
+// guard and the `return` does NOT hide it; what it cannot see is a condition
+// carrying a call (the condition class stops at the first `)`) or a guard moved
+// into a helper the test calls. Rule 6 is also the one rule here that
+// OVER-reports: it matches text, not scope, so a `return` under a platform guard
+// inside a nested callback — a loop `continue`, which neither ends the test nor
+// skips an assertion — is reported as though it were the defect. Treat their
+// silence as "found nothing," not "there is nothing."
 
 export interface ScannedFile {
   path: string;
@@ -41,7 +50,9 @@ export type RuleId =
   | 'bare-timeout-command'
   | 'path-comparison-case'
   | 'concurrency-missing-timeout'
-  | 'path-separator-literal';
+  | 'path-separator-literal'
+  | 'platform-guard-early-return'
+  | 'platform-guard-stale-allowance';
 
 export interface RuleInfo {
   title: string;
@@ -69,6 +80,37 @@ export const RULES: Record<RuleId, RuleInfo> = {
     title: "PATH joined or split on a literal ':'",
     help: "Windows joins PATH with ';', so a ':'-joined value is one malformed entry there and a prepended bin dir is not on PATH at all. Use path.delimiter. This one fails OPEN, which is why it is worth a rule: a test shim that does not land is not an ENOENT — resolution walks on and runs the REAL installed binary, so the suite reaches a live tool while still looking hermetic (see plugins/*/test/helpers/path-shim.ts).",
   },
+  'platform-guard-early-return': {
+    title: 'Platform guard that ends the test body with a bare return',
+    help: "a returning test is a PASSING test, so on every platform the guard excludes this case reports as covered while reaching no assertion at all — and the property it exists to pin can then be deleted with CI still green. Say so instead: take the test context and call ctx.skip('<why this platform cannot run it>') at the top of the body. Where the test does still assert something on the guarded platform, keep it running and gate only the platform-specific assertions — `if (process.platform !== 'win32') expect(…)` — since a skip there throws away a real result.",
+  },
+  'platform-guard-stale-allowance': {
+    title: 'Grandfathered platform-guard allowance is larger than the file',
+    help: 'a file carrying fewer guards than its recorded allowance leaves room for new ones to land unnoticed, which is the hole the allowance exists to close. Lower the number in GRANDFATHERED_PLATFORM_GUARDS to what the file now carries, or delete the entry once it carries none.',
+  },
+};
+
+// Files that already carried rule 6's shape when it was written, with the exact
+// number of guards each may keep. CLAUDE.md's "older suites" note grandfathers
+// these — converting a neighbour in passing is explicitly not wanted — so the
+// rule exempts them rather than reporting a backlog nobody is going to clear in
+// one go.
+//
+// An allowance is a RATCHET, not a floor. Exceeding it is a violation, so a new
+// guard cannot hide inside an exempt file; falling below it is a violation too
+// (`platform-guard-stale-allowance`), so converting one guard means lowering the
+// number in the same commit and the exemption can only ever shrink. A file that
+// reaches zero leaves the map entirely.
+//
+// An allowance is keyed by PATH, so a rename leaves it behind: the entry then
+// covers nothing and the file arrives with an allowance of zero, which reports
+// every guard in it. That is loud and correct. A DELETED file's entry is the one
+// case nothing reports — it is dead weight rather than a hole, since it can only
+// ever exempt a path the scan never sees.
+export const GRANDFATHERED_PLATFORM_GUARDS: Readonly<Record<string, number>> = {
+  'packages/persistence/test/fingerprint.test.ts': 1,
+  'packages/persistence/test/settings.test.ts': 2,
+  'packages/plugin-sdk/test/config.test.ts': 3,
 };
 
 export interface Violation {
@@ -418,6 +460,90 @@ function checkPathSeparatorLiteral(
     }));
 }
 
+// Located on codeMasked, so a `process.platform` named in a comment or quoted in
+// a test description is not a candidate at all.
+const PLATFORM_GUARD_RE = /\bif\s*\(\s*process\.platform\b/g;
+// Matched on codeMasked, then the RETURNED EXPRESSION is read back out of the
+// raw source. Both halves are load-bearing and they pull in opposite directions:
+//
+//   - Structure has to come from the masked text, because a comment is blanked
+//     to spaces there. Read the raw source for structure instead and a block
+//     that explains itself first —
+//     `if (…) {\n  // no POSIX modes here\n  return;\n}` — stops matching, which
+//     is the defect wearing the most natural comment anyone would write.
+//   - Whether anything is RETURNED has to come from the raw source, because a
+//     literal is blanked to spaces in the masked text. Read the masked text for
+//     that instead and `return '<reason>';` reads as bare — a helper handing its
+//     caller a skip reason, flagged as a test bailing out. That is not
+//     hypothetical: it is
+//     packages/plugin-sdk/test/performance/project-files-walk.test.ts.
+//
+// codeMasked is the same length as the source, so the capture's offsets index
+// both alike. Returning a VALUE is the helper signal, so `return undefined;`
+// is deliberately NOT flagged — a helper typed `(): string | undefined` returns
+// it legitimately, and a test body bailing out that way is a spelling nobody
+// reaches for.
+//
+// `[^)\n]*` holds the condition to one line and to no nested parens, so
+// `process.platform === 'win32' || process.platform === 'linux'` matches while a
+// condition carrying a call does not. The consequent is a `return` either
+// trailing on the same line or alone in a block — a block that does anything
+// first (`ctx.skip(reason); return;`, the fixed form) is not a match, because
+// that statement is code and survives masking.
+// Sticky rather than anchored: `y` matches at lastIndex, which lets the guard be
+// located in place instead of slicing a fresh copy of the file tail per match.
+const PLATFORM_EARLY_RETURN_RE =
+  /if\s*\(\s*process\.platform\s*[!=]==?[^)\n]*\)\s*(?:\{\s*return([^;{}]*);\s*\}|return([^;\n]*);)/dy;
+
+function checkPlatformGuardEarlyReturn(
+  file: ScannedFile,
+  codeMasked: string,
+  allowance: number,
+): Violation[] {
+  const lines: number[] = [];
+  PLATFORM_GUARD_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = PLATFORM_GUARD_RE.exec(codeMasked)) !== null) {
+    PLATFORM_EARLY_RETURN_RE.lastIndex = match.index;
+    const consequent = PLATFORM_EARLY_RETURN_RE.exec(codeMasked);
+    if (consequent === null) continue;
+    const groups = consequent.indices;
+    // The `d` flag is what makes the raw-source read below possible at all, so a
+    // missing `indices` is a broken rule rather than a clean file — skipping
+    // here would disable rule 6 across the whole tree with lint still green.
+    if (groups === undefined) {
+      throw new Error(
+        'platform-guard-early-return: regex lost its `d` flag, so no guard can be read',
+      );
+    }
+    const span = groups[1] ?? groups[2];
+    if (span === undefined) continue;
+    const returned = file.content.slice(span[0], span[1]);
+    if (returned.trim() !== '') continue;
+    lines.push(lineAt(codeMasked, match.index));
+  }
+
+  if (lines.length < allowance) {
+    return [
+      {
+        rule: 'platform-guard-stale-allowance',
+        file: file.path,
+        line: 1,
+        message: `Allowance of ${String(allowance)} but the file carries ${String(lines.length)} — ${RULES['platform-guard-stale-allowance'].help}`,
+      },
+    ];
+  }
+  // The allowance covers the guards that were already here, so the ones past it
+  // are the new ones. Reporting the tail rather than the head puts the violation
+  // on a line the author just wrote.
+  return lines.slice(allowance).map((line) => ({
+    rule: 'platform-guard-early-return' as const,
+    file: file.path,
+    line,
+    message: `Platform guard returns instead of skipping — ${RULES['platform-guard-early-return'].help}`,
+  }));
+}
+
 function checkConcurrencyMissingTimeout(
   file: ScannedFile,
   codeMasked: string,
@@ -518,11 +644,20 @@ function owningPackageHasTimeout(filePath: string, packages: PackageTimeoutInfo[
   return best?.hasTestTimeout ?? false;
 }
 
+export interface ScanOptions {
+  // Defaults to GRANDFATHERED_PLATFORM_GUARDS. Overridden by the unit suite so
+  // rule 6's allowance arithmetic is driven with synthetic paths rather than by
+  // asserting the contents of the real exempt files, which would put a second,
+  // stale copy of that list in the tests.
+  grandfatheredPlatformGuards?: Readonly<Record<string, number>>;
+}
+
 // files is the whole set the caller found worth handing in — vitest configs
 // are needed to resolve rule 4's package-level override and are silently
-// skipped by the TEST_FILE_RE filter below, so passing every tracked file is
+// skipped by the SPEC_FILE_RE filter below, so passing every tracked file is
 // fine and expected.
-export function scanTree(files: ScannedFile[]): Violation[] {
+export function scanTree(files: ScannedFile[], options: ScanOptions = {}): Violation[] {
+  const grandfathered = options.grandfatheredPlatformGuards ?? GRANDFATHERED_PLATFORM_GUARDS;
   const packages = derivePackageTimeouts(files);
   const violations: Violation[] = [];
   for (const file of files) {
@@ -535,11 +670,14 @@ export function scanTree(files: ScannedFile[]): Violation[] {
       ...checkPathComparisonCase(file, codeMasked),
       ...checkPathSeparatorLiteral(file, codeMasked, strings),
       ...(isSpec
-        ? checkConcurrencyMissingTimeout(
-            file,
-            codeMasked,
-            owningPackageHasTimeout(file.path, packages),
-          )
+        ? [
+            ...checkConcurrencyMissingTimeout(
+              file,
+              codeMasked,
+              owningPackageHasTimeout(file.path, packages),
+            ),
+            ...checkPlatformGuardEarlyReturn(file, codeMasked, grandfathered[file.path] ?? 0),
+          ]
         : []),
     );
   }

--- a/tools/portability-gate/test/check-portability.test.ts
+++ b/tools/portability-gate/test/check-portability.test.ts
@@ -4,7 +4,13 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-import { formatReport, isRelevantPath, type ScannedFile, scanTree } from '../src/lib.ts';
+import {
+  formatReport,
+  GRANDFATHERED_PLATFORM_GUARDS,
+  isRelevantPath,
+  type ScannedFile,
+  scanTree,
+} from '../src/lib.ts';
 
 // Fixtures live in their own directory with a non-".test.ts" extension on
 // purpose: a real run of check-portability.ts walks the tracked test tree, so
@@ -240,6 +246,110 @@ describe('concurrency-missing-timeout', () => {
     const violations = scanTree(files);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.file).toBe('pkg-a/test/scan.test.ts');
+  });
+});
+
+describe('platform-guard-early-return', () => {
+  // A real spec path: the allowance cases below all assert on a SHORT violation
+  // list, so a path scanTree skips outright satisfies them without the rule ever
+  // running. The bytes are built here rather than read from a fixture because
+  // the string literal is masked out of this file's own scan.
+  const SPEC = 'pkg/test/legacy.test.ts';
+  const guards = (n: number): string =>
+    Array.from({ length: n }, () => "if (process.platform === 'win32') return;").join('\n');
+
+  // The last two are the comment-bearing blocks. They matter because a comment
+  // is the most natural thing to write next to a bail-out, and the rule locates
+  // its candidate on masked text precisely so one cannot hide the defect —
+  // matching structure against the raw source instead leaves both unflagged.
+  it('flags the one-line form, the block form, the !== form and a commented block', () => {
+    const violations = scanTree([
+      testFile('paths.test.ts', fixture('platform-guard-return.bad.txt')),
+    ]);
+    expect(violations.map((v) => v.line)).toEqual([7, 12, 19, 26, 34]);
+    expect(violations.every((v) => v.rule === 'platform-guard-early-return')).toBe(true);
+    expect(violations[0]?.message).toContain('ctx.skip');
+  });
+
+  // Five shapes at once, and each is load-bearing. ctx.skip + return is the
+  // fixed form, so flagging it would make the rule unsatisfiable. The positive
+  // conditional is the fix for a test that still asserts something on the
+  // guarded platform. it.skipIf reports as a skip already. And `return
+  // '<reason>';` is a helper handing back a value — in both the one-line and the
+  // block spelling, which pull against each other: the block is only reachable
+  // by matching on masked text, and only reading the RAW source there keeps the
+  // returned literal visible enough to exempt it.
+  it('does not flag ctx.skip, a positive conditional, it.skipIf, or a returned value', () => {
+    expect(
+      scanTree([testFile('paths.test.ts', fixture('platform-guard-return.clean.txt'))]),
+    ).toEqual([]);
+  });
+
+  it('does not flag the same shape inside a comment', () => {
+    const violations = scanTree([
+      testFile(
+        'paths.test.ts',
+        [
+          "// if (process.platform === 'win32') return; is what this rule catches.",
+          'const x = 1;',
+        ].join('\n'),
+      ),
+    ]);
+    expect(violations).toEqual([]);
+  });
+
+  // The defect is a TEST reporting a pass, which a helper does not do. The same
+  // bytes at a spec path are the control: without it this case would pass on a
+  // rule that had stopped firing anywhere.
+  it('does not apply to a non-spec file, but still does at a spec path', () => {
+    const bytes = fixture('platform-guard-return.bad.txt');
+    expect(scanTree([testFile('pkg/test/helpers/modes.ts', bytes)])).toEqual([]);
+    expect(scanTree([testFile('pkg/test/modes.test.ts', bytes)])).toHaveLength(5);
+  });
+
+  it('exempts a grandfathered file up to its allowance', () => {
+    const files = [testFile(SPEC, guards(3))];
+    expect(scanTree(files, { grandfatheredPlatformGuards: { [SPEC]: 3 } })).toEqual([]);
+  });
+
+  // Reported at the LAST guard rather than the first: the allowance covers what
+  // was already there, so the new one is on the end, and that is the line whose
+  // author needs to read the message.
+  it('flags the guard past the allowance, at its own line', () => {
+    const violations = scanTree([testFile(SPEC, guards(3))], {
+      grandfatheredPlatformGuards: { [SPEC]: 2 },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ rule: 'platform-guard-early-return', line: 3 });
+  });
+
+  // The ratchet's other direction. Without this an allowance stays at its
+  // original number for ever, so converting two of three guards silently leaves
+  // room for two new ones — an exemption that grows back.
+  it('reports a stale allowance when the file carries fewer than it allows', () => {
+    const violations = scanTree([testFile(SPEC, guards(1))], {
+      grandfatheredPlatformGuards: { [SPEC]: 3 },
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ rule: 'platform-guard-stale-allowance', line: 1 });
+    expect(violations[0]?.message).toContain('carries 1');
+  });
+
+  // Everything above drives an injected map, so all of it would still pass with
+  // the shipped one unused. This is what pins that omitting the option reads the
+  // real GRANDFATHERED_PLATFORM_GUARDS, with the empty-map scan as its control.
+  it('reads the shipped allowance map when no override is passed', () => {
+    const entries = Object.entries(GRANDFATHERED_PLATFORM_GUARDS);
+    // Once this map empties the allowance branch is dead and this case should go
+    // with it — an empty map runs the loop zero times, so every assertion in it
+    // holds vacuously and only this line says so.
+    expect(entries.length).toBeGreaterThan(0);
+
+    for (const [path, allowance] of entries) {
+      const files = [testFile(path, guards(allowance))];
+      expect(scanTree(files), path).toEqual([]);
+      expect(scanTree(files, { grandfatheredPlatformGuards: {} }), path).toHaveLength(allowance);
+    }
   });
 });
 

--- a/tools/portability-gate/test/fixtures/platform-guard-return.bad.txt
+++ b/tools/portability-gate/test/fixtures/platform-guard-return.bad.txt
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { tightenFile, writeOwnerOnlyFileSync } from '../src/paths.ts';
+
+describe('tightenFile', () => {
+  it('sets 0600 on a single file', () => {
+    if (process.platform === 'win32') return;
+    expect(mode(file)).toBe(0o600);
+  });
+
+  it('never chmods THROUGH a symlink', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+    expect(mode(victim)).toBe(0o644);
+  });
+
+  it('refuses to follow a planted tmp symlink the unlink could not clear', () => {
+    if (process.platform !== 'darwin') return;
+    expect(() => {
+      writeOwnerOnlyFileSync(file, 'PWNED\n');
+    }).toThrow(/EEXIST/);
+  });
+
+  it('explains itself before bailing out', () => {
+    if (process.platform === 'win32') {
+      // POSIX modes do not apply on Windows.
+      return;
+    }
+    expect(mode(file)).toBe(0o600);
+  });
+
+  it('explains itself after bailing out', () => {
+    if (process.platform === 'win32') {
+      return; // POSIX modes do not apply on Windows.
+    }
+    expect(mode(file)).toBe(0o600);
+  });
+});

--- a/tools/portability-gate/test/fixtures/platform-guard-return.clean.txt
+++ b/tools/portability-gate/test/fixtures/platform-guard-return.clean.txt
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { tightenFile } from '../src/paths.ts';
+
+// Returning a VALUE is a helper handing its caller a reason, not a test bailing
+// out — the real occurrence of this shape lives in plugin-sdk's walk benchmark.
+function skipReason(): string | undefined {
+  if (process.platform === 'win32') return 'chmod does not deny reads on win32';
+  return undefined;
+}
+
+// The same helper spelled as a block. The rule locates the block on masked text,
+// where the literal is blanked to spaces, so only reading the RAW source keeps
+// this one from being flagged as a bare return.
+function blockSkipReason(): string | undefined {
+  if (process.platform === 'win32') {
+    return 'chmod does not deny reads on win32';
+  }
+  return undefined;
+}
+
+describe('tightenFile', () => {
+  it('sets 0600 on a single file', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    expect(mode(file)).toBe(0o600);
+  });
+
+  // Still asserts something on Windows, so it stays a running test and gates
+  // only the assertion that does not apply there.
+  it('creates the file, and tightens it where POSIX modes apply', () => {
+    expect(existsSync(file)).toBe(true);
+    if (process.platform !== 'win32') expect(mode(file)).toBe(0o600);
+  });
+
+  it.skipIf(process.platform === 'win32')('refuses a symlink at the final path', () => {
+    expect(lstatSync(link).isSymbolicLink()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

An `if (process.platform === 'win32') return;` at the top of a test body is reported as a **PASS** on every platform the guard excludes — the case reaches no assertion, but the tick reads as coverage.

The macOS-only `O_EXCL` case in `paths.test.ts` is the worked example, and it shows the real cost: it is the only thing anywhere pinning `flag: 'wx'`, so while it returned, deleting that flag left every other leg green.

This converts the 22 such guards and adds a gate so the shape cannot come back.

## The decision rule

Which shape a guard becomes is decided by **what the test still asserts on the guarded platform**, not by taste:

- A guard that ends the body before any assertion runs → `ctx.skip(reason)`. A pass there is a claim the run never checked.
- A guard that only gates a subset, where the test still verifies something real → a positive conditional, `if (process.platform !== 'win32') expect(…)`. A skip at the tail **throws away a result that genuinely held** and reports the case as uncovered where it was not.

Neither leaves an `if (process.platform …) return;` behind.

## The gate

`platform-guard-early-return` (rule 6) in `tools/portability-gate`, spec files only, wired into `pnpm lint` and so into lefthook's `pre-push`.

Three suites predate it (`settings.test.ts`, `fingerprint.test.ts`, `plugin-sdk`'s `config.test.ts`) and are exempt through `GRANDFATHERED_PLATFORM_GUARDS`, which records the exact count each may keep. The allowance is a **ratchet**: exceeding it is a violation, so a new guard cannot hide inside an exempt file, and falling *below* it is also a violation (`platform-guard-stale-allowance`), so an exemption can only ever shrink.

One honest limitation, documented in the rule's header: rule 6 is the one rule here that **over-reports**. It matches text, not scope, so a `return` under a platform guard inside a nested callback is flagged as though it were the defect. Fixing that properly needs brace/scope tracking, which would turn a deliberately non-parsing scanner into a parser.

## Scope of the conversion

```
$ git diff -U0 -- <file> | grep -cE "^-[[:space:]]*if \(process\.platform[^)]*\) return;"
12  packages/persistence/test/paths.test.ts
 4  packages/persistence/test/database.test.ts
 5  packages/persistence/test/local-layout.test.ts
 1  cli/test/commands/init.test.ts
--- total --- 22
```

## Windows impact

```
$ git show HEAD -- packages/persistence/test cli/test \
    | grep -B2 "^+.*ctx\.skip(" | grep -cE "^\+.*if \(process\.platform === 'win32'\) \{"
10
```

10 cases now report as **skipped** on Windows rather than as passes. Two of those already returned on the first line of the body and so executed nothing there before this change; the other 8 ran setup before returning.

No assertion is lost — each of the 10 reached none on Windows. The incidental execution the 8 gave up (`openLocalDatabase`, `ensureDataDirSync`, `ensureLayoutDirSync` not throwing) is retained by unguarded neighbours in the same files:

```
$ grep -c "openLocalDatabase(" packages/persistence/test/database.test.ts
27
```

— e.g. `applies the schema and is safe to open repeatedly (idempotent migrations)` and `seeds one enabled policy per default category`, neither platform-guarded.

## Verification

Every check re-run from a clean slate with `--force`, since turbo's cache is shared across worktrees and a doc-reading guard's `inputs` globs never hash a `.md` — and `CLAUDE.md` changed here.

| Check | Exit | Raw |
| --- | --- | --- |
| `turbo run lint --force` | 0 | `Tasks: 20 successful, 20 total` / `Cached: 0 cached, 20 total` |
| `pnpm lint:root` | 0 | no output |
| `pnpm check:portability` | 0 | `Portability check passed: no violations found.` |
| `turbo run typecheck --force` | 0 | — |
| `pnpm typecheck:root` | 0 | no output |
| `pnpm format:check` | 0 | — |
| `turbo run test --force` | 0 | `Tasks: 39 successful, 39 total` / `Cached: 0 cached, 39 total` |
| `turbo run build --force` | 0 | `Tasks: 20 successful, 20 total` / `Cached: 0 cached, 20 total` |

### Mutation proofs

Both drive the **real gate** via `pnpm check:portability`, not its unit tests, and both were restored by checksum afterwards (`shasum -a 256 -c` → `OK` for each file, gate green again).

**1 — the rule fires on a reintroduced defect.** Reverting `paths.test.ts:66` to the early-return shape:

```
::error file=packages/persistence/test/paths.test.ts,line=66::[platform-guard-early-return]
Platform guard returns instead of skipping — a returning test is a PASSING test […]
Portability check failed: 1 violation(s).
```

**2 — the ratchet's other direction fires against the shipped map.** Raising `settings.test.ts`'s allowance from 2 to 5:

```
::error file=packages/persistence/test/settings.test.ts,line=1::[platform-guard-stale-allowance]
Allowance of 5 but the file carries 2 — a file carrying fewer guards than its recorded
allowance leaves room for new ones to land unnoticed […]
```

That second one incidentally confirms the shipped allowance numbers are accurate: the gate reports the file carries exactly the 2 recorded for it.

### Not verified here

The Windows leg cannot be run locally — it covers `@akasecurity/cli` and `@akasecurity/persistence`, exactly the two packages changed, so CI's `Windows · Unit tests` job is the first real execution of the 10 new skips.

## Notes

Issue reference tracked separately.
