### PR TITLE
refactor(eslint-config): state the dependency wall in capability terms (H1)

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -331,33 +331,36 @@ export const base = [
   prettier,
 ];
 
-// OSS/enterprise dependency wall (see CLAUDE.md "Package dependency rules"):
-// packages that ship in the public oss/ tree must never import enterprise-only
-// modules — @akasecurity/client (the tenant-aware HTTP client), drizzle-orm and
-// @akasecurity/schema-enterprise (the Postgres/tenancy layer). Apply this to
-// every OSS package except the plugin, which is the documented exception
-// allowed to use @akasecurity/client to sync to a backend when attached.
-const ENTERPRISE_IMPORT_MESSAGE =
-  'OSS packages must never import enterprise-only modules (this keeps tenancy/auth/Postgres code out of the public oss/ tree). See CLAUDE.md "Package dependency rules".';
+// The store-reading dependency wall (see CLAUDE.md "Package dependency rules").
+//
+// A package that reads the local SQLite store reaches it through
+// @akasecurity/persistence and nothing else: no HTTP client, no server-side
+// ORM. The specifiers below are the names those two capabilities have in this
+// workspace; a new HTTP client or ORM belongs in the same list.
+//
+// Opt in per package, from the package's own eslint config. A package this
+// does not describe simply does not apply it — there is no exemption list.
+const STORE_READER_IMPORT_MESSAGE =
+  'A package that reads the local SQLite store must not depend on an HTTP client or a server-side ORM — reach the store through @akasecurity/persistence. See CLAUDE.md "Package dependency rules".';
 
-// This carries the network import bans forward alongside the enterprise ones.
+// This carries the network import bans forward alongside the wall's own.
 // `no-restricted-imports` does not merge across flat-config entries, and this is
-// layered on top of `base` in the packages that use it, so declaring the
-// enterprise restrictions on their own would silently drop base's network bans
-// for exactly those packages.
+// layered on top of `base` in the packages that use it, so declaring the wall's
+// restrictions on their own would silently drop base's network bans for exactly
+// those packages.
 /** @type {import('typescript-eslint').ConfigArray} */
 export const noEnterpriseImports = [
   {
     rules: {
       'no-restricted-imports': noNetworkImports({
         paths: [
-          { name: '@akasecurity/client', message: ENTERPRISE_IMPORT_MESSAGE },
-          { name: 'drizzle-orm', message: ENTERPRISE_IMPORT_MESSAGE },
-          { name: '@akasecurity/schema-enterprise', message: ENTERPRISE_IMPORT_MESSAGE },
+          { name: '@akasecurity/client', message: STORE_READER_IMPORT_MESSAGE },
+          { name: 'drizzle-orm', message: STORE_READER_IMPORT_MESSAGE },
+          { name: '@akasecurity/schema-enterprise', message: STORE_READER_IMPORT_MESSAGE },
         ],
         patterns: [
-          { group: ['drizzle-orm/*'], message: ENTERPRISE_IMPORT_MESSAGE },
-          { group: ['@akasecurity/schema-enterprise/*'], message: ENTERPRISE_IMPORT_MESSAGE },
+          { group: ['drizzle-orm/*'], message: STORE_READER_IMPORT_MESSAGE },
+          { group: ['@akasecurity/schema-enterprise/*'], message: STORE_READER_IMPORT_MESSAGE },
         ],
       }),
     },

--- a/packages/eslint-config/test/no-network.test.js
+++ b/packages/eslint-config/test/no-network.test.js
@@ -337,7 +337,7 @@ describe('networkGuard (the scripts/ pass)', () => {
 });
 
 describe('noEnterpriseImports merge', () => {
-  // The enterprise config is layered on top of `base` in some packages. Flat
+  // The wall config is layered on top of `base` in some packages. Flat
   // config does not merge two no-restricted-imports entries, so this config must
   // carry the network bans forward or those packages would silently lose them.
   const entry = noEnterpriseImports.find((c) => c.rules?.['no-restricted-imports']);
@@ -355,18 +355,39 @@ describe('noEnterpriseImports merge', () => {
     expect(messages[0].ruleId).toBe('no-restricted-imports');
   });
 
-  it('also bans the enterprise HTTP client', () => {
+  it('also bans the HTTP client, with the wall message rather than the network one', () => {
     const messages = lintWithRules("import c from '@akasecurity/client';", {
       'no-restricted-imports': ruleValue,
     });
     expect(messages).toHaveLength(1);
-    expect(messages[0].message).toContain('enterprise-only');
+    // 'server-side ORM' appears only in the wall's message, so this asserts the
+    // ban that fired was the wall's and not base's network ban, which also
+    // covers some of these specifiers.
+    expect(messages[0].message).toContain('server-side ORM');
   });
 
-  it('keeps BOTH pattern groups (network subpaths + enterprise) after the merge', () => {
+  // H1: the wall's message is public-facing text in a public repo. It states a
+  // capability boundary ("no HTTP client, no server-side ORM") and must not
+  // describe the private layer it happens to exclude, or name an unshipped
+  // feature. Asserting on the emitted message rather than on the source keeps
+  // this honest: whatever a future edit writes, this is what a contributor
+  // actually reads.
+  it('states the boundary as a capability and leaks no private-layer detail', () => {
+    const messages = lintWithRules("import c from '@akasecurity/client';", {
+      'no-restricted-imports': ruleValue,
+    });
+    const message = messages[0].message;
+    expect(message).toContain('HTTP client');
+    expect(message).toContain('server-side ORM');
+    for (const leak of ['tenancy', 'Postgres', 'attached', 'enterprise-only', 'multi-tenant']) {
+      expect(message.toLowerCase()).not.toContain(leak.toLowerCase());
+    }
+  });
+
+  it('keeps BOTH pattern groups (network subpaths + wall) after the merge', () => {
     // The network `<client>/*` groups are prepended to noEnterpriseImports' own
     // `patterns` (drizzle-orm/*, schema-enterprise/*). A regressed merge that
-    // declared only enterprise patterns would drop the network subpath ban.
+    // declared only the wall's patterns would drop the network subpath ban.
     const deep = lintWithRules("import x from 'axios/lib/adapters/http.js';", {
       'no-restricted-imports': ruleValue,
     });


### PR DESCRIPTION
## What

The `noEnterpriseImports` rule's prose is public text in a public repo, and it described the systems on the other side of the boundary rather than the boundary itself. This rewrites the comment and the lint message in capability terms. **The rule's behaviour does not change** — the same three specifiers stay banned, with the same `paths`/`patterns` shape.

## Why

Four problems. Described rather than quoted, deliberately: a PR body and a commit message are permanent public text, and reproducing the removed sentences would defeat removing them.

1. Both banned packages carried a parenthetical gloss naming what each one *is* — describing an architecture this repository does not contain.
2. The lint message explained what the ban keeps out, in those same terms, and located this repository as a subdirectory of a larger one. From inside here, that parent path does not exist.
3. The comment **named an unreleased feature** and granted one package an exception for it. Grepping the whole tree, that clause was the *only* mention of that feature anywhere here.
4. It wasn't even true of this tree. No `package.json` here depends on the package it named, and `CLAUDE.md`'s dependency graph shows no such edge. It documented an arrangement a reader of this repository cannot observe.

## The replacement

States what a contributor can act on: a package that reads the local SQLite store reaches it through `@akasecurity/persistence` and nothing else — no HTTP client, no server-side ORM.

That framing is also the more useful one. "Does this package speak HTTP or SQL?" is answerable from the file in front of you; the question the old prose posed is not, and a rule you cannot evaluate locally decays into a list someone forgets to extend. It matches the wording `CLAUDE.md`'s own "Package dependency rules" section already uses.

## Deliberately unchanged

- **The three banned specifiers.** They are the mechanism; renaming them would disable the rule.
- **The exported symbol's name.** Renaming it touches three package configs and two test files here, and strands a comment in a downstream consumer that refers to it by name — blast radius out of proportion to a symbol no published artifact exposes. Worth its own pass.

## Tests

One assertion keyed on a token from the old message, so it moves to a token from the new one. It deliberately does **not** key on `'local-first'` — four other assertions use that against the network message, and sharing it would let this one pass on the wrong rule's message, the exact confusion the neighbouring test exists to catch.

Added a guard asserting the **emitted** message states the capability and carries no term naming another system or an unshipped feature. Asserting on the emitted message rather than the source keeps it honest: whatever a future edit writes, that is what a contributor actually reads. Verified it bites — reintroducing such a term fails it.

## Verification

- `@akasecurity/eslint-config`: **1084/1084**
- `persistence` + `local-ops` + `web-ui` lint (the packages that opt in): clean
- Prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
