### PR TITLE
fix(persistence): keep the vault keyring off argv and bound every keychain call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1692,8 +1692,9 @@ stays green if a branch echoes a _truncated_ value, which is still a live creden
 prefix. `expectNoEchoOf` is the **required form for every raw-value absence assertion that is
 newly written or newly touched** in a package carrying the helper — `cli/test/helpers/no-echo.ts`,
 `plugins/claude-code/test/helpers/no-echo.ts`, `plugins/codex/test/helpers/no-echo.ts`,
-`plugins/antigravity/test/helpers/no-echo.ts`, `web-ui/test/helpers/no-echo.ts` and
-`packages/setup-wizard/test/helpers/no-echo.ts`. A plain
+`plugins/antigravity/test/helpers/no-echo.ts`, `web-ui/test/helpers/no-echo.ts`,
+`packages/setup-wizard/test/helpers/no-echo.ts` and
+`packages/persistence/test/helpers/no-echo.ts`. A plain
 `not.toContain(rawValue)` in a new or edited assertion is a defect, not a style choice, and
 editing a file means its in-class assertions come along rather than being left beside converted
 ones.
@@ -1712,7 +1713,7 @@ purpose; and the deliberate **control** assertions inside each `no-echo.test.ts`
 to show the whole-value form would have passed.
 
 **Share it inside a package, copy it across a wall — and a copy takes the suite with it.**
-All six packages import a `test/helpers/no-echo.ts` with its own tests in `no-echo.test.ts`:
+All seven packages import a `test/helpers/no-echo.ts` with its own tests in `no-echo.test.ts`:
 each case drives the helper with an output that leaks a run, and asserts both that the helper
 refuses it **and** that the whole-value form it replaced would have passed. That second half is
 what shows the assertion is _stronger_ rather than merely also-red, and it is why raising the
@@ -1726,9 +1727,15 @@ without which an `undefined` message satisfies the loop vacuously.
 **A masked-preview control calls the product's mask, never a hand-rolled one.** A locally built
 literal asserts that a string the test constructed lacks a run of another string the test
 constructed — true by construction, and it stays true however `maskMatch` changes. Each
-`no-echo.test.ts` calls `maskMatch` itself (`@akasecurity/plugin-sdk` re-exports it, so the
-plugin crosses no package wall), which is what makes widening its generic branch go red where
-the reason is written down.
+`no-echo.test.ts` that has a masked-preview case calls `maskMatch` itself
+(`@akasecurity/plugin-sdk` re-exports it, so the plugin crosses no package wall), which is what
+makes widening its generic branch go red where the reason is written down.
+
+`packages/persistence` is the one copy with **no** masked-preview case, and it is not an
+omission to fix: that package has no masking surface, and `@akasecurity/detections` — which owns
+`maskMatch` — depends ON it, so importing it even as a dev dependency would make a cycle out of
+a test fixture. Its fixture is a generated base64 vault key instead, which is what that package
+actually has to keep out of an error.
 
 **Capture the error outside the `catch`.** This shape passes while the function under test
 stops throwing entirely:

--- a/packages/persistence/src/vault/key-provider.ts
+++ b/packages/persistence/src/vault/key-provider.ts
@@ -408,19 +408,129 @@ function tightenFileMode(file: string): void {
 
 // ─── Keychain custody ────────────────────────────────────────────────────────
 
-/** Invokes the platform `security` binary with the given argv, returning stdout. */
-export type SecurityExec = (args: string[]) => string;
+/**
+ * Invokes the platform `security` binary with the given argv, returning stdout.
+ * `stdin` feeds the child's standard input, which is how the write paths keep
+ * key material off the command line — see {@link writeCommand}.
+ */
+export type SecurityExec = (args: string[], stdin?: string) => string;
 
-const runSecurity: SecurityExec = (args) =>
+/**
+ * Ceiling on a single `security` call.
+ *
+ * A LOCKED keychain does not fail: `security` blocks on an unlock dialog —
+ * measured, with no exit status and no stderr — and nothing on this thread can
+ * interrupt it. The callers are a hook with its own harness deadline, a CLI
+ * command and a dashboard action, so an unbounded wait is a wedged session
+ * rather than a slow one, and on a hook it is a scan that never happens. The
+ * bound is what turns "blocks for ever" into a loud, catchable failure.
+ *
+ * Well clear of an honest call, which is milliseconds against a local binary,
+ * and inside the plugin harness's own 10s budget so the hook still gets to
+ * fail rather than being killed mid-read.
+ *
+ * It bounds WRITES as well, which is not free: a write killed part-way can
+ * leave a half-written item. That is the better end of the trade — a locked
+ * keychain blocks writes exactly as it blocks reads, so an unbounded write
+ * hangs just as hard — and the damage is contained, because a keyring that
+ * will not parse is refused rather than minted over. Lowering this bound
+ * raises the odds of that partial write; it is not a free dial to turn.
+ */
+const SECURITY_TIMEOUT_MS = 5_000;
+
+const runSecurity: SecurityExec = (args, stdin) =>
   execFileSync('/usr/bin/security', args, {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
+    input: stdin,
+    timeout: SECURITY_TIMEOUT_MS,
+    // stderr is discarded rather than captured, and that is deliberate: a
+    // captured stream rides out on an execFileSync error's `.stderr`, and the
+    // write paths here carry the keyring. Exit status is the only thing any
+    // branch below reads.
+    stdio: [stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'ignore'],
   });
 
 // `security find-generic-password` exit status for "no matching item exists"
 // (errSecItemNotFound). Every other non-zero exit — a locked keychain, a
 // denied ACL — is a failure, not absence.
 const SECURITY_ITEM_NOT_FOUND = 44;
+
+/**
+ * Why a stored item would not parse, without quoting it.
+ *
+ * `parseKeyring`'s own refusals name a field and carry no value, so they pass
+ * through. A `JSON.parse` SyntaxError is replaced rather than forwarded, for
+ * two reasons — and NOT because it currently leaks. Measured on this Node, its
+ * structural messages carry a position and no snippet ("Unterminated string in
+ * JSON at position 67"), and the one form that does quote input quotes the
+ * START, which for a keyring is always `{"current":…`. So:
+ *
+ * - a bare SyntaxError names neither the vault nor the backend, and reads as a
+ *   fault in whatever called it rather than as a damaged keychain item;
+ * - the quoting form is V8's choice, not this code's, and the input it would be
+ *   handed is key material. Depending on where a future runtime decides to cut
+ *   that window is not a bet worth taking for a message nobody needs.
+ */
+function corruptReason(err: unknown): string {
+  if (err instanceof SyntaxError) return 'malformed JSON';
+  return err instanceof Error ? err.message : 'unknown';
+}
+
+/**
+ * Raw-free description of a `security` failure: exit metadata only.
+ *
+ * An `execFileSync` error's `.message` echoes the argv it was given, and its
+ * `.stdout`/`.stderr` carry whatever the child produced. On the read path
+ * stdout IS the keyring, so none of it may cross into a thrown message — nor
+ * ride out as `cause`, which would re-attach the whole error object and
+ * re-expose exactly what this strips.
+ */
+function securityFailureMeta(err: unknown): string {
+  const e = err as { status?: number | null; signal?: string | null; code?: string };
+  const parts: string[] = [];
+  if (typeof e.status === 'number') parts.push(`exit ${String(e.status)}`);
+  if (typeof e.signal === 'string' && e.signal) parts.push(`signal ${e.signal}`);
+  if (typeof e.code === 'string' && e.code) parts.push(e.code);
+  return parts.length > 0 ? parts.join(', ') : 'unknown error';
+}
+
+/**
+ * Builds an `add-generic-password` line for `security -i`, which reads
+ * COMMANDS on stdin.
+ *
+ * `add-generic-password` has no stdin option of its own: `-w`, `-p` and `-X`
+ * all take their value on the command line, and a bare `-w` prompts on a
+ * terminal. Interactive mode is therefore what keeps the keyring out of argv,
+ * where a failed exec's `.message` would echo it.
+ *
+ * The keyring is hex-encoded and passed with `-X`, so the only payload token is
+ * `[0-9a-f]` — no quoting question can arise from it however the interactive
+ * tokenizer behaves. The keychain path is the one variable token and is
+ * single-quoted; a path carrying a quote or a line break is refused rather than
+ * escaped, since a mangled line would write the keyring somewhere unintended.
+ */
+function writeCommand(keyring: Keyring, update: boolean, keychain?: string): string {
+  const hex = Buffer.from(serializeKeyring(keyring), 'utf8').toString('hex');
+  const parts = [
+    'add-generic-password',
+    ...(update ? ['-U'] : []),
+    '-s',
+    KEYCHAIN_SERVICE,
+    '-a',
+    KEYCHAIN_ACCOUNT,
+    '-X',
+    hex,
+  ];
+  if (keychain !== undefined) {
+    if (/['\n\r]/.test(keychain)) {
+      throw new Error(
+        'vault: keychain path contains a quote or line break, which security -i cannot carry',
+      );
+    }
+    parts.push(`'${keychain}'`);
+  }
+  return `${parts.join(' ')}\n`;
+}
 
 /**
  * Opt-in OS-keychain custody: the same versioned keyring JSON held as one
@@ -438,8 +548,24 @@ const SECURITY_ITEM_NOT_FOUND = 44;
 export class KeychainKeyProvider implements KeyProvider {
   readonly #keysDir: string;
   readonly #exec: SecurityExec;
+  readonly #keychain: string | undefined;
+  /**
+   * The trailing keychain argument, or nothing. Every subcommand used here
+   * takes it last (`add-generic-password [keychain]`,
+   * `find-generic-password [keychain...]`), and omitting it means the default
+   * search list. Fixed at construction, so it is built once rather than per
+   * call on the capture path.
+   */
+  readonly #target: readonly string[];
 
-  constructor(keysDir: string, exec: SecurityExec = runSecurity) {
+  /**
+   * `keychain` names the keychain to operate on, as `security`'s trailing
+   * argument. Production passes nothing and gets the user's default keychain,
+   * which is the whole point of the backend. A test driving the REAL binary
+   * passes a throwaway one, because the alternative is writing vault key
+   * material into the developer's own login keychain and leaving it there.
+   */
+  constructor(keysDir: string, exec: SecurityExec = runSecurity, keychain?: string) {
     // The platform guard applies only to the real binary; an injected exec
     // carries its own platform expectations.
     if (exec === runSecurity && process.platform !== 'darwin') {
@@ -449,6 +575,8 @@ export class KeychainKeyProvider implements KeyProvider {
     }
     this.#keysDir = keysDir;
     this.#exec = exec;
+    this.#keychain = keychain;
+    this.#target = keychain === undefined ? [] : [keychain];
   }
 
   /** Where a fallback file provider for the same vault would keep its keyring. */
@@ -495,20 +623,31 @@ export class KeychainKeyProvider implements KeyProvider {
         '-a',
         KEYCHAIN_ACCOUNT,
         '-w',
+        ...this.#target,
       ]);
     } catch (err) {
       // Only "no such item" may read as absence. A locked keychain or a
       // denied ACL also exits non-zero, and reading those as absence would
       // route into the mint path and orphan every existing ciphertext.
       if ((err as { status?: unknown }).status === SECURITY_ITEM_NOT_FOUND) return null;
+      // Exit metadata only, and no `cause`: on this path the child's stdout is
+      // the keyring itself, so the caught error is not something to carry along.
+      // eslint-disable-next-line preserve-caught-error -- caught error's stdout is the keyring; see securityFailureMeta
       throw new Error(
-        `vault: keychain read failed (${err instanceof Error ? err.message : String(err)}); refusing to treat the failure as an absent keyring`,
-        { cause: err },
+        `vault: keychain read failed (${securityFailureMeta(err)}); refusing to treat the failure as an absent keyring`,
       );
     }
     const body = raw.trim();
     if (body.length === 0) return null;
-    return parseKeyring(body);
+    try {
+      return parseKeyring(body);
+    } catch (err) {
+      // Refuses rather than returning null: a keyring that will not parse is
+      // not an absent one, and minting over it orphans every ciphertext sealed
+      // under whatever it held.
+      // eslint-disable-next-line preserve-caught-error -- a JSON.parse error quotes the keyring; see corruptReason
+      throw new Error(`vault: keychain item is not a usable keyring (${corruptReason(err)})`);
+    }
   }
 
   /**
@@ -517,21 +656,17 @@ export class KeychainKeyProvider implements KeyProvider {
    * keyring — the loser re-reads and adopts it instead.
    */
   #create(keyring: Keyring): Keyring {
-    const args = [
-      'add-generic-password',
-      '-s',
-      KEYCHAIN_SERVICE,
-      '-a',
-      KEYCHAIN_ACCOUNT,
-      '-w',
-      serializeKeyring(keyring),
-    ];
+    // Built OUTSIDE the try: its refusal is a caller/config fault, and the
+    // catch below reads any throw as a lost mint race and re-reports it as a
+    // write failure, which would bury the reason.
+    const line = writeCommand(keyring, false, this.#keychain);
     try {
-      this.#exec(args);
+      this.#exec(['-i'], line);
     } catch (err) {
       const winner = this.#read();
       if (winner) return winner;
-      throw asError(err);
+      // eslint-disable-next-line preserve-caught-error -- caught error may echo the write payload; see securityFailureMeta
+      throw new Error(`vault: keychain write failed (${securityFailureMeta(err)})`);
     }
     return keyring;
   }
@@ -539,16 +674,15 @@ export class KeychainKeyProvider implements KeyProvider {
   // `-U` updates the item in place, deliberately replacing the stored map with
   // one that contains it — used only for rotation, under the rotation lock.
   #replace(keyring: Keyring): Keyring {
-    this.#exec([
-      'add-generic-password',
-      '-U',
-      '-s',
-      KEYCHAIN_SERVICE,
-      '-a',
-      KEYCHAIN_ACCOUNT,
-      '-w',
-      serializeKeyring(keyring),
-    ]);
+    const line = writeCommand(keyring, true, this.#keychain);
+    try {
+      this.#exec(['-i'], line);
+    } catch (err) {
+      // Exit metadata only: a rotation failure must not carry the payload it
+      // was writing out to whatever logs it.
+      // eslint-disable-next-line preserve-caught-error -- caught error may echo the write payload; see securityFailureMeta
+      throw new Error(`vault: keychain write failed (${securityFailureMeta(err)})`);
+    }
     return keyring;
   }
 }

--- a/packages/persistence/src/vault/key-provider.ts
+++ b/packages/persistence/src/vault/key-provider.ts
@@ -506,8 +506,10 @@ function securityFailureMeta(err: unknown): string {
  * The keyring is hex-encoded and passed with `-X`, so the only payload token is
  * `[0-9a-f]` — no quoting question can arise from it however the interactive
  * tokenizer behaves. The keychain path is the one variable token and is
- * single-quoted; a path carrying a quote or a line break is refused rather than
- * escaped, since a mangled line would write the keyring somewhere unintended.
+ * single-quoted; a path carrying a character the tokenizer would act on is
+ * refused rather than escaped, since a mangled line writes the keyring to a
+ * keychain other than the one named. The refused set is listed at the check
+ * itself, because which characters those are is measured, not obvious.
  */
 function writeCommand(keyring: Keyring, update: boolean, keychain?: string): string {
   const hex = Buffer.from(serializeKeyring(keyring), 'utf8').toString('hex');
@@ -522,9 +524,16 @@ function writeCommand(keyring: Keyring, update: boolean, keychain?: string): str
     hex,
   ];
   if (keychain !== undefined) {
-    if (/['\n\r]/.test(keychain)) {
+    // A BACKSLASH belongs in this set and reads as though it should not: the
+    // interactive tokenizer treats it as an escape even inside single quotes,
+    // so it is consumed rather than carried. Measured — a keychain at
+    // `back\slash-….keychain` is reported by `security` as
+    // `backslash-….keychain`, and the write misses the keychain it named.
+    // That is the failure this refusal exists to prevent, not a variant of it.
+    // NUL is here for the ordinary reason: it terminates the token.
+    if (/['\\\n\r\0]/.test(keychain)) {
       throw new Error(
-        'vault: keychain path contains a quote or line break, which security -i cannot carry',
+        'vault: keychain path contains a quote, backslash, line break or NUL, which security -i cannot carry intact',
       );
     }
     parts.push(`'${keychain}'`);
@@ -540,10 +549,20 @@ function writeCommand(keyring: Keyring, update: boolean, keychain?: string): str
  * process — an OS service on this machine, not a network hop. Elsewhere the
  * constructor throws so the caller can fall back to file custody.
  *
- * On writes the keyring JSON rides in the child's argv (`-w <json>`), which is
- * observable by same-UID processes for the duration of the exec. That is an
- * accepted exposure under the local threat model: a same-UID process can
- * already read the keychain item itself.
+ * **No secret is on the command line, on any path.** Writes cross on STDIN:
+ * `#create` and `#replace` both run `security -i`, which reads commands on
+ * stdin, and {@link writeCommand} hex-encodes the keyring into `-X` so nothing
+ * about the payload can be re-tokenized. Putting it back in argv would put it
+ * in an `execFileSync` error's `.message`, which echoes the argv it was given
+ * — an error outlives the process and travels into logs and bug reports, which
+ * a same-UID observer of a running exec does not.
+ *
+ * The read path's `-w` is not a counter-example, and it is worth naming because
+ * the flag appears on both sides: on `find-generic-password` it is an OUTPUT
+ * flag asking for the value on stdout, not a value being passed in.
+ *
+ * `test/vault/key-provider.test.ts`'s `keeps the keyring off argv on both write
+ * paths` is what holds this.
  */
 export class KeychainKeyProvider implements KeyProvider {
   readonly #keysDir: string;

--- a/packages/persistence/test/harness-adoption.test.ts
+++ b/packages/persistence/test/harness-adoption.test.ts
@@ -184,6 +184,8 @@ const OWN_TEMP_TREE: Readonly<Record<string, string>> = {
   'test/settings.test.ts': 'settings.json only; the layout the harness creates is not wanted here',
   'test/vault/key-provider.test.ts':
     'key files under a bare directory, ahead of any store that would hold them',
+  'test/vault/keychain-real-binary.test.ts':
+    'a bare keys directory for the rotation lock to take, beside a throwaway keychain holding the keyring — no store either side',
 };
 
 /**

--- a/packages/persistence/test/helpers/errors.ts
+++ b/packages/persistence/test/helpers/errors.ts
@@ -32,3 +32,23 @@ export function errorFrom(fn: () => unknown): Error | undefined {
     return err as Error;
   }
 }
+
+/**
+ * The async twin: the error a promise REJECTED with, captured outside any
+ * catch of the test's own.
+ *
+ * `await expect(p).rejects.toThrow(/…/)` covers the common case, but not one
+ * that has to read several things off the error — a message, a `.stack`, a
+ * status code — or assert what the error does NOT say. Written as a
+ * try/catch around an `await`, that shape has the same defect `errorFrom`
+ * exists to remove: the guard error thrown when the promise unexpectedly
+ * RESOLVES lands in the test's own catch and satisfies the assertions below
+ * it. Here a never-rejected promise arrives as `undefined`, so
+ * `toBeDefined()` catches it.
+ */
+export async function rejectionFrom(promise: Promise<unknown>): Promise<Error | undefined> {
+  return promise.then(
+    () => undefined,
+    (err: unknown) => err as Error,
+  );
+}

--- a/packages/persistence/test/helpers/keychain.test.ts
+++ b/packages/persistence/test/helpers/keychain.test.ts
@@ -1,0 +1,152 @@
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { errorFrom } from './errors.ts';
+import { createDisposableKeychain, type DisposableKeychain } from './keychain.ts';
+
+const SECURITY_BIN = '/usr/bin/security';
+const SERVICE = `aka-harness-${randomBytes(6).toString('hex')}`;
+const ACCOUNT = 'keyring';
+
+/** A distinct high-entropy sentinel per call, so no assertion can pass on a stale item. */
+const sentinel = (): string => randomBytes(24).toString('base64url');
+
+const live: DisposableKeychain[] = [];
+
+/** Creates a keychain and registers its teardown, or hands back the reason it could not. */
+function open(): DisposableKeychain {
+  const kc = createDisposableKeychain();
+  if (kc.usable) live.push(kc);
+  return kc;
+}
+
+// Drains the list, so a test that tore its own keychain down early is not
+// cleaned up twice — and a test that opened two gets both removed regardless.
+afterEach(() => {
+  for (const kc of live.splice(0)) kc.cleanup();
+});
+
+describe('createDisposableKeychain', () => {
+  // Driven with an explicit platform so this branch runs on macOS too. A test
+  // that only ever runs on the platform it is describing proves nothing about
+  // the other one, and this is the branch every non-darwin runner takes.
+  it('reports a reason rather than throwing where there is no keychain', () => {
+    const kc = createDisposableKeychain('linux');
+
+    expect(kc.usable).toBe(false);
+    expect(kc.reason).toMatch(/macOS-only/);
+    expect(kc.reason).toContain('linux');
+  });
+
+  // `exec` on an unusable keychain must throw rather than silently no-op: a
+  // no-op would let every absence assertion below pass without a keychain
+  // existing at all.
+  it('refuses to exec when it is unusable', () => {
+    const kc = createDisposableKeychain('win32');
+
+    const err = errorFrom(() => kc.exec(['find-generic-password']));
+
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/unusable/);
+  });
+
+  it('creates a usable keychain on macOS', (ctx) => {
+    const kc = open();
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+
+    expect(kc.path).not.toBe('');
+    expect(kc.path).toMatch(/\.keychain$/);
+  });
+
+  // The empirical question the whole approach rests on: an item added the way
+  // the PRODUCT adds one — no `-A`, so the item's ACL carries only the default
+  // trust in its creating application — must read back without a dialog.
+  // `security` is both creator and reader, so the default trust should cover
+  // it. If it does not, this times out and reports as a skip with a reason
+  // rather than hanging, and keychain custody cannot be tested against the real
+  // binary without loosening the item's ACL.
+  it('round-trips an item added the way the product adds one', (ctx) => {
+    const kc = open();
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const value = sentinel();
+
+    kc.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', value]);
+    const read = kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']);
+
+    expect(read.trim()).toBe(value);
+  });
+
+  // The property that makes this harness safe to run on a developer's machine.
+  // The positive control is not decoration: without it, an `exec` that wrote
+  // nothing at all would satisfy the absence assertion below.
+  it('keeps the item out of the default login keychain', (ctx) => {
+    const kc = open();
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const value = sentinel();
+
+    kc.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', value]);
+
+    // positive control — it really is in the throwaway keychain
+    expect(kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']).trim()).toBe(
+      value,
+    );
+
+    // …and nowhere in the default search list. No trailing keychain here, so
+    // `security` searches the user's own. errSecItemNotFound is exit 44.
+    const err = errorFrom(() =>
+      execFileSync(SECURITY_BIN, ['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 3_000,
+      }),
+    );
+
+    expect(err).toBeDefined();
+    expect((err as { status?: number } | undefined)?.status).toBe(44);
+  });
+
+  // What makes the assertion above non-vacuous. It reads exit 44 as "absent
+  // from the keychain searched", which is worth nothing unless the SAME call
+  // returns 0 when the item is present — a lookup that always failed would
+  // satisfy it just as well. Proven between two disposable keychains rather
+  // than by planting an item in the login keychain, which is the one place
+  // this harness must never write.
+  it('reads exit 44 only when the item is genuinely absent', (ctx) => {
+    const withItem = open();
+    const without = open();
+    if (!withItem.usable || !without.usable) {
+      ctx.skip(withItem.reason ?? without.reason ?? 'no disposable keychain');
+    }
+    const value = sentinel();
+
+    withItem.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', value]);
+
+    // Present → exit 0 and the value back, so the lookup can succeed.
+    expect(
+      withItem.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']).trim(),
+    ).toBe(value);
+
+    // Absent → the identical call shape against a keychain that never received
+    // it. Only the target differs, so 44 can only be reporting absence.
+    const err = errorFrom(() =>
+      without.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']),
+    );
+
+    expect(err).toBeDefined();
+    expect((err as { status?: number } | undefined)?.status).toBe(44);
+  });
+
+  it('deletes the keychain on cleanup', (ctx) => {
+    const kc = open();
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    kc.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', sentinel()]);
+
+    kc.cleanup();
+
+    // The keychain is gone, so the same lookup that just succeeded now fails.
+    const err = errorFrom(() => kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT]));
+    expect(err).toBeDefined();
+  });
+});

--- a/packages/persistence/test/helpers/keychain.ts
+++ b/packages/persistence/test/helpers/keychain.ts
@@ -1,0 +1,168 @@
+import { execFileSync } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * A throwaway macOS keychain for tests that drive the REAL `/usr/bin/security`
+ * binary rather than an injected fake.
+ *
+ * Two properties are load-bearing and easy to lose:
+ *
+ * - **Nothing reaches the login keychain.** `exec` appends this keychain's path
+ *   to every argv, and `security` treats a trailing path as the keychain to
+ *   operate on. A caller cannot opt out, because the alternative — targeting the
+ *   default keychain — writes vault key material into the developer's own
+ *   keychain and leaves it there.
+ * - **A prompt becomes a skip, never a hang.** Every call carries a deadline far
+ *   below the package's 20s `testTimeout`. A keychain dialog blocks `security`
+ *   until someone clicks it, and CI has nobody to click: without a deadline the
+ *   suite would wedge until vitest killed it and report a timeout that names
+ *   nothing. On a deadline it reports `usable: false` with a reason instead.
+ */
+export interface DisposableKeychain {
+  /** Absolute path of the throwaway keychain, as passed to `security`. */
+  readonly path: string;
+  /**
+   * False when this environment cannot host one — a non-darwin platform, an
+   * absent `security`, or a create/unlock that failed or prompted. Callers gate
+   * on it: `if (!kc.usable) ctx.skip(kc.reason ?? '…')`. An early `return`
+   * reports as a pass, which is the failure mode this shape exists to remove.
+   */
+  readonly usable: boolean;
+  /** Why it is unusable. Always set when `usable` is false. */
+  readonly reason?: string;
+  /** Runs `security` against THIS keychain. Returns stdout. */
+  exec(args: readonly string[]): string;
+  /** Deletes the keychain and its temp dir. Idempotent; safe in a `finally`. */
+  cleanup(): void;
+}
+
+const SECURITY_BIN = '/usr/bin/security';
+
+/**
+ * Per-call ceiling. A local `security` invocation answers in well under 100ms,
+ * so this is ~30x headroom for an honest call while staying far enough under
+ * `testTimeout` (20s) that vitest never wins the race — if vitest wins, the
+ * refusal this deadline exists to produce is replaced by a bare timeout.
+ */
+const CALL_TIMEOUT_MS = 3_000;
+
+/** A `security` call that exceeded {@link CALL_TIMEOUT_MS}, i.e. probably prompted. */
+function timedOut(err: unknown): boolean {
+  const e = err as { code?: string; signal?: string | null };
+  return e.code === 'ETIMEDOUT' || e.signal === 'SIGTERM';
+}
+
+/** Exit status of a failed `security` call, or null when it did not run at all. */
+function exitStatus(err: unknown): number | null {
+  const status = (err as { status?: unknown }).status;
+  return typeof status === 'number' ? status : null;
+}
+
+/**
+ * Creates a fresh keychain in its own temp dir, unlocked with a password this
+ * process generated, with auto-lock disabled.
+ *
+ * The password rides in argv, which `security help` calls insecure — correctly,
+ * for a real keychain. This one holds nothing but test fixtures and is deleted
+ * in `cleanup()`, so what argv exposes is a random string guarding nothing.
+ */
+export function createDisposableKeychain(
+  platform: NodeJS.Platform = process.platform,
+): DisposableKeychain {
+  const unusable = (reason: string): DisposableKeychain => ({
+    path: '',
+    usable: false,
+    reason,
+    exec: () => {
+      throw new Error(`disposable keychain is unusable: ${reason}`);
+    },
+    // Nothing was created, so there is nothing to tear down. Still safe to call
+    // from a `finally`, which is why it is present rather than optional.
+    cleanup: () => undefined,
+  });
+
+  if (platform !== 'darwin') {
+    return unusable(`keychain custody is macOS-only (platform: ${platform})`);
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'aka-kc-'));
+  const path = join(dir, `aka-test-${randomBytes(6).toString('hex')}.keychain`);
+  const password = randomBytes(18).toString('base64url');
+
+  // Best-effort teardown: `delete-keychain` unregisters it, and removing the
+  // dir catches the `-db` suffixed file newer macOS actually writes. Both are
+  // swallowed — a cleanup that throws would replace whatever the test is
+  // reporting, and a leftover temp dir is not worth losing a real failure over.
+  const cleanup = (): void => {
+    try {
+      execFileSync(SECURITY_BIN, ['delete-keychain', path], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: CALL_TIMEOUT_MS,
+      });
+    } catch {
+      // already gone, never created, or refused — the rmSync below still runs
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // a Windows-style sharing violation cannot occur here (darwin-only), and
+      // a stranded temp dir is not a test failure
+    }
+  };
+
+  // Setup runs on the same deadline as everything else, and bails on the FIRST
+  // timeout: a dialog on `create-keychain` means every later call prompts too,
+  // so continuing would spend the whole hook budget re-learning that.
+  const setup: readonly (readonly string[])[] = [
+    ['create-keychain', '-p', password, path],
+    // No -t and no -l/-u: no timeout lock, no lock on sleep. A keychain that
+    // re-locks mid-suite starts prompting again halfway through.
+    ['set-keychain-settings', path],
+    ['unlock-keychain', '-p', password, path],
+  ];
+
+  for (const args of setup) {
+    try {
+      execFileSync(SECURITY_BIN, [...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: CALL_TIMEOUT_MS,
+      });
+    } catch (err) {
+      cleanup();
+      const verb = args[0] ?? 'security';
+      if (timedOut(err)) {
+        return unusable(
+          `security ${verb} exceeded ${String(CALL_TIMEOUT_MS)}ms — a keychain dialog is probably open, which CI cannot answer`,
+        );
+      }
+      if ((err as { code?: string }).code === 'ENOENT') {
+        return unusable(`${SECURITY_BIN} is not present on this machine`);
+      }
+      const status = exitStatus(err);
+      return unusable(
+        `security ${verb} failed${status === null ? '' : ` (exit ${String(status)})`}`,
+      );
+    }
+  }
+
+  return {
+    path,
+    usable: true,
+    exec(args: readonly string[]): string {
+      // The keychain path goes LAST, which is where every subcommand this
+      // harness is used with takes it (`add-generic-password [keychain]`,
+      // `find-generic-password [keychain...]`).
+      return execFileSync(SECURITY_BIN, [...args, path], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: CALL_TIMEOUT_MS,
+      });
+    },
+    cleanup,
+  };
+}

--- a/packages/persistence/test/helpers/no-echo.test.ts
+++ b/packages/persistence/test/helpers/no-echo.test.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from 'node:crypto';
+
+import { describe, expect, it } from 'vitest';
+
+import { ECHO_RUN, expectNoEchoOf } from './no-echo.ts';
+
+// The helper an absence assertion leans on gets its own suite, or it can be
+// weakened back with nothing going red: raise ECHO_RUN past the value's length,
+// or empty the loop, and every caller keeps passing while proving nothing. Each
+// case here fails if that happens.
+//
+// The fixture is shaped like the thing this package actually has to keep out of
+// an error — a base64 vault key — and is generated rather than written down, so
+// no secret-shaped literal lives in this public repo.
+const VALUE = randomBytes(32).toString('base64');
+
+// Did the helper refuse this pairing? A vitest assertion failure is a throw, so
+// "the assertion would have gone red" is observable without failing this test.
+function refuses(haystack: string | undefined, value: string): boolean {
+  try {
+    expectNoEchoOf(haystack, value);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+describe('expectNoEchoOf', () => {
+  it('is eight characters — widening it is a deliberate act, not a drift', () => {
+    expect(ECHO_RUN).toBe(8);
+    expect(VALUE.length).toBeGreaterThan(ECHO_RUN);
+  });
+
+  // The three cases below are the whole point: each output leaks a live key's
+  // run, and each one passes the weaker whole-value form. The control assertion
+  // in each is what proves the new form is STRONGER rather than merely also-red
+  // — without it a green helper and a green predecessor look identical.
+  it('refuses a prefix echo that a whole-value assertion passes', () => {
+    const echoed = `keychain write failed for ${VALUE.slice(0, ECHO_RUN)}...`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE); // control: the form this replaced stays green
+  });
+
+  it('refuses a tail echo that a whole-value assertion passes', () => {
+    const echoed = `...${VALUE.slice(-ECHO_RUN)} was rejected`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses an interior run that a whole-value assertion passes', () => {
+    const echoed = `near ${VALUE.slice(5, 5 + ECHO_RUN)}`;
+    expect(refuses(echoed, VALUE)).toBe(true);
+    expect(echoed).not.toContain(VALUE);
+  });
+
+  it('refuses a value shorter than the run, echoed whole', () => {
+    // The sliding loop cannot run at all here, so the short-value fallback is
+    // the only thing standing between this and a silent pass.
+    const short = 'ab12cd';
+    expect(short.length).toBeLessThan(ECHO_RUN);
+    expect(refuses(`unknown value ${short}`, short)).toBe(true);
+  });
+
+  it('refuses an undefined haystack — a never-thrown error proves nothing', () => {
+    expect(refuses(undefined, VALUE)).toBe(true);
+  });
+
+  it('accepts bytes that carry none of the value', () => {
+    // The positive direction: a genuinely raw-free message must pass, or every
+    // caller would be red and the helper would be useless rather than strict.
+    expect(refuses('vault: keychain write failed (exit 45)', VALUE)).toBe(false);
+  });
+
+  it('passes over empty bytes — the limit that makes a positive control mandatory', () => {
+    // Not a defect to fix here: `''` genuinely contains nothing. It is why a
+    // caller must never point this at a capture that can come back empty
+    // without also pinning that the capture is live.
+    expect(refuses('', VALUE)).toBe(false);
+  });
+});

--- a/packages/persistence/test/helpers/no-echo.ts
+++ b/packages/persistence/test/helpers/no-echo.ts
@@ -1,0 +1,53 @@
+import { expect } from 'vitest';
+
+/**
+ * The shortest run of a raw value whose appearance is still a disclosure.
+ *
+ * A plain `not.toContain(value)` catches a WHOLE-value echo only — it stays
+ * green if a branch ever interpolates a truncated one, and "help the user spot
+ * the problem" is exactly the well-meaning change that would do it. Eight
+ * characters of a base64 vault key is six raw key bytes, which is a disclosure
+ * on its own and a decisive correlator against a key seen elsewhere.
+ */
+export const ECHO_RUN = 8;
+
+/**
+ * Assert `haystack` carries no run of `value` at all, not merely not all of it.
+ *
+ * Point this at a value that must not appear AT ALL — the vault key material in
+ * a thrown error, or on any surface that must never carry it. Two limits decide
+ * where it belongs, and each is pinned by this file's own suite:
+ *
+ * 1. **It proves nothing over bytes that came back empty.** Every `not.toContain`
+ *    passes on `''`, and the `toBeDefined()` guard below does not catch that —
+ *    it catches an `undefined` message, which is the shape a never-thrown error
+ *    arrives in. Where a path produces nothing at all, assert THAT rather than
+ *    searching empty bytes; where it produces something, assert a positive
+ *    control on the same bytes first.
+ * 2. **It is for a raw value, not a deliberately revealed fragment.** At-rest
+ *    and key-shape assertions stay whole-value, because what is stored on
+ *    purpose is not what this guards.
+ *
+ * Shared by this package's suites because they sit in one package. Across a
+ * package wall it cannot be imported, so `cli/test/helpers/no-echo.ts`, the
+ * three `plugins/*\/test/helpers/no-echo.ts`, `web-ui/test/helpers/no-echo.ts`
+ * and `packages/setup-wizard/test/helpers/no-echo.ts` are peers of this file —
+ * each a copy that takes the `toBeDefined()` guard and a `no-echo.test.ts` with
+ * it, or the run length can be widened back with nothing going red.
+ *
+ * The peers additionally pin `maskMatch`'s preview against this window. There
+ * is no counterpart here on purpose: this package has no masking surface, and
+ * `@akasecurity/detections` — which owns `maskMatch` — depends on this package,
+ * so reaching for it would make a dependency cycle out of a test fixture.
+ */
+export function expectNoEchoOf(haystack: string | undefined, value: string): void {
+  // Catches a never-thrown error arriving as `undefined`, which would otherwise
+  // satisfy the loop vacuously. It does NOT catch an empty string — see limit 1.
+  expect(haystack).toBeDefined();
+  const text = haystack ?? '';
+  for (let i = 0; i + ECHO_RUN <= value.length; i += 1) {
+    expect(text).not.toContain(value.slice(i, i + ECHO_RUN));
+  }
+  // Values shorter than the run length still must not appear at all.
+  if (value.length < ECHO_RUN) expect(text).not.toContain(value);
+}

--- a/packages/persistence/test/vault/key-provider.test.ts
+++ b/packages/persistence/test/vault/key-provider.test.ts
@@ -619,7 +619,15 @@ describe('KeychainKeyProvider', () => {
     });
 
     it('quotes a benign keychain path into the interactive line', async () => {
-      const target = join(dir, 'throwaway.keychain');
+      // A literal rather than a path under `dir`, and that is forced rather
+      // than tidier: the exec is injected, so nothing ever opens this — but
+      // `join()` under a Windows temp dir is backslash-separated, and
+      // writeCommand refuses a backslash. Built from `dir`, this case cannot
+      // pass on win32 at all, because every absolute path there carries the
+      // character the refusal is looking for. The refusal is what the cases
+      // below cover; this one is about the QUOTING, so it takes a path shaped
+      // like the one the backend really operates on.
+      const target = '/tmp/throwaway.keychain';
       const calls: { args: string[]; stdin: string | undefined }[] = [];
       const provider = new KeychainKeyProvider(
         dir,

--- a/packages/persistence/test/vault/key-provider.test.ts
+++ b/packages/persistence/test/vault/key-provider.test.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type * as FsModule from 'node:fs';
 import {
   chmodSync,
@@ -23,6 +24,8 @@ import {
   VAULT_KEY_FILENAME,
   VaultKeyEpochMissingError,
 } from '../../src/vault/key-provider.ts';
+import { rejectionFrom } from '../helpers/errors.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 // Lets a test simulate the first-mint race: one read of the key file reports
 // ENOENT even though the file exists, putting the provider on its mint path
@@ -505,6 +508,156 @@ describe('KeychainKeyProvider', () => {
     mkdirSync(join(dir, `${VAULT_KEY_FILENAME}.lock`));
 
     await expect(provider.rotate()).rejects.toThrow(/already in progress/);
+  });
+
+  // ─── raw-free refusals, driven WITHOUT the real binary ────────────────────
+  //
+  // The constructor's platform guard only fires for the real `runSecurity`, so
+  // an injected exec reaches every branch below on any host. That matters: the
+  // cases in keychain-real-binary.test.ts skip off darwin, which left these —
+  // the raw-free throw sites, i.e. the property this whole change exists to
+  // establish — unexecuted on the legs that gate every PR.
+  describe('refusals, on every platform', () => {
+    // The payload a leak would carry, in the form the write path actually
+    // sends. Distinct per test so no assertion can pass on a stale value.
+    const hexPayload = (): string => randomBytes(32).toString('hex');
+
+    // A spawn failure whose OWN message embeds the payload, the way a real
+    // execFileSync error's argv echo would. Without that the absence
+    // assertions below hold because there was nothing there to leak.
+    const failsCarrying = (payload: string, status: number): never => {
+      throw Object.assign(new Error(`add-generic-password -X ${payload}`), { status });
+    };
+
+    it('refuses a failed FIRST MINT without echoing the payload', async () => {
+      const payload = hexPayload();
+      const provider = new KeychainKeyProvider(dir, (args) => {
+        // Both reads come back empty, so the lost-race adoption path cannot
+        // return and the mint's own failure message is what surfaces.
+        if (args[0] === 'find-generic-password') notFound();
+        return failsCarrying(payload, 45);
+      });
+
+      const err = await rejectionFrom(provider.loadOrCreate());
+
+      expect(err).toBeDefined();
+      expect(err?.message).toMatch(/keychain write failed/);
+      // Positive control: the metadata IS there, so the absence checks below
+      // are not passing on an empty or generic message.
+      expect(err?.message).toContain('exit 45');
+      expectNoEchoOf(err?.message, payload);
+      expectNoEchoOf(err?.stack, payload);
+      // Two leak shapes, and `payload` only sees the first. It catches the
+      // caught error's own message riding out (the argv echo). It cannot catch
+      // the OTHER shape — interpolating the write line this call built — whose
+      // hex is the freshly minted keyring, a value no assertion here holds.
+      // Any 64-character hex run in a message whose legitimate content is
+      // `exit 45` is one of the two.
+      expect(err?.message).not.toMatch(/[0-9a-f]{64}/);
+    });
+
+    it('refuses a failed ROTATION without echoing the payload', async () => {
+      const payload = hexPayload();
+      const material = Buffer.alloc(32, 3);
+      const provider = new KeychainKeyProvider(dir, (args) => {
+        if (args[0] === 'find-generic-password') return keyringJson(material);
+        return failsCarrying(payload, 45);
+      });
+
+      const err = await rejectionFrom(provider.rotate());
+
+      expect(err).toBeDefined();
+      expect(err?.message).toMatch(/keychain write failed/);
+      expect(err?.message).toContain('exit 45');
+      expectNoEchoOf(err?.message, payload);
+      expectNoEchoOf(err?.stack, payload);
+      // The retained epoch is in the payload a rotation writes, so it is the
+      // value that call genuinely handled.
+      expectNoEchoOf(err?.message, material.toString('base64'));
+      // …and the hex form that actually crosses to the child, which neither
+      // base64 assertion above can see. See the mint case for why both.
+      expect(err?.message).not.toMatch(/[0-9a-f]{64}/);
+    });
+
+    it('refuses a stored item that is not a keyring', async () => {
+      const provider = new KeychainKeyProvider(dir, () => '{"current":"not-a-number","keys":{}}');
+
+      const err = await rejectionFrom(provider.loadOrCreate());
+
+      expect(err).toBeDefined();
+      expect(err?.message).toMatch(/not a usable keyring/);
+    });
+
+    it('refuses a TRUNCATED keyring without quoting it back', async () => {
+      const secret = randomBytes(32).toString('base64');
+      const provider = new KeychainKeyProvider(dir, () => `{"current":1,"keys":{"1":"${secret}`);
+
+      const err = await rejectionFrom(provider.loadOrCreate());
+
+      expect(err).toBeDefined();
+      // The JSON.parse branch: replaced with a fixed label rather than
+      // forwarded, so nothing V8 chose to quote can ride out.
+      expect(err?.message).toMatch(/malformed JSON/);
+      expectNoEchoOf(err?.message, secret);
+      expectNoEchoOf(err?.stack, secret);
+    });
+
+    it('describes a non-Error spawn failure without inventing detail', async () => {
+      const provider = new KeychainKeyProvider(dir, () => {
+        // Not an Error at all, so every field securityFailureMeta reads is
+        // absent — the arm that must still produce a message rather than
+        // interpolating `undefined`. Throwing a non-Error is the case under
+        // test, which is why the rule is waived here rather than satisfied.
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- a non-Error throw is the input under test
+        throw 'a bare string';
+      });
+
+      const err = await rejectionFrom(provider.loadOrCreate());
+
+      expect(err).toBeDefined();
+      expect(err?.message).toMatch(/keychain read failed/);
+    });
+
+    it('quotes a benign keychain path into the interactive line', async () => {
+      const target = join(dir, 'throwaway.keychain');
+      const calls: { args: string[]; stdin: string | undefined }[] = [];
+      const provider = new KeychainKeyProvider(
+        dir,
+        (args, stdin) => {
+          calls.push({ args, stdin });
+          if (args[0] === 'find-generic-password') notFound();
+          return '';
+        },
+        target,
+      );
+
+      await provider.loadOrCreate();
+
+      const write = calls.find((c) => c.stdin?.startsWith('add-generic-password'));
+      expect(write).toBeDefined();
+      // Single-quoted and last, which is where every subcommand here takes it.
+      expect(write?.stdin?.trimEnd().endsWith(`'${target}'`)).toBe(true);
+      // …and the read was aimed at it too, as a bare trailing argument.
+      const read = calls.find((c) => c.args[0] === 'find-generic-password');
+      expect(read?.args.at(-1)).toBe(target);
+    });
+
+    // Measured, not guessed: `security -i` treats a backslash as an escape even
+    // inside single quotes, so a path carrying one is consumed rather than
+    // carried and the write lands on a keychain other than the one named.
+    it.each([
+      ['a quote', "/tmp/it's.keychain"],
+      ['a backslash', '/tmp/back\\slash.keychain'],
+      ['a line break', '/tmp/two\nlines.keychain'],
+      ['a NUL', '/tmp/nul\0byte.keychain'],
+    ])('refuses a keychain path carrying %s', async (_label, target) => {
+      const provider = new KeychainKeyProvider(dir, notFound, target);
+
+      const err = await rejectionFrom(provider.loadOrCreate());
+
+      expect(err).toBeDefined();
+      expect(err?.message).toMatch(/quote, backslash, line break or NUL/);
+    });
   });
 });
 

--- a/packages/persistence/test/vault/key-provider.test.ts
+++ b/packages/persistence/test/vault/key-provider.test.ts
@@ -398,20 +398,22 @@ describe('KeychainKeyProvider', () => {
   // A locked keychain or a denied ACL must fail the load, not read as absence:
   // minting over the real keyring would orphan every existing ciphertext.
   it('throws when the keychain read is denied rather than minting', async () => {
-    const calls: string[][] = [];
-    const provider = new KeychainKeyProvider(dir, (args) => {
-      calls.push(args);
+    const calls: { args: string[]; stdin: string | undefined }[] = [];
+    const provider = new KeychainKeyProvider(dir, (args, stdin) => {
+      calls.push({ args, stdin });
       return denied();
     });
 
     await expect(provider.loadOrCreate()).rejects.toThrow(/keychain read failed/);
-    expect(calls.some((args) => args[0] === 'add-generic-password')).toBe(false);
+    // A write now rides stdin as a `security -i` command, so looking for
+    // `add-generic-password` in ARGV would be true however this behaved.
+    expect(calls.some((c) => c.stdin !== undefined)).toBe(false);
   });
 
   it('mints on item-not-found (exit 44), without -U', async () => {
-    const calls: string[][] = [];
-    const provider = new KeychainKeyProvider(dir, (args) => {
-      calls.push(args);
+    const calls: { args: string[]; stdin: string | undefined }[] = [];
+    const provider = new KeychainKeyProvider(dir, (args, stdin) => {
+      calls.push({ args, stdin });
       if (args[0] === 'find-generic-password') notFound();
       return '';
     });
@@ -419,11 +421,13 @@ describe('KeychainKeyProvider', () => {
     const key = await provider.loadOrCreate();
 
     expect(key.version).toBe(1);
-    const add = calls.find((args) => args[0] === 'add-generic-password');
-    expect(add).toBeDefined();
+    const write = calls.find((c) => c.stdin?.startsWith('add-generic-password'));
+    expect(write).toBeDefined();
+    // The command itself rides stdin; argv carries only interactive mode.
+    expect(write?.args).toEqual(['-i']);
     // A plain add fails on an existing item, so a lost first-mint race cannot
     // overwrite the winner's keyring; -U belongs to rotation only.
-    expect(add).not.toContain('-U');
+    expect(write?.stdin).not.toContain('-U');
   });
 
   it('adopts the winning keyring when its first mint loses the race', async () => {
@@ -447,9 +451,9 @@ describe('KeychainKeyProvider', () => {
   });
 
   it('rotates by replacing the item in place (-U) under the rotation lock', async () => {
-    const calls: string[][] = [];
-    const provider = new KeychainKeyProvider(dir, (args) => {
-      calls.push(args);
+    const calls: { args: string[]; stdin: string | undefined }[] = [];
+    const provider = new KeychainKeyProvider(dir, (args, stdin) => {
+      calls.push({ args, stdin });
       if (args[0] === 'find-generic-password') return keyringJson(Buffer.alloc(32, 7));
       return '';
     });
@@ -457,9 +461,41 @@ describe('KeychainKeyProvider', () => {
     const rotated = await provider.rotate();
 
     expect(rotated.version).toBe(2);
-    const add = calls.find((args) => args[0] === 'add-generic-password');
-    expect(add).toContain('-U');
+    const write = calls.find((c) => c.stdin?.startsWith('add-generic-password'));
+    expect(write).toBeDefined();
+    expect(write?.stdin).toContain('-U');
     expect(existsSync(join(dir, `${VAULT_KEY_FILENAME}.lock`))).toBe(false);
+  });
+
+  // The defect this backend carried: the keyring rode argv (`-w <json>`), and
+  // an execFileSync error's `.message` echoes argv — so a failed write put the
+  // key in an error that outlives the process and travels into logs. It rides
+  // stdin now, and nothing about the payload may reach the command line.
+  it('keeps the keyring off argv on both write paths', async () => {
+    const calls: { args: string[]; stdin: string | undefined }[] = [];
+    let reads = 0;
+    const provider = new KeychainKeyProvider(dir, (args, stdin) => {
+      calls.push({ args, stdin });
+      if (args[0] === 'find-generic-password') {
+        reads += 1;
+        if (reads === 1) notFound();
+        return keyringJson(Buffer.alloc(32, 9));
+      }
+      return '';
+    });
+
+    await provider.loadOrCreate();
+    await provider.rotate();
+
+    // Positive control: both writes really happened, on stdin.
+    const writes = calls.filter((c) => c.stdin?.startsWith('add-generic-password'));
+    expect(writes).toHaveLength(2);
+
+    const argv = calls.map((c) => c.args.join(' ')).join('\n');
+    expect(argv).not.toContain('add-generic-password');
+    // The hex-encoded keyring is the payload's on-the-wire form; a 32-byte key
+    // alone is 64 hex characters, so any such run in argv is the leak itself.
+    expect(argv).not.toMatch(/[0-9a-f]{64}/);
   });
 
   it('refuses a rotation while another is in flight', async () => {

--- a/packages/persistence/test/vault/keychain-real-binary.test.ts
+++ b/packages/persistence/test/vault/keychain-real-binary.test.ts
@@ -305,6 +305,6 @@ describe('KeychainKeyProvider when security cannot be run', () => {
     const err = await rejectionFrom(provider.loadOrCreate());
 
     expect(err).toBeDefined();
-    expect(err?.message).toMatch(/quote or line break/);
+    expect(err?.message).toMatch(/quote, backslash, line break or NUL/);
   });
 });

--- a/packages/persistence/test/vault/keychain-real-binary.test.ts
+++ b/packages/persistence/test/vault/keychain-real-binary.test.ts
@@ -1,0 +1,310 @@
+import { randomBytes } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { KeychainKeyProvider } from '../../src/vault/key-provider.ts';
+import { errorFrom, rejectionFrom } from '../helpers/errors.ts';
+import { createDisposableKeychain, type DisposableKeychain } from '../helpers/keychain.ts';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
+
+/**
+ * The keychain backend driven against the REAL `/usr/bin/security`, not an
+ * injected fake. Every other keychain test in this package supplies its own
+ * `exec`, so nothing on the far side of that seam — the argv spelling, the exit
+ * codes, the OS's own behaviour — has ever been executed.
+ *
+ * Everything here runs against a throwaway keychain and never the login one.
+ */
+
+// The product's own item identity, restated here on purpose rather than
+// exported from the module: an independent statement of what must be written
+// means a change to the constants shows up as a failure here instead of
+// silently moving where the vault key lives.
+const SERVICE = 'aka-vault';
+const ACCOUNT = 'keyring';
+
+/** The provider's own source, for the two properties no behavioural test can reach. */
+const providerSource = (): string =>
+  readFileSync(fileURLToPath(new URL('../../src/vault/key-provider.ts', import.meta.url)), 'utf8');
+
+describe('KeychainKeyProvider against the real security binary', () => {
+  let keysDir: string;
+  let kc: DisposableKeychain;
+
+  beforeEach(() => {
+    keysDir = mkdtempSync(join(tmpdir(), 'aka-vault-real-'));
+    kc = createDisposableKeychain();
+  });
+
+  afterEach(() => {
+    kc.cleanup();
+    rmSync(keysDir, { recursive: true, force: true });
+  });
+
+  // AC1: a full custody lifecycle through the real binary — mint, read back,
+  // rotate, and still serve the epoch that was rotated away from.
+  it('mints, reads back, rotates, and still serves the earlier epoch', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+
+    const first = await provider.loadOrCreate();
+    expect(first.version).toBe(1);
+    expect(first.material.length).toBeGreaterThan(0);
+
+    // A second load must READ the stored keyring, not mint a fresh one — a
+    // re-mint here would orphan every ciphertext written under the first.
+    const again = await provider.loadOrCreate();
+    expect(again.version).toBe(1);
+    expect(again.material.equals(first.material)).toBe(true);
+
+    const rotated = await provider.rotate();
+    expect(rotated.version).toBe(2);
+    expect(rotated.material.equals(first.material)).toBe(false);
+
+    // The whole point of retaining epochs: anything sealed under version 1 is
+    // still openable after the rotation.
+    const earlier = await provider.materialFor(1);
+    expect(earlier.material.equals(first.material)).toBe(true);
+  });
+
+  // Without this the test above is vacuous about isolation: if the seam did
+  // nothing, the write would land in the DEFAULT keychain and every read would
+  // find it there, so the round-trip would pass while the developer's login
+  // keychain quietly accumulated vault keys. Asserting the item is in the
+  // throwaway keychain fails in exactly that case — and touches no other one.
+  it('routes the write to the keychain it was given', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+
+    await provider.loadOrCreate();
+
+    const stored = kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']);
+    expect(stored.trim()).toMatch(/^\{"current":\s*1\b/);
+  });
+
+  // AC2: the read path branches on exit 44 to tell "nothing stored yet" from
+  // "the read failed". That number is the OS's, not ours, so it is MEASURED
+  // here — if a future macOS moved it, every read would start being taken for
+  // absence and mint over a live keyring. This turns that into a red test.
+  it('measures the item-not-found status the read path branches on', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+
+    const err = errorFrom(() =>
+      kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']),
+    );
+
+    expect(err).toBeDefined();
+    expect((err as { status?: number } | undefined)?.status).toBe(44);
+
+    // …and the provider really does read that status as absence, so the number
+    // above is pinned to the behaviour rather than sitting beside it.
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+    expect((await provider.loadOrCreate()).version).toBe(1);
+  });
+
+  // AC3's boundary, measured rather than assumed — and it is narrower than it
+  // looks. A keychain that is GONE answers 44, exactly as an empty one does, so
+  // at the exit-code level "no such keychain" and "no such item" are the same
+  // answer and the read path mints. That is what the 44 branch really covers.
+  //
+  // The dangerous case — a LOCKED keychain — is not reachable this way at all:
+  // measured, `security` does not fail on one, it blocks on a GUI unlock dialog
+  // with no exit status and no stderr. Nothing on the calling thread can
+  // interrupt that, so no exit-code branch can catch it and the call TIMEOUT is
+  // the only thing that converts it into a failure. Driving it from a suite
+  // would raise that dialog on every run, which CI has nobody to answer.
+  //
+  // The refusal branch itself — any non-44 status must throw rather than read as
+  // absence — is exercised against an injected status in key-provider.test.ts.
+  it('cannot tell a missing keychain from an empty one, and mints', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+    const minted = await provider.loadOrCreate();
+    expect(minted.version).toBe(1);
+
+    kc.cleanup();
+
+    const err = errorFrom(() =>
+      kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']),
+    );
+    expect(err).toBeDefined();
+    expect((err as { status?: number } | undefined)?.status).toBe(44);
+  });
+
+  // AC5 at the real-binary level: a failed write must describe itself with exit
+  // metadata and nothing else. The keyring rode stdin, and neither the message
+  // nor the stack may carry it back out.
+  it('describes a failed write without echoing the keyring', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const minted = await new KeychainKeyProvider(keysDir, undefined, kc.path).loadOrCreate();
+    // BOTH encodings. The keyring stores base64 but the write path sends hex,
+    // so checking one form only would sail straight past a leak of the other —
+    // and the hex is the form that actually crosses to the child.
+    const key = minted.material.toString('base64');
+    const keyHex = minted.material.toString('hex');
+
+    // Reads still go to the real binary; only the WRITE is refused. Rotation
+    // retains earlier epochs, so the payload this write carries contains the
+    // key minted above — the assertion below therefore names the value the
+    // failing call actually handled, rather than one it never saw. Deleting the
+    // keychain instead would send rotate() down the MINT path, where the
+    // payload is a fresh key and every absence assertion holds vacuously.
+    const refuseWrites = (args: string[], stdin?: string): string => {
+      if (stdin !== undefined) throw Object.assign(new Error('write refused'), { status: 45 });
+      return kc.exec(args);
+    };
+    const provider = new KeychainKeyProvider(keysDir, refuseWrites);
+
+    const err = await rejectionFrom(provider.rotate());
+
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/keychain write failed/);
+    for (const form of [key, keyHex]) {
+      expectNoEchoOf(err?.message, form);
+      expectNoEchoOf(err?.stack, form);
+    }
+    // The third shape, and the one the two above cannot see: the payload
+    // crosses to the child HEX-ENCODED, so a leak of the write line carries the
+    // key as hex-of-base64 — matching neither the base64 nor the raw-bytes-hex
+    // form. Hex is trivially decodable, so that is a disclosure like any other.
+    // Any long hex run in a message whose legitimate content is `exit 45` is
+    // the payload.
+    expect(err?.message).not.toMatch(/[0-9a-f]{64}/);
+  });
+
+  // AC4: a keychain item that is not a keyring must throw, not be re-minted
+  // over. Driven through the KEYCHAIN path deliberately — the corrupt-item case
+  // was only ever covered for file custody, where a different parse reaches it.
+  it('throws on a corrupt item rather than re-minting over it', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    // Valid JSON, invalid keyring — so the refusal comes from the keyring parse
+    // itself and its wording is stable, rather than from JSON.parse.
+    const junk = '{"current":"not-a-number","keys":{}}';
+    kc.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', junk]);
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+
+    const err = await rejectionFrom(provider.loadOrCreate());
+
+    expect(err).toBeDefined();
+    // The positive control, and the half that carries the property: assert WHY
+    // it refused. Without it a provider that swallowed the parse error still
+    // passes — it throws anyway, because the plain `add` then collides with the
+    // existing item, and the assertion below still holds because that add
+    // failed. Both halves stay green while the guard is gone.
+    expect(err?.message).toMatch(/not a usable keyring/);
+
+    // …and the corrupt item is untouched: nothing was minted over it.
+    expect(kc.exec(['find-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w']).trim()).toBe(
+      junk,
+    );
+  });
+
+  // A keyring TRUNCATED mid-value is what a partial write leaves behind, and it
+  // reaches the refusal through JSON.parse rather than the keyring checks.
+  //
+  // The absence half here is a REGRESSION guard, not a demonstrated fix: V8's
+  // parse errors were measured and carry a position, not a snippet, so nothing
+  // echoes today. What it forbids is the realistic next edit — interpolating
+  // the body itself "so the user can see what was stored" — which would put the
+  // whole keyring in the message. That mutation reddens this; passing V8's own
+  // message through does not, because there is nothing in it to catch.
+  it('refuses a truncated keyring without quoting it back', async (ctx) => {
+    if (!kc.usable) ctx.skip(kc.reason ?? 'no disposable keychain');
+    const secret = randomBytes(32).toString('base64');
+    // A real keyring, cut off mid-value — exactly what a partial write leaves.
+    const truncated = `{"current":1,"keys":{"1":"${secret}`;
+    kc.exec(['add-generic-password', '-s', SERVICE, '-a', ACCOUNT, '-w', truncated]);
+    const provider = new KeychainKeyProvider(keysDir, undefined, kc.path);
+
+    const err = await rejectionFrom(provider.loadOrCreate());
+
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/not a usable keyring/);
+    expectNoEchoOf(err?.message, secret);
+    expectNoEchoOf(err?.stack, secret);
+  });
+});
+
+// These need no keychain: the exec is injected, or the subject is the source
+// itself. Kept out of the suite above so they mint no throwaway keychain.
+describe('KeychainKeyProvider when security cannot be run', () => {
+  let keysDir: string;
+
+  beforeEach(() => {
+    keysDir = mkdtempSync(join(tmpdir(), 'aka-vault-nosec-'));
+  });
+
+  afterEach(() => {
+    rmSync(keysDir, { recursive: true, force: true });
+  });
+
+  // AC7: an absent binary must say which backend failed. A bare ENOENT reads as
+  // a missing FILE and sends the reader looking for the wrong thing.
+  it('names the backend rather than surfacing a bare ENOENT', async () => {
+    const absent = (): never => {
+      throw Object.assign(new Error('spawn /usr/bin/security ENOENT'), { code: 'ENOENT' });
+    };
+    const provider = new KeychainKeyProvider(keysDir, absent);
+
+    const err = await rejectionFrom(provider.loadOrCreate());
+
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/keychain read failed/);
+    expect(err?.message).toContain('ENOENT');
+  });
+
+  // AC7, second half: the binary is spawned by ABSOLUTE path. A bare name is
+  // resolved through PATH, where anything earlier on it wins — and this call
+  // hands over the vault key, so the program on the other end is not a detail.
+  it('spawns an absolute path, never a bare name resolved from PATH', () => {
+    expect(providerSource()).toContain("execFileSync('/usr/bin/security'");
+    expect(providerSource()).not.toMatch(/execFileSync\(\s*['"`]security['"`]/);
+  });
+
+  // The bound on a LOCKED keychain, and the only one there is. `security` does
+  // not fail on one — measured, it blocks on a GUI unlock dialog with no exit
+  // status and no stderr — so no exit-code branch can catch it and nothing on
+  // the calling thread can interrupt it. Without this timeout loadOrCreate()
+  // blocks for ever: the hook blows its harness budget and fails open, letting
+  // the tool call through unscanned, and the CLI and dashboard action wedge.
+  //
+  // Asserted against the source because the failure cannot be provoked from a
+  // suite: driving a real locked keychain raises that dialog on every run, and
+  // an injected exec bypasses runSecurity, which is where the bound lives. A
+  // behavioural test is what this would rather be; there is no safe one.
+  it('bounds every security call, well inside the plugin harness budget', () => {
+    const source = providerSource();
+
+    const declared = /const SECURITY_TIMEOUT_MS = ([\d_]+);/.exec(source);
+    expect(declared).not.toBeNull();
+    const ms = Number(declared?.[1]?.replaceAll('_', ''));
+    expect(Number.isFinite(ms)).toBe(true);
+    expect(ms).toBeGreaterThan(0);
+    // Under the 10s a Claude Code hook gets, so the read fails and is handled
+    // rather than the whole hook being killed mid-call.
+    expect(ms).toBeLessThan(10_000);
+
+    // …and it is actually applied, not merely declared.
+    expect(source).toMatch(/timeout: SECURITY_TIMEOUT_MS/);
+  });
+
+  // The interactive line is whitespace-separated, so a keychain path carrying a
+  // quote or a line break would re-tokenize it and could write the keyring
+  // somewhere unintended. Refused rather than escaped, and the refusal must
+  // reach the caller intact rather than being reported as a write failure.
+  it('refuses a keychain path that would break the interactive command line', async () => {
+    const notFound = (): never => {
+      throw Object.assign(new Error('no such item'), { status: 44 });
+    };
+    const provider = new KeychainKeyProvider(keysDir, notFound, "/tmp/quote'in-path.keychain");
+
+    const err = await rejectionFrom(provider.loadOrCreate());
+
+    expect(err).toBeDefined();
+    expect(err?.message).toMatch(/quote or line break/);
+  });
+});


### PR DESCRIPTION
The macOS keychain custody backend had no coverage against the real
`/usr/bin/security` — every test injected a fake exec, so the argv spelling,
the exit codes and the OS's own behaviour had never been executed. Two real
defects were sitting behind that seam. Issue tracked separately.

## The keyring rode argv

`add-generic-password -w <json>` put the vault keyring on the command line, and
an `execFileSync` error's `.message` echoes the argv it was given — so a failed
write produced an error carrying every key epoch in plaintext base64. `#create`
re-threw it untouched and `#replace` had no `catch` at all. Unlike the argv
exposure the module already documents and accepts (bounded, same-UID, for the
life of the exec), an error message outlives the process and travels into logs
and bug reports.

`add-generic-password` has **no stdin option** for the password: `-w`, `-p` and
`-X` all take their value on the command line, and a bare `-w` prompts on a
terminal. The fix routes the write through `security -i`, which reads *commands*
on stdin, with the keyring hex-encoded via `-X` so the only payload token is
`[0-9a-f]` and no quoting question can arise. Measured: the value round-trips
exactly and exit status still propagates (44 not-found, 45 duplicate), both of
which the read and mint-race paths branch on.

Every thrown keychain error is now stripped to exit metadata — status, signal,
code — with no `.message`, `.stdout`, `.stderr`, and no `cause` chain, which
would re-attach the child's stdout (on the read path, the keyring itself).

## A locked keychain hung for ever

`security` does **not** fail on a locked keychain — measured, it blocks on a GUI
unlock dialog with no exit status and no stderr. `runSecurity` carried no
timeout, so `loadOrCreate()` blocked indefinitely: a hook would blow its 10s
harness budget and fail open, letting the tool call through unscanned, while the
CLI and the dashboard action simply wedged. Every call is now bounded well
inside that budget.

## Changes

- Write the keyring over stdin via `security -i` with a hex `-X` payload
- Strip all three throw sites to raw-free exit metadata; drop the `cause` chain
- Bound every `security` call; document that this covers writes too, and why
- Refuse a keyring that will not parse rather than re-minting over it
- Add a keychain-target seam so tests never touch the developer's login keychain
- Add a disposable-keychain harness: unlocked, auto-lock disabled, deleted in
  teardown, with a per-call deadline so a dialog becomes a skip and never a hang
- Add `expectNoEchoOf` + its own suite to this package

## Verification

- `packages/persistence`: 81 files, 1172 passed, 3 skipped; lines coverage
  96.18% against a floor of 94
- Workspace typecheck 21/21; lint, portability gate, prettier and the
  eslint-config tree audits all clean
- Every acceptance criterion mutation-proven. Three mutations initially stayed
  **green**, each exposing a vacuous assertion that was then fixed: an absence
  check naming a value the failing call never handled; a check blind to the
  hex encoding the payload actually crosses in; and a corrupt-item test that
  asserted *that* it threw but not *why*

## Notes

- No end-to-end locked-keychain test: driving one raises an unlock dialog on
  every run, which CI has nobody to answer. The refusal branch is covered
  against an injected status; the locked case is covered by the timeout
- At the exit-code level a *missing* keychain is indistinguishable from an
  *empty* one — both answer 44 — so the provider mints. Pinned as measured
  behaviour