### PR TITLE
test: cover the async ensureDataDir twin's owner-only contract

### DIFF
--- a/packages/persistence/test/local-layout.test.ts
+++ b/packages/persistence/test/local-layout.test.ts
@@ -1,4 +1,13 @@
-import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { beforeEach, describe, expect, it } from 'vitest';
@@ -6,6 +15,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   dataDir,
   dbPath,
+  ensureDataDir,
   ensureLayoutDirSync,
   migrateLegacyLayout,
   settingsDir,
@@ -14,7 +24,9 @@ import { useTempStore } from './helpers/temp-store.ts';
 
 // The harness owns the temp tree, for the retrying removal and the teardown
 // failure it demotes to a `cause` rather than reporting in place of the body's
-// own error — cases below leave a directory at 0777 and one at 0755.
+// own error — cases below leave a directory at 0777 and one at 0755, and the
+// async symlink cases leave a dangling-free symlink the removal unlinks rather
+// than recurses into.
 //
 // `base` is a subdirectory rather than the store's own root: this suite is what
 // tests the layout helpers, so it has to create `settings/` and `data/` itself
@@ -27,6 +39,8 @@ beforeEach(() => {
   base = join(store.home, 'base');
   mkdirSync(base);
 });
+
+const mode = (p: string): number => statSync(p).mode & 0o777;
 
 describe('layout helpers', () => {
   it('compose settings/, data/, and the db path from a base', () => {
@@ -41,7 +55,7 @@ describe('ensureLayoutDirSync', () => {
     const dir = dataDir(base);
     ensureLayoutDirSync(dir);
     expect(existsSync(dir)).toBe(true);
-    if (process.platform !== 'win32') expect(statSync(dir).mode & 0o777).toBe(0o700);
+    if (process.platform !== 'win32') expect(mode(dir)).toBe(0o700);
   });
 
   it('tightens an existing loose base directory to 0700', (ctx) => {
@@ -55,7 +69,7 @@ describe('ensureLayoutDirSync', () => {
     mkdirSync(home);
     chmodSync(home, 0o755);
     ensureLayoutDirSync(home);
-    expect(statSync(home).mode & 0o777).toBe(0o700);
+    expect(mode(home)).toBe(0o700);
   });
 
   it('leaves the whole ~/.aka layout owner-only (0700 base, settings/, data/) — the `aka init` shape', (ctx) => {
@@ -70,9 +84,127 @@ describe('ensureLayoutDirSync', () => {
     ensureLayoutDirSync(home);
     ensureLayoutDirSync(settingsDir(home));
     ensureLayoutDirSync(dataDir(home));
-    expect(statSync(home).mode & 0o777).toBe(0o700);
-    expect(statSync(settingsDir(home)).mode & 0o777).toBe(0o700);
-    expect(statSync(dataDir(home)).mode & 0o777).toBe(0o700);
+    expect(mode(home)).toBe(0o700);
+    expect(mode(settingsDir(home))).toBe(0o700);
+    expect(mode(dataDir(home))).toBe(0o700);
+  });
+});
+
+// The async twin is published API of BOTH @akasecurity/persistence and
+// @akasecurity/plugin-sdk, so a consumer can call it even though nothing in this
+// repository does. Three properties are under test here: the mode passed to
+// mkdir (which is all that reaches the levels ABOVE the leaf), the shared
+// tightenDir (all that reaches a leaf that pre-existed), and the DELEGATION to
+// that shared helper rather than a chmod of its own — the last is what carries
+// the symlink guard onto this path, and is the divergence the shared helper was
+// introduced to prevent.
+//
+// Every case passes an explicit dir. Never call `ensureDataDir()` bare to cover
+// its default parameter: that resolves to the real ~/.aka and would create and
+// chmod the developer's own home, outside the temp store entirely.
+describe('ensureDataDir (async)', () => {
+  it('creates the directory owner-only (0700) where POSIX modes apply', async () => {
+    const dir = dataDir(base);
+
+    await ensureDataDir(dir);
+
+    expect(existsSync(dir)).toBe(true);
+    if (process.platform !== 'win32') expect(mode(dir)).toBe(0o700);
+  });
+
+  it('tightens an existing loose directory to 0700 (chmods after mkdir)', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // A dir that already existed with looser permissions must be tightened, not
+    // left as it was found — mkdir applies its mode at CREATION only, so on a
+    // pre-existing dir the tighten is the only thing that can reach it.
+    const dir = join(base, 'loose-data');
+    mkdirSync(dir);
+    chmodSync(dir, 0o777);
+    // Unguarded because the ctx.skip at the top of this body already returned on
+    // Windows; narrowing that skip means restoring a platform guard here.
+    expect(mode(dir)).toBe(0o777); // precondition: genuinely loose
+
+    await ensureDataDir(dir);
+
+    expect(mode(dir)).toBe(0o700);
+  });
+
+  it('holds every level it creates at 0700, not just the leaf it tightens', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    // The tighten reaches the LEAF only, so the mode passed to mkdir is the one
+    // thing holding the levels above it. Without a case that creates a PARENT,
+    // dropping that mode is invisible: the leaf self-heals through the tighten
+    // while every level above it is left at the caller's umask — 0755 on a
+    // default host, 0777 under a permissive one.
+    const dir = join(base, 'a', 'b', 'c');
+
+    await ensureDataDir(dir);
+
+    for (const p of [join(base, 'a'), join(base, 'a', 'b'), dir]) {
+      // Named, so a failure says WHICH level was left loose: a leaf that
+      // self-healed above a loose parent is a different defect from a leaf that
+      // was never tightened, and the bare mode numbers cannot tell them apart.
+      expect(mode(p), p).toBe(0o700);
+    }
+  });
+
+  it('never chmods THROUGH a directory symlink (a victim dir keeps its mode)', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
+    // The symlink guard lives in the shared tightenDir, so the async path gets
+    // it only by delegating rather than chmod'ing itself. A planted store-dir
+    // symlink must leave its target's mode alone, and mkdir must no-op on it
+    // rather than refuse: a hook has to keep working on a hostile home.
+    //
+    // This asserts a chmod did NOT happen, which a tighten that never runs at
+    // all satisfies equally well — the case below is its positive control.
+    const victim = join(base, 'victim-shared');
+    mkdirSync(victim);
+    chmodSync(victim, 0o755);
+    const link = join(base, '.aka');
+    symlinkSync(victim, link);
+
+    await ensureDataDir(link);
+
+    expect(mode(victim)).toBe(0o755); // victim NOT tightened through the link
+    expect(lstatSync(link).isSymbolicLink()).toBe(true); // link left as-is
+  });
+
+  it('still tightens a real directory created INSIDE a symlinked home', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
+    // Only the FINAL component is checked, so a real inode inside a deliberately
+    // symlinked home is still ours to hold at 0700 — widening the guard to any
+    // symlinked ancestor would drop the store's only at-rest control instead.
+    //
+    // This is also the positive control for the case above: together they
+    // separate "the symlink guard works" from "nothing is tightened any more",
+    // which an absence assertion alone cannot do.
+    //
+    // data/ must PRE-EXIST loose for either half to mean anything: mkdir applies
+    // its mode at creation, so on a fresh dir the assertion passes whether or
+    // not the chmod ran.
+    const victim = join(base, 'victim-shared');
+    mkdirSync(join(victim, 'data'), { recursive: true });
+    chmodSync(join(victim, 'data'), 0o755);
+    chmodSync(victim, 0o755);
+    const link = join(base, '.aka');
+    symlinkSync(victim, link);
+
+    await ensureDataDir(join(link, 'data'));
+
+    expect(mode(join(victim, 'data'))).toBe(0o700);
+    expect(mode(victim)).toBe(0o755); // and the link's own target still untouched
   });
 });
 
@@ -107,7 +239,7 @@ describe('migrateLegacyLayout', () => {
     migrateLegacyLayout(base);
 
     expect(existsSync(join(settingsDir(base), 'config.json'))).toBe(true);
-    if (process.platform !== 'win32') expect(statSync(settingsDir(base)).mode & 0o777).toBe(0o700);
+    if (process.platform !== 'win32') expect(mode(settingsDir(base))).toBe(0o700);
   });
 
   it('tightens a moved legacy config.json to 0600 (it can carry a token)', () => {
@@ -122,6 +254,6 @@ describe('migrateLegacyLayout', () => {
 
     const moved = join(settingsDir(base), 'config.json');
     expect(existsSync(moved)).toBe(true);
-    if (process.platform !== 'win32') expect(statSync(moved).mode & 0o777).toBe(0o600);
+    if (process.platform !== 'win32') expect(mode(moved)).toBe(0o600);
   });
 });

--- a/packages/plugin-sdk/test/data-dir.test.ts
+++ b/packages/plugin-sdk/test/data-dir.test.ts
@@ -23,29 +23,46 @@ describe('data-dir re-export', () => {
     expect(DATA_FILE_MODE).toBe(PERSISTENCE_FILE_MODE);
   });
 
-  // Every binding here must BE persistence's, not a copy that happens to agree
-  // today. Identity is what carries persistence's own behavioural coverage of
-  // each one onto this package's surface — for `ensureDataDir` that is the 0700
-  // mkdir and the shared, symlink-guarded tighten, which a local
-  // reimplementation would satisfy every SDK consumer's import without
-  // delivering.
-  //
-  // Derived from the shim's own exports rather than listed by hand, so a
-  // binding added to the module is checked the day it lands instead of the day
-  // someone remembers to extend this table. `ensureDataDirSync` is the one
-  // renamed export — the SDK's spelling of persistence's `ensureLayoutDirSync`.
+  // Derived from the shim's own exports rather than listed by hand, so a binding
+  // added to the module is checked the day it lands instead of the day someone
+  // remembers to extend this table. `ensureDataDirSync` is the one renamed
+  // export — the SDK's spelling of persistence's `ensureLayoutDirSync`.
   const RENAMED: Record<string, string> = { ensureDataDirSync: 'ensureLayoutDirSync' };
   const bindings = Object.keys(shim).sort();
+  const at = (mod: object, name: string): unknown => (mod as Record<string, unknown>)[name];
 
-  it('re-exports a non-empty surface (the table below is derived from it)', () => {
-    // Without this the it.each below generates zero cases and passes silently,
-    // which is exactly how a shim that stopped re-exporting anything would read.
+  // Split by what `toBe` can actually prove about each kind, because one name
+  // cannot be true of both. For a FUNCTION, `toBe` is reference identity, so it
+  // genuinely rules out a local reimplementation — that is what carries
+  // persistence's own behavioural coverage (for `ensureDataDir`, the 0700 mkdir
+  // and the shared symlink-guarded tighten) onto this package's surface.
+  //
+  // For a NUMBER it is value equality, and `Object.is(0o700, 0o700)` is true, so
+  // no assertion over the values alone can tell persistence's constant from a
+  // local `export const DATA_DIR_MODE = 0o700`. Those two are pinned
+  // STRUCTURALLY instead, by `declares no mode of its own` below, which reads
+  // the module's bytes. Naming this case "not a local copy" would be a title
+  // that cannot go red for the reason it states.
+  const fnBindings = bindings.filter((n) => typeof at(shim, n) === 'function');
+  const valueBindings = bindings.filter((n) => typeof at(shim, n) !== 'function');
+
+  it('splits its whole surface across the two tables below', () => {
+    // Both halves are derived, so a binding could fall out of BOTH and every
+    // it.each below would simply generate one case fewer — silently, since a
+    // table that shrank still passes. This is what makes that loud, and it
+    // subsumes the non-empty check: zero exports fails the union too.
+    expect([...fnBindings, ...valueBindings].sort()).toEqual(bindings);
     expect(bindings.length).toBeGreaterThan(5);
   });
 
-  it.each(bindings)('serves persistence %s, not a local copy', (name) => {
-    const source = RENAMED[name] ?? name;
-    expect(shim[name as keyof typeof shim]).toBe(persistence[source as keyof typeof persistence]);
+  it.each(fnBindings)('serves persistence %s, not a local reimplementation', (name) => {
+    expect(at(shim, name)).toBe(at(persistence, RENAMED[name] ?? name));
+  });
+
+  // Value equality only — see above. `declares no mode of its own` is what rules
+  // out a local copy of these.
+  it.each(valueBindings)('agrees with persistence %s', (name) => {
+    expect(at(shim, name)).toBe(at(persistence, RENAMED[name] ?? name));
   });
 
   // Equality alone still holds if someone re-declares the same literals here, so

--- a/packages/plugin-sdk/test/data-dir.test.ts
+++ b/packages/plugin-sdk/test/data-dir.test.ts
@@ -1,11 +1,13 @@
 import { readFileSync } from 'node:fs';
 
+import * as persistence from '@akasecurity/persistence';
 import {
   DATA_DIR_MODE as PERSISTENCE_DIR_MODE,
   DATA_FILE_MODE as PERSISTENCE_FILE_MODE,
 } from '@akasecurity/persistence';
 import { describe, expect, it } from 'vitest';
 
+import * as shim from '../src/data-dir.ts';
 import { DATA_DIR_MODE, DATA_FILE_MODE } from '../src/data-dir.ts';
 
 /**
@@ -19,6 +21,31 @@ describe('data-dir re-export', () => {
   it('serves the persistence modes, not a copy', () => {
     expect(DATA_DIR_MODE).toBe(PERSISTENCE_DIR_MODE);
     expect(DATA_FILE_MODE).toBe(PERSISTENCE_FILE_MODE);
+  });
+
+  // Every binding here must BE persistence's, not a copy that happens to agree
+  // today. Identity is what carries persistence's own behavioural coverage of
+  // each one onto this package's surface — for `ensureDataDir` that is the 0700
+  // mkdir and the shared, symlink-guarded tighten, which a local
+  // reimplementation would satisfy every SDK consumer's import without
+  // delivering.
+  //
+  // Derived from the shim's own exports rather than listed by hand, so a
+  // binding added to the module is checked the day it lands instead of the day
+  // someone remembers to extend this table. `ensureDataDirSync` is the one
+  // renamed export — the SDK's spelling of persistence's `ensureLayoutDirSync`.
+  const RENAMED: Record<string, string> = { ensureDataDirSync: 'ensureLayoutDirSync' };
+  const bindings = Object.keys(shim).sort();
+
+  it('re-exports a non-empty surface (the table below is derived from it)', () => {
+    // Without this the it.each below generates zero cases and passes silently,
+    // which is exactly how a shim that stopped re-exporting anything would read.
+    expect(bindings.length).toBeGreaterThan(5);
+  });
+
+  it.each(bindings)('serves persistence %s, not a local copy', (name) => {
+    const source = RENAMED[name] ?? name;
+    expect(shim[name as keyof typeof shim]).toBe(persistence[source as keyof typeof persistence]);
   });
 
   // Equality alone still holds if someone re-declares the same literals here, so


### PR DESCRIPTION
## What this covers

`ensureDataDir` — the **async** twin of `ensureDataDirSync` in
`packages/persistence/src/local-layout.ts` — has no caller in this repository, but it is
published API of both `@akasecurity/persistence` and `@akasecurity/plugin-sdk`. Nothing
tested what calling it actually does: the only test naming it asserted that the string
appears in a list of exports.

Both lines that decide its permissions could be deleted with the whole `persistence` suite
staying green, so a refactor could silently stop delivering the owner-only contract its
comment promises. On POSIX those modes are the only at-rest control on the store.

Tests only — no source changes. `git diff main...HEAD -- '*/src/*'` is empty.

## Changes

**`packages/persistence/test/local-layout.test.ts`** — five async cases:

- creates a directory at `0700`
- tightens one that pre-existed loose (`mkdir` applies its mode at creation only)
- holds **every level it creates** at `0700`, not just the leaf — the tighten reaches the
  leaf alone, so the `mkdir` mode is the only thing holding the parents, and those are real
  store paths (`openLocalDatabase(dataDir(home))` creates `~/.aka` as a parent on a machine
  that has never run `aka init`)
- never chmods **through** a directory symlink
- still tightens a real directory created **inside** a symlinked home — the positive control
  for the case above, which on its own passes just as well when the tighten never runs at all

**`packages/plugin-sdk/test/data-dir.test.ts`** — pins every binding the `data-dir` shim
re-exports to persistence's own, derived from `Object.keys(shim)` rather than listed by
hand, so a binding added to the module is checked the day it lands. Carries a non-empty
guard, since `it.each` over an empty array generates zero cases and passes silently.

Also adds a local `mode()` helper mirroring the one in `paths.test.ts`, replacing 12
repetitions of `statSync(p).mode & 0o777`.

## Verification

Mutations applied by hand to `packages/persistence/src/local-layout.ts` and
`packages/plugin-sdk/src/data-dir.ts`, each run with `pnpm vitest run <file>` from the
package, restored from a pristine copy between runs. Landing was confirmed each time with
`grep -c` on the original line returning 0.

| Mutation | Test that went red | Assertion |
| --- | --- | --- |
| drop `mode: DATA_DIR_MODE` | `holds every level it creates at 0700…` | `expected 493 to be 448` |
| delete `tightenDir(dir)` | `tightens an existing loose directory to 0700` **and** `still tightens a real directory created INSIDE a symlinked home` | `511 → 448`, `493 → 448` |
| `tightenDir(dir)` → direct `chmodSync(dir, DATA_DIR_MODE)` | `never chmods THROUGH a directory symlink` | `448 → 493` (victim locked through the link) |
| both mode and tighten removed | `creates the directory owner-only (0700)…` (+ 3 others) | `expected 493 to be 448` |
| `settingsDir` re-export reimplemented locally | `serves persistence settingsDir, not a local copy` | identity |

The second and third rows are the pair that matters: deleting the tighten reddens the
positive control, while bypassing the shared helper reddens only the absence assertion.
Neither test alone separates "the symlink guard works" from "nothing is tightened any more".

Coverage of `local-layout.ts` from its own suite, measured with
`pnpm vitest run test/local-layout.test.ts --coverage.reporter=text`: uncovered lines
`22, 46-57` → `22, 46` (lines 46-57 are the whole `ensureDataDir` body); functions
62.5% → 75%.

Suites, from `pnpm --filter <pkg> test`:

- `@akasecurity/persistence` — `Test Files 78 passed (78)`, `Tests 1150 passed | 3 skipped (1153)`
- `@akasecurity/plugin-sdk` — `Test Files 31 passed (31)`, `Tests 436 passed (436)`

`lint`, `typecheck`, `format:check` and `check:portability` all exit 0 (the pre-push hook
ran the workspace lint and the portability gate on this branch).

Mutation A's kill is umask-dependent (taken under `umask 022`). That is acceptable rather
than a hole: for a parent to end up looser than `0700` the umask must permit group/other
bits, so the test's blindness coincides exactly with the mutation being harmless. The sync
twin's equivalent test has the same property.

## Follow-up

`packages/plugin-sdk` has no export-surface test at all — `persistence` pins its surface in
`test/index.test.ts`, but the SDK, which is what plugin authors import, pins nothing. This
PR pins the `data-dir` shim module; the package index is still unguarded. Tracked
separately.
