### PR TITLE
perf(persistence): bound the three /security reads that grew with the store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1107,14 +1107,17 @@ scaling one. They catch different defects; neither substitutes for the other.
 The numbers, measured on arm64 macOS / Node 24 against corpora from
 `src/test-fixtures/generate.ts`:
 
-| Property                                  | Measured                           | Gate                    |
-| ----------------------------------------- | ---------------------------------- | ----------------------- |
-| Store growth, 5k → 10k                    | **797.9 B/event** marginal         | ±15% band ✅            |
-| `recordCapture` 2k → 20k                  | ratio **1.02** (fastest of 200)    | ratio < 3 ✅            |
-| `openLocalDatabase` 2k → 20k              | ratio **0.99** (fastest of 20)     | ratio < 3 ✅            |
-| `recordCapture` at 1M rows                | 0.076 ms median, 0.116 p95 (n=200) | backstop ≤ 1,000 ms ✅  |
-| `openLocalDatabase` at 1M rows            | 0.55 ms median, 0.72 p95 (n=20)    | backstop ≤ 1,000 ms ✅  |
-| `/security` (8 aggregations) at 1M events | **5,945 ms** median of 5           | ungated (misses 2 s) ❌ |
+| Property                                    | Measured                           | Gate                   |
+| ------------------------------------------- | ---------------------------------- | ---------------------- |
+| Store growth, 5k → 10k                      | **902.8 B/event** marginal         | ±15% band ✅           |
+| `recordCapture` 2k → 20k                    | ratio **1.02** (fastest of 200)    | ratio < 3 ✅           |
+| `openLocalDatabase` 2k → 20k                | ratio **0.99** (fastest of 20)     | ratio < 3 ✅           |
+| `recordCapture` at 1M rows                  | 0.076 ms median, 0.116 p95 (n=200) | backstop ≤ 1,000 ms ✅ |
+| `openLocalDatabase` at 1M rows              | 0.55 ms median, 0.72 p95 (n=20)    | backstop ≤ 1,000 ms ✅ |
+| `/security` (8 aggregations) at 50k events  | **159 ms** (was 11,197)            | 3 flatness ratios ✅   |
+| `/security` (8 aggregations) at 150k events | **350 ms** (was 125,987)           | 3 flatness ratios ✅   |
+| `/security` (8 aggregations) at 300k events | **729 ms**                         | 3 flatness ratios ✅   |
+| `/security` at 1M events                    | **~2.5–3 s** extrapolated          | ungated, unmeasured ❌ |
 
 **Both pairs came down from a decade higher, and the reason is worth carrying.** They
 were 5k → 50k and 10k → 20k, and at those sizes the two files were the largest single
@@ -1124,9 +1127,17 @@ macOS CI run that passed and 135 s on one that did not, against a 120 s hook cei
 each case is a RATIO or a SLOPE, and neither needs a particular absolute size, so the
 corpus came down rather than the ceiling going up. The prices are stated where they are
 paid: the ratio's sensitivity floor moved by 2.5x (below), and the growth band's centre
-had to be retaken, because the marginal creeps with size — 791.3 B/event across 2.5k→5k,
-797.9 across 5k→10k, 818.4 across 10k→20k, all measured, all byte-identical run to run.
+had to be retaken, because the marginal creeps with size — 902.8 B/event across 2.5k→5k,
+902.8 across 5k→10k, 923.2 across 10k→20k, all measured, all byte-identical run to run.
 **Do not carry a centre across a size change**; a stale one still reads green.
+
+**Nor across a CORPUS change, which is the harder one to remember because the test's own
+size did not move.** That centre was 797.9 until the generator's finding rate went from
+0.1 to a measured 0.33: three times the finding rows per event took the marginal to 902.8,
+which the old band's 917.6 ceiling **passed, by 1.6%**. So a 13% growth regression went
+undetected and the band was left one unrelated commit away from failing for no reason — at
+which point widening it is the obvious-looking fix. Re-take the centre whenever anything
+about the corpus moves, not only its event count.
 
 **A ratio gate has a sensitivity floor, and it is worth knowing before trusting one.**
 The quotient is `(base + 10k) / (base + k)`, so clearing a ceiling of 3 needs the
@@ -1139,23 +1150,75 @@ fails. So a ratio gate catches a linear cost that changes what the operation cos
 one inside its noise floor — and the floor is proportional to the SMALL size, so cutting
 the pair by 2.5x raised it by 2.5x.
 
-**`/security` misses its budget, and it is not a missing index.**
+**Three of `/security`'s eight reads are BOUNDED, and a plan test cannot tell you that.**
 `hot-read-query-plans.test.ts` drives every read the `/security`, `/activity` and
 `/vault` pages issue and confirms each one runs indexed. That capture runs at 3k and
 nothing re-captures the plans above it: the store carries no `ANALYZE` statistics, so
 SQLite plans from the schema rather than from row counts and the plans are EXPECTED to
-hold at 1M — reasoning, not a second measurement, and worth wording that way. The
-cost is that FOUR of the eight never shrink with the window at all: `severitySummary`,
-`recentFindings` and `recentlyResolved` take no range argument, and `mttrTrend` takes one
-whose `EXISTS` prefilter bounds the RESULT rather than the scan (measured at 1,523 ms
-returning zero rows). All four are linear in total FINDINGS, not events. And the page's
-`Promise.all` buys nothing: every repository method here runs its SQL **synchronously**
-and returns an already-resolved promise, so the page costs the SUM of the eight.
+hold at 1M — reasoning, not a second measurement, and worth wording that way.
 
-Linear past 100k at 6.19 ms per thousand events (373 ms at 100k, 5,945 ms at 1M, both
-measured), so the budget is crossed near **363k events** (~300 MB). Fixing it means
-bounding what the page reads — retention, pre-aggregation or a cap — which is a product
-decision, not tuning.
+An indexed plan is not a bound, in either direction, and this page is where both halves of
+that were learned. `mttrTrend` ran every step of its plan as a SEARCH while driving from
+`audit_events` and joining every capture event before its window predicate could reject a
+row. `recentFindings` now deliberately SCANS `idx_audit_started_at` so its `LIMIT` can stop
+early, and EXPLAIN QUERY PLAN has no text for "terminates after 500 rows". So the plans pin
+the mechanism and `security-page-scale.test.ts` pins the consequence, as a ratio across a
+10x store step with `severitySummary` as the growth control. Neither implies the other.
+
+`recentFindings`, `recentlyResolved` and `mttrTrend` are the three now flat in store size —
+ratios **1.10**, **1.26** and **1.32** over 2k → 20k, against a ceiling of 3 and a control
+reading 18.30. What each needed differs, and none of it was tuning:
+
+- **`recentlyResolved` was QUADRATIC**, O(code_change events x resolved keys), because the
+  join key was unreachable: `f` was reached FROM `latest`, so `latest` got probed on
+  (rn, status, method) and the plan enumerated every pair before `f` could reject it. 10,966
+  ms at 50k events and 125,322 ms at 150k — 3x the store for 11.4x the cost — returning 20
+  rows. It read 8 ms to everyone who measured it before, because an EMPTY
+  `finding_resolution` collapses the cross product to nothing.
+- **`mttrTrend`'s `EXISTS` bounded the RESULT, not the scan.** Fixed by driving from
+  `finding_resolution` over a `resolved_at` range. Migration **0021**'s index on that column
+  is NOT what buys the flatness — remove it and the ratio does not move, because the
+  latest-resolution derived table already passes over the whole table, so the read is
+  O(resolutions) either way and resolutions are not the store. What it buys is the criterion
+  the plan test hard-fails on: without it the driving step is a bare `SCAN fr`. Two guards,
+  two different defects, and neither catches the other's.
+- **`recentFindings` could not push its LIMIT down**, since the sort key sat on the joined
+  table. Fixed with `+e.event_type` (making `idx_audit_type_t` unattractive, so
+  `idx_audit_started_at` yields `started_at` order directly) plus `CROSS JOIN`.
+
+**`CROSS JOIN` is load-bearing in all three and must not be tidied into `JOIN`.** In SQLite
+it is semantically identical and exists only to stop the tables being reordered; with no
+`ANALYZE` statistics the planner prices `event_type IN (...)` as a selective probe and puts
+`audit_events` back on the outside. On `recentFindings` the unary plus ALONE recovers almost
+none of the win — 23.6 ms against 0.9 ms with both, from 35.0 ms.
+
+The page's `Promise.all` still buys nothing: every repository method here runs its SQL
+**synchronously** and returns an already-resolved promise, so the page costs the SUM of the
+eight.
+
+**What remains is `severitySummary`, the budget is still missed at 1M, and closing it is a
+product decision.** Measured at three points — 159 ms at 50k, 350 ms at 150k, 729 ms at 300k
+— and the page is mildly SUPERLINEAR rather than linear, which is the part a two-point
+reading gets wrong. `severitySummary` carries that: 46.6 → 177.7 → 472.2 ms, i.e. 0.93 →
+1.19 → 1.57 us per event, a cost per event rising ~1.33x per doubling (an all-time `GROUP BY`
+whose temp B-tree and working set both grow with it). Everything else is flat or
+window-bounded, so it goes from 29% of the page at 50k to 65% at 300k.
+
+Carrying that factor from 300k to 1M puts `severitySummary` near **2.6 s** and the page at
+**~2.5–3 s** — still OVER the 2,000 ms budget, with that one read accounting for ~85% of it.
+Read the RANGE as the finding, not either endpoint: it is an extrapolation over 1.7 doublings
+from three points whose slope is itself moving.
+
+**Nothing here measures 1M, and the reason is the corpus rather than the reads.** Seeding is
+badly superlinear — 142 s at 150k against 733 s at 300k, **5.2x for 2x the events** — so a 1M
+corpus is tens of minutes and belongs in neither a test nor a session. Do not size a change
+against a 1M figure from this section without taking it.
+
+So the engineering half is done and the arithmetic says it is not sufficient. Bounding
+`severitySummary` means a maintained rollup (exact, but invalidated from the resolution path
+as well as the capture path, plus a backfill for existing stores), windowing the card (cheap,
+changes what the number means from "ever" to "the last 30 days"), or retention on the corpus
+itself. All three are product calls, not tuning.
 
 **Two tables have a retention policy; six do not.**
 `BLOCKED_DETECTIONS_RETENTION_MS` (24 h) sweeps `blocked_detections`, and

--- a/packages/persistence/bench/queries.bench.ts
+++ b/packages/persistence/bench/queries.bench.ts
@@ -1,6 +1,5 @@
 /**
- * The dashboard's read surface at a stated store size — and the one budget in
- * this package that is currently missed.
+ * The dashboard's read surface at a stated store size.
  *
  * `/security` renders eight aggregations. The page awaits them in a single
  * `Promise.all`, which reads like eight concurrent queries and is not: every
@@ -11,46 +10,59 @@
  *
  * | store size | `/security` (8 aggregations) | verdict vs the 2,000 ms budget |
  * | ---------- | ---------------------------: | ------------------------------ |
- * | 100k       |            373 ms † (median) | inside                         |
- * | 200k       |                       963 ms | inside                         |
- * | 300k       |                     1,515 ms | inside                         |
- * | 500k       |                     2,964 ms | **over**                       |
- * | 1M         |          5,945 ms † (median) | **3.0× over**                  |
+ * | 50k        |                       159 ms | inside                         |
+ * | 150k       |                       350 ms | inside                         |
+ * | 300k       |                       729 ms | inside                         |
+ * | 1M         |    ~2.5-3 s (extrapolated)   | **over**                       |
  *
- * † re-measured since, median of 5 (100k samples 356/357/373/390/392; 1M samples
- * 5905/5915/5945/7399/7418). The three middle rows are from the original sweep
- * and have not been re-taken — a `/security` figure is a wall clock, so treat
- * any single one as ±20% and the SHAPE as the finding.
+ * The 1M row is NOT a measurement, and it is not a straight-line one either: the
+ * page is mildly superlinear, so a two-point slope reads ~2.0 s and a fit over
+ * all three reads 2.5-3 s. `severitySummary` is what bends it — 46.6 / 177.7 /
+ * 472.2 ms, i.e. 0.93 / 1.19 / 1.57 us per event, a per-event cost rising ~1.33x
+ * per doubling — and at 1M it is ~85% of the page on its own. Take the range as
+ * the finding rather than either end.
  *
- * Growth is linear past 100k at 6.19 ms per additional thousand events (the slope
- * through the two re-measured endpoints), so the budget is crossed near 362,800
- * events — about 300 MB of store, well inside
- * what a year of daily use produces. Five of the eight are over a second each at
- * 1M (`enforcementActions` 2,079 ms, `findingsTimeseries` 1,227 ms,
- * `severitySummary` 1,191 ms, `mttrTrend` 1,164 ms, `recentFindings` 1,160 ms;
- * `topSources` 414 ms and `recentlyResolved` 8 ms are the cheap two), so no
- * single query is the culprit and no single index fixes it.
+ * Nothing here reaches 1M because SEEDING does not scale: 142 s at 150k against
+ * 733 s at 300k, 5.2x for 2x the events. A 1M corpus is tens of minutes, which is
+ * why this file's largest measured point is 300k and why the row above is a fit.
  *
- * It is not a missing index either: `test/performance/hot-read-query-plans.test.ts`
- * confirms every one of these runs indexed. That check runs at 3k, and nothing
- * re-captures the plans above it — SQLite has no `ANALYZE` statistics on this
- * store, so it plans from the schema rather than from row counts and the plans
- * are EXPECTED to be the same at 1M. The cost is
- * that four of them do not shrink with the window at all — `severitySummary`,
- * `recentFindings` and `recentlyResolved` take no range, and `mttrTrend`'s
- * `EXISTS` prefilter bounds the RESULT rather than the scan — while the rest of
- * the cost is that the windowed ones are bounded by a WINDOW rather than a limit, and the
- * corpus is dense enough that a 30-day window at 1M events still contains most
- * of the store. Fixing it means bounding what the page reads — a product
- * decision (retention, pre-aggregation, or a cap), not a tuning one.
+ * ## The figures this table replaced, and why they were wrong in BOTH directions
+ *
+ * The earlier sweep read 5,945 ms at 1M and 373 ms at 100k, crossing the budget
+ * near 363k events. Those numbers were taken correctly and described the wrong
+ * store, on two counts that pulled opposite ways:
+ *
+ *  - **Too pessimistic on density.** `spacingMs` was 1 s, so a million events
+ *    spanned 11.6 days and a 30-day window held the WHOLE corpus — every windowed
+ *    read cost what an unwindowed one does. No install does that.
+ *  - **Far too optimistic on `recentlyResolved`**, which it recorded at 8 ms and
+ *    called one of "the cheap two". The corpus wrote no `finding_resolution` rows
+ *    at all, so that read was measured on an empty table. Seed resolutions and it
+ *    is 10,966 ms at 50k events and 125,322 ms at 150k — QUADRATIC, since the plan
+ *    enumerated every (code_change event x resolved key) pair. The page took 126
+ *    SECONDS at 150k, not 5.9 s at 1M.
+ *
+ * Both are fixed: the generator now seeds resolutions and finding keys, and its
+ * finding rate is a measured 0.33 rather than 0.1. `recentlyResolved`, `mttrTrend`
+ * and `recentFindings` were rewritten to drive from the bounded side of their
+ * joins, and `test/performance/security-page-scale.test.ts` pins all three as
+ * ratios so a regression is a red test rather than a number in this comment.
+ *
+ * What remains is `severitySummary` — 65% of the page at 300k (472.2 ms of 729) and
+ * ~85% of it by 1M, an all-time `GROUP BY` over every finding whose cost IS its
+ * semantics. It is also why the budget is still missed at 1M after everything
+ * above: bounding it is a product decision (a maintained rollup, windowing the
+ * card, or retention on the corpus itself), not a tuning one.
  *
  * WHY THE CLOCK IS PINNED, and why it is the difference between a real number
  * and a comfortable one. Six of the eight filter on a window ending "now", and
  * the generator stamps its events from a fixed 2024 epoch so the corpus is
  * identical on every machine. Left on the wall clock the window sits years past
- * every row, six of the eight match NOTHING, and the same 1M store reports
- * 3,831 ms — inside half the real cost, from a run that looks perfectly valid.
- * A benchmark whose input is empty is the failure mode to watch for here.
+ * every row, six of the eight match NOTHING, and the same 1M store reported
+ * 3,831 ms — inside half the cost measured then, from a run that looks perfectly
+ * valid. A benchmark whose input is empty is the failure mode to watch for here,
+ * and the retracted `recentlyResolved` figure above is the same mistake reached by
+ * a different route: not an empty window, but an empty TABLE.
  *
  * NO ASSERTIONS: nothing in this repository gates a PR on wall-clock. The
  * measurement above is a finding, recorded here so it is re-taken rather than

--- a/packages/persistence/bench/queries.bench.ts
+++ b/packages/persistence/bench/queries.bench.ts
@@ -42,8 +42,17 @@
  *    enumerated every (code_change event x resolved key) pair. The page took 126
  *    SECONDS at 150k, not 5.9 s at 1M.
  *
- * Both are fixed: the generator now seeds resolutions and finding keys, and its
- * finding rate is a measured 0.33 rather than 0.1. `recentlyResolved`, `mttrTrend`
+ * Both are fixed HERE, in this file's own fixture, and that is worth stating as a
+ * property of the CALL rather than of the generator. The generator gaining
+ * `resolutionRate` and `spacingMs` changes nothing for a caller that never turns
+ * them on: `DEFAULT_RESOLUTION_RATE` is 0 and `spacingMs` defaults to one second,
+ * so the fixture below passes both explicitly. An earlier revision of this header
+ * claimed the fix while the call beneath it still took the defaults, which
+ * reproduced the retracted numbers under a comment disowning them — the same
+ * empty-table measurement, one level up. (Finding KEYS are the exception and need
+ * no argument: the generator mints those unconditionally for a `code_change`
+ * capture.) Its finding rate is a measured 0.33 rather than 0.1, which IS a
+ * default and so arrives without being asked for. `recentlyResolved`, `mttrTrend`
  * and `recentFindings` were rewritten to drive from the bounded side of their
  * joins, and `test/performance/security-page-scale.test.ts` pins all three as
  * ratios so a regression is a red test rather than a number in this comment.
@@ -103,6 +112,24 @@ interface Surfaces {
   readonly now: number;
 }
 
+/**
+ * Milliseconds between consecutive events — the real figure, not the
+ * generator's default. See the note at the `seedCaptureCorpus` call.
+ */
+const REAL_SPACING_MS = 74_528;
+
+/**
+ * Fraction of TRACKABLE findings carrying a resolution row.
+ *
+ * Deliberately NOT the generator's measured default, which is 0 — that zero is
+ * honest about a real install (nothing writes `finding_resolution` until a user
+ * runs the at-rest remediation flow) and is exactly the wrong input for a
+ * benchmark, since it makes three of the eight reads free. A benchmark wants the
+ * join to cost something; 0.5 is chosen for that, and is a stated assumption
+ * rather than a measurement.
+ */
+const BENCH_RESOLUTION_RATE = 0.5;
+
 const fixtures = new Map<number, Surfaces>();
 
 function fixtureFor(events: number): Surfaces {
@@ -111,7 +138,25 @@ function fixtureFor(events: number): Surfaces {
 
   const store = createTempStore(`aka-bench-queries-${String(events)}-`);
   const db = store.open();
-  const corpus = seedCaptureCorpus(db, { events, sessions: 200, seed: 1 });
+  const corpus = seedCaptureCorpus(db, {
+    events,
+    sessions: 200,
+    seed: 1,
+    // Both of these are the difference between measuring this page and measuring
+    // its cheapest path, and neither has a default that would do.
+    //
+    // `spacingMs` is DENSITY. At the 1 s default even a million events span 11.6
+    // days, so a 30-day window contains the whole store and the four windowed
+    // reads cost exactly what unwindowed ones do. 74,528 ms is the real figure,
+    // read off a live store: 16,390 capture events over 14.1 days.
+    spacingMs: REAL_SPACING_MS,
+    // `resolutionRate` is the one that produced the retracted number above.
+    // `finding_resolution` is EMPTY by default, and empty is the cheapest path
+    // through the three reads that join it — `recentlyResolved` measured 8 ms
+    // that way and 10,966 ms once rows existed. A benchmark that leaves this at
+    // the default is timing an absence.
+    resolutionRate: BENCH_RESOLUTION_RATE,
+  });
   const raw = corpusConnection(db);
 
   // The corpus's own end, not the wall clock, and read off the corpus rather

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -253,6 +253,42 @@ export class SqliteFindingsRepository
 {
   constructor(private readonly db: DatabaseSync) {}
 
+  /**
+   * The newest `limit` findings, newest first.
+   *
+   * THE PLAN IS THE POINT HERE, and two things in the SQL below exist only to
+   * pin it. The natural spelling — drive from `inspection_findings`, order by the
+   * JOINED `e.started_at` — cannot push the LIMIT down, because the sort key is
+   * not on the driving table: SQLite sorts every finding in the store through a
+   * temp B-tree to return 500 rows. Measured at 35.0 ms on a 40,000-event corpus
+   * against 0.9 ms for the form below, and the gap is a ratio of the store size
+   * rather than a constant.
+   *
+   * What it takes to make `started_at` order come out of an index instead:
+   *
+   *  - **`+e.event_type`** — the unary plus makes that term non-indexable, so the
+   *    planner stops choosing `idx_audit_type_t` (`event_type, started_at`). That
+   *    index cannot serve the ORDER BY: the predicate spans four event types, so
+   *    satisfying a global `started_at` order across them needs a range merge
+   *    SQLite will not do, and it sorts instead. Freed of it, the planner scans
+   *    `idx_audit_started_at` — a bare `started_at` index — in DESC order and
+   *    filters the type per row, which lets the LIMIT stop the scan early.
+   *  - **`CROSS JOIN`** — semantically identical to JOIN in SQLite, and there
+   *    purely to stop the tables being reordered. With plain JOINs the planner
+   *    drives from `f` and sorts everything again: measured at 23.6 ms, i.e. the
+   *    unary plus ALONE recovers almost none of the win. Both are needed.
+   *
+   * Neither is a micro-optimisation that a later reader should tidy away, and
+   * `packages/persistence/test/performance/hot-read-query-plans.test.ts` fails if
+   * the temp B-tree comes back.
+   *
+   * Degrading gracefully was the reason for `+` over `INDEXED BY`, which measured
+   * identically (0.9 ms): `INDEXED BY` is a hard requirement, so dropping or
+   * renaming the index turns this read into an ERROR, where `+` turns it into a
+   * scan-and-sort — slower, still correct. The worst case for the chosen form is
+   * a store whose recent captures carry no findings at all, where the scan walks
+   * the whole index; that is still no worse than the full sort it replaced.
+   */
   recentFindings(opts?: { limit?: number }): Promise<FindingView[]> {
     const limit = opts?.limit ?? 50;
     const rows = allRows<FindingRowJoined>(
@@ -261,10 +297,10 @@ export class SqliteFindingsRepository
                 f.masked_match, f.action_taken, f.confidence, e.started_at AS occurred_at,
                 json_extract(e.attributes, '$.source_tool') AS source_tool,
                 e.event_type AS kind
-         FROM inspection_findings f
-         JOIN audit_events e ON e.id = f.audit_event_id
-         JOIN inspection_definitions d ON d.id = f.inspection_definition_id
-         WHERE e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})
+         FROM audit_events e
+         CROSS JOIN inspection_findings f ON f.audit_event_id = e.id
+         CROSS JOIN inspection_definitions d ON d.id = f.inspection_definition_id
+         WHERE +e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})
          ORDER BY e.started_at DESC, f.rowid DESC
          LIMIT :limit`,
       ),

--- a/packages/persistence/src/repositories/resolutions.ts
+++ b/packages/persistence/src/repositories/resolutions.ts
@@ -83,6 +83,13 @@ export class SqliteResolutionsRepository {
   constructor(
     private readonly db: DatabaseSync,
     private readonly now: () => number = () => Date.now(),
+    // Row id, injectable for the same reason `now` is: a deterministic corpus
+    // cannot contain ambient entropy. `id` is opaque to every read on this
+    // table (all of them key by finding_key), so a caller supplying its own
+    // changes nothing a query can observe — see
+    // src/test-fixtures/generate.ts, which needs byte-identical rows across
+    // runs and therefore cannot let either default fire.
+    private readonly newId: () => string = () => randomUUID(),
   ) {
     this.insertStmt = db.prepare(
       `INSERT INTO finding_resolution (id, finding_key, status, method, resolved_at, evidence, created_at)
@@ -123,7 +130,8 @@ export class SqliteResolutionsRepository {
   }
 
   /**
-   * Insert one disposition row. The repo mints the id and stamps created_at.
+   * Insert one disposition row. The repo mints the id and stamps created_at,
+   * both through the constructor's injectable seams.
    * `status`/`method` are typed AND re-parsed here against @akasecurity/schema's
    * FindingStatus/ResolutionMethod, so the persisted vocabulary can never drift
    * from the schema enums. NOTE for future manual-resolution writers: this is
@@ -135,7 +143,7 @@ export class SqliteResolutionsRepository {
    */
   insertResolution(r: ResolutionInput): void {
     this.insertStmt.run({
-      id: randomUUID(),
+      id: this.newId(),
       findingKey: r.findingKey,
       status: FindingStatus.parse(r.status),
       method: ResolutionMethod.parse(r.method),

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -286,10 +286,10 @@ export class SqliteSecurityRepository implements SecurityViews {
   // count; a superseding open/redetected row means the finding is not
   // remediated and is excluded, same invariant as severitySummary. Legacy
   // at-rest findings with finding_key IS NULL can never have a resolution row
-  // (the lifecycle is keyed by finding_key), so the SQL guard excludes them
-  // outright. One raw-row query (fetch every trackable finding + its latest
-  // resolution's status/method/resolved_at) + pure-JS filter/bucket/mean,
-  // mirroring this file's other methods.
+  // (the lifecycle is keyed by finding_key), so they cannot reach the driving
+  // set below. One raw-row query (fetch the findings with resolution activity in
+  // the window + each one's latest resolution status/method/resolved_at) +
+  // pure-JS filter/bucket/mean, mirroring this file's other methods.
   mttrTrend(range: TimeRange): Promise<MttrTrendResponse> {
     const granularity = granularityFor(range);
     const bucketMs = (granularity === 'day' ? 1 : 7) * DAY_MS;
@@ -301,6 +301,8 @@ export class SqliteSecurityRepository implements SecurityViews {
     const windowStart = startOfUtcDay(now) - (lenDays - 1) * DAY_MS;
 
     const rows = allRows<{
+      /** Selected for DISTINCT's benefit, not read below — see the note on the SQL. */
+      finding_key: string;
       first_detected_at: number;
       severity: string;
       latest_status: string | null;
@@ -314,29 +316,80 @@ export class SqliteSecurityRepository implements SecurityViews {
         // started_at the upsert overwrites onto inspection_findings.audit_event_id.
         // COALESCE onto the parent event's started_at defends against any
         // legacy/edge row the backfill left null.
-        `SELECT COALESCE(f.first_detected_at, e.started_at) AS first_detected_at, d.severity AS severity,
+        `SELECT DISTINCT f.finding_key AS finding_key,
+                COALESCE(f.first_detected_at, e.started_at) AS first_detected_at, d.severity AS severity,
                 latest.status AS latest_status,
                 latest.method AS latest_method,
                 latest.resolved_at AS latest_resolved_at
-         FROM inspection_findings f
-         JOIN audit_events e ON e.id = f.audit_event_id
-         JOIN inspection_definitions d ON d.id = f.inspection_definition_id
+         FROM finding_resolution fr
+         CROSS JOIN inspection_findings f ON f.finding_key = fr.finding_key
+         CROSS JOIN audit_events e ON e.id = f.audit_event_id
+         CROSS JOIN inspection_definitions d ON d.id = f.inspection_definition_id
          LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
            ON latest.finding_key = f.finding_key
-         WHERE f.finding_key IS NOT NULL
-           AND e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})
-           AND EXISTS (
-             SELECT 1 FROM finding_resolution fr
-              WHERE fr.finding_key = f.finding_key
-                AND fr.resolved_at >= :windowStart
-           )`,
-        // The EXISTS is a SUPERSET prefilter that bounds the scan to keys with
-        // any resolution activity at/after the window start — a row this method
+         WHERE fr.resolved_at >= :windowStart
+           AND e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})`,
+        // `fr` is a SUPERSET prefilter, not the answer: a finding this method
         // ultimately counts has its LATEST resolution inside the window, which
-        // implies such a row exists, so nothing wanted is dropped. The exact
-        // latest-wins + status/method + window gate stays in JS below,
-        // dialect-agnostic. Without this, a
-        // 7d request evaluated the store's entire trackable-findings history.
+        // implies a resolution row at/after the window start exists, so nothing
+        // wanted is dropped. The exact latest-wins + status/method + window gate
+        // stays in JS below, dialect-agnostic. `f.finding_key IS NOT NULL` is
+        // implied rather than dropped — the join key comes from
+        // finding_resolution, whose finding_key is NOT NULL.
+        //
+        // IT IS THE DRIVING TABLE THAT MAKES THAT PREFILTER A BOUND, which is
+        // the correction this replaced. Spelled as an `EXISTS` in the WHERE it
+        // READ as a bound and was not one: SQLite drove from `audit_events` on
+        // event_type, joined every capture event to its findings, and evaluated
+        // the EXISTS last — bounding the RESULT and not the scan, so a 7d request
+        // still cost the store's whole trackable history. Measured at 44.6 ms on
+        // 50,000 events and 171.3 ms on 150,000 — linear in the STORE, and in
+        // both cases returning rows for a window holding a fraction of it.
+        //
+        // Two things carry it, and they answer DIFFERENT halves — which is worth
+        // stating precisely, because the obvious reading (both are needed for the
+        // speed) is wrong and was measured to be wrong:
+        //
+        //  - **`CROSS JOIN`** is the whole of the store-size fix. In SQLite the
+        //    keyword is semantically identical to JOIN and exists only to stop the
+        //    tables being reordered; with plain JOINs the planner puts `e` back on
+        //    the outside, because with no ANALYZE statistics it prices
+        //    `event_type IN (...)` as a selective probe. Reverting it alone takes
+        //    the 2k->20k flatness ratio from 1.32 to 16.87.
+        //  - **`idx_finding_resolution_resolved_at`** (migration 0021) makes
+        //    `resolved_at >= :windowStart` a range SEARCH instead of a bare
+        //    `SCAN fr` — finding_key was this table's only index before it, so the
+        //    range had none. It buys NO flatness in store size: remove it and the
+        //    ratio above does not move, because the latest-resolution derived
+        //    table already passes over the whole of finding_resolution, so this
+        //    read is O(resolutions) either way and resolutions are not the store.
+        //    What it buys is the criterion `hot-read-query-plans.test.ts` enforces
+        //    — no hot read may pass over a table with no index — and that is the
+        //    guard that goes red when it is dropped. Neither test catches the
+        //    other's defect.
+        //
+        // SELECT DISTINCT is a CORRECTNESS requirement of driving from `fr`, not a
+        // tidy-up. finding_resolution is append-only, so a key that was fixed,
+        // redetected and fixed again carries several rows inside one window and
+        // matches once per row — and the value below is a MEAN, so a key matched
+        // three times is a key weighted three times.
+        //
+        // The skew is easy to argue away and the argument is wrong, so it is worth
+        // recording. Duplicate rows for ONE key are identical (every projected
+        // column is per-key: `latest.*` is latest-wins, `first_detected_at` is
+        // preserved), so sums and counts scale together and that key's own mean
+        // does not move. What moves is a bucket holding TWO findings that duplicate
+        // UNEQUALLY: three rows for a 5.9-day fix and one for a 1.9-day fix average
+        // 4.9 days weighted against 3.9 unweighted. Measured, and pinned by
+        // `security.test.ts`'s "weights a finding ONCE however many resolution rows
+        // it has inside the window" — which needed a fixture built for it, since no
+        // single-key case can show it.
+        //
+        // `finding_key` is selected to make the DISTINCT dedup by KEY rather than
+        // by value tuple. On the other columns alone, two genuinely different
+        // findings sharing a severity, a first-detection event and a resolution
+        // instant — one commit fixing two secrets in one file — are one tuple, and
+        // collapsing them would under-count in the other direction.
       ),
       { windowStart },
     );
@@ -417,16 +470,47 @@ export class SqliteSecurityRepository implements SecurityViews {
 
   // Recently-resolved activity feed: findings whose finding_key's LATEST
   // finding_resolution row is status:'resolved'/method:'fixed-at-source' —
-  // same latest-resolution-wins correlated subquery as severitySummary /
-  // mttrTrend (NOT a plain JOIN, which would surface every historical
-  // resolution row for a key rather than just its current disposition). A key
-  // whose latest row is a superseding 'open'/'redetected' row (the same
-  // secret came back) is excluded — it is not currently resolved. Legacy
-  // at-rest findings with finding_key IS NULL are excluded outright (the
-  // resolution lifecycle can never attach to them). Path comes from the
-  // finding's parent event (event_type 'code_change', attributes.file_path) —
-  // mirrors resolutions.ts's openAtRestStmt accessor. Ordered by resolved_at
-  // DESC, capped at `limit`.
+  // same latest-resolution-wins derived table as severitySummary / mttrTrend
+  // (NOT a plain JOIN, which would surface every historical resolution row for
+  // a key rather than just its current disposition). A key whose latest row is
+  // a superseding 'open'/'redetected' row (the same secret came back) is
+  // excluded — it is not currently resolved. Legacy at-rest findings with
+  // finding_key IS NULL are excluded outright (the resolution lifecycle can
+  // never attach to them). Path comes from the finding's parent event
+  // (event_type 'code_change', attributes.file_path) — mirrors resolutions.ts's
+  // openAtRestStmt accessor. Ordered by resolved_at DESC, capped at `limit`.
+  //
+  // THE RESOLUTION SET DRIVES THIS QUERY, and that is a correctness property of
+  // the plan rather than a preference. Written the other way round — driving
+  // from inspection_findings/audit_events with `latest` LEFT JOINed on — SQLite
+  // cannot use the join key: `f` is reached FROM `latest` by finding_key, so
+  // `latest` gets probed on (rn, status, method) instead and the plan enumerates
+  // every (code_change event x resolved key) pair before `f` can reject it. That
+  // is a cross product, and it is quadratic in the store: measured at 10,966 ms
+  // on a corpus of 50,000 events carrying 2,051 resolutions, against 20 rows
+  // returned. It was invisible for as long as it was, and reported at 8 ms,
+  // because an empty finding_resolution table makes the inner side empty and the
+  // cross product collapses to nothing — so the shape is only observable on a
+  // corpus that seeds resolutions.
+  //
+  // Driving from `latest` instead makes every step below it a unique-index or
+  // primary-key lookup (uq_inspection_findings_key, then audit_events' own PK),
+  // so the cost is the derived table's own — linear in resolutions, which is
+  // what this feed is legitimately about.
+  //
+  // CROSS JOIN is what actually pins that, and it is load-bearing rather than
+  // decorative: in SQLite the keyword is semantically identical to JOIN and
+  // exists only to stop the optimizer reordering the tables. Written as plain
+  // JOINs in this order the planner puts `e` back on the outside — it has no
+  // ANALYZE statistics to price the alternatives with, so it takes
+  // `event_type = 'code_change'` for a selective index probe and rebuilds the
+  // cross product. The FROM order alone was measured to change the plan not at
+  // all.
+  //
+  // The LEFT JOIN it replaced was already an inner join in effect: three
+  // `latest.*` predicates sit in the WHERE, and each of them is false for a
+  // null-extended row. Spelling it JOIN changes no row and stops the plan
+  // reading as though the findings side could drive.
   recentlyResolved(limit = 20): Promise<RecentlyResolvedResponse> {
     const rows = allRows<{
       finding_key: string;
@@ -443,17 +527,15 @@ export class SqliteSecurityRepository implements SecurityViews {
                 json_extract(e.attributes, '$.file_path') AS path,
                 COALESCE(f.first_detected_at, e.started_at) AS first_detected_at,
                 latest.resolved_at AS latest_resolved_at
-         FROM inspection_findings f
-         JOIN audit_events e ON e.id = f.audit_event_id
-         JOIN inspection_definitions d ON d.id = f.inspection_definition_id
-         LEFT JOIN ${LATEST_RESOLUTION_BY_KEY_SQL} latest
-           ON latest.finding_key = f.finding_key
-         WHERE e.event_type = 'code_change'
-           AND f.finding_key IS NOT NULL
-           AND latest.status = 'resolved'
+         FROM ${LATEST_RESOLUTION_BY_KEY_SQL} latest
+         CROSS JOIN inspection_findings f ON f.finding_key = latest.finding_key
+         CROSS JOIN audit_events e ON e.id = f.audit_event_id
+         CROSS JOIN inspection_definitions d ON d.id = f.inspection_definition_id
+         WHERE latest.status = 'resolved'
            AND latest.method = 'fixed-at-source'
            AND latest.resolved_at IS NOT NULL
-         ORDER BY latest_resolved_at DESC
+           AND e.event_type = 'code_change'
+         ORDER BY latest.resolved_at DESC
          LIMIT :limit`,
       ),
       { limit },

--- a/packages/persistence/src/test-fixtures/generate.ts
+++ b/packages/persistence/src/test-fixtures/generate.ts
@@ -7,7 +7,7 @@
  * cannot live in git at any fidelity. So this generates one from a seed
  * instead: same seed, same rows, byte for byte, on every machine and every run.
  *
- * Four properties are load-bearing.
+ * Five properties are load-bearing.
  *
  * **It writes through the PRODUCT's write path, not a copy of it.** Every row
  * lands via the caller's `recordCapture`, so the corpus is whatever
@@ -30,19 +30,47 @@
  * seeding 100k or more belongs in a `beforeAll`, where it is charged to the
  * hook budget rather than to a test's own timeout.
  *
+ * **A corpus is realistic on the axes a READ is sensitive to, or it measures
+ * the wrong store.** Four of them, and every one has cost a wrong number:
+ * `spacingMs` (density — at 1 s a million events span 11.6 days, so a 30-day
+ * window holds the whole store and a windowed read costs what an unwindowed one
+ * does), `findingRate` (three of `/security`'s reads are linear in findings
+ * rather than events), whether a finding carries a `finding_key` (every read
+ * that branches on trackability returns nothing without one, while still
+ * running and still reporting a plan), and `resolutionRate` (an empty
+ * `finding_resolution` is the cheapest path through the three reads that join
+ * it). The first two are options with measured defaults; the third is not an
+ * option at all, because the product decides it (see the note at the `findingKey`
+ * assignment); the fourth is an option whose measured
+ * default is zero, which is why a caller that needs it non-trivial has to say so.
+ *
  * **It verifies what LANDED.** `recordCapture` is fail-open by design — a
  * locked, full or read-only store swallows the write and returns. A benchmark
  * has no assertions, so a generator that trusted its own calls would hand back
  * an EMPTY store and every downstream measurement would be a timing of nothing,
  * reported as a fast one. `generateCaptureCorpus` counts the rows it asked for
- * — capture events AND findings, since a corpus with no findings measures a
- * different store from the one requested — and throws when they are not there.
- * That check is the harness's positive control and must not be softened into a
- * warning.
+ * — capture events, findings, TRACKABLE findings and resolutions, four counts
+ * because none of them implies another: a corpus can land every event and no
+ * finding (a changed dedup key), every finding and no key (a dropped
+ * `findingKey`), or every key and no resolution row (a second repository
+ * writing to a table with no foreign key onto findings). Each of those leaves a
+ * different read measuring nothing while still reporting a number. All four
+ * throw rather than warn.
  *
  * Determinism means no ambient entropy: no `Math.random`, no `randomUUID`, no
  * `Date.now`. Ids come from the seeded PRNG and timestamps from a fixed epoch,
- * so two runs of the same options produce identical bytes.
+ * so two runs of the same options produce identical bytes. That reaches through
+ * `SqliteResolutionsRepository` too, which mints an id and stamps `created_at`
+ * on every write — both are constructor seams, and this module supplies both
+ * rather than letting either default fire.
+ *
+ * One axis is deliberately NOT modelled, and the gap is stated rather than
+ * papered over: `KINDS` is sampled uniformly, so about a quarter of captures are
+ * `code_change` and therefore about a quarter of findings are trackable. The
+ * real store measured ~40% (2,149 of 5,410), because findings do not land evenly
+ * across event kinds there. Fitting per-kind rates to one install would be
+ * over-fitting a sample of one; what these reads are sensitive to is that
+ * trackable findings are a MINORITY of a known size, which holds either way.
  *
  * TEST AND BENCHMARK FIXTURES ONLY, like the rest of this directory. It is
  * reached from `test/helpers/corpus.ts` — by suites under `test/` and by the
@@ -54,6 +82,7 @@ import type { DetectedFinding, EventKind, IngestEvent, SourceTool } from '@akase
 import { CAPTURE_EVENT_TYPES_SQL } from '@akasecurity/schema';
 
 import { withTransaction } from '../internal/transactions.ts';
+import { SqliteResolutionsRepository } from '../repositories/resolutions.ts';
 
 /**
  * What the generator needs of a store, and nothing more.
@@ -105,6 +134,27 @@ export interface CaptureCorpusOptions {
    * property under test is what a windowed read costs.
    */
   readonly spacingMs?: number;
+  /**
+   * Fraction (0..1) of TRACKABLE findings that also carry a
+   * `finding_resolution` row. Defaults to `DEFAULT_RESOLUTION_RATE`.
+   *
+   * Only a trackable finding can have one: the lifecycle is keyed by
+   * `finding_key`, and an in-flight finding has none (see the invariant note at
+   * the `findingKey` assignment below). So this is a fraction of the trackable
+   * subset, not of every finding.
+   *
+   * It exists because `finding_resolution` being EMPTY is not a neutral
+   * starting point for a measurement — it is the cheapest path through three
+   * of `/security`'s reads. `severitySummary`'s caught/open-at-rest buckets,
+   * `mttrTrend` and `recentlyResolved` all read the latest resolution per key,
+   * and the derived table they read it through
+   * (`LATEST_RESOLUTION_BY_KEY_SQL`) is materialized and sorted per call. On an
+   * empty table all of that is free, so a corpus with no resolutions measures
+   * those three reads on an input no store carrying resolution history
+   * presents. A measurement that needs them non-trivial passes a rate here and
+   * says why.
+   */
+  readonly resolutionRate?: number;
 }
 
 export interface GeneratedCaptureCorpus {
@@ -114,6 +164,17 @@ export interface GeneratedCaptureCorpus {
   readonly sessions: number;
   /** Findings that landed — asserted equal to the number generated. */
   readonly findings: number;
+  /**
+   * Of `findings`, how many carry a `finding_key` — asserted on disk.
+   *
+   * Reported separately because it is the number three of `/security`'s reads
+   * are actually linear in, and it is NOT derivable from `findings` and a
+   * rate: which findings are trackable follows from the event kind they landed
+   * on, which the seeded stream chooses.
+   */
+  readonly trackableFindings: number;
+  /** `finding_resolution` rows that landed — asserted equal to the number generated. */
+  readonly resolutions: number;
   /**
    * The instant just past the last generated event, in epoch milliseconds.
    *
@@ -129,7 +190,44 @@ export interface GeneratedCaptureCorpus {
 
 const DEFAULT_SEED = 1;
 const DEFAULT_SESSIONS = 50;
-const DEFAULT_FINDING_RATE = 0.1;
+
+/**
+ * Findings per capture event.
+ *
+ * MEASURED, not chosen. Read off a real `~/.aka/data/aka.db` with 16,390
+ * capture events carrying 5,410 findings on them — 0.330 — as counts only, no
+ * content. That is a single install and a heavy one (its operator develops the
+ * detection rules, so it detects more than a typical user would), so read it as
+ * an upper-ish bound on a real rate rather than a population mean. It is still
+ * the only number here taken from a real store rather than picked, and it is
+ * the axis the reads that dominate `/security` are linear in.
+ *
+ * The value it replaced was 0.1. Anything sizing work against this constant
+ * should re-measure rather than trusting the figure to have aged well — a rate
+ * is a property of how a user works, and one install cannot establish it.
+ */
+const DEFAULT_FINDING_RATE = 0.33;
+
+/**
+ * Of the trackable findings, how many carry a resolution row.
+ *
+ * MEASURED at 0 — the same real store holds 24,492 findings, 2,149 of them
+ * trackable, and ZERO `finding_resolution` rows, because nothing writes that
+ * table until a user runs the at-rest remediation flow. So the honest default
+ * is the empty table.
+ *
+ * That makes the default corpus the cheap path for the three resolution-reading
+ * aggregations, which is exactly the trap `resolutionRate` exists to let a
+ * caller step out of. Deliberately NOT defaulted to a made-up non-zero rate:
+ * this repository does not state an estimated number as a measured one, and a
+ * plausible-looking constant here would be read as realism by everything
+ * downstream. A measurement that needs the resolution join to cost something
+ * passes an explicit rate and states that as its reason.
+ */
+const DEFAULT_RESOLUTION_RATE = 0;
+
+/** Deterministic file paths for `code_change` captures — a repo's worth of files, reused. */
+const CORPUS_FILE_COUNT = 400;
 
 /**
  * A fixed epoch for every generated timestamp: 2024-01-01T00:00:00.000Z.
@@ -267,6 +365,7 @@ export function generateCaptureCorpus(
   const sessions = options.sessions ?? DEFAULT_SESSIONS;
   const findingRate = options.findingRate ?? DEFAULT_FINDING_RATE;
   const spacingMs = options.spacingMs ?? CORPUS_EVENT_SPACING_MS;
+  const resolutionRate = options.resolutionRate ?? DEFAULT_RESOLUTION_RATE;
 
   if (!Number.isInteger(events) || events < 0) {
     throw new TypeError(
@@ -295,6 +394,15 @@ export function generateCaptureCorpus(
       `generateCaptureCorpus: findingRate must be a finite number within 0..1, got ${String(findingRate)}`,
     );
   }
+  // Same `Number.isFinite` first, same reason: NaN fails both comparisons, so a
+  // bare range check admits it and then makes every `rng() < resolutionRate`
+  // false — a corpus silently carrying no resolutions, which is the input this
+  // option exists to stop a measurement being taken on.
+  if (!Number.isFinite(resolutionRate) || resolutionRate < 0 || resolutionRate > 1) {
+    throw new RangeError(
+      `generateCaptureCorpus: resolutionRate must be a finite number within 0..1, got ${String(resolutionRate)}`,
+    );
+  }
 
   const rng = createSeededRandom(seed);
 
@@ -306,17 +414,42 @@ export function generateCaptureCorpus(
 
   const baseline = countCaptureEvents(target.connection);
   const findingsBaseline = countFindings(target.connection);
+  const trackableBaseline = countTrackableFindings(target.connection);
+  const resolutionsBaseline = countResolutions(target.connection);
   let generated = 0;
+  let generatedTrackable = 0;
+  let generatedResolutions = 0;
+
+  // Resolutions go through the product's own writer, like the captures — see
+  // this module's header. Both of its entropy seams are supplied so the rows
+  // stay byte-identical run to run: the id from the seeded stream, and
+  // `created_at` from the corpus clock rather than the wall clock. Constructed
+  // outside the transaction because its constructor only prepares statements.
+  const resolutions = new SqliteResolutionsRepository(
+    target.connection,
+    () => CORPUS_EPOCH_MS,
+    () => seededGuid(rng),
+  );
 
   withTransaction(target.connection, () => {
     for (let i = 0; i < events; i += 1) {
       const sessionId = sessionAt(sessionIds, i % sessions);
       const kind = KINDS[Math.floor(rng() * KINDS.length)] ?? 'prompt';
+      // Only a code_change capture carries one, which is what the product does
+      // and what makes its findings trackable. It is also half of captureId's
+      // content-addressing and the key of the partial index
+      // `idx_audit_code_change_path`, so a corpus that left it null would drive
+      // the at-rest path reads against an index holding nothing.
+      const filePath =
+        kind === 'code_change'
+          ? `src/module-${String(Math.floor(rng() * CORPUS_FILE_COUNT))}.ts`
+          : undefined;
+      const occurredAtMs = CORPUS_EPOCH_MS + i * spacingMs;
       const event: IngestEvent = {
         id: seededGuid(rng),
         sourceTool: TOOLS[Math.floor(rng() * TOOLS.length)] ?? 'claude-code',
         kind,
-        occurredAt: new Date(CORPUS_EPOCH_MS + i * spacingMs).toISOString(),
+        occurredAt: new Date(occurredAtMs).toISOString(),
         // The capture row is content-addressed on (sessionId, contentHash,
         // filePath), so a shared hash would collapse every event in a session
         // onto ONE row and the corpus would silently be `sessions` rows deep
@@ -324,11 +457,31 @@ export function generateCaptureCorpus(
         // construction rather than by luck.
         contentHash: `corpus-${String(seed)}-${String(i)}`,
         content: seededText(rng, CONTENT_CHARS),
-        metadata: { sessionId },
+        metadata: { sessionId, ...(filePath === undefined ? {} : { filePath }) },
       };
 
       const detected: DetectedFinding[] = [];
       if (rng() < findingRate) {
+        // TRACKABLE EXACTLY WHEN THE PRODUCT WOULD MAKE IT SO, which is why the
+        // condition is `filePath` and not a knob. `@akasecurity/plugin-sdk`'s
+        // runtime sets `isAtRest = kind === 'code_change' && filePath !== undefined`
+        // and keys those findings and no others; here only a `code_change` capture
+        // is given a path, so the two conditions coincide. Confirmed against the
+        // real store, where the split is exact — every one of its 2,149
+        // `code_change` findings carries a key, and all 22,343 findings on every
+        // other event type carry none.
+        //
+        // A corpus free to key an in-flight finding could produce a store no
+        // product path can write, and every read branching on
+        // `finding_key IS NOT NULL` would then be measured against a shape that
+        // cannot occur — so this deliberately has no option governing it.
+        //
+        // The key's VALUE is opaque to every read (all of them test it for null or
+        // join on it), so it comes from the seeded stream rather than being
+        // recomputed with the plugin's own hash, which sits behind a package wall
+        // this one may not cross.
+        const findingKey =
+          filePath === undefined ? undefined : `corpus-key-${String(seed)}-${String(i)}`;
         detected.push({
           id: seededGuid(rng),
           eventId: event.id,
@@ -336,6 +489,7 @@ export function generateCaptureCorpus(
           category: 'secret',
           severity: 'critical',
           span: { start: 0, end: 8 },
+          ...(findingKey === undefined ? {} : { findingKey }),
           // Half the finding-level session dedup key. A constant here would
           // make every finding after the first in a session land as zero rows
           // BY DESIGN, so the corpus would carry `sessions` findings whatever
@@ -346,9 +500,42 @@ export function generateCaptureCorpus(
           confidence: 0.9,
         });
         generated += 1;
+        if (findingKey !== undefined) generatedTrackable += 1;
       }
 
       target.recordCapture(event, detected);
+    }
+
+    // Resolutions are written from the keys that LANDED, read back out of the
+    // store, rather than from the keys the loop above asked for. That is the
+    // same argument as the two count checks below, applied to the selection
+    // rather than to the tally: recordCapture is fail-open and drops a finding
+    // that trips either dedup gate, so a rate applied to the REQUESTED keys
+    // would write resolution rows against keys with no finding — orphans no
+    // product path can produce, and ones that would then be invisible to every
+    // read here, since all of them reach resolutions THROUGH a finding.
+    //
+    // Still inside the enclosing transaction: this is thousands of inserts at
+    // corpus scale, and the per-commit flush is what this module's header
+    // explains it cannot afford.
+    if (resolutionRate > 0) {
+      for (const row of landedTrackableFindings(target.connection)) {
+        if (rng() >= resolutionRate) continue;
+        // Resolved AFTER first detection, by a spread of the corpus's own
+        // spacing. MTTR is `resolved_at - first_detected_at` and the read clamps
+        // a negative to zero, so a resolution stamped before its detection would
+        // be counted as an instant fix rather than rejected — a wrong number,
+        // not a missing one.
+        const resolvedAt = row.first_detected_at + Math.floor(rng() * 30 * spacingMs) + spacingMs;
+        resolutions.insertResolution({
+          findingKey: row.finding_key,
+          status: 'resolved',
+          method: 'fixed-at-source',
+          resolvedAt,
+          evidence: 'corpus',
+        });
+        generatedResolutions += 1;
+      }
     }
   });
 
@@ -375,14 +562,87 @@ export function generateCaptureCorpus(
     );
   }
 
+  // Trackable findings and resolutions get their own checks for the same reason
+  // the two above exist, and they are not implied by either. The findings tally
+  // says nothing about how many carry a key: drop `findingKey` from the insert
+  // and every finding still lands, while three of `/security`'s reads quietly
+  // go back to matching nothing. And a resolution row is written through a
+  // second repository against a table with no foreign key onto findings, so
+  // every one of them could fail to land with the findings check still green.
+  const trackableFindings = countTrackableFindings(target.connection) - trackableBaseline;
+  if (trackableFindings !== generatedTrackable) {
+    throw new Error(
+      `generateCaptureCorpus wrote ${String(trackableFindings)} trackable findings, expected ` +
+        `${String(generatedTrackable)}. A finding is trackable exactly when its capture is a ` +
+        'code_change carrying a file path; a corpus with none measures every finding_key read ' +
+        'against an empty result.',
+    );
+  }
+  const resolutionsWritten = countResolutions(target.connection) - resolutionsBaseline;
+  if (resolutionsWritten !== generatedResolutions) {
+    throw new Error(
+      `generateCaptureCorpus wrote ${String(resolutionsWritten)} resolutions, expected ` +
+        `${String(generatedResolutions)}. The three reads that join finding_resolution are at ` +
+        'their cheapest against an empty table, so a corpus that lost them reports those reads ' +
+        'as fast rather than as unmeasured.',
+    );
+  }
+
   return {
     seed,
     events: landed,
     sessions,
     findings,
+    trackableFindings,
+    resolutions: resolutionsWritten,
     endsAt: CORPUS_EPOCH_MS + events * spacingMs,
     spacingMs,
   };
+}
+
+/**
+ * Trackable findings on disk — those carrying a `finding_key`.
+ *
+ * No event-type predicate, deliberately. The product only ever keys a
+ * `code_change` finding, so a key appearing on any other kind is a defect this
+ * count must SEE rather than filter out.
+ */
+function countTrackableFindings(connection: DatabaseSync): number {
+  const row = connection
+    .prepare('SELECT COUNT(*) AS c FROM inspection_findings WHERE finding_key IS NOT NULL')
+    .get() as { c: number } | undefined;
+  return row?.c ?? 0;
+}
+
+/** `finding_resolution` rows on disk. */
+function countResolutions(connection: DatabaseSync): number {
+  const row = connection.prepare('SELECT COUNT(*) AS c FROM finding_resolution').get() as
+    { c: number } | undefined;
+  return row?.c ?? 0;
+}
+
+/**
+ * Every trackable finding that landed, with its preserved first-detection time,
+ * in a deterministic order.
+ *
+ * Ordered by `finding_key` rather than by rowid: the selection below walks this
+ * consuming from the seeded stream per row, so the order decides WHICH keys get
+ * a resolution. A rowid order is insertion order, which is stable today and is
+ * not a property SQLite promises, whereas the key is unique and self-ordering.
+ */
+function landedTrackableFindings(
+  connection: DatabaseSync,
+): { finding_key: string; first_detected_at: number }[] {
+  return connection
+    .prepare(
+      `SELECT f.finding_key AS finding_key,
+              COALESCE(f.first_detected_at, e.started_at) AS first_detected_at
+         FROM inspection_findings f
+         JOIN audit_events e ON e.id = f.audit_event_id
+        WHERE f.finding_key IS NOT NULL
+        ORDER BY f.finding_key`,
+    )
+    .all() as { finding_key: string; first_detected_at: number }[];
 }
 
 /**

--- a/packages/persistence/src/test-fixtures/generate.ts
+++ b/packages/persistence/src/test-fixtures/generate.ts
@@ -417,8 +417,10 @@ export function generateCaptureCorpus(
   const trackableBaseline = countTrackableFindings(target.connection);
   const resolutionsBaseline = countResolutions(target.connection);
   let generated = 0;
-  let generatedTrackable = 0;
   let generatedResolutions = 0;
+  // The trackable keys THIS call minted, which is not the same set as the
+  // trackable keys on disk — see `landedTrackableFindings`.
+  const mintedKeys = new Set<string>();
 
   // Resolutions go through the product's own writer, like the captures — see
   // this module's header. Both of its entropy seams are supplied so the rows
@@ -500,7 +502,7 @@ export function generateCaptureCorpus(
           confidence: 0.9,
         });
         generated += 1;
-        if (findingKey !== undefined) generatedTrackable += 1;
+        if (findingKey !== undefined) mintedKeys.add(findingKey);
       }
 
       target.recordCapture(event, detected);
@@ -519,7 +521,7 @@ export function generateCaptureCorpus(
     // corpus scale, and the per-commit flush is what this module's header
     // explains it cannot afford.
     if (resolutionRate > 0) {
-      for (const row of landedTrackableFindings(target.connection)) {
+      for (const row of landedTrackableFindings(target.connection, mintedKeys)) {
         if (rng() >= resolutionRate) continue;
         // Resolved AFTER first detection, by a spread of the corpus's own
         // spacing. MTTR is `resolved_at - first_detected_at` and the read clamps
@@ -570,10 +572,10 @@ export function generateCaptureCorpus(
   // second repository against a table with no foreign key onto findings, so
   // every one of them could fail to land with the findings check still green.
   const trackableFindings = countTrackableFindings(target.connection) - trackableBaseline;
-  if (trackableFindings !== generatedTrackable) {
+  if (trackableFindings !== mintedKeys.size) {
     throw new Error(
       `generateCaptureCorpus wrote ${String(trackableFindings)} trackable findings, expected ` +
-        `${String(generatedTrackable)}. A finding is trackable exactly when its capture is a ` +
+        `${String(mintedKeys.size)}. A finding is trackable exactly when its capture is a ` +
         'code_change carrying a file path; a corpus with none measures every finding_key read ' +
         'against an empty result.',
     );
@@ -622,18 +624,32 @@ function countResolutions(connection: DatabaseSync): number {
 }
 
 /**
- * Every trackable finding that landed, with its preserved first-detection time,
- * in a deterministic order.
+ * The trackable findings THIS call minted that actually landed, with each one's
+ * preserved first-detection time, in a deterministic order.
  *
- * Ordered by `finding_key` rather than by rowid: the selection below walks this
+ * Read from the store rather than from the loop — the point of the read is to
+ * see what survived `recordCapture`'s dedup gates — but intersected with
+ * `minted`, and the intersection is load-bearing rather than tidiness. The
+ * generator is ADDITIVE by design (`adds to a store that already holds a corpus
+ * rather than counting it twice`), so a bare read returns every trackable
+ * finding in the store, including every earlier corpus's. A second
+ * `seedCaptureCorpus(db, { resolutionRate: r })` would then write resolutions
+ * against keys it never created, and the landed-row check could not see it: that
+ * check is a DELTA, and rows written for older keys land inside the delta just
+ * the same. Measured before this filter existed — a second 1,000-event corpus
+ * added 76 trackable findings and wrote 148 resolutions, 72 of them against the
+ * first corpus's keys, and reported success.
+ *
+ * Ordered by `finding_key` rather than by rowid: the selection walks this
  * consuming from the seeded stream per row, so the order decides WHICH keys get
  * a resolution. A rowid order is insertion order, which is stable today and is
  * not a property SQLite promises, whereas the key is unique and self-ordering.
  */
 function landedTrackableFindings(
   connection: DatabaseSync,
+  minted: ReadonlySet<string>,
 ): { finding_key: string; first_detected_at: number }[] {
-  return connection
+  const rows = connection
     .prepare(
       `SELECT f.finding_key AS finding_key,
               COALESCE(f.first_detected_at, e.started_at) AS first_detected_at
@@ -643,6 +659,7 @@ function landedTrackableFindings(
         ORDER BY f.finding_key`,
     )
     .all() as { finding_key: string; first_detected_at: number }[];
+  return rows.filter((r) => minted.has(r.finding_key));
 }
 
 /**

--- a/packages/persistence/test/performance/hot-read-query-plans.test.ts
+++ b/packages/persistence/test/performance/hot-read-query-plans.test.ts
@@ -14,13 +14,22 @@
  *
  * **The full INDEX scans are pinned as an exact set.** `SCAN t USING INDEX i` is
  * not a defect — for a whole-table aggregate it is usually the best plan there
- * is — but it is still O(rows), so every one of them is a place where the
+ * is — and it is USUALLY O(rows), so most of them are a place where the
  * dashboard gets slower as the store grows. Left unpinned, a new one could
  * appear and the first assertion would stay green, because the query would have
  * an index and would still visit every row. The set is compared EXACTLY, in both
  * directions: an entry that disappears fails too, so someone who adds an index
  * that turns a scan into a search is told to delete the line rather than leaving
  * a stale claim behind.
+ *
+ * **"Usually" is doing real work in that sentence, and the exception is why this
+ * file cannot be the only guard.** A `SCAN` under a `LIMIT` whose order comes
+ * from the index terminates early, and EXPLAIN QUERY PLAN prints it exactly like
+ * one that does not — there is no plan text for "stops after 500 rows".
+ * `recentFindings` is that case and is annotated at its entry. It means a reader
+ * cannot infer growth from this set alone, in either direction: an entry may be
+ * bounded, and a plan that looks ideal can still be linear in the store, which
+ * is what `security-page-scale.test.ts` measures as a ratio across two sizes.
  *
  * **The plans are taken from the reads, never restated here.** `recordingConnection`
  * captures the SQL and the bound parameters as the repositories execute them; a
@@ -170,7 +179,19 @@ const EXPECTED_FULL_INDEX_SCANS: Readonly<Record<string, readonly string[]>> = {
   '/security scanCoverage': [],
   '/security topSources': [],
   '/security recentlyResolved': ['finding_resolution'],
-  '/security recentFindings': [],
+  // The ONE entry in this set that does not grow with the store, and the reason
+  // the paragraph above says "usually" rather than "always". `recentFindings`
+  // scans `idx_audit_started_at` in DESC order precisely so its `LIMIT` can stop
+  // the scan after `limit` findings — EXPLAIN QUERY PLAN has no way to say
+  // "terminates early", so a bounded scan and an unbounded one print the same
+  // word. Measured at 0.9 ms against 35.0 ms for the temp-B-tree form it
+  // replaced, on the same 40,000-event store.
+  //
+  // So this row must not be read as a cost to remove: removing it means going
+  // back to sorting every finding in the store. What DOES bound it is a ratio
+  // across two store sizes, which a plan cannot express and
+  // `security-page-scale.test.ts` asserts instead.
+  '/security recentFindings': ['audit_events'],
   '/activity stats': [],
   '/activity listSessions': [],
   '/activity tokenReports': [],

--- a/packages/persistence/test/performance/retention-surface.test.ts
+++ b/packages/persistence/test/performance/retention-surface.test.ts
@@ -7,8 +7,8 @@
  * after 24 h and terminal `exceptions` after 90 days — and it is easy to read
  * those two constants as evidence that the store manages its own size. It does
  * not. Everything else grows for as long as the machine is used, and at the
- * measured 797.9 B/event `store-growth.test.ts` pins that is the difference between a store
- * that settles and one that reaches a gigabyte per million events and keeps going.
+ * measured 902.8 B/event `store-growth.test.ts` pins that is the difference between a store
+ * that settles and one that reaches nearly a gigabyte per million events and keeps going.
  *
  * This pins the split BEHAVIOURALLY rather than by reading the source. A text
  * scan for `DELETE FROM` cannot tell a retention sweep from a cascade, a

--- a/packages/persistence/test/performance/scale-budgets.test.ts
+++ b/packages/persistence/test/performance/scale-budgets.test.ts
@@ -146,9 +146,13 @@
  * timeout, which is a red for the wrong reason and proves nothing about
  * flatness. Pick a cost above the floor and well under it.
  *
- * `/security` gets no test here, and the omission is deliberate rather than an
- * oversight: it MISSES its 2,000 ms budget at 1M events (5,945 ms measured), so
- * there is no passing assertion to write.
+ * `/security` gets no test here, and it is not untested either — see
+ * `security-page-scale.test.ts`, which states the three reads that must stay flat
+ * in store size as ratios over this same pair. It is a separate file because the
+ * experiment differs: this one grows everything and measures per-call store cost,
+ * while that one holds the ANSWER size fixed and grows only the store, which is
+ * what separates a read that is linear in the store from one that is linear in
+ * the rows it returns.
  *
  * ## The corpora are built in a HOOK, under a SETUP-sized ceiling
  *
@@ -225,6 +229,15 @@ const GROSS_REGRESSION_MS = 1_000;
  */
 const SEED_TIMEOUT_MS = 120_000;
 
+/**
+ * The finding rate the seed-time figures in this file's header were taken at.
+ *
+ * Not the generator's default, which is higher and measured — see the note at
+ * the `seedCaptureCorpus` call. Changing this invalidates the header's ms/event
+ * table and the 120 s ceiling sized from it, so re-take both if it moves.
+ */
+const SEED_FINDING_RATE = 0.1;
+
 const CAPTURE_SAMPLES = 200;
 const OPEN_SAMPLES = 20;
 
@@ -274,7 +287,24 @@ function seedAndMeasure(store: OwnedTempStore, events: number): Measured {
   // time, and the fastest possible store is an empty one — so without this the
   // whole file would pass most convincingly at the moment the corpus stopped
   // being written.
-  const corpus = seedCaptureCorpus(db, { events, sessions: 200, seed: 1 });
+  const corpus = seedCaptureCorpus(db, {
+    events,
+    sessions: 200,
+    seed: 1,
+    // Pinned rather than inherited, and this is a SEED-COST decision, not a
+    // realism one. What this file measures is the flatness of a `recordCapture`
+    // that writes NO findings (see `makeEvent` below, called with `[]`) and of
+    // `openLocalDatabase`; the corpus is here only to make the store large, so
+    // its finding rate is a cost paid and never measured. The generator's
+    // default moved to a measured 0.33, which triples the finding rows and takes
+    // the seed for this pair from 1.20 s to 2.65 s locally — and at the ~30x CI
+    // factor the header derives, from ~36 s to ~80 s against the 120,000 ms
+    // ceiling below. This file has ALREADY overrun that ceiling once, at
+    // 135,237 ms, so spending its remaining margin on a rate it does not measure
+    // is the wrong trade. The alternative the header rules out is cutting the
+    // pair again, which would raise the sensitivity floor a second time.
+    findingRate: SEED_FINDING_RATE,
+  });
 
   const captures: number[] = [];
   for (let i = 0; i < CAPTURE_SAMPLES; i += 1) {

--- a/packages/persistence/test/performance/security-page-scale.test.ts
+++ b/packages/persistence/test/performance/security-page-scale.test.ts
@@ -72,15 +72,27 @@ const SMALL_EVENTS = 2_000;
 const LARGE_EVENTS = 20_000;
 
 /**
- * Real per-event spacing, so a 30-day window holds a FRACTION of the store.
+ * Real per-event spacing: 74,528 ms, measured on a real `~/.aka/data/aka.db`
+ * (16,390 capture events spanning 14.1 days).
  *
- * Measured on a real `~/.aka/data/aka.db`: 16,390 capture events spanning 14.1
- * days, i.e. 74,528 ms between events. At the generator's 1 s default a corpus
- * of any size fits inside a 30-day window, which makes every windowed read cost
- * exactly what an unwindowed one does — so `mttrTrend`'s window would bound
- * nothing here and the case would hold whether or not the fix worked.
+ * **It does NOT make the 30-day window bind at these sizes, and an earlier
+ * version of this comment claimed it did.** The arithmetic follows from the
+ * measurement it cites: 20,000 x 74,528 ms is 17.25 days, so the whole large
+ * corpus sits inside a 30-day window, exactly as it does at the generator's 1 s
+ * default. Crossing that boundary needs **34,779** events, and a later change
+ * raising `LARGE_EVENTS` past it would silently alter the experiment rather than
+ * fail — which is the reason to write the number down.
+ *
+ * What holds `mttrTrend`'s answer fixed here is `RESOLUTION_TARGET`, not the
+ * window. So this constant earns its place for a narrower reason than the one it
+ * used to give: it keeps the corpus's TIMESTAMPS plausible, so the reads run
+ * against a shape a real store could present, and it stops the two corpora
+ * differing in density as well as in size. Do not cite it as a windowing bound.
  */
 const REAL_SPACING_MS = 74_528;
+
+/** Events needed for a corpus to outlast a 30-day window at `REAL_SPACING_MS`. */
+const WINDOW_SPANNING_EVENTS = Math.ceil((30 * 86_400_000) / REAL_SPACING_MS);
 
 /** Resolutions both corpora carry, so the ANSWER size is what stays fixed. */
 const RESOLUTION_TARGET = 120;
@@ -133,19 +145,72 @@ const CONTROL_FLOOR = 2;
 const GROSS_REGRESSION_MS = 500;
 
 const SAMPLES = 25;
-const SEED_TIMEOUT_MS = 120_000;
+/**
+ * The hook's ceiling. Nothing is measured against it — it exists so a slow seed
+ * on a contended runner is not reported as a test timeout, which reads as a
+ * budget failure and is not one.
+ *
+ * **Sized for THIS file's work rather than copied**, which is the mistake it
+ * corrects. It was 120,000 ms, taken from `scale-budgets.test.ts`, whose hook
+ * does substantially less: measured here at 3.53 s of hook time against that
+ * file's 1.42-1.92 s for the nominally identical 2k + 20k pair. The difference
+ * is the corpus, not the sampling — 3,119 ms of seeding against 539 ms of
+ * samples — because this file needs the generator's measured 0.33 finding rate
+ * and writes resolution rows, where that one pins 0.1 and writes none.
+ *
+ * At the ~30x macOS-CI factor `scale-budgets` derives, 3.53 s lands near 106 s:
+ * inside 120,000 ms by about 12%, which a single preemption erases. That file
+ * has already overrun this same ceiling once, at 135,237 ms.
+ *
+ * **Cutting the corpus is the usual remedy and is not available here**, so the
+ * ceiling moves instead. `findingRate` cannot come down: at 0.1 the small corpus
+ * holds 191 findings and `recentFindings` returns 191 rows against the large
+ * corpus's 500, so the two sides would measure different amounts of work and the
+ * ratio would stop meaning anything. And 2k -> 20k is already the cheapest pair
+ * giving a 10x separation. Raising a ceiling that asserts nothing is not the same
+ * act as relaxing a budget that does.
+ */
+const SEED_TIMEOUT_MS = 240_000;
 
 /** The fastest of `samples` — the estimator note in the file header says why. */
 function fastest(samples: number[]): number {
   return Math.min(...samples);
 }
 
-function measure(fn: () => void): number[] {
+/**
+ * `SAMPLES` timings of the read's SYNCHRONOUS work.
+ *
+ * Every repository method here runs its SQL synchronously and returns an
+ * already-resolved promise, so the elapsed time around the bare call is the
+ * whole of the work and the promise is never awaited. (That same fact is why
+ * `/security`'s `Promise.all` buys nothing and the page costs the SUM of its
+ * reads rather than the max.)
+ *
+ * The rejection is CAUGHT rather than discarded, and the reason is diagnostic
+ * rather than cosmetic. A bare `void promise` that rejects is an unhandled
+ * rejection — one per sample, 25 per read — and vitest may attribute that to an
+ * unrelated test, so a broken read here would fail somewhere else in the suite
+ * instead of failing as the clean assertion this file exists to give.
+ *
+ * The `catch` is deliberately EMPTY, and that is not a swallowed error: what
+ * surfaces a broken read is the awaited `run[name]()` in `seedAndMeasure`, which
+ * runs before any sampling and rejects the `beforeAll` with the read's own error.
+ * Collecting the rejection here and rethrowing it after the loop looks stronger
+ * and cannot work — a `.catch` callback runs in a MICROTASK, so it has not fired
+ * by the time a synchronous loop finishes, and the check would read `undefined`
+ * every time. That exact dead code was written here first, and what caught it was
+ * fault-injecting a read that rejects only after its first call: the suite stayed
+ * green through all 8 cases.
+ */
+function measure(fn: () => Promise<unknown>): number[] {
   const out: number[] = [];
   for (let i = 0; i < SAMPLES; i += 1) {
-    const t = performance.now();
-    fn();
-    out.push(performance.now() - t);
+    const started = performance.now();
+    void fn().catch(() => {
+      // See above: the awaited call in `seedAndMeasure` is what reports a broken
+      // read. This exists only so a rejection is never unhandled.
+    });
+    out.push(performance.now() - started);
   }
   return out;
 }
@@ -188,10 +253,24 @@ async function seedAndMeasure(store: OwnedTempStore, events: number): Promise<Sc
   // zero. That shipped here first time round, and what caught it was the vacuity
   // case below rather than review — every flatness ratio was a clean 1.00,
   // because zero rows cost the same at both sizes.
+  // Each entry reports how many rows the read MATCHED — a number that must go to
+  // zero when the read finds nothing, or the vacuity check below cannot fire.
+  //
+  // `mttrTrend` is the one where the obvious metric is a trap, and it shipped
+  // here first time round: it returns `points`, which is
+  // `Array.from({ length: numBuckets })` — 30 for a '30d' range — whether or not
+  // a single finding matched. So `points.length` is the CONSTANT 30, and a
+  // corpus seeding zero countable resolutions still reported 30 while every
+  // bucket held null. Verified: at 2,000 events with `resolutionRate: 0` the read
+  // returns 30 points and 0 non-null buckets. Counting non-null buckets is what
+  // makes the guard mean "this read found something".
   const run: Record<ReadName, () => Promise<number>> = {
     recentFindings: async () => (await findings.recentFindings({ limit: 500 })).length,
     recentlyResolved: async () => (await security.recentlyResolved(20)).items.length,
-    mttrTrend: async () => (await security.mttrTrend('30d')).points.length,
+    mttrTrend: async () =>
+      (await security.mttrTrend('30d')).points.filter((point) =>
+        Object.values(point.bySeverity).some((mean) => mean !== null),
+      ).length,
     severitySummary: async () => (await security.severitySummary()).total,
   };
 
@@ -199,7 +278,7 @@ async function seedAndMeasure(store: OwnedTempStore, events: number): Promise<Sc
   const samples: Record<string, number[]> = {};
   for (const name of READS) {
     returned[name] = await run[name]();
-    samples[name] = measure(() => void run[name]());
+    samples[name] = measure(run[name]);
   }
   return { corpus, returned, samples };
 }
@@ -247,6 +326,21 @@ describe(`/security read costs from ${SMALL_EVENTS.toLocaleString('en-US')} to $
         'TRACKABLE_PER_EVENT needs re-measuring — the flatness cases below would ' +
         'otherwise be measuring resolution growth rather than store growth',
     ).toBeLessThan(RESOLUTION_TOLERANCE);
+  });
+
+  it('the corpus sits inside the 30-day window, so no case may claim the window bounds it', () => {
+    // Pinned as a fact rather than left in prose, because it is the assumption
+    // `REAL_SPACING_MS` used to state backwards. Every case here holds its
+    // answer fixed through RESOLUTION_TARGET and the LIMITs, never through the
+    // window — and if a later change raises LARGE_EVENTS past the boundary, the
+    // windowed reads start shrinking and the experiment quietly becomes a
+    // different one. This fails first and names the number.
+    expect(
+      LARGE_EVENTS,
+      `LARGE_EVENTS has passed ${String(WINDOW_SPANNING_EVENTS)}, so the 30-day window now ` +
+        'excludes part of the corpus. That changes what the windowed reads measure; re-read the ' +
+        'note on REAL_SPACING_MS before raising the ceiling on this assertion.',
+    ).toBeLessThan(WINDOW_SPANNING_EVENTS);
   });
 
   it('every read returns rows at both sizes, and the samples describe real work', () => {

--- a/packages/persistence/test/performance/security-page-scale.test.ts
+++ b/packages/persistence/test/performance/security-page-scale.test.ts
@@ -1,0 +1,295 @@
+/**
+ * The three `/security` reads whose cost must NOT grow with the store, asserted
+ * as a ratio across two store sizes.
+ *
+ * ## Why this file exists next to the plan guard
+ *
+ * `hot-read-query-plans.test.ts` asserts what SQLite DOES — which index, which
+ * scan — and that is the right shape for "no hot read passes over an unindexed
+ * table". It cannot express the property here, in either direction. A plan that
+ * reads as ideal can still be linear in the store: `mttrTrend` used to drive
+ * from `audit_events` on an index, joining every capture event before its window
+ * predicate could reject a row, and every step of that plan was a SEARCH. And a
+ * plan that reads as a full scan can be bounded: `recentFindings` deliberately
+ * scans `idx_audit_started_at` so its LIMIT can stop early, and EXPLAIN QUERY
+ * PLAN has no text for "terminates after 500 rows".
+ *
+ * So the plans pin the mechanism and this pins the consequence. Neither implies
+ * the other.
+ *
+ * ## The experiment: hold the ANSWER fixed, grow the store
+ *
+ * All three reads return a bounded answer — the newest 500 findings, the newest
+ * 20 resolutions, a 30-day MTTR trend over a fixed resolution set. So the
+ * property is stated as: with the same number of rows to RETURN, a ten-fold
+ * larger store must not cost meaningfully more.
+ *
+ * That is sharper than growing everything at once. If the corpus's resolutions
+ * scaled with its events, the old quadratic form of `recentlyResolved`
+ * (O(code_change events x resolved keys)) would read ~100x at a 10x step while a
+ * correct linear-in-resolutions form read ~10x — a real separation, but one where
+ * both arms move and the ceiling has to sit somewhere in between. Holding the
+ * resolution count fixed instead makes the correct answer FLAT and the defective
+ * one linear, so the ceiling separates 1 from 10 rather than 10 from 100.
+ *
+ * `RESOLUTION_TARGET` is what that costs: `resolutionRate` is a fraction of
+ * trackable findings, and trackable findings scale with events, so the rate is
+ * scaled by 1/events to keep the product roughly constant. "Roughly" is not good
+ * enough to leave unchecked — a calibration that drifted would silently turn this
+ * back into the both-arms-move experiment — so the two corpora's actual
+ * resolution counts are asserted to be within `RESOLUTION_TOLERANCE` of each
+ * other before any ratio is read.
+ *
+ * ## The estimator is the MINIMUM, and the bound is a RATIO
+ *
+ * Both for the reasons `scale-budgets.test.ts` sets out at length and does not
+ * need repeating: this repository does not gate a PR on wall-clock, because a
+ * shared runner does not get uniformly slower, it gets PREEMPTED, and a preempted
+ * sample has no upper bound. A ratio cancels the machine, and the fastest of n
+ * samples is the one statistic a loaded runner cannot inflate.
+ *
+ * ## The positive control is not optional here
+ *
+ * Every assertion below is of the form "this ratio is small", and the failure
+ * mode of the harness is a ratio of 1.0 for everything — two measurements taken
+ * against the same store, a corpus that did not grow, a read that returned
+ * nothing at either size. All of those pass every flatness assertion.
+ * `severitySummary` is the control: it is an all-time aggregate over every
+ * finding, so it IS linear in the store BY DESIGN, and its ratio is asserted to
+ * be LARGE. If that goes flat, the harness has stopped measuring growth and every
+ * other case in this file is worthless.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SqliteFindingsRepository } from '../../src/repositories/findings.ts';
+import { SqliteSecurityRepository } from '../../src/repositories/security.ts';
+import type { GeneratedCaptureCorpus } from '../helpers/corpus.ts';
+import { corpusConnection, seedCaptureCorpus } from '../helpers/corpus.ts';
+import type { OwnedTempStore } from '../helpers/temp-store.ts';
+import { createTempStore } from '../helpers/temp-store.ts';
+
+const SMALL_EVENTS = 2_000;
+const LARGE_EVENTS = 20_000;
+
+/**
+ * Real per-event spacing, so a 30-day window holds a FRACTION of the store.
+ *
+ * Measured on a real `~/.aka/data/aka.db`: 16,390 capture events spanning 14.1
+ * days, i.e. 74,528 ms between events. At the generator's 1 s default a corpus
+ * of any size fits inside a 30-day window, which makes every windowed read cost
+ * exactly what an unwindowed one does — so `mttrTrend`'s window would bound
+ * nothing here and the case would hold whether or not the fix worked.
+ */
+const REAL_SPACING_MS = 74_528;
+
+/** Resolutions both corpora carry, so the ANSWER size is what stays fixed. */
+const RESOLUTION_TARGET = 120;
+
+/**
+ * Trackable findings per event, used only to aim `resolutionRate` at
+ * `RESOLUTION_TARGET`.
+ *
+ * Measured, not derived: at the default finding rate about a third of captures
+ * carry a finding and about a quarter of captures are `code_change`, and the
+ * product of two seeded draws is not worth predicting in closed form. Read off a
+ * 4,000-event corpus (319 trackable) and cross-checked at 40,000. It only has to
+ * be close — `RESOLUTION_TOLERANCE` is what makes being wrong loud instead of
+ * silent.
+ */
+const TRACKABLE_PER_EVENT = 0.08;
+
+/** How far the two resolution counts may differ before the experiment is void. */
+const RESOLUTION_TOLERANCE = 0.35;
+
+/**
+ * A flat read may not cost more than this multiple at ten times the store.
+ *
+ * The same ceiling `scale-budgets.test.ts` uses, and for the same reason: a cost
+ * that went linear in the store reads ~10x at a 10x step, so 3 sits with wide
+ * margin on both sides of the boundary it has to separate. Measured ratios for
+ * the three reads below are in the test names' own failure messages.
+ */
+const FLATNESS_CEILING = 3;
+
+/**
+ * The control must exceed this, or the harness is not measuring growth.
+ *
+ * `severitySummary` is linear in findings, which scale with events, so its true
+ * ratio is ~10. Asserting only 2 leaves room for a runner where the constant
+ * overhead is a larger share of the small measurement, while still being
+ * unreachable by a harness that has gone flat.
+ */
+const CONTROL_FLOOR = 2;
+
+/**
+ * A gross-regression backstop, for the defect a ratio is structurally blind to.
+ *
+ * A cost that becomes 500 ms at EVERY size keeps a ratio of 1.0 and passes every
+ * flatness assertion here. This is orders of magnitude above the measured costs
+ * (single-digit ms at 20k) and is sized against `/security`'s own 2,000 ms budget
+ * rather than tuned to a measurement, so it cannot flake on a preempted sample.
+ * It is not the flatness guard and neither substitutes for the other.
+ */
+const GROSS_REGRESSION_MS = 500;
+
+const SAMPLES = 25;
+const SEED_TIMEOUT_MS = 120_000;
+
+/** The fastest of `samples` — the estimator note in the file header says why. */
+function fastest(samples: number[]): number {
+  return Math.min(...samples);
+}
+
+function measure(fn: () => void): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < SAMPLES; i += 1) {
+    const t = performance.now();
+    fn();
+    out.push(performance.now() - t);
+  }
+  return out;
+}
+
+interface Scale {
+  readonly corpus: GeneratedCaptureCorpus;
+  /** Rows each read returned — a read that returns nothing measures nothing. */
+  readonly returned: Record<string, number>;
+  readonly samples: Record<string, number[]>;
+}
+
+const READS = ['recentFindings', 'recentlyResolved', 'mttrTrend', 'severitySummary'] as const;
+type ReadName = (typeof READS)[number];
+
+async function seedAndMeasure(store: OwnedTempStore, events: number): Promise<Scale> {
+  const db = store.open();
+  const corpus = seedCaptureCorpus(db, {
+    events,
+    spacingMs: REAL_SPACING_MS,
+    resolutionRate: Math.min(1, RESOLUTION_TARGET / (events * TRACKABLE_PER_EVENT)),
+  });
+  const raw = corpusConnection(db);
+  const findings = new SqliteFindingsRepository(raw);
+  // The corpus's own clock, never `Date.now()`: the corpus is stamped from a
+  // fixed 2024 epoch, so on the wall clock every windowed read is years past its
+  // data and matches nothing — while still running, and still returning a
+  // number, which is the failure this file could not detect from the outside.
+  const security = new SqliteSecurityRepository(raw, () => corpus.endsAt);
+
+  // Each entry runs the read and reports how many rows it produced. The COUNT is
+  // awaited once per read and the TIMING never is: every method here runs its SQL
+  // synchronously and hands back an already-resolved promise, so the elapsed time
+  // around the bare call is the whole of the work. (That same fact is why
+  // `/security`'s `Promise.all` buys nothing and the page costs the SUM of its
+  // reads rather than the max.)
+  //
+  // Awaiting is not optional for the count, and the reason cost this file a bug:
+  // a `.then` callback runs in a MICROTASK even on an already-resolved promise,
+  // so reading the row count out of one and returning synchronously always yields
+  // zero. That shipped here first time round, and what caught it was the vacuity
+  // case below rather than review — every flatness ratio was a clean 1.00,
+  // because zero rows cost the same at both sizes.
+  const run: Record<ReadName, () => Promise<number>> = {
+    recentFindings: async () => (await findings.recentFindings({ limit: 500 })).length,
+    recentlyResolved: async () => (await security.recentlyResolved(20)).items.length,
+    mttrTrend: async () => (await security.mttrTrend('30d')).points.length,
+    severitySummary: async () => (await security.severitySummary()).total,
+  };
+
+  const returned: Record<string, number> = {};
+  const samples: Record<string, number[]> = {};
+  for (const name of READS) {
+    returned[name] = await run[name]();
+    samples[name] = measure(() => void run[name]());
+  }
+  return { corpus, returned, samples };
+}
+
+describe(`/security read costs from ${SMALL_EVENTS.toLocaleString('en-US')} to ${LARGE_EVENTS.toLocaleString('en-US')} events`, () => {
+  let smallStore: OwnedTempStore;
+  let largeStore: OwnedTempStore;
+  let small: Scale;
+  let large: Scale;
+
+  beforeAll(async () => {
+    smallStore = createTempStore('aka-security-scale-small-');
+    largeStore = createTempStore('aka-security-scale-large-');
+    small = await seedAndMeasure(smallStore, SMALL_EVENTS);
+    large = await seedAndMeasure(largeStore, LARGE_EVENTS);
+  }, SEED_TIMEOUT_MS);
+
+  afterAll(() => {
+    smallStore.destroy();
+    largeStore.destroy();
+  });
+
+  it('both corpora are at the stated scale, and ten times apart', () => {
+    expect(small.corpus.events).toBe(SMALL_EVENTS);
+    expect(large.corpus.events).toBe(LARGE_EVENTS);
+    // Findings are what three of these reads are linear in, so the SIZE step has
+    // to be visible there too — a corpus that grew its events and not its
+    // findings would leave every ratio below flat for the wrong reason.
+    expect(large.corpus.findings / small.corpus.findings).toBeGreaterThan(5);
+  });
+
+  it('the two corpora carry the same number of resolutions, so only the store grew', () => {
+    const a = small.corpus.resolutions;
+    const b = large.corpus.resolutions;
+    expect(a, 'small corpus seeded no resolutions').toBeGreaterThan(0);
+    expect(b, 'large corpus seeded no resolutions').toBeGreaterThan(0);
+    // The whole experiment rests on this. If the counts diverge, the reads that
+    // are linear in RESOLUTIONS grow for a legitimate reason and their ratios
+    // stop testing the store at all — so this fails rather than being reported
+    // alongside a green flatness assertion.
+    const skew = Math.abs(a - b) / Math.max(a, b);
+    expect(
+      skew,
+      `resolution counts drifted apart (${String(a)} vs ${String(b)}); ` +
+        'TRACKABLE_PER_EVENT needs re-measuring — the flatness cases below would ' +
+        'otherwise be measuring resolution growth rather than store growth',
+    ).toBeLessThan(RESOLUTION_TOLERANCE);
+  });
+
+  it('every read returns rows at both sizes, and the samples describe real work', () => {
+    for (const name of READS) {
+      // A read matching nothing is the vacuity this whole file is exposed to:
+      // its cost would be flat at every size and every assertion below would
+      // pass while measuring an empty result.
+      expect(small.returned[name], `${name} returned nothing at the small size`).toBeGreaterThan(0);
+      expect(large.returned[name], `${name} returned nothing at the large size`).toBeGreaterThan(0);
+      expect(fastest(small.samples[name] ?? []), `${name} small floor`).toBeGreaterThan(0);
+      expect(fastest(large.samples[name] ?? []), `${name} large floor`).toBeGreaterThan(0);
+    }
+  });
+
+  for (const name of ['recentFindings', 'recentlyResolved', 'mttrTrend'] as const) {
+    it(`${name} stays flat as the store grows`, () => {
+      const smallest = fastest(small.samples[name] ?? []);
+      const largest = fastest(large.samples[name] ?? []);
+      const ratio = largest / smallest;
+      expect(
+        ratio,
+        `${name} fastest-of-${String(SAMPLES)} was ${smallest.toFixed(3)} ms at ` +
+          `${SMALL_EVENTS.toLocaleString('en-US')} events and ${largest.toFixed(3)} ms at ` +
+          `${LARGE_EVENTS.toLocaleString('en-US')} — ratio ${ratio.toFixed(2)} against a ceiling ` +
+          `of ${String(FLATNESS_CEILING)}. A cost that went linear in the store reads ~10x here.`,
+      ).toBeLessThan(FLATNESS_CEILING);
+      expect(largest, `${name} gross-regression backstop`).toBeLessThan(GROSS_REGRESSION_MS);
+    });
+  }
+
+  it('the control grows: severitySummary is linear in findings by design', () => {
+    const smallest = fastest(small.samples.severitySummary ?? []);
+    const largest = fastest(large.samples.severitySummary ?? []);
+    const ratio = largest / smallest;
+    // Without this the file cannot tell a genuinely flat read from a harness that
+    // measures the same store twice, and every case above passes either way.
+    expect(
+      ratio,
+      `severitySummary was ${smallest.toFixed(3)} ms at ${SMALL_EVENTS.toLocaleString('en-US')} ` +
+        `events and ${largest.toFixed(3)} ms at ${LARGE_EVENTS.toLocaleString('en-US')} — ratio ` +
+        `${ratio.toFixed(2)}, which must exceed ${String(CONTROL_FLOOR)}. This read is an ` +
+        'all-time aggregate over every finding, so a FLAT result here means the harness has ' +
+        'stopped measuring store growth and every flatness case above is vacuous.',
+    ).toBeGreaterThan(CONTROL_FLOOR);
+  });
+});

--- a/packages/persistence/test/performance/store-growth.test.ts
+++ b/packages/persistence/test/performance/store-growth.test.ts
@@ -72,25 +72,36 @@ const BASE_EVENTS = 5_000;
 const DOUBLE_EVENTS = 10_000;
 
 /**
- * The band the marginal cost must land in: ±15% of a measured 797.9 B/event for
+ * The band the marginal cost must land in: ±15% of a measured 902.8 B/event for
  * the generator's 240-character events.
  *
  * TIGHT, and it can be, because this is not a timing measurement. The corpus is
  * deterministic and so is SQLite's page allocation, so the figure is
- * byte-identical run to run — two consecutive runs produced 4,395,008 B at 5k
- * and 8,384,512 B at 10k, the same integers each time. Nothing here can flake
+ * byte-identical run to run — two consecutive runs produced 4,956,160 B at 5k
+ * and 9,469,952 B at 10k, the same integers each time. Nothing here can flake
  * the way a wall-clock bound does, so the band is sized to catch a regression
  * rather than to survive one.
  *
- * **The centre is a property of the PAIR, not of an event**, which is why it is
- * retaken whenever the pair moves rather than carried across. Measured on the
- * same corpus at three consecutive decades: 791.3 B/event across 2.5k→5k, 797.9
- * across 5k→10k, 818.4 across 10k→20k. The slope creeps as the store grows —
- * ~3.4% over that range — so the old 818.4 sits 2.5% above where this pair
- * actually lands. Inside a ±15% band that would still have passed, which is
- * exactly the hazard: a centre nobody re-measured drifts the band off the
- * measurement it is supposed to bracket, one size change at a time, and the
- * band only ever reads as green while it happens.
+ * **The centre is a property of the CORPUS, not of an event**, so it is retaken
+ * whenever anything about the corpus moves — not only its size. Measured at
+ * three consecutive decades: 902.8 B/event across 2.5k→5k, 902.8 across 5k→10k,
+ * 923.2 across 10k→20k. The slope still creeps as the store grows, ~2.3% over
+ * that range.
+ *
+ * **What moved it last was the generator's finding RATE, not its size**, and that
+ * is the case this paragraph exists to stop being learned again. The rate went
+ * from 0.1 to a measured 0.33 (see `DEFAULT_FINDING_RATE`), so every event now
+ * carries about three times the finding rows, and the marginal went 797.9 →
+ * 902.8. Against the OLD centre's 917.6 ceiling that is a pass — by 1.6%. So the
+ * band did not catch a 13% growth regression and would not have caught the next
+ * one either; it would simply have started failing on some unrelated commit, at
+ * which point the obvious-looking fix is to widen it. A centre nobody re-measured
+ * drifts off the measurement it is supposed to bracket, one change at a time, and
+ * reads as green throughout.
+ *
+ * The three decades above were measured at the current rate. The figures the old
+ * centre rested on (791.3 / 797.9 / 818.4) described a corpus with a third of
+ * the findings and are retracted rather than kept for comparison.
  *
  * A band this narrow was chosen after a loose one failed to earn its place: at
  * a 1,800 B ceiling, a mutation that wrote a SECOND copy of every event's
@@ -98,11 +109,13 @@ const DOUBLE_EVENTS = 10_000;
  * ceiling has to sit below the smallest regression worth catching, not below the
  * absurd ones.
  *
- * That mutation is what re-earns the band at THIS pair, since a smaller corpus
- * is where a size-derived ceiling is likeliest to have gone slack: replanted, it
- * reads 1,129.7 B/event (6,057,984 B at 5k against 11,706,368 B at 10k) and
- * fails the 917.6 ceiling above. Replant it, rather than trusting this
- * paragraph, before moving the pair again.
+ * That mutation is what re-earns the band at THIS centre, and it was replanted
+ * when the centre moved rather than scaled forward from the old figure: it reads
+ * 1,214.1 B/event (6,516,736 B at 5k against 12,587,008 B at 10k) and fails the
+ * 1,038.2 ceiling above. Scaling the old 1,129.7 by the centre's own movement
+ * would have predicted 1,282.0 and been wrong by 5%, which is the reason to
+ * replant rather than extrapolate. Replant it, rather than trusting this
+ * paragraph, the next time either the pair or the corpus changes.
  *
  * The 15% is for cross-platform slack, not for noise: a SQLite build with a
  * different default page size would shift the figure, and this should fail
@@ -111,7 +124,7 @@ const DOUBLE_EVENTS = 10_000;
  * the corpus stopped writing what it claims to, and a growth test over a store
  * that is not growing proves nothing.
  */
-const MEASURED_MARGINAL_BYTES_PER_EVENT = 797.9;
+const MEASURED_MARGINAL_BYTES_PER_EVENT = 902.8;
 const MARGINAL_TOLERANCE = 0.15;
 const MIN_MARGINAL_BYTES_PER_EVENT = MEASURED_MARGINAL_BYTES_PER_EVENT * (1 - MARGINAL_TOLERANCE);
 const MAX_MARGINAL_BYTES_PER_EVENT = MEASURED_MARGINAL_BYTES_PER_EVENT * (1 + MARGINAL_TOLERANCE);

--- a/packages/persistence/test/repositories/security.test.ts
+++ b/packages/persistence/test/repositories/security.test.ts
@@ -317,6 +317,55 @@ describe('mttrTrend', () => {
     expect(todaysPoint?.bySeverity.critical).toBe(0);
   });
 
+  it('weights a finding ONCE however many resolution rows it has inside the window', async () => {
+    // finding_resolution is APPEND-ONLY, so a key fixed, redetected and fixed
+    // again carries several rows in one window. The read drives from that table,
+    // which means such a key matches once PER ROW — and this bucket's value is a
+    // MEAN, so a key matched three times is a key weighted three times.
+    //
+    // The skew only shows when two findings in one bucket duplicate UNEQUALLY and
+    // have different MTTRs. With a single key, or with equal duplication, sums and
+    // counts scale by the same factor and the mean is unchanged — which is why a
+    // fixture has to be built for it deliberately rather than expected to fall out
+    // of the cases above.
+    //
+    // key-a: detected 6 days ago, fixed today, and THREE rows inside the window.
+    record({ daysAgo: 6, severity: 'critical', kind: 'code_change', findingKey: 'key-dup' });
+    for (const [status, method, at] of [
+      ['resolved', 'fixed-at-source', NOW - 3 * DAY_MS],
+      ['open', 'redetected', NOW - 2 * DAY_MS],
+      ['resolved', 'fixed-at-source', NOW - 0.1 * DAY_MS],
+    ] as const) {
+      db.resolutions.insertResolution({
+        findingKey: 'key-dup',
+        status,
+        method,
+        resolvedAt: at,
+        evidence: '',
+      });
+    }
+    // key-b: detected 2 days ago, fixed today, ONE row. Same bucket, same
+    // severity, a different MTTR.
+    record({ daysAgo: 2, severity: 'critical', kind: 'code_change', findingKey: 'key-single' });
+    db.resolutions.insertResolution({
+      findingKey: 'key-single',
+      status: 'resolved',
+      method: 'fixed-at-source',
+      resolvedAt: NOW - 0.1 * DAY_MS,
+      evidence: '',
+    });
+
+    const res = await security().mttrTrend('7d');
+    const today = res.points.at(-1);
+    // Unweighted mean of the two: (5.9 + 1.9) / 2 days. Weighted 3:1 by the
+    // duplicate rows it would be (3 * 5.9 + 1.9) / 4 = 4.9 days — so a fixture
+    // this shape is what separates the two, and the expected value is the one
+    // that counts each FINDING once.
+    const a = 5.9 * DAY_MS;
+    const b = 1.9 * DAY_MS;
+    expect(today?.bySeverity.critical).toBeCloseTo((a + b) / 2, -3);
+  });
+
   it('excludes a superseded (redetected) resolution — latest-resolution-wins', async () => {
     record({ daysAgo: 1, severity: 'critical', kind: 'code_change', findingKey: 'key-redetected' });
     db.resolutions.insertResolution({

--- a/packages/persistence/test/test-fixtures/generate.test.ts
+++ b/packages/persistence/test/test-fixtures/generate.test.ts
@@ -367,6 +367,45 @@ describe('generateCaptureCorpus', () => {
     }
   });
 
+  it('resolves only the keys ITS OWN call minted, not the whole store', () => {
+    // The generator is additive, so a bare "every trackable finding" read would
+    // pick up an earlier corpus's keys and write resolutions against findings
+    // this call never created. The landed-row check cannot catch that on its
+    // own: it is a DELTA, and rows written for older keys land inside the delta
+    // exactly the same way. Measured before the fix — a second 1,000-event
+    // corpus added 76 trackable findings and wrote 148 resolutions.
+    const db = store.open();
+    const first = seedCaptureCorpus(db, { events: 1_000, seed: 1, resolutionRate: 0 });
+    expect(
+      first.trackableFindings,
+      'first corpus minted no keys to contaminate with',
+    ).toBeGreaterThan(0);
+    expect(first.resolutions).toBe(0);
+
+    const second = seedCaptureCorpus(db, { events: 1_000, seed: 2, resolutionRate: 1 });
+    // At a rate of 1, every key the SECOND call minted gets exactly one row —
+    // so the total on disk is that call's trackable count and no more.
+    expect(second.resolutions).toBe(second.trackableFindings);
+
+    const onDisk = (
+      raw(db).prepare('SELECT COUNT(*) AS c FROM finding_resolution').get() as { c: number }
+    ).c;
+    expect(onDisk).toBe(second.trackableFindings);
+
+    // The sharper form of the same claim: no resolution may name a key the
+    // second call did not mint. Asserted over the store rather than over the
+    // tally, because the tally is what the defect kept green.
+    const foreign = (
+      raw(db)
+        .prepare(
+          `SELECT COUNT(*) AS c FROM finding_resolution
+            WHERE finding_key NOT LIKE 'corpus-key-2-%'`,
+        )
+        .get() as { c: number }
+    ).c;
+    expect(foreign, 'a resolution was written against a key from another corpus').toBe(0);
+  });
+
   it('stays deterministic with resolutions on, ids and clock included', () => {
     // The resolution writer mints an id and stamps created_at, so it is a second
     // entropy surface the corpus has to close — and one that a row-count check

--- a/packages/persistence/test/test-fixtures/generate.test.ts
+++ b/packages/persistence/test/test-fixtures/generate.test.ts
@@ -15,6 +15,14 @@
  *    one.
  *  - **The refusal is real.** The size check has to go red when the rows are
  *    missing, or it is decoration.
+ *
+ * A fourth was added once the corpus grew the axes `/security`'s reads are
+ * sensitive to: **the shape has to land, not just the row count.** A corpus can
+ * hold every event and finding it promised while carrying no `finding_key` and no
+ * resolution row, and three of that page's reads then return NOTHING — while
+ * still running, still producing a plan, and still reporting a duration. That is
+ * the failure the four separate landed-row checks exist for, and the cases below
+ * drive each of them independently, because none implies another.
  */
 import type { DatabaseSync } from 'node:sqlite';
 
@@ -248,6 +256,192 @@ describe('generateCaptureCorpus', () => {
     );
   });
 
+  it('makes a code_change capture trackable and every other kind not', () => {
+    // Mirrors the product: plugin-sdk's runtime sets
+    // `isAtRest = kind === 'code_change' && filePath !== undefined` and keys those
+    // findings alone. Asserted as a PARTITION rather than a count, because a
+    // corpus that keyed every finding would satisfy a bare "some are keyed" check
+    // while presenting a store no product path can write — and every read that
+    // branches on `finding_key IS NOT NULL` would then be measured on it.
+    const db = store.open();
+    const corpus = seedCaptureCorpus(db, { events: 600, seed: 3 });
+    const split = raw(db)
+      .prepare(
+        `SELECT e.event_type AS kind,
+                SUM(CASE WHEN f.finding_key IS NULL THEN 0 ELSE 1 END) AS keyed,
+                SUM(CASE WHEN f.finding_key IS NULL THEN 1 ELSE 0 END) AS unkeyed
+           FROM inspection_findings f
+           JOIN audit_events e ON e.id = f.audit_event_id
+          GROUP BY e.event_type`,
+      )
+      .all() as { kind: string; keyed: number; unkeyed: number }[];
+
+    // Vacuity: a corpus with no findings on either side of the partition would
+    // satisfy every row assertion below.
+    expect(corpus.findings, 'corpus produced no findings to partition').toBeGreaterThan(0);
+    expect(corpus.trackableFindings).toBeGreaterThan(0);
+    expect(corpus.trackableFindings).toBeLessThan(corpus.findings);
+
+    for (const row of split) {
+      if (row.kind === 'code_change') {
+        expect(row.unkeyed, 'a code_change finding was left unkeyed').toBe(0);
+        expect(row.keyed).toBeGreaterThan(0);
+      } else {
+        expect(row.keyed, `${row.kind} findings must carry no finding_key`).toBe(0);
+      }
+    }
+
+    // The reported tally is what a caller sizes a measurement against, so it is
+    // read back off disk rather than trusted.
+    const onDisk = (
+      raw(db)
+        .prepare('SELECT COUNT(*) AS c FROM inspection_findings WHERE finding_key IS NOT NULL')
+        .get() as { c: number }
+    ).c;
+    expect(corpus.trackableFindings).toBe(onDisk);
+  });
+
+  it('gives every code_change capture a file path, and no other kind one', () => {
+    // `file_path` is half of captureId's content-addressing and the key of the
+    // partial index `idx_audit_code_change_path`, so a corpus without it drives
+    // the at-rest path reads against an index holding nothing.
+    const db = store.open();
+    seedCaptureCorpus(db, { events: 400, seed: 4 });
+    const rows = raw(db)
+      .prepare(
+        `SELECT event_type AS kind,
+                SUM(CASE WHEN json_extract(attributes, '$.file_path') IS NULL THEN 0 ELSE 1 END) AS withPath,
+                SUM(CASE WHEN json_extract(attributes, '$.file_path') IS NULL THEN 1 ELSE 0 END) AS without
+           FROM audit_events
+          WHERE event_type IN ('prompt', 'response', 'code_change', 'tool_use')
+          GROUP BY event_type`,
+      )
+      .all() as { kind: string; withPath: number; without: number }[];
+
+    expect(rows.length, 'corpus produced no capture events').toBeGreaterThan(0);
+    for (const row of rows) {
+      if (row.kind === 'code_change') {
+        expect(row.without, 'a code_change capture has no file path').toBe(0);
+        expect(row.withPath).toBeGreaterThan(0);
+      } else {
+        expect(row.withPath, `${row.kind} captures must carry no file path`).toBe(0);
+      }
+    }
+  });
+
+  it('writes resolutions only for trackable findings, and only when asked', () => {
+    const db = store.open();
+    const none = seedCaptureCorpus(db, { events: 300, seed: 5 });
+    // The measured default is zero — the real store holds no resolution rows —
+    // so the option has to be the only way to get them.
+    expect(none.resolutions).toBe(0);
+
+    const other = createTempStore('aka-generate-res-');
+    try {
+      const withRes = seedCaptureCorpus(other.open(), {
+        events: 300,
+        seed: 5,
+        resolutionRate: 1,
+      });
+      expect(withRes.resolutions).toBeGreaterThan(0);
+      // At a rate of 1 every trackable finding gets exactly one row, which is
+      // also what pins the selection to the TRACKABLE set rather than to all
+      // findings — the looser reading would produce `findings` rows here.
+      expect(withRes.resolutions).toBe(withRes.trackableFindings);
+
+      const orphans = (
+        raw(other.open())
+          .prepare(
+            `SELECT COUNT(*) AS c FROM finding_resolution r
+              WHERE NOT EXISTS (SELECT 1 FROM inspection_findings f
+                                 WHERE f.finding_key = r.finding_key)`,
+          )
+          .get() as { c: number }
+      ).c;
+      // A resolution keyed to no finding is invisible to every read here (all of
+      // them reach resolutions THROUGH a finding), so it would inflate the tally
+      // while changing no measurement.
+      expect(orphans, 'a resolution was written against a key with no finding').toBe(0);
+    } finally {
+      other.destroy();
+    }
+  });
+
+  it('stays deterministic with resolutions on, ids and clock included', () => {
+    // The resolution writer mints an id and stamps created_at, so it is a second
+    // entropy surface the corpus has to close — and one that a row-count check
+    // cannot see, since non-deterministic ids still count correctly.
+    const shape = (db: LocalDatabase): unknown[] =>
+      raw(db)
+        .prepare(
+          'SELECT id, finding_key, status, method, resolved_at, created_at ' +
+            'FROM finding_resolution ORDER BY id',
+        )
+        .all();
+
+    const a = createTempStore('aka-generate-det-a-');
+    const b = createTempStore('aka-generate-det-b-');
+    try {
+      const dbA = a.open();
+      const dbB = b.open();
+      const seeded = seedCaptureCorpus(dbA, { events: 300, seed: 7, resolutionRate: 0.5 });
+      seedCaptureCorpus(dbB, { events: 300, seed: 7, resolutionRate: 0.5 });
+      expect(seeded.resolutions, 'no resolutions to compare').toBeGreaterThan(0);
+      expect(shape(dbA)).toEqual(shape(dbB));
+    } finally {
+      a.destroy();
+      b.destroy();
+    }
+  });
+
+  it('refuses a store that lost its resolutions, independently of its findings', () => {
+    // The positive control for the fourth landed-row check. Findings land
+    // normally and the resolution writer's table is emptied underneath it, which
+    // is what a fail-open swallow on that insert looks like from here — the
+    // events and findings checks both stay green.
+    const db = store.open();
+    const connection = raw(db);
+    // A Proxy, not a spread copy: `DatabaseSync`'s methods live on its prototype,
+    // so `{ ...connection }` carries none of them and the generator fails on a
+    // missing `exec` long before reaching the check under test — which is this
+    // case passing for the wrong reason unless the assertion names the message.
+    //
+    // Anything not intercepted is re-BOUND to the real target rather than handed
+    // back loose. `DatabaseSync` and `StatementSync` are host objects that reject
+    // a proxy as their receiver, so an unbound method throws `Illegal invocation`
+    // on the first call and an accessor throws at the read — the same reason
+    // `test/helpers/query-plans.ts` binds in its own pass-through.
+    const bound = (target: object, prop: string | symbol): unknown => {
+      const value: unknown = Reflect.get(target, prop, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    };
+    const swallowResolutionInserts = new Proxy(connection, {
+      get(target, prop) {
+        if (prop !== 'prepare') return bound(target, prop);
+        return (sql: string) => {
+          const stmt = target.prepare(sql);
+          if (!sql.trimStart().startsWith('INSERT INTO finding_resolution')) return stmt;
+          return new Proxy(stmt, {
+            get(statement, statementProp) {
+              if (statementProp !== 'run') return bound(statement, statementProp);
+              return () => ({ changes: 0, lastInsertRowid: 0 });
+            },
+          });
+        };
+      },
+    });
+    const target: CaptureCorpusTarget = {
+      recordCapture: (event, findings) => {
+        db.recordCapture(event, findings);
+      },
+      connection: swallowResolutionInserts,
+    };
+
+    expect(() =>
+      generateCaptureCorpus(target, { events: 300, seed: 7, resolutionRate: 1 }),
+    ).toThrow(/wrote 0 resolutions, expected [1-9]/);
+  });
+
   it('rejects options it cannot honour', () => {
     const db = store.open();
     const target: CaptureCorpusTarget = {
@@ -261,6 +455,15 @@ describe('generateCaptureCorpus', () => {
     expect(() => generateCaptureCorpus(target, { events: 1.5 })).toThrow(TypeError);
     expect(() => generateCaptureCorpus(target, { events: 10, sessions: 0 })).toThrow(TypeError);
     expect(() => generateCaptureCorpus(target, { events: 10, findingRate: 2 })).toThrow(RangeError);
+    expect(() => generateCaptureCorpus(target, { events: 10, resolutionRate: 2 })).toThrow(
+      RangeError,
+    );
+    // NaN fails BOTH range comparisons, so a bare range check admits it and the
+    // corpus then silently carries no resolutions at all — the one outcome the
+    // landed-row checks exist to refuse.
+    expect(() => generateCaptureCorpus(target, { events: 10, resolutionRate: NaN })).toThrow(
+      RangeError,
+    );
   });
 
   it('leaves no transaction open', () => {

--- a/packages/schema/drizzle/local-sqlite/0021_finding_resolution_resolved_at_index.sql
+++ b/packages/schema/drizzle/local-sqlite/0021_finding_resolution_resolved_at_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_finding_resolution_resolved_at` ON `finding_resolution` (`resolved_at`);

--- a/packages/schema/drizzle/local-sqlite/meta/0021_snapshot.json
+++ b/packages/schema/drizzle/local-sqlite/meta/0021_snapshot.json
@@ -1,0 +1,2626 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8731ccf3-5672-4c1c-be96-68314d29de0d",
+  "prevId": "e11bdc7c-f5af-4286-a192-82f7aa1286a3",
+  "tables": {
+    "audit_events": {
+      "name": "audit_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "root_session_id": {
+          "name": "root_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_project_id": {
+          "name": "source_project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.output_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_creation_input_tokens": {
+          "name": "cache_creation_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_creation_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "cache_read_input_tokens": {
+          "name": "cache_read_input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.cache_read_input_tokens'))",
+            "type": "virtual"
+          }
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.model'))",
+            "type": "virtual"
+          }
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.provider'))",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_audit_parent": {
+          "name": "idx_audit_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session": {
+          "name": "idx_audit_session",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_harness_t": {
+          "name": "idx_audit_harness_t",
+          "columns": [
+            "harness_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_project_t": {
+          "name": "idx_audit_project_t",
+          "columns": [
+            "source_project_id",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_session_type": {
+          "name": "idx_audit_session_type",
+          "columns": [
+            "root_session_id",
+            "started_at"
+          ],
+          "isUnique": false,
+          "where": "event_type = 'llm_call'"
+        },
+        "idx_audit_type_t": {
+          "name": "idx_audit_type_t",
+          "columns": [
+            "event_type",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "idx_audit_started_at": {
+          "name": "idx_audit_started_at",
+          "columns": [
+            "started_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "audit_events_parent_id_audit_events_id_fk": {
+          "name": "audit_events_parent_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_root_session_id_audit_events_id_fk": {
+          "name": "audit_events_root_session_id_audit_events_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "root_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_host_id_inventory_id_fk": {
+          "name": "audit_events_host_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_harness_id_inventory_id_fk": {
+          "name": "audit_events_harness_id_inventory_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_events_source_project_id_source_project_id_fk": {
+          "name": "audit_events_source_project_id_source_project_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "source_project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "available_packs": {
+      "name": "available_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recorded_by": {
+          "name": "recorded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_available_packs_pack": {
+          "name": "uq_available_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "classified_data": {
+      "name": "classified_data",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class": {
+          "name": "class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "egress_decision_override": {
+      "name": "egress_decision_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_egress_decision_override": {
+          "name": "uq_egress_decision_override",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": true
+        },
+        "uq_egress_decision_override_host": {
+          "name": "uq_egress_decision_override_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true,
+          "where": "`host` IS NOT NULL"
+        }
+      },
+      "foreignKeys": {
+        "egress_decision_override_destination_id_share_destination_id_fk": {
+          "name": "egress_decision_override_destination_id_share_destination_id_fk",
+          "tableFrom": "egress_decision_override",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_tool": {
+          "name": "source_tool",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_events_occurred": {
+          "name": "idx_events_occurred",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "exceptions": {
+      "name": "exceptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_value": {
+          "name": "masked_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'suppress'"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_count": {
+          "name": "use_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "justification": {
+          "name": "justification",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by": {
+          "name": "revoked_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoke_reason": {
+          "name": "revoke_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_exceptions_active": {
+          "name": "uq_exceptions_active",
+          "columns": [
+            "rule_id",
+            "value_fingerprint",
+            "key_version"
+          ],
+          "isUnique": true,
+          "where": "revoked_at IS NULL"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_access_override": {
+      "name": "file_access_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access": {
+          "name": "access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_file_access_override_project": {
+          "name": "idx_file_access_override_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_file_access_override": {
+          "name": "uq_file_access_override",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "file_access_override_project_id_source_project_id_fk": {
+          "name": "file_access_override_project_id_source_project_id_fk",
+          "tableFrom": "file_access_override",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "finding_resolution": {
+      "name": "finding_resolution",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_finding_resolution_key": {
+          "name": "idx_finding_resolution_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": false
+        },
+        "idx_finding_resolution_resolved_at": {
+          "name": "idx_finding_resolution_resolved_at",
+          "columns": [
+            "resolved_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "findings": {
+      "name": "findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_findings_event": {
+          "name": "idx_findings_event",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_findings_key": {
+          "name": "uq_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "findings_event_id_events_id_fk": {
+          "name": "findings_event_id_events_id_fk",
+          "tableFrom": "findings",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "harness_asset": {
+      "name": "harness_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "harness_id": {
+          "name": "harness_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_harness_asset_harness": {
+          "name": "idx_harness_asset_harness",
+          "columns": [
+            "harness_id"
+          ],
+          "isUnique": false
+        },
+        "uq_harness_asset": {
+          "name": "uq_harness_asset",
+          "columns": [
+            "harness_id",
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "harness_asset_harness_id_inventory_id_fk": {
+          "name": "harness_asset_harness_id_inventory_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "harness_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "harness_asset_asset_id_inventory_asset_id_fk": {
+          "name": "harness_asset_asset_id_inventory_asset_id_fk",
+          "tableFrom": "harness_asset",
+          "tableTo": "inventory_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_definitions": {
+      "name": "inspection_definitions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "definition": {
+          "name": "definition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inspection_findings": {
+      "name": "inspection_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audit_event_id": {
+          "name": "audit_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inspection_definition_id": {
+          "name": "inspection_definition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "classified_data_id": {
+          "name": "classified_data_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "span_start": {
+          "name": "span_start",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "span_end": {
+          "name": "span_end",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action_taken": {
+          "name": "action_taken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finding_key": {
+          "name": "finding_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "first_detected_at": {
+          "name": "first_detected_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inspection_findings_event": {
+          "name": "idx_inspection_findings_event",
+          "columns": [
+            "audit_event_id"
+          ],
+          "isUnique": false
+        },
+        "uq_inspection_findings_key": {
+          "name": "uq_inspection_findings_key",
+          "columns": [
+            "finding_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "inspection_findings_audit_event_id_audit_events_id_fk": {
+          "name": "inspection_findings_audit_event_id_audit_events_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "audit_events",
+          "columnsFrom": [
+            "audit_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_inspection_definition_id_inspection_definitions_id_fk": {
+          "name": "inspection_findings_inspection_definition_id_inspection_definitions_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "inspection_definitions",
+          "columnsFrom": [
+            "inspection_definition_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "inspection_findings_classified_data_id_classified_data_id_fk": {
+          "name": "inspection_findings_classified_data_id_classified_data_id_fk",
+          "tableFrom": "inspection_findings",
+          "tableTo": "classified_data",
+          "columnsFrom": [
+            "classified_data_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "installed_packs": {
+      "name": "installed_packs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pack_id": {
+          "name": "pack_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rules_json": {
+          "name": "rules_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "policy_id": {
+          "name": "policy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_installed_packs_pack": {
+          "name": "uq_installed_packs_pack",
+          "columns": [
+            "namespace",
+            "pack_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory": {
+      "name": "inventory",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "host_id": {
+          "name": "host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "os_version": {
+          "name": "os_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.os_version'))",
+            "type": "virtual"
+          }
+        },
+        "harness_version": {
+          "name": "harness_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(json_extract(attributes, '$.harness_version'))",
+            "type": "virtual"
+          }
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_type": {
+          "name": "idx_inventory_type",
+          "columns": [
+            "object_type"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_osver": {
+          "name": "idx_inventory_type_osver",
+          "columns": [
+            "object_type",
+            "os_version"
+          ],
+          "isUnique": false
+        },
+        "idx_inventory_type_harnessver": {
+          "name": "idx_inventory_type_harnessver",
+          "columns": [
+            "object_type",
+            "harness_version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "inventory_host_id_inventory_id_fk": {
+          "name": "inventory_host_id_inventory_id_fk",
+          "tableFrom": "inventory",
+          "tableTo": "inventory",
+          "columnsFrom": [
+            "host_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "inventory_asset": {
+      "name": "inventory_asset",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_type": {
+          "name": "asset_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "meta_json": {
+          "name": "meta_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tools_json": {
+          "name": "tools_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_inventory_asset_type": {
+          "name": "idx_inventory_asset_type",
+          "columns": [
+            "asset_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_trust_override": {
+      "name": "mcp_trust_override",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_mcp_trust_override": {
+          "name": "uq_mcp_trust_override",
+          "columns": [
+            "asset_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "_pack_write_gate": {
+      "name": "_pack_write_gate",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "open": {
+          "name": "open",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "ck_pack_write_gate_single_row": {
+          "name": "ck_pack_write_gate_single_row",
+          "value": "\"_pack_write_gate\".\"id\" = 1"
+        }
+      }
+    },
+    "policies": {
+      "name": "policies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "custom_keywords": {
+          "name": "custom_keywords",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_policies_scope_target": {
+          "name": "uq_policies_scope_target",
+          "columns": [
+            "scope",
+            "target"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_file": {
+      "name": "project_file",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "default_access": {
+          "name": "default_access",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "findings_count": {
+          "name": "findings_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "blocked_at": {
+          "name": "blocked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_file_project": {
+          "name": "idx_project_file_project",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "uq_project_file": {
+          "name": "uq_project_file",
+          "columns": [
+            "project_id",
+            "path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "project_file_project_id_source_project_id_fk": {
+          "name": "project_file_project_id_source_project_id_fk",
+          "tableFrom": "project_file",
+          "tableTo": "source_project",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault": {
+      "name": "secret_vault",
+      "columns": {
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value_fingerprint": {
+          "name": "value_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fingerprint_key_version": {
+          "name": "fingerprint_key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_version": {
+          "name": "key_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "format_version": {
+          "name": "format_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "masked_match": {
+          "name": "masked_match",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ciphertext": {
+          "name": "ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "nonce": {
+          "name": "nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_tag": {
+          "name": "auth_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "occurrence_count": {
+          "name": "occurrence_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_value": {
+          "name": "uq_secret_vault_value",
+          "columns": [
+            "value_fingerprint"
+          ],
+          "isUnique": true
+        },
+        "idx_secret_vault_last_seen": {
+          "name": "idx_secret_vault_last_seen",
+          "columns": [
+            "last_seen",
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_reuse": {
+          "name": "idx_secret_vault_reuse",
+          "columns": [
+            "occurrence_count",
+            "pointer_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_deref": {
+      "name": "secret_vault_deref",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "at": {
+          "name": "at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "grant_id": {
+          "name": "grant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pointer_count": {
+          "name": "pointer_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "idx_secret_vault_deref_pointer": {
+          "name": "idx_secret_vault_deref_pointer",
+          "columns": [
+            "pointer_id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_reason_at": {
+          "name": "idx_secret_vault_deref_reason_at",
+          "columns": [
+            "reason",
+            "at"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_at": {
+          "name": "idx_secret_vault_deref_at",
+          "columns": [
+            "at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_secret_vault_deref_signal": {
+          "name": "idx_secret_vault_deref_signal",
+          "columns": [
+            "at",
+            "id"
+          ],
+          "isUnique": false,
+          "where": "\"secret_vault_deref\".\"reason\" NOT IN ('display', 'view-render')"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "secret_vault_sighting": {
+      "name": "secret_vault_sighting",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pointer_id": {
+          "name": "pointer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uq_secret_vault_sighting": {
+          "name": "uq_secret_vault_sighting",
+          "columns": [
+            "pointer_id",
+            "location"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_call_site": {
+      "name": "share_call_site",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_id": {
+          "name": "endpoint_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project": {
+          "name": "project",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snippet": {
+          "name": "snippet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dynamic": {
+          "name": "dynamic",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "vendored": {
+          "name": "vendored",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_call_site_endpoint": {
+          "name": "idx_share_call_site_endpoint",
+          "columns": [
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "idx_share_call_site_project": {
+          "name": "idx_share_call_site_project",
+          "columns": [
+            "project_key",
+            "endpoint_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_call_site": {
+          "name": "uq_share_call_site",
+          "columns": [
+            "endpoint_id",
+            "project_key",
+            "file",
+            "line"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_call_site_endpoint_id_share_endpoint_id_fk": {
+          "name": "share_call_site_endpoint_id_share_endpoint_id_fk",
+          "tableFrom": "share_call_site",
+          "tableTo": "share_endpoint",
+          "columnsFrom": [
+            "endpoint_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_destination": {
+      "name": "share_destination",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "trust": {
+          "name": "trust",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "network_json": {
+          "name": "network_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scan'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_destination_kind": {
+          "name": "idx_share_destination_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "uq_share_destination_host": {
+          "name": "uq_share_destination_host",
+          "columns": [
+            "host"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "share_endpoint": {
+      "name": "share_endpoint",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "destination_id": {
+          "name": "destination_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template": {
+          "name": "template",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "data_class": {
+          "name": "data_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_share_endpoint_dest": {
+          "name": "idx_share_endpoint_dest",
+          "columns": [
+            "destination_id"
+          ],
+          "isUnique": false
+        },
+        "uq_share_endpoint": {
+          "name": "uq_share_endpoint",
+          "columns": [
+            "destination_id",
+            "method",
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "share_endpoint_destination_id_share_destination_id_fk": {
+          "name": "share_endpoint_destination_id_share_destination_id_fk",
+          "tableFrom": "share_endpoint",
+          "tableTo": "share_destination",
+          "columnsFrom": [
+            "destination_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "source_project": {
+      "name": "source_project",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen": {
+          "name": "first_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen": {
+          "name": "last_seen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/schema/drizzle/local-sqlite/meta/_journal.json
+++ b/packages/schema/drizzle/local-sqlite/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1786009795585,
       "tag": "0020_secret_vault_pagination_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1787071229876,
+      "tag": "0021_finding_resolution_resolved_at_index",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -95,7 +95,15 @@ export const findingResolution = sqliteTable(
       .notNull()
       .$defaultFn(() => Date.now()),
   },
-  (t) => [index('idx_finding_resolution_key').on(t.findingKey)],
+  (t) => [
+    index('idx_finding_resolution_key').on(t.findingKey),
+    // Serves the resolution-driven /security reads, which ask "which findings
+    // were resolved in this window" and therefore drive from a resolved_at range.
+    // With finding_key as the table's only index that range had none to scan, so
+    // the read passed over the whole table — a bare `SCAN fr`, which is the one
+    // thing `hot-read-query-plans.test.ts` hard-fails on.
+    index('idx_finding_resolution_resolved_at').on(t.resolvedAt),
+  ],
 );
 
 export const policies = sqliteTable(

--- a/packages/schema/src/drizzle/sqlite-ddl.ts
+++ b/packages/schema/src/drizzle/sqlite-ddl.ts
@@ -111,4 +111,8 @@ export const SQLITE_MIGRATIONS: readonly SqliteMigration[] = [
     tag: '0020_secret_vault_pagination_indexes',
     sql: "CREATE INDEX `idx_secret_vault_last_seen` ON `secret_vault` (`last_seen`,`pointer_id`);--> statement-breakpoint\nCREATE INDEX `idx_secret_vault_reuse` ON `secret_vault` (`occurrence_count`,`pointer_id`);--> statement-breakpoint\nCREATE INDEX `idx_secret_vault_deref_at` ON `secret_vault_deref` (`at`,`id`);--> statement-breakpoint\nCREATE INDEX `idx_secret_vault_deref_signal` ON `secret_vault_deref` (`at`,`id`) WHERE `reason` NOT IN ('display', 'view-render');",
   },
+  {
+    tag: '0021_finding_resolution_resolved_at_index',
+    sql: 'CREATE INDEX `idx_finding_resolution_resolved_at` ON `finding_resolution` (`resolved_at`);\n',
+  },
 ];


### PR DESCRIPTION
## The defect

`recentlyResolved` was **quadratic** — O(`code_change` events × resolved keys) — costing
**10,966 ms at 50,000 events** and **125,322 ms at 150,000** to return 20 rows. The join key
was unreachable: `inspection_findings` was reached *from* the latest-resolution derived table
by `finding_key`, so that table got probed on `(rn, status, method)` and the plan enumerated
every pair before the findings row could reject it.

It went unseen because every measurement of it ran against an **empty `finding_resolution`
table**, which collapses the cross product to nothing — it had been recorded at 8 ms and
written off as one of the page's cheap reads.

The corpus generator is why: it wrote **no resolution rows** and set **no `finding_key` on any
finding, at any size**. So `recentlyResolved`, all of `mttrTrend`, and both of
`severitySummary`'s lifecycle buckets were measured against structurally empty results — still
running, still returning a plan, still reporting a duration.

## Result

| store size | before | after |
| ---------- | -----: | ----: |
| 50k events | 11,197 ms | **159 ms** |
| 150k events | 125,987 ms | **350 ms** |
| 300k events | — | **729 ms** |

<details>
<summary>Raw output — arm64 macOS 26.5.2 / Node v24.18.0, realistic density (74,528 ms/event, measured from a real store)</summary>

```
=== BEFORE ===
EVENTS=50000 seed_ms=13390 findings=16517 trackable=4046 resolutions=2051 span_days=43
  severitySummary 46.2 ms
  recentFindings 46.7 ms
  recentlyResolved 10966.0 ms
  enforcementActions 48.3 ms
  findingsTimeseries 32.1 ms
  mttrTrend 44.6 ms
  topSources 13.6 ms
  PAGE 11197 ms
EVENTS=150000 seed_ms=135905 findings=49388 trackable=12266 resolutions=6144 span_days=129
  severitySummary 177.3 ms
  recentFindings 170.7 ms
  recentlyResolved 125322.4 ms
  enforcementActions 89.7 ms
  findingsTimeseries 41.3 ms
  mttrTrend 171.3 ms
  topSources 14.1 ms
  PAGE 125987 ms

=== AFTER ===
EVENTS=50000  PAGE 159 ms   (severitySummary 46.6, recentFindings 1.8, recentlyResolved 6.9, mttrTrend 7.1)
EVENTS=150000 PAGE 350 ms   (severitySummary 177.7, recentFindings 2.2, recentlyResolved 20.1, mttrTrend 11.4)
EVENTS=300000 PAGE 729 ms   (severitySummary 472.2, recentFindings 3.1, recentlyResolved 49.5, mttrTrend 17.4)
```

</details>

## What changed

Each read now drives from the bounded side of its joins:

- **`recentlyResolved`** — from the latest-resolution set, making every step below it a
  unique-index or primary-key lookup.
- **`mttrTrend`** — from `finding_resolution` over a `resolved_at` range, with `SELECT
  DISTINCT`. That table is append-only, so a key fixed → redetected → fixed matches once per
  row, and **unequal** duplication across two findings in one bucket skews the mean: 4.9 days
  against a correct 3.9 on the fixture that pins it.
- **`recentFindings`** — from `audit_events` in `started_at` order so the `LIMIT` terminates
  the scan.

**`CROSS JOIN` is load-bearing in all three and must not be tidied into `JOIN`.** In SQLite it
is semantically identical and exists only to stop the tables being reordered; with no `ANALYZE`
statistics the planner prices `event_type IN (...)` as a selective probe and puts
`audit_events` back on the outside. Measured on `recentFindings` at 40k events:

| form | cost |
| --- | ---: |
| as written | 35.0 ms |
| `+e.event_type` only | 23.6 ms |
| `CROSS JOIN` only | 34.5 ms |
| both | **0.9 ms** |

**Migration `0021`** adds `finding_resolution(resolved_at)`. Precisely what it buys: *no*
flatness in store size — remove it and the ratio does not move, since the latest-resolution
derived table already passes over the whole table. What it buys is the criterion the plan guard
hard-fails on; without it `mttrTrend`'s driving step is a bare `SCAN fr`.

**Corpus realism**, since a measurement is only as good as its input: `finding_key` on
`code_change` findings (mirroring the runtime's own `isAtRest`), a file path on those captures,
a `resolutionRate` option, and a finding rate raised from `0.1` to a **measured 0.33** (read
off a real store, counts only, no content — 5,410 findings on 16,390 capture events). Four
landed-row checks where there were two, so a corpus that loses its trackability or its
resolutions now **refuses to build** rather than silencing a read.

**New gate** — `security-page-scale.test.ts` states flatness as a *ratio* across a 10× store
step with the answer size held fixed, plus `severitySummary` as a growth control. A plan cannot
express this in either direction: an indexed plan can be linear in the store (`mttrTrend` was),
and a `SCAN` under a `LIMIT` can be bounded (`recentFindings` now is). No wall-clock gate.

## Mutation evidence

Tree restored and re-verified green after each.

| mutation | result |
| --- | --- |
| `recentlyResolved` → findings-driven | ratio **17.84** vs ceiling 3 |
| `mttrTrend` → `EXISTS` in WHERE | ratio **16.87** |
| drop `+e.event_type` only | ratio **8.88** + plan guard |
| `CROSS JOIN` → `JOIN` only | ratio **7.24** |
| neutralise migration 0021 | `no hot read scans a table with no index`: `SCAN fr` |
| measure the same store twice | control at ratio **1.00** — *all three flatness cases stayed green* |
| seed no resolutions | vacuity check: `recentlyResolved returned nothing` |
| drop `findingKey` | generator refuses: `wrote 0 trackable findings, expected 17` |
| drop `SELECT DISTINCT` | **4.9 days vs 3.9** |
| plant a second copy of `content` | `store-growth`: 1,214.1 B/event vs a 1,038.2 ceiling |

Three of those caught defects in **this** work rather than confirming the guards:

1. **A latent flake nearly shipped.** The realistic finding rate moved `store-growth`'s
   marginal to 902.8 B/event against a 917.6 ceiling — passing by **1.6%**, because the centre
   had been measured at the old rate. Re-centred across three re-measured decades, with the
   mutation control replanted rather than scaled forward (it reads 1,214.1; scaling the old
   figure would have predicted 1,282.0 and been wrong by 5%).
2. **A real bug in `mttrTrend`.** I wrote `DISTINCT` as a correctness fix, then talked myself
   out of it by reasoning about one key in isolation, where the mean genuinely is invariant.
   The mutation proved the retraction wrong.
3. **A vacuous harness.** The scale guard first read row counts out of a `.then()`, which never
   runs synchronously, so every ratio was a clean 1.00. Its own vacuity check caught it.

## Known limitation

**The 2 s budget is still missed at 1M.** The page is mildly *superlinear* and
`severitySummary` carries it — 0.93 → 1.19 → 1.57 µs per event across the three sizes, rising
~1.33× per doubling, going from 29% of the page at 50k to 65% at 300k. Extrapolated to 1M:
**~2.5–3 s**, with that one read ~85% of it. Read the range as the finding, not either
endpoint.

1M is **not measured**, and the blocker is the corpus rather than the reads: seeding is 142 s
at 150k against 733 s at 300k — 5.2× for 2× the events.

`severitySummary` is an all-time `GROUP BY` over every finding whose cost *is* its semantics.
Bounding it means a maintained rollup, windowing the card, or retention on the corpus — all
product decisions, tracked separately. Not attempted here.

The page's `Promise.all` still buys nothing (every read is synchronous and returns an
already-resolved promise, so the page costs the SUM). Left alone deliberately — making it
concurrent needs a worker per read, a large change for a page now at 350 ms.

## Verification

```
pnpm lint          → 0
pnpm typecheck     → 0
pnpm format:check  → clean
pnpm turbo run test --force → 42/42 tasks
```

Migration upgrade path checked by winding a store back to pre-`0021` (dropping the index and
its ledger row) and reopening; incremental application by tag is already covered generically by
`migrations.test.ts`, so no bespoke test was added.

## Follow-up found on the way

`pnpm --filter @akasecurity/schema gen:sqlite-ddl` emits a **spurious extra migration**:
pre-existing drift between the drizzle schema source and migration `0020`'s hand-written
partial index makes it re-create `idx_secret_vault_deref_signal`, which would fail on every
existing store (`CREATE INDEX` on an existing name). Stripped from this change; anyone
regenerating hits it again. Not fixed here.
