### PR TITLE
refactor(plugin): extract decideUserPromptSubmit from the hook entry

### DIFF
--- a/plugins/claude-code/src/hooks/user-prompt-submit-decision.ts
+++ b/plugins/claude-code/src/hooks/user-prompt-submit-decision.ts
@@ -1,0 +1,143 @@
+// The pure decision half of the UserPromptSubmit hook: collapse the runtime's
+// capture result into the hook's stdout payload. Pure object building — the
+// vault and the clipboard arrive as injected seams — so it unit-tests without a
+// hook process; hook entry files run main() on import and must NEVER be
+// imported by tests (same split as pre-tool-use-decision.ts).
+//
+// Two things here are easy to get wrong by reading the neighbouring hook:
+//
+//   - The block shape is `{"decision":"block"}` at the TOP LEVEL, not
+//     PreToolUse's `hookSpecificOutput.permissionDecision`. UserPromptSubmit
+//     reads a different field, so borrowing the sibling's shape is silently a
+//     no-opinion (allow).
+//   - A `redact` policy BLOCKS here. Claude Code exposes no prompt-rewrite
+//     channel on this event, so warning and passing the prompt through would
+//     send the raw value to the model under a message claiming it was masked.
+//     Blocking is the only outcome that is at least as strong as the policy.
+//     True in-place redaction happens in pre-tool-use via updatedInput.
+import type { CaptureResult } from '@akasecurity/plugin-sdk';
+import { uniqueRuleIds } from '@akasecurity/plugin-sdk';
+
+import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
+import { resubmitMessage } from './resubmit-message.ts';
+
+// The two payloads this hook may write. Both are already arms of `HookOutput`
+// in shared.ts, so this narrows what the entry can emit without widening what
+// `emit` accepts.
+export type UserPromptSubmitOutput =
+  { decision: 'block'; reason: string } | { systemMessage: string };
+
+// The vault seam: rewrite the prompt with each detected span replaced by a
+// vault pointer. Mirrors `FieldTokenizer` in pre-tool-use-decision.ts, minus
+// the `degraded` list, which this surface does not read: the prompt is blocked
+// whether or not a span vaulted, so degradation cannot change the VERDICT.
+//
+// It does change what is TRUE of the rewrite, and that gap is not closed here.
+// A span tokenizeText degrades is destroyed one-way, while resubmitMessage
+// says "the real values stay in your local vault" — accurate for the pointers,
+// false for the degraded spans. Widening this type is the first half of
+// fixing that; the second is deciding what the message should say instead,
+// which is a copy decision rather than a refactor.
+export type PromptTokenizer = (
+  prompt: string,
+  findings: CaptureResult['findings'],
+) => Promise<{ text: string; pointers: readonly string[] }>;
+
+export interface UserPromptSubmitDeps {
+  // Supplied ONLY when a valid vault-consent grant exists. Absence is what
+  // enforces "no consent → the vault is never touched": there is no consent
+  // flag to check here, because a missing tokenizer cannot touch anything.
+  tokenizePrompt?: PromptTokenizer | undefined;
+  // Best-effort clipboard write, whose result changes exactly one sentence of
+  // the resubmit message. Absent (or false) → the message tells the user to
+  // copy the rewrite by hand.
+  writeClipboard?: ((text: string) => boolean) | undefined;
+}
+
+// The payload to write, or null for "no opinion" — which the entry then uses
+// as its onboarding-nudge slot. Null covers monitor/log and allow alike,
+// including an allow that carried findings.
+export async function decideUserPromptSubmit(
+  prompt: string,
+  result: CaptureResult,
+  deps: UserPromptSubmitDeps = {},
+): Promise<UserPromptSubmitOutput | null> {
+  if (result.action === 'block' || result.action === 'redact') {
+    const ruleIds = uniqueRuleIds(result.findings);
+    const blockedRef = result.blockedReferences?.[0];
+
+    // Removal-based guidance is the floor. With consent it upgrades to the
+    // resubmit message carrying a pointerized rewrite of the user's own
+    // prompt — same block, strictly more the user can do about it.
+    const rewrite = deps.tokenizePrompt
+      ? await pointerizedRewrite(prompt, result.findings, deps.tokenizePrompt)
+      : null;
+    if (rewrite !== null) {
+      // Only the pointerized text ever reaches the clipboard — never the raw
+      // prompt. Guarded because this is an injected seam: a throw here would
+      // escape into the entry's fail-open catch, which writes nothing and
+      // exits 0 — and silence is how this host spells ALLOW, so a clipboard
+      // fault would send the very prompt this branch is blocking. The
+      // clipboard only decides one sentence; it may never decide the verdict.
+      const clipboardWrote = writeClipboardSafely(rewrite, deps.writeClipboard);
+      return {
+        decision: 'block',
+        reason: resubmitMessage({ ruleIds, rewrite, clipboardWrote, blockedRef }),
+      };
+    }
+    return { decision: 'block', reason: blockMessage({ subject: 'prompt', ruleIds, blockedRef }) };
+  }
+
+  if (result.action === 'warn') {
+    // A warn never escalates: the prompt continues, flagged. A warned value is
+    // ledgered like a blocked one, so when a reference exists the message
+    // points at the same out-of-band approve flow.
+    return {
+      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}) — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
+    };
+  }
+
+  return null;
+}
+
+// A best-effort clipboard write that cannot change the verdict: any fault (or
+// no seam at all) reads as "not copied", which downgrades one sentence of the
+// resubmit message rather than losing the block.
+function writeClipboardSafely(
+  text: string,
+  write: UserPromptSubmitDeps['writeClipboard'],
+): boolean {
+  try {
+    return write?.(text) ?? false;
+  } catch {
+    return false;
+  }
+}
+
+// The pointerized rewrite offered in the block reason, or null when it cannot
+// be offered safely. Every DETECTED span is pointerized (not only the enforced
+// ones) — the whole prompt is blocked regardless, so vaulting more never leaks
+// more. Null on any fault, on a rewrite that minted no pointer, or — the
+// never-leak gate — when any finding's raw match still appears in the
+// rewritten text; the caller then falls back to the removal-based message.
+//
+// That gate is the reason this is a function rather than an inline await: a
+// partial rewrite still reads like a success (it has pointers in it), and
+// putting it in the block reason would print the raw value back to the user
+// under a message saying it never reached the model.
+export async function pointerizedRewrite(
+  prompt: string,
+  findings: CaptureResult['findings'],
+  tokenize: PromptTokenizer,
+): Promise<string | null> {
+  try {
+    const tokenized = await tokenize(prompt, findings);
+    if (tokenized.pointers.length === 0) return null;
+    for (const finding of findings) {
+      if (finding.rawMatch !== '' && tokenized.text.includes(finding.rawMatch)) return null;
+    }
+    return tokenized.text;
+  } catch {
+    return null;
+  }
+}

--- a/plugins/claude-code/src/hooks/user-prompt-submit.ts
+++ b/plugins/claude-code/src/hooks/user-prompt-submit.ts
@@ -14,7 +14,9 @@
  * pointerized rewrite of the prompt (each secret replaced by a vault pointer)
  * for the user to paste and resubmit, copied to the clipboard best-effort;
  * without consent the reason is the plain removal-based block message. True
- * in-place redaction happens in pre-tool-use via updatedInput.
+ * in-place redaction happens in pre-tool-use via updatedInput. That collapse
+ * lives in user-prompt-submit-decision.ts, which is importable and unit-tested;
+ * this file is the I/O around it.
  *
  * This is also the first-run nudge point: on a clean prompt from a machine that
  * hasn't completed `/aka:setup`, surface a one-line pointer to it (fail-open
@@ -30,20 +32,18 @@ import {
   createPluginRuntime,
   createVaultGlue,
   loadConfig,
-  uniqueRuleIds,
 } from '@akasecurity/plugin-sdk';
 import { isVaultConsentValid } from '@akasecurity/schema';
 
-import { blockMessage, exceptionPointer } from '../exception-guidance.ts';
 import { writeClipboard } from './clipboard.ts';
 import { ONBOARDING_NUDGE } from './onboarding-nudge.ts';
-import { resubmitMessage } from './resubmit-message.ts';
 import { baseMetadata, emit, getString, parseJson, readStdin } from './shared.ts';
 import {
   claimStoreUnavailableWarning,
   openGatewayOrNull,
   storeUnavailableMessage,
 } from './store-health.ts';
+import { decideUserPromptSubmit } from './user-prompt-submit-decision.ts';
 
 async function main(): Promise<void> {
   const input = parseJson(await readStdin());
@@ -80,35 +80,21 @@ async function main(): Promise<void> {
     await runtime.close();
   }
 
-  if (result.action === 'block' || result.action === 'redact') {
-    // A redact policy blocks here too: this surface has no prompt-rewrite
-    // channel, so the only way to honor "the raw value must not reach the
-    // model" is to stop the prompt. Removal-based guidance first; with a valid
-    // vault-consent grant the reason upgrades to the resubmit message carrying
-    // a pointerized rewrite of the prompt (and the clipboard gets the same
-    // rewrite, best-effort). Consent absent → the vault is never touched.
-    const ruleIds = uniqueRuleIds(result.findings);
-    const blockedRef = result.blockedReferences?.[0];
-    let reason = blockMessage({ subject: 'prompt', ruleIds, blockedRef });
-    if (isVaultConsentValid(config.settings.vaultConsent)) {
-      const rewrite = await pointerizedRewrite(prompt, result.findings);
-      if (rewrite !== null) {
-        // Only the pointerized text ever reaches the clipboard — never the raw
-        // prompt.
-        const clipboardWrote = writeClipboard(rewrite);
-        reason = resubmitMessage({ ruleIds, rewrite, clipboardWrote, blockedRef });
-      }
-    }
-    await emit({ decision: 'block', reason });
-    return;
-  }
-  if (result.action === 'warn') {
-    // A warn never escalates: the prompt continues, flagged. A warned value is
-    // ledgered like a blocked one, so when a reference exists the message
-    // points at the same out-of-band approve flow.
-    await emit({
-      systemMessage: `AKA flagged sensitive content (${uniqueRuleIds(result.findings)}) — sent unchanged.${exceptionPointer(result.blockedReferences)}`,
-    });
+  // Consent is resolved HERE rather than inside the decision: an absent
+  // tokenizer is what makes "no consent → the vault is never touched" a
+  // structural property instead of a flag the decision could forget to read.
+  const decision = await decideUserPromptSubmit(prompt, result, {
+    tokenizePrompt: isVaultConsentValid(config.settings.vaultConsent)
+      ? (text, findings) =>
+          createVaultGlue().tokenizeText(text, {
+            findings,
+            sighting: { location: 'prompt', kind: 'prompt' },
+          })
+      : undefined,
+    writeClipboard,
+  });
+  if (decision !== null) {
+    await emit(decision);
     return;
   }
 
@@ -119,31 +105,6 @@ async function main(): Promise<void> {
   // pre-onboarding session isn't spammed every prompt.
   if (!config.onboarded && claimOnboardingNudge(config.dataDir, sessionId)) {
     await emit({ systemMessage: ONBOARDING_NUDGE });
-  }
-}
-
-// The pointerized rewrite offered in the block reason, or null when it cannot
-// be offered safely. Every DETECTED span is pointerized (not only the enforced
-// ones) — the whole prompt is blocked regardless, so vaulting more never leaks
-// more. Null on any fault, on a rewrite that minted no pointer, or — the
-// never-leak gate — when any finding's raw match still appears in the
-// rewritten text; the caller then falls back to the removal-based message.
-async function pointerizedRewrite(
-  prompt: string,
-  findings: CaptureResult['findings'],
-): Promise<string | null> {
-  try {
-    const tokenized = await createVaultGlue().tokenizeText(prompt, {
-      findings,
-      sighting: { location: 'prompt', kind: 'prompt' },
-    });
-    if (tokenized.pointers.length === 0) return null;
-    for (const finding of findings) {
-      if (finding.rawMatch !== '' && tokenized.text.includes(finding.rawMatch)) return null;
-    }
-    return tokenized.text;
-  } catch {
-    return null;
   }
 }
 

--- a/plugins/claude-code/test/e2e/user-prompt-submit-wire.e2e.test.ts
+++ b/plugins/claude-code/test/e2e/user-prompt-submit-wire.e2e.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The UserPromptSubmit wire contract for the arm nothing else pins: **allow is
+ * silence**. Driving the REAL built script, because "writes nothing" is a
+ * property of the process's stdout, not of a return value — the decision
+ * module returning null is a different claim, and a unit test cannot see the
+ * difference between that and an entry that emits anyway.
+ *
+ * Why the gap existed. The two neighbouring suites both assert around this
+ * case without covering it:
+ *
+ *   - `test/hooks/user-prompt-submit.test.ts` asserts a clean prompt carries
+ *     `not.toContain('"decision":"block"')`, which is satisfied by the
+ *     onboarding nudge — a payload, not silence.
+ *   - `test/e2e/fail-open.e2e.test.ts`'s enforcement matrix runs its
+ *     `monitor` row against an UN-onboarded home, so it expects
+ *     `"systemMessage"` (the nudge) rather than an empty stdout.
+ *
+ * Neither home is onboarded, so no test has ever driven the one configuration
+ * in which this hook is supposed to say nothing at all.
+ *
+ * An empty stdout is the weakest possible assertion — a hook that crashed on
+ * import, or one whose store never opened, satisfies it perfectly. So the
+ * silence case is bracketed by two controls on the same built script: an
+ * onboarded home that still BLOCKS a flagged prompt (the hook is alive and
+ * reaching the store), and an un-onboarded home that emits the nudge for the
+ * very same clean prompt (the silence is attributable to `onboardedAt`, not to
+ * a store that failed open).
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+import type { BuiltinPolicyId } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { ONBOARDING_NUDGE } from '../../src/hooks/onboarding-nudge.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { runHook, tempHomeEnv, withTempHome } from '../helpers/run-hook.ts';
+
+const SESSION_ID = 'ups-wire-e2e-session';
+const CLEAN_PROMPT = 'rename this variable across the module';
+
+// `runHook` layers its env over the HOST's, so an inherited NODE_OPTIONS would
+// put Node's own diagnostics on the child's stderr and redden the empty-stderr
+// assertion for a reason that has nothing to do with the hook. Blank it.
+function hookEnv(home: string): Record<string, string> {
+  return { ...tempHomeEnv(home), NODE_OPTIONS: '' };
+}
+
+// The secret comes from the bundled rule's own `examples` fixture, so no
+// secret-shaped literal lives in this file. Same rule the sibling suite picks,
+// and for the same reason: its example matches no other bundled rule.
+const RULE_ID = 'secrets/twilio-key';
+
+function secretExample(): { pack: ReturnType<typeof bundledDetections>[number]; example: string } {
+  const pack = bundledDetections().find((p) => p.rules.some((r) => r.id === RULE_ID));
+  const example = pack?.rules.find((r) => r.id === RULE_ID)?.examples?.[0];
+  if (pack === undefined || example === undefined) {
+    throw new Error(`bundled rule ${RULE_ID} is missing from the pack registry or has no example`);
+  }
+  return { pack, example };
+}
+
+const { pack: SECRET_PACK, example: SECRET } = secretExample();
+
+function projectDir(home: string): string {
+  const dir = join(home, 'project');
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// `config.onboarded` is `settings.onboardedAt != null` — the single field that
+// decides whether the allow path is silent or carries the calibration nudge.
+function markOnboarded(home: string): void {
+  const dir = join(home, '.aka', 'settings');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'settings.json'),
+    JSON.stringify({ onboardedAt: '2026-01-01T00:00:00Z' }),
+  );
+}
+
+function seedPolicy(home: string, policy: BuiltinPolicyId): void {
+  const db = openLocalDatabase(join(home, '.aka', 'data'));
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+    db.installedPacks.setPolicy(SECRET_PACK.namespace, SECRET_PACK.packId, policy);
+  } finally {
+    db.close();
+  }
+}
+
+function submit(home: string, prompt: string): ReturnType<typeof runHook> {
+  return runHook(
+    'user-prompt-submit',
+    JSON.stringify({
+      prompt,
+      session_id: SESSION_ID,
+      cwd: projectDir(home),
+      hook_event_name: 'UserPromptSubmit',
+    }),
+    { env: hookEnv(home) },
+  );
+}
+
+describe('user-prompt-submit wire contract — allow is silence', () => {
+  it('onboarded machine, clean prompt → exit 0 and an empty stdout', () => {
+    withTempHome((home) => {
+      markOnboarded(home);
+      const run = submit(home, CLEAN_PROMPT);
+
+      expect(run.status).toBe(0);
+      // The whole point: no opinion is the ABSENCE of a payload, not an
+      // `{"decision":"allow"}`. Claude Code reads exit-0-and-silence as allow.
+      expect(run.stdout).toBe('');
+      expect(run.stderr).toBe('');
+    });
+  });
+
+  it('control: the same onboarded home still blocks a flagged prompt', () => {
+    withTempHome((home) => {
+      markOnboarded(home);
+      seedPolicy(home, 'block');
+      const run = submit(home, `please deploy using this key: ${SECRET}`);
+
+      // Without this the silence above is worthless — a hook that emits
+      // nothing under every input satisfies an empty-stdout assertion. Assert
+      // the emptiness directly rather than letting JSON.parse('') throw, so a
+      // regression names the property instead of a SyntaxError.
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toBe('');
+      const payload = JSON.parse(run.stdout) as { decision?: string; reason?: string };
+      expect(payload.decision).toBe('block');
+      expect(payload.reason).toContain(RULE_ID);
+      expectNoEchoOf(run.stdout, SECRET);
+    });
+  });
+
+  it('control: an un-onboarded home emits the nudge for the same clean prompt', () => {
+    withTempHome((home) => {
+      const run = submit(home, CLEAN_PROMPT);
+
+      // Attributes the silence above to `onboardedAt` specifically. Without
+      // this, a store that failed to open would produce the same empty stdout
+      // and read as a passing allow case.
+      expect(run.status).toBe(0);
+      expect(run.stdout).not.toBe('');
+      const payload = JSON.parse(run.stdout) as { systemMessage?: string };
+      // Against the exported constant, not a substring of it: the constant is
+      // the single source of truth for this copy, and a substring match would
+      // also accept a regression to the stale installation-type framing.
+      expect(payload.systemMessage).toBe(ONBOARDING_NUDGE);
+    });
+  });
+});

--- a/plugins/claude-code/test/hooks/user-prompt-submit-decision.test.ts
+++ b/plugins/claude-code/test/hooks/user-prompt-submit-decision.test.ts
@@ -1,0 +1,433 @@
+// Tests the pure UserPromptSubmit decision module directly — NEVER via the hook
+// entry file (src/hooks/*.ts run main() on import and hang vitest collection).
+// The spawn-driven suite next door (user-prompt-submit.test.ts) stays as the
+// wire contract; this one reaches the branches a spawn cannot reach cheaply —
+// a vault that faults, a rewrite that minted nothing, and the never-leak gate.
+//
+// Two shapes here are the whole point, because both are easy to break by
+// borrowing from the neighbouring hook:
+//
+//   - block is `{"decision":"block", reason}` at the TOP LEVEL. PreToolUse's
+//     `hookSpecificOutput.permissionDecision` is a DIFFERENT field that
+//     UserPromptSubmit does not read, so emitting it here is silently an allow.
+//   - a `redact` policy BLOCKS. This surface has no prompt-rewrite channel, so
+//     the older "sent unchanged" warn would put the raw value in front of the
+//     model under a message claiming it was masked. That regression is pinned
+//     by name below.
+//
+// The fixture secret is assembled at runtime rather than written contiguously:
+// this repo is developed with the AKA plugin active, so a contiguous literal
+// would be redacted out of the test source as it is written. It is high-entropy
+// but deliberately NOT credential-shaped — this repo is public.
+import type { CaptureResult } from '@akasecurity/plugin-sdk';
+import { describe, expect, it } from 'vitest';
+
+import type {
+  PromptTokenizer,
+  UserPromptSubmitOutput,
+} from '../../src/hooks/user-prompt-submit-decision.ts';
+import {
+  decideUserPromptSubmit,
+  pointerizedRewrite,
+} from '../../src/hooks/user-prompt-submit-decision.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
+
+const SECRET = ['7hK2', 'wQ9x', 'Lm4T', 'vB8z'].join('');
+const PROMPT = `please deploy using this key: ${SECRET}`;
+const POINTER = '[[aka:secret:c0ffee11]]';
+const REWRITTEN = `please deploy using this key: ${POINTER}`;
+const RULE = 'secrets/twilio-key';
+const REF = { reference: '3f2a91', ruleId: RULE, maskedValue: '7******z' };
+
+// The message the old redact-degrades-to-warn branch printed. It exists in this
+// file only so its return can be caught: a `redact` that warns instead of
+// blocking sends the raw prompt to the model.
+const STALE_REDACT_COPY = 'cannot be redacted';
+
+type Finding = CaptureResult['findings'][number];
+
+function finding(rawMatch: string, text: string): Finding {
+  const start = text.indexOf(rawMatch);
+  return {
+    ruleId: RULE,
+    category: 'secret',
+    severity: 'high',
+    span: { start, end: start + rawMatch.length },
+    rawMatch,
+    confidence: 0.95,
+  };
+}
+
+// `text` mirrors what the runtime really hands back per action: null for a
+// block (nothing to pass through) and the REDACTED form for a redact. The
+// decision reads neither today, but a fixture carrying the raw prompt where
+// the runtime carries a masked one would validate a future `result.text`
+// reader against data no runtime produces.
+const REDACTED = PROMPT.replace(SECRET, '[REDACTED:SECRET]');
+
+function result(action: CaptureResult['action'], opts: { ref?: boolean } = {}): CaptureResult {
+  return {
+    action,
+    text: action === 'block' ? null : action === 'redact' ? REDACTED : PROMPT,
+    findings: [finding(SECRET, PROMPT)],
+    ...(opts.ref ? { blockedReferences: [REF] } : {}),
+  };
+}
+
+// A tokenizer that swaps the secret for a pointer — the happy path the vault
+// takes when consent is granted and every span vaults cleanly.
+const tokenizerOk: PromptTokenizer = () =>
+  Promise.resolve({ text: REWRITTEN, pointers: [POINTER] });
+
+function blockReason(output: UserPromptSubmitOutput | null): string {
+  if (output === null || !('decision' in output)) {
+    throw new Error(`expected a block decision, got ${JSON.stringify(output)}`);
+  }
+  return output.reason;
+}
+
+function warnMessage(output: UserPromptSubmitOutput | null): string {
+  if (output === null || !('systemMessage' in output)) {
+    throw new Error(`expected a systemMessage, got ${JSON.stringify(output)}`);
+  }
+  return output.systemMessage;
+}
+
+describe('decideUserPromptSubmit — block', () => {
+  it('emits the top-level {decision:"block", reason} shape, not PreToolUse\'s', async () => {
+    const output = await decideUserPromptSubmit(PROMPT, result('block'));
+
+    expect(output).not.toBeNull();
+    // The shape UserPromptSubmit actually reads. Borrowing the sibling hook's
+    // `hookSpecificOutput.permissionDecision` here is read as no opinion.
+    expect(output).toHaveProperty('decision', 'block');
+    expect(typeof blockReason(output)).toBe('string');
+    expect(JSON.stringify(output)).not.toContain('hookSpecificOutput');
+    expect(JSON.stringify(output)).not.toContain('permissionDecision');
+  });
+
+  it('names the flagged rule and leads with removal', async () => {
+    const reason = blockReason(await decideUserPromptSubmit(PROMPT, result('block')));
+
+    expect(reason).toMatch(/^AKA blocked this prompt — flagged /);
+    expect(reason).toContain(RULE);
+    expect(reason).toContain('Remove the flagged content and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+
+  it('never touches the vault when no tokenizer is supplied (consent absent)', async () => {
+    const reason = blockReason(await decideUserPromptSubmit(PROMPT, result('block')));
+
+    // Positive control first: every other assertion here is an absence, and an
+    // absence over an empty reason proves nothing.
+    expect(reason).toContain('Remove the flagged content and resubmit');
+    // Consent-off surfaces mint no pointer and say nothing about a vault.
+    expect(reason).not.toContain('[[aka:');
+    expect(reason).not.toContain('paste and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+});
+
+describe('decideUserPromptSubmit — redact blocks, it does not degrade to warn', () => {
+  it('returns the same block shape a block policy returns', async () => {
+    const output = await decideUserPromptSubmit(PROMPT, result('redact'));
+
+    expect(output).toHaveProperty('decision', 'block');
+    const reason = blockReason(output);
+    expect(reason).toMatch(/^AKA blocked this prompt — flagged /);
+    expect(reason).toContain('Remove the flagged content and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+
+  it('never emits a systemMessage, and never the stale "sent unchanged" copy', async () => {
+    const output = await decideUserPromptSubmit(PROMPT, result('redact'));
+
+    // The positive control comes first, and is load-bearing twice over: a null
+    // output would make `toHaveProperty` throw a TypeError (red for the wrong
+    // reason) and would make both `not.toContain` checks below pass on the
+    // string "null".
+    expect(output).toHaveProperty('decision', 'block');
+    // The regression this pins: warning here passes the raw prompt through to
+    // the model, because this surface cannot rewrite it.
+    expect(output).not.toHaveProperty('systemMessage');
+    expect(JSON.stringify(output)).not.toContain(STALE_REDACT_COPY);
+    expect(JSON.stringify(output)).not.toContain('sent unchanged');
+  });
+
+  it('upgrades to the pointerized resubmit message when the vault is available', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('redact'), { tokenizePrompt: tokenizerOk }),
+    );
+
+    expect(reason).toContain('never reached the model');
+    expect(reason).toContain(POINTER);
+    expect(reason).toContain('paste and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+});
+
+describe('decideUserPromptSubmit — the pointerized resubmit branch', () => {
+  it('reports the clipboard write when one landed', async () => {
+    const written: string[] = [];
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), {
+        tokenizePrompt: tokenizerOk,
+        writeClipboard: (text) => {
+          written.push(text);
+          return true;
+        },
+      }),
+    );
+
+    expect(reason).toContain('It is already on your clipboard');
+    // Only the pointerized text ever reaches the clipboard — never the raw
+    // prompt. Assert what DID land before asserting what did not.
+    expect(written).toEqual([REWRITTEN]);
+    expectNoEchoOf(written.join('\n'), SECRET);
+  });
+
+  it('tells the user to copy by hand when the clipboard write failed', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), {
+        tokenizePrompt: tokenizerOk,
+        writeClipboard: () => false,
+      }),
+    );
+
+    expect(reason).toContain('Copy it, then paste and resubmit');
+    expect(reason).not.toContain('already on your clipboard');
+  });
+
+  it('does not claim a clipboard write when no clipboard seam was supplied', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), { tokenizePrompt: tokenizerOk }),
+    );
+
+    expect(reason).toContain('Copy it, then paste and resubmit');
+    expect(reason).not.toContain('already on your clipboard');
+  });
+
+  it('still blocks when the clipboard seam throws', async () => {
+    // The clipboard decides one sentence, never the verdict. An escaping throw
+    // would land in the entry's fail-open catch, which writes nothing and exits
+    // 0 — and silence is ALLOW on this host, so a clipboard fault would send
+    // the very prompt being blocked.
+    const output = await decideUserPromptSubmit(PROMPT, result('block'), {
+      tokenizePrompt: tokenizerOk,
+      writeClipboard: () => {
+        throw new Error('no clipboard utility on this machine');
+      },
+    });
+
+    expect(output).toHaveProperty('decision', 'block');
+    const reason = blockReason(output);
+    expect(reason).toContain(POINTER);
+    // Degraded to the copy-it-yourself sentence, not lost.
+    expect(reason).toContain('Copy it, then paste and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+
+  it('never offers the clipboard the raw prompt on the fallback path', async () => {
+    const written: string[] = [];
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), {
+        // A vault that mints nothing: the rewrite is refused, so the clipboard
+        // must never be reached at all.
+        tokenizePrompt: () => Promise.resolve({ text: PROMPT, pointers: [] }),
+        writeClipboard: (text) => {
+          written.push(text);
+          return true;
+        },
+      }),
+    );
+
+    expect(written).toEqual([]);
+    expect(reason).toContain('Remove the flagged content and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+});
+
+describe('pointerizedRewrite — the never-leak gate', () => {
+  it('returns the rewrite when every span was pointerized', async () => {
+    const rewrite = await pointerizedRewrite(PROMPT, [finding(SECRET, PROMPT)], tokenizerOk);
+
+    expect(rewrite).toBe(REWRITTEN);
+  });
+
+  it('refuses a rewrite that still carries the raw match', async () => {
+    // The gate: a partial rewrite has pointers in it and reads like a success,
+    // so without this check the raw value is printed back to the user under a
+    // message saying it never reached the model.
+    const leaky = `${PROMPT} (also ${POINTER})`;
+    const rewrite = await pointerizedRewrite(PROMPT, [finding(SECRET, PROMPT)], () =>
+      Promise.resolve({ text: leaky, pointers: [POINTER] }),
+    );
+
+    expect(rewrite).toBeNull();
+  });
+
+  it('refuses a rewrite that minted no pointer', async () => {
+    const rewrite = await pointerizedRewrite(PROMPT, [finding(SECRET, PROMPT)], () =>
+      Promise.resolve({ text: REWRITTEN, pointers: [] }),
+    );
+
+    expect(rewrite).toBeNull();
+  });
+
+  it('refuses on a vault fault rather than propagating it', async () => {
+    const rewrite = await pointerizedRewrite(PROMPT, [finding(SECRET, PROMPT)], () => {
+      throw new Error('vault unavailable');
+    });
+
+    expect(rewrite).toBeNull();
+  });
+
+  it('ignores a finding whose raw match is empty', async () => {
+    // An empty rawMatch is `includes('')` === true for every string, so without
+    // the `!== ''` guard the gate would refuse every rewrite.
+    const blank: Finding = { ...finding(SECRET, PROMPT), rawMatch: '' };
+    const rewrite = await pointerizedRewrite(PROMPT, [blank], tokenizerOk);
+
+    expect(rewrite).toBe(REWRITTEN);
+  });
+
+  it('falls back to the removal-based block when the gate refuses', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), {
+        tokenizePrompt: () => Promise.resolve({ text: PROMPT, pointers: [POINTER] }),
+      }),
+    );
+
+    expect(reason).toContain('Remove the flagged content and resubmit');
+    expect(reason).not.toContain('paste and resubmit');
+    expectNoEchoOf(reason, SECRET);
+  });
+});
+
+describe('decideUserPromptSubmit — warn', () => {
+  it('emits a systemMessage and never a block', async () => {
+    const output = await decideUserPromptSubmit(PROMPT, result('warn'));
+
+    // Accessor first: it names what it actually got, where a bare
+    // `not.toHaveProperty` on a null output throws a TypeError instead.
+    const message = warnMessage(output);
+    expect(output).not.toHaveProperty('decision');
+    expect(message).toContain(RULE);
+    expect(message).toContain('sent unchanged');
+    expectNoEchoOf(message, SECRET);
+  });
+
+  it('never escalates to a block even with a tokenizer available', async () => {
+    // A warn is not an enforcement, so the vault must not be reached for it.
+    let tokenized = false;
+    const output = await decideUserPromptSubmit(PROMPT, result('warn'), {
+      tokenizePrompt: () => {
+        tokenized = true;
+        return Promise.resolve({ text: REWRITTEN, pointers: [POINTER] });
+      },
+    });
+
+    // Assert the warn shape through the accessor, which names what it got: a
+    // bare `not.toHaveProperty` on a null output throws a TypeError instead,
+    // which is red for the wrong reason.
+    expect(warnMessage(output)).toContain(RULE);
+    expect(output).not.toHaveProperty('decision');
+    expect(tokenized).toBe(false);
+  });
+});
+
+describe('decideUserPromptSubmit — allow', () => {
+  it('returns null (no output) for a clean prompt', async () => {
+    const clean: CaptureResult = { action: 'log', text: PROMPT, findings: [] };
+
+    expect(await decideUserPromptSubmit(PROMPT, clean)).toBeNull();
+  });
+
+  it('returns null for a monitor/log action that still carried findings', async () => {
+    // Findings without enforcement are not an opinion — this is the slot the
+    // entry uses for the onboarding nudge, so a payload here would suppress it.
+    expect(await decideUserPromptSubmit(PROMPT, result('log'))).toBeNull();
+  });
+
+  it("returns null for the literal 'allow' action", async () => {
+    // `ActionTaken` is warn | redact | block | allow | log, and 'allow' reaches
+    // this function as a real value — every other case here drives 'log', so
+    // without this the enum member the AC is actually named after is untested.
+    expect(await decideUserPromptSubmit(PROMPT, result('allow'))).toBeNull();
+  });
+
+  it('never reaches the vault on an allow', async () => {
+    let tokenized = false;
+    const output = await decideUserPromptSubmit(PROMPT, result('log'), {
+      tokenizePrompt: () => {
+        tokenized = true;
+        return Promise.resolve({ text: REWRITTEN, pointers: [POINTER] });
+      },
+    });
+
+    expect(output).toBeNull();
+    expect(tokenized).toBe(false);
+  });
+});
+
+describe('decideUserPromptSubmit — the exception-pointer suffix', () => {
+  it('appends the approve command to a warn when a ledger row exists', async () => {
+    const message = warnMessage(
+      await decideUserPromptSubmit(PROMPT, result('warn', { ref: true })),
+    );
+
+    expect(message).toContain(`aka exception approve ${REF.reference}`);
+    expect(message).toContain('To allow this exact value intentionally');
+  });
+
+  it('omits it from a warn when nothing was ledgered', async () => {
+    const message = warnMessage(await decideUserPromptSubmit(PROMPT, result('warn')));
+
+    // The command would find no block, so it is not offered.
+    expect(message).not.toContain('aka exception approve');
+  });
+
+  it('carries the ledger reference and masked preview into a block', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block', { ref: true })),
+    );
+
+    expect(reason).toContain(`aka exception approve ${REF.reference}`);
+    // Preview and reference come from the same ledger row.
+    expect(reason).toContain(REF.maskedValue);
+    expectNoEchoOf(reason, SECRET);
+  });
+
+  it('degrades a block to the bare approve command when nothing was ledgered', async () => {
+    const reason = blockReason(await decideUserPromptSubmit(PROMPT, result('block')));
+
+    expect(reason).toContain('aka exception approve       (asks for scope + reason');
+    expect(reason).not.toContain(REF.reference);
+  });
+
+  it('appends the approve command to the pointerized resubmit message', async () => {
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block', { ref: true }), {
+        tokenizePrompt: tokenizerOk,
+      }),
+    );
+
+    expect(reason).toContain(POINTER);
+    expect(reason).toContain(`aka exception approve ${REF.reference}`);
+    expectNoEchoOf(reason, SECRET);
+  });
+
+  it('omits it from the resubmit message when nothing was ledgered', async () => {
+    // The third surface carrying the suffix, and the cell that completes the
+    // matrix: present/absent on the warn message, the block message, and the
+    // resubmit message alike.
+    const reason = blockReason(
+      await decideUserPromptSubmit(PROMPT, result('block'), { tokenizePrompt: tokenizerOk }),
+    );
+
+    // Positive control first — the absence below is meaningless over a reason
+    // that is not the resubmit message at all.
+    expect(reason).toContain(POINTER);
+    expect(reason).not.toContain('aka exception approve');
+  });
+});


### PR DESCRIPTION
## Why

`UserPromptSubmit` was the last Claude Code hook whose decision logic lived inline in
`main()`. A hook entry runs `main()` on import and then exits, so a test can never import
one — which meant this hook's block/redact/warn collapse could only be reached by spawning
the built script. Every other hook already avoids that:

| Hook entry | Decision layer |
| --- | --- |
| `pre-tool-use.ts` | `decidePreToolUse` |
| `post-tool-use.ts` | `responseEmitPayload` |
| `stop.ts` | `parseStopPayload` |
| `message-display.ts` | `message-display-transform.ts` |
| **`user-prompt-submit.ts`** | **inline, 58 lines** |

Its logic is also the subtlest of the set: the block shape is a top-level
`{"decision":"block"}` rather than PreToolUse's `hookSpecificOutput.permissionDecision`,
and a `redact` policy **blocks** here because this event exposes no prompt-rewrite channel.

## What changed

- **New `user-prompt-submit-decision.ts`** — the payload decision as pure object building,
  mirroring `pre-tool-use-decision.ts`. The vault and the clipboard arrive as injected
  seams, so the module does no I/O and unit-tests without a hook process.
- **`user-prompt-submit.ts` is now wiring only** — read stdin, open the store, capture,
  hand the result to the decision, emit. Vault consent stays resolved in the entry, so
  "no consent → the vault is never touched" holds because no tokenizer is passed, not
  because a flag was read.
- **Guarded the clipboard seam.** It is best-effort and decides one sentence of the
  resubmit message, but an escaping throw would land in the entry's fail-open catch, which
  writes nothing and exits 0 — and silence is how this host spells *allow*. A clipboard
  fault would have sent the very prompt being blocked. The tokenizer call beside it was
  already guarded; this one was not.

## Tests

Unit coverage for all four decision arms, the pointerized-resubmit branch, the never-leak
gate (a rewrite still carrying a raw match is refused), and the exception-pointer suffix on
each of the three surfaces that can carry it.

Plus a new e2e for the one arm nothing covered: **allow is an empty stdout**. Both
neighbouring suites assert *around* that case without covering it — `user-prompt-submit.test.ts`
checks a clean prompt for `not.toContain('"decision":"block"')`, which the onboarding nudge
satisfies, and `fail-open.e2e.test.ts`'s enforcement matrix runs its `monitor` row against an
un-onboarded home, so it expects the nudge rather than silence. No test had ever driven the
one configuration where this hook is supposed to say nothing at all. The empty-stdout case is
bracketed by two controls on the same built script, since a hook that crashed would satisfy it
just as well.

Both pre-existing suites are byte-identical — they are the wire contract and this does not
replace them.

## Verification

```
$ pnpm test          # in plugins/claude-code
 Test Files  82 passed (82)
      Tests  1001 passed | 3 skipped (1004)
```

`pnpm lint`, `pnpm typecheck`, `pnpm format:check` and `pnpm check:portability` are clean.

Every behaviour claimed above was mutation-tested: the guarded branch was deliberately
broken, the named test confirmed red, the tree restored, and green re-confirmed. Notably,
reverting the clipboard guard makes the injected throw escape and kill the block, and
restoring the historical redact-degrades-to-warn branch reddens the three cases that pin
redact as a block.

## Follow-ups (not in this PR)

- `plugins/codex/src/hooks/user-prompt-submit.ts` has the same inline-decision shape and no
  decision module. Antigravity has no `UserPromptSubmit` event, so codex is the only other
  case. Tracked separately.
- `PromptTokenizer` deliberately omits `tokenizeText`'s `degraded` list. It cannot change the
  verdict — the prompt is blocked either way — but the resubmit message tells the user "the
  real values stay in your local vault", which is false for a span that was destroyed one-way
  instead of vaulted. Pre-existing; fixing it means deciding what that message should say, so
  it is a copy decision rather than a refactor. The comment at the type says so.
