### PR TITLE
test(detections): enforce the 2+2 fixture bar on every rule pack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -590,7 +590,12 @@ the live examples); and a class assembled from a non-literal.
 
 ## Detection rules
 
-See `skills/write-detection-rule/SKILL.md`. A rule PR without fixtures is rejected by CI.
+See `skills/write-detection-rule/SKILL.md`. A rule PR carrying fewer than 2 positive or
+2 negative fixtures is rejected by CI — `packages/detections/test/engine.test.ts` asserts
+the bar per rule, and `packages/detections/test/posture/config-posture.test.ts` asserts it
+for posture rules. Both read it from `packages/detections/test/helpers/fixture-bar.ts`, so
+the number and its message live in one place; the count is of DISTINCT cases, because a
+repeated fixture exercises nothing the first one did not.
 
 Any change to the `installed_packs` / `available_packs` **write semantics** must extend the
 legacy-writers suite (`packages/persistence/test/repositories/legacy-writers.test.ts`) — it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,8 +118,8 @@ from our dependency tree, add a waiver to `.github/audit-waivers.json`:
 
 ## Contributing detection rules
 
-Detection rules live in [`rules/`](rules/). Every rule ships with **positive and
-negative fixtures**; a rule PR without fixtures will not pass CI. See
+Detection rules live in [`rules/`](rules/). Every rule ships with **at least 2 positive
+and 2 negative fixtures**; a rule PR below that bar will not pass CI. See
 `skills/write-detection-rule/SKILL.md` for the format.
 
 Rules merged here are published as **first-party, verified** packs, so rule PRs get

--- a/packages/detections/test/engine.test.ts
+++ b/packages/detections/test/engine.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 import { redact, scan } from '../src/engine.ts';
 import type { MatchResult } from '../src/types.ts';
+import { expectFixtureBar, MIN_FIXTURES_PER_POLARITY } from './helpers/fixture-bar.ts';
 import { bundledPackDirs, discoverBundledRuleFiles, loadRule, RULES_DIR } from './helpers/rules.ts';
 
 type Fixture = RuleFixture;
@@ -21,6 +22,13 @@ function loadFixtures(packDir: string, ruleFile: string): Fixture[] {
   }
   const raw = JSON.parse(readFileSync(fixturePath, 'utf-8')) as unknown;
   return (raw as unknown[]).map((f) => RuleFixtureSchema.parse(f));
+}
+
+// What makes one fixture a distinct case: the text actually scanned, plus the
+// file context that gates `appliesTo`. Two fixtures may share a `text` and
+// still be separate cases when only one carries a `filePath`.
+function fixtureIdentity(fixture: Fixture): string {
+  return JSON.stringify([fixture.text, fixture.filePath ?? null]);
 }
 
 const packDirs = bundledPackDirs();
@@ -54,8 +62,8 @@ for (const { packDir, ruleFile, rule, fixtures } of discovered) {
   const ruleset = gated ? allRules : [rule];
 
   describe(`${packDir}/${ruleFile}`, () => {
-    it('has at least one fixture', () => {
-      expect(fixtures.length).toBeGreaterThan(0);
+    it(`has at least ${String(MIN_FIXTURES_PER_POLARITY)} positive and ${String(MIN_FIXTURES_PER_POLARITY)} negative fixtures`, () => {
+      expectFixtureBar(`${packDir}/${ruleFile}`, fixtures, fixtureIdentity);
     });
 
     for (const fixture of fixtures) {

--- a/packages/detections/test/helpers/fixture-bar.ts
+++ b/packages/detections/test/helpers/fixture-bar.ts
@@ -1,0 +1,55 @@
+import { expect } from 'vitest';
+
+// The documented fixture bar, in one place.
+//
+// Two suites gate on it — the rule-pack gate in `engine.test.ts` and the posture
+// gate in `posture/config-posture.test.ts` — over fixture shapes that share only
+// `shouldMatch`. Holding the number and the message here is what stops the two
+// from drifting apart while both stay green.
+
+/**
+ * The minimum labeled cases of each polarity every rule ships with. Negatives
+ * are what keep a pattern from over-matching, so the bar applies to both.
+ */
+export const MIN_FIXTURES_PER_POLARITY = 2;
+
+const FIXTURE_BAR = String(MIN_FIXTURES_PER_POLARITY);
+
+/** Same shape as the missing-fixture message: name the subject, say what was
+ * found, and point at the authority for the bar. */
+function belowFixtureBar(
+  subject: string,
+  polarity: 'positive' | 'negative',
+  count: number,
+): string {
+  return (
+    `Rule "${subject}" has ${String(count)} distinct ${polarity} fixture${count === 1 ? '' : 's'} — ` +
+    `expected at least ${FIXTURE_BAR}. Every rule must have at least ${FIXTURE_BAR} positive and ` +
+    `${FIXTURE_BAR} negative fixtures per skills/write-detection-rule/SKILL.md.`
+  );
+}
+
+/**
+ * Assert `cases` clears the bar in both polarities.
+ *
+ * Counts DISTINCT cases: a repeated case exercises nothing the first one did
+ * not, so it must not buy its way past a bar that exists to demand coverage.
+ * `identity` maps a case to what makes it distinct — the scanned input, not the
+ * label, since two differently-labeled copies of one input are still one case.
+ *
+ * Both polarities are asserted softly so a subject short on both reports both
+ * in one run rather than one shortfall per fix-and-rerun cycle.
+ */
+export function expectFixtureBar<T extends { shouldMatch: boolean }>(
+  subject: string,
+  cases: readonly T[],
+  identity: (fixture: T) => string,
+): void {
+  for (const polarity of ['positive', 'negative'] as const) {
+    const wanted = polarity === 'positive';
+    const distinct = new Set(cases.filter((c) => c.shouldMatch === wanted).map(identity)).size;
+    expect
+      .soft(distinct, belowFixtureBar(subject, polarity, distinct))
+      .toBeGreaterThanOrEqual(MIN_FIXTURES_PER_POLARITY);
+  }
+}

--- a/packages/detections/test/posture/config-posture.test.ts
+++ b/packages/detections/test/posture/config-posture.test.ts
@@ -10,6 +10,7 @@ import {
   configPostureDefinitions,
   evaluateConfigPosture,
 } from '../../src/posture/config-posture.ts';
+import { expectFixtureBar, MIN_FIXTURES_PER_POLARITY } from '../helpers/fixture-bar.ts';
 
 const fixturesDir = join(
   fileURLToPath(new URL('.', import.meta.url)),
@@ -37,14 +38,13 @@ function scan(hooks: HookScanEntry[]): ConfigScanResult {
   };
 }
 
-// The same bar the rule-pack CI gate sets: every rule has labeled positive AND
-// negative fixtures, and every fixture passes.
+// The same bar the rule-pack CI gate sets, from the same constant: every rule
+// has labeled positive AND negative fixtures, and every fixture passes.
 describe.each(CONFIG_POSTURE_RULES.map((r) => r.ruleId))('fixtures: %s', (ruleId) => {
   const cases = loadFixtures(ruleId);
 
-  it('has at least 2 positive and 2 negative cases', () => {
-    expect(cases.filter((c) => c.shouldMatch).length).toBeGreaterThanOrEqual(2);
-    expect(cases.filter((c) => !c.shouldMatch).length).toBeGreaterThanOrEqual(2);
+  it(`has at least ${String(MIN_FIXTURES_PER_POLARITY)} positive and ${String(MIN_FIXTURES_PER_POLARITY)} negative cases`, () => {
+    expectFixtureBar(ruleId, cases, (c) => JSON.stringify(c.hooks));
   });
 
   it.each(cases.map((c) => [c.label, c] as const))('%s', (_label, c) => {

--- a/rules/core-code-context/fixtures/localhost-ref.json
+++ b/rules/core-code-context/fixtures/localhost-ref.json
@@ -18,5 +18,15 @@
     "label": "not localhost",
     "text": "hostname: server.internal",
     "shouldMatch": false
+  },
+  {
+    "label": "private network CIDR, not the wildcard bind address",
+    "text": "Allow ingress from 10.0.0.0/8 only",
+    "shouldMatch": false
+  },
+  {
+    "label": "identifier containing the word, not a loopback reference",
+    "text": "localhostname = socket.gethostname()",
+    "shouldMatch": false
   }
 ]

--- a/rules/core-phi/fixtures/group-id.json
+++ b/rules/core-phi/fixtures/group-id.json
@@ -5,6 +5,16 @@
     "shouldMatch": true
   },
   {
+    "label": "group number corroborated by the subscriber label",
+    "text": "Subscriber: Jane Roe - Group Number 88213004",
+    "shouldMatch": true
+  },
+  {
+    "label": "group no corroborated by the health plan label",
+    "text": "Health plan enrollment, Group No HP4471902",
+    "shouldMatch": true
+  },
+  {
     "label": "group id alone, no member context (gated out)",
     "text": "Group ID: GRP12345678",
     "shouldMatch": false

--- a/rules/core-pii/fixtures/passport-us.json
+++ b/rules/core-pii/fixtures/passport-us.json
@@ -5,6 +5,16 @@
     "shouldMatch": true
   },
   {
+    "label": "passport number in prose",
+    "text": "Applicant passport number Z98765432 was verified.",
+    "shouldMatch": true
+  },
+  {
+    "label": "passport label follows the number",
+    "text": "M40928311 appears on the passport bio page.",
+    "shouldMatch": true
+  },
+  {
     "label": "bare number without passport context",
     "text": "Document A12345678 is ready",
     "shouldMatch": false

--- a/skills/write-detection-rule/SKILL.md
+++ b/skills/write-detection-rule/SKILL.md
@@ -119,11 +119,11 @@ rules/<pack-id>/
     <rule-name>.json    # REQUIRED: array of { label, text, shouldMatch: bool }
 ```
 
-**A rule without fixtures will be rejected by CI.**
+**A rule without fixtures will be rejected by CI** — see the bar below.
 
 ## Fixture requirements
 
-Every rule must have labeled **positive** fixtures (where `shouldMatch: true`) and **negative** fixtures (where `shouldMatch: false`). Aim for at least 2 of each. Negatives are as important as positives — they prove your pattern doesn't over-match.
+Every rule must have labeled **positive** fixtures (where `shouldMatch: true`) and **negative** fixtures (where `shouldMatch: false`). **At least 2 distinct cases of each — CI enforces this**, and a rule below the bar fails the build. Distinct means a different scanned `text`/`filePath`, so a repeated fixture does not count twice. Negatives are as important as positives — they prove your pattern doesn't over-match.
 
 ```json
 [


### PR DESCRIPTION
## Summary

The 2+2 fixture bar was documented in three places but enforced in only one — and
not the one that matters. `skills/write-detection-rule/SKILL.md` states it,
`config-posture.test.ts` enforced it for **posture** rules, but `engine.test.ts`
— the gate every bundled detection rule passes through — only asserted
`fixtures.length > 0`. Three rules had already drifted below the bar unnoticed.

Negative fixtures are how a pattern is kept from over-matching, so an unenforced
bar is a false-positive risk that reads as covered.

## Changes

- **`engine.test.ts` now asserts the bar per rule** — at least 2 positive and 2
  negative fixtures, replacing the `> 0` check.
- **Counts DISTINCT cases** (`text` + `filePath`), so a duplicated fixture cannot
  buy its way past a bar that exists to demand coverage. `filePath` is part of the
  identity because `code-flaws/sql-inject-concat-dot` legitimately reuses one
  `text` with and without a `.php` path to exercise `appliesTo` gating.
- **The bar lives in one place** — `packages/detections/test/helpers/fixture-bar.ts`
  holds the constant and the failure message; both `engine.test.ts` and
  `posture/config-posture.test.ts` read it, so the two gates can no longer drift.
  Assertions are soft, so a rule short on both polarities reports both shortfalls
  in one run instead of one per fix-and-rerun cycle.
- **The failure message points at `skills/write-detection-rule/SKILL.md`**,
  matching the existing missing-fixture message's style.
- **Fixtures added to the three below-bar rules**, chosen to cover untested ground
  rather than pad a count:
  - `core-code-context/localhost-ref` — two negatives that pin the pattern's word
    boundaries (a `10.0.0.0/8` CIDR, and an identifier merely containing the word).
  - `core-phi/group-id` — positives exercising the previously untested `number` and
    `no` keyword arms, and the `labels` corroboration path rather than `ruleIds`.
  - `core-pii/passport-us` — one in prose, and one with the label *after* the value,
    which pins that the proximity window looks backwards.
- **Docs corrected** — SKILL.md, CONTRIBUTING.md and CLAUDE.md all described the bar
  as aspirational ("aim for", "without fixtures"). `config-posture.test.ts`'s comment
  claiming it set "the same bar the rule-pack CI gate sets" is now true.

## Verification

`cd packages/detections && npx vitest run` → exit 0, `Test Files 15 passed (15)`,
`Tests 1260 passed (1260)`. Workspace-wide `pnpm test` → `Tasks: 39 successful, 39
total`; `pnpm lint` → exit 0.

Coverage is complete rather than partial: 101 rules on disk resolve to 101 fixture
files and **101 executed bar tests** (counted from `vitest --reporter=json`). The 7
other top-level pack JSONs are per-pack `manifest.json`, not rules.

Each assertion was proven non-vacuous by mutation, restoring the tree between runs:

| Mutation | Exit | Result |
| --- | --- | --- |
| Drop a negative from an unrelated rule | 1 | Bar test red, naming rule and polarity |
| *Control:* same mutation, old `> 0` assertion restored | **0** | The old check cannot catch it |
| Revert the three fixture files | 1 | 3 failures, each naming its own shortfall |
| Invert `shouldMatch` on all 6 added fixtures | 1 | All 6 red by their own label |
| Rule cut to 1 positive + 1 negative | 1 | Both shortfalls reported in one run |
| Duplicate fixture added (raw count = 2) | 1 | `has 1 distinct negative fixture` |
| Same two mutations against the posture gate | 1 | Shared bar fires there too |
| Strip the SKILL.md pointer from the message | — | Failure output loses it (1 → 0 occurrences) |

The control run is the load-bearing one: identical mutation, only the assertion
swapped, exit code flips 1 → 0.

## Follow-up (not in this PR)

While writing the `localhost-ref` fixtures I found its `::1` alternative is **dead
code**. The pattern is `\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0|::1)\b`, and `\b`
before a `:` requires a preceding word character, so it never fires:

```
"Bind to ::1 port 8080"  -> no match
"http://[::1]:3000"      -> no match
"ping ::1"               -> no match
```

The same rule is case-sensitive (`flags: "g"`), so `LOCALHOST` also goes undetected.
Both are deliberately left alone here — fixing them changes what a shipped rule
flags for every user and deserves its own change with its own fixtures. Neither is
encoded as a negative fixture, which would have enshrined a false negative as
intended behaviour. Tracked separately.
