### PR TITLE
test: fix two Windows-only flakes in the settings-race barrier and the status-bar render test

### DIFF
--- a/packages/persistence/test/concurrency/settings-race.test.ts
+++ b/packages/persistence/test/concurrency/settings-race.test.ts
@@ -26,7 +26,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { applyOnboarding, readWorkspaceSettings, SETTINGS_FILENAME } from '../../src/settings.ts';
 import type { WriterJob } from '../helpers/settings-writers.ts';
-import { allReleasedTogether, runConcurrentSettingsWriters } from '../helpers/settings-writers.ts';
+import {
+  BARRIER_HELD,
+  barrierReport,
+  runConcurrentSettingsWriters,
+} from '../helpers/settings-writers.ts';
 
 let base: string;
 
@@ -77,7 +81,7 @@ describe('concurrent applyOnboarding', () => {
     // Positive control on the barrier itself. Writers that ran one after
     // another would satisfy every assertion below without a race ever having
     // happened, so the contention is asserted before its consequences are.
-    expect(allReleasedTogether(run)).toBe(true);
+    expect(barrierReport(run)).toBe(BARRIER_HELD);
     expect(run.outcomes.filter((o) => !o.ok).map((o) => o.error)).toEqual([]);
 
     const settings = readWorkspaceSettings(base);
@@ -111,7 +115,7 @@ describe('concurrent applyOnboarding', () => {
       { set: { vaultInlineReveal: 'off' } },
     ]);
 
-    expect(allReleasedTogether(run)).toBe(true);
+    expect(barrierReport(run)).toBe(BARRIER_HELD);
     expect(run.outcomes.filter((o) => !o.ok).map((o) => o.error)).toEqual([]);
     expect(readWorkspaceSettings(base).modelJudgeConsent).toBeUndefined();
     // The revoke is the only answer under test; the rest must still be there,
@@ -168,7 +172,7 @@ describe('concurrent applyOnboarding', () => {
       { set: { policy: 'warn' } },
       { set: { historicalAccess: 'full' } },
     ]);
-    expect(allReleasedTogether(run)).toBe(true);
+    expect(barrierReport(run)).toBe(BARRIER_HELD);
 
     const raw: unknown = JSON.parse(readFileSync(settingsFile(), 'utf8'));
     expect(raw).toMatchObject({ policy: 'warn', historicalAccess: 'full' });

--- a/packages/persistence/test/helpers/settings-writer-child.ts
+++ b/packages/persistence/test/helpers/settings-writer-child.ts
@@ -21,7 +21,8 @@ import { existsSync, writeFileSync, writeSync } from 'node:fs';
 
 import { applyOnboarding } from '../../src/settings.ts';
 
-const [base, jobJson, readyFile, goFile, barrierTimeoutArg, parentPidArg] = process.argv.slice(2);
+const [base, jobJson, readyFile, goFile, barrierTimeoutArg, parentPidArg, readyToken] =
+  process.argv.slice(2);
 if (
   base === undefined ||
   jobJson === undefined ||
@@ -29,7 +30,7 @@ if (
   goFile === undefined
 ) {
   throw new Error(
-    'settings-writer-child: expected <base> <jobJson> <readyFile> <goFile> [barrierTimeoutMs] [parentPid]',
+    'settings-writer-child: expected <base> <jobJson> <readyFile> <goFile> [barrierTimeoutMs] [parentPid] [readyToken]',
   );
 }
 
@@ -141,7 +142,7 @@ for (const field of job.clear ?? []) answers[field] = undefined;
 // and a hot loop each would take a core apiece off the rest of the suite —
 // enough to push a timing-sensitive test elsewhere over its threshold. The
 // extra millisecond of release latency costs nothing here, since the barrier's
-// assertion tolerates a late start (see allReleasedTogether).
+// assertion tolerates a late start (see barrierReport).
 //
 // The wait is bounded, but NOT by a clock standing in for the handshake. The
 // distinction is the whole point: a deadline-based barrier expires and lets the
@@ -155,10 +156,22 @@ for (const field of job.clear ?? []) answers[field] = undefined;
 // would all sit unrun until the barrier lifted, which is precisely when they
 // are no longer needed.
 const PARK = new Int32Array(new SharedArrayBuffer(4));
-const readyAt = Date.now();
-const barrierDeadline = readyAt + barrierTimeoutMs;
-let nextLivenessCheck = readyAt + LIVENESS_POLL_MS;
-writeFileSync(readyFile, '');
+// How long this process took to get here — a DURATION, measured against this
+// process's own start, so it carries no instant the parent could be tempted to
+// compare against one of its own. That comparison is what this harness was last
+// fixed for.
+const bootMs = performance.now();
+// Local-only, and compared against this process's own Date.now() below. It is
+// not reported: an instant that crossed the boundary is what the parent used to
+// mis-compare against its own.
+const parkedAt = Date.now();
+const barrierDeadline = parkedAt + barrierTimeoutMs;
+let nextLivenessCheck = parkedAt + LIVENESS_POLL_MS;
+// The token names WHICH writer this is, so the parent counts a ready file only
+// against the writer that wrote it. Mere existence would let one writer's file
+// satisfy every index if the paths were ever shared, releasing the barrier
+// while the rest were still booting.
+writeFileSync(readyFile, readyToken ?? '');
 while (!existsSync(goFile)) {
   const now = Date.now();
   if (now >= barrierDeadline) {
@@ -188,5 +201,5 @@ try {
 // passed one. Left to the default it would be dead configuration: the bound
 // would still hold, but at a value nothing in the harness chose.
 process.stdout.write(
-  `${JSON.stringify({ ok, error, readyAt, startedAt, endedAt: Date.now(), barrierTimeoutMs })}\n`,
+  `${JSON.stringify({ ok, error, bootMs, startedAt, endedAt: Date.now(), barrierTimeoutMs })}\n`,
 );

--- a/packages/persistence/test/helpers/settings-writers.test.ts
+++ b/packages/persistence/test/helpers/settings-writers.test.ts
@@ -383,18 +383,26 @@ describe('barrierReport', () => {
     );
   });
 
-  it('tolerates a writer scheduled late AFTER the release, which is not a defect', () => {
-    // A released child can sit unscheduled for longer than another writer's
-    // whole call on a loaded runner. Only readiness is the barrier's business,
-    // so that must not read as a broken barrier — otherwise the suite fails on
-    // machine load rather than on the product. Enforced by shape rather than by
-    // this case: startedAt/endedAt are unreachable from barrierReport, so the
-    // case can only show the fields exist. It is kept for the reader.
-    const late = run(100, [{ observedAt: 20 }, { observedAt: 60 }]);
-    const scheduledLate = late.outcomes.map((o, i) =>
-      i === 1 ? { ...o, startedAt: 9_000, endedAt: 9_010 } : o,
+  it('reads no child stamp, however impossible that stamp looks', () => {
+    // Two writers with child stamps that cannot both be true of a barrier that
+    // held: one descheduled so long it started 9s late, and one reporting a
+    // start BEFORE the release it was waiting on. Neither is a defect. The
+    // first is ordinary runner load, and the second is the cross-process clock
+    // disagreement this whole harness was rewritten for — startedAt is stamped
+    // by the child, releasedAt by the parent, so their arithmetic means
+    // nothing even though the causal order is certain.
+    //
+    // Both values are the point. A version of barrierReport that reached for
+    // startedAt at all fails here whichever direction it compared: `>=
+    // releasedAt` rejects writer 0, `<=` rejects writer 1. Without the early
+    // stamp the case was a tautology — a late-only fixture satisfies a
+    // `startedAt >= releasedAt` conjunct, so the conjunct could be added with
+    // the suite green.
+    const run_ = run(100, [{ observedAt: 20 }, { observedAt: 60 }]);
+    const impossible = run_.outcomes.map((o, i) =>
+      i === 0 ? { ...o, startedAt: 50, endedAt: 70 } : { ...o, startedAt: 9_000, endedAt: 9_010 },
     );
-    expect(barrierReport({ ...late, outcomes: scheduledLate })).toBe(BARRIER_HELD);
+    expect(barrierReport({ ...run_, outcomes: impossible })).toBe(BARRIER_HELD);
   });
 
   it('fails for no writers at all', () => {

--- a/packages/persistence/test/helpers/settings-writers.test.ts
+++ b/packages/persistence/test/helpers/settings-writers.test.ts
@@ -96,14 +96,28 @@ afterEach(() => {
   rmSync(base, { recursive: true, force: true });
 });
 
-function run(releasedAt: number, readies: number[]): ConcurrentRun {
+/**
+ * One writer's timings, as the two clocks see it.
+ *
+ * `observedAt` is the parent's — omitted for a writer it never saw park.
+ * `readyAt` is the child's own claim, which the barrier check must ignore; it
+ * defaults to the parent's reading so a case that says nothing about the child
+ * clock is not quietly asserting the two agree.
+ */
+interface WriterTiming {
+  observedAt?: number;
+  readyAt?: number;
+}
+
+function run(releasedAt: number, writers: WriterTiming[]): ConcurrentRun {
   return {
     releasedAt,
-    outcomes: readies.map((readyAt) => ({
+    readyObservedAt: writers.map((w) => w.observedAt),
+    outcomes: writers.map((w) => ({
       ok: true,
-      readyAt,
+      readyAt: w.readyAt ?? w.observedAt ?? 0,
       // Every writer starts after the release; that is true by construction and
-      // is precisely why the barrier check reads readyAt instead.
+      // is precisely why the barrier check does not read startedAt.
       startedAt: releasedAt + 1,
       endedAt: releasedAt + 11,
       barrierTimeoutMs: 60_000,
@@ -302,14 +316,37 @@ describe('a writer that is never released', () => {
 
 describe('allReleasedTogether', () => {
   it('is true when every writer was parked before the release', () => {
-    expect(allReleasedTogether(run(100, [20, 60, 100]))).toBe(true);
+    expect(
+      allReleasedTogether(run(100, [{ observedAt: 20 }, { observedAt: 60 }, { observedAt: 100 }])),
+    ).toBe(true);
   });
 
   it('is false when a writer was still loading at the release', () => {
     // The failure mode it exists to catch: a barrier that stopped holding, so
     // the writers ran as each finished booting, one after another — under which
-    // "no answer was lost" is trivially true.
-    expect(allReleasedTogether(run(100, [20, 140]))).toBe(false);
+    // "no answer was lost" is trivially true. The parent never saw that writer
+    // park, so its observation is the gap rather than a late number.
+    expect(allReleasedTogether(run(100, [{ observedAt: 20 }, {}]))).toBe(false);
+  });
+
+  it('is false when the parent released without watching every writer', () => {
+    // A handshake that waits for the first ready file and then releases leaves
+    // the rest unobserved. Reported per writer, that is a short set — which is
+    // why the check counts observations against outcomes rather than trusting
+    // the ones it got.
+    const partial = run(100, [{ observedAt: 20 }, { observedAt: 40 }]);
+    expect(allReleasedTogether({ ...partial, readyObservedAt: [20] })).toBe(false);
+  });
+
+  it('ignores a child clock that disagrees with the parent’s', () => {
+    // Two processes stamping Date.now() ask two independently-maintained
+    // clocks, and on Windows they routinely differ by a few milliseconds. A
+    // child that parked before the release can therefore REPORT a readyAt after
+    // it. Deciding the barrier on that comparison is what reddened main from a
+    // green tree; the parent's own observation is what settles it.
+    expect(
+      allReleasedTogether(run(100, [{ observedAt: 20, readyAt: 118 }, { observedAt: 60 }])),
+    ).toBe(true);
   });
 
   it('tolerates a writer scheduled late AFTER the release, which is not a defect', () => {
@@ -317,7 +354,7 @@ describe('allReleasedTogether', () => {
     // whole call on a loaded runner. Only readiness is the barrier's business,
     // so that must not read as a broken barrier — otherwise the suite fails on
     // machine load rather than on the product.
-    const late = run(100, [20, 60]);
+    const late = run(100, [{ observedAt: 20 }, { observedAt: 60 }]);
     const scheduledLate = late.outcomes.map((o, i) =>
       i === 1 ? { ...o, startedAt: 9_000, endedAt: 9_010 } : o,
     );

--- a/packages/persistence/test/helpers/settings-writers.test.ts
+++ b/packages/persistence/test/helpers/settings-writers.test.ts
@@ -18,7 +18,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { readWorkspaceSettings } from '../../src/settings.ts';
 import type { ConcurrentRun, WriterJob } from './settings-writers.ts';
-import { allReleasedTogether, runConcurrentSettingsWriters } from './settings-writers.ts';
+import { BARRIER_HELD, barrierReport, runConcurrentSettingsWriters } from './settings-writers.ts';
 
 const CHILD = fileURLToPath(new URL('./settings-writer-child.ts', import.meta.url));
 
@@ -97,16 +97,15 @@ afterEach(() => {
 });
 
 /**
- * One writer's timings, as the two clocks see it.
+ * One writer, as the PARENT saw it.
  *
- * `observedAt` is the parent's — omitted for a writer it never saw park.
- * `readyAt` is the child's own claim, which the barrier check must ignore; it
- * defaults to the parent's reading so a case that says nothing about the child
- * clock is not quietly asserting the two agree.
+ * `observedAt` is when the parent read this writer's ready token; omit it for a
+ * writer it never saw park. `bootMs` is the writer's own boot duration, quoted
+ * back in a fault message and read by nothing else.
  */
 interface WriterTiming {
   observedAt?: number;
-  readyAt?: number;
+  bootMs?: number;
 }
 
 function run(releasedAt: number, writers: WriterTiming[]): ConcurrentRun {
@@ -115,9 +114,12 @@ function run(releasedAt: number, writers: WriterTiming[]): ConcurrentRun {
     readyObservedAt: writers.map((w) => w.observedAt),
     outcomes: writers.map((w) => ({
       ok: true,
-      readyAt: w.readyAt ?? w.observedAt ?? 0,
-      // Every writer starts after the release; that is true by construction and
-      // is precisely why the barrier check does not read startedAt.
+      bootMs: w.bootMs ?? 1,
+      // Every writer starts after the release CAUSALLY — it is stamped by the
+      // child once it observes the go file. These fixture numbers are not a
+      // cross-process comparison and must not be read as licence for one: that
+      // is the mistake this harness was last fixed for, and the barrier check
+      // reads neither field.
       startedAt: releasedAt + 1,
       endedAt: releasedAt + 11,
       barrierTimeoutMs: 60_000,
@@ -154,7 +156,7 @@ describe('runConcurrentSettingsWriters', () => {
       { set: { historicalAccess: 'full' } },
       { set: { dataSharesInPlace: false } },
     ]);
-    expect(allReleasedTogether(result)).toBe(true);
+    expect(barrierReport(result)).toBe(BARRIER_HELD);
   });
 
   it('carries a revoke across the process boundary', async () => {
@@ -187,11 +189,15 @@ describe('runConcurrentSettingsWriters', () => {
 
   it('runs its writers under its own barrier ceiling, not the child’s default', async () => {
     // The ceiling only bounds anything if it is actually sent. The child's
-    // fallback is deliberately a different number, so this reads as 60s exactly
-    // when the harness passed 60s — drop the argument and it reports the
+    // fallback is deliberately a different number, so this reads as 30s exactly
+    // when the harness passed 30s — drop the argument and it reports the
     // fallback instead of quietly agreeing.
+    //
+    // Spelled out rather than imported: the harness derives it as
+    // READY_TIMEOUT_MS * 2, and a test that recomputed the derivation would
+    // agree with any value the harness chose, including none.
     const result = await runConcurrentSettingsWriters(base, [{ set: { policy: 'warn' } }]);
-    expect(result.outcomes[0]?.barrierTimeoutMs).toBe(60_000);
+    expect(result.outcomes[0]?.barrierTimeoutMs).toBe(30_000);
   });
 });
 
@@ -314,54 +320,84 @@ describe('a writer that is never released', () => {
   }, 40_000);
 });
 
-describe('allReleasedTogether', () => {
-  it('is true when every writer was parked before the release', () => {
+describe('barrierReport', () => {
+  it('holds when every writer was parked before the release', () => {
     expect(
-      allReleasedTogether(run(100, [{ observedAt: 20 }, { observedAt: 60 }, { observedAt: 100 }])),
-    ).toBe(true);
+      barrierReport(run(100, [{ observedAt: 20 }, { observedAt: 60 }, { observedAt: 100 }])),
+    ).toBe(BARRIER_HELD);
   });
 
-  it('is false when a writer was still loading at the release', () => {
-    // The failure mode it exists to catch: a barrier that stopped holding, so
-    // the writers ran as each finished booting, one after another — under which
-    // "no answer was lost" is trivially true. The parent never saw that writer
-    // park, so its observation is the gap rather than a late number.
-    expect(allReleasedTogether(run(100, [{ observedAt: 20 }, {}]))).toBe(false);
+  // The two conjuncts, one case each. Each catches what the other cannot, and
+  // the pair is what stops either being deleted with the suite green — which is
+  // how the ordering half shipped unexercised: the gap case alone left
+  // `at <= releasedAt` removable with all six cases passing.
+
+  it('fails when a writer was never parked at all', () => {
+    // A barrier that stopped holding lets the writers run as each finishes
+    // booting, one after another — under which "no answer was lost" is
+    // trivially true. The parent never saw that writer park, so the gap is what
+    // reports it.
+    expect(barrierReport(run(100, [{ observedAt: 20 }, { bootMs: 4_000 }]))).toBe(
+      'writer 1 never parked (booted in 4000ms)',
+    );
   });
 
-  it('is false when the parent released without watching every writer', () => {
-    // A handshake that waits for the first ready file and then releases leaves
-    // the rest unobserved. Reported per writer, that is a short set — which is
-    // why the check counts observations against outcomes rather than trusting
-    // the ones it got.
+  it('fails when a writer was not observed until AFTER the release', () => {
+    // The ordering half, which no gap can reach: every writer parked and was
+    // seen, but one of them only after the go file went out. That is what a
+    // release reordered ahead of the handshake looks like from here — hoist
+    // `releasedAt`/`writeFileSync(goFile)` above the wait and every observation
+    // lands on this side of it.
+    expect(barrierReport(run(100, [{ observedAt: 20 }, { observedAt: 140 }]))).toBe(
+      'writer 1 was not observed until 40ms after the release (booted in 1ms)',
+    );
+  });
+
+  it('names every writer at fault, not just the first', () => {
+    // The whole reason this returns a sentence: a run with two bad writers has
+    // to say so, or the second is found on the next CI cycle.
+    expect(barrierReport(run(100, [{ observedAt: 20 }, {}, { observedAt: 150 }]))).toBe(
+      'writer 1 never parked (booted in 1ms); writer 2 was not observed until 50ms after the release (booted in 1ms)',
+    );
+  });
+
+  it('rejects a run carrying fewer observations than writers', () => {
+    // An arity guard on an exported function, not a shape the helper can
+    // return — `readyObservedAt` and `outcomes` both derive from the job list.
+    // A caller assembling a ConcurrentRun by hand can still reach it.
     const partial = run(100, [{ observedAt: 20 }, { observedAt: 40 }]);
-    expect(allReleasedTogether({ ...partial, readyObservedAt: [20] })).toBe(false);
+    expect(barrierReport({ ...partial, readyObservedAt: [20] })).toBe(
+      'run is malformed: 1 observations for 2 writers',
+    );
   });
 
-  it('ignores a child clock that disagrees with the parent’s', () => {
-    // Two processes stamping Date.now() ask two independently-maintained
-    // clocks, and on Windows they routinely differ by a few milliseconds. A
-    // child that parked before the release can therefore REPORT a readyAt after
-    // it. Deciding the barrier on that comparison is what reddened main from a
-    // green tree; the parent's own observation is what settles it.
-    expect(
-      allReleasedTogether(run(100, [{ observedAt: 20, readyAt: 118 }, { observedAt: 60 }])),
-    ).toBe(true);
+  it('does not skip a hole in the observations', () => {
+    // `Array.prototype.every` SKIPS holes, so a sparse array would never visit
+    // the missing index and the run would report that the barrier held. No
+    // production path builds one — both arrays are dense — so this pins the
+    // trap rather than a live defect.
+    const sparse = run(100, [{ observedAt: 20 }, { observedAt: 40 }, { observedAt: 60 }]);
+    // eslint-disable-next-line no-sparse-arrays -- the hole IS the fixture
+    expect(barrierReport({ ...sparse, readyObservedAt: [20, , 60] })).toBe(
+      'writer 1 never parked (booted in 1ms)',
+    );
   });
 
   it('tolerates a writer scheduled late AFTER the release, which is not a defect', () => {
     // A released child can sit unscheduled for longer than another writer's
     // whole call on a loaded runner. Only readiness is the barrier's business,
     // so that must not read as a broken barrier — otherwise the suite fails on
-    // machine load rather than on the product.
+    // machine load rather than on the product. Enforced by shape rather than by
+    // this case: startedAt/endedAt are unreachable from barrierReport, so the
+    // case can only show the fields exist. It is kept for the reader.
     const late = run(100, [{ observedAt: 20 }, { observedAt: 60 }]);
     const scheduledLate = late.outcomes.map((o, i) =>
       i === 1 ? { ...o, startedAt: 9_000, endedAt: 9_010 } : o,
     );
-    expect(allReleasedTogether({ ...late, outcomes: scheduledLate })).toBe(true);
+    expect(barrierReport({ ...late, outcomes: scheduledLate })).toBe(BARRIER_HELD);
   });
 
-  it('is false for no writers at all', () => {
-    expect(allReleasedTogether(run(100, []))).toBe(false);
+  it('fails for no writers at all', () => {
+    expect(barrierReport(run(100, []))).toBe('no writers ran');
   });
 });

--- a/packages/persistence/test/helpers/settings-writers.ts
+++ b/packages/persistence/test/helpers/settings-writers.ts
@@ -68,7 +68,14 @@ export interface WriterOutcome {
   ok: boolean;
   /** `Name: message` when it threw; absent when it returned. */
   error?: string;
-  /** When this writer finished loading and parked at the barrier. */
+  /**
+   * When this writer finished loading and parked at the barrier, on ITS clock.
+   *
+   * Diagnostic only — it says how long this writer took to boot, which is worth
+   * having when a run fails. It is not comparable with anything stamped by the
+   * parent; `ConcurrentRun.readyObservedAt` is the parent-clock counterpart the
+   * barrier check reads.
+   */
   readyAt: number;
   startedAt: number;
   endedAt: number;
@@ -87,6 +94,15 @@ export interface ConcurrentRun {
   outcomes: WriterOutcome[];
   /** The instant the parent released every parked writer. */
   releasedAt: number;
+  /**
+   * When THIS process first saw each writer's ready file, by writer index, and
+   * `undefined` for one it never saw park at all.
+   *
+   * Stamped here rather than taken from the writer's own `readyAt` because the
+   * barrier check compares these against `releasedAt`, and two stamps only
+   * order each other when one clock took them both. See allReleasedTogether.
+   */
+  readyObservedAt: (number | undefined)[];
 }
 
 interface Writer {
@@ -141,25 +157,47 @@ function spawnWriter(base: string, job: WriterJob, readyFile: string, goFile: st
   return { child, done };
 }
 
-// Poll until every writer has announced itself, or give up loudly.
+// Poll until every writer has announced itself, or give up loudly, and report
+// WHEN each one was seen — on this process's clock, which is also the clock that
+// stamps the release.
 //
 // A silent give-up would release the ones that are ready and leave the rest to
 // arrive afterwards — the serialised run this handshake exists to rule out. A
 // writer that DIED is the other way to wait forever, so an exited child ends the
 // wait at once rather than at the timeout: its readiness is never coming, and
-// the caller has a real failure to report.
-async function waitForAllReady(writers: Writer[], readyFiles: string[]): Promise<void> {
+// the caller has a real failure to report. It returns what it saw either way,
+// so a writer left unobserved is visible as a gap rather than inferred from a
+// timestamp that never arrived.
+async function waitForAllReady(
+  writers: Writer[],
+  readyFiles: string[],
+): Promise<(number | undefined)[]> {
   const deadline = Date.now() + READY_TIMEOUT_MS;
-  while (!readyFiles.every((f) => existsSync(f))) {
-    if (writers.some((w) => w.child.exitCode !== null || w.child.signalCode !== null)) return;
+  const observedAt: (number | undefined)[] = readyFiles.map(() => undefined);
+  const seen = (): boolean => observedAt.every((at) => at !== undefined);
+  // Stamped on the first pass that finds each file, not once at the end: a
+  // single stamp for the whole set would say when the LAST writer parked and
+  // claim it for every one of them.
+  const sweep = (): void => {
+    readyFiles.forEach((f, i) => {
+      if (observedAt[i] === undefined && existsSync(f)) observedAt[i] = Date.now();
+    });
+  };
+  sweep();
+  while (!seen()) {
+    if (writers.some((w) => w.child.exitCode !== null || w.child.signalCode !== null)) {
+      return observedAt;
+    }
     if (Date.now() >= deadline) {
-      const missing = readyFiles.filter((f) => !existsSync(f)).length;
+      const missing = observedAt.filter((at) => at === undefined).length;
       throw new Error(
         `${String(missing)} of ${String(readyFiles.length)} settings writers never reported ready`,
       );
     }
     await delay(5);
+    sweep();
   }
+  return observedAt;
 }
 
 /**
@@ -187,8 +225,9 @@ export async function runConcurrentSettingsWriters(
   const writers = jobs.map((job, i) => spawnWriter(base, job, readyFiles[i] ?? '', goFile));
   let results: ChildResult[];
   let releasedAt: number;
+  let readyObservedAt: (number | undefined)[];
   try {
-    await waitForAllReady(writers, readyFiles);
+    readyObservedAt = await waitForAllReady(writers, readyFiles);
     // Released only once every writer is loaded and waiting. Timing the barrier
     // instead ties the contention to Node's boot time, which under a full
     // parallel suite can outrun any deadline — and a barrier that expired early
@@ -226,7 +265,7 @@ export async function runConcurrentSettingsWriters(
       );
     }
   });
-  return { outcomes, releasedAt };
+  return { outcomes, releasedAt, readyObservedAt };
 }
 
 /**
@@ -237,11 +276,26 @@ export async function runConcurrentSettingsWriters(
  * would let each writer run as it finished booting, one after another. Every
  * no-loss assertion downstream then holds for want of a race, silently.
  *
- * It compares `readyAt` — stamped by each child as it parks — against the
- * instant the parent released them. Comparing `startedAt` instead cannot fail:
- * a child stamps that only after it observes the release, so `startedAt >=
- * releasedAt` is true by construction and stays true with the handshake deleted.
- * `readyAt` is the one of the two the barrier actually decides.
+ * It reads the PARENT's observations — the instant this process saw each ready
+ * file — against the instant this process released them. Both stamps come off
+ * one clock, which is what makes the comparison mean anything.
+ *
+ * It used to compare the child's own `readyAt` against `releasedAt`, and that
+ * is a cross-process comparison: two processes stamping `Date.now()` are asking
+ * two independently-maintained clocks, and on Windows those disagree by a few
+ * milliseconds routinely. The causal order was never in doubt — a child stamps
+ * `readyAt` BEFORE writing the file the parent then waits for — so a run this
+ * check failed was one where the clocks disagreed, not one where the barrier
+ * did. It reddened main from a genuinely green tree. The child's `readyAt` is
+ * still reported, for reading a slow boot out of a failure; do not decide the
+ * barrier on it again.
+ *
+ * The file is the evidence, not the timestamp, and it is evidence of the whole
+ * property: the ready file exists only because the child wrote it on its way
+ * into the park loop. So requiring one observation per writer, all of them
+ * before the release, is the handshake itself. Delete the handshake and there
+ * are no observations; break it so it waits for only the first writer, or
+ * returns early on a child that died, and the gaps are what this reads.
  *
  * What it deliberately does NOT assert is that the calls overlapped in wall
  * clock. A released child can be descheduled — on a runner with more test
@@ -250,5 +304,8 @@ export async function runConcurrentSettingsWriters(
  */
 export function allReleasedTogether(run: ConcurrentRun): boolean {
   if (run.outcomes.length === 0) return false;
-  return run.outcomes.every((o) => o.readyAt <= run.releasedAt);
+  // Per WRITER, not merely as many observations as writers: a run that saw one
+  // writer park twice would otherwise count as a full set.
+  if (run.readyObservedAt.length !== run.outcomes.length) return false;
+  return run.readyObservedAt.every((at) => at !== undefined && at <= run.releasedAt);
 }

--- a/packages/persistence/test/helpers/settings-writers.ts
+++ b/packages/persistence/test/helpers/settings-writers.ts
@@ -9,16 +9,45 @@
  */
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 
+/**
+ * A file's contents, or `undefined` when it is not there yet.
+ *
+ * Only ENOENT is absence. Anything else — a permission fault, a Windows sharing
+ * violation — is a real fault and is raised, rather than being folded into "not
+ * ready" and waited out until the deadline reports the wrong diagnosis.
+ */
+function readFileIfPresent(file: string): string | undefined {
+  try {
+    return readFileSync(file, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
 const CHILD = fileURLToPath(new URL('./settings-writer-child.ts', import.meta.url));
 
-/** How long to wait for every writer to report itself loaded and ready. */
-const READY_TIMEOUT_MS = 30_000;
+/**
+ * How long to wait for every writer to report itself loaded and ready.
+ *
+ * Deliberately UNDER this package's 20s `testTimeout`, so the give-up below is
+ * the thing that fails the run. At 30s it could never fire: vitest won the race
+ * every time and a run where writers failed to boot died on a bare
+ * `Test timed out in 20000ms`, naming neither the count nor which ones were
+ * missing. Same trap CLAUDE.md records for the PATH shim's probe deadline.
+ *
+ * The headroom is still large. Seven writers boot in ~200ms locally, and
+ * CLAUDE.md measures this package's CI factor at ~30x, so this is roughly two
+ * orders of magnitude clear of a legitimate wait. Raising it past the
+ * `testTimeout` buys nothing and costs the diagnosis.
+ */
+const READY_TIMEOUT_MS = 15_000;
 
 /**
  * The ceiling on how long a parked writer waits to be released.
@@ -69,14 +98,16 @@ export interface WriterOutcome {
   /** `Name: message` when it threw; absent when it returned. */
   error?: string;
   /**
-   * When this writer finished loading and parked at the barrier, on ITS clock.
+   * How long this writer took to load and reach the barrier, in ms.
    *
-   * Diagnostic only — it says how long this writer took to boot, which is worth
-   * having when a run fails. It is not comparable with anything stamped by the
-   * parent; `ConcurrentRun.readyObservedAt` is the parent-clock counterpart the
-   * barrier check reads.
+   * A DURATION, measured child-locally, where this used to be a `readyAt`
+   * instant. An instant invites the comparison this whole file exists to
+   * retire — the parent has instants of its own, and nothing in the type said
+   * they were incomparable — so the misuse is now unexpressible rather than
+   * forbidden by a comment. `barrierReport` quotes it when a writer is late or
+   * missing, which is the case where "this one took 4s to boot" is the answer.
    */
-  readyAt: number;
+  bootMs: number;
   startedAt: number;
   endedAt: number;
   /**
@@ -92,15 +123,28 @@ export interface WriterOutcome {
 /** One concurrent run: what each writer reported, and when they were released. */
 export interface ConcurrentRun {
   outcomes: WriterOutcome[];
-  /** The instant the parent released every parked writer. */
+  /**
+   * When the parent released every parked writer, on `performance.now()`.
+   *
+   * Monotonic, and that is load-bearing rather than tidy. One clock is
+   * necessary but not sufficient: `Date.now()` steps BACKWARDS on an NTP
+   * correction or a VM host time sync, and CI runners are VMs — so a resync
+   * landing between the last sweep and this stamp reads an observation as later
+   * than the release and reddens a run whose barrier held. That is the same
+   * failure this file was opened to fix, merely rarer. Both stamps are
+   * in-process and compared only to each other, so nothing here needs a wall
+   * clock at all.
+   */
   releasedAt: number;
   /**
-   * When THIS process first saw each writer's ready file, by writer index, and
+   * When THIS process first saw each writer's ready token, by writer index, and
    * `undefined` for one it never saw park at all.
    *
-   * Stamped here rather than taken from the writer's own `readyAt` because the
-   * barrier check compares these against `releasedAt`, and two stamps only
-   * order each other when one clock took them both. See allReleasedTogether.
+   * On the same monotonic clock as `releasedAt`, which is what makes the
+   * comparison mean anything. The resolution is one poll interval, so writers
+   * that park inside the same 5ms gap share a stamp — these order writers
+   * against the RELEASE, and are not a per-writer boot measurement. `bootMs` is
+   * that.
    */
   readyObservedAt: (number | undefined)[];
 }
@@ -116,7 +160,13 @@ interface ChildResult {
   stderr: string;
 }
 
-function spawnWriter(base: string, job: WriterJob, readyFile: string, goFile: string): Writer {
+function spawnWriter(
+  base: string,
+  job: WriterJob,
+  readyFile: string,
+  goFile: string,
+  token: string,
+): Writer {
   const child = spawn(
     process.execPath,
     [
@@ -130,6 +180,7 @@ function spawnWriter(base: string, job: WriterJob, readyFile: string, goFile: st
       // the child is still booting, the child's own first read of `ppid` is
       // already the adoptive parent and its liveness check can never fire.
       String(process.pid),
+      token,
     ],
     { stdio: ['ignore', 'pipe', 'pipe'] },
   );
@@ -157,47 +208,75 @@ function spawnWriter(base: string, job: WriterJob, readyFile: string, goFile: st
   return { child, done };
 }
 
-// Poll until every writer has announced itself, or give up loudly, and report
-// WHEN each one was seen — on this process's clock, which is also the clock that
-// stamps the release.
-//
-// A silent give-up would release the ones that are ready and leave the rest to
-// arrive afterwards — the serialised run this handshake exists to rule out. A
-// writer that DIED is the other way to wait forever, so an exited child ends the
-// wait at once rather than at the timeout: its readiness is never coming, and
-// the caller has a real failure to report. It returns what it saw either way,
-// so a writer left unobserved is visible as a gap rather than inferred from a
-// timestamp that never arrived.
+/**
+ * What a writer must have written into its ready file for the parent to count
+ * it — the writer's own index, as the PARENT numbered it.
+ *
+ * Mere existence is not enough, and the difference is not theoretical. Point
+ * every writer at one shared path — a plausible simplification of the
+ * `ready-${i}` construction, or a bad merge — and writer 0's file satisfies
+ * every index the moment it lands: the parent releases while the rest are still
+ * booting, which is exactly the serialised run the barrier rules out, and the
+ * observations come back full and in order so nothing downstream notices.
+ *
+ * Reading the index back is what makes the check independent again. The parent
+ * is no longer taking its own word for having waited; the evidence is a byte
+ * sequence only THAT child could have written, and it crosses the process
+ * boundary without a clock, which is the whole point of this file.
+ */
+function readyToken(index: number): string {
+  return `writer-${String(index)}`;
+}
+
+/**
+ * Poll until every writer has announced ITSELF, or give up loudly, reporting
+ * when each one was seen — on this process's monotonic clock, which is also the
+ * clock that stamps the release.
+ *
+ * A silent give-up would release the ones that are ready and leave the rest to
+ * arrive afterwards — the serialised run this handshake exists to rule out. A
+ * writer that DIED is the other way to wait forever, so an exited child ends the
+ * wait at once rather than at the timeout: its readiness is never coming, and
+ * the caller has a real failure to report.
+ *
+ * A ready file whose token does not match yet counts as not-ready and is polled
+ * again, which also covers the harmless race of reading one mid-write.
+ */
 async function waitForAllReady(
   writers: Writer[],
   readyFiles: string[],
 ): Promise<(number | undefined)[]> {
-  const deadline = Date.now() + READY_TIMEOUT_MS;
+  const deadline = performance.now() + READY_TIMEOUT_MS;
   const observedAt: (number | undefined)[] = readyFiles.map(() => undefined);
-  const seen = (): boolean => observedAt.every((at) => at !== undefined);
-  // Stamped on the first pass that finds each file, not once at the end: a
-  // single stamp for the whole set would say when the LAST writer parked and
-  // claim it for every one of them.
-  const sweep = (): void => {
+  // One loop with one sweep site. Two sweep calls — one before the loop, one at
+  // the foot of it — is a shape that drifts: deleting either is silent, since
+  // the only effect is shifting every observation by one poll interval and no
+  // assertion here reads an interval.
+  for (;;) {
     readyFiles.forEach((f, i) => {
-      if (observedAt[i] === undefined && existsSync(f)) observedAt[i] = Date.now();
+      if (observedAt[i] !== undefined) return;
+      // A token that is not this writer's leaves the slot empty, so a shared or
+      // crossed ready path times out below rather than passing as a full set.
+      if (readFileIfPresent(f)?.trim() === readyToken(i)) observedAt[i] = performance.now();
     });
-  };
-  sweep();
-  while (!seen()) {
+    if (observedAt.every((at) => at !== undefined)) return observedAt;
     if (writers.some((w) => w.child.exitCode !== null || w.child.signalCode !== null)) {
       return observedAt;
     }
-    if (Date.now() >= deadline) {
-      const missing = observedAt.filter((at) => at === undefined).length;
+    if (performance.now() >= deadline) {
+      // Names WHICH writers, not merely how many. This branch is the one a
+      // person reads on a real failure, and an index is what tells them whose
+      // stderr to go and read; a bare count was the whole of it before, and it
+      // discarded the per-writer structure the sweep had just built.
+      const missing = observedAt
+        .map((at, i) => (at === undefined ? String(i) : undefined))
+        .filter((i) => i !== undefined);
       throw new Error(
-        `${String(missing)} of ${String(readyFiles.length)} settings writers never reported ready`,
+        `${String(missing.length)} of ${String(readyFiles.length)} settings writers never reported ready (writers ${missing.join(', ')})`,
       );
     }
     await delay(5);
-    sweep();
   }
-  return observedAt;
 }
 
 /**
@@ -222,7 +301,9 @@ export async function runConcurrentSettingsWriters(
   // polling for `goFile`, so a throw that removed the sync dir without killing
   // the children would leave them waiting on a path that can never appear —
   // orphans polling for the life of the CI job.
-  const writers = jobs.map((job, i) => spawnWriter(base, job, readyFiles[i] ?? '', goFile));
+  const writers = jobs.map((job, i) =>
+    spawnWriter(base, job, readyFiles[i] ?? '', goFile, readyToken(i)),
+  );
   let results: ChildResult[];
   let releasedAt: number;
   let readyObservedAt: (number | undefined)[];
@@ -233,7 +314,7 @@ export async function runConcurrentSettingsWriters(
     // parallel suite can outrun any deadline — and a barrier that expired early
     // does not fail, it just serialises the writers, leaving every no-loss
     // assertion downstream true for want of a race.
-    releasedAt = Date.now();
+    releasedAt = performance.now();
     writeFileSync(goFile, '');
     results = await Promise.all(writers.map((w) => w.done));
   } finally {
@@ -268,44 +349,72 @@ export async function runConcurrentSettingsWriters(
   return { outcomes, releasedAt, readyObservedAt };
 }
 
+/** What `barrierReport` says when the barrier did its job. */
+export const BARRIER_HELD = 'every writer parked before the release';
+
 /**
- * Whether every writer was already parked at the barrier before ANY of them was
- * released — the barrier's own positive control.
+ * Whether every writer was parked at the barrier before ANY of them was
+ * released — the barrier's own positive control — as a SENTENCE.
  *
  * The point of a barrier is contention, and one that quietly stopped working
  * would let each writer run as it finished booting, one after another. Every
  * no-loss assertion downstream then holds for want of a race, silently.
  *
- * It reads the PARENT's observations — the instant this process saw each ready
- * file — against the instant this process released them. Both stamps come off
- * one clock, which is what makes the comparison mean anything.
+ * A sentence rather than a boolean because this is what the three assertions in
+ * `concurrency/settings-race.test.ts` fail on, and `expected false to be true`
+ * names neither the writer nor the reason. The run holds the answer — which
+ * writer was late, by how long, and how long each took to boot — and a boolean
+ * throws all of it away at the last step. Compare against `BARRIER_HELD`.
  *
- * It used to compare the child's own `readyAt` against `releasedAt`, and that
- * is a cross-process comparison: two processes stamping `Date.now()` are asking
- * two independently-maintained clocks, and on Windows those disagree by a few
- * milliseconds routinely. The causal order was never in doubt — a child stamps
- * `readyAt` BEFORE writing the file the parent then waits for — so a run this
- * check failed was one where the clocks disagreed, not one where the barrier
- * did. It reddened main from a genuinely green tree. The child's `readyAt` is
- * still reported, for reading a slow boot out of a failure; do not decide the
- * barrier on it again.
+ * It reads the PARENT's observations against the PARENT's release, both on one
+ * monotonic clock. It used to compare the child's own `readyAt` against
+ * `releasedAt`: two processes stamping `Date.now()` ask two independently-
+ * maintained clocks, and on Windows those disagree by a few milliseconds
+ * routinely. The causal order was never in doubt — a child stamps its readiness
+ * before writing the file the parent waits for — so a run that failed this
+ * check was one where the clocks disagreed, not one where the barrier did. It
+ * reddened main from a genuinely green tree. There is no longer an instant on
+ * `WriterOutcome` to make that mistake with.
  *
- * The file is the evidence, not the timestamp, and it is evidence of the whole
- * property: the ready file exists only because the child wrote it on its way
- * into the park loop. So requiring one observation per writer, all of them
- * before the release, is the handshake itself. Delete the handshake and there
- * are no observations; break it so it waits for only the first writer, or
- * returns early on a child that died, and the gaps are what this reads.
+ * The ready TOKEN is the evidence, not the timestamp, and it is evidence of the
+ * whole property: the file carries the writer's own index, so only that child
+ * could have written it, and it only exists because the child wrote it on its
+ * way into the park loop. Two conjuncts, and each catches what the other
+ * cannot — a writer never seen at all (the barrier released without it), and a
+ * writer seen only AFTER the release (the release was reordered ahead of the
+ * handshake). Both have cases; drop either conjunct and one of them reddens.
  *
  * What it deliberately does NOT assert is that the calls overlapped in wall
  * clock. A released child can be descheduled — on a runner with more test
  * processes than cores, for longer than another writer's whole call — so an
  * overlap check fails on a scheduling artifact rather than on a defect.
+ * `startedAt` and `endedAt` are unreachable from here, which is what enforces
+ * that; there is no case pinning it, because a case could only restate the
+ * function's shape.
  */
-export function allReleasedTogether(run: ConcurrentRun): boolean {
-  if (run.outcomes.length === 0) return false;
-  // Per WRITER, not merely as many observations as writers: a run that saw one
-  // writer park twice would otherwise count as a full set.
-  if (run.readyObservedAt.length !== run.outcomes.length) return false;
-  return run.readyObservedAt.every((at) => at !== undefined && at <= run.releasedAt);
+export function barrierReport(run: ConcurrentRun): string {
+  if (run.outcomes.length === 0) return 'no writers ran';
+  // An arity guard on an exported predicate that takes an arbitrary
+  // ConcurrentRun — NOT a claim about a shape this helper can produce. It
+  // cannot: `readyObservedAt` and `outcomes` both derive from `jobs`, and
+  // `sweep` writes slot `i` at most once, so a real run's lengths are always
+  // equal and a double-observation would overwrite rather than lengthen.
+  if (run.readyObservedAt.length !== run.outcomes.length) {
+    return `run is malformed: ${String(run.readyObservedAt.length)} observations for ${String(run.outcomes.length)} writers`;
+  }
+  // Spread first: `every` SKIPS holes, so a sparse `readyObservedAt` would
+  // never visit the missing index and a run with an unobserved writer would
+  // report that the barrier held.
+  const faults = [...run.readyObservedAt].flatMap((at, i) => {
+    const boot = run.outcomes[i]?.bootMs;
+    const took = boot === undefined ? '' : ` (booted in ${String(Math.round(boot))}ms)`;
+    if (at === undefined) return [`writer ${String(i)} never parked${took}`];
+    if (at > run.releasedAt) {
+      return [
+        `writer ${String(i)} was not observed until ${String(Math.round(at - run.releasedAt))}ms after the release${took}`,
+      ];
+    }
+    return [];
+  });
+  return faults.length === 0 ? BARRIER_HELD : faults.join('; ');
 }

--- a/plugins/claude-code/test/onboard-vault-consent.test.ts
+++ b/plugins/claude-code/test/onboard-vault-consent.test.ts
@@ -24,6 +24,33 @@ function readRawSettings(journey: SetupJourney): Record<string, unknown> {
   return JSON.parse(readFileSync(journey.settingsPath, 'utf8')) as Record<string, unknown>;
 }
 
+/**
+ * How far a child's stamp may fall outside the parent's bracket.
+ *
+ * The bracket below reads a timestamp minted by a SPAWNED PROCESS against two
+ * `Date.now()` readings taken here, and two processes ask two independently-
+ * maintained clocks: on Windows those disagree by a few milliseconds routinely,
+ * and an NTP or VM host correction can step one of them further. With zero
+ * slack the assertion fails on that disagreement rather than on a defect —
+ * which is exactly how the settings-race barrier reddened main from a green
+ * tree, and this is the same comparison one file over.
+ *
+ * The property survives the tolerance intact, because what the bracket is
+ * really worth is "the writer stamped this run, not a value it was handed".
+ * The stamps it must reject — the 1999 literal smuggled in below, a hardcoded
+ * date, a field left at the epoch, one carried over from an earlier run — are
+ * all wrong by years, not by seconds.
+ */
+const CLOCK_SKEW_TOLERANCE_MS = 5_000;
+
+/** Whether a child-minted epoch stamp falls in the parent's run window. */
+function stampedDuringRun(stampedMs: number, beforeMs: number, afterMs: number): boolean {
+  return (
+    stampedMs >= beforeMs - CLOCK_SKEW_TOLERANCE_MS &&
+    stampedMs <= afterMs + CLOCK_SKEW_TOLERANCE_MS
+  );
+}
+
 describe('grant — records a writer-stamped VaultConsent', () => {
   let journey: SetupJourney;
   let stdout: string;
@@ -53,8 +80,7 @@ describe('grant — records a writer-stamped VaultConsent', () => {
     expect(acknowledgedAt).toBeDefined();
     const stampedMs = Date.parse(acknowledgedAt ?? '');
     expect(Number.isNaN(stampedMs)).toBe(false);
-    expect(stampedMs).toBeGreaterThanOrEqual(beforeMs);
-    expect(stampedMs).toBeLessThanOrEqual(afterMs);
+    expect(stampedDuringRun(stampedMs, beforeMs, afterMs)).toBe(true);
   });
 
   it('confirms on stdout in plain language', () => {
@@ -124,8 +150,9 @@ describe('grant — the stamp cannot be smuggled in from the caller', () => {
     const persisted = WorkspaceSettings.parse(readRawSettings(journey));
     expect(persisted.vaultConsent?.version).toBe(VAULT_CONSENT_VERSION);
     const stampedMs = Date.parse(persisted.vaultConsent?.acknowledgedAt ?? '');
-    expect(stampedMs).toBeGreaterThanOrEqual(beforeMs);
-    expect(stampedMs).toBeLessThanOrEqual(afterMs);
+    // The 1999 literal above is 27 years outside the window, so the tolerance
+    // costs this assertion nothing: it still fails if the arg is ever honoured.
+    expect(stampedDuringRun(stampedMs, beforeMs, afterMs)).toBe(true);
   });
 });
 

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 import { handleCapture, resolveDataGateway } from '@akasecurity/plugin-runtime';
 import type { FindingView, HealthSummary, PluginConfig } from '@akasecurity/plugin-sdk';
-import { severityFloorPosture } from '@akasecurity/plugin-sdk';
+import { createPluginRuntime, severityFloorPosture } from '@akasecurity/plugin-sdk';
 import type { BuiltinPolicyId, DetectionCategory, DetectionException } from '@akasecurity/schema';
 import { SetupHandoffOffer } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -1242,12 +1242,34 @@ describe('runQuery — against a seeded standalone gateway', () => {
   it('status bar stays stable across surfaces even when /findings truncates its page', async () => {
     // Seed more findings than the /findings page limit (25) so the listed rows
     // are a truncated slice while /health and /recommend read a wider window.
+    // 30 is pinned by that limit, not chosen, so the corpus cannot come down.
+    //
+    // Seeded on ONE store handle rather than through 30 handleCapture calls.
+    // handleCapture resolves a gateway, captures, and closes it again per call,
+    // so the loop's cost is 30 store opens rather than 30 writes — measured at
+    // 140ms against 20ms for the same writes on a single handle. That gap is
+    // paid in the operations Windows is slowest at (file create, fsync, and a
+    // virus scanner reading each new file), which is why this test alone hit the
+    // 20s ceiling on that leg while its one-capture neighbours never came close.
+    // The write path is unchanged: handleCapture is a fail-open wrapper around
+    // exactly this runtime, and the test at the top of this block covers it.
     const cfg = config(dir);
-    for (let i = 0; i < 30; i++) {
-      await handleCapture(
-        { kind: 'prompt', sourceTool: 'claude-code', text: `key ${String(i)} ${SECRET}` },
-        cfg,
-      );
+    const seed = createPluginRuntime(resolveDataGateway(cfg), cfg.settings, {
+      dataDir: cfg.dataDir,
+    });
+    try {
+      for (let i = 0; i < 30; i++) {
+        await seed.capture({
+          kind: 'prompt',
+          sourceTool: 'claude-code',
+          text: `key ${String(i)} ${SECRET}`,
+        });
+      }
+    } finally {
+      // Closes the gateway with it. The queries below then read the store back
+      // through a handle of their own, so the rows have to be on disk and not
+      // merely in the connection that wrote them.
+      await seed.close();
     }
 
     const gateway = resolveDataGateway(cfg);

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -11,6 +11,7 @@ import type { BuiltinPolicyId, DetectionCategory, DetectionException } from '@ak
 import { SetupHandoffOffer } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { readRegisteredCommands } from '../src/command-registry.ts';
 import { NAME, ONE_LINER, TAGLINE } from '../src/identity.ts';
 import { buildIntroCard, buildVerifiedIntroCard, type Manifest } from '../src/intro-card.ts';
@@ -1188,7 +1189,11 @@ describe('runQuery — against a seeded standalone gateway', () => {
     dir = mkdtempSync(join(tmpdir(), 'aka-query-'));
   });
   afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
+    // removeTree, not a bare rmSync: this block leaves a real SQLite store with
+    // its -wal/-shm siblings, and `force` suppresses only ENOENT — not the
+    // sharing violation Windows raises for a file still held open. 37 files in
+    // the repo already take it for exactly this.
+    removeTree(dir);
   });
 
   const SECRET = AWS_EXAMPLE_KEY;
@@ -1241,23 +1246,38 @@ describe('runQuery — against a seeded standalone gateway', () => {
 
   it('status bar stays stable across surfaces even when /findings truncates its page', async () => {
     // Seed more findings than the /findings page limit (25) so the listed rows
-    // are a truncated slice while /health and /recommend read a wider window.
-    // 30 is pinned by that limit, not chosen, so the corpus cannot come down.
+    // are a truncated slice while /health and /recommend read a wider window
+    // (both ask for 500 — see render.ts). Any N in 26..500 pins the truncation;
+    // 30 is comfortably inside that and the corpus stays available as a lever.
     //
     // Seeded on ONE store handle rather than through 30 handleCapture calls.
     // handleCapture resolves a gateway, captures, and closes it again per call,
-    // so the loop's cost is 30 store opens rather than 30 writes — measured at
-    // 140ms against 20ms for the same writes on a single handle. That gap is
-    // paid in the operations Windows is slowest at (file create, fsync, and a
-    // virus scanner reading each new file), which is why this test alone hit the
-    // 20s ceiling on that leg while its one-capture neighbours never came close.
+    // and the gateway constructor is eager — openLocalDatabase plus a whole
+    // recordInventory over the bundled packs — so the loop's cost was 30 store
+    // opens rather than 30 writes. Measured on arm64 macOS at 140ms against
+    // 20ms for the same writes on a single handle.
+    //
+    // Those are the operations Windows is slowest at (file create, fsync, and a
+    // virus scanner reading each new file), which is the leading HYPOTHESIS for
+    // why this test hit the 20s ceiling there. It is not established: no
+    // Windows figure was taken, 140ms to 20s needs a ~140x factor against the
+    // ~30x CLAUDE.md records for this work, and ci.yml already notes that this
+    // leg times out on a different file each run under a starved runner. The
+    // change stands on removing real load from a shared leg either way.
+    //
     // The write path is unchanged: handleCapture is a fail-open wrapper around
     // exactly this runtime, and the test at the top of this block covers it.
     const cfg = config(dir);
-    const seed = createPluginRuntime(resolveDataGateway(cfg), cfg.settings, {
-      dataDir: cfg.dataDir,
-    });
+    // The gateway gets its own binding, taken BEFORE the try, because
+    // resolveDataGateway has already opened the store by the time
+    // createPluginRuntime is called — and createPluginRuntime can throw on its
+    // first call in a process, where it registers the bundled packs. Built as an
+    // argument expression, that throw would leave the handle open with nothing
+    // holding it, and the afterEach removal then meets a live file.
+    const seedGateway = resolveDataGateway(cfg);
+    let seed: ReturnType<typeof createPluginRuntime> | undefined;
     try {
+      seed = createPluginRuntime(seedGateway, cfg.settings, { dataDir: cfg.dataDir });
       for (let i = 0; i < 30; i++) {
         await seed.capture({
           kind: 'prompt',
@@ -1266,32 +1286,38 @@ describe('runQuery — against a seeded standalone gateway', () => {
         });
       }
     } finally {
-      // Closes the gateway with it. The queries below then read the store back
-      // through a handle of their own, so the rows have to be on disk and not
-      // merely in the connection that wrote them.
-      await seed.close();
+      // runtime.close() closes the gateway with it, so close the gateway
+      // directly only when there is no runtime to do it. The queries below then
+      // read the store back through a handle of their own, so the rows have to
+      // be on disk and not merely in the connection that wrote them.
+      if (seed === undefined) await seedGateway.close();
+      else await seed.close();
     }
 
     const gateway = resolveDataGateway(cfg);
     try {
-      const footer = (surface: string): string => {
+      // Takes the surface's NAME as well as its text: three call sites feed this
+      // now, and `surface` holds rendered output rather than anything that
+      // identifies it, so an unnamed throw cannot say which one lost its status
+      // bar.
+      const footer = (name: string, surface: string): string => {
         const line = strip(surface)
           .split('\n')
           .find((l) => l.includes('open findings'));
-        if (line === undefined) throw new Error('no status bar on surface');
+        if (line === undefined) throw new Error(`no status bar on /${name}`);
         return line;
       };
 
       const findings = strip(await runQuery('findings', gateway));
       // The page is capped at 25 rows, but the footer reports the whole store.
       expect(findings).toContain('Recent findings (25)');
-      const findingsFooter = footer(findings);
+      const findingsFooter = footer('findings', findings);
       expect(findingsFooter).toContain('⚑ 30 open findings');
 
       // Same footer on /health and /recommend — derived from the summary, not the
       // page — so the count no longer drifts with each command's row limit.
-      expect(footer(await runQuery('health', gateway))).toBe(findingsFooter);
-      expect(footer(await runQuery('recommend', gateway))).toBe(findingsFooter);
+      expect(footer('health', await runQuery('health', gateway))).toBe(findingsFooter);
+      expect(footer('recommend', await runQuery('recommend', gateway))).toBe(findingsFooter);
     } finally {
       await gateway.close();
     }


### PR DESCRIPTION
## Summary

Two Windows-only test flakes that reddened `main` on 2026-08-13 (runs #262, #266, #267). Both are test defects — no product code changes. Reruns of those jobs were green, which is the symptom, not the fix.

**1. The writer barrier was decided by comparing two different clocks.**
`allReleasedTogether` compared the child's `readyAt` against the parent's `releasedAt` — two processes each calling `Date.now()`, i.e. two independently-maintained clocks, which on Windows disagree by a few milliseconds routinely. The causal order was never in doubt (a child stamps `readyAt` *before* writing the ready file the parent waits on), so a failing run was one where the clocks disagreed, not one where the barrier did.

`waitForAllReady` now reports `readyObservedAt` — the **parent's own** clock, stamped per writer on the first poll pass that finds each ready file — and the check requires one observation per outcome, all at or before the release. Both stamps now come off the clock that ordered them.

The file is the evidence rather than the timestamp, and it covers the whole property: a ready file exists only because the child wrote it on its way into the park loop. Delete the handshake and there are no observations; break it to wait for only the first writer, or to return early on a child that died, and the gaps are what the check reads.

**2. The status-bar render test was 86% store-opening.**
It seeded 30 findings through 30 `handleCapture` calls, and `handleCapture` resolves a gateway and closes it *per call* — so the loop cost 30 store opens, not 30 writes. Measured locally:

| Seeding shape | Cost |
|---|---|
| 30 × `handleCapture` | 140 ms |
| one gateway + runtime, 30 × `capture` | 20 ms |

That gap is paid in the operations Windows is slowest at (file create, fsync, a virus scanner reading each new file), which is why this test alone hit the 20s ceiling there while its one-capture neighbours never came close.

The corpus is **not** the lever here: 30 is pinned by the product's `/findings` page limit of 25 — the truncation the test exists to check — so the usual "cut the corpus rather than raise the ceiling" does not apply. Removing the per-call open is what was available.

No `retry` was added to either.

## Changes

| File | Change |
|------|--------|
| `packages/persistence/test/helpers/settings-writers.ts` | `waitForAllReady` returns per-writer parent-clock observations; `ConcurrentRun.readyObservedAt` added; `allReleasedTogether` reads those instead of the child's `readyAt`, which stays as a documented boot-time diagnostic |
| `packages/persistence/test/helpers/settings-writers.test.ts` | `run()` fixture takes `{observedAt?, readyAt?}` per writer; three new cases — released-without-observing-everyone, a short observation set, and the Windows regression (child `readyAt` *after* `releasedAt` must still read true) |
| `plugins/claude-code/test/render.test.ts` | Status-bar test seeds on one runtime, then closes it and reopens a fresh gateway for the queries |

## Verification

Mutation-tested the new barrier check — flipping `every()` to `some()` in `waitForAllReady` (release as soon as the first writer parks) reddens the `settings-race` assertions, so it is not vacuous:

```
× keeps every writer's answer when all of them write at once
× does not resurrect a consent that a concurrent writer revoked
   80|  expect(allReleasedTogether(run)).toBe(true);
```

- [x] `pnpm format:check` passes (changed files)
- [x] `pnpm lint` passes (20 tasks)
- [x] `pnpm typecheck` passes
- [x] `@akasecurity/persistence` — 1147 passed, 3 skipped
- [x] `@akasecurity/ai-tc-claude-code` — 1020 passed, 4 skipped
- [x] PR title follows Conventional Commits

**Caveat:** verified on arm64 macOS; neither fix could be reproduced or confirmed on Windows locally. The clock fix removes the cross-process comparison outright, so it cannot fail that way on any platform. The render fix removes 29 of 30 store opens, which sharply reduces the exposure but is not a hard bound — the Windows leg on this PR is what confirms it.

### Detection-rule changes only (`rules/`)

n/a — no rule changes.
