### PR TITLE
test(cli): pin the masked-preview margin the stdout no-echo binding spends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1977,10 +1977,14 @@ control, and the two approve **selectors** that stand in for a value a user type
 hand-written `'A******E'` on both sides of one of those is true by construction and moves with
 nothing, which is the rule two paragraphs above, applied to a group rather than to a single
 control. **That is a claim about that group, not about every preview in the package**: a
-preview the CALLER supplies is a different thing, and `exception-reveal.test.ts` asserts
-against its own `MASKED` constant on purpose, because a vault pointer's preview is chosen at
-tokenize time rather than produced by `maskMatch`. Derive from `maskMatch` where the product
-masks; derive from the raw value where the caller does.
+preview the CALLER supplies is a different thing, and `exception-reveal.test.ts`'s **vault**
+seeds assert against its own `MASKED` constant on purpose, because a vault pointer's preview
+is chosen at tokenize time rather than produced by `maskMatch`. **The line is drawn per ROW,
+not per file.** The same file's `recordBlocked` seeds are `blocked_detections` rows, and
+`packages/plugin-sdk/src/runtime.ts` masks the finding with `maskMatch` before recording one
+— the only writer of that table — so those derive from `maskMatch` like any other product
+mask. Derive from `maskMatch` where the product masks; derive from the raw value where the
+caller does, and decide that per table rather than by which suite you are in.
 `packages/detections/test/mask.test.ts` keeps its exact-string cases: they are the right pin
 for the mask's own contract, and deliberately not a pin on the CLI's margin.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1947,15 +1947,42 @@ The CLI's `exception` suites bind it **wider than an error** — to their **stdo
 assertions too, because a CLI's terminal output is where a leaked value gets scrolled,
 pasted into a bug report and captured by CI logs. That is safe rather than fragile **for
 the values those suites use**: what they print of a blocked **generic** secret is
-`maskMatch`'s first-and-last preview (`A******E`), two characters, which cannot fill an
-eight-character window. **It does not generalize to every value `maskMatch` handles.** The
+`maskMatch`'s first-and-last preview (`A******E`) — two characters, sitting in two runs of
+**one**. The RUN is the quantity that matters, not the count: the window slides over
+**contiguous** slices, so two characters that are never adjacent cannot fill one of any
+width. **It does not generalize to every value `maskMatch` handles.** The
 email branch reveals the first local character plus the **whole domain**
 (`user@example.com` → `u***@example.com`), and a single-character local part returns the
 input unchanged — both fill the window on purpose. A surface printing a pii/email preview is
 out of scope for the stdout half, not a leak it found; `no-echo.test.ts` pins both branches
-so that boundary is written down rather than re-derived. If the **generic** branch is ever
-widened past two characters, that suite goes red first, which is the correct answer and not
-a reason to loosen the callers back.
+so that boundary is written down rather than re-derived.
+
+**Two different things are pinned there, and only one of them is the margin.** The
+acceptance case (`refuses(maskMatch(VALUE), VALUE)` is `false`) says the preview is safe
+**today**; it cannot say how much room is left, because it fires only once the preview holds
+a contiguous run of `ECHO_RUN` characters. So widening the generic branch to anything from
+two revealed characters up to seven leaves it green — and that band is precisely where a
+usability change lands ("show enough to tell two blocked secrets apart"). In that band the
+only red is `packages/detections/test/mask.test.ts`, whose failure reads as _"you changed the
+mask, update the expectation"_ and gives no signal that a downstream safety argument moved.
+The **margin** is therefore pinned by its own case in `cli/test/helpers/no-echo.test.ts`,
+which derives the longest revealed run from `maskMatch` and holds it at one: that goes red on
+the **first** character of widening, where the reasoning is written down. Widening is a
+deliberate act to be argued against the window — not a reason to loosen the callers back, and
+not something raising `ECHO_RUN` can buy back, since the same file owns both numbers.
+
+`exception.test.ts`'s masked-preview group is **derived from `maskMatch`** for the same reason
+— the seeded ledger `maskedValue`, the grant-shape assertions over it, the stdout positive
+control, and the two approve **selectors** that stand in for a value a user types. A
+hand-written `'A******E'` on both sides of one of those is true by construction and moves with
+nothing, which is the rule two paragraphs above, applied to a group rather than to a single
+control. **That is a claim about that group, not about every preview in the package**: a
+preview the CALLER supplies is a different thing, and `exception-reveal.test.ts` asserts
+against its own `MASKED` constant on purpose, because a vault pointer's preview is chosen at
+tokenize time rather than produced by `maskMatch`. Derive from `maskMatch` where the product
+masks; derive from the raw value where the caller does.
+`packages/detections/test/mask.test.ts` keeps its exact-string cases: they are the right pin
+for the mask's own contract, and deliberately not a pin on the CLI's margin.
 
 **Bind it per assertion, never per file.** `cli/test/commands/vault.test.ts` is the worked
 example: its forged-pointer refusal pins absence like any other, but `aka vault show`'s

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -179,7 +179,11 @@ describe('aka exception approve <pointer> --reveal', () => {
         category: 'secret',
         valueFingerprint: fingerprintValue(key, RAW),
         keyVersion: key.version,
-        maskedValue: 'A******E',
+        // MASKED, like the sibling ledger seed below. The literal this replaced
+        // was another value's preview entirely, so the row paired one value's
+        // fingerprint with a different value's mask — a ledger state the product
+        // cannot produce.
+        maskedValue: MASKED,
         sessionId: 'sess-1',
         repo: null,
       });

--- a/cli/test/commands/exception-reveal.test.ts
+++ b/cli/test/commands/exception-reveal.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { maskMatch } from '@akasecurity/detections';
 import {
   applyOnboarding,
   createKeyProvider,
@@ -38,9 +39,14 @@ import { expectNoEchoOf } from '../helpers/no-echo.ts';
 // catching a leak. Random-looking and rule-shaped for nothing satisfies both.
 const RAW = 'zq7vk2mx9tw4hb6njf3pd8sr5gc1ly';
 const RULE_ID = 'secrets/test-rule';
-// Derived so the two cannot drift apart. Seven characters, which is shorter
-// than the echo window on purpose: this preview is stored and shown, so it must
-// never be able to fill it.
+// Derived so the two cannot drift apart. What keeps it printable is its longest
+// revealed RUN — three characters at each end, against an eight-character
+// window — not its seven-character length: the window slides over CONTIGUOUS
+// slices, so length alone is a coarser test that happens to agree here.
+//
+// This is the preview a CALLER supplies at tokenize time, so it belongs on vault
+// entries and on grants minted from them. A blocked-detections row is the
+// PRODUCT masking, and those seeds use maskMatch(RAW) below.
 const MASKED = `${RAW.slice(0, 3)}…${RAW.slice(-3)}`;
 
 // Scripted, non-interactive Prompter with captured output.
@@ -179,11 +185,11 @@ describe('aka exception approve <pointer> --reveal', () => {
         category: 'secret',
         valueFingerprint: fingerprintValue(key, RAW),
         keyVersion: key.version,
-        // MASKED, like the sibling ledger seed below. The literal this replaced
-        // was another value's preview entirely, so the row paired one value's
-        // fingerprint with a different value's mask — a ledger state the product
-        // cannot produce.
-        maskedValue: MASKED,
+        // What the product writes for a blocked-detections row: plugin-sdk's
+        // runtime masks the finding with maskMatch before recording it. The
+        // literal this replaced was another value's preview entirely, so the row
+        // paired one value's fingerprint with a different value's mask.
+        maskedValue: maskMatch(RAW),
         sessionId: 'sess-1',
         repo: null,
       });
@@ -384,7 +390,8 @@ describe('aka exception approve <pointer> --reveal', () => {
           category: 'secret',
           valueFingerprint: fingerprintValue(rowKey, RAW),
           keyVersion: rowKey.version,
-          maskedValue: MASKED,
+          // A blocked-detections row, so the product's mask — see the seed above.
+          maskedValue: maskMatch(RAW),
           sessionId: 'sess-1',
           repo: null,
         });

--- a/cli/test/commands/exception.test.ts
+++ b/cli/test/commands/exception.test.ts
@@ -45,9 +45,19 @@ const VALUE: string = exampleValue;
 
 // A second value the SAME rule detects: the ASIA form of the fixture. Distinct
 // from VALUE with identical entropy, derived rather than written out, and it
-// masks to the same `A******E` preview — which is the point wherever a test
-// needs two values one surface must keep apart.
+// masks to the SAME preview — which is the point wherever a test needs two
+// values one surface must keep apart. That identity is a property of the mask
+// rather than of these two strings, so it is asserted rather than left standing
+// in a comment: widen maskMatch's generic branch and the two previews diverge,
+// at which point the refusal below stops being about a value the message could
+// not name usefully even if naming it were safe.
 const SECOND_VALUE = `ASIA${VALUE.slice(4)}`;
+
+// What the product stores and prints of a blocked VALUE. Bound once so the six
+// places that must move together — the ledger seed, the two grant-shape
+// assertions, the stdout positive control and the two approve selectors — are
+// visibly one thing rather than six copies of the same call.
+const MASKED_VALUE = maskMatch(VALUE);
 
 // A value the engine detects under a DIFFERENT rule, for the branch that builds
 // the "did you mean" hint out of the other matches — the one rejection in this
@@ -62,8 +72,12 @@ const OTHER_VALUE: string = otherExample;
 // command has, which is wider than the web-ui original it mirrors: an ERROR,
 // where no part of the value has any business appearing, and STDOUT, where the
 // only thing this command ever prints of a blocked SECRET is maskMatch's
-// first-and-last-character preview (`A******E`) — two characters, so it cannot
-// fill the window. That scoping is load-bearing: maskMatch's email branch
+// first-and-last-character preview — two characters, and they sit in two runs
+// of ONE, which is the number that matters because the window slides over
+// CONTIGUOUS slices. That run is pinned in test/helpers/no-echo.test.ts, which
+// derives it from maskMatch and reddens on the first character of widening;
+// the acceptance case beside it does not, because it fires only at a run of
+// ECHO_RUN. That scoping is load-bearing: maskMatch's email branch
 // reveals the whole domain, so the stdout half does not extend to a surface
 // printing a pii/email preview. Where a path prints nothing at all, assert the
 // emptiness instead — searching empty bytes proves nothing.
@@ -314,7 +328,10 @@ describe('aka exception add → enforcement full loop', () => {
     );
     // The count is what the operator needs; the spans themselves are two live
     // credentials, and they mask identically, so the message could not name one
-    // usefully even if it were safe to.
+    // usefully even if it were safe to. Derived, not asserted in prose — that
+    // last clause is a claim about maskMatch, and it stops holding the moment
+    // its generic branch reveals enough to tell the two apart.
+    expect(maskMatch(SECOND_VALUE)).toBe(MASKED_VALUE);
     expect(err?.message).toMatch(/contains 2 distinct values/);
     expectNoEchoOf(err?.message, VALUE);
     expectNoEchoOf(err?.message, SECOND_VALUE);
@@ -341,7 +358,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
         category: 'secret',
         valueFingerprint: fingerprintValue(key, VALUE),
         keyVersion: key.version,
-        maskedValue: 'A******E',
+        maskedValue: MASKED_VALUE,
         sessionId: 'sess-1',
         repo: null,
       });
@@ -366,7 +383,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
       const grant = (await db.exceptions.list())[0];
       expect(grant?.ruleId).toBe(RULE_ID);
       expect(grant?.createdVia).toBe('cli-approve');
-      expect(grant?.maskedValue).toBe('A******E');
+      expect(grant?.maskedValue).toBe(MASKED_VALUE);
 
       const runtime = createPluginRuntime(gatewayOver(db, dir), defaultWorkspaceSettings(), {
         dataDir: dir,
@@ -385,7 +402,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
   it('accepts the masked value as the selector (what the block message showed)', async () => {
     await seedBlocked('9c04d7');
     await runException(
-      ['approve', 'A******E', '--home', home, '--for', '1h', '--reason', 'mask selector'],
+      ['approve', MASKED_VALUE, '--home', home, '--for', '1h', '--reason', 'mask selector'],
       scriptedIo(),
     );
     const db = openLocalDatabase(dir);
@@ -409,14 +426,14 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
       const grant = (await db.exceptions.list())[0];
       expect(grant?.ruleId).toBe(RULE_ID);
       expect(grant?.createdVia).toBe('cli-approve');
-      expect(grant?.maskedValue).toBe('A******E');
+      expect(grant?.maskedValue).toBe(MASKED_VALUE);
     } finally {
       db.close();
     }
     // Positive control FIRST: this path really does print, and what it prints of
     // the value is the masked preview. Without it the assertion below could not
     // tell a clean confirmation from a capture that stopped receiving anything.
-    expect(io.output()).toContain('A******E');
+    expect(io.output()).toContain(MASKED_VALUE);
     // The raw value must never be echoed back — not even a run of it.
     expectNoEchoOf(io.output(), VALUE);
   });
@@ -690,7 +707,7 @@ describe('aka exception approve — from the blocked-detections ledger', () => {
 
         await expect(
           runException(
-            ['approve', 'A******E', '--home', home, '--for', '1h', '--reason', 'mask selector'],
+            ['approve', MASKED_VALUE, '--home', home, '--for', '1h', '--reason', 'mask selector'],
             scriptedIo(),
           ),
         ).rejects.toThrow(/could never match/);
@@ -958,7 +975,7 @@ describe('aka exception rotate-key — the cost it discloses before committing',
         category: 'secret',
         valueFingerprint: fingerprintValue(key, VALUE),
         keyVersion: key.version,
-        maskedValue: maskMatch(VALUE),
+        maskedValue: MASKED_VALUE,
         sessionId: 'sess-rotate',
         repo: null,
       });

--- a/cli/test/helpers/no-echo.test.ts
+++ b/cli/test/helpers/no-echo.test.ts
@@ -16,6 +16,35 @@ const GENERIC = getLoadedRules().find((r) => r.id === 'secrets/aws-access-key')?
 if (GENERIC === undefined) throw new Error('bundled rule secrets/aws-access-key has no example');
 const VALUE: string = GENERIC;
 
+// maskMatch's generic branch reveals the first and last character around six
+// fixed asterisks. That is two characters, but they sit in two runs of ONE —
+// and the RUN is the number that matters here, because expectNoEchoOf's window
+// slides over contiguous slices. Two characters that are never adjacent cannot
+// fill a window of any width; two adjacent ones start eating into it.
+const GENERIC_PREVIEW_RUN = 1;
+
+// The pii fixture both email cases below share: one calibrates the measurement
+// against a branch that discloses a long run, the other pins that such a preview
+// is refused. They must describe the SAME value or neither says what it claims.
+const EMAIL = 'user@example.com';
+
+// The longest contiguous run of `raw` that `preview` discloses, derived rather
+// than read off the mask's current output — a literal here would assert that a
+// string this file built lacks a run of another string this file built, which
+// is the shape CLAUDE.md forbids for exactly this reason.
+function longestRevealedRun(preview: string, raw: string): number {
+  let longest = 0;
+  for (let i = 0; i < raw.length; i += 1) {
+    // A preview holding raw.slice(i, i + len) holds every shorter slice from
+    // the same start, so the first miss ends this start's search.
+    for (let len = longest + 1; i + len <= raw.length; len += 1) {
+      if (!preview.includes(raw.slice(i, i + len))) break;
+      longest = len;
+    }
+  }
+  return longest;
+}
+
 // Did the helper refuse this pairing? A vitest assertion failure is a throw, so
 // "the assertion would have gone red" is observable without failing this test.
 function refuses(haystack: string | undefined, value: string): boolean {
@@ -73,10 +102,37 @@ describe('expectNoEchoOf', () => {
   it('accepts the masked preview of a generic secret, which callers do print', () => {
     // The coexistence the CLI's stdout assertions depend on: a generic secret's
     // preview reveals its first and last character around fixed asterisks, so it
-    // cannot fill the window. Widen maskMatch past that and this goes red HERE,
-    // where the reason is written down, rather than in a caller that reads like
-    // an unrelated regression.
+    // cannot fill the window. This pins that the preview is safe TODAY. It does
+    // NOT pin how much margin is left — see the case below, which is the one
+    // that holds the number the callers reason about.
     expect(refuses(maskMatch(VALUE), VALUE)).toBe(false);
+  });
+
+  it('measures a revealed run — the instrument the margin pin below is read on', () => {
+    // Calibration, kept as its own case so its failure names the INSTRUMENT
+    // rather than the pin it feeds. An implementation that always answered "one"
+    // would hold the margin pin green for ever — this rule's own failure mode,
+    // one level down — and from inside that pin the two are indistinguishable.
+    // maskMatch's email branch reveals the '@' and the WHOLE domain after it, so
+    // the measurement has to report exactly that run here.
+    expect(longestRevealedRun(maskMatch(EMAIL), EMAIL)).toBe(EMAIL.length - EMAIL.indexOf('@'));
+  });
+
+  it("reveals a run of one — the margin the CLI's stdout binding spends", () => {
+    // The acceptance case above fires only once a preview holds a contiguous run
+    // of ECHO_RUN characters, so it stays green through every widening from two
+    // revealed characters up to seven. That band is exactly where a usability
+    // change lands ("show enough of the value to tell two blocked secrets
+    // apart"), and it is the band in which the CLI's stdout binding quietly
+    // loses the margin its own comment claims.
+    //
+    // So the margin is pinned here, derived from maskMatch, and it goes red on
+    // the FIRST character of widening. detections/test/mask.test.ts also reddens
+    // on that change, but its failure reads as "you changed the mask, update the
+    // expectation" and says nothing about a downstream safety argument moving.
+    // This one goes red where that argument is written down.
+    expect(longestRevealedRun(maskMatch(VALUE), VALUE)).toBe(GENERIC_PREVIEW_RUN);
+    expect(GENERIC_PREVIEW_RUN).toBeLessThan(ECHO_RUN);
   });
 
   it('refuses an email preview — why the stdout rule is scoped to generic secrets', () => {
@@ -84,9 +140,8 @@ describe('expectNoEchoOf', () => {
     // local part returns the input unchanged. Both fill the window legitimately,
     // so a surface printing a pii/email preview is out of scope for this helper
     // rather than a leak it found.
-    const email = 'user@example.com';
-    expect(maskMatch(email)).toContain('example.com');
-    expect(refuses(maskMatch(email), email)).toBe(true);
+    expect(maskMatch(EMAIL)).toContain('example.com');
+    expect(refuses(maskMatch(EMAIL), EMAIL)).toBe(true);
     expect(maskMatch('a@b.com')).toBe('a@b.com');
   });
 

--- a/cli/test/helpers/no-echo.ts
+++ b/cli/test/helpers/no-echo.ts
@@ -31,18 +31,23 @@ export const ECHO_RUN = 8;
  *    assertions stay whole-value.
  * 3. **A masked preview only stays under the window for a GENERIC secret.**
  *    `maskMatch` reveals a generic secret's first and last character around six
- *    fixed asterisks — two characters, which cannot fill an eight-character
- *    window. Its email branch reveals the first local character plus the WHOLE
- *    DOMAIN, and a single-character local part returns the input unchanged, so
- *    an email's own preview fills the window legitimately. Do not point this at
- *    a surface that prints the preview of a pii/email value.
+ *    fixed asterisks — two characters, and they sit in two runs of ONE. The RUN
+ *    is what decides this, not the count: the loop below slides over contiguous
+ *    slices, so two characters that are never adjacent cannot fill a window of
+ *    any width. `no-echo.test.ts` derives that run from `maskMatch` and pins it
+ *    at one, so the first character of widening reddens there rather than
+ *    silently spending the margin. Its email branch reveals the first local
+ *    character plus the WHOLE DOMAIN, and a single-character local part returns
+ *    the input unchanged, so an email's own preview fills the window
+ *    legitimately. Do not point this at a surface that prints the preview of a
+ *    pii/email value.
  *
  * Shared by the CLI suites because they sit in one package. Across a package
- * wall it cannot be imported, so `plugins/claude-code/test/helpers/no-echo.ts`,
- * `web-ui/test/helpers/no-echo.ts`, and
- * `packages/setup-wizard/test/helpers/no-echo.ts` are peers of this file — each
- * a copy that takes the `toBeDefined()` guard and a `no-echo.test.ts` with it,
- * or the run length can be widened back with nothing going red.
+ * wall it cannot be imported, so the copies under `plugins/claude-code`,
+ * `plugins/codex`, `plugins/antigravity`, `web-ui`, `packages/setup-wizard` and
+ * `packages/persistence` are peers of this file — each a copy that takes the
+ * `toBeDefined()` guard and a `no-echo.test.ts` with it, or the run length can
+ * be widened back with nothing going red.
  */
 export function expectNoEchoOf(haystack: string | undefined, value: string): void {
   // Catches a never-thrown error arriving as `undefined`, which would otherwise


### PR DESCRIPTION
## Summary

The CLI's `exception` suites bind `expectNoEchoOf` to **stdout**, not just to errors — wider than the `web-ui` original they mirror. The argument for that is a **margin**: what the command prints of a blocked generic secret is `maskMatch`'s first-and-last preview (`A******E`) — two characters, in two runs of **one** — and `expectNoEchoOf` slides an **eight-character contiguous** window, so a run of one cannot fill it.

Nothing in the CLI held that margin, and `CLAUDE.md` named a guard that could not enforce it.

## The gap, measured

Widening `maskMatch`'s generic branch and running the CLI suites:

| generic branch reveals | `no-echo.test.ts` | `exception.test.ts` | what actually reddened |
| --- | --- | --- | --- |
| 2 (today) | green | green | — |
| **4** | **green** | **green** | only `detections/test/mask.test.ts` |
| 8 | red | — | — |

So the real threshold was **8** (`ECHO_RUN`), not 3. The acceptance case asserts the preview is *accepted*, so by construction it cannot fire until the preview already contains a full window — it pins that the preview is safe today, never how much room is left. In the 3–7 band the only red reads *"you changed the mask, update the expectation"*, which says nothing about a downstream safety argument moving. That band is exactly where a usability change lands ("show enough to tell two blocked secrets apart").

`exception.test.ts` could not notice either: `seedBlocked` wrote the literal `'A******E'` into the ledger row and the assertions compared against the same literal — true by construction, and it would have gone on exercising a stale preview the product could no longer produce.

## Changes

- **Pin the margin** — `cli/test/helpers/no-echo.test.ts` derives the longest revealed run from `maskMatch` and holds it at one. Reddens on the *first* character of widening, where the reasoning is written down.
- **Calibrate the instrument** — a measurement stuck at a constant would hold that pin green for ever, so a separate case checks it against `maskMatch`'s email branch (which discloses the whole domain). Its own case, so a stubbed instrument reddens by name rather than looking like the pin failing.
- **Derive the ledger group** — the seed, both grant-shape assertions, the stdout positive control and both approve **selectors** now come from `maskMatch` and move as one.
- **Fix an incoherent seed** — `exception-reveal.test.ts` paired one value's fingerprint with a *different* value's preview; it now uses the file's own `MASKED` constant, matching its sibling ledger seed.
- **Correct `CLAUDE.md`** — state the true threshold, name the guard that enforces it, and scope the derive-from-`maskMatch` rule to the group it covers (a caller-supplied vault-pointer preview is deliberately not `maskMatch`'s).

`detections/test/mask.test.ts` is untouched: its exact-string cases are the right pin for the mask's own contract, and deliberately not a pin on the CLI's margin.

## Verification

Every claim below was measured in this session, not estimated.

Mask-widening sweep against the new pin:

| reveal | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
| --- | --- | --- | --- | --- | --- | --- | --- |
| margin case red | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
| pre-existing acceptance case red | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |

Mutation proofs (mutation applied → test that went red):

- `longestRevealedRun` → `return 1` → `measures a revealed run …` (`expected 1 to be 12`)
- `maskedValue: entry.maskedValue` → `'***'` → both `approve` grant-shape cases
- dropped `${ex.maskedValue}` from the granted line → `accepts the blocked value itself as the selector`
- removed `|| e.maskedValue === selector` → both masked-value selector cases
- mask widened to 8, **control run**: the pre-change literal version stayed **green**; the derived version reddens on `expected 'Exception granted: …' not to contain 'AKIAIOSF'` — the stdout assertion now sees the preview production actually emits

Suites run: `cli` 286 passed / 5 skipped · `persistence` 1213 · `plugins/claude-code` 1048 · `plugin-sdk` 472 · `eslint-config` 1306 · `audit-gate` 90 · `detections` mask 10/10 (every suite that parses `CLAUDE.md`, plus the changed package). `eslint`, `tsc --noEmit`, `prettier --check` and the portability gate all exit 0.