### PR TITLE
chore(release): merge release/0.9.6 back to main

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/antigravity/package.json
+++ b/plugins/antigravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-antigravity",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Antigravity CLI",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "aka-antigravity",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control — inspect and govern AI prompts in Antigravity. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks.json",
   "skills": "./skills",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka-codex",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-codex",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Merge the tagged release/0.9.6 branch back to main.

Bumps the seven version files from 0.9.5 to 0.9.6:

- `cli/package.json`
- `plugins/claude-code/package.json` + `.claude-plugin/plugin.json`
- `plugins/codex/package.json` + `.codex-plugin/plugin.json`
- `plugins/antigravity/package.json` + `plugin.json`

All five artifacts are tagged and published from `dc73c73f`:

| Artifact | Tag | Status |
|---|---|---|
| `@akasecurity/cli` | `cli-v0.9.6` | published to npm `latest` |
| `@akasecurity/ai-tc-claude-code` | `plugin-claude-v0.9.6` | published to npm `latest` |
| `@akasecurity/ai-tc-codex` | `plugin-codex-v0.9.6` | published to npm `latest` |
| `@akasecurity/ai-tc-antigravity` | `plugin-antigravity-v0.9.6` | published to npm `latest` |
| `aka` binaries | `bin-v0.9.6` | building |

This is bookkeeping only — the tags point at commits that already existed, so merging cannot change what shipped.