### PR TITLE
fix(persistence): close the at-rest permission gaps under ~/.aka

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,15 +65,20 @@ schema, or a recovery resets a store it cannot open, it snapshots `aka.db` to a
 sibling `.bak` file. Where the store cannot be copied at all — a corrupt page, or
 no room for a second copy — it moves the whole set aside instead, so that backup
 carries its own `-wal`/`-shm`/`-journal` sidecars. Those copies hold the same
-prompt corpus and are written `0600` too.
+prompt corpus and are held at `0600` too.
 
-A snapshot cut short part-way — a plugin hook killed at its timeout — can leave a
-`.bak.partial` behind at the process umask instead (the default permissions a new
-file gets, commonly `0644`, i.e. readable by every account on the machine).
-`ai-tc` clears abandoned ones only when it next takes a snapshot, so on a machine
-that never migrates or resets again, that copy stays as it is. Treat a
-`.bak.partial` under `~/.aka/data` as a full, readable copy of the store, and
-delete it.
+A snapshot cut short part-way — a plugin hook killed at its timeout — leaves a
+`.bak.partial` **directory** behind, holding as much of the copy as had been
+written. That directory is created owner-only (`0700`) before the copy starts,
+which is what protects the copy for the whole time it is being written: SQLite
+refuses to write a copy over a file that already exists, so the copy itself
+cannot be pre-created at `0600` and lands at the process umask (commonly `0644`)
+until it is complete. Only the directory around it can cover that interval, and
+it survives a kill exactly as the copy does. `ai-tc` clears an abandoned
+`.bak.partial` **on the next open of the store**, once nothing has written to it
+for five minutes — a copy another process has in flight is left alone. Treat a
+`.bak.partial` under `~/.aka/data` as a full copy of the store, and delete one
+that outlives the process that was writing it.
 
 Those POSIX modes are a **no-op on Windows**: Node cannot apply them, so `ai-tc`
 sets no at-rest protection there. On Windows the store simply inherits whatever ACL

--- a/cli/src/commands/init.ts
+++ b/cli/src/commands/init.ts
@@ -65,8 +65,9 @@ function storeTargets(home: string): string[] {
 
 // Every path whose owner-only MODE this command stands behind. The layout above
 // has to stay enumerated — some of it does not exist yet on a first run, and an
-// absent target is not a loose one — but the artifacts beside the store are not
-// a fixed list, so they are walked instead. SQLite's `-wal`/`-shm`/`-journal`
+// absent target is not a loose one — but the artifacts beside the store and
+// beside the vault key are not a fixed list, so both directories are walked
+// instead. SQLite's `-wal`/`-shm`/`-journal`
 // appear with whichever journal mode is active, and the legacy drop leaves an
 // `aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the prompt corpus
 // — on every run, including a first one. `tightenPerms`/`tightenFile` already
@@ -75,20 +76,27 @@ function storeTargets(home: string): string[] {
 // next migration adds.
 function storeModeTargets(home: string): string[] {
   const targets = new Set(storeTargets(home));
-  const data = dataDir(home);
-  try {
-    for (const name of readdirSync(data)) {
-      // A `.partial` is the one artifact deliberately left at the umask: it
-      // exists for the whole of the `VACUUM INTO` that writes it and is only
-      // tightened just before the rename, so a copy cut short by a kill leaves
-      // a 0644 one behind on purpose (see snapshotStore). Reporting it would
-      // blame the filesystem for a mode nothing tried to apply — the wrong
-      // diagnosis, which is the same reason a symlinked path is skipped below.
-      if (name.endsWith('.partial')) continue;
-      targets.add(join(data, name));
+  // Both directories that accumulate artifacts the enumerated layout cannot
+  // name. data/ holds the sidecars and the backups; keys/ holds `vault.key`
+  // itself — enumerated only as a DIRECTORY above, so the key inside it, and the
+  // rotation lock beside it, were checked by nothing until this walked here too.
+  for (const dir of [dataDir(home), keysDir(home)]) {
+    try {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        // A `.partial` FILE is the legacy staging shape: an older version wrote
+        // its snapshot copy straight to one and only tightened it just before
+        // the rename, so a copy cut short by a kill left a 0644 file behind on
+        // purpose. Reporting it would blame the filesystem for a mode nothing
+        // tried to apply — the wrong diagnosis, which is the same reason a
+        // symlinked path is skipped below. The current shape is a `.partial`
+        // DIRECTORY created owner-only before the copy starts (see
+        // snapshotStore), and that mode IS one this command stands behind.
+        if (entry.name.endsWith('.partial') && !entry.isDirectory()) continue;
+        targets.add(join(dir, entry.name));
+      }
+    } catch {
+      // absent or unreadable — the enumerated layout still applies
     }
-  } catch {
-    // absent or unreadable data dir — the enumerated layout still applies
   }
   return [...targets];
 }

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -692,16 +692,17 @@ describe('looseStorePaths', () => {
     expect(looseStorePaths(dir)).toEqual([]);
   });
 
-  it('does not report a `.partial` (loose by design mid-copy, not a rejected chmod)', (ctx) => {
+  it('does not report a legacy `.partial` FILE (loose by design, not a rejected chmod)', (ctx) => {
     if (process.platform === 'win32') {
       ctx.skip('POSIX modes do not apply on Windows');
       return;
     }
-    // snapshotStore tightens its staging copy only just before the rename, so
-    // the file exists at the caller's umask for the whole VACUUM INTO and a copy
-    // cut short by a kill leaves a 0644 `.partial` behind on purpose. Naming it
-    // here would blame the filesystem for a mode nothing tried to apply — the
-    // same wrong diagnosis the symlink case below avoids.
+    // An older version wrote its staging copy straight to a `.partial` file and
+    // tightened it only just before the rename, so the file existed at the
+    // caller's umask for the whole VACUUM INTO and a copy cut short by a kill
+    // left a 0644 one behind on purpose. Naming it here would blame the
+    // filesystem for a mode nothing tried to apply — the same wrong diagnosis
+    // the symlink case below avoids.
     mkdirSync(dataDir(dir), { recursive: true });
     mkdirSync(settingsDir(dir), { recursive: true });
     for (const p of [dir, settingsDir(dir), dataDir(dir)]) chmodSync(p, 0o700);
@@ -710,6 +711,50 @@ describe('looseStorePaths', () => {
     chmodSync(partial, 0o644);
 
     expect(looseStorePaths(dir)).toEqual([]);
+  });
+
+  // The current shape, and the opposite answer: a staging DIRECTORY is created
+  // owner-only before the copy starts, so its mode IS one this command stands
+  // behind and a loose one is a rejected chmod like any other. The pair of cases
+  // is the point — a rule that skipped every `.partial` would pass the one above
+  // while saying nothing about the artifact that actually holds the corpus now.
+  it('does report a loose `.partial` staging DIRECTORY, whose mode it does apply', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    mkdirSync(dataDir(dir), { recursive: true });
+    mkdirSync(settingsDir(dir), { recursive: true });
+    for (const p of [dir, settingsDir(dir), dataDir(dir)]) chmodSync(p, 0o700);
+    const stage = join(dataDir(dir), 'aka.db.pre-drop.1.bbbbbbbb.bak.partial');
+    mkdirSync(stage);
+    chmodSync(stage, 0o755);
+
+    expect(looseStorePaths(dir)).toEqual([stage]);
+  });
+
+  // `keys/` was enumerated as a DIRECTORY and never walked, so `vault.key`
+  // itself — the one file under ~/.aka that is not a copy of the data but the
+  // means to read it — was checked by nothing, and neither was the rotation lock
+  // beside it. A rejected chmod there left the key world-readable with `aka init`
+  // reporting the store as fully protected.
+  it('reports a loose file inside keys/, not just the directory', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    mkdirSync(dataDir(dir), { recursive: true });
+    mkdirSync(settingsDir(dir), { recursive: true });
+    const keys = keysDir(dir);
+    mkdirSync(keys, { recursive: true });
+    for (const p of [dir, settingsDir(dir), dataDir(dir), keys]) chmodSync(p, 0o700);
+    expect(looseStorePaths(dir)).toEqual([]); // precondition: the dirs are tight
+
+    const key = join(keys, 'vault.key');
+    writeFileSync(key, '{"current":1,"keys":{}}');
+    chmodSync(key, 0o644);
+
+    expect(looseStorePaths(dir)).toEqual([key]);
   });
 
   it('makes `aka init` print a warning when a mode could not be applied', async (ctx) => {

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -276,8 +276,12 @@ function openWithPragmas(file: string): DatabaseSync {
 //
 // The handle is closed on every path. Returns the backup path.
 function backupLegacyStore(db: DatabaseSync, file: string): string {
-  // A prior open killed mid-snapshot leaves a `.partial` beside the store that
-  // nothing else reaps; clear the abandoned ones before writing a new copy.
+  // Redundant with openLocalDatabase's own sweep — this function is private and
+  // reached only through openAndInitialize, which only openLocalDatabase calls,
+  // so nothing arrives here unswept. Kept anyway because it is cheap and this is
+  // the one moment a SECOND full-size copy is about to land beside the first:
+  // the sweep's contract is local to the snapshot it precedes, not inherited
+  // from whatever ran before it.
   reapStalePartials(file);
   const backup = backupPath(file, 'legacy');
   let snapshotted = false;
@@ -395,6 +399,15 @@ function openAndInitialize(file: string) {
 export function openLocalDatabase(dir: string): LocalDatabase {
   ensureDataDirSync(dir);
   const file = join(dir, DB_FILENAME);
+  // A snapshot killed part-way leaves a staging directory holding a full copy of
+  // the prompt corpus, and nothing else clears one: `discardStore` sweeps only
+  // the store and its sidecars. The two snapshot paths below each sweep before
+  // taking a copy, but both are reached only by a migration or a foreign-lineage
+  // reset — so on an already-migrated store, which is every open after the
+  // first, no sweep ran at all and the leftover stayed indefinitely.
+  // Best-effort and age-bounded: it never touches a copy another opener has in
+  // flight (see reapStalePartials).
+  reapStalePartials(file);
   const {
     db,
     events,

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -45,6 +45,7 @@ export {
   DATA_DIR_MODE,
   DATA_FILE_MODE,
   DB_FILENAME,
+  dbSidecars,
   ensureDataDirSync,
   KeyUnclaimableError,
   tightenFile,

--- a/packages/persistence/src/internal/snapshot.ts
+++ b/packages/persistence/src/internal/snapshot.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 
-import { dbSidecars, tightenFile, tightenPerms } from '../paths.ts';
+import { dbSidecars, mkdirOwnerOnlySync, tightenDir, tightenFile, tightenPerms } from '../paths.ts';
 
 /**
  * A backup path beside the store: `<file>.<tag>.<millis>.<random>.bak`.
@@ -21,27 +21,111 @@ export function backupPath(file: string, tag: string): string {
 
 // A snapshot copy of a local store finishes in well under this, and VACUUM INTO
 // keeps touching the file as it writes, so a live copy's mtime stays recent. A
-// `.partial` whose mtime has been frozen this long is therefore a leftover from
-// a killed process, not a copy another opener has in flight — the bound is what
-// lets a reap run without pulling a live staging file out from under its writer.
+// staging copy whose mtime has been frozen this long is therefore a leftover
+// from a killed process, not a copy another opener has in flight — the bound is
+// what lets a reap run without pulling a live staging file out from under its
+// writer.
 const STALE_PARTIAL_MS = 5 * 60_000;
 
+// The suffix that turns a `backupPath` into its staging area. `backupPath`
+// already ends in `.bak`, so a staged copy is `<store>.<tag>.<…>.bak.partial` —
+// which is the whole name the reap below matches on, deliberately narrower than
+// a bare `.partial` so it can never sweep something else's staging file.
+export const SNAPSHOT_STAGING_SUFFIX = '.partial';
+const STAGED_NAME_SUFFIX = `.bak${SNAPSHOT_STAGING_SUFFIX}`;
+
+// The copy's fixed name INSIDE the staging directory. Fixed rather than random
+// because the directory it sits in already carries the unguessable suffix.
+// Exported so the guards that classify what `~/.aka` holds derive this name
+// rather than spelling it — `copy` is an ordinary word, and a hand-written copy
+// of it in a test would keep matching after a rename here.
+export const SNAPSHOT_STAGING_COPY = 'copy';
+
 /**
- * Remove abandoned `.partial` staging files left beside the store.
+ * Create the staging area for a snapshot of `backup`: a directory beside the
+ * store, owner-only BEFORE SQLite writes anything into it, and the path the
+ * copy goes to inside it.
  *
- * `snapshotStore` writes its copy to a `<backup>.partial` and renames it into
- * place; a throw removes it, but a KILL — a hook cut off at its timeout, mid
- * `VACUUM INTO` — cannot, and nothing else reaps it: `discardStore` clears only
- * the store and its sidecars. On the plugin path (a store opened per hook,
- * killable at its timeout) that is one leftover per attempt, each up to store
- * size and at the process umask.
+ * The directory is the point. `VACUUM INTO` refuses a target that already
+ * exists, so the copy cannot be pre-created at 0600 and then written — it lands
+ * at the process UMASK and stays there until the tighten that runs after the
+ * copy completes. A `throw` removes it; a KILL cannot, and the plugin opens a
+ * store per hook and is killable at its 10 s harness timeout. So a killed hook
+ * used to leave a byte-complete copy of the whole prompt corpus at 0644.
  *
- * Runs before a snapshot, over every `<store>.*.bak.partial` beside the store,
- * so it covers both the `.legacy.` and `.pre-drop.` names. Age-bounded because a
- * concurrent opener's copy in flight shares the prefix: only a `.partial` whose
- * mtime has not moved for STALE_PARTIAL_MS is treated as abandoned. A pid bound
- * would be wrong — the name is random-suffixed, not pid-scoped. Best-effort
- * throughout: it runs on the fail-open open path and must never throw.
+ * Nothing can narrow that window at the file, because the file does not exist
+ * until SQLite creates it. Enclosing it does: an owner-only directory is
+ * untraversable to every other account from the instant it exists, whatever the
+ * copy inside it is later created as, and it survives a kill exactly as the
+ * copy does.
+ */
+export function createSnapshotStaging(backup: string): { stage: string; copy: string } {
+  const stage = `${backup}${SNAPSHOT_STAGING_SUFFIX}`;
+  // SQLite FOLLOWS a symlink at its output path, and a dangling link passes its
+  // "output file already exists" check — so a link planted here would send the
+  // whole prompt corpus to the link's target. Clearing the path first acts on
+  // the link itself, never on what it points at, and the `mkdirSync` that
+  // follows then OWNS the name: the copy is written at a path inside a directory
+  // this call just created, so it cannot be a link somebody planted in advance.
+  rmSync(stage, { recursive: true, force: true });
+  mkdirOwnerOnlySync(stage);
+  // mkdir's mode is subject to the umask, which only ever clears bits — the
+  // tighten is what holds 0700 under one that would have taken some away. The
+  // create mode is the half that matters and the half no assertion on a
+  // finished snapshot can see, since a completed one removes this directory;
+  // `test/internal/snapshot.test.ts` asserts this function directly for that
+  // reason, under a permissive umask.
+  tightenDir(stage);
+  return { stage, copy: join(stage, SNAPSHOT_STAGING_COPY) };
+}
+
+/**
+ * How long ago a staging leftover was last written, or null when it cannot be
+ * told. The directory's own mtime moves only when an entry is added or removed,
+ * so a copy that has been growing for minutes leaves it frozen at creation —
+ * reading it would age a LIVE copy into staleness. The copy inside is what
+ * VACUUM INTO keeps touching, so it is what the bound is measured against; the
+ * directory is the fallback for a staging area that never got that far.
+ *
+ * A leftover written by an older version is a `.partial` FILE rather than a
+ * directory, and its own mtime is the right reading. Both shapes are swept, so
+ * an upgrade does not strand the copy the previous version left behind.
+ */
+function idleMs(entry: string): number | null {
+  for (const candidate of [join(entry, SNAPSHOT_STAGING_COPY), entry]) {
+    try {
+      return Date.now() - statSync(candidate).mtimeMs;
+    } catch {
+      // The copy is absent (a staging dir cut short before VACUUM INTO created
+      // it, or a legacy file-shaped leftover) — fall through to the entry.
+    }
+  }
+  return null;
+}
+
+/**
+ * Remove abandoned staging areas left beside the store.
+ *
+ * `snapshotStore` writes its copy inside a `<backup>.bak.partial` directory and
+ * renames it into place; a throw clears it, but a KILL — a hook cut off at its
+ * timeout, mid `VACUUM INTO` — cannot, and nothing else reaps it:
+ * `discardStore` clears only the store and its sidecars. On the plugin path (a
+ * store opened per hook, killable at its timeout) that is one leftover per
+ * attempt, each up to store size.
+ *
+ * Runs on EVERY open, not only before a snapshot. The snapshot paths are
+ * reached by a migration or a foreign-lineage reset, so hanging the sweep off
+ * them alone meant a machine that never did either kept its leftover
+ * indefinitely — the copy holds the same prompt corpus as the store, so
+ * "indefinitely" was the half that mattered most.
+ *
+ * Covers every `<store>.*.bak.partial` beside the store, so both the `.legacy.`
+ * and `.pre-drop.` names, and both shapes: the directory this version stages
+ * into and the bare `.partial` FILE an older version left. Age-bounded because
+ * a concurrent opener's copy in flight shares the prefix: only a leftover idle
+ * for STALE_PARTIAL_MS is treated as abandoned. A pid bound would be wrong —
+ * the name is random-suffixed, not pid-scoped. Best-effort throughout: it runs
+ * on the fail-open open path and must never throw.
  */
 export function reapStalePartials(file: string): void {
   const dir = dirname(file);
@@ -53,14 +137,17 @@ export function reapStalePartials(file: string): void {
     return; // the data dir is unreadable or absent — nothing to sweep
   }
   for (const name of entries) {
-    if (!name.startsWith(prefix) || !name.endsWith('.bak.partial')) continue;
-    const partial = join(dir, name);
+    if (!name.startsWith(prefix) || !name.endsWith(STAGED_NAME_SUFFIX)) continue;
+    const staging = join(dir, name);
     try {
-      if (Date.now() - statSync(partial).mtimeMs > STALE_PARTIAL_MS) {
-        rmSync(partial, { force: true });
+      const idle = idleMs(staging);
+      if (idle !== null && idle > STALE_PARTIAL_MS) {
+        // `recursive` covers the directory shape; `force` covers a leftover
+        // that raced away between the reading above and here.
+        rmSync(staging, { recursive: true, force: true });
       }
     } catch {
-      // best-effort: raced away by another opener, or unstattable — leave it
+      // best-effort: raced away by another opener, or unremovable — leave it
     }
   }
 }
@@ -76,43 +163,50 @@ export function reapStalePartials(file: string): void {
  * all and those frames stay in the `-wal`. The bound parameter avoids any
  * path-quoting hazard.
  *
- * The copy lands on a `.partial` sibling and is renamed into place only once it
- * is complete, so a snapshot cut short by a kill rather than a throw (a hook
- * killed at its timeout) leaves a `.partial`, never a truncated file that reads
- * as a usable backup at recovery time.
+ * The copy lands inside a `.bak.partial` staging DIRECTORY and is renamed into
+ * place only once it is complete, so a snapshot cut short by a kill rather than
+ * a throw (a hook killed at its timeout) leaves a staging directory, never a
+ * truncated file that reads as a usable backup at recovery time.
  *
- * Throws on failure, having removed its own partial file.
+ * That directory is created owner-only before SQLite writes anything into it,
+ * which is the only way to cover the copy for the whole time it is being
+ * written: `VACUUM INTO` refuses an existing target, so the copy itself cannot
+ * be pre-created at 0600, and a kill leaves whatever the umask gave it. An
+ * enclosing 0700 directory is untraversable from the first instant and survives
+ * the kill with the copy (see createSnapshotStaging).
+ *
+ * Throws on failure, having removed its own staging directory.
  */
 export function snapshotStore(db: DatabaseSync, backup: string): void {
-  const partial = `${backup}.partial`;
+  // Built before the try so a failure to create the staging area throws with
+  // nothing to clean up — there is no stage to remove until this returns.
+  const { stage, copy } = createSnapshotStaging(backup);
   try {
-    // SQLite FOLLOWS a symlink at its output path, and a dangling link passes
-    // its "output file already exists" check — so a link planted here would send
-    // the whole prompt corpus to the link's target. Unlink acts on the link
-    // itself, never on what it points at. The rename below does not cover this:
-    // it protects the `backup` path, and `partial` is the path actually written.
-    rmSync(partial, { force: true });
-    db.prepare('VACUUM INTO ?').run(partial);
+    db.prepare('VACUUM INTO ?').run(copy);
     // VACUUM INTO writes a brand-new file at the process umask (typically 0644),
     // but it is a full copy of the prompt corpus, so hold it to the store's own
     // 0600. This runs before the rename, which carries the inode and its mode
-    // across, so the PUBLISHED backup is always 0600. It does NOT make the copy
-    // itself owner-only: the file exists at the umask for the whole VACUUM INTO
-    // above, so a process killed DURING the copy still leaves a 0644 `.partial`
-    // — the widest window, and the one reapStalePartials cleans up on a later
-    // open. The tighten cannot run any earlier: the file does not exist until
-    // VACUUM INTO creates it.
-    tightenFile(partial);
-    renameSync(partial, backup);
+    // across, so the PUBLISHED backup is always 0600. The copy is only ever
+    // reachable through the owner-only directory above until then.
+    tightenFile(copy);
+    renameSync(copy, backup);
   } catch (error) {
     // A partial copy left behind would read as a usable backup, so drop it. A
     // cleanup failure never replaces the error that caused it.
     try {
-      rmSync(partial, { force: true });
+      rmSync(stage, { recursive: true, force: true });
     } catch {
       // nothing to undo: no backup was published either way
     }
     throw error;
+  }
+  // The published backup is out; the staging directory has nothing left in it.
+  // Outside the try because a removal failure here must not be mistaken for a
+  // failed snapshot — the copy is already at `backup`.
+  try {
+    rmSync(stage, { recursive: true, force: true });
+  } catch {
+    // best-effort: an empty directory the next reap will clear
   }
 }
 

--- a/packages/persistence/src/local-layout.ts
+++ b/packages/persistence/src/local-layout.ts
@@ -22,9 +22,16 @@ export function defaultDataDir(): string {
   return join(homedir(), '.aka');
 }
 
-// On-disk layout (shared by ALL plugins):
+// On-disk layout (shared by ALL plugins). The sidecar set is the one dbSidecars
+// creates and tightens — three, not two: -wal/-shm are the pair SQLite keeps in
+// write-ahead logging, and -journal is what it writes instead wherever WAL is
+// unavailable (a DrvFs `/mnt/c` path under WSL, some network mounts). data/ also
+// accumulates `.bak` snapshot copies of the store and, after a snapshot cut
+// short by a kill, a `.bak.partial` staging directory:
 //   ~/.aka/settings/  settings.json
-//   ~/.aka/data/      aka.db (+ -wal/-shm sidecars) · policy-cache.json
+//   ~/.aka/data/      aka.db (+ -wal/-shm/-journal sidecars) · policy-cache.json
+//                     · aka.db.<tag>.<millis>.<random>.bak (+ .partial staging)
+//   ~/.aka/keys/      vault.key (see keysDir — deliberately its own directory)
 export function settingsDir(base: string = defaultDataDir()): string {
   return join(base, 'settings');
 }

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -289,10 +289,12 @@ export function applyLegacyDropMigration(db: DatabaseSync, file: string | undefi
 
 // Snapshots the live store aside immediately before the irreversible
 // legacy-table drop, while it stays open and in place — see snapshotStore for
-// why the copy goes through VACUUM INTO and lands via a `.partial` rename. A
-// failure still throws and is caught by the caller, which defers the drop.
+// why the copy goes through VACUUM INTO and is renamed out of a `.bak.partial`
+// staging directory into place. A failure still throws and is caught by the
+// caller, which defers the drop.
 export function backupBeforeLegacyDrop(db: DatabaseSync, file: string): string {
-  // Clear any `.partial` a prior open left behind before staging a new copy.
+  // Clear any `.bak.partial` staging area a prior open left behind (and the bare
+  // `.partial` file an older version wrote) before staging a new copy.
   reapStalePartials(file);
   const backup = backupPath(file, 'pre-drop');
   snapshotStore(db, backup);

--- a/packages/persistence/src/paths.ts
+++ b/packages/persistence/src/paths.ts
@@ -80,6 +80,33 @@ export function tightenDir(dir: string): void {
   chmodBestEffort(dir, DATA_DIR_MODE);
 }
 
+/**
+ * Create `dir` owner-only from the instant it exists — the directory twin of
+ * {@link writeExclusiveOwnerOnlySync}, and load-bearing for the same reason.
+ *
+ * Every caller follows this with a `tightenDir`, which is deliberate: `mkdir`'s
+ * mode is subject to the umask, and a umask only ever CLEARS bits, so one that
+ * would take some away (0o277 and up) leaves a directory this create alone
+ * cannot hold at 0700. That belt-and-suspenders pair is also why the create mode
+ * cannot be defended by looking at the finished directory — the tighten repairs
+ * the end state, so deleting the `mode` here leaves every post-hoc assertion in
+ * the workspace green while the directory is briefly traversable by every
+ * account on the machine. It matters most where something is written INTO the
+ * directory during that window: the snapshot staging area is a full copy of the
+ * prompt corpus, and the rotation lock is stamped immediately after it is made.
+ *
+ * `paths.test.ts` asserts this function directly, under a permissive umask and
+ * with no tighten in the way, so the create mode has one test of its own that a
+ * deletion reddens.
+ *
+ * `recursive` is passed through rather than fixed: the layout dirs are created
+ * parents-and-all, while the lock and the staging area need `mkdir`'s EEXIST to
+ * propagate — that refusal is how the lock picks exactly one winner.
+ */
+export function mkdirOwnerOnlySync(dir: string, recursive = false): void {
+  mkdirSync(dir, { recursive, mode: DATA_DIR_MODE });
+}
+
 // Create the data dir owner-only, tightening it even if it pre-existed with
 // looser permissions. chmod is best-effort (a no-op on platforms without POSIX
 // modes, e.g. Windows) and must never break the fail-open open path.
@@ -92,7 +119,7 @@ export function tightenDir(dir: string): void {
 // unusual home), and `aka init` names the link and its target, since inheriting
 // those permissions silently is the part a user has to know about.
 export function ensureDataDirSync(dir: string): void {
-  mkdirSync(dir, { recursive: true, mode: DATA_DIR_MODE });
+  mkdirOwnerOnlySync(dir, true);
   tightenDir(dir);
 }
 
@@ -119,6 +146,29 @@ export function tightenPerms(file: string): void {
   for (const path of [file, ...dbSidecars(file)]) chmodBestEffort(path, DATA_FILE_MODE);
 }
 
+/**
+ * Create `file` with `data`, owner-only from the instant it exists.
+ *
+ * The single place a store file is BROUGHT INTO BEING, so the create mode lives
+ * in one place rather than beside each writer. `mode` is applied by the create
+ * itself, so the file is never briefly world-readable with its contents already
+ * in it — which a `writeFileSync` + `chmod` pair cannot promise, and which is
+ * the half a reader cannot see afterwards because the end state is identical
+ * either way. That is also why the mode is not defensible by any assertion on a
+ * published file: every caller below re-tightens after publishing, so dropping
+ * the `mode` here leaves every end state correct. `paths.test.ts` asserts this
+ * function directly, under a permissive umask and with no tighten in the way, so
+ * the create mode has one test of its own that a deletion reddens.
+ *
+ * `wx` (O_EXCL) is the other half of the contract and is equally load-bearing:
+ * it refuses to follow a symlink, so a leftover or planted link at `file` can
+ * neither be written through nor have its target chmod'd, and it picks exactly
+ * one winner when two callers race the same path.
+ */
+export function writeExclusiveOwnerOnlySync(file: string, data: string): void {
+  writeFileSync(file, data, { mode: DATA_FILE_MODE, flag: 'wx' });
+}
+
 // Atomic owner-only write of `file`: write a sibling tmp, then rename it into
 // place. The caller must have created the parent dir (ensureDataDirSync).
 //
@@ -141,7 +191,7 @@ export function writeOwnerOnlyFileSync(file: string, data: string): void {
     // target; the exclusive `wx` create below still refuses to follow a symlink.
   }
   try {
-    writeFileSync(tmp, data, { mode: DATA_FILE_MODE, flag: 'wx' });
+    writeExclusiveOwnerOnlySync(tmp, data);
     renameSync(tmp, file);
   } finally {
     try {
@@ -276,7 +326,7 @@ export function createOwnerOnlyFileSync(file: string, data: string): boolean {
   }
   let created: boolean;
   try {
-    writeFileSync(tmp, data, { mode: DATA_FILE_MODE, flag: 'wx' });
+    writeExclusiveOwnerOnlySync(tmp, data);
     created = publishByLink(tmp, file, data);
   } finally {
     try {
@@ -321,7 +371,7 @@ function publishByLink(tmp: string, file: string, data: string): boolean {
     if (!LINK_UNSUPPORTED.has(code ?? '')) throw err;
   }
   try {
-    writeFileSync(file, data, { mode: DATA_FILE_MODE, flag: 'wx' });
+    writeExclusiveOwnerOnlySync(file, data);
     return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;

--- a/packages/persistence/src/vault/key-provider.ts
+++ b/packages/persistence/src/vault/key-provider.ts
@@ -19,15 +19,7 @@
 //             process against an OS service on this machine, no network hop.
 import { execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
-import {
-  chmodSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { chmodSync, readFileSync, renameSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import {
@@ -36,7 +28,10 @@ import {
   DATA_FILE_MODE,
   ensureDataDirSync,
   KeyUnclaimableError,
+  mkdirOwnerOnlySync,
   type Occupant,
+  tightenDir,
+  writeOwnerOnlyFileSync,
 } from '../paths.ts';
 
 // The keyring's wording for the three states classifyOccupant tells apart.
@@ -197,7 +192,12 @@ interface RotationLease {
 // than leaving behind a lock nobody can prove ownership of — and so release.
 function claimRotationLock(lock: string, owner: string): boolean {
   try {
-    mkdirSync(lock);
+    // Owner-only like every other directory under ~/.aka: it sits in the keys
+    // dir and names the holder, and the owner file is stamped into it
+    // immediately below. Non-recursive, so `mkdir` still reports EEXIST and the
+    // atomic create-or-lose answer is unchanged; only the mode is.
+    mkdirOwnerOnlySync(lock);
+    tightenDir(lock);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
     throw asError(err);
@@ -386,14 +386,18 @@ export class FileKeyProvider implements KeyProvider {
    * Atomic tmp + rename so a crash mid-write cannot truncate the keyring.
    * Used only for rotation, under the rotation lock — first creation goes
    * through the creation-exclusive path instead.
+   *
+   * Delegated to the shared owner-only write rather than spelled here, so the
+   * create mode this file is published at is the one paths.ts owns and tests
+   * directly. A local copy of the pair was a second place the mode could be
+   * dropped with the trailing tighten still repairing the end state, which is
+   * the shape no assertion on a published file can see. It also picks up that
+   * primitive's per-process tmp name, its stale-tmp sweep, and an exclusive
+   * create that refuses to follow a symlink planted at the tmp path.
    */
   #write(keyring: Keyring): Keyring {
     ensureDataDirSync(this.#keysDir);
-    const file = this.filePath;
-    const tmp = `${file}.tmp`;
-    writeFileSync(tmp, `${serializeKeyring(keyring)}\n`, { mode: DATA_FILE_MODE });
-    renameSync(tmp, file);
-    tightenFileMode(file);
+    writeOwnerOnlyFileSync(this.filePath, `${serializeKeyring(keyring)}\n`);
     return keyring;
   }
 }

--- a/packages/persistence/test/at-rest-docs.test.ts
+++ b/packages/persistence/test/at-rest-docs.test.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { describe, expect, it } from 'vitest';
 
 import { EXCEPTION_KEY_FILENAME } from '../src/fingerprint.ts';
+import { SNAPSHOT_STAGING_SUFFIX } from '../src/internal/snapshot.ts';
 import { dataDir, defaultDataDir, keysDir, settingsDir } from '../src/local-layout.ts';
 import { DATA_DIR_MODE, DATA_FILE_MODE, DB_FILENAME, dbSidecars } from '../src/paths.ts';
 import { SETTINGS_FILENAME } from '../src/settings.ts';
@@ -139,7 +140,29 @@ const upToClaim = (text: string, claim: string): string => {
 
 const enumeration = upToClaim(atRest, FILE_MODE_CLAIM);
 
+// How many times the slice anchor occurs in the section it slices.
+const occurrences = (text: string, needle: string): number =>
+  needle === '' ? 0 : text.split(needle).length - 1;
+
 describe('SECURITY.md "Data at rest" enumerates the store', () => {
+  /**
+   * The slice above narrows the window to the enumeration, and it holds only
+   * while the anchor it slices on occurs ONCE. Nothing used to assert that.
+   *
+   * The claim is a sentence, not a marker, so it is reachable by an ordinary
+   * reword — and `are written 0600` already appeared a second time further down,
+   * in the paragraph about the backup copies. Reword the first occurrence and
+   * `upToClaim` falls through to that one, the window silently grows back to the
+   * whole section, and the guard is a whole-section text search again: dropping
+   * both `-journal` and `vault.key` from the list then stays green, because the
+   * WAL paragraph and the `vault.key` paragraph mention them anyway. That is
+   * exactly the failure mode the slice exists to prevent, so it is asserted
+   * rather than assumed — one line, beside the thing it protects.
+   */
+  it('slices on an anchor that occurs exactly once', () => {
+    expect(occurrences(atRest, FILE_MODE_CLAIM)).toBe(1);
+  });
+
   it.each(STORE_DIRS)('lists the %s directory among the tightened set', (dir) => {
     expect(enumeration).toContain(dir);
   });
@@ -166,14 +189,27 @@ describe('SECURITY.md "Data at rest" enumerates the store', () => {
     expect(atRest).toMatch(/moves the whole set aside/i);
   });
 
-  // The staging file is the widest window in the at-rest story: a full copy at
-  // the umask, and reapStalePartials runs from the two snapshot paths only —
-  // never on an ordinary open. Copy that implies routine cleanup understates how
-  // long it can sit there, so the note has to bound the sweep and say what to do.
+  // The staging copy is the one at-rest artifact that cannot be created
+  // owner-only — VACUUM INTO refuses an existing target, so the copy lands at
+  // the umask and only an enclosing directory can cover it while it is written.
+  // Both halves of that have to be in the note, and the suffix is DERIVED from
+  // the module that builds the path rather than spelled here: the name is what a
+  // reader greps their own data dir for, so a rename that left the note behind
+  // would send them looking for a file they do not have.
+  it('names the staging directory, and says it is owner-only', () => {
+    expect(atRest).toContain(`.bak${SNAPSHOT_STAGING_SUFFIX}`);
+    expect(atRest).toMatch(/created owner-only \(`0700`\) before the copy starts/i);
+  });
+
+  // And says when it goes. The previous wording — cleared "only when it next
+  // takes a snapshot" — was accurate and is now false: the sweep runs on every
+  // open. Copy that still implied a snapshot were needed would overstate the
+  // exposure, which is its own kind of wrong answer for someone auditing a
+  // machine.
   it('bounds when the abandoned staging copy is cleared, and says to delete it', () => {
-    expect(atRest).toContain('.bak.partial');
-    expect(atRest).toMatch(/only when it next takes a snapshot/i);
-    expect(atRest).toMatch(/delete it/i);
+    expect(atRest).toMatch(/on the next open of the store/i);
+    expect(atRest).toMatch(/in flight is left alone/i);
+    expect(atRest).toMatch(/delete one that outlives/i);
   });
 });
 

--- a/packages/persistence/test/at-rest-surface.test.ts
+++ b/packages/persistence/test/at-rest-surface.test.ts
@@ -1,0 +1,290 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { basename, join, relative, sep } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { EXCEPTION_KEY_FILENAME, loadOrCreateFingerprintKey } from '../src/fingerprint.ts';
+import { SNAPSHOT_STAGING_COPY, SNAPSHOT_STAGING_SUFFIX } from '../src/internal/snapshot.ts';
+import { keysDir } from '../src/local-layout.ts';
+import { DATA_DIR_MODE, DATA_FILE_MODE, DB_FILENAME, dbSidecars } from '../src/paths.ts';
+import { applyOnboarding, SETTINGS_FILENAME } from '../src/settings.ts';
+import { FileKeyProvider, VAULT_KEY_FILENAME } from '../src/vault/key-provider.ts';
+import { capWarnEraEnforcementOnce } from '../src/warn-era-cap.ts';
+import { useTempStore } from './helpers/temp-store.ts';
+
+/**
+ * Everything `~/.aka` actually holds, against what is claimed about it.
+ *
+ * `at-rest-docs.test.ts` derives each NAME from the module that writes it, which
+ * is what stops a renamed constant drifting out of SECURITY.md's enumeration.
+ * What it cannot do is notice a FIFTH file: the list of modules it reads is a
+ * literal, so an artifact nobody thought to add to it reddens nothing — the same
+ * shape as the hardcoded directory list that guard's review round removed, one
+ * level up. `policy-cache.json`, the warn-era marker and the vault rotation lock
+ * were all live instances.
+ *
+ * This is the other half, and it derives the SET rather than the names: the store
+ * is exercised through its real writers and the tree is then walked, so a new
+ * artifact has to be either owner-only and classified, or it fails here. That
+ * makes the two guards complements — neither subsumes the other, and a file has
+ * to get past both.
+ */
+const store = useTempStore('aka-at-rest-surface-');
+
+/** Every path under `home`, files and directories alike, relative and posix. */
+function walk(home: string): string[] {
+  const out: string[] = [];
+  const visit = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      out.push(relative(home, path).split(sep).join('/'));
+      if (entry.isDirectory()) visit(path);
+    }
+  };
+  visit(home);
+  return out.sort();
+}
+
+/**
+ * Put the store through every writer that lands something under `~/.aka`.
+ *
+ * Run under a 0o000 umask, which is the whole instrument for the mode assertion
+ * below: a umask only ever CLEARS bits, so under 0o077 a create that passed no
+ * mode at all would still come out 0600 and the assertion would hold over the
+ * mutant. Under 0o000 a create keeps exactly what it asked for.
+ *
+ * `applyOnboarding` takes the settings file's own lock, and the vault provider
+ * takes its rotation lock, so this also exercises the two lock files — which is
+ * deliberate: both are artifacts under `~/.aka` and both are what item 5 of the
+ * enumeration gap was about.
+ */
+async function exerciseStore(): Promise<void> {
+  const previous = process.umask(0o000);
+  let pending: Promise<unknown>[];
+  try {
+    const db = store.open();
+    db.policies.upsertCategoryAction('secret', 'block');
+    capWarnEraEnforcementOnce(db, 'warn', store.dataDir);
+    applyOnboarding({ policy: 'warn' }, store.home);
+    loadOrCreateFingerprintKey(store.dataDir);
+    // Rotated as well as minted, so the keyring's REWRITE path runs and not only
+    // its first-mint one — separate writers, and only the rewrite takes the
+    // rotation lock. Both provider bodies run synchronously and are wrapped in
+    // an already-settled promise (see asAsync), so every write below has landed
+    // by the time the umask is restored; awaiting them outside the `finally` is
+    // what turns a rejection into a failed test rather than an unhandled
+    // rejection that fails some later one.
+    const vault = new FileKeyProvider(keysDir(store.home));
+    pending = [vault.loadOrCreate(), vault.rotate()];
+  } finally {
+    process.umask(previous);
+  }
+  await Promise.all(pending);
+}
+
+// A literal taken from a source module, made safe to embed in a pattern. The
+// names below are DERIVED rather than spelled, so whatever the module holds has
+// to survive the trip into a RegExp — a bare `.replace('.', '\\.')` escaped only
+// the first dot and would mis-anchor the day a suffix grew a second one.
+const escapeRe = (literal: string): string => literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * What the store may hold beyond SECURITY.md's enumerated set, and why each is
+ * not in it. Every entry is still held to the owner-only modes — the exclusion
+ * is from the NOTE's file list, never from the at-rest control.
+ *
+ * Matched against the walk's RELATIVE PATH, not the bare basename. A basename
+ * match reads as tidier and is too wide in exactly the places it matters: `copy`
+ * and `owner` are ordinary words, and exempting them everywhere would let a
+ * future `data/copy` or `settings/owner` through the classification case
+ * unnoticed — the one thing this guard exists to catch. Anchoring each to the
+ * directory that gives it its meaning keeps the exemption as narrow as the
+ * reason for it.
+ *
+ * `coveredBy` is what separates the two kinds, and the distinction is not
+ * bookkeeping. An entry WITHOUT it names something that survives a write, so the
+ * walk below sees it and a pattern that stopped matching is reported as stale —
+ * an exclusion for an artifact nothing writes any more reads as reviewed and
+ * covers nothing. An entry WITH it names something that exists only for the
+ * length of one operation: a lock is released, a staging directory is removed on
+ * both the success and the failure path, and a policy cache is written by a
+ * different package altogether. No post-hoc walk can observe those, so the
+ * staleness ratchet cannot apply to them, and what stands in for it is the suite
+ * named — each of which asserts the artifact's own mode where it is live.
+ */
+const DOCUMENTED_EXCLUSIONS: readonly {
+  pattern: RegExp;
+  reason: string;
+  coveredBy?: string;
+}[] = [
+  {
+    pattern: /\.bak$/,
+    reason:
+      'a snapshot copy of the store; the note covers these in their own paragraph rather than in the file list, because the name carries a timestamp',
+  },
+  {
+    pattern: new RegExp(`\\.bak${escapeRe(SNAPSHOT_STAGING_SUFFIX)}$`),
+    reason:
+      'the staging directory a killed snapshot leaves; covered by its own paragraph in the note, and owner-only from before the copy starts',
+    coveredBy:
+      "test/internal/snapshot.test.ts — 'creates the staging directory owner-only, before anything is written into it'",
+  },
+  {
+    pattern: new RegExp(
+      `\\.bak${escapeRe(SNAPSHOT_STAGING_SUFFIX)}/${escapeRe(SNAPSHOT_STAGING_COPY)}$`,
+    ),
+    reason: 'the in-progress copy inside a staging directory, reachable only through it',
+    coveredBy:
+      "test/internal/snapshot.test.ts — 'publishes a complete copy and leaves no partial file behind'",
+  },
+  {
+    pattern: /(?:^|\/)warn-era-capped$/,
+    reason:
+      'a one-time marker holding an ISO timestamp — no store content, so the note does not list it among the files that hold the corpus',
+  },
+  {
+    pattern: /(?:^|\/)policy-cache\.json$/,
+    reason:
+      'a cache of the policy snapshot, rebuildable from the store; written by the plugin SDK rather than this package, and relocated into data/ by migrateLegacyLayout',
+    coveredBy: 'test/local-layout.test.ts — the legacy-layout relocation',
+  },
+  {
+    pattern: /\.lock$/,
+    reason:
+      'a lock held for the length of one write (settings.json, or a vault rotation), not an artifact that outlives it',
+    coveredBy:
+      "test/vault/key-provider.test.ts — 'holds the rotation lock and its owner file owner-only'",
+  },
+  {
+    pattern: /\.lock\/owner$/,
+    reason:
+      'the holder token inside a rotation lock directory, named so a release can prove it still owns the lock',
+    coveredBy:
+      "test/vault/key-provider.test.ts — 'holds the rotation lock and its owner file owner-only'",
+  },
+  {
+    pattern: /^(settings|data|keys)$/,
+    reason: 'the layout directories, which the note enumerates as directories rather than files',
+  },
+];
+
+/**
+ * The names SECURITY.md's own file list covers, derived as that guard does.
+ *
+ * `dbSidecars` is given the bare filename, so what comes back is already bare —
+ * no basename step, which only read as one because `DB_FILENAME` has no
+ * directory in it to strip.
+ */
+const ENUMERATED = new Set<string>([
+  DB_FILENAME,
+  ...dbSidecars(DB_FILENAME),
+  EXCEPTION_KEY_FILENAME,
+  SETTINGS_FILENAME,
+  VAULT_KEY_FILENAME,
+]);
+
+describe('the ~/.aka surface', () => {
+  it('is exercised into more than the store file alone', async () => {
+    await exerciseStore();
+    // The precondition every case below rests on. An exerciser that wrote
+    // nothing would satisfy a "every file is owner-only" claim over an empty
+    // tree, and satisfy the classification claim the same way.
+    const found = walk(store.home);
+    expect(found.length).toBeGreaterThan(6);
+    expect(found).toContain(`data/${DB_FILENAME}`);
+    expect(found).toContain(`settings/${SETTINGS_FILENAME}`);
+    expect(found).toContain(`${basename(keysDir(store.home))}/${VAULT_KEY_FILENAME}`);
+    expect(found).toContain(`data/${EXCEPTION_KEY_FILENAME}`);
+  });
+
+  // The property the note actually claims, over the tree rather than over a
+  // list: EVERY file the store writes is 0600 and every directory 0700. A file
+  // added tomorrow is covered without an edit here, which is what the guard next
+  // door cannot do.
+  it('holds every file 0600 and every directory 0700', async (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    await exerciseStore();
+
+    const loose = walk(store.home)
+      .map((path) => ({ path, stat: statSync(join(store.home, path)) }))
+      .filter(
+        ({ stat }) => (stat.mode & 0o777) !== (stat.isDirectory() ? DATA_DIR_MODE : DATA_FILE_MODE),
+      )
+      .map(({ path, stat }) => `${path} is 0${(stat.mode & 0o777).toString(8)}`);
+
+    expect(loose).toEqual([]);
+  });
+
+  // And every one of them is either in the note's list or recorded above as a
+  // deliberate omission. This is the half that fails when a fifth artifact
+  // appears: it cannot be quietly absent from both.
+  it('writes nothing that is neither enumerated nor a recorded exclusion', async () => {
+    await exerciseStore();
+
+    const unclassified = walk(store.home).filter((path) => {
+      // The note's list is a set of FILENAMES wherever the layout puts them;
+      // an exclusion is anchored to the path that gives it its meaning.
+      if (ENUMERATED.has(basename(path))) return false;
+      return !DOCUMENTED_EXCLUSIONS.some(({ pattern }) => pattern.test(path));
+    });
+
+    expect(unclassified).toEqual([]);
+  });
+
+  // An exclusion for something the store stopped writing reads as reviewed and
+  // covers nothing, so it is reported rather than left to rot. Scoped to the
+  // entries that survive a write — the rest name where they are covered instead,
+  // and the case below is what keeps that from being a way out of this one.
+  it('records no persistent exclusion that matches nothing the store writes', async () => {
+    await exerciseStore();
+    const paths = walk(store.home);
+
+    const stale = DOCUMENTED_EXCLUSIONS.filter(
+      ({ pattern, coveredBy }) => coveredBy === undefined && !paths.some((p) => pattern.test(p)),
+    ).map(({ pattern }) => pattern.source);
+
+    expect(stale).toEqual([]);
+  });
+
+  // The other side of that scoping. `coveredBy` is what buys an entry out of the
+  // staleness ratchet, so it has to name a case that exists — otherwise the way
+  // to silence a stale exclusion is to invent a citation for it.
+  //
+  // Checking the FILE alone is not enough, and that is the whole point: every
+  // path cited here is a file that plainly exists, so a fabricated or drifted
+  // case NAME inside one sails through. The name is read out of the quotes and
+  // matched against the file's own text, which is what makes a renamed case fail
+  // here rather than quietly leaving the exclusion backed by nothing.
+  it('names a real case for every exclusion the walk cannot observe', () => {
+    const cited = DOCUMENTED_EXCLUSIONS.filter(({ coveredBy }) => coveredBy !== undefined).map(
+      ({ pattern, coveredBy }) => ({
+        pattern: pattern.source,
+        file: (/^[\w./-]+/.exec(coveredBy ?? '') ?? [''])[0],
+        // Everything between the first pair of straight quotes, when there is
+        // one. An entry that cites a file and no case (the legacy-layout
+        // relocation, which is a whole suite rather than one case) is held to
+        // the file alone.
+        name: (/'([^']+)'/.exec(coveredBy ?? '') ?? [])[1],
+      }),
+    );
+
+    const missing = cited
+      .filter(({ file, name }) => {
+        const url = new URL(`./${file.replace(/^test\//, '')}`, import.meta.url);
+        if (!existsSync(url)) return true;
+        return name !== undefined && !readFileSync(url, 'utf8').includes(name);
+      })
+      .map(({ pattern, file, name }) => `${pattern} -> ${file}${name ? ` :: '${name}'` : ''}`);
+
+    expect(missing).toEqual([]);
+  });
+
+  it('gives every exclusion a reason', () => {
+    for (const { pattern, reason } of DOCUMENTED_EXCLUSIONS) {
+      expect(reason.length, pattern.source).toBeGreaterThan(20);
+    }
+  });
+});

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -1,5 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import { chmodSync, existsSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
@@ -299,6 +308,93 @@ describe('openLocalDatabase — open / migrate / seed', () => {
 
     expect(existsSync(backup)).toBe(true);
     if (process.platform !== 'win32') expect(statSync(backup).mode & 0o777).toBe(0o600);
+  });
+});
+
+/**
+ * A snapshot cut short by a KILL — a plugin hook cut off at its 10 s harness
+ * timeout, mid `VACUUM INTO` — leaves its staging directory behind holding a
+ * byte-complete copy of the whole prompt corpus. A throw clears it; a kill
+ * cannot, and `discardStore` sweeps only the store and its sidecars.
+ *
+ * The sweep used to hang off the two snapshot paths alone, both of which sit
+ * immediately before taking ANOTHER snapshot — so it ran only if the machine
+ * performed a further migration or foreign-lineage reset, and on one that never
+ * did, the copy stayed indefinitely. That is the half that mattered: the copy
+ * holds the same content as the store, and the store's whole at-rest control is
+ * a mode on files beside it.
+ */
+describe('openLocalDatabase sweeps abandoned snapshot staging', () => {
+  const anHourAgo = new Date(Date.now() - 60 * 60_000);
+
+  /**
+   * A store that has already been migrated, which is what makes every case here
+   * mean anything.
+   *
+   * The FIRST open of a fresh store performs the legacy-table drop, and that
+   * path snapshots — so it reaps on its own way past, through the call site that
+   * predates this sweep. Planting a leftover before a first open therefore
+   * passes whether or not `openLocalDatabase` sweeps at all: measured, all three
+   * cases below were green against a `database.ts` with no sweep in it. The
+   * steady state — an already-migrated store, i.e. every open after the first —
+   * is the state in which nothing ran, and it is the one the gap lived in.
+   */
+  function migratedStore(): void {
+    store.open();
+    expect(readdirSync(store.dataDir).some((name) => name.endsWith('.bak'))).toBe(true); // the first open really did take its pre-drop snapshot
+  }
+
+  // A staging area exactly as a killed process leaves one: the directory, and
+  // the part-written copy inside it.
+  function abandonedStaging(name: string): string {
+    const stage = join(store.dataDir, name);
+    mkdirSync(stage);
+    const copy = join(stage, 'copy');
+    writeFileSync(copy, 'a full copy of the prompt corpus');
+    utimesSync(copy, anHourAgo, anHourAgo);
+    utimesSync(stage, anHourAgo, anHourAgo);
+    return stage;
+  }
+
+  it('clears one left by a killed snapshot, on an ordinary open', () => {
+    migratedStore();
+    const stage = abandonedStaging('aka.db.legacy.1.aaaaaaaa.bak.partial');
+
+    store.open();
+
+    expect(existsSync(stage)).toBe(false);
+  });
+
+  // The shape an older version left: a bare `.partial` FILE rather than a
+  // directory. An upgrade must not strand the copy its predecessor abandoned.
+  it('clears a legacy file-shaped one too', () => {
+    migratedStore();
+    const legacy = join(store.dataDir, 'aka.db.pre-drop.1.bbbbbbbb.bak.partial');
+    writeFileSync(legacy, 'a full copy of the prompt corpus');
+    utimesSync(legacy, anHourAgo, anHourAgo);
+
+    store.open();
+
+    expect(existsSync(legacy)).toBe(false);
+  });
+
+  // The positive control the sweep is worthless without: a copy another opener
+  // has IN FLIGHT shares the prefix, and pulling it out from under its writer is
+  // the failure the age bound exists to prevent. Without this case, a sweep that
+  // removed everything matching would pass the two above.
+  it('leaves a copy another opener has in flight, and the published backup', () => {
+    migratedStore();
+    const live = join(store.dataDir, 'aka.db.legacy.1.cccccccc.bak.partial');
+    mkdirSync(live);
+    writeFileSync(join(live, 'copy'), 'in flight');
+    const published = join(store.dataDir, 'aka.db.legacy.1.dddddddd.bak');
+    writeFileSync(published, 'a real backup');
+    utimesSync(published, anHourAgo, anHourAgo);
+
+    store.open();
+
+    expect(existsSync(live)).toBe(true);
+    expect(existsSync(published)).toBe(true);
   });
 });
 

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -60,6 +60,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'createKeyProvider',
   'dataDir',
   'dbPath',
+  'dbSidecars',
   'defaultDataDir',
   'deriveSubkeys',
   'ensureDataDir',

--- a/packages/persistence/test/internal/snapshot.test.ts
+++ b/packages/persistence/test/internal/snapshot.test.ts
@@ -13,13 +13,14 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   backupPath,
+  createSnapshotStaging,
   discardStore,
   moveStoreAside,
   reapStalePartials,
@@ -392,6 +393,64 @@ describe('discardStore', () => {
   });
 });
 
+describe('createSnapshotStaging', () => {
+  // The whole point of the staging DIRECTORY, and the one property no assertion
+  // on a finished snapshot can reach: a completed snapshot removes it, and a
+  // failed one removes it too, so by the time `snapshotStore` returns there is
+  // nothing left to stat. What the mode covers is the interval in between —
+  // `VACUUM INTO` refuses an existing target, so the copy cannot be
+  // pre-created at 0600 and lands at the umask instead, and a process KILLED
+  // during the copy leaves it there. An owner-only enclosing directory is
+  // untraversable to every other account from the instant it exists and
+  // survives the kill exactly as the copy does.
+  //
+  // The umask is the instrument, as in `paths.test.ts`: it only ever CLEARS
+  // bits, so under 0o000 the create keeps what it asked for and a dropped mode
+  // shows as 0777. A runner's own 0o077 would hand back 0700 either way.
+  it('creates the staging directory owner-only, before anything is written into it', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const backup = backupPath(join(dir, 'aka.db'), 'legacy');
+    const previous = process.umask(0o000);
+    let stage: string;
+    let copy: string;
+    try {
+      ({ stage, copy } = createSnapshotStaging(backup));
+    } finally {
+      process.umask(previous);
+    }
+
+    expect(statSync(stage).mode & 0o777).toBe(0o700);
+    // The copy goes INSIDE it — a sibling would inherit none of the protection.
+    expect(copy.startsWith(`${stage}${sep}`)).toBe(true);
+    expect(existsSync(copy)).toBe(false); // nothing written yet
+  });
+
+  // The symlink guard moved here with the create. A dangling link at the
+  // staging path used to be the route to the whole prompt corpus, because
+  // VACUUM INTO follows one and its "already exists" check passes on a dangling
+  // one. Clearing the path acts on the link, never on its target — and the
+  // mkdir that follows then owns the name, so the copy path inside cannot have
+  // been planted in advance.
+  it('replaces a symlink planted at the staging path rather than following it', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
+    const backup = backupPath(join(dir, 'aka.db'), 'legacy');
+    const target = join(dir, 'elsewhere.txt');
+    symlinkSync(target, `${backup}.partial`);
+
+    const { stage } = createSnapshotStaging(backup);
+
+    expect(existsSync(target)).toBe(false);
+    expect(lstatSync(stage).isSymbolicLink()).toBe(false);
+    expect(lstatSync(stage).isDirectory()).toBe(true);
+  });
+});
+
 describe('reapStalePartials', () => {
   it('reaps an abandoned .partial but spares a fresh one and the published .bak', () => {
     const file = join(dir, 'aka.db');
@@ -415,6 +474,52 @@ describe('reapStalePartials', () => {
     expect(existsSync(live)).toBe(true); // in flight → left alone
     expect(existsSync(published)).toBe(true); // published backup → never touched
     expect(existsSync(file)).toBe(true); // the store itself → never touched
+  });
+
+  // The directory's OWN mtime moves only when an entry is added or removed, so
+  // a copy that has been growing for minutes leaves it frozen at creation.
+  // Reading it would age a LIVE staging area into staleness and pull the copy
+  // out from under the process writing it — which is the one thing the age
+  // bound exists to prevent. The copy inside is what VACUUM INTO keeps
+  // touching, so that is what the bound is measured against.
+  it('measures a staging directory by the copy inside it, not by the directory', () => {
+    const file = join(dir, 'aka.db');
+    writeFileSync(file, 'store');
+    const anHourAgo = new Date(Date.now() - 60 * 60_000);
+
+    // A live copy: the directory was created an hour ago and the copy inside it
+    // is still being written, so its mtime is now.
+    const live = `${file}.legacy.1.aaaaaaaa.bak.partial`;
+    mkdirSync(live);
+    writeFileSync(join(live, 'copy'), 'in flight');
+    utimesSync(live, anHourAgo, anHourAgo);
+
+    // Abandoned: the copy itself has not been touched for an hour.
+    const abandoned = `${file}.pre-drop.1.bbbbbbbb.bak.partial`;
+    mkdirSync(abandoned);
+    const inner = join(abandoned, 'copy');
+    writeFileSync(inner, 'killed part-way');
+    utimesSync(inner, anHourAgo, anHourAgo);
+
+    reapStalePartials(file);
+
+    expect(existsSync(live)).toBe(true);
+    expect(existsSync(abandoned)).toBe(false);
+  });
+
+  // A staging directory cut short before VACUUM INTO created anything has no
+  // copy to read, so the directory's own mtime is the only reading left.
+  it('falls back to the directory when the copy was never created', () => {
+    const file = join(dir, 'aka.db');
+    writeFileSync(file, 'store');
+    const empty = `${file}.legacy.1.dddddddd.bak.partial`;
+    mkdirSync(empty);
+    const anHourAgo = new Date(Date.now() - 60 * 60_000);
+    utimesSync(empty, anHourAgo, anHourAgo);
+
+    reapStalePartials(file);
+
+    expect(existsSync(empty)).toBe(false);
   });
 
   it('does nothing, and never throws, when the data dir has no stale partials', () => {

--- a/packages/persistence/test/paths.test.ts
+++ b/packages/persistence/test/paths.test.ts
@@ -23,9 +23,11 @@ import {
   dbSidecars,
   ensureDataDirSync,
   KeyUnclaimableError,
+  mkdirOwnerOnlySync,
   tightenDir,
   tightenFile,
   tightenPerms,
+  writeExclusiveOwnerOnlySync,
   writeOwnerOnlyFileSync,
 } from '../src/paths.ts';
 import { useTempStore } from './helpers/temp-store.ts';
@@ -328,6 +330,140 @@ describe('tightenFile', () => {
 
     expect(mode(victim)).toBe(0o644); // victim NOT tightened through the link
     expect(lstatSync(link).isSymbolicLink()).toBe(true); // link left as-is
+  });
+});
+
+describe('mkdirOwnerOnlySync', () => {
+  // The directory twin of the case above, and undetectable for the same reason:
+  // every caller follows it with a `tightenDir`, so the finished directory is
+  // 0700 whether or not the create carried a mode. The window it closes is the
+  // one where something is written INTO the directory — a snapshot staging area
+  // takes a full copy of the prompt corpus, and the rotation lock is stamped
+  // straight after the mkdir. Same instrument: under a 0o000 umask the create
+  // keeps exactly what it asked for (0700 with the mode, 0777 without it), where
+  // a runner's own 0o077 would hand back 0700 either way.
+  it('creates the directory owner-only, by the create itself and not a later chmod', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const dir = join(base, 'staging');
+    const previous = process.umask(0o000);
+    try {
+      mkdirOwnerOnlySync(dir);
+      expect(mode(dir)).toBe(DATA_DIR_MODE);
+    } finally {
+      process.umask(previous);
+    }
+  });
+
+  // Non-recursive by default, because that EEXIST is what the rotation lock uses
+  // to pick exactly one winner — a `recursive: true` default would silently turn
+  // every claim into a success and put two writers in the section.
+  it('refuses an existing directory, so a caller can use EEXIST to claim it', () => {
+    const dir = join(base, 'lock');
+    mkdirOwnerOnlySync(dir);
+
+    expect(() => {
+      mkdirOwnerOnlySync(dir);
+    }).toThrow(expect.objectContaining({ code: 'EEXIST' }));
+  });
+
+  // The recursive create and its idempotency hold on every platform, so this is
+  // a positive conditional rather than a skip: only the mode half is gated. A
+  // `ctx.skip` at the tail would throw away a result that genuinely held and
+  // report the case as uncovered where it was not.
+  it('creates missing parents when asked, and is then idempotent', () => {
+    const dir = join(base, 'a', 'b', 'c');
+    // Under the same 0o000 umask as the case above, and for the same reason: on
+    // a runner whose own umask is 0o077, mkdir's default 0o777 is masked down to
+    // 0o700 — equal to DATA_DIR_MODE — so every assertion below would hold with
+    // the create mode deleted. The idempotency half needs no umask and is left
+    // outside it.
+    const previous = process.umask(0o000);
+    try {
+      mkdirOwnerOnlySync(dir, true);
+      if (process.platform !== 'win32') {
+        // Every level it created, not just the leaf it tightens.
+        expect(mode(join(base, 'a'))).toBe(DATA_DIR_MODE);
+        expect(mode(join(base, 'a', 'b'))).toBe(DATA_DIR_MODE);
+        expect(mode(dir)).toBe(DATA_DIR_MODE);
+      }
+    } finally {
+      process.umask(previous);
+    }
+
+    expect(() => {
+      mkdirOwnerOnlySync(dir, true);
+    }).not.toThrow();
+  });
+});
+
+describe('writeExclusiveOwnerOnlySync', () => {
+  // The one place a store file is created, and the only place its CREATE mode
+  // can be asserted at all: every caller re-tightens what it publishes, so on a
+  // published file the end state is 0600 whether or not the create carried a
+  // mode. Deleting `mode` there leaves a window — the file exists with its
+  // contents already in it, at the umask, until the chmod lands — and no
+  // assertion on the finished file can see it. Asserting the primitive is what
+  // makes that half deletable-with-consequences.
+  //
+  // The umask is the instrument. It only ever CLEARS bits, so under 0o000
+  // nothing is taken off a create: with the mode the file is 0600, without it
+  // 0666. A developer or runner whose umask is already 0o077 would get 0600
+  // either way and the case would pass over the mutant, which is why the umask
+  // is set here rather than inherited. Restored in a `finally` because it is
+  // process-global.
+  it('creates the file owner-only, by the create itself and not a later chmod', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const file = join(base, 'minted');
+    const previous = process.umask(0o000);
+    try {
+      writeExclusiveOwnerOnlySync(file, 'material\n');
+      expect(mode(file)).toBe(DATA_FILE_MODE);
+    } finally {
+      process.umask(previous);
+    }
+    expect(readFileSync(file, 'utf8')).toBe('material\n');
+  });
+
+  // The other half of the contract, and the reason the exclusive create is not
+  // interchangeable with a plain write: an occupied path is refused rather than
+  // replaced, so a planted symlink is never written through.
+  it('refuses an occupied path rather than replacing it', () => {
+    const file = join(base, 'incumbent');
+    writeFileSync(file, 'first');
+
+    // EEXIST specifically, not merely "something threw": a bare toThrow is
+    // satisfied by an ENOENT from a bad parent or an EACCES from the mode, so it
+    // would stay green over a change that never reached the O_EXCL guarantee
+    // this case is named for.
+    expect(() => {
+      writeExclusiveOwnerOnlySync(file, 'second');
+    }).toThrow(expect.objectContaining({ code: 'EEXIST' }));
+    expect(readFileSync(file, 'utf8')).toBe('first');
+  });
+
+  it('never writes THROUGH a symlink planted at the path', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('unprivileged symlink creation is not available on Windows');
+      return;
+    }
+    const victim = join(base, 'victim');
+    writeFileSync(victim, 'SECRET');
+    const link = join(base, 'planted');
+    symlinkSync(victim, link);
+
+    // O_EXCL reports an existing symlink as EEXIST — pinned, because the victim
+    // assertion below holds for any throw at all and cannot tell a refusal from
+    // an unrelated failure.
+    expect(() => {
+      writeExclusiveOwnerOnlySync(link, 'attacker payload');
+    }).toThrow(expect.objectContaining({ code: 'EEXIST' }));
+    expect(readFileSync(victim, 'utf8')).toBe('SECRET');
   });
 });
 

--- a/packages/persistence/test/vault/key-provider.test.ts
+++ b/packages/persistence/test/vault/key-provider.test.ts
@@ -17,6 +17,7 @@ import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { DATA_DIR_MODE, DATA_FILE_MODE } from '../../src/paths.ts';
 import {
   createKeyProvider,
   FileKeyProvider,
@@ -97,6 +98,45 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 const POSIX_MODES = process.platform !== 'win32';
+
+// The real platform in the two forms the cases below need, both read at module
+// load, before anything can have faked it: the plain value is what the
+// order-independent guard compares against, and the DESCRIPTOR is what the
+// restore puts back. It has to be the descriptor — `process.platform` is a
+// non-writable own property, so a case that fakes it must redefine it, and
+// undoing that means reinstating the original definition rather than assigning
+// the old string back.
+const REAL_PLATFORM: NodeJS.Platform = process.platform;
+const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+if (!realPlatform) {
+  // Refuse rather than restore nothing: a fake that is never undone leaks into
+  // every later case in this worker, including the temp-dir teardowns.
+  throw new Error('process.platform has no own property descriptor to restore');
+}
+
+// KeychainKeyProvider's guard reads `process.platform` at CONSTRUCTION time, so
+// redefining it here reaches it. Faking rather than gating is the whole point:
+// `it.skipIf(process.platform === 'darwin')` runs one direction on one runner
+// and leaves the other unasserted everywhere — a guard hardcoded to ALWAYS fire
+// makes the backend unconstructable on macOS and no runner catches it.
+function stubPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+// Unconditional and file-scoped rather than scoped to the block that fakes: a
+// case throwing mid-body would otherwise hand its fake to every case after it.
+// A no-op for every case that never faked.
+afterEach(() => {
+  Object.defineProperty(process, 'platform', realPlatform);
+});
+
+// The order-INDEPENDENT half of that guarantee. A single case asserting the
+// platform was restored covers only the cases declared before it, so appending
+// a faking case below it silently moves that case outside the guard. This runs
+// before every case in the file instead.
+beforeEach(() => {
+  expect(process.platform).toBe(REAL_PLATFORM);
+});
 
 describe('FileKeyProvider', () => {
   let dir: string;
@@ -470,6 +510,56 @@ describe('KeychainKeyProvider', () => {
     expect(existsSync(join(dir, `${VAULT_KEY_FILENAME}.lock`))).toBe(false);
   });
 
+  // Nothing repairs either of these. The keyring itself is re-tightened on every
+  // load, so a dropped mode there is a window; the lock is created, stamped and
+  // removed within one rotation, so a dropped mode there is simply a
+  // group/other-readable directory and owner file for as long as the lock is
+  // held. Neither carries a secret — the owner is a random token — but they sit
+  // in the keys dir, and SECURITY.md's at-rest note makes no carve-out for
+  // low-sensitivity files.
+  //
+  // Observed from INSIDE the lock through the injected `exec`, which the
+  // keychain backend calls while `withRotationLock` is still holding it. The
+  // file provider offers no such seam: its rotation takes, stamps and releases
+  // the lock in one synchronous stretch, so by the time `rotate()` resolves
+  // there is nothing left on disk to stat.
+  // `ctx.skip(reason)` rather than the file's usual `it.skipIf(!POSIX_MODES)`:
+  // both report as skipped rather than as a pass, but only this form carries the
+  // reason into the runner's output, which is what someone reading a Windows leg
+  // needs in order to tell a deliberate gate from a case that quietly vanished.
+  it('holds the rotation lock and its owner file owner-only', async (ctx) => {
+    if (!POSIX_MODES) {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const lock = join(dir, `${VAULT_KEY_FILENAME}.lock`);
+    let observed: { dir: number; owner: number } | undefined;
+    // As in the marker case: the umask only clears bits, so 0o000 is what makes
+    // a dropped `mode` argument show as 0666/0777 instead of being masked back
+    // down to the very value under test on a runner whose own umask is 0o077.
+    const previous = process.umask(0o000);
+    try {
+      const provider = new KeychainKeyProvider(dir, (args) => {
+        observed ??= {
+          dir: statSync(lock).mode & 0o777,
+          owner: statSync(join(lock, 'owner')).mode & 0o777,
+        };
+        if (args[0] === 'find-generic-password') return keyringJson(Buffer.alloc(32, 7));
+        return '';
+      });
+      await provider.rotate();
+    } finally {
+      process.umask(previous);
+    }
+
+    expect(observed).toBeDefined();
+    expect(observed?.owner).toBe(DATA_FILE_MODE);
+    expect(observed?.dir).toBe(DATA_DIR_MODE);
+    // And the lock really was released, so the modes above were read from a
+    // live lock rather than from a leftover one.
+    expect(existsSync(lock)).toBe(false);
+  });
+
   // The defect this backend carried: the keyring rode argv (`-w <json>`), and
   // an execFileSync error's `.message` echoes argv — so a failed write put the
   // key in an error that outlives the process and travels into logs. It rides
@@ -690,10 +780,48 @@ describe('createKeyProvider', () => {
     expect(createKeyProvider('hsm-cluster', dir)).toBeInstanceOf(FileKeyProvider);
   });
 
-  it.skipIf(process.platform === 'darwin')(
-    'rejects keychain custody on a platform without one',
-    () => {
-      expect(() => new KeychainKeyProvider(dir)).toThrow(/not available on this platform/);
-    },
-  );
+  /**
+   * The platform guard, driven from a FAKED platform rather than gated on the
+   * real one — so both directions run on every runner.
+   *
+   * A gated case can only ever assert the direction its host happens to be on,
+   * and the direction it cannot reach is the worse of the two: a guard
+   * hardcoded to ALWAYS fire makes `KeychainKeyProvider` unconstructable, which
+   * silently kills keychain custody for every macOS user — the backend a
+   * security-conscious user deliberately opts into. Measured before this
+   * landed: replacing the `process.platform` read with `'linux'` left the whole
+   * suite green on a macOS host AND on a Linux one, because the only case
+   * taking the default was `it.skipIf(process.platform === 'darwin')` — which
+   * expects a throw and is satisfied by a guard that is right for the wrong
+   * reason.
+   *
+   * Neither case reaches `runSecurity`: the constructor stores `exec` and
+   * returns, so construction is the whole subject here. Executing the real
+   * `/usr/bin/security` is a separate gap, and it needs a macOS runner —
+   * `test/vault/keychain-real-binary.test.ts` is where that lives.
+   */
+  describe('the platform guard, on every runner', () => {
+    it('constructs with the real exec on darwin', () => {
+      stubPlatform('darwin');
+
+      expect(() => new KeychainKeyProvider(dir)).not.toThrow();
+    });
+
+    it('refuses the real exec off darwin, naming the platform', () => {
+      stubPlatform('linux');
+
+      expect(() => new KeychainKeyProvider(dir)).toThrow(
+        /not available on this platform \(linux\)/,
+      );
+    });
+
+    // The guard is scoped to the real binary on purpose: an injected exec
+    // carries its own platform expectations, and every case above it depends on
+    // that. Pinned so the guard cannot be widened to the seam by accident.
+    it('lets an injected exec through off darwin', () => {
+      stubPlatform('linux');
+
+      expect(() => new KeychainKeyProvider(dir, () => '')).not.toThrow();
+    });
+  });
 });

--- a/packages/persistence/test/warn-era-cap.test.ts
+++ b/packages/persistence/test/warn-era-cap.test.ts
@@ -1,8 +1,9 @@
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { DATA_FILE_MODE } from '../src/paths.ts';
 import { capWarnEraEnforcementOnce } from '../src/warn-era-cap.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
@@ -25,6 +26,35 @@ describe('capWarnEraEnforcementOnce', () => {
     expect(result).toEqual({ capped: 1 });
     expect(db.policies.getCategoryAction('secret')).toBe('warn');
     expect(existsSync(join(store.dataDir, 'warn-era-capped'))).toBe(true);
+  });
+
+  // Nothing repairs this one. Every other owner-only write under ~/.aka is
+  // followed by a tighten that would restore the mode on a later pass, so
+  // dropping their create mode leaves a window; drop this one and the marker is
+  // group/other-readable for good. It carries no secret — it is an ISO
+  // timestamp — but it dates the machine's onboarding, and SECURITY.md's
+  // at-rest note makes no carve-out for low-sensitivity files.
+  it('writes the marker owner-only, with nothing to repair it afterwards', (ctx) => {
+    if (process.platform === 'win32') {
+      ctx.skip('POSIX modes do not apply on Windows');
+      return;
+    }
+    const db = store.open();
+    db.policies.upsertCategoryAction('secret', 'block');
+
+    // The umask only ever CLEARS bits, so under 0o000 the create keeps exactly
+    // what it asked for: 0600 with the mode, 0666 without it. Inheriting a
+    // runner's own 0o077 would hand back 0600 either way and the case would
+    // pass over the very mutant it exists to catch. Process-global, so restored
+    // in a `finally`.
+    const previous = process.umask(0o000);
+    try {
+      capWarnEraEnforcementOnce(db, 'warn', store.dataDir);
+    } finally {
+      process.umask(previous);
+    }
+
+    expect(statSync(join(store.dataDir, 'warn-era-capped')).mode & 0o777).toBe(DATA_FILE_MODE);
   });
 
   it('never runs twice, even if a fresh block row appears after the marker exists', () => {

--- a/web-ui/test/actions/exceptions.test.ts
+++ b/web-ui/test/actions/exceptions.test.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac } from 'node:crypto';
 import {
   chmodSync,
+  existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -23,6 +24,7 @@ import { maskMatch } from '@akasecurity/detections';
 import {
   BLOCKED_DETECTIONS_RETENTION_MS,
   dataDir,
+  dbSidecars,
   fingerprintValue,
   loadOrCreateFingerprintKey,
   type LocalDatabase,
@@ -279,6 +281,68 @@ beforeEach(() => {
 afterEach(() => {
   resetSingleton();
   removeTree(home);
+});
+
+/**
+ * Make the store unopenable: overwrite `aka.db` with bytes SQLite must refuse,
+ * then remove the sidecars that could roll it back over them.
+ *
+ * The sidecar set is `dbSidecars`, not a hand-spelled `-wal`/`-shm` pair. Those
+ * two are what SQLite keeps in write-ahead logging, which is what a CI temp dir
+ * does — but where WAL is unavailable it writes a `-journal` instead (a DrvFs
+ * `/mnt/c` path under WSL, some network mounts). A live rollback journal left
+ * behind lets SQLite roll the store back over the injected bytes, so the store
+ * OPENS, the action never takes its failure branch, and a case named for the
+ * "local store" error path stops exercising it — while still passing, because
+ * the assertions check the returned error shape rather than that corruption
+ * happened. Deriving the set means a fourth sidecar reaches these sites without
+ * an edit.
+ *
+ * The caller must have closed its handle first (`resetSingleton`).
+ */
+function clearSidecars(file: string): void {
+  for (const sidecar of dbSidecars(file)) rmSync(sidecar, { force: true });
+}
+
+function corruptTheStore(): void {
+  const file = join(dir, 'aka.db');
+  writeFileSync(file, 'not a database\n');
+  clearSidecars(file);
+  // The precondition, asserted rather than assumed: without it every case below
+  // would pass whether or not the injection took, which is the vacuity the
+  // hardcoded pair risked in the first place.
+  expect(() => openLocalDatabase(dir)).toThrow();
+}
+
+/**
+ * The injector's own guard. Every case that uses it asserts a returned error
+ * shape, so a narrowed sidecar set costs nothing there — the store still refuses
+ * to open under WAL, which is what a CI temp dir gives. The defect it is guarding
+ * against is therefore invisible to its callers by construction, and only an
+ * assertion on the injector can see it.
+ *
+ * Planting all three as plain files makes the check deterministic on every
+ * platform: no journal mode has to be coaxed into existence, and narrowing the
+ * set back to the `-wal`/`-shm` pair leaves `-journal` behind and fails here.
+ */
+describe('the corrupt-store injector clears every sidecar SQLite might have left', () => {
+  it('removes each path dbSidecars names, not just the WAL pair', () => {
+    resetSingleton();
+    const file = join(dir, 'aka.db');
+    const sidecars = dbSidecars(file);
+    // More than the pair, or this asserts nothing about the third.
+    expect(sidecars.length).toBeGreaterThan(2);
+    for (const sidecar of sidecars) writeFileSync(sidecar, 'leftover');
+
+    // The removal alone, NOT the whole injector. `corruptTheStore` ends by
+    // opening the store to prove the injection took, and a failed open UNLINKS a
+    // hot journal on its way out — measured: a planted `aka.db-journal` is gone
+    // after `openLocalDatabase` throws. So driving the whole injector here
+    // destroys the evidence, and a narrowed sidecar set stays green through it.
+    clearSidecars(file);
+
+    expect(sidecars.filter((sidecar) => existsSync(sidecar))).toEqual([]);
+  });
 });
 
 describe('addException — the only web code touching a raw secret', () => {
@@ -1218,10 +1282,7 @@ describe('approveBlocked — granting from the ledger, no value in play', () => 
       // store is replaced with bytes SQLite will refuse, which is the shape a
       // truncated or byte-flipped store arrives in.
       resetSingleton(); // close the handle before overwriting the file
-      writeFileSync(join(dir, 'aka.db'), 'not a database\n');
-      for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
-        rmSync(join(dir, sidecar), { force: true });
-      }
+      corruptTheStore();
 
       const res = await approveBlocked({ reference: REFERENCE, scope: '1h', reason: 'x' });
       expect(res.ok).toBe(false);
@@ -1230,10 +1291,7 @@ describe('approveBlocked — granting from the ledger, no value in play', () => 
 
     it('returns an error instead of rejecting when the ruleset read throws', async () => {
       resetSingleton();
-      writeFileSync(join(dir, 'aka.db'), 'not a database\n');
-      for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
-        rmSync(join(dir, sidecar), { force: true });
-      }
+      corruptTheStore();
 
       const res = await addException({ ruleId: RULE_ID, value: VALUE, scope: 'once', reason: 'x' });
       expect(res.ok).toBe(false);
@@ -1474,10 +1532,7 @@ describe('revokeException — terminal, audit-retained, and easy to no-op silent
       // returns.
       const grant = await activeGrant();
       resetSingleton(); // close the handle before overwriting the file
-      writeFileSync(join(dir, 'aka.db'), 'not a database\n');
-      for (const sidecar of ['aka.db-wal', 'aka.db-shm']) {
-        rmSync(join(dir, sidecar), { force: true });
-      }
+      corruptTheStore();
 
       const res = await revokeException(grant.id, 'x');
       expect(res.ok).toBe(false);

--- a/web-ui/test/helpers/store-bytes.test.ts
+++ b/web-ui/test/helpers/store-bytes.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
 
@@ -76,6 +76,25 @@ describe('storeBytes — the at-rest leak scanner', () => {
     const bytes = storeBytes(dir);
     expect(bytes).toContain('main-db-marker');
     for (const marker of Object.values(planted)) expect(bytes).toContain(marker);
+  });
+
+  // The data dir is not flat, and the one artifact that is nested is the one
+  // most worth reading: a snapshot cut short by a KILL leaves a `.bak.partial`
+  // staging DIRECTORY holding `copy`, a byte-complete image of the whole store,
+  // created at the process umask rather than 0600 (see `snapshotStore`). A
+  // top-level `isFile()` filter skipped it entirely, so a raw value sitting in
+  // that copy satisfied every `not.toContain` in the calling suite.
+  //
+  // Planted rather than produced by a real killed snapshot: nothing here can
+  // kill a process mid-`VACUUM INTO`. What is pinned is that the READER
+  // descends; that the product leaves this shape behind is
+  // `packages/persistence/test/internal/snapshot.test.ts`'s job.
+  it('descends into a staging directory, where a killed snapshot leaves a full copy', () => {
+    const stage = join(dir, 'aka.db.legacy.1.aaaaaaaa.bak.partial');
+    mkdirSync(stage);
+    writeFileSync(join(stage, 'copy'), 'staged-full-copy-marker');
+
+    expect(storeBytes(dir)).toContain('staged-full-copy-marker');
   });
 
   it('throws rather than reporting clean when the store is not where it expects', () => {

--- a/web-ui/test/helpers/store-bytes.ts
+++ b/web-ui/test/helpers/store-bytes.ts
@@ -23,10 +23,15 @@ function errnoCode(err: unknown): string | undefined {
  * (`aka.db.legacy.<ts>.<rand>.bak`) leave real copies in the same directory, and
  * a snapshot killed part-way leaves a `.bak.partial` beside them.
  *
- * Files only: `isFile()` skips directories, and nothing writes one under the
- * data dir today (`paths.ts`, `fingerprint.ts` and `warn-era-cap.ts` all write
- * flat). A future subdirectory would need this to recurse — it is not covered
- * for free the way a future sibling file is.
+ * It RECURSES, and that is load-bearing rather than defensive. The data dir is
+ * no longer flat: a snapshot cut short by a kill leaves a `.bak.partial`
+ * staging DIRECTORY holding `copy`, a byte-complete image of the whole store
+ * (see `snapshotStore` in `packages/persistence/src/internal/snapshot.ts`). An
+ * earlier version of this reader filtered to `isFile()` at the top level, so
+ * that copy — the single artifact most likely to hold a raw value at a loose
+ * mode — was the one thing a leak scan could not see, and every
+ * `not.toContain` over it reported clean. Directories are descended into;
+ * only their FILES contribute bytes.
  *
  * Nothing here is lenient, because an empty string contains no secret: any
  * silent shortfall turns every `not.toContain` caller into a no-op that reports
@@ -38,9 +43,18 @@ function errnoCode(err: unknown): string | undefined {
  * that branch must not be pinned only where it is easy to provoke.
  */
 export function storeBytes(dir: string, read: (path: string) => Buffer = readFileSync): string {
-  const names = readdirSync(dir, { withFileTypes: true })
-    .filter((entry) => entry.isFile())
-    .map((entry) => entry.name);
+  // Every FILE at or below `dir`, relative to it. A `Dirent` reports a symlink
+  // as neither a file nor a directory, so a planted link is skipped rather than
+  // followed — which also means this cannot loop on a symlink cycle.
+  const walk = (from: string, prefix = ''): string[] =>
+    readdirSync(from, { withFileTypes: true }).flatMap((entry) =>
+      entry.isDirectory()
+        ? walk(join(from, entry.name), `${prefix}${entry.name}/`)
+        : entry.isFile()
+          ? [`${prefix}${entry.name}`]
+          : [],
+    );
+  const names = walk(dir);
   if (!names.includes(DB_FILENAME)) {
     throw new Error(
       `no ${DB_FILENAME} under ${dir} — the at-rest scan is not reading the real store`,


### PR DESCRIPTION
The POSIX modes on `~/.aka` are the only at-rest control the store has. Several of them were
set but defended by nothing, and one artifact was left readable by construction. This closes
all of it, and makes each guarantee fail a test when it is removed.

## What was wrong

**A killed snapshot left a world-readable copy of the prompt corpus.** `VACUUM INTO` refuses a
target that already exists, so the staging copy could not be pre-created at `0600` — it landed
at the process umask and was tightened only just before the rename. A throw removed it; a
**kill** could not, and a plugin hook is killable at its 10s harness timeout. The sweep that
cleared abandoned ones ran only immediately before *another* snapshot, so on a machine that
never migrated again the copy stayed indefinitely.

**Every owner-only write set its mode twice** — once as the create mode, once as a `chmod`
afterwards — so either half could be deleted and the suite stayed green, because the other
repaired the end state and every assertion read the end state. The window that opens without
the create mode is real: the file exists *with its contents already in it* at the umask until
the chmod lands.

**Two files had no repair at all** — the warn-era marker and the vault rotation lock's owner
file. Drop their mode and they stay group/other-readable for good.

**The keychain platform guard was unasserted in the direction that matters.** A guard hardcoded
to always fire makes `KeychainKeyProvider` unconstructable, silently killing keychain custody
for every macOS user — and no runner caught it, because the only case taking the default was
`it.skipIf(process.platform === 'darwin')`.

## What changed

- Snapshot staging moved into an **owner-only directory** created before SQLite writes anything
  into it — untraversable from the first instant, and it survives a kill exactly as the copy
  does. Abandoned ones are now swept on **every store open**, age-bounded so a copy another
  opener has in flight is left alone. Both the new directory shape and the bare `.partial` file
  an older version left are swept, so an upgrade strands nothing.
- The file and directory create modes now live in **one primitive each** —
  `writeExclusiveOwnerOnlySync` and `mkdirOwnerOnlySync` — asserted directly under a `0o000`
  umask with no tighten in the way. The umask is the instrument: it only ever clears bits, so a
  runner's own `0o077` would return `0600` either way and pass over the mutant.
- Owner-only modes pinned on the warn-era marker and the rotation lock (directory and owner
  file). `aka init` now walks `keys/` as well as `data/` — `vault.key` itself, the one file that
  is not a copy of your data but the means to read it, was checked by nothing.
- The platform guard is driven from a **redefined** `process.platform` rather than gated on the
  real one, so both directions run on every runner.
- The `~/.aka` enumeration is now **derived from a tree walk** rather than a hand-picked module
  list, so a fifth artifact fails on both mode and classification. The doc guard's slice anchor
  is asserted unique — it occurred twice, and one reword would have silently widened the window
  back to the whole section.
- Corrupt-store fault injection derives its sidecars from `dbSidecars()` instead of a hardcoded
  `-wal`/`-shm` pair, so a live `-journal` can no longer let SQLite recover and quietly make
  those cases test nothing.
- The at-rest byte scanner now recurses, so the nested staging copy is actually read. Its own
  docblock had predicted this case; without it a raw value in that copy satisfied every
  `not.toContain`.

`SECURITY.md`'s "Data at rest" note is updated to match, including dropping the old advice to
hunt down and delete a `.bak.partial` by hand.

## Verification

Every guarantee above is mutation-proven: the behaviour was deliberately broken, the named test
confirmed red, the tree restored, and green re-confirmed. Examples — drop the create mode from
`writeExclusiveOwnerOnlySync` and `creates the file owner-only, by the create itself and not a
later chmod` fails; remove `reapStalePartials` from `openLocalDatabase` and `clears one left by
a killed snapshot, on an ordinary open` fails; set the platform guard to `'linux' !== 'darwin'`
and `constructs with the real exec on darwin` fails.

```
$ pnpm turbo run test --force
 Tasks:    45 successful, 45 total

$ pnpm lint
 Tasks:    24 successful, 24 total
Portability check passed: no violations found.

$ pnpm typecheck
 Tasks:    24 successful, 24 total

$ pnpm format:check
All matched files use Prettier code style!
```

Taken on macOS / Node 24.18. The QA-plan companion updates are tracked separately.