### PR TITLE
test: convert the last grandfathered platform guards to ctx.skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1569,15 +1569,19 @@ the same edit to make, and neither leaves an `if (process.platform …) return;`
 
 That last part is enforced rather than asked: `tools/portability-gate`'s
 `platform-guard-early-return` (rule 6, spec files only) fails `pnpm lint` on the shape.
-Three older suites predate it — `settings.test.ts`, `fingerprint.test.ts` and
-`plugin-sdk`'s `config.test.ts` — and are exempt through `GRANDFATHERED_PLATFORM_GUARDS`,
-which records the exact count each may keep. Leave them be unless you are already changing
-that test for another reason, and do not convert a neighbour in passing; the allowance is a
-ratchet, so converting one means lowering its number in the same commit, and a file that
-reaches zero leaves the map. The ratchet is on the COUNT, though, not on which guards make
-it up: converting one and adding another in the same commit holds the number and passes
-both rules, so the gate cannot tell that pairing from an honest conversion. All three carry
-the top-of-body shape, so each is a real `ctx.skip` still owed.
+Three older suites predated it — `settings.test.ts`, `fingerprint.test.ts` and
+`plugin-sdk`'s `config.test.ts` — and were exempt through `GRANDFATHERED_PLATFORM_GUARDS`
+while their six guards were owed. All six are converted, so **that map is now empty and
+nothing is exempt**: a guard in any spec file is reported. The mechanism stays, because it
+is what lets a rule of this kind land on a tree that already carries its shape, and an
+allowance is a ratchet in both directions — exceeding it is a violation, falling below it is
+`platform-guard-stale-allowance`, so converting a guard means lowering the number in the
+same commit and a file that reaches zero leaves the map. The ratchet is on the COUNT,
+though, not on which guards make it up: converting one and adding another in the same
+commit holds the number and passes both rules, so the gate cannot tell that pairing from an
+honest conversion. That is the reason to keep the map empty rather than to re-open it —
+with no entry at all, every guard in every spec file is reported and the pairing has
+nowhere to hide.
 
 ### Testing a web-ui Server Action
 

--- a/packages/persistence/test/fingerprint.test.ts
+++ b/packages/persistence/test/fingerprint.test.ts
@@ -54,8 +54,11 @@ describe('loadOrCreateFingerprintKey', () => {
     expect(second.material.equals(first.material)).toBe(true);
   });
 
-  it('re-tightens a pre-existing loose key file to 0600 on load (not re-minted)', () => {
-    if (process.platform === 'win32') return;
+  it('re-tightens a pre-existing loose key file to 0600 on load (not re-minted)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const key = loadOrCreateFingerprintKey(dir);
     // Simulate a key written before the mode was enforced at write time.
     chmodSync(keyFile(), 0o644);

--- a/packages/persistence/test/settings.test.ts
+++ b/packages/persistence/test/settings.test.ts
@@ -1,5 +1,6 @@
 import {
   chmodSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
@@ -77,8 +78,11 @@ describe('readWorkspaceSettings', () => {
     expect(settings.onboardedAt).toBeUndefined();
   });
 
-  it('is a pure reader — reading does not alter settings.json mode', () => {
-    if (process.platform === 'win32') return;
+  it('is a pure reader — reading does not alter settings.json mode', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // The self-heal deliberately lives in the write/init/loadConfig paths, not
     // here: a documented fail-open reader (also called from a web-ui page render)
     // must not chmod on every read. This pins that contract so nobody re-adds it.
@@ -108,19 +112,35 @@ describe('applyOnboarding', () => {
     }
   });
 
-  it('writes settings.json 0600 even over a leftover loose .tmp', () => {
-    if (process.platform === 'win32') return;
+  it('writes settings.json 0600 even over a leftover loose .tmp', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     const dir = join(base, 'settings');
     mkdirSync(dir, { recursive: true });
-    // A crash between the tmp write and the rename can leave a settings.json.tmp
-    // behind. writeFileSync's `mode` option is honored only on creation, so the
-    // owner-only writer clears a stale tmp first (and re-tightens after the
-    // rename) rather than carrying its loose mode onto settings.json.
-    const tmp = join(dir, 'settings.json.tmp');
+    // A crash between the tmp write and the rename can leave a stale tmp behind.
+    // writeFileSync's `mode` option is honored only on creation, so the owner-only
+    // writer clears that tmp first (and re-tightens after the rename) rather than
+    // carrying its loose mode onto settings.json.
+    //
+    // The tmp name has to carry THIS process's pid, because that is the path the
+    // writer builds and therefore the only one it can collide with. A plain
+    // `settings.json.tmp` is a file the writer never touches, so the fixture is
+    // inert and the case holds on the create mode alone — which is what it did
+    // until the writer's tmp became per-process.
+    const tmp = join(dir, `settings.json.${String(process.pid)}.tmp`);
     writeFileSync(tmp, 'stale');
     chmodSync(tmp, 0o666);
 
     applyOnboarding({ policy: 'warn' }, base);
+
+    // The writer consumed the planted tmp — it clears that path, writes it
+    // exclusively, and removes it again. A tmp still sitting there is one the
+    // writer never touched, i.e. the name above has drifted from the one it
+    // builds and the fixture is back to being inert. Assert it before the mode,
+    // because a mode of 0600 holds on the create mode alone either way.
+    expect(existsSync(tmp)).toBe(false);
 
     const file = join(dir, 'settings.json');
     expect(statSync(file).mode & 0o777).toBe(0o600);

--- a/packages/plugin-sdk/test/config.test.ts
+++ b/packages/plugin-sdk/test/config.test.ts
@@ -98,8 +98,11 @@ describe('loadConfig', () => {
     expect(existsSync(join(base, 'config.json'))).toBe(false);
   });
 
-  it('tightens a pre-existing loose base ~/.aka to 0700 on load (the plugin path)', () => {
-    if (process.platform === 'win32') return;
+  it('tightens a pre-existing loose base ~/.aka to 0700 on load (the plugin path)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // A base a user or an older release left group/other-readable: only `aka init`
     // tightened it before, so the plugin hook path (loadConfig) has to, since
     // openLocalDatabase only ensures the data/ leaf. See the "Data at rest" note
@@ -111,8 +114,11 @@ describe('loadConfig', () => {
     expect(statSync(base).mode & 0o777).toBe(0o700);
   });
 
-  it('self-heals a loose settings.json to 0600 on load (plugin entry path)', () => {
-    if (process.platform === 'win32') return;
+  it('self-heals a loose settings.json to 0600 on load (plugin entry path)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
     // A plugin-only user who never runs `aka init`: loadConfig re-tightens a
     // settings.json a prior release left group/other-readable, on the next hook.
     const dir = join(base, 'settings');
@@ -126,8 +132,11 @@ describe('loadConfig', () => {
     expect(statSync(file).mode & 0o777).toBe(0o600);
   });
 
-  it('does not chmod THROUGH a settings.json symlink on load (never tightens an arbitrary target)', () => {
-    if (process.platform === 'win32') return;
+  it('does not chmod THROUGH a settings.json symlink on load (never tightens an arbitrary target)', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
     // The loose-~/.aka state this repairs is attacker-writable; a planted
     // settings.json symlink must not let the self-heal chmod its target.
     const dir = join(base, 'settings');

--- a/tools/portability-gate/src/lib.ts
+++ b/tools/portability-gate/src/lib.ts
@@ -101,6 +101,13 @@ export const RULES: Record<RuleId, RuleInfo> = {
 // switched off instead. Filling it again is a deliberate edit, and the ratchet
 // below is what makes it a shrinking one.
 //
+// One consequence of the map being empty: `platform-guard-stale-allowance` can no
+// longer fire on a real scan at all — every allowance resolves to 0, and its
+// condition is `lines.length < 0`. That is a ratchet with nothing left to ratchet,
+// NOT dead code, and its coverage now rests entirely on the injected-map cases in
+// the unit suite. Deleting it because no real file reaches it would remove the
+// half of the ratchet that stops an exemption growing back the day one is added.
+//
 // An allowance is an exact COUNT, pinned in both directions: exceeding it is a
 // violation, and falling below it is one too (`platform-guard-stale-allowance`),
 // so converting a guard means lowering the number in the same commit. A file
@@ -661,21 +668,29 @@ export interface ScanOptions {
   grandfatheredPlatformGuards?: Readonly<Record<string, number>>;
 }
 
-// files is the whole set the caller found worth handing in — vitest configs
-// are needed to resolve rule 4's package-level override and are silently
-// skipped by the SPEC_FILE_RE filter below, so passing every tracked file is
-// fine and expected.
 // Which allowance map a scan runs under: the caller's, else the shipped one.
-// Split out so that binding is assertable by IDENTITY. It cannot be observed
-// through scanTree's output while the shipped map is empty — an empty map and a
-// missing default produce byte-identical violations — so the only thing standing
-// behind `?? GRANDFATHERED_PLATFORM_GUARDS` would otherwise be that nobody
-// rewrote it. Re-adding an exemption to a map the scan never reads would exempt
-// nothing, and the entry would look like it had.
+// Split out so that binding is assertable by IDENTITY, which is the only way to
+// reach it while the shipped map is empty — an empty map and a missing default
+// produce byte-identical violations, so nothing about the scan's OUTPUT can
+// separate them.
+//
+// Be precise about how far that reaches, because the gap it leaves is exactly
+// the one it looks like it closed. The identity test pins that THIS function
+// reads the constant. It does not pin that `scanTree` still calls this function:
+// rewrite the call below to `options.grandfatheredPlatformGuards ?? {}` and the
+// whole suite stays green, for the same unobservability reason. What covers that
+// is the source assertion in the unit suite, which is reaching for the shape this
+// repo uses where behaviour cannot get there (see plugin-sdk's data-dir.test.ts).
+// Re-filling the map retires both workarounds: an exemption that exempts
+// something is observable again, and a behavioural case should replace them.
 export function resolveGrandfatheredGuards(options: ScanOptions): Readonly<Record<string, number>> {
   return options.grandfatheredPlatformGuards ?? GRANDFATHERED_PLATFORM_GUARDS;
 }
 
+// files is the whole set the caller found worth handing in — vitest configs
+// are needed to resolve rule 4's package-level override and are silently
+// skipped by the SPEC_FILE_RE filter below, so passing every tracked file is
+// fine and expected.
 export function scanTree(files: ScannedFile[], options: ScanOptions = {}): Violation[] {
   const grandfathered = resolveGrandfatheredGuards(options);
   const packages = derivePackageTimeouts(files);

--- a/tools/portability-gate/src/lib.ts
+++ b/tools/portability-gate/src/lib.ts
@@ -91,10 +91,15 @@ export const RULES: Record<RuleId, RuleInfo> = {
 };
 
 // Files that already carried rule 6's shape when it was written, with the exact
-// number of guards each may keep. CLAUDE.md's "older suites" note grandfathers
-// these — converting a neighbour in passing is explicitly not wanted — so the
-// rule exempts them rather than reporting a backlog nobody is going to clear in
-// one go.
+// number of guards each may keep. It held three suites when the rule landed, all
+// six of their guards have since been converted, and it is now EMPTY — so rule 6
+// reports every guard in every spec file, with nothing exempt.
+//
+// The mechanism stays because the map is the only way to add a rule of this kind
+// to a tree that already carries its shape: a backlog nobody can clear in one go
+// is exempted here rather than turned into a wall of violations that gets
+// switched off instead. Filling it again is a deliberate edit, and the ratchet
+// below is what makes it a shrinking one.
 //
 // An allowance is an exact COUNT, pinned in both directions: exceeding it is a
 // violation, and falling below it is one too (`platform-guard-stale-allowance`),
@@ -107,18 +112,15 @@ export const RULES: Record<RuleId, RuleInfo> = {
 // paired with a conversion. Closing that needs guard identity — either a line
 // number, which shifts on any unrelated edit, or the enclosing test name — so
 // the count stands and the limit is written down instead. The exposure is the
-// map: a file with no allowance reports every guard in it.
+// map: a file with no allowance reports every guard in it, which is now every
+// file.
 //
 // An allowance is keyed by PATH, so a rename leaves it behind: the entry then
 // covers nothing and the file arrives with an allowance of zero, which reports
 // every guard in it. That is loud and correct. A DELETED file's entry is the one
 // case nothing reports — it is dead weight rather than a hole, since it can only
 // ever exempt a path the scan never sees.
-export const GRANDFATHERED_PLATFORM_GUARDS: Readonly<Record<string, number>> = {
-  'packages/persistence/test/fingerprint.test.ts': 1,
-  'packages/persistence/test/settings.test.ts': 2,
-  'packages/plugin-sdk/test/config.test.ts': 3,
-};
+export const GRANDFATHERED_PLATFORM_GUARDS: Readonly<Record<string, number>> = {};
 
 export interface Violation {
   rule: RuleId;
@@ -663,8 +665,19 @@ export interface ScanOptions {
 // are needed to resolve rule 4's package-level override and are silently
 // skipped by the SPEC_FILE_RE filter below, so passing every tracked file is
 // fine and expected.
+// Which allowance map a scan runs under: the caller's, else the shipped one.
+// Split out so that binding is assertable by IDENTITY. It cannot be observed
+// through scanTree's output while the shipped map is empty — an empty map and a
+// missing default produce byte-identical violations — so the only thing standing
+// behind `?? GRANDFATHERED_PLATFORM_GUARDS` would otherwise be that nobody
+// rewrote it. Re-adding an exemption to a map the scan never reads would exempt
+// nothing, and the entry would look like it had.
+export function resolveGrandfatheredGuards(options: ScanOptions): Readonly<Record<string, number>> {
+  return options.grandfatheredPlatformGuards ?? GRANDFATHERED_PLATFORM_GUARDS;
+}
+
 export function scanTree(files: ScannedFile[], options: ScanOptions = {}): Violation[] {
-  const grandfathered = options.grandfatheredPlatformGuards ?? GRANDFATHERED_PLATFORM_GUARDS;
+  const grandfathered = resolveGrandfatheredGuards(options);
   const packages = derivePackageTimeouts(files);
   const violations: Violation[] = [];
   for (const file of files) {

--- a/tools/portability-gate/test/check-portability.test.ts
+++ b/tools/portability-gate/test/check-portability.test.ts
@@ -8,6 +8,7 @@ import {
   formatReport,
   GRANDFATHERED_PLATFORM_GUARDS,
   isRelevantPath,
+  resolveGrandfatheredGuards,
   type ScannedFile,
   scanTree,
 } from '../src/lib.ts';
@@ -335,21 +336,34 @@ describe('platform-guard-early-return', () => {
     expect(violations[0]?.message).toContain('carries 1');
   });
 
-  // Everything above drives an injected map, so all of it would still pass with
-  // the shipped one unused. This is what pins that omitting the option reads the
-  // real GRANDFATHERED_PLATFORM_GUARDS, with the empty-map scan as its control.
-  it('reads the shipped allowance map when no override is passed', () => {
-    const entries = Object.entries(GRANDFATHERED_PLATFORM_GUARDS);
-    // Once this map empties the allowance branch is dead and this case should go
-    // with it — an empty map runs the loop zero times, so every assertion in it
-    // holds vacuously and only this line says so.
-    expect(entries.length).toBeGreaterThan(0);
+  // The shipped map is empty, so nothing distinguishes omitting the option from
+  // passing {} — both exempt nothing — and a case driving the default through it
+  // could only hold vacuously. What is left to pin is the emptiness itself: an
+  // entry here exempts a real guard in a real spec file, so re-adding one is a
+  // deliberate edit with a reason rather than a line that slips in beside a
+  // conversion. The arithmetic behind the allowance is covered by the injected-map
+  // cases above, which is why emptying this does not retire the mechanism.
+  it('ships an empty allowance map — no spec file is exempt from rule 6', () => {
+    // Object.keys rather than toEqual({}), which is satisfied by an entry whose
+    // value is undefined — the declared type is otherwise all that rules one out.
+    expect(Object.keys(GRANDFATHERED_PLATFORM_GUARDS)).toEqual([]);
+    // The control: with nothing exempt, a guard at any spec path is reported on
+    // the default map, which is the behaviour an entry would take away. It pins
+    // the RULE and not just the count — these bytes are also a same-line path
+    // comparison, so a count alone would survive rule 6 going silent while rule 4
+    // fired in its place.
+    const violations = scanTree([testFile(SPEC, guards(1))]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]).toMatchObject({ rule: 'platform-guard-early-return', line: 1 });
+  });
 
-    for (const [path, allowance] of entries) {
-      const files = [testFile(path, guards(allowance))];
-      expect(scanTree(files), path).toEqual([]);
-      expect(scanTree(files, { grandfatheredPlatformGuards: {} }), path).toHaveLength(allowance);
-    }
+  // The default above is unobservable through scanTree's output while the map is
+  // empty, so the binding is pinned by identity instead: `{}` is not the shipped
+  // constant, and Object.is separates them where a value comparison could not.
+  it('defaults to the shipped allowance map, and prefers an explicit one', () => {
+    expect(resolveGrandfatheredGuards({})).toBe(GRANDFATHERED_PLATFORM_GUARDS);
+    const injected = { [SPEC]: 1 };
+    expect(resolveGrandfatheredGuards({ grandfatheredPlatformGuards: injected })).toBe(injected);
   });
 });
 

--- a/tools/portability-gate/test/check-portability.test.ts
+++ b/tools/portability-gate/test/check-portability.test.ts
@@ -365,6 +365,25 @@ describe('platform-guard-early-return', () => {
     const injected = { [SPEC]: 1 };
     expect(resolveGrandfatheredGuards({ grandfatheredPlatformGuards: injected })).toBe(injected);
   });
+
+  // ...and that the scan actually goes through it, which the case above does NOT
+  // cover: it never calls scanTree, and scanTree inlining `?? {}` instead is
+  // invisible in its output for the same reason the helper exists. So the last
+  // link is asserted against the source, the shape this repo reaches for where
+  // behaviour cannot (plugin-sdk's data-dir.test.ts pins its mode constants the
+  // same way). Ugly, and load-bearing only while the shipped map is empty — once
+  // an exemption is added, a behavioural case can replace this outright.
+  it('resolves the allowance map through that helper, not a second inline default', () => {
+    const source = readFileSync(new URL('../src/lib.ts', import.meta.url), 'utf8');
+    expect(source).toContain('const grandfathered = resolveGrandfatheredGuards(options);');
+    // Exactly one place resolves the default, so a second one reintroduced beside
+    // the call above is caught too. Both assertions read RAW source, comments
+    // included — an absence assertion here would fire on prose that merely names
+    // the shape it forbids, which is why this pins what must be PRESENT instead.
+    // (The gate masks comments before matching for the same reason; that
+    // machinery is internal, and a two-line guard does not earn exporting it.)
+    expect(source.match(/\?\? GRANDFATHERED_PLATFORM_GUARDS/g)).toHaveLength(1);
+  });
 });
 
 describe('regex literals', () => {


### PR DESCRIPTION
## Summary

Six `if (process.platform === 'win32') return;` guards remained in three suites that
predate the `platform-guard-early-return` rule, exempted through
`GRANDFATHERED_PLATFORM_GUARDS` rather than converted. Every one of them was the first
statement in its test body, so on Windows those six cases ran **zero assertions and
reported as a pass** — the exact failure mode that rule exists to remove. All six guard
at-rest permission behaviour, including the refusal to `chmod` through a planted
`settings.json` symlink.

The exemption map is now empty: no spec file is exempt from the rule.

## Changes

- **Convert all six** to `ctx.skip(reason)` in `fingerprint.test.ts` (1),
  `settings.test.ts` (2) and `plugin-sdk`'s `config.test.ts` (3).
- **Empty `GRANDFATHERED_PLATFORM_GUARDS`**, keeping the allowance mechanism and its
  unit coverage in place. The ratchet (`platform-guard-stale-allowance`) is what forced
  this: leaving an entry behind fails `pnpm lint`.
- **Add `resolveGrandfatheredGuards`** so the "default reads the shipped map" binding
  stays assertable. Once the shipped map is empty, an empty map and a missing default
  produce byte-identical violations, so nothing else could pin it — it is now checked by
  identity.
- **Repair an inert fixture** in `settings.test.ts`: the leftover-`.tmp` case planted
  `settings.json.tmp`, but the writer's tmp became per-process (`settings.json.<pid>.tmp`)
  in a later change that touched this same file. The planted file was one the writer never
  touched, so the case held on the create mode alone. It now plants the real path and
  asserts the tmp was consumed, so a future drift fails instead of going quiet.
- **Update CLAUDE.md**'s platform-guard paragraph to match.

## Verification

Every claim below was measured in this session, not assumed.

**The ratchet fires.** With the six converted but the entries left in place,
`pnpm check:portability` exits 1 with exactly three `platform-guard-stale-allowance`
violations naming the recorded counts (1 / 2 / 3).

**Each conversion still fails on POSIX when its guarded behaviour breaks** — one mutation
per site, each proven to have landed, each restored:

| Test | Mutation | Result |
| --- | --- | --- |
| re-tightens loose key file | drop `tightenFile(keyFilePath(dataDir))` | RED `expected 420 to be 384` |
| pure reader | add a `tightenFile` into `readWorkspaceSettings` | RED `expected 384 to be 420` |
| 0600 over loose `.tmp` | create mode → `0o666` + drop trailing `tightenFile(file)` | RED `expected 420 to be 384` |
| tightens loose base | drop `ensureDataDirSync(base)` | RED `expected 511 to be 448` |
| self-heals settings.json | drop `if (existsSync(…)) tightenFile(…)` | RED `expected 420 to be 384` |
| no chmod through symlink | drop `if (isSymlink(path)) return` | RED `expected 384 to be 420` |

**Each reports as skipped, not passed, where it cannot run.** Windows is not available
here, so the guard's platform literal was flipped to this host — the guard then fires
exactly as it would on Windows. The evidence is the **per-test status of the named cases**,
not a suite total:

| Case | Pre-conversion (guard fired) | Converted (guard fired) |
| --- | --- | --- |
| `re-tightens a pre-existing loose key file` | `✓ passed` | `↓ skipped` |
| `is a pure reader` | `✓ passed` | `↓ skipped` |
| `writes settings.json 0600 even over a leftover loose .tmp` | `✓ passed` | `↓ skipped` |
| `tightens a pre-existing loose base ~/.aka` | `✓ passed` | `↓ skipped` |
| `self-heals a loose settings.json to 0600` | `✓ passed` | `↓ skipped` |
| `does not chmod THROUGH a settings.json symlink` | `✓ passed` | `↓ skipped` |

Six cases that reported *passed* now report *skipped*, each with its reason. The first
real Windows CI leg is what confirms it in situ.

> **Correction.** An earlier revision of this section published suite totals as the control
> (`config.test.ts` 13 passed, `fingerprint.test.ts` 26, `settings.test.ts` 16). Those rows
> did not survive checking and have been replaced. Two things were wrong with them: the
> `config.test.ts` rows came from different flip sets (4 guards vs 3, because that file
> already carried one `ctx.skip` before this PR) — a consistent all-four flip gives
> `12 passed | 1 skipped`, not 13. And more importantly all three totals are **degenerate**:
> running the pre-conversion files completely unflipped on macOS gives 13 / 26 / 16 as well,
> so the number cannot distinguish "guard fired, passed vacuously" from "guard never fired,
> ran fully". The per-test statuses above are what actually carry the claim.

**The new seam and guards are non-vacuous too:** `?? GRANDFATHERED_PLATFORM_GUARDS` → `?? {}`
reddens the identity test (it previously left 54/54 green); reporting rule 6 under a
different rule id with the count unchanged reddens the emptiness control; dropping the pid
from the writer's tmp reddens the repaired fixture, and is green with the new assertion
removed.

**Green:** `check:portability`, `lint`, `typecheck`, `format:check` all exit 0;
persistence 1145 passed / 3 skipped, plugin-sdk 426 passed, portability-gate 55 passed.
