### PR TITLE
fix(ci): bound turbo concurrency on the Windows lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,6 +635,22 @@ jobs:
     name: Windows · Lint
     runs-on: windows-latest
     timeout-minutes: 25
+    # `pnpm lint` fans `turbo run lint` across every package, and this was the one
+    # lint-or-test step in this file with no bound on that — every Test step
+    # carries `--concurrency=2`, and this leg needs it for the same reason the
+    # Windows test leg does. Unbounded, each package spawns its own ESLint (several
+    # spawn two, for the src+test pass split), and Windows answers a process storm
+    # of that size with STATUS_DLL_INIT_FAILED (0xC0000142, surfacing as exit
+    # 3221225794) rather than a lint error: the child never starts, so no lint
+    # output precedes it and the victim moves between runs.
+    #
+    # Bounded through the environment rather than the flag because the run step has
+    # to stay exactly `pnpm lint`. Going to turbo directly drops `lint:root` and
+    # `check:portability`, which the root script chains and which are the only
+    # coverage the repo root gets — required-checks.test.js pins that step for that
+    # reason, and this bound is pinned beside it.
+    env:
+      TURBO_CONCURRENCY: 2
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,27 @@ jobs:
     name: Lint · Typecheck · Test · Build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Three steps in this job fan turbo with no bound of their own — `pnpm lint`,
+    # `pnpm typecheck` and `pnpm build` each expand to a bare `turbo run …`, so
+    # each fans every package at turbo's default of 10. None of them can take the
+    # flag: `pnpm lint -- --concurrency=4` appends to the END of a `&&` chain and
+    # lands on `check:portability`, not on turbo. The environment is the only lever
+    # that reaches all three, which is the same reason the Windows lint leg uses it.
+    #
+    # This does NOT disturb the Test step below. A `--concurrency` flag supersedes
+    # this variable outright — measured against the pinned turbo, where an invalid
+    # env value is rejected on its own (exit 1) but ignored entirely when the flag
+    # is present (exit 0) — so that step keeps its explicit 2.
+    #
+    # 4 rather than the Windows leg's 2, and the asymmetry is deliberate. That leg
+    # answers an OBSERVED process-launch failure (0xC0000142) and is conservative
+    # for it; nothing equivalent has been seen here — both recent attempt-1 failures
+    # of this job were the Diff coverage step. This is preventive: it caps the fan
+    # below turbo's default so 22 concurrent type-aware ESLint processes cannot
+    # crowd the runner's memory, without giving up parallelism the job is not
+    # actually losing, since a bound above the core count buys no more of it.
+    env:
+      TURBO_CONCURRENCY: 4
     steps:
       # fetch-depth: 0 for the Diff coverage step below. The default depth-1
       # checkout has no merge base to diff against, so the gate could only be

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -774,13 +774,26 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 25
     # `pnpm lint` fans `turbo run lint` across every package, and this was the one
-    # lint-or-test step in this file with no bound on that — every Test step
-    # carries `--concurrency=2`, and this leg needs it for the same reason the
-    # Windows test leg does. Unbounded, each package spawns its own ESLint (several
-    # spawn two, for the src+test pass split), and Windows answers a process storm
-    # of that size with STATUS_DLL_INIT_FAILED (0xC0000142, surfacing as exit
-    # 3221225794) rather than a lint error: the child never starts, so no lint
-    # output precedes it and the victim moves between runs.
+    # lint-or-test step on the WINDOWS legs with no bound on that — every
+    # `turbo run test` invocation carries `--concurrency=2`, and this leg needs it
+    # for the same reason the Windows test leg does. Unbounded, each package task
+    # runs its own ESLint, and Windows answers a process storm of that size with
+    # STATUS_DLL_INIT_FAILED (0xC0000142, surfacing as exit 3221225794) rather than
+    # a lint error: the child never starts, so no lint output precedes it and the
+    # victim moves between runs.
+    #
+    # Scoped to the Windows legs deliberately, because the file-wide claim is false
+    # and the next person debugging this class of failure would be misdirected by
+    # it: the Linux `Lint · Typecheck · Test · Build` job fans turbo unbounded three
+    # times over — `pnpm lint`, `pnpm typecheck` and `pnpm build` each expand to a
+    # bare `turbo run …`. It fans the same package count this leg did and gets away
+    # with it on a far larger process budget than the Windows desktop heap, not
+    # because anything bounds it.
+    #
+    # Peak parallelism is turbo's concurrency and nothing else. A package whose
+    # lint script makes two ESLint passes chains them with `&&`, so they are
+    # sequential and add nothing to the peak — which is exactly what makes
+    # TURBO_CONCURRENCY the whole lever here rather than one of two.
     #
     # Bounded through the environment rather than the flag because the run step has
     # to stay exactly `pnpm lint`. Going to turbo directly drops `lint:root` and

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -964,3 +964,84 @@ describe('the branch-freshness decision in CONTRIBUTING.md', () => {
     }
   });
 });
+
+// A step that shells a root script fans turbo at its DEFAULT of 10 unless
+// something bounds it, and the bound cannot be a flag on the step: `pnpm lint --
+// --concurrency=4` appends to the end of a `&&` chain, landing on
+// `check:portability` rather than on turbo. The job-level environment is the only
+// lever that reaches every fan in a job at once.
+//
+// Derived rather than listed. The Windows lint leg was bounded on its own after a
+// real 0xC0000142, and the file-wide claim written beside it was wrong — the Linux
+// job fanned unbounded three separate times and nobody noticed, because nothing
+// asked. Naming the two jobs here would repeat that: the property is "a job that
+// fans turbo unbounded declares a bound", and a third job added tomorrow is
+// covered by it on the day it lands.
+describe('the turbo fans in ci.yml are bounded', () => {
+  const ci = readWorkflow('ci.yml');
+
+  // Which root scripts expand to a `turbo run` carrying no `--concurrency` of its
+  // own. Read from the manifest rather than listed, so a script that grows or
+  // loses a bound is reflected here without an edit.
+  const unboundedScripts = Object.entries(rootScripts())
+    .filter(([, cmd]) => /\bturbo run\b/.test(cmd) && !/--concurrency/.test(cmd))
+    .map(([name]) => name);
+
+  // Scope is computed OUT here rather than branched on inside the test body. A
+  // body that returns before asserting reports as a pass, so looping over every
+  // job and returning early for the ones out of scope would have three of the five
+  // claiming a check the run never made — the shape this repo requires a
+  // `ctx.skip` for, and `it.each` passes no context to skip with. Deriving the
+  // in-scope set instead means every registered case asserts, and the set itself
+  // is what the vacuity test pins.
+  //
+  // This reader does NOT assert, deliberately: it runs in the `describe` body, and
+  // an assertion there is a collection error that reports the whole FILE as
+  // `(0 test)`. Each `it` re-resolves its block through `jobBlock`, which does
+  // assert, where a failure is a test failure.
+  const jobNames = [...ci.matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)]
+    .map(([, name]) => name)
+    .filter((name) => name !== 'push');
+
+  // `pnpm <script>` as the WHOLE command — `pnpm turbo run test --concurrency=2`
+  // is a direct call carrying its own flag, and `pnpm lint:root` is a different
+  // script that fans nothing, so the boundary excludes `:` and `-`.
+  const fansOf = (block) =>
+    unboundedScripts.filter((s) => new RegExp(`run: pnpm ${s}(?![\\w:-])`).test(block));
+
+  const jobsWithFans = jobNames.filter((job) => {
+    const raw = new RegExp(
+      `^ {2}${job}:[^\\S\\n]*$([\\s\\S]*?)(?=^ {2}\\S|\\s*$(?![\\s\\S]))`,
+      'm',
+    ).exec(ci)?.[1];
+    return raw !== undefined && fansOf(dropComments(raw)).length > 0;
+  });
+
+  // Pins the derivation from both ends. The scripts must include the three that
+  // really are unbounded, and the in-scope jobs must be exactly the two that run
+  // them — an EXACT set, because a floor would stay green if the scoping regex
+  // quietly stopped matching a job, which is the failure that empties the loop.
+  it('derives the scripts and jobs to check, so the loop below is not vacuous', () => {
+    expect(unboundedScripts).toEqual(expect.arrayContaining(['lint', 'typecheck', 'build']));
+    expect(jobsWithFans).toEqual(['ci', 'windows-lint']);
+  });
+
+  // The property, over jobs that are all genuinely in scope. `jobBlock` strips
+  // comments first, so a bound that has been commented out reads as absent —
+  // which is the point.
+  it.each(jobsWithFans)('%s bounds every turbo fan it runs', (job) => {
+    const block = jobBlock(ci, job);
+    const fans = fansOf(block);
+    expect(
+      fans.length,
+      `${job} was selected as fanning turbo but runs none of the scripts`,
+    ).toBeGreaterThan(0);
+    const bound = /^ {6}TURBO_CONCURRENCY: (\d+)$/m.exec(block);
+    expect(
+      bound,
+      `${job} runs ${fans.map((f) => `\`pnpm ${f}\``).join(', ')} but declares no TURBO_CONCURRENCY`,
+    ).not.toBeNull();
+    expect(Number(bound[1]), `${job}'s bound must be a positive integer`).toBeGreaterThan(0);
+    expect(Number(bound[1]), `${job}'s bound is high enough to be no bound`).toBeLessThanOrEqual(8);
+  });
+});

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -560,13 +560,18 @@ describe('the Windows legs', () => {
   });
 
   // Unfiltered AND unbounded is what this leg cannot be. `pnpm lint` fans
-  // `turbo run lint` across every package, and each spawns its own ESLint —
-  // several spawn two, for the src+test pass split. Windows answers a process
-  // storm of that size with STATUS_DLL_INIT_FAILED (0xC0000142, exit 3221225794):
-  // the child never starts, so there is no lint output to read and the package
-  // that dies moves between runs, which is what distinguishes it from a real
-  // violation. Every `turbo run test` invocation in this file is bounded for the
-  // same reason; this leg was the one that never got it.
+  // `turbo run lint` across every package, and each package task runs its own
+  // ESLint. Windows answers a process storm of that size with
+  // STATUS_DLL_INIT_FAILED (0xC0000142, exit 3221225794): the child never starts,
+  // so there is no lint output to read and the package that dies moves between
+  // runs, which is what distinguishes it from a real violation. Every
+  // `turbo run test` invocation in this file is bounded for the same reason; this
+  // leg was the one that never got it.
+  //
+  // Peak parallelism is turbo's concurrency and nothing else — a package making
+  // two ESLint passes chains them with `&&`, so they are sequential and add
+  // nothing to the peak. That is what makes the env var the whole lever, and it
+  // is why this asserts a bound rather than counting passes.
   //
   // The bound is asserted through `env:` rather than a flag on the step, and that
   // is forced rather than chosen: the two assertions above pin the step as exactly

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -415,6 +415,37 @@ describe('the Windows legs', () => {
     expect(block).not.toMatch(/--filter/);
   });
 
+  // Unfiltered AND unbounded is what this leg cannot be. `pnpm lint` fans
+  // `turbo run lint` across every package, and each spawns its own ESLint —
+  // several spawn two, for the src+test pass split. Windows answers a process
+  // storm of that size with STATUS_DLL_INIT_FAILED (0xC0000142, exit 3221225794):
+  // the child never starts, so there is no lint output to read and the package
+  // that dies moves between runs, which is what distinguishes it from a real
+  // violation. Every `turbo run test` invocation in this file is bounded for the
+  // same reason; this leg was the one that never got it.
+  //
+  // The bound is asserted through `env:` rather than a flag on the step, and that
+  // is forced rather than chosen: the two assertions above pin the step as exactly
+  // `pnpm lint`, because going to turbo directly drops `lint:root` and
+  // `check:portability`. `TURBO_CONCURRENCY` is turbo's own spelling of the flag —
+  // verified against the pinned turbo, where an invalid value fails with the same
+  // `--concurrency` parse error the flag produces, which an unread variable could
+  // not do.
+  //
+  // Paired with the positive control for the reason the filter check is: a block
+  // that captured nothing satisfies an absence, and it would satisfy a bare
+  // presence check here too if the value were never read. So read the value and
+  // require it to be a small positive integer — `TURBO_CONCURRENCY: 0` is refused
+  // by turbo at startup, and a large one is the unbounded case wearing a number.
+  it('bounds how many packages lint at once', () => {
+    const block = jobBlock(ci, 'windows-lint');
+    expect(block).toMatch(LINT_STEP);
+    const bound = /^ {6}TURBO_CONCURRENCY: (\d+)$/m.exec(block);
+    expect(bound, 'the Windows lint job declares no TURBO_CONCURRENCY bound').not.toBeNull();
+    expect(Number(bound[1])).toBeGreaterThan(0);
+    expect(Number(bound[1])).toBeLessThanOrEqual(4);
+  });
+
   // Same reasoning as the macOS leg: a job-level `if:` does not save a PR the
   // wait, because GitHub reports a skipped job as PENDING for a required check.
   it.each(['windows', 'windows-lint'])('%s carries no condition that could skip it', (job) => {


### PR DESCRIPTION
## Summary

`Windows · Lint` dies with exit `3221225794` = `0xC0000142` =
**`STATUS_DLL_INIT_FAILED`**. That is a Windows *process-launch* failure — the child
never got as far as running ESLint — so it is not a lint violation and no lint output
precedes it.

This is an **ambient failure on `main`**, not a defect in any one PR.

## Why it is resource exhaustion, not a code defect

The victim moves between runs, which is the tell — a real defect fails in the same place
every time:

| Where | Run | Package that died |
|---|---|---|
| `main` @ `ae379c5c`, **attempt 1** | `31740640174` | `@akasecurity/plugin-sdk#lint` |
| PR #271 | `31781402954` | `@akasecurity/ai-tc-antigravity#lint` |

Both exited `-1073741502`. Raw log lines:

```
$ gh api repos/akasecurity/ai-tc/actions/jobs/94582888644/logs   # main, attempt 1
Failed:    @akasecurity/plugin-sdk#lint
  ERROR  run failed: command  exited (-1073741502)
  ELIFECYCLE  Command failed with exit code 3221225794.

$ gh run view 31781402954 --log-failed                            # PR #271
Failed:    @akasecurity/ai-tc-antigravity#lint
##[error]command (D:\a\ai-tc\ai-tc\plugins\antigravity) …pnpm.CMD run lint exited (-1073741502)
```

> **`main` looks green in `gh run list`, and is not.** Run `31740640174` reports
> `conclusion=success` because it has `run_attempt=3` — the job failed on attempt 1 and
> was re-run. Any failure-rate measurement taken from run-level conclusions undercounts
> for this reason; the numbers below are taken from attempt 1.

## Root cause

The Windows lint job was the only lint-or-test step in `ci.yml` with **no concurrency
bound**. Every Test step carries one:

```yaml
run: pnpm turbo run test --concurrency=2      # ci, macOS, Windows unit tests
```

whereas `Windows · Lint` ran bare `pnpm lint`, and the root script is:

```
lint: turbo run lint && pnpm lint:root && pnpm check:portability
```

so `turbo run lint` fanned across all 21 packages unbounded, each spawning ESLint —
several spawning two, for the `src` + `test` pass split. `0xC0000142` is the classic
symptom of exhausting the desktop heap or handle table under exactly that.

## Fix

A job-level `env:` on `windows-lint`. The run step is **unchanged**:

```yaml
    env:
      TURBO_CONCURRENCY: 2
```

**Why the env var and not the flag.** `required-checks.test.js` pins this step as exactly
`pnpm lint` (`LINT_STEP = /run: pnpm lint(?![\w:])/`), because going to turbo directly
would drop `lint:root` and `check:portability` — the only coverage the repo root gets.
Rewriting the step would fail that guard, correctly. An `env:` block satisfies it
unchanged.

**`TURBO_CONCURRENCY` is verified to be honoured**, not assumed — an invalid value
produces the same parse error the flag does, which an unread variable could not:

```
$ TURBO_CONCURRENCY=not-a-number pnpm exec turbo run lint --dry=text ; echo "exit=$?"
  x Invalid value for `--concurrency` flag. This should be a positive integer
exit=1

$ pnpm exec turbo run lint --concurrency=not-a-number --dry=text ; echo "exit=$?"   # control
  x Invalid value for `--concurrency` flag. This should be a positive integer
exit=1
```

(`--dry=json` does **not** report concurrency — there is no such field — so the
invalid-value probe is the evidence, not the dry run.)

## Guard

The bound is pinned in `required-checks.test.js` beside the assertions that force the
step's spelling, so it cannot be dropped silently. Mutations, each reverted after:

```
remove the env: block entirely   → KILLED by "bounds how many packages lint at once"
TURBO_CONCURRENCY: 0             → KILLED (turbo refuses 0 at startup)
TURBO_CONCURRENCY: 99            → KILLED (a number that is not a bound)
```

## Verification

```
$ pnpm format:check    All matched files use Prettier code style!
$ pnpm lint            Tasks: 21 successful, 21 total  · Portability check passed
$ pnpm typecheck       Tasks: 21 successful, 21 total
$ pnpm turbo run test --concurrency=2 --continue
                       Tasks: 41 successful, 41 total
$ actionlint .github/workflows/ci.yml      (no expression or syntax errors)
```

**Timeout headroom.** Bounding parallelism makes the job slower, so successful attempt-1
durations were measured against the job's 25-minute (1500s) limit: `197s 203s 211s 213s
242s 451s` — median ~210s, worst 451s. Ample room for a bound that roughly halves
parallelism. The guard accepts 1–4, so raising it to 4 is a one-character change if it
proves tight.

## Do not declare victory on one green run

Baseline over the last 17 completed CI runs, **attempt 1 only**, `cancelled` dropped
(not a verdict):

```
$ gh run list --repo akasecurity/ai-tc --workflow ci.yml --limit 20 \
    --json databaseId,conclusion,status
$ gh api repos/akasecurity/ai-tc/actions/runs/<id>/attempts/1/jobs   # per run

job                                       runs  fail  fail%
Windows · Unit tests (shipped surface)      16     9    56%
Windows · Lint                              16     3    19%
macOS · Full suite                          16     3    19%
No-network · Full suite, egress blocked     16     3    19%
Lint · Typecheck · Test · Build             16     3    19%
```

Of the 3 `Windows · Lint` failures, **one was a broken commit** (`31829544036` — macOS
and Linux failed too). Only **2 of 16 were Windows-specific**, i.e. a true base rate near
**12.5%**.

That is low enough that a green run means little: at 12.5%, the chance of n consecutive
greens with no fix at all is `0.875^n` — 51% at n=5, and n≈23 before it drops under 5%.
Re-take the same attempt-1 measurement after this lands rather than reading one green
tick as proof.

## What this does not fix

`Windows · Unit tests (shipped surface)` fails at **56%** on attempt 1 — the worst job in
the workspace by a wide margin — with 20s test timeouts across `persistence` and
`web-ui`. That is the same ambient Windows slowness, but that step **already** carries
`--concurrency=2`, so this change cannot touch it. Different investigation, tracked
separately.
