### PR TITLE
test(cli): pin rotate-key's disclosure and recovery hint on an unusable key

### DIFF
--- a/cli/src/commands/exception.ts
+++ b/cli/src/commands/exception.ts
@@ -921,7 +921,15 @@ async function runRevoke(argv: string[], io: Prompter): Promise<void> {
  * surface refuses on, so the number and the rows a user can act on agree.
  *
  * An unreadable key is not a reason to fail the rotation — it yields zero,
- * which is true: nothing can be matched right now either way.
+ * which is true: nothing can be matched right now either way. That fallback is
+ * load-bearing rather than defensive: the read sits between the preamble and
+ * the confirm prompt, so an escaping throw lands ABOVE the rotate step that
+ * composes the recovery guidance. The preamble and the permanent-grant list
+ * have already printed and are not at risk; what a throw costs is the ledger
+ * disclosure below, and then the hint — leaving a bare parse or errno error in
+ * their place. Since the two hints say opposite things about the same file,
+ * losing them is worse than losing a count.
+ * cli/test/commands/exception.test.ts pins both fault cases against that.
  */
 async function countApprovableBlocked(db: LocalDatabase, dir: string): Promise<number> {
   const key = ((): FingerprintKeyState => {

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -1020,6 +1020,21 @@ describe('aka exception rotate-key — the cost it discloses before committing',
     return readFingerprintKey(dir)?.version;
   }
 
+  // The control the two key-fault cases below lean on. The zero variant is ALSO
+  // what an EMPTY ledger prints, so a fault case asserting it proves nothing
+  // about the count on its own. This reads the same store and the same seeded
+  // rows back through the real command while the key is still healthy: a
+  // declined interactive run makes the disclosure and rotates nothing, so it
+  // can be spent here. It has to report `count` — otherwise the zero those
+  // cases then assert is a ledger that never held anything, rather than a key
+  // that could not be read.
+  async function expectSeededRowsApprovable(count: number): Promise<void> {
+    const control = confirmIo('n');
+    await runException(['rotate-key', '--home', home], control);
+    expect(control.output()).toContain(rotationBlockedLedgerNote(count));
+    expect(keyVersion()).toBe(1);
+  }
+
   it('states the ledger cost under --yes, which skips the prompt but not the preamble', async () => {
     await seedBlocked('a11ce5');
 
@@ -1094,6 +1109,89 @@ describe('aka exception rotate-key — the cost it discloses before committing',
     const unattended = scriptedIo();
     await runException(['rotate-key', '--home', home, '--yes'], unattended);
     expect(unattended.output()).toContain(zero);
+  });
+
+  it('discloses the ledger cost, then says "delete it", when the key file is CORRUPT', async () => {
+    // The count comes from a read of the key file, and that read throws on a key
+    // it cannot parse. Unguarded, the throw escapes from ABOVE the rotate step
+    // that composes the recovery guidance: the preamble has already printed, so
+    // what is lost is the ledger disclosure and then the hint. The command still
+    // exits non-zero either way, so only what it TELLS the user changes.
+    // Truncated rather than garbage: a half-written key is what an interrupted
+    // write leaves, and it is the shape the approve-side case injects for the
+    // same reason.
+    await seedBlocked('a1c0de');
+    await expectSeededRowsApprovable(1);
+
+    const keyPath = join(dir, 'exception.key');
+    truncateSync(keyPath, 10);
+    const onDisk = readFileSync(keyPath);
+
+    const io = scriptedIo();
+    const err = await runException(['rotate-key', '--home', home, '--yes'], io).then(
+      () => undefined,
+      (e: unknown) => e as Error,
+    );
+
+    // The count side. A key that cannot be read leaves every ledger row
+    // unmatchable, which is true rather than a degradation — nothing can be
+    // approved right now either way — so the disclosure is still made, at zero.
+    // The first line is what separates that from a run whose disclosure never
+    // happened at all, which contains neither variant. The second is against the
+    // count the control just produced from these same rows, so a fallback that
+    // guessed at a key version instead of reporting none goes red here.
+    const out = io.output();
+    expect(out).toContain(rotationBlockedLedgerNote(0));
+    expect(out).not.toContain(rotationBlockedLedgerNote(1));
+
+    // ...and the failure side, with the one hint that is safe to act on here.
+    expect(err?.message).toMatch(/cannot rotate:/);
+    expect(err?.message).toMatch(/Delete .*exception\.key to start fresh/);
+    expect(err?.message).not.toMatch(/do not delete it/i);
+
+    // Nothing minted over the refusal: a replacement written here would hand
+    // fresh material a version the stored rows already claim.
+    expect(readFileSync(keyPath)).toEqual(onDisk);
+  });
+
+  it('discloses the ledger cost, then refuses to say "delete it", when the key is UNREADABLE', async (ctx) => {
+    // Same path, opposite guidance. Aimed at a permissions failure, "delete it
+    // to start fresh" destroys every grant on the machine to fix a chmod, so
+    // WHICH hint is reached is the property — not that one was printed. rotate
+    // is where getting it wrong costs the most: it is the irreversible verb,
+    // and the one that runs unattended under --yes.
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX mode bits do not gate reads under Windows ACLs');
+    }
+    if (process.getuid?.() === 0) {
+      ctx.skip('root bypasses the mode bits this case depends on');
+    }
+    await seedBlocked('b10ced');
+    await expectSeededRowsApprovable(1);
+
+    const keyPath = join(dir, 'exception.key');
+    chmodSync(keyPath, 0o000);
+    try {
+      const io = scriptedIo();
+      const err = await runException(['rotate-key', '--home', home, '--yes'], io).then(
+        () => undefined,
+        (e: unknown) => e as Error,
+      );
+
+      const out = io.output();
+      expect(out).toContain(rotationBlockedLedgerNote(0));
+      expect(out).not.toContain(rotationBlockedLedgerNote(1));
+
+      expect(err?.message).toMatch(/cannot rotate:/);
+      expect(err?.message).toMatch(/do not delete it/i);
+      expect(err?.message).not.toMatch(/delete .*exception\.key to start fresh/i);
+    } finally {
+      chmodSync(keyPath, 0o600); // so the key can be read back, and the tree removed
+    }
+    // Read back only once the mode is restored — under 0000 this throws rather
+    // than reporting absence. Still v1: rotating over a permissions error is
+    // the outcome the hint above exists to prevent.
+    expect(keyVersion()).toBe(1);
   });
 
   it('lists the permanent grants and the ledger cost together, without the value', async () => {


### PR DESCRIPTION
## Summary

`aka exception rotate-key` reads the fingerprint key before it does anything else with it,
to count the blocked-ledger rows a rotation would cost. That read is wrapped in a fallback
that treats a corrupt or unreadable key as "nothing is matchable right now", which is true.

The fallback was doing much more than tidying a count, and nothing tested it. Deleting the
`try`/`catch` left the whole CLI suite green, while the user silently lost the ledger
disclosure **and** the recovery guidance — the command still exits non-zero either way, so
only the content of what it tells you changes.

That guidance is the part worth guarding, because there are two opposite messages:

| key state | hint |
| --- | --- |
| corrupt | `Delete <dir>/exception.key to start fresh` |
| unreadable (`chmod 000`) | `Check the permissions … do not delete it, that invalidates every existing grant` |

Acting on the wrong one destroys every exception grant on the machine to fix a file mode.
`rotate-key` is where that costs the most: it is the irreversible verb, and the one that
runs unattended under `--yes`.

## Changes

- **`cli/test/commands/exception.test.ts`** — two cases in the `rotate-key` describe, for a
  corrupt key and an unreadable one. Each asserts the disclosure is still printed, the
  refusal still carries `cannot rotate:`, and **which** hint is reached (both the positive
  and the negative, so a message that hedged by printing both would fail).
- A shared control, `expectSeededRowsApprovable`, spends a declined interactive run against
  the same seeded store while the key is still healthy. The zero variant of the note is also
  what an *empty* ledger prints, so without this the fault assertions would pass vacuously.
- The unreadable case is gated with `ctx.skip(reason)` on Windows and on root — an early
  `return` would report as a pass.
- **`cli/src/commands/exception.ts`** — comment only. Records why the fallback is
  load-bearing rather than defensive, and corrects an inaccuracy: the read sits between the
  preamble and the confirm prompt, so an escaping throw costs the ledger disclosure and the
  hint, not output that has already been printed.

## Verification

`pnpm test` in `cli/`:

```
Test Files  20 passed (20)
     Tests  286 passed | 5 skipped (291)
Lines      : 58.95% ( 777/1318 )
```

`pnpm typecheck`, `pnpm lint`, `pnpm check:portability` and `prettier --check` all clean;
`packages/persistence` re-run at `1213 passed | 3 skipped`.

Each assertion was proven non-vacuous by mutation — break the guarded behaviour, confirm the
red, restore, confirm green:

| Mutation | Red at | Assertion |
| --- | --- | --- |
| delete the `try`/`catch` in `countApprovableBlocked` | 1144, 1182 | disclosure never printed |
| fallback claims a present `v1` key instead of `unreadable` | 1144, 1182 | `toContain(note(0))` |
| swap the two branches of `keyAccessHint` | 1149, 1186 | the hint identity |
| hint hedges and prints **both** opposite instructions | 1150, 1187 | the `not.toMatch` negatives |
| drop the `cannot rotate:` prefix | 1148, 1185 | `toMatch(/cannot rotate:/)` |
| remove the seeding | 1034, 1123 | the control |
| invert the win32 / root guards | — | reports `skipped`, not passed |
| `rotateFingerprintKey` swallows the read | 1153 | key file unchanged after a refusal |

## Follow-up, not addressed here

`web-ui/app/(app)/exceptions/page.tsx` carries a byte-for-byte identical fallback and is
equally unpinned — deleting it left web-ui at 500 passed, unchanged. There the escaping
throw takes the whole exceptions Server Component down rather than swapping a hint, so it
deserves its own change. Tracked separately.