### PR TITLE
docs: add test/helpers to the lint:root target list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -669,8 +669,9 @@ tools/                repo tooling: installer one-liners + the audit-gate worksp
    steps. The chain has to be unconditional: behind a `||` the root pass runs only
    once the workspace pass has already failed, which is every green run skipping
    the repo root. `lint:root` is a single invocation: `eslint.root.config.mjs` runs
-   the full ruleset over `test/setup/**`, `test/fixtures/**`, `tools/ci/**`, and the
-   repo-root `*.config.*`. `typecheck:root` runs `tsc -p tsconfig.root.json`.
+   the full ruleset over `test/setup/**`, `test/fixtures/**`, `test/helpers/**`,
+   `tools/ci/**`, and the repo-root `*.config.*`. `typecheck:root` runs
+   `tsc -p tsconfig.root.json`.
 
    It used to carry a second, network-only invocation over the plain-JS
    enforcement suites in `packages/eslint-config/test/**`, because that package's


### PR DESCRIPTION
One line of `CLAUDE.md`. The `lint:root` description enumerated its targets and
omitted `test/helpers`, which the script has actually covered for some time.

**Before**

> `lint:root` is a single invocation: `eslint.root.config.mjs` runs the full ruleset
> over `test/setup/**`, `test/fixtures/**`, `tools/ci/**`, and the repo-root `*.config.*`.

**The script**

```
"lint:root": "eslint --no-config-lookup -c eslint.root.config.mjs test/setup test/fixtures test/helpers tools/ci *.config.*"
```

The other two changed lines are prettier reflow; no wording is altered.

## Why it matters, and how far the fix goes

`test/helpers/` holds `remove-tree.ts`, imported across the workspace:

```
$ git grep -lE "^import .*from '.*remove-tree" origin/main -- '*.ts' \
    | grep -v '^test/helpers/remove-tree.ts$' | wc -l
37
```

So a reader checking whether that directory was linted got the wrong answer from the
document that exists to answer it. The directory *is* linted — this corrects the text,
not the behaviour.

**This adds no guard.** The coverage check derives its target set from the `lint:root`
script itself (`eslintInvocations(lintScript)`), never from this sentence, which is
exactly why the prose drifted without anything going red. The same drift can recur the
next time a target is added. Making it self-enforcing would mean a test that parses this
sentence and diffs it against the script — a real change, and deliberately not this one.

## Verification

```
$ pnpm exec prettier --check CLAUDE.md
All matched files use Prettier code style!
```

Prose targets now match the script's, in the same order:

```
script:  test/setup  test/fixtures  test/helpers  tools/ci  *.config.*
prose:   test/setup/**  test/fixtures/**  test/helpers/**  tools/ci/**  *.config.*
```

Full workspace lint (including `lint:root` and the portability gate) passed on the
pre-push hook. Documentation-only: no source, config, or workflow file is touched.
