### PR TITLE
test(eslint-config): assert turbo's hash moves for a repo-root file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -881,6 +881,18 @@ tools/                repo tooling, never shipped: the installer one-liners and
    enumerates by — a file whose extension it counts as lintable and the glob omits
    is the same cached-green hole one extension wide.
 
+   Those checks read `turbo.json` as TEXT and match its globs with
+   `path.matchesGlob`, which is a MODEL of turbo's hashing rather than turbo's
+   hashing. One case asks turbo instead: it plants a lintable file at the repo
+   root, runs `--dry=json`, and asserts the hash really moves — the only reading
+   that decides whether this suite RUNS. Two things in it are load-bearing. It
+   selects the task by `taskId`, because `tasks[0]` is `#build`, whose inputs are
+   package-local and which no repo-root file ever moves. And it carries a
+   POSITIVE CONTROL that plants under a different input (`tools/ci/**`) first, so
+   a broken measurement is reported as a broken measurement rather than as a
+   missing glob — without it, "the hash did not move" reads the same whether the
+   glob went or the selection did.
+
 6. Add the package name to `EXPECTED_WORKSPACE_PACKAGE_NAMES` in
    `packages/eslint-config/test/effective-config.test.js`. That pinned list only
    forces a human to notice the new package — what actually stops it shipping

--- a/packages/detections/test/security/redos-probe.test.ts
+++ b/packages/detections/test/security/redos-probe.test.ts
@@ -260,9 +260,30 @@ describe('checkRuleTiming', () => {
 describe('worstProbeMs attributes a probe to its interpreted tier', () => {
   // The verdict test above buys its directness with a ~1.3x margin. This one
   // carries no absolute millisecond threshold at all: both quantities are
-  // measured on the machine running them, so hardware speed and CPU contention
-  // move them together and cancel — the same reason `backtrackRatio` and
-  // CATASTROPHIC_RATIO exist rather than a fixed ms bound.
+  // measured on the machine running them, so a faster or slower MACHINE scales
+  // the numerator and the denominator alike and cancels out of the ratio — the
+  // same reason `backtrackRatio` and CATASTROPHIC_RATIO exist rather than a
+  // fixed ms bound.
+  //
+  // CPU CONTENTION does not cancel, and this comment used to say it did. Two
+  // quantities cancel only when they are sampled in the same window, and these
+  // are not: the numerator is timed inside `worstProbeMs` and the denominator
+  // ~135ms later. Load spanning both windows is the harmless direction — it
+  // RAISES the ratio, measured below — but load arriving only in the gap
+  // inflates the denominator alone, and the ratio then reports the runner
+  // rather than the tier — down to the 0.84x recorded below, on a gate that was
+  // working perfectly. That is a false failure, not a caught bypass, and it is
+  // why this case reddened runs of the full suite at turbo's default fan-out
+  // while passing the same commit standalone.
+  //
+  // So what makes the pair comparable is sampling shape, not the threshold, and
+  // it is two mechanisms rather than one. The denominator is a min over seven
+  // samples, which recovers the native tier wherever a quiet slot exists inside
+  // the window. And a fixed CPU-bound calibration is timed on either side of the
+  // whole measurement, so the one case `min` cannot rescue — a machine that
+  // changed speed BETWEEN the windows, where there is no quiet slot left to
+  // find — abstains instead of returning a verdict its sampling cannot support.
+  // Both are taken below, beside the reasoning that sizes them.
   it('reports the first probe at its interpreted cost, not its native cost', (ctx) => {
     // Read the machine's speed before anything is measured against it, and again
     // after. Neither reading touches `rule`.

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1369,6 +1369,254 @@ describe('every file outside every workspace package is linted by a repo-root pa
   });
 });
 
+describe("turbo's own hash moves when a lintable file appears at the repo root", () => {
+  // The three checks above read turbo.json as TEXT and match its globs with
+  // `path.matchesGlob`. That is a MODEL of turbo's hashing, not turbo's hashing:
+  // it holds only while `$TURBO_ROOT$` resolves where the helper assumes and the
+  // two glob dialects agree about `*` versus `**`. Nothing in this package has
+  // ever asked the one reader whose answer decides whether this suite RUNS.
+  //
+  // The hazard is the one turbo.json's own comments describe at length. Drop
+  // `$TURBO_ROOT$/*.{ts,…}` — the only entry that reaches a file sitting
+  // directly at the repo root, since the two per-package globs above it both
+  // require a directory segment — and adding a lintable file there moves this
+  // task's hash not at all. turbo replays the cached pass, every guard in this
+  // package is skipped at the one moment it exists to fire, `pnpm lint` and CI
+  // stay green, and the file ships with a `fetch()` in it.
+  const PKG = '@akasecurity/eslint-config';
+  const TASK_ID = `${PKG}#test`;
+  const BUILD_TASK_ID = `${PKG}#build`;
+
+  // Spawned as a Node script rather than through `node_modules/.bin/turbo`: that
+  // shim is a `.cmd` on Windows, which libuv's executable search cannot load
+  // without a shell (CLAUDE.md "A command spawned by BARE NAME"). The
+  // launcher turbo's own manifest names is plain JS, so `process.execPath` runs
+  // it identically on every platform and no argument is ever handed to `cmd.exe`
+  // to re-parse.
+  //
+  // Read out of that manifest rather than spelled here. A hardcoded
+  // `bin/turbo` survives only until turbo moves its launcher, and the failure
+  // then is an `existsSync` miss reported as "run pnpm install" — a confident
+  // instruction to reinstall a dependency that is installed correctly.
+  const TURBO_BIN = (() => {
+    const manifest = join(REPO_ROOT, 'node_modules', 'turbo', 'package.json');
+    if (!existsSync(manifest)) return '';
+    const bin = JSON.parse(readFileSync(manifest, 'utf8')).bin;
+    const entry = typeof bin === 'string' ? bin : bin?.turbo;
+    return typeof entry === 'string' ? join(REPO_ROOT, 'node_modules', 'turbo', entry) : '';
+  })();
+
+  // Five dry runs at ~0.1s each locally. The budget is not sized against that:
+  // it is a hung-subprocess backstop, and it is deliberately the same 120s as
+  // RESOLVE_TIMEOUT_MS above rather than a second number to keep in step —
+  // both answer "this stopped terminating", neither measures anything.
+  const HASH_TIMEOUT_MS = RESOLVE_TIMEOUT_MS;
+
+  // Neither name matches `*.config.*`, so neither is a target of any lint pass
+  // that a concurrently-running case in this package might make. Both are
+  // untracked for the whole of their short life, so every guard here that
+  // derives its file set from `git ls-files` is blind to them by construction.
+  const ROOT_PROBE = '__aka_turbo_hash_probe__.mjs';
+  const rootProbeAbs = join(REPO_ROOT, ROOT_PROBE);
+  const CONTROL_PROBE = '__aka_turbo_hash_control__.txt';
+  const controlRel = 'tools/ci';
+  const controlAbs = join(REPO_ROOT, controlRel, CONTROL_PROBE);
+
+  // Belt and braces with the finallys below: an assertion that throws mid-test
+  // must never leave a file behind that perturbs the next run's hash — or a
+  // later `pnpm lint` — for a reason nobody can trace back to here.
+  afterAll(() => {
+    rmSync(rootProbeAbs, { force: true });
+    rmSync(controlAbs, { force: true });
+  });
+
+  /** The hashes turbo computes for this package's two tasks, right now. */
+  function hashes() {
+    let stdout;
+    try {
+      stdout = execFileSync(
+        process.execPath,
+        [TURBO_BIN, 'run', 'test', `--filter=${PKG}`, '--dry=json'],
+        // stderr piped rather than inherited: turbo prints a version banner on
+        // every run, and inheriting it would put one in the middle of vitest's
+        // output for a case that succeeded.
+        {
+          cwd: REPO_ROOT,
+          encoding: 'utf8',
+          maxBuffer: 64 * 1024 * 1024,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+    } catch (err) {
+      // Piping stderr captures it onto `err.stderr`, and vitest renders only
+      // `message` and `stack` — so without this rethrow the whole reported
+      // failure is `Command failed: <argv>`, naming no reason at all. That is
+      // the shape a CI-only failure arrives in, which is the one place nobody
+      // can re-run it by hand to find out why.
+      const { stderr, status } = /** @type {{ stderr?: string, status?: number }} */ (err);
+      throw new Error(
+        `turbo dry run failed (exit ${String(status ?? 'unknown')}). Its stderr:\n` +
+          `${(stderr ?? '').trim() || '(empty)'}`,
+        { cause: err },
+      );
+    }
+
+    // Parsed defensively because the two ways this breaks both produce an error
+    // naming neither turbo nor this case. A notice on stdout — turbo prints a
+    // telemetry note on a machine that has never run it, which describes every
+    // fresh CI runner — makes `JSON.parse` throw about a token at position 0;
+    // and a payload without `tasks` makes `.find` throw about a property of
+    // undefined, from inside a helper.
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch (err) {
+      throw new Error(
+        `turbo's --dry=json output did not parse as JSON. First 200 characters:\n` +
+          `${stdout.slice(0, 200)}`,
+        { cause: err },
+      );
+    }
+    const tasks = parsed.tasks;
+    expect(
+      Array.isArray(tasks),
+      "turbo's --dry=json payload carries no `tasks` array, so the shape this case reads has " +
+        'changed and no assertion below means what it says.',
+    ).toBe(true);
+
+    // Select by taskId, never by position. `tasks[0]` is `#build` today, whose
+    // inputs are package-local: read THAT and no probe below moves the hash, so
+    // the case reports a missing glob when the real fault is the selection. The
+    // build hash comes back too, so the control can say which of the two it is.
+    const test = tasks.find((t) => t.taskId === TASK_ID);
+    const build = tasks.find((t) => t.taskId === BUILD_TASK_ID);
+    expect(test, `no ${TASK_ID} in the dry run's task list`).toBeDefined();
+    expect(build, `no ${BUILD_TASK_ID} in the dry run's task list`).toBeDefined();
+
+    // Both hashes are asserted to be non-empty STRINGS, and that is not
+    // belt-and-braces. Every assertion in this case is a comparison between two
+    // of these values, so a renamed field hands back `undefined` on both sides:
+    // the stability check then passes for the best possible reason and the
+    // wrongest one, and the control fails blaming task selection. A guard whose
+    // whole job is to catch a cached green must not be able to go green because
+    // it read nothing.
+    for (const [label, task] of [
+      [TASK_ID, test],
+      [BUILD_TASK_ID, build],
+    ]) {
+      expect(
+        typeof task.hash === 'string' && task.hash.length > 0,
+        `${label} came back from the dry run with no \`hash\` string (got ` +
+          `${JSON.stringify(task.hash)}). Every comparison in this case is between two of these ` +
+          'values, so reading a missing field would make them all compare equal and pass.',
+      ).toBe(true);
+    }
+    return { test: test.hash, build: build.hash };
+  }
+
+  it(
+    'changes for a repo-root file, and holds still for an unchanged tree',
+    () => {
+      expect(
+        existsSync(TURBO_BIN),
+        `${TURBO_BIN} is missing, so this case cannot ask turbo anything. turbo is a root ` +
+          'devDependency; run `pnpm install`.',
+      ).toBe(true);
+
+      const baseline = hashes();
+
+      // An unchanged tree must hash to the same thing twice. Without this the
+      // two assertions below would be satisfied by a hash that simply is not
+      // stable — one that moves for every probe proves nothing about any of them.
+      //
+      // "Unchanged" is a claim about the WHOLE repo for the length of this case,
+      // and it is load-bearing rather than incidental: any concurrent writer
+      // under a path this task hashes moves the baseline underneath the
+      // comparisons. THIS FILE contains three such writers — the planted-probe
+      // describes below write `cli/__aka_network_probe__.config.ts` (matched by
+      // `$TURBO_ROOT$/*/**/*.{ts,…}`) and a repo-root
+      // `__aka_root_network_probe__.config.mjs` (matched by the very glob under
+      // test). They cannot overlap this case only because vitest runs one
+      // FILE's tests sequentially. So this case must stay in the same file as
+      // them; splitting either side into its own suite puts them in parallel
+      // workers, and the symptom is this assertion failing intermittently while
+      // naming turbo.json, which would be innocent.
+      expect(
+        hashes().test,
+        `${TASK_ID}'s hash is not stable across two dry runs of an unchanged tree, so nothing ` +
+          'below can attribute a change to the file that was planted rather than to the noise. ' +
+          'Check for a concurrent writer under a path this task hashes before suspecting turbo: ' +
+          'the planted-probe cases in this file write into `cli/` and the repo root, and are safe ' +
+          "only while they share this file's sequential execution.",
+      ).toBe(baseline.test);
+
+      // The positive control runs FIRST, and deliberately does not use the glob
+      // under test: it plants under `$TURBO_ROOT$/tools/ci/**`, an input this
+      // task lists by hand and `#build` does not carry at all. So it fails
+      // exactly when the MEASUREMENT is broken — the wrong task selected, a dry
+      // run that cannot see a new file — which is what lets the assertion after
+      // it be read as a verdict on the root glob rather than on the method.
+      //
+      // Not a CLAUDE.md edit, though that document is an equally decisive input
+      // of this task and not of `#build`: two describes in this package parse it,
+      // vitest runs test files in parallel, and mutating it mid-run reddens them
+      // for a reason nobody could trace back to here. Creating a file nothing
+      // reads carries the same discriminating power with none of that.
+      writeFileSync(controlAbs, 'turbo hash control probe\n');
+      let control;
+      try {
+        control = hashes();
+      } finally {
+        rmSync(controlAbs, { force: true });
+      }
+      expect(
+        control.test,
+        `planting ${controlRel}/${CONTROL_PROBE} moved no hash. Two edits produce exactly this ` +
+          'symptom and this case cannot tell them apart, so check both. (1) The dry run is being ' +
+          `read wrong — most likely by position, since \`tasks[0]\` is ${BUILD_TASK_ID}, whose ` +
+          `inputs are package-local. (2) \`$TURBO_ROOT$/${controlRel}/**\` was narrowed or ` +
+          "removed from this task's turbo.json inputs, in which case the control has stopped " +
+          'being a control. Settle that before reading the repo-root assertion below as a ' +
+          'verdict on turbo.json.',
+      ).not.toBe(baseline.test);
+      expect(
+        control.build,
+        `planting ${controlRel}/${CONTROL_PROBE} moved ${BUILD_TASK_ID}'s hash, which hashes only ` +
+          'package-local files. The two tasks are no longer distinguishable by what they hash, so ' +
+          'the control above no longer proves the selection is right.',
+      ).toBe(baseline.build);
+
+      // The property itself: a lintable file at the repo root — the shape the
+      // per-package globs structurally cannot reach — must move this task's hash.
+      writeFileSync(rootProbeAbs, 'export const probe = 1;\n');
+      let planted;
+      try {
+        planted = hashes();
+      } finally {
+        rmSync(rootProbeAbs, { force: true });
+      }
+      expect(
+        planted.test,
+        `adding ${ROOT_PROBE} at the repo root moved no hash for ${TASK_ID}, while the control ` +
+          'above did move it — so the measurement is sound and turbo.json is not. The repo-root ' +
+          'entry `$TURBO_ROOT$/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` is the only one that reaches a ' +
+          'file directly at the root; the per-package globs above it each require a directory ' +
+          'segment. Without it, every guard in this package replays a cached green on the commit ' +
+          'that adds an unlinted repo-root file.',
+      ).not.toBe(baseline.test);
+
+      // And the tree is back where it started, so the next reader of this hash
+      // is not charged for a file this case planted.
+      expect(
+        hashes().test,
+        'the planted files were removed but the hash did not return to its baseline, so this ' +
+          'case has left the tree perturbed for every task that hashes it next.',
+      ).toBe(baseline.test);
+    },
+    HASH_TIMEOUT_MS,
+  );
+});
+
 describe(`the root pass states the ignore-flag rule (${CONVENTIONS_DOC} step 5)`, () => {
   // The ignore rule is enforced for the ROOT pass by nonPackageFilesNotWired, and
   // stated for a PACKAGE by the paragraph earlier in step 5. Prose sitting beside

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -1500,18 +1500,27 @@ describe("turbo's own hash moves when a lintable file appears at the repo root",
     // wrongest one, and the control fails blaming task selection. A guard whose
     // whole job is to catch a cached green must not be able to go green because
     // it read nothing.
-    for (const [label, task] of [
-      [TASK_ID, test],
-      [BUILD_TASK_ID, build],
-    ]) {
+    //
+    // The check and the RETURN read one expression, through this accessor,
+    // because the obvious spelling of it — validate `task.hash` in a loop, then
+    // return `task.hash` separately — leaves two places naming the field and
+    // nothing tying them together. Point either one at something else and the
+    // guard goes on passing while the value it vouched for is not the value
+    // handed back: the case still fails, but on the control, reporting a
+    // renamed field as "the dry run is being read wrong — most likely by
+    // position". Reading the field once is what makes that impossible rather
+    // than merely unlikely.
+    const hashOf = (label, task) => {
+      const value = task.hash;
       expect(
-        typeof task.hash === 'string' && task.hash.length > 0,
+        typeof value === 'string' && value.length > 0,
         `${label} came back from the dry run with no \`hash\` string (got ` +
-          `${JSON.stringify(task.hash)}). Every comparison in this case is between two of these ` +
+          `${JSON.stringify(value)}). Every comparison in this case is between two of these ` +
           'values, so reading a missing field would make them all compare equal and pass.',
       ).toBe(true);
-    }
-    return { test: test.hash, build: build.hash };
+      return value;
+    };
+    return { test: hashOf(TASK_ID, test), build: hashOf(BUILD_TASK_ID, build) };
   }
 
   it(

--- a/packages/eslint-config/vitest.config.ts
+++ b/packages/eslint-config/vitest.config.ts
@@ -11,13 +11,19 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
 
-// No package-wide timeout override on purpose. The slow work here is config
-// resolution, which is confined to `beforeAll` hooks that carry their own
-// budgets (no-network.test.js's CONFIG_LOAD_TIMEOUT_MS, effective-config.test.js's
-// RESOLVE_TIMEOUT_MS). Raising testTimeout for the package would spend that
-// budget on ~112 fixture-lint assertions that each run in well under a
-// millisecond, where a regression to multiple seconds should fail rather than
-// pass quietly.
+// No package-wide timeout override on purpose. Almost every case here is a
+// sub-millisecond assertion over an already-resolved config, and raising
+// testTimeout for the package would spend a multi-second budget on ~112
+// fixture-lint assertions, where a regression to multiple seconds should fail
+// rather than pass quietly.
+//
+// The slow work carries its OWN budget instead, named at each site rather than
+// inherited: no-network.test.js's CONFIG_LOAD_TIMEOUT_MS and
+// effective-config.test.js's RESOLVE_TIMEOUT_MS for config resolution in a
+// `beforeAll`, and effective-config.test.js's HASH_TIMEOUT_MS for the turbo-hash
+// case, which spawns dry runs from the test BODY. That last one is why this
+// paragraph no longer says the slow work is confined to hooks: a slow case is
+// allowed here, it just has to name its own deadline.
 export default defineConfig({
   test: {
     setupFiles: [noNetworkGuard],


### PR DESCRIPTION
## Why

Two independent gaps in the test suite.

**`packages/eslint-config` — nothing asserted that this suite still re-runs.**
`@akasecurity/eslint-config#test` executes only when turbo decides its hash moved, and a
single entry in `turbo.json` — `$TURBO_ROOT$/*.{ts,tsx,mts,cts,js,jsx,mjs,cjs}` — is what
makes a file added at the repo root move it, since the two per-package globs above it each
require a directory segment. Delete that entry and every guard in this package replays a
cached green on the very commit that adds an unlinted repo-root file, with CI green
throughout. The three existing checks read `turbo.json` as *text* and match its globs with
`path.matchesGlob`, which is a model of turbo's hashing rather than turbo's hashing.

**`packages/detections` — a comment contradicting the code beneath it.** The probe-tier
ratio's header claimed hardware speed and CPU contention "move them together and cancel".
Contention does not cancel: the numerator is timed inside `worstProbeMs` and the
denominator ~135 ms later, so load arriving only in that gap inflates the denominator
alone. The file already explains this correctly further down, beside the min-of-7 native
floor and the calibration drift guard that do the bounding — the header was left behind
when those landed.

## Changes

- **New case, `turbo's own hash moves when a lintable file appears at the repo root`.**
  Plants a lintable file at the repo root, runs `--dry=json`, and requires the hash to
  move. Selects the task by `taskId` — `tasks[0]` is `#build`, whose inputs are
  package-local, so reading that would report a missing glob for every probe. A positive
  control planted under `tools/ci/**` runs first, so a broken *measurement* is reported as
  one instead of as a missing glob; the two are otherwise indistinguishable.
- **The dry-run helper fails loudly rather than cryptically.** It rethrows carrying
  turbo's stderr (which vitest drops from `err.stderr`), checks the payload parses and
  carries a `tasks` array, and requires a non-empty `hash` string — without that last
  check a renamed field would leave every comparison in the case passing on
  `undefined === undefined`.
- **Corrected the probe-tier header comment** in `redos-probe.test.ts` to say what makes
  the two samples comparable, and removed the claim that was wrong.
- **Updated `packages/eslint-config/vitest.config.ts`'s comment**, whose inventory of
  per-case budgets no longer held that the slow work is confined to `beforeAll` hooks.
- **`CLAUDE.md`**: recorded the new case beside the existing turbo-inputs guidance,
  including why the task is selected by id and why the control exists.

## Verification

Every assertion was checked non-vacuous by mutation — break the guarded behaviour, confirm
the named test goes red, restore, confirm green.

| Mutation applied | Test that went red |
| --- | --- |
| Delete `$TURBO_ROOT$/*.{ts,…}` from `turbo.json` | `changes for a repo-root file…` — *"…moved no hash…while the control above did move it"* |
| Read `tasks[0]` instead of selecting by `taskId` | same case, on the **control** first — *"…most likely by position, since `tasks[0]` is …#build"* |
| Make the returned hash non-deterministic | the stability assertion |
| `delete t.hash` on every task | *"came back from the dry run with no `hash` string (got undefined)"* |
| Prepend a notice to stdout ahead of the JSON | *"turbo's --dry=json output did not parse as JSON"* |
| Pass turbo an invalid flag | *"turbo dry run failed (exit 1). Its stderr: ERROR unexpected argument…"* |
| Keep a second, tiered-up sample of probe #0 in `worstProbeMs` | two cases: `flags a rule whose interpreted-tier cost alone blows the budget` (`expected 'safe' to be 'over-budget'`) and `reports the first probe at its interpreted cost` (`expected 26 to be 24`) |

Ran on macOS 26.5.2 / Node 24.18.0, 14 cores:

- `pnpm exec turbo run test --force` — `45 successful, 45 total`, `Cached: 0 cached, 45 total`
- `pnpm lint`, `pnpm typecheck`, `pnpm exec prettier --check .` — all exit 0

**On flakiness, since this adds subprocess work to a package that has a load-sensitive
one.** `packages/eslint-config/test/no-network-runtime.test.js` → *"the CI script refuses
to run vacuously"* fails intermittently under full fan-out (`Test timed out in 5000ms`;
those cases spawn a shell script under vitest's default 5 s budget). It reproduces on this
branch's base with no changes applied — `pnpm exec turbo run test --force` ×5 on a stashed
tree gave 1 red — against 2 red in 15 runs with these changes, the last 10 of them
consecutive and green. No evidence this branch makes it worse. Giving those spawning cases
an explicit deadline is worth doing separately.
