### PR TITLE
test: build the migrated store once per worker and copy it per test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -902,6 +902,17 @@ tools/                repo tooling, never shipped: the installer one-liners and
    test: { setupFiles: [noNetworkGuard], … }
    ```
 
+   A package that also declares `testTimeout`/`hookTimeout` in that config must add
+   itself to `TIMEOUTS` in `packages/eslint-config/test/hook-timeout-ratchet.test.js`,
+   which pins every package's ceilings as an EXACT map. The ratchet holds in BOTH
+   directions on purpose. Raising a timeout is the change that must not pass unnoticed:
+   the per-test SQLite migration above was 'fixed' once by moving this number from
+   vitest's 10s default to 20s, which bought a green run and let the same failure spread
+   from one package to four. Lowering it is a good change — setup is a file copy now, so
+   there is headroom to give back — but a deliberate one. Raising it through the `test`
+   script's CLI flags instead is refused by the same suite, since the pin reads config
+   literals and a flag would bypass it silently.
+
    The runner is not incidental: the guard is a vitest `setupFiles` entry, so a
    package testing through anything else (`node --test`, say) runs with no runtime
    network guard at all. That suite enumerates every package with a `test` script
@@ -1594,6 +1605,25 @@ not reach for a `./testing` export instead.
   `data/`) whose handles are closed and tree removed for you. Use `useTempStore` when the
   suite shares setup across hooks, `withTempStore` when one test body owns the store. An
   async body is awaited before teardown.
+- **`{ migrated: true }`** — the second argument to all three, and the one to reach for by
+  default. `openLocalDatabase` runs every migration in the ledger on a store that has none,
+  so a suite with per-test isolation rebuilds the whole schema on every test; this seeds
+  `data/` from a template built ONCE per worker and copied. Isolation is unchanged — each
+  test still gets its own file, and no handle is shared. Measured at roughly 9-10x cheaper
+  per setup (`packages/persistence/bench/store-template.bench.ts`), which matters because
+  the Windows leg charges about 30x local cost for exactly this work and a `beforeEach`
+  that blows the hook ceiling fails a package the PR never touched.
+
+  **It is opt-IN, and that is load-bearing.** A seeded store has nothing left to migrate,
+  so a suite whose SUBJECT is the open path must not take it: migrations, the lineage
+  reset, the `.bak` a fresh migration leaves beside the store, `aka init` creating the
+  store, a first-run flow, or a fault injected so that `applyMigrations` is the thing that
+  refuses. Those assertions would hold **vacuously** rather than fail — which is worse
+  than losing them, because they go on reporting green. `test/helpers/store-template.ts`
+  is the shared builder (six packages copy from it; `migrated-store.ts` is this package's
+  build step), and it refuses a build that left no store, one that left a live `-wal`, and
+  any seed over a store or a foreign log that is already there.
+
 - `withTwoWriters(fn)` / `withWriters(n, fn)` — N independent `LocalDatabase` handles on
   one file, the shape the product runs in (hooks, CLI and dashboard share `aka.db` with
   only WAL and `busy_timeout` between them).

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -23,6 +23,7 @@ import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { runException } from '../../src/commands/exception.ts';
 import type { Prompter } from '../../src/lib/prompter.ts';
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { migratedStore } from '../helpers/store-templates.ts';
 
 // `aka exception approve <pointer> --reveal` is the sanctioned door for "the
 // agent legitimately needs this raw value": it mints a reveal_to_model grant
@@ -65,6 +66,8 @@ let home: string;
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-cli-exc-reveal-'));
+  // Schema by file copy rather than a migration this test would only repeat.
+  migratedStore.seed(dataDir(home));
   // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
   applyOnboarding(
     {

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -30,6 +30,7 @@ import { homeBase } from '../../src/lib/args.ts';
 import type { Prompter } from '../../src/lib/prompter.ts';
 import { main } from '../../src/main.ts';
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { migratedStore } from '../helpers/store-templates.ts';
 
 // The test value comes from the bundled rule's own `examples` fixture, so no
 // secret-shaped literal lives in this file and the value stays in step with
@@ -193,6 +194,8 @@ let dir: string;
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-cli-ex-'));
   dir = dataDir(homeBase(home));
+  // Schema by file copy rather than a migration this test would only repeat.
+  migratedStore.seed(dir);
 });
 
 afterEach(() => {

--- a/cli/test/helpers/store-templates.ts
+++ b/cli/test/helpers/store-templates.ts
@@ -1,0 +1,21 @@
+// The pre-migrated store this package's suites copy from, instead of running
+// every migration on a fresh store per test.
+//
+// `createStoreTemplate` lives at the repo root because several packages need
+// the same shape and `@akasecurity/persistence`'s own harness is behind a
+// package wall; what belongs here is the build step, plus a single module-scope
+// instance so every suite loaded into a worker shares one build.
+//
+// Per-test isolation is unchanged: each test still gets its own file, in its
+// own directory, with no handle shared between them. A suite whose SUBJECT is
+// the open path — `aka init` creating the store, a first-run flow, a fault
+// injected so that `applyMigrations` is the thing that refuses — must not use
+// this: a seeded store has nothing left to migrate, so those assertions would
+// hold vacuously rather than fail.
+import { openLocalDatabase } from '@akasecurity/persistence';
+
+import { createStoreTemplate } from '../../../test/helpers/store-template.ts';
+
+export const migratedStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -657,6 +657,7 @@ const EXPECTED_NON_PACKAGE_FILES = [
   'test/fixtures/adversarial/hostile-repo/index.ts',
   'test/helpers/perf.ts',
   'test/helpers/remove-tree.ts',
+  'test/helpers/store-template.ts',
   'test/setup/no-network.ts',
   'test/vitest/coverage.ts',
   'tools/ci/egress-probe.mjs',

--- a/packages/eslint-config/test/hook-timeout-ratchet.test.js
+++ b/packages/eslint-config/test/hook-timeout-ratchet.test.js
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  readPackageManifest,
+  REPO_ROOT,
+  workspacePackageDirs,
+} from './helpers/lint-invocations.js';
+
+// The vitest hook/test ceilings, pinned as an EXACT map.
+//
+// These are not a comfort setting. A store suite with per-test isolation used to
+// migrate a whole SQLite schema in `beforeEach`, and on the Windows leg that ran
+// 1–4 s per test against a 20 s ceiling — so the leg failed on a hook timeout in
+// a different package almost every run, never in the package the PR touched. The
+// fix applied to it the first time was raising this number from vitest's 10 s
+// default to 20 s, which moved the threshold rather than removing the cost; the
+// failure then spread from one package to four.
+//
+// So the number is the thing to hold still while the cost comes down. A raise
+// here is the change that must not pass unnoticed — it buys a green run today
+// and hides the next regression in setup cost, which is how this arrived. It is
+// pinned in BOTH directions rather than as a ceiling: a lowering is a good
+// change (the setup cost is now a file copy, so there is headroom to give back)
+// but it is a deliberate one, and a ratchet that only forbids raises would let
+// a package be lowered into flakiness with nothing to say so.
+//
+// This lives in @akasecurity/eslint-config for the reason coverage-config.test.js
+// does: only this package's turbo `inputs` cover the whole workspace, so only a
+// suite here re-runs when a DIFFERENT package edits its config. The same check
+// inside each package would be the one guard that cannot see the edit it exists
+// to catch.
+//
+// A package absent from this map must declare NEITHER timeout — it runs on
+// vitest's own defaults, which is the cheapest thing to be true.
+const TIMEOUTS = {
+  '@akasecurity/cli': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/detections': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/local-ops': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/persistence': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/plugin-runtime': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/plugin-sdk': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/scanner': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/ai-tc-antigravity': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/plugin-browser-extension': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/ai-tc-claude-code': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/ai-tc-codex': { testTimeout: 20_000, hookTimeout: 20_000 },
+  '@akasecurity/web-ui': { testTimeout: 20_000, hookTimeout: 20_000 },
+  // The installer suite drives the real `install.sh`/`install.ps1` end to end
+  // against a loopback fixture release — a genuinely long operation, and not a
+  // per-test store setup at all.
+  '@akasecurity/installer': { testTimeout: 120_000, hookTimeout: 120_000 },
+};
+
+/**
+ * A timeout as the config declares it. Read from the TEXT rather than by
+ * importing the config: importing executes it, plugins and all, and the value
+ * this pins is a literal in the file either way. Both spellings the workspace
+ * uses are accepted — `20_000` and `20000` are the same number, and a ratchet
+ * that saw only one of them would report every package using the other as
+ * undeclared.
+ */
+function declaredTimeout(configText, key) {
+  const match = new RegExp(`^\\s*${key}:\\s*([0-9_]+)\\s*,`, 'm').exec(configText);
+  return match ? Number(match[1].replaceAll('_', '')) : undefined;
+}
+
+/** A package's npm scripts, or an empty set when it declares none. */
+function scriptsFor(dir) {
+  return readPackageManifest(dir).scripts ?? {};
+}
+
+const PACKAGES = workspacePackageDirs()
+  .map((dir) => ({ dir, name: readPackageManifest(dir).name }))
+  .filter(({ dir }) => existsSync(join(REPO_ROOT, dir, 'vitest.config.ts')))
+  .map((pkg) => {
+    const text = readFileSync(join(REPO_ROOT, pkg.dir, 'vitest.config.ts'), 'utf8');
+    return {
+      ...pkg,
+      testTimeout: declaredTimeout(text, 'testTimeout'),
+      hookTimeout: declaredTimeout(text, 'hookTimeout'),
+    };
+  });
+
+describe('vitest timeout ratchet', () => {
+  it('raises no timeout through a test script instead of the config', () => {
+    // The pin below reads config LITERALS, so a package that passed
+    // `--hookTimeout=60000` on its `vitest` command line would clear every
+    // assertion here while the ceiling this exists to hold had been raised.
+    // No package does that today; the guard is what keeps it that way, since
+    // the flag is the obvious next move for anyone hitting the timeout again.
+    const viaFlag = workspacePackageDirs()
+      .map((dir) => ({ name: readPackageManifest(dir).name, script: scriptsFor(dir).test ?? '' }))
+      .filter(({ script }) => /--(test|hook)Timeout\b/.test(script))
+      .map(({ name }) => name);
+    expect(viaFlag).toEqual([]);
+  });
+
+  it('declares exactly the pinned timeouts, in both directions', () => {
+    const declared = Object.fromEntries(
+      PACKAGES.filter((p) => p.testTimeout !== undefined || p.hookTimeout !== undefined).map(
+        (p) => [p.name, { testTimeout: p.testTimeout, hookTimeout: p.hookTimeout }],
+      ),
+    );
+    // One comparison over the whole map, not a per-package assertion: a package
+    // that ADDS a timeout is the same defect as one that raises an existing
+    // one, and only an exact set catches both.
+    expect(declared).toEqual(TIMEOUTS);
+  });
+
+  it('is not a table of vitest defaults', () => {
+    // A positive control. Every assertion above would hold with the map emptied
+    // and every config's timeouts deleted, which is a different repo from this
+    // one — so the pin has to be shown to be pinning something.
+    expect(Object.keys(TIMEOUTS).length).toBeGreaterThan(5);
+    for (const [name, pinned] of Object.entries(TIMEOUTS)) {
+      expect(pinned.hookTimeout, name).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/local-ops/test/egress-record.test.ts
+++ b/packages/local-ops/test/egress-record.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { recordProjectEgress } from '../src/egress-record.ts';
 import { scanPathIntoStore } from '../src/fs-scan.ts';
+import { migratedStore } from './helpers/store-templates.ts';
 
 const REMOTE_URL = 'https://github.com/acme/payments-api.git';
 
@@ -89,6 +90,8 @@ beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'aka-egress-'));
   store = mkdtempSync(join(tmpdir(), 'aka-egress-db-'));
   base = mkdtempSync(join(tmpdir(), 'aka-egress-home-'));
+  // Schema by file copy rather than a migration this test would only repeat.
+  migratedStore.seed(store);
   db = openLocalDatabase(store);
 });
 

--- a/packages/local-ops/test/fs-scan.test.ts
+++ b/packages/local-ops/test/fs-scan.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { collectFiles, scanPathIntoStore } from '../src/fs-scan.ts';
+import { migratedStore } from './helpers/store-templates.ts';
 
 /** The error a thunk threw, captured OUTSIDE its own catch so a never-thrown one is `undefined`. */
 function errorFrom(fn: () => unknown): Error | undefined {
@@ -87,6 +88,8 @@ let store: string;
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'aka-fs-scan-'));
   store = mkdtempSync(join(tmpdir(), 'aka-fs-scan-db-'));
+  // Schema by file copy rather than a migration this test would only repeat.
+  migratedStore.seed(store);
 });
 
 afterEach(() => {

--- a/packages/local-ops/test/helpers/store-templates.ts
+++ b/packages/local-ops/test/helpers/store-templates.ts
@@ -1,0 +1,21 @@
+// The pre-migrated store this package's suites copy from, instead of running
+// every migration on a fresh store per test.
+//
+// `createStoreTemplate` lives at the repo root because several packages need
+// the same shape and `@akasecurity/persistence`'s own harness is behind a
+// package wall; what belongs here is the build step, plus a single module-scope
+// instance so every suite loaded into a worker shares one build.
+//
+// Per-test isolation is unchanged: each test still gets its own file, in its
+// own directory, with no handle shared between them. A suite whose SUBJECT is
+// the open path — `aka init` creating the store, a first-run flow, a fault
+// injected so that `applyMigrations` is the thing that refuses — must not use
+// this: a seeded store has nothing left to migrate, so those assertions would
+// hold vacuously rather than fail.
+import { openLocalDatabase } from '@akasecurity/persistence';
+
+import { createStoreTemplate } from '../../../../test/helpers/store-template.ts';
+
+export const migratedStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});

--- a/packages/persistence/bench/store-template.bench.ts
+++ b/packages/persistence/bench/store-template.bench.ts
@@ -1,0 +1,121 @@
+/**
+ * The per-test store setup cost, which is a CI-reliability property rather than
+ * a product one.
+ *
+ * A suite with per-test isolation opens a store in `beforeEach`, and
+ * `openLocalDatabase` runs every migration in the ledger on a store that has
+ * none. That work is identical on every test and its result is a file, so it
+ * can be done once per worker and copied. This is the trend behind that: three
+ * shapes of the same per-test sequence, at the same scale a real `beforeEach`
+ * runs it.
+ *
+ *   migrate per test   mkdtemp → openLocalDatabase (22 migrations) → close → rm
+ *   copy the file      mkdtemp → copyFileSync a prepared store → open → close → rm
+ *   copy cached bytes  mkdtemp → writeFileSync bytes held in memory → open → …
+ *
+ * Measured on arm64 macOS 26.5.2 / Node 24.18.0, tinybench mean, two runs:
+ *
+ * | shape             |    run 1 |    run 2 |
+ * | ----------------- | -------: | -------: |
+ * | migrate per test  | 11.10 ms | 14.81 ms |
+ * | copy the file     |  1.39 ms |  1.62 ms |
+ * | copy cached bytes |  1.21 ms |  1.42 ms |
+ *
+ * Both runs put the template at roughly 9-10x the migrating shape. Two are
+ * quoted rather than one because the migrating row alone moved from ±0.50% rme
+ * to ±13.37% between them: the RATIO is what holds, which is exactly why this
+ * reports a trend and asserts nothing.
+ *
+ * These are `vitest bench` figures, taken WITHOUT coverage instrumentation. The
+ * test suites always run with it on, so what a real `beforeEach` pays is higher
+ * than the first column — the paired suite measurement behind this change was
+ * 2.14 s of `tests` time across 101 store-opening tests before, 0.529 s after.
+ *
+ * The third is what `test/helpers/store-template.ts` does, and the gap between
+ * the last two is why: the store is ~470 KB, so re-reading a template file per
+ * test is the larger half of a copy.
+ *
+ * This gates NOTHING, in line with every other bench in this repo — a
+ * wall-clock check on a shared runner fails for reasons unrelated to the diff.
+ * What it is for is the platform it was written for: Windows charges most for
+ * file creation and fsync, CI has measured this work at roughly 30x its local
+ * cost there, and the per-test migration is what put four packages' suites over
+ * their hook ceilings. A regression here is a regression in how much of that
+ * ceiling every store suite in the workspace consumes.
+ *
+ * The template is built OUTSIDE the timed region for the reason the corpus is
+ * in `capture.bench.ts`: it is setup, it is paid once by construction, and
+ * folding it in would measure the very thing this exists to stop paying.
+ */
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, bench, describe } from 'vitest';
+
+import { removeTree } from '../../../test/helpers/remove-tree.ts';
+import { openLocalDatabase } from '../src/database.ts';
+
+const DB_FILE = 'aka.db';
+
+/** One prepared store, built once, standing in for the shared template. */
+const templateHome = mkdtempSync(join(tmpdir(), 'aka-bench-template-'));
+const templateDir = join(templateHome, 'data');
+openLocalDatabase(templateDir).close();
+const templateFile = join(templateDir, DB_FILE);
+const templateBytes = readFileSync(templateFile);
+
+// The template outlives every iteration, so it is the one tree nothing in a
+// bench body can remove. Without this each `pnpm bench` leaves a store and the
+// `.bak` a fresh migration writes beside it — about 1 MB a run — for the OS
+// temp sweeper to find.
+afterAll(() => {
+  removeTree(templateHome);
+});
+
+/** The mkdtemp + data-dir pair every shape below starts from. */
+function freshHome(prefix: string): { home: string; dataDir: string } {
+  const home = mkdtempSync(join(tmpdir(), prefix));
+  const dataDir = join(home, 'data');
+  mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  return { home, dataDir };
+}
+
+describe('per-test store setup', () => {
+  bench('migrate per test', () => {
+    const { home, dataDir } = freshHome('aka-bench-migrate-');
+    openLocalDatabase(dataDir).close();
+    removeTree(home);
+  });
+
+  bench('copy a template file, then open', () => {
+    const { home, dataDir } = freshHome('aka-bench-copy-');
+    copyFileSync(templateFile, join(dataDir, DB_FILE));
+    openLocalDatabase(dataDir).close();
+    removeTree(home);
+  });
+
+  bench('write cached template bytes, then open', () => {
+    const { home, dataDir } = freshHome('aka-bench-bytes-');
+    // What `createStoreTemplate().seed()` does, minus the staging rename — the
+    // rename is a correctness measure for a partially-written header, not part
+    // of the cost being compared.
+    const file = join(dataDir, DB_FILE);
+    const staging = `${file}.template-partial`;
+    writeAndRename(staging, file);
+    openLocalDatabase(dataDir).close();
+    removeTree(home);
+  });
+});
+
+function writeAndRename(staging: string, file: string): void {
+  writeFileSync(staging, templateBytes, { mode: 0o600 });
+  renameSync(staging, file);
+}

--- a/packages/persistence/test/exception-policy.test.ts
+++ b/packages/persistence/test/exception-policy.test.ts
@@ -40,7 +40,7 @@ function identity(overrides: Partial<PointerIdentity> = {}): PointerIdentity {
 describe('UserGrantPolicyProvider', () => {
   // The shared harness owns the temp store and closes its handles at teardown,
   // so no test here can leave the tree undeletable on Windows.
-  const store = useTempStore('aka-policy-');
+  const store = useTempStore('aka-policy-', { migrated: true });
   let db: LocalDatabase;
   let provider: UserGrantPolicyProvider;
 

--- a/packages/persistence/test/helpers/migrated-store.ts
+++ b/packages/persistence/test/helpers/migrated-store.ts
@@ -1,0 +1,17 @@
+// The one pre-migrated store every suite in this worker copies from.
+//
+// `createStoreTemplate` is at the repo root because six packages need this
+// shape; what belongs here is the build step — the persistence-specific half —
+// and a single module-scope instance, so every suite loaded into a worker
+// shares one build rather than one each.
+//
+// Deliberately empty beyond what `openLocalDatabase` itself writes (the schema,
+// the migration ledger, the default policies). A template carrying fixture rows
+// would make every suite that copies it depend on rows it never seeded, which
+// is the order-dependence per-test isolation exists to prevent.
+import { createStoreTemplate } from '../../../../test/helpers/store-template.ts';
+import { openLocalDatabase } from '../../src/database.ts';
+
+export const migratedStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});

--- a/packages/persistence/test/helpers/store-template.test.ts
+++ b/packages/persistence/test/helpers/store-template.test.ts
@@ -1,0 +1,294 @@
+/**
+ * The repo-root `test/helpers/store-template.ts`, driven from the package whose
+ * store it templates.
+ *
+ * Two things have to hold, and they fail differently. The template must be
+ * built ONCE — a rebuild per seed would satisfy every equivalence assertion
+ * below while saving nothing, which is the whole point of the helper. And a
+ * seeded store must be indistinguishable from one `openLocalDatabase` migrated
+ * itself, because the suites that copy it read it as if it were: a template
+ * missing a table, an index or a ledger row would not fail here, it would fail
+ * somewhere else, as an assertion about the repository under test.
+ *
+ * Every tree below comes from the store harness rather than a `mkdtempSync` of
+ * its own — `harness-adoption.test.ts` allows no exception for a suite that
+ * opens a store, and this one does. `createTempStore` is the shape that fits:
+ * the seeding cases need a data dir with NO store in it yet, which is exactly
+ * what an unseeded temp store is.
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, expect, it } from 'vitest';
+
+import { createStoreTemplate } from '../../../../test/helpers/store-template.ts';
+import { openLocalDatabase } from '../../src/database.ts';
+import { errorFrom } from './errors.ts';
+import { migratedStore } from './migrated-store.ts';
+import { createTempStore, useTempStore } from './temp-store.ts';
+
+/** Run `fn` against an unseeded temp store, then tear it down. */
+function withPlainStore<T>(fn: (store: ReturnType<typeof createTempStore>) => T): T {
+  const store = createTempStore('aka-tpl-');
+  try {
+    return fn(store);
+  } finally {
+    store.destroy();
+  }
+}
+
+/** Every user object the store carries, as a stable, comparable list. */
+function schemaOf(file: string): string[] {
+  const db = new DatabaseSync(file);
+  try {
+    return (
+      db
+        .prepare(
+          "SELECT type, name, COALESCE(sql, '') AS sql FROM sqlite_master " +
+            "WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name",
+        )
+        .all() as { type: string; name: string; sql: string }[]
+    ).map((row) => `${row.type} ${row.name} :: ${row.sql.replace(/\s+/g, ' ').trim()}`);
+  } finally {
+    db.close();
+  }
+}
+
+function ledgerTagsOf(file: string): string[] {
+  const db = new DatabaseSync(file);
+  try {
+    return (
+      db.prepare('SELECT tag FROM migration_ledger ORDER BY tag').all() as { tag: string }[]
+    ).map((row) => row.tag);
+  } finally {
+    db.close();
+  }
+}
+
+function ledgerStampsOf(file: string): number[] {
+  const db = new DatabaseSync(file);
+  try {
+    return (
+      db.prepare('SELECT applied_at FROM migration_ledger').all() as { applied_at: number }[]
+    ).map((row) => row.applied_at);
+  } finally {
+    db.close();
+  }
+}
+
+function userVersionOf(file: string): number {
+  const db = new DatabaseSync(file);
+  try {
+    return (db.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;
+  } finally {
+    db.close();
+  }
+}
+
+describe('createStoreTemplate builds once', () => {
+  it('runs the build step on the first seed and never again', () => {
+    let calls = 0;
+    const template = createStoreTemplate((dataDir) => {
+      calls += 1;
+      openLocalDatabase(dataDir).close();
+    });
+
+    expect(template.isBuilt()).toBe(false);
+    expect(calls).toBe(0);
+
+    for (let i = 0; i < 3; i++) {
+      withPlainStore((store) => {
+        template.seed(store.dataDir);
+        expect(existsSync(store.dbFile)).toBe(true);
+      });
+    }
+
+    // The claim is build-once, so it is read off the build step itself. Three
+    // seeds that each produced a usable store would look identical here if the
+    // template rebuilt every time — which is precisely the regression that
+    // would make the helper pointless while every suite stayed green.
+    expect(calls).toBe(1);
+    expect(template.buildCount()).toBe(1);
+    expect(template.isBuilt()).toBe(true);
+  });
+
+  it('does not build at all until something seeds', () => {
+    let calls = 0;
+    const template = createStoreTemplate((dataDir) => {
+      calls += 1;
+      openLocalDatabase(dataDir).close();
+    });
+    expect(calls).toBe(0);
+    expect(template.buildCount()).toBe(0);
+  });
+});
+
+describe('createStoreTemplate refuses a build it cannot trust', () => {
+  it('refuses a build step that leaves no store', () => {
+    const template = createStoreTemplate(() => {
+      // Opens nothing.
+    });
+    withPlainStore((store) => {
+      const err = errorFrom(() => {
+        template.seed(store.dataDir);
+      });
+      expect(err?.message).toContain('left no aka.db');
+    });
+  });
+
+  it('refuses a build step that never closed its handle', () => {
+    // A live WAL is the observable form of an unclosed handle, and the reason
+    // it matters is that the copy would silently lack whatever is still only in
+    // the log. Provoked directly rather than by leaking a real handle, so the
+    // case does not depend on leaving one open across the assertion.
+    const template = createStoreTemplate((dataDir) => {
+      openLocalDatabase(dataDir).close();
+      writeFileSync(join(dataDir, 'aka.db-wal'), Buffer.alloc(64, 1));
+    });
+    withPlainStore((store) => {
+      const err = errorFrom(() => {
+        template.seed(store.dataDir);
+      });
+      expect(err?.message).toContain('non-empty -wal');
+    });
+  });
+
+  it('refuses to seed beside a foreign log left with no store', () => {
+    // An absent `aka.db` is not an empty data dir. A `-wal` from an earlier
+    // store would be paired by SQLite with the template copied over it, and a
+    // log belonging to a different database reads as corruption — attributed to
+    // the template rather than to the leftover, which is why it is named here.
+    withPlainStore((store) => {
+      writeFileSync(`${store.dbFile}-wal`, Buffer.alloc(64, 1));
+      const err = errorFrom(() => {
+        migratedStore.seed(store.dataDir);
+      });
+      expect(err?.message).toContain('-wal is present with no aka.db');
+      // And the refusal left nothing half-written behind.
+      expect(existsSync(store.dbFile)).toBe(false);
+      expect(existsSync(`${store.dbFile}.template-partial`)).toBe(false);
+    });
+  });
+
+  it('reports the same failure on every seed without rebuilding', () => {
+    let calls = 0;
+    const template = createStoreTemplate(() => {
+      calls += 1;
+    });
+    withPlainStore((store) => {
+      const first = errorFrom(() => {
+        template.seed(store.dataDir);
+      });
+      const second = errorFrom(() => {
+        template.seed(store.dataDir);
+      });
+      expect(first?.message).toContain('left no aka.db');
+      // The SAME error object, not a fresh one from a second failing build: a
+      // suite calls seed per test, and re-paying a failing build each time
+      // turns one clear setup fault into a slow cascade of identical ones.
+      expect(second).toBe(first);
+      expect(calls).toBe(1);
+    });
+  });
+
+  it('refuses to seed over a store that is already there', () => {
+    withPlainStore((store) => {
+      migratedStore.seed(store.dataDir);
+      const err = errorFrom(() => {
+        migratedStore.seed(store.dataDir);
+      });
+      expect(err?.message).toContain('already exists');
+    });
+  });
+});
+
+describe('a seeded store is what a migration would have produced', () => {
+  it('carries the identical schema, ledger and user_version', () => {
+    withPlainStore((fresh) => {
+      // A real migration, for comparison — the handle is closed at once so the
+      // file it leaves is complete.
+      fresh.open().close();
+
+      withPlainStore((seeded) => {
+        migratedStore.seed(seeded.dataDir);
+
+        // Read BEFORE the seeded store is opened: the equivalence that matters
+        // is of the file the copy hands over, not of one openLocalDatabase has
+        // since had a chance to repair.
+        expect(schemaOf(seeded.dbFile)).toEqual(schemaOf(fresh.dbFile));
+        expect(ledgerTagsOf(seeded.dbFile)).toEqual(ledgerTagsOf(fresh.dbFile));
+        expect(userVersionOf(seeded.dbFile)).toEqual(userVersionOf(fresh.dbFile));
+        // Positive controls: an empty comparison satisfies all three above.
+        expect(ledgerTagsOf(seeded.dbFile).length).toBeGreaterThan(0);
+        expect(schemaOf(seeded.dbFile).length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('runs no migration when it is opened', () => {
+    // The saving is the claim, so it is asserted on the ledger's own clock:
+    // every tag was written when the TEMPLATE was built, so a store that
+    // migrated on open would carry rows stamped after the seed.
+    withPlainStore((store) => {
+      migratedStore.seed(store.dataDir);
+      const seededAt = Date.now();
+      const before = ledgerTagsOf(store.dbFile);
+
+      store.open().close();
+
+      expect(ledgerTagsOf(store.dbFile)).toEqual(before);
+      const stamps = ledgerStampsOf(store.dbFile);
+      expect(stamps.length).toBeGreaterThan(0);
+      expect(stamps.every((at) => at <= seededAt)).toBe(true);
+    });
+  });
+});
+
+describe('useTempStore({ migrated: true })', () => {
+  const store = useTempStore('aka-tpl-hook-', { migrated: true });
+
+  it('hands each test its own file, already migrated', async () => {
+    expect(existsSync(store.dbFile)).toBe(true);
+    const db = store.open();
+    // Usable as any other store: the repositories prepare against this schema
+    // eagerly, so a template short of a column would throw on open, and
+    // seedDefaults has to find the tables it writes.
+    expect((await db.policies.readPolicies()).length).toBeGreaterThan(0);
+    await db.exceptions.create({
+      ruleId: 'aws-access-key-id',
+      category: 'secret',
+      valueFingerprint: '1'.repeat(64),
+      keyVersion: 1,
+      maskedValue: 'AKIA******Q',
+      scope: 'temporary',
+      expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+      maxUses: null,
+      justification: 'proves the seeded store is writable, and is not carried over',
+      conditions: null,
+      createdBy: 'alice',
+      createdVia: 'cli-approve',
+    });
+    expect((await db.exceptions.list()).length).toBe(1);
+  });
+
+  it('carries nothing the previous test wrote', async () => {
+    // The row the test above recorded must not be here: a template seeded once
+    // and then shared would carry it, and so would a store the hook failed to
+    // replace.
+    const db = store.open();
+    expect((await db.exceptions.list()).length).toBe(0);
+    expect(readFileSync(store.dbFile).length).toBeGreaterThan(0);
+  });
+});
+
+describe('useTempStore() without the option', () => {
+  const store = useTempStore('aka-tpl-off-');
+
+  it('leaves the store absent until something opens it', () => {
+    // The opt-in is what keeps the open-path suites honest, so the default must
+    // stay "nothing seeded" — a template arriving by default would make every
+    // migration and fault assertion in this package vacuous at once.
+    expect(existsSync(store.dbFile)).toBe(false);
+  });
+});

--- a/packages/persistence/test/helpers/temp-store.ts
+++ b/packages/persistence/test/helpers/temp-store.ts
@@ -24,6 +24,7 @@ import type { LocalDatabase } from '../../src/database.ts';
 import { openLocalDatabase } from '../../src/database.ts';
 import { dataDir, dbPath, settingsDir } from '../../src/local-layout.ts';
 import { ensureDataDirSync } from '../../src/paths.ts';
+import { migratedStore } from './migrated-store.ts';
 
 export interface TempStore {
   /** The mkdtemp root, standing in for `~/.aka`. */
@@ -80,11 +81,31 @@ interface TrackedHandle {
   isOpen: () => boolean;
 }
 
+/** What a caller can vary about the store it gets. */
+export interface TempStoreOptions {
+  /**
+   * Seed `data/` from the pre-migrated template instead of letting the first
+   * `open()` run every migration — the same file each test would have built for
+   * itself, built once per worker and copied. Per-test isolation is unchanged:
+   * the copy is this store's own file, and no handle is shared.
+   *
+   * Leave it off for a suite whose SUBJECT is the open path — migrations, the
+   * lineage reset, the `.bak` a fresh migration leaves behind, or a fault
+   * injected so that `applyMigrations` is the thing that refuses. A seeded
+   * store has nothing left to migrate, so those assertions would hold
+   * vacuously rather than fail.
+   */
+  readonly migrated?: boolean;
+}
+
 /**
  * A temp store the caller destroys by hand. Prefer `withTempStore` (scoped) or
  * `useTempStore` (hook-driven); reach for this only when neither shape fits.
  */
-export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
+export function createTempStore(
+  prefix = 'aka-temp-store-',
+  options: TempStoreOptions = {},
+): OwnedTempStore {
   const home = mkdtempSync(join(tmpdir(), prefix));
   // Both subdirs up front, through the same helper the product uses: a bare
   // `mkdirSync` mode is umask-masked and is not applied to a directory that
@@ -92,8 +113,27 @@ export function createTempStore(prefix = 'aka-temp-store-'): OwnedTempStore {
   // a guarantee rather than a request. `data/` would otherwise appear only on
   // the first `open()`, and a test seeding the store by hand — a
   // policy-cache.json, a read-only directory — would meet an absent path.
-  ensureDataDirSync(settingsDir(home));
-  ensureDataDirSync(dataDir(home));
+  // Anything that can throw between the mkdtemp and the returned store has to
+  // take the tree with it. Nothing here is reachable by `destroy()` yet — the
+  // caller has no handle to call it on, and under `useTempStore` a throwing
+  // `beforeEach` leaves `current` undefined, so its `afterEach` no-ops and the
+  // tree is stranded once per test in the file rather than once.
+  try {
+    ensureDataDirSync(settingsDir(home));
+    ensureDataDirSync(dataDir(home));
+    // Before any handle exists, so the first `open()` finds a store with every
+    // migration already ledgered and skips the lot.
+    if (options.migrated === true) migratedStore.seed(dataDir(home));
+  } catch (err) {
+    // The setup failure is the one worth reading; a teardown that also fails
+    // must not speak over it.
+    try {
+      removeTree(home);
+    } catch {
+      // Nothing to add — the original error is already on its way out.
+    }
+    throw err;
+  }
 
   const handles: TrackedHandle[] = [];
   const cleanups: (() => void)[] = [];
@@ -256,8 +296,12 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
  * the body would then run against closed handles and a deleted tree — green,
  * and asserting nothing.
  */
-export function withTempStore<T>(fn: (store: TempStore) => T, prefix?: string): T {
-  const store = createTempStore(prefix);
+export function withTempStore<T>(
+  fn: (store: TempStore) => T,
+  prefix?: string,
+  options?: TempStoreOptions,
+): T {
+  const store = createTempStore(prefix, options);
   let result: T;
   try {
     result = fn(store);
@@ -311,11 +355,11 @@ function destroyAfterFailure(store: OwnedTempStore, err: unknown): void {
  * destroyed before a suite's own `afterEach`, and a suite that reads the store
  * in teardown would break with no compile-time signal.
  */
-export function useTempStore(prefix?: string): TempStore {
+export function useTempStore(prefix?: string, options?: TempStoreOptions): TempStore {
   let current: OwnedTempStore | undefined;
 
   beforeEach(() => {
-    current = createTempStore(prefix);
+    current = createTempStore(prefix, options);
   });
 
   afterEach(() => {

--- a/packages/persistence/test/raw-handle-seam.test.ts
+++ b/packages/persistence/test/raw-handle-seam.test.ts
@@ -27,7 +27,7 @@ import { captureEvent, captureFinding } from './helpers/capture-fixtures.ts';
 import { fillStore } from './helpers/fault-injection.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
-const store = useTempStore('aka-raw-seam-');
+const store = useTempStore('aka-raw-seam-', { migrated: true });
 
 /** Big enough that a capture needs a new page, not free space in an old one. */
 const PAGE_HUNGRY_CONTENT = 'x'.repeat(4096);

--- a/packages/persistence/test/record-capture.test.ts
+++ b/packages/persistence/test/record-capture.test.ts
@@ -14,7 +14,7 @@ import { schemaObjectExists } from '../src/db/migrations/introspection.ts';
 import { captureId } from '../src/ids.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
-const store = useTempStore('aka-record-capture-');
+const store = useTempStore('aka-record-capture-', { migrated: true });
 
 const MASKED = 'AKIA…MPLE';
 

--- a/packages/persistence/test/repositories/activity.test.ts
+++ b/packages/persistence/test/repositories/activity.test.ts
@@ -17,7 +17,7 @@ const HOUR_MS = 3_600_000;
 // deterministic: [2026-06-29T00:00Z, 2026-06-30T00:00Z).
 const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
-const store = useTempStore('aka-activity-');
+const store = useTempStore('aka-activity-', { migrated: true });
 let db: LocalDatabase;
 let raw: DatabaseSync;
 

--- a/packages/persistence/test/repositories/audit-events.test.ts
+++ b/packages/persistence/test/repositories/audit-events.test.ts
@@ -9,7 +9,7 @@ import { assertNoOpenTransaction } from '../helpers/transactions.ts';
 
 const SESSION_ID = 'session-audit-events-test';
 
-const store = useTempStore('aka-audit-events-');
+const store = useTempStore('aka-audit-events-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/classified-data.test.ts
+++ b/packages/persistence/test/repositories/classified-data.test.ts
@@ -24,7 +24,7 @@ import { errorFrom } from '../helpers/errors.ts';
 import { SQLITE_CONSTRAINT_FOREIGNKEY, sqliteErrcode } from '../helpers/fault-injection.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-classified-data-');
+const store = useTempStore('aka-classified-data-', { migrated: true });
 
 let db: LocalDatabase;
 let raw: DatabaseSync;

--- a/packages/persistence/test/repositories/config-inventory.test.ts
+++ b/packages/persistence/test/repositories/config-inventory.test.ts
@@ -6,7 +6,7 @@ import type { LocalDatabase } from '../../src/database.ts';
 import { inventoryId as inventoryIdOf } from '../../src/ids.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-config-inv-');
+const store = useTempStore('aka-config-inv-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/detections.test.ts
+++ b/packages/persistence/test/repositories/detections.test.ts
@@ -11,7 +11,7 @@ const DAY_MS = 86_400_000;
 // A fixed clock so the 30-day findings window is deterministic.
 const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
-const store = useTempStore('aka-detections-');
+const store = useTempStore('aka-detections-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/exceptions-clock.test.ts
+++ b/packages/persistence/test/repositories/exceptions-clock.test.ts
@@ -394,7 +394,7 @@ describe('SqliteExceptionsRepository — default clock', () => {
   // product's normal shape: a frozen clock there stops list() ever expiring a
   // grant and leaves activeRevealGrant authorizing model reveals past expiry.
   // Only a second read at a later instant separates the two.
-  const store = useTempStore('aka-exceptions-clock-');
+  const store = useTempStore('aka-exceptions-clock-', { migrated: true });
 
   // Anchored to real time, not to `clock` — these repositories never see the
   // injected timeline, and a T0-anchored expiry would be months stale.

--- a/packages/persistence/test/repositories/findings-flat.test.ts
+++ b/packages/persistence/test/repositories/findings-flat.test.ts
@@ -18,7 +18,7 @@ import { useTempStore } from '../helpers/temp-store.ts';
 // listFindingLocations (folded by repo → file). Both run against a real store,
 // like every other repository suite here.
 
-const store = useTempStore('aka-findings-flat-');
+const store = useTempStore('aka-findings-flat-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/findings.test.ts
+++ b/packages/persistence/test/repositories/findings.test.ts
@@ -29,7 +29,7 @@ function findingKeyFor(ruleId: string, filePath: string, valueFingerprint: strin
   return createHash('sha256').update(`${ruleId}\0${filePath}\0${valueFingerprint}`).digest('hex');
 }
 
-const store = useTempStore('aka-findings-');
+const store = useTempStore('aka-findings-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/installed-packs.test.ts
+++ b/packages/persistence/test/repositories/installed-packs.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { REJECTED_RULE_DETAIL_CAP } from '../../src/repositories/installed-packs.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-packs-');
+const store = useTempStore('aka-packs-', { migrated: true });
 
 function rule(id: string): Rule {
   return {

--- a/packages/persistence/test/repositories/inventory-assets-config.test.ts
+++ b/packages/persistence/test/repositories/inventory-assets-config.test.ts
@@ -10,7 +10,7 @@ import { useTempStore } from '../helpers/temp-store.ts';
 // exercises the projection that makes the Inventory page render them: a real
 // (non-sample) harness row + a config scan, read back through inventoryAssets.
 
-const store = useTempStore('aka-inv-config-');
+const store = useTempStore('aka-inv-config-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/inventory-assets-projects.test.ts
+++ b/packages/persistence/test/repositories/inventory-assets-projects.test.ts
@@ -8,7 +8,7 @@ import { useTempStore } from '../helpers/temp-store.ts';
 // per `.claude/worktrees/*` session, and an older plugin can re-mint one at any
 // time. The checkout is already part of its head project.
 
-const store = useTempStore('aka-inv-projects-');
+const store = useTempStore('aka-inv-projects-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/project-files.test.ts
+++ b/packages/persistence/test/repositories/project-files.test.ts
@@ -8,7 +8,7 @@ import { useTempStore } from '../helpers/temp-store.ts';
 // the SAME views the Inventory page uses (listProjects access counts +
 // getProjectTree folders/files) — the write is only correct if the page renders.
 
-const store = useTempStore('aka-projfiles-db-');
+const store = useTempStore('aka-projfiles-db-', { migrated: true });
 let db: LocalDatabase;
 let projectId: string;
 

--- a/packages/persistence/test/repositories/resolution-consistency.test.ts
+++ b/packages/persistence/test/repositories/resolution-consistency.test.ts
@@ -23,7 +23,7 @@ import { useTempStore } from '../helpers/temp-store.ts';
 
 const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
-const store = useTempStore('aka-resolution-consistency-');
+const store = useTempStore('aka-resolution-consistency-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/resolutions.test.ts
+++ b/packages/persistence/test/repositories/resolutions.test.ts
@@ -7,7 +7,7 @@ import type { LocalDatabase } from '../../src/database.ts';
 import { SqliteResolutionsRepository } from '../../src/repositories/resolutions.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-resolutions-');
+const store = useTempStore('aka-resolutions-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/repositories/rule-probe-cache.test.ts
+++ b/packages/persistence/test/repositories/rule-probe-cache.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { lockStore } from '../helpers/fault-injection.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-rule-probe-');
+const store = useTempStore('aka-rule-probe-', { migrated: true });
 
 describe('SqliteRuleProbeCacheRepository (via LocalDatabase.ruleProbeCache)', () => {
   it('returns undefined for an unseen rule key', () => {

--- a/packages/persistence/test/repositories/scan-ledger.test.ts
+++ b/packages/persistence/test/repositories/scan-ledger.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { ScanLedgerEntry } from '../../src/repositories/scan-ledger.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
-const store = useTempStore('aka-ledger-');
+const store = useTempStore('aka-ledger-', { migrated: true });
 
 function entry(path: string, overrides: Partial<ScanLedgerEntry> = {}): ScanLedgerEntry {
   return {

--- a/packages/persistence/test/repositories/secret-vault.test.ts
+++ b/packages/persistence/test/repositories/secret-vault.test.ts
@@ -13,7 +13,7 @@ const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
 // The package's shared store harness owns the temp tree and closes every handle
 // it hands out at teardown.
-const store = useTempStore('aka-vault-');
+const store = useTempStore('aka-vault-', { migrated: true });
 let raw: DatabaseSync;
 let vault: SqliteSecretVaultRepository;
 

--- a/packages/persistence/test/repositories/security.test.ts
+++ b/packages/persistence/test/repositories/security.test.ts
@@ -19,7 +19,7 @@ const DAY_MS = 86_400_000;
 // 2026-06-29; windows align to UTC midnight (00:00) of that day.
 const NOW = Date.parse('2026-06-29T12:00:00.000Z');
 
-const store = useTempStore('aka-security-');
+const store = useTempStore('aka-security-', { migrated: true });
 let db: LocalDatabase;
 
 beforeEach(() => {

--- a/packages/persistence/test/vault/vault.test.ts
+++ b/packages/persistence/test/vault/vault.test.ts
@@ -39,7 +39,7 @@ describe('SecretVault', () => {
   // The package's shared store harness owns the temp tree and every handle it
   // hands out. Re-rolling this by hand is what leaked a migration handle here
   // and broke the suite's teardown on Windows.
-  const store = useTempStore('aka-vault-');
+  const store = useTempStore('aka-vault-', { migrated: true });
   let dir: string;
   let db: DatabaseSync;
   let repo: SqliteSecretVaultRepository;

--- a/packages/persistence/test/warn-era-cap.test.ts
+++ b/packages/persistence/test/warn-era-cap.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { capWarnEraEnforcementOnce } from '../src/warn-era-cap.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
-const store = useTempStore('aka-warn-era-cap-');
+const store = useTempStore('aka-warn-era-cap-', { migrated: true });
 
 describe('capWarnEraEnforcementOnce', () => {
   it('is a no-op for a redact-era store, no marker written', () => {

--- a/packages/plugin-runtime/test/handle-session-start.test.ts
+++ b/packages/plugin-runtime/test/handle-session-start.test.ts
@@ -11,6 +11,7 @@ import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { EXCEPTION_RETENTION_MS, handleSessionStart } from '../src/handle-session-start.ts';
 import { setDefaultGatewayFactory } from '../src/resolve.ts';
 import { StandaloneDataGateway } from '../src/standalone-gateway.ts';
+import { migratedStore } from './helpers/store-templates.ts';
 
 let dir: string; // the ~/.aka data dir
 let cwd: string; // a working dir with a git origin (the "project")
@@ -18,6 +19,9 @@ let home: string; // a hermetic fake ~ so the config scan never reads the real o
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'aka-session-'));
+  // Schema by file copy: identical every test, and migrating it per test is
+  // what put suites of this shape over the Windows hook ceiling.
+  migratedStore.seed(dir);
   cwd = mkdtempSync(join(tmpdir(), 'aka-session-cwd-'));
   home = mkdtempSync(join(tmpdir(), 'aka-session-home-'));
   mkdirSync(join(cwd, '.git'), { recursive: true });
@@ -251,9 +255,18 @@ describe('handleSessionStart (standalone)', () => {
   });
 
   it('no-ops without a session id (returns before even opening the store)', async () => {
-    await handleSessionStart(start(undefined), config(dir));
-    // It bails before resolving the gateway, so the store is never even created.
-    expect(existsSync(join(dir, 'aka.db'))).toBe(false);
+    // Its OWN data dir, deliberately not seeded from the template: the claim is
+    // that nothing creates the store, and `dir` arrives with one already
+    // copied in, which would satisfy the assertion for the wrong reason — or,
+    // as it did, fail it for one.
+    const pristine = mkdtempSync(join(tmpdir(), 'aka-session-pristine-'));
+    try {
+      await handleSessionStart(start(undefined), config(pristine));
+      // It bails before resolving the gateway, so the store is never even created.
+      expect(existsSync(join(pristine, 'aka.db'))).toBe(false);
+    } finally {
+      removeTree(pristine);
+    }
   });
 
   it('is fail-open: an unusable data dir never throws', async () => {

--- a/packages/plugin-runtime/test/helpers/store-templates.ts
+++ b/packages/plugin-runtime/test/helpers/store-templates.ts
@@ -1,0 +1,17 @@
+// The pre-migrated store this package's suites copy from, instead of running
+// every migration on a fresh store per test.
+//
+// `createStoreTemplate` lives at the repo root because six packages need the
+// same shape and `@akasecurity/persistence`'s own harness is behind a package
+// wall; what belongs here is the build step, plus a single module-scope
+// instance so every suite loaded into a worker shares one build.
+//
+// Per-test isolation is unchanged: each test still gets its own file, in its
+// own directory, with no handle shared between them.
+import { openLocalDatabase } from '@akasecurity/persistence';
+
+import { createStoreTemplate } from '../../../../test/helpers/store-template.ts';
+
+export const migratedStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});

--- a/packages/plugin-runtime/test/standalone-gateway.test.ts
+++ b/packages/plugin-runtime/test/standalone-gateway.test.ts
@@ -21,11 +21,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { StandaloneDataGateway } from '../src/standalone-gateway.ts';
+import { migratedStore } from './helpers/store-templates.ts';
 
 let dir: string;
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'aka-standalone-'));
+  // Schema by file copy: identical every test, and migrating it per test is
+  // what put suites of this shape over the Windows hook ceiling.
+  migratedStore.seed(dir);
 });
 
 afterEach(() => {

--- a/plugins/claude-code/test/helpers/store-templates.ts
+++ b/plugins/claude-code/test/helpers/store-templates.ts
@@ -1,0 +1,17 @@
+// The pre-migrated store this package's suites copy from, instead of running
+// every migration on a fresh store per test.
+//
+// `createStoreTemplate` lives at the repo root because six packages need the
+// same shape and `@akasecurity/persistence`'s own harness is behind a package
+// wall; what belongs here is the build step, plus a single module-scope
+// instance so every suite loaded into a worker shares one build.
+//
+// Per-test isolation is unchanged: each test still gets its own file, in its
+// own directory, with no handle shared between them.
+import { openLocalDatabase } from '@akasecurity/persistence';
+
+import { createStoreTemplate } from '../../../../test/helpers/store-template.ts';
+
+export const migratedStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -41,6 +41,7 @@ import {
   runQuery,
   topFindings,
 } from '../src/render.ts';
+import { migratedStore } from './helpers/store-templates.ts';
 
 // The real shipped plugin manifest — the same plugin.json the intro adapter
 // reads at runtime. Read here so the provenance assertions track the actual
@@ -1187,6 +1188,9 @@ describe('runQuery — against a seeded standalone gateway', () => {
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'aka-query-'));
+    // Schema by file copy: identical every test, and migrating it per test is
+    // what put suites of this shape over the Windows hook ceiling.
+    migratedStore.seed(dir);
   });
   afterEach(() => {
     // removeTree, not a bare rmSync: this block leaves a real SQLite store with

--- a/test/helpers/store-template.ts
+++ b/test/helpers/store-template.ts
@@ -1,0 +1,223 @@
+// Build a migrated SQLite store ONCE, then hand out copies of the file.
+//
+// `openLocalDatabase` runs every migration in the ledger on a store that has
+// none, and a suite with per-test isolation pays that on every single test. The
+// work is identical each time and its result is a file, so it can be done once
+// per worker process and copied — which keeps per-test isolation exactly as it
+// was (each test still gets its own file, in its own directory, with no shared
+// handle) while removing the repeated schema build.
+//
+// Measured by `packages/persistence/bench/store-template.bench.ts` on arm64
+// macOS 26.5.2 / Node 24.18.0, 22 migrations, end to end per iteration
+// (mkdtemp → seed → open → close → rm), tinybench mean over two runs:
+//
+//   migrate per test         11.10 ms / 14.81 ms
+//   copyFileSync + open       1.39 ms /  1.62 ms
+//   write cached bytes+open   1.21 ms /  1.42 ms
+//
+// Roughly 9-10x either way. Two runs rather than one because the migrating row
+// alone went from ±0.50% rme to ±13.37% between them — the RATIO is the stable
+// part, which is why the bench reports a trend and asserts nothing.
+//
+// The bytes are cached in memory rather than re-read from a template file
+// because the read is the larger half of the copy: the store is ~470 KB and
+// every test would otherwise pull it back off disk. That matters most on the
+// platform this exists for — Windows charges most for file creation, fsync and
+// a scanner reading each new file, and CI has measured this work at roughly 30x
+// its local cost there.
+//
+// It sits at the repo root for the reason `remove-tree.ts` does: six packages'
+// suites need the SAME pre-migrated store (persistence, web-ui, plugin-runtime,
+// claude-code, cli and local-ops), `@akasecurity/persistence`'s own
+// harness is behind a package wall and is importable from none of them, and
+// private copies drift apart. It imports nothing but `node:fs`/`node:path` —
+// the caller supplies the build step, so this file needs no workspace package
+// and stays resolvable from every one of them.
+//
+// Its suite is `packages/persistence/test/helpers/store-template.test.ts`, not
+// a sibling: the repo root is not a workspace package, so `turbo run test`
+// reaches no test task here, and persistence is where the store's own semantics
+// (schema, migration ledger) can be asserted against a real freshly-migrated
+// store.
+//
+// `test/helpers/**` is in turbo's `globalDependencies`, so a change here
+// rehashes every package's `test` task — without which a suite would replay a
+// cached green produced against different template bytes.
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { removeTree } from './remove-tree.ts';
+
+/** The store filename every caller here builds and seeds. */
+const DB_FILE = 'aka.db';
+
+// A store that was closed cleanly has no sidecar: SQLite checkpoints the WAL
+// into the main file and removes `-wal`/`-shm` on the last connection's close.
+// One left behind means the build step handed back a handle it never closed, so
+// the bytes read here are missing whatever is still only in the log. That is a
+// silent shortfall — the copy opens fine and simply lacks rows — so it is
+// refused rather than tolerated.
+const SIDECARS = ['-wal', '-shm', '-journal'] as const;
+
+export interface StoreTemplate {
+  /**
+   * Write the pre-migrated store into `dataDir` as `aka.db`, creating the
+   * directory if it is absent. Builds the template on the first call.
+   *
+   * Refuses rather than overwrites when a store is already there: seeding over
+   * a live store would discard whatever a test had written, and the only way to
+   * reach that is a caller seeding twice or seeding after an open.
+   */
+  readonly seed: (dataDir: string) => void;
+  /**
+   * Whether the template has been built yet. For this helper's own suite — a
+   * build-once claim is otherwise unobservable, and a template rebuilt per
+   * `seed` would pass every other assertion here while saving nothing.
+   */
+  readonly isBuilt: () => boolean;
+  /** How many times the build step has run. Its suite asserts this is 1. */
+  readonly buildCount: () => number;
+}
+
+/**
+ * A template built by `build`, which must open a store under the directory it
+ * is given, do whatever seeding the caller wants baked in, and CLOSE it.
+ *
+ * Call this once at module scope so every test in the worker shares one build.
+ * The build is lazy, so a module that is loaded but whose tests are all
+ * filtered out pays nothing.
+ *
+ * What the copy does NOT carry is the `aka.db.pre-drop.<ts>.<rand>.bak` a fresh
+ * migration leaves beside the store — only `aka.db` is copied. Nothing is lost
+ * by that: the backup is snapshotted during the open, so it always predates
+ * every write a test makes, and an at-rest scan over it can contain no test
+ * value. A suite whose subject IS that backup must not use a template.
+ */
+export function createStoreTemplate(build: (dataDir: string) => void): StoreTemplate {
+  let bytes: Buffer | undefined;
+  let failure: Error | undefined;
+  let builds = 0;
+
+  const ensureBuilt = (): Buffer => {
+    if (bytes !== undefined) return bytes;
+    // A build that failed once fails the same way every time, and a suite calls
+    // this per test — so the first error is kept and re-thrown rather than
+    // paying an mkdtemp, a failed open and a removeTree again for each of them.
+    // Every test still reports, and reports the real cause.
+    if (failure !== undefined) throw failure;
+    const base = mkdtempSync(join(tmpdir(), 'aka-store-template-'));
+    try {
+      const dataDir = join(base, 'data');
+      mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+      builds += 1;
+      build(dataDir);
+      const file = join(dataDir, DB_FILE);
+      if (!existsSync(file)) {
+        throw new Error(
+          `createStoreTemplate: the build step left no ${DB_FILE} in ${dataDir} — it must open a store under the directory it is given.`,
+        );
+      }
+      const live = liveSidecar(file);
+      if (live !== undefined) {
+        throw new Error(
+          `createStoreTemplate: the build step left a non-empty ${live} beside ${DB_FILE} — it must close the handle it opened, or the template would be missing whatever is still only in the log.`,
+        );
+      }
+      bytes = readFileSync(file);
+      return bytes;
+    } catch (err) {
+      failure = err instanceof Error ? err : new Error(String(err));
+      throw failure;
+    } finally {
+      // The build tree has served its purpose either way: on the throw path it
+      // must not be stranded, and on the success path the bytes are already in
+      // memory. A failure to remove it is not worth speaking over the build's
+      // own error, and on win32 `removeTree` already tolerates a held handle.
+      removeTree(base);
+    }
+  };
+
+  return {
+    seed: (dataDir: string): void => {
+      const template = ensureBuilt();
+      mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+      const file = join(dataDir, DB_FILE);
+      if (existsSync(file)) {
+        throw new Error(
+          `createStoreTemplate: ${file} already exists — seed a store before it is opened, and only once.`,
+        );
+      }
+      // An absent `aka.db` is not on its own an empty data dir. A `-wal` or
+      // `-journal` left by an earlier store — a partial teardown, or a win32
+      // `removeTree` that tolerated a held handle — would be paired by SQLite
+      // with the template copied over it, and a log whose header belongs to a
+      // different database reads as `database disk image is malformed`. That
+      // gets attributed to the template rather than to the leftover, so it is
+      // refused here where the leftover can still be named.
+      const stale = liveSidecar(file);
+      if (stale !== undefined) {
+        throw new Error(
+          `createStoreTemplate: ${file}${stale} is present with no ${DB_FILE} beside it — an earlier store left a log here, and seeding over it would pair the template with a foreign one. Remove the data dir first.`,
+        );
+      }
+      // A temp file plus a rename, not a direct write: the store is only ever
+      // read through SQLite, and a reader meeting a partially-written database
+      // header reports corruption rather than a short file. The rename is
+      // atomic on both platforms, so `aka.db` either is not there or is the
+      // whole template.
+      writeThenRename(template, file);
+    },
+    isBuilt: (): boolean => bytes !== undefined,
+    buildCount: (): number => builds,
+  };
+}
+
+function writeThenRename(bytes: Buffer, file: string): void {
+  const staging = `${file}.template-partial`;
+  try {
+    // `writeFileSync`'s mode applies only where it CREATES the file, and is
+    // umask-masked besides — the store's real 0600 is set by the product's own
+    // `tightenPerms` on the open that follows. This only has to avoid being
+    // wider than that in the window between.
+    writeFileSync(staging, bytes, { mode: 0o600 });
+    renameSync(staging, file);
+  } catch (err) {
+    // A rename that lost to a scanner holding the file (win32 EPERM) leaves the
+    // staging copy in the data dir, where an at-rest scan over that directory
+    // would read template bytes as store contents. `force` swallows the ENOENT
+    // of the path that never got written.
+    try {
+      rmSync(staging, { force: true });
+    } catch {
+      // Nothing to add — the write failure below is the one worth reading.
+    }
+    throw err;
+  }
+}
+
+/**
+ * The first sidecar beside `file` that carries bytes, or `undefined` when the
+ * store stands alone.
+ *
+ * A store closed cleanly has none: SQLite checkpoints the WAL into the main
+ * file and removes `-wal`/`-shm` on the last connection's close. One with bytes
+ * in it therefore means a live or abandoned log, which matters at both ends —
+ * reading a template out from under one loses whatever is still only in the
+ * log, and writing a template in beside one pairs it with a foreign database.
+ */
+function liveSidecar(file: string): (typeof SIDECARS)[number] | undefined {
+  return SIDECARS.find((suffix) => {
+    const sidecar = `${file}${suffix}`;
+    return existsSync(sidecar) && statSync(sidecar).size > 0;
+  });
+}

--- a/tsconfig.root.json
+++ b/tsconfig.root.json
@@ -3,7 +3,9 @@
   // the shared adversarial fixture corpus (whose whole point is that three
   // packages' walkers drive the SAME hostile trees, so it can live inside none of
   // them), the shared temp-tree teardown helper (nine packages' teardowns need
-  // the SAME win32 rule, for the same reason), the shared vitest coverage block
+  // the SAME win32 rule, for the same reason), the shared pre-migrated store
+  // template (six packages' suites copy one store rather than each migrating a
+  // fresh one per test), the shared vitest coverage block
   // and per-package floor table (every package's vitest config imports it), the
   // CI egress probe, and
   // lint:root's own ESLint config (a root-level file, not a directory — it

--- a/web-ui/test/actions/exceptions-reveal.test.ts
+++ b/web-ui/test/actions/exceptions-reveal.test.ts
@@ -23,6 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { grantRevealFromPointer } from '../../app/(app)/exceptions/actions.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 // `grantRevealFromPointer` mints the strictly-stronger capability: while the
 // grant is active the model may receive the value's raw form at tool
@@ -62,6 +63,8 @@ function resetSingleton(): void {
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-reveal-'));
   osHome.dir = home;
+  // Schema by file copy rather than a migration this test would only repeat.
+  emptyStore.seed(dataDir());
   // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
   applyOnboarding({
     vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -47,6 +47,7 @@ import {
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
 import { expectNoRejection } from '../helpers/no-throw.ts';
 import { storeBytes } from '../helpers/store-bytes.ts';
+import { withBundledPacks } from '../helpers/store-templates.ts';
 
 // Every mutating Server Action on the exceptions surface, each covered against a
 // real node:sqlite store and a real fingerprint key file — no mocking of either
@@ -267,12 +268,10 @@ beforeEach(() => {
   dir = dataDir();
   // Seed the installed ruleset the way the plugin/CLI do on open — addException
   // scans against this DB snapshot, not the engine's process-global registry.
-  const db = openLocalDatabase(dir);
-  try {
-    db.installedPacks.recordInventory(bundledDetections());
-  } finally {
-    db.close();
-  }
+  // The schema and the installed ruleset arrive as a file copy: both are
+  // identical every test, and migrating plus re-reading the bundled set per
+  // test is what put this suite's `beforeEach` over the Windows hook ceiling.
+  withBundledPacks.seed(dir);
   resetSingleton();
 });
 

--- a/web-ui/test/actions/findings-load-more.test.ts
+++ b/web-ui/test/actions/findings-load-more.test.ts
@@ -13,6 +13,7 @@ import {
   loadMoreFindingInstances,
   loadMoreGroupedFindings,
 } from '../../app/(app)/findings/actions.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 /**
  * The findings list's "Load more" actions.
@@ -52,6 +53,8 @@ beforeEach(() => {
   // dataDir()'s argument is the ~/.aka ROOT, not the home — with the mock in
   // place the no-argument form resolves to exactly what the action will open.
   dir = dataDir();
+  // Schema by file copy rather than a migration this test would only repeat.
+  emptyStore.seed(dir);
   dropMemoisedDb();
 });
 

--- a/web-ui/test/actions/vault-manage.test.ts
+++ b/web-ui/test/actions/vault-manage.test.ts
@@ -29,6 +29,7 @@ import {
   revokeRevealGrant,
   rotateVaultKey,
 } from '../../app/(app)/vault/actions.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 // The vault manage surface: reveal-by-row-id, grant revocation, the purge, and
 // the key rotation. The suite pins the audit and survival properties — one
@@ -68,6 +69,8 @@ function resetSingleton(): void {
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-vault-manage-'));
   osHome.dir = home;
+  // Schema by file copy rather than a migration this test would only repeat.
+  emptyStore.seed(dataDir());
   revalidate.mockClear();
   // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
   applyOnboarding({

--- a/web-ui/test/actions/vault-pagination.test.ts
+++ b/web-ui/test/actions/vault-pagination.test.ts
@@ -22,6 +22,7 @@ import {
   purgeVault,
   revealEntry,
 } from '../../app/(app)/vault/actions.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 /**
  * The vault page's three paged READ actions.
@@ -68,6 +69,8 @@ beforeEach(() => {
   // dataDir()'s argument is the ~/.aka ROOT, not the home — with the mock in
   // place the no-argument form resolves to exactly what the action will open.
   dir = dataDir();
+  // Schema by file copy rather than a migration this test would only repeat.
+  emptyStore.seed(dir);
   revalidate.mockClear();
   dropMemoisedDb();
 });

--- a/web-ui/test/actions/vault.test.ts
+++ b/web-ui/test/actions/vault.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { revealPointer } from '../../app/(app)/vault/actions.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 // `revealPointer` is the dashboard's reveal surface. It must return the raw
 // value ONLY for a pointer this machine minted (auditing the reveal), return
@@ -54,6 +55,8 @@ function resetSingleton(): void {
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-vault-'));
   osHome.dir = home;
+  // Schema by file copy rather than a migration this test would only repeat.
+  emptyStore.seed(dataDir());
   // Vaulting (tokenize) is consent-gated; grant it for the seeding step.
   applyOnboarding({
     vaultConsent: { acknowledgedAt: new Date().toISOString(), version: VAULT_CONSENT_VERSION },

--- a/web-ui/test/helpers/store-templates.ts
+++ b/web-ui/test/helpers/store-templates.ts
@@ -1,0 +1,41 @@
+// The pre-built stores this package's suites copy from, instead of migrating a
+// fresh one per test.
+//
+// `createStoreTemplate` is at the repo root because four packages need the same
+// shape; what belongs here is the build step. Two are worth having, because the
+// two costs a web-ui suite pays are separable:
+//
+//   `emptyStore`      — the schema alone, for a suite that seeds its own rows.
+//   `withBundledPacks` — the schema plus the installed ruleset, for the action
+//                        suites: `addException` scans against the DB snapshot
+//                        rather than the engine's process-global registry, so
+//                        every one of them needs `installed_packs` populated,
+//                        and doing it per test re-reads the whole bundled set.
+//
+// Both are module-scope, so each is built once per worker and every suite
+// loaded into that worker shares it. Per-test isolation is untouched: each test
+// still gets its own file under its own mkdtemp home, and no handle is shared.
+//
+// `@akasecurity/plugin-sdk` is a dev-only dependency of this package for
+// `bundledDetections()`, which is what it is already taken for elsewhere in
+// these suites — a dev-only test dependency is not a runtime package-wall
+// crossing.
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { bundledDetections } from '@akasecurity/plugin-sdk';
+
+import { createStoreTemplate } from '../../../test/helpers/store-template.ts';
+
+/** Schema and default policies only — what `openLocalDatabase` writes itself. */
+export const emptyStore = createStoreTemplate((dataDir) => {
+  openLocalDatabase(dataDir).close();
+});
+
+/** The same, plus the bundled ruleset in `installed_packs`. */
+export const withBundledPacks = createStoreTemplate((dataDir) => {
+  const db = openLocalDatabase(dataDir);
+  try {
+    db.installedPacks.recordInventory(bundledDetections());
+  } finally {
+    db.close();
+  }
+});

--- a/web-ui/test/pages/exceptions-page.test.ts
+++ b/web-ui/test/pages/exceptions-page.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { ExceptionsClient } from '../../app/(app)/exceptions/ExceptionsClient.tsx';
 import ExceptionsPage from '../../app/(app)/exceptions/page.tsx';
+import { withBundledPacks } from '../helpers/store-templates.ts';
 
 // The exceptions route issues TWO reads of the same blocked-detections ledger,
 // over two different windows, and hands both to the client — and which read
@@ -144,12 +145,10 @@ beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-exp-'));
   osHome.dir = home;
   dir = dataDir();
-  const db = openLocalDatabase(dir);
-  try {
-    db.installedPacks.recordInventory(bundledDetections());
-  } finally {
-    db.close();
-  }
+  // The schema and the installed ruleset arrive as a file copy: both are
+  // identical every test, and migrating plus re-reading the bundled set per
+  // test is what put this suite's `beforeEach` over the Windows hook ceiling.
+  withBundledPacks.seed(dir);
   resetSingleton();
 });
 


### PR DESCRIPTION
## Why

`openLocalDatabase` runs every migration in the ledger on a store that has none, so a suite with per-test isolation rebuilds the whole schema on **every test**. The result is identical each time and it is a file, so it can be built once per worker and copied.

On the Windows CI leg this is not a comfort issue. That leg charges roughly 30x local cost for file creation and fsync, so a `beforeEach` doing a full migration ran 1–4 s per test against a 20 s hook ceiling — and failed with `Hook timed out in 20000ms` in a rotating package, almost never the one the PR touched. The previous response to this was raising the ceiling from vitest's 10 s default to 20 s, which moved the threshold rather than removing the cost; the failure then spread from one package to four.

## What changed

- **`test/helpers/store-template.ts`** — a dependency-free shared builder at the repo root (the same reason `remove-tree.ts` lives there: six packages need it and `@akasecurity/persistence`'s harness is behind a package wall). Each package supplies its own build step, so the file imports nothing but `node:fs`/`node:path` and stays resolvable everywhere. It refuses a build that left no store, one that left a live `-wal` (an unclosed handle, whose copy would silently lack rows), and any seed over a store or a foreign log already in the destination.
- **`useTempStore` / `withTempStore` / `createTempStore`** take `{ migrated: true }`. Adopted across persistence, web-ui, plugin-runtime, claude-code, cli and local-ops.
- **The option is opt-IN, and that is load-bearing.** A seeded store has nothing left to migrate, so a suite whose subject *is* the open path — migrations, the lineage reset, the `.bak` a fresh migration leaves, `aka init` creating the store, a first-run flow, a fault where `applyMigrations` is the thing that refuses — must not take it. Those assertions would hold **vacuously** rather than fail. One such test caught this during development and now gets its own unseeded directory.
- **A vitest timeout ratchet** (`packages/eslint-config/test/hook-timeout-ratchet.test.js`) pins every package's `testTimeout`/`hookTimeout` as an exact map, in both directions, and refuses the same raise made through a test-script CLI flag (which reads config literals and would otherwise be bypassed silently).
- A bench for the trend, plus CLAUDE.md and `tsconfig.root.json` updated.

Per-test isolation is unchanged throughout: every test still gets its own file, in its own directory, with no handle shared.

## Verification

Primary metric is the **count of full migrations executed**, which unlike wall clock does not move with runner load. Measured by instrumenting `applyMigrations` (instrumentation not committed):

| package | before | after |
| --- | ---: | ---: |
| web-ui | 256 | **10** |
| plugin-runtime | 62 | **13** |
| persistence | 757 | **392** |
| cli | 105 | **61** |
| local-ops | 61 | **28** |

Wall clock, minimum of 3 runs each, four store-heavy persistence suites (101 tests): **1.93 s → 0.569 s**.

```
pnpm --filter @akasecurity/persistence bench   # store-template.bench.ts, ~9-10x
```

`pnpm turbo run test --force` → 45/45 tasks green; lint, `lint:root`, portability, typecheck and `format:check` clean.

Each guarded property was mutation-tested — disabling the build-once cache, neutering the `migrated` option, sharing one store across tests, and raising a `hookTimeout` each turn the corresponding assertion red for its own reason.

## Follow-ups (not in this PR)

- Remaining per-test migrations are diffuse rather than concentrated: claude-code 139, codex 74, cli 61, antigravity 54, plugin-sdk 30, local-ops 28. Most sit in first-run and e2e suites where seeding would make the assertion vacuous.
- Product, not tests: every fresh `openLocalDatabase` on a brand-new store writes a ~479 KB `aka.db.pre-drop.*.bak` backing up a store with nothing in it. Real cost on `aka init` and first hook run, but it sits on the history-preservation path.