### PR TITLE
test(vault): pin the deref audit straddle above the page boundary

### DIFF
--- a/web-ui/test/pages/vault-page.test.ts
+++ b/web-ui/test/pages/vault-page.test.ts
@@ -19,6 +19,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import VaultPage from '../../app/(app)/vault/page.tsx';
 import { VaultDashboardClient } from '../../app/(app)/vault/VaultDashboardClient.tsx';
+import { db as appDb } from '../../app/lib/db.ts';
 
 // The vault route issues THREE DISTINCT store reads and hands each to its own
 // prop:
@@ -192,7 +193,26 @@ const OLDEST_OCCURRENCES = 5;
 
 // Far more batched render rows than a reader wants to scroll past, and enough
 // model/reveal crossings to overflow a page on their own.
+//
+// BATCHED_DEREFS is NOT a free knob, and the coupling is invisible from here:
+// what makes the row-list assertion below discriminating is that these rows are
+// seeded NEWER than every reveal (see `seedFixture`), so one leads the trail the
+// moment they stop being hidden. Seeded over the reveals' own range instead they
+// land ON the fifty-row cutoff, tied on `at` with a reveal and split from it by a
+// `randomUUID()` tie-break. Measured that way, with the route's read widened so
+// the assertion SHOULD fire: at seven both tied rows still fall inside the page,
+// at six it fired 2 runs in 3, and at three and at one it fired in none of them
+// — below six the guard does not weaken, it stops working altogether. Green,
+// guarding nothing, with no red run to say so. The `two deref reads disagree`
+// control below is what fails instead if this stops straddling.
 const BATCHED_DEREFS = 7;
+// BOTH batched reasons, alternating, so the trail carries each one. Asserting a
+// page excludes `view-render` proves nothing while every batched row seeded is a
+// `display`: the assertion holds for want of a candidate, not because the filter
+// works. Which of the two leads the wide page therefore depends on
+// BATCHED_DEREFS' parity, so the control below asserts membership of this set
+// rather than naming one reason.
+const BATCHED_REASONS = ['display', 'view-render'] as const;
 const SURFACED_DEREFS = DEFAULT_VAULT_DEREFS_LIMIT + 5;
 
 async function seedFixture(): Promise<void> {
@@ -227,7 +247,15 @@ async function seedFixture(): Promise<void> {
         });
       };
       for (let i = 0; i < SURFACED_DEREFS; i += 1) deref(BASE + i * 1_000, 'explicit-reveal');
-      for (let i = 0; i < BATCHED_DEREFS; i += 1) deref(BASE + i * 1_000, 'display');
+      // Newest-first: these sit ABOVE every reveal, not inside their range, so a
+      // read that stops hiding them puts one at the head of the very first page
+      // whatever BATCHED_DEREFS is — no reliance on where the cutoff happens to
+      // fall, and none on the tie-break that decides a row sitting exactly on it.
+      for (let i = 0; i < BATCHED_DEREFS; i += 1)
+        deref(
+          BASE + (SURFACED_DEREFS + i) * 1_000,
+          i % 2 === 0 ? BATCHED_REASONS[0] : BATCHED_REASONS[1],
+        );
     });
   } finally {
     db.close();
@@ -301,6 +329,41 @@ describe('the vault route wires each read to the prop that needs it', () => {
       `vault-${String(SEEDED_VALUES - 2).padStart(2, '0')}`,
     );
     expect(props.reuse.items.map((e) => e.pointerId)).not.toContain(NEWEST_POINTER);
+  });
+
+  it('is a fixture the two deref reads disagree on', () => {
+    // The control for the case below. The route issues only the NARROW read, so
+    // nothing downstream can see whether the wide one would have differed — and
+    // if the batched rows sat below the page cutoff, both reads would return the
+    // same fifty rows and `not.toContain('display')` would hold whichever one the
+    // route used. Pin the disagreement itself, so a fixture that stops straddling
+    // the filter fails here by name rather than quietly emptying the assertion.
+    //
+    // Both reads go through the app's memoised handle — the one the route itself
+    // uses — rather than a second connection of their own. It is not necessarily
+    // already open: `seedFixture` drops it, so whichever case runs first re-opens
+    // it, and under a `-t` filter that is this one. Read-only either way.
+    const vault = appDb().secretVault;
+    const narrow = vault.listDerefs();
+    const wide = vault.listDerefs({ includeBatched: true });
+
+    // The two reads lead with DIFFERENT rows, stated from both sides so each
+    // half can fail on its own. A batched row leads the wide page — the property
+    // that survives any BATCHED_DEREFS, where "appears somewhere in it" would
+    // not — and the narrow one still leads with a reveal, which is what goes red
+    // if the filter itself stops excluding. Asserting the two ID lists merely
+    // differ would be implied by the first line and could never fail alone.
+    expect(BATCHED_REASONS).toContain(wide.items[0]?.reason);
+    expect(narrow.items[0]?.reason).toBe('explicit-reveal');
+    // And they are separated STRICTLY in time, never tied. This is the half the
+    // comments above promise and nothing else states: a batched row that merely
+    // ties with the newest reveal would be ordered by the `randomUUID()`
+    // tie-break, turning the assertion above into a coin flip rather than a
+    // failure. `Date.parse` of a missing row is NaN, which fails rather than
+    // passes.
+    expect(Date.parse(wide.items[0]?.at ?? '')).toBeGreaterThan(
+      Date.parse(narrow.items[0]?.at ?? ''),
+    );
   });
 
   it('hides the batched render reasons from the trail and counts them whole', () => {

--- a/web-ui/test/pages/vault-page.test.ts
+++ b/web-ui/test/pages/vault-page.test.ts
@@ -199,12 +199,20 @@ const OLDEST_OCCURRENCES = 5;
 // seeded NEWER than every reveal (see `seedFixture`), so one leads the trail the
 // moment they stop being hidden. Seeded over the reveals' own range instead they
 // land ON the fifty-row cutoff, tied on `at` with a reveal and split from it by a
-// `randomUUID()` tie-break. Measured that way, with the route's read widened so
-// the assertion SHOULD fire: at seven both tied rows still fall inside the page,
-// at six it fired 2 runs in 3, and at three and at one it fired in none of them
-// — below six the guard does not weaken, it stops working altogether. Green,
-// guarding nothing, with no red run to say so. The `two deref reads disagree`
-// control below is what fails instead if this stops straddling.
+// `randomUUID()` tie-break.
+//
+// What that costs is measured against the mutation the row-list assertion is the
+// ONLY guard against: dropping `listDerefs`' row filter while leaving its
+// `hiddenBatched` count alone. Those are independent statements, so the count
+// still reads BATCHED_DEREFS and nothing but `not.toContain` can notice. Widening
+// the route's read is the WRONG probe for this and proves nothing here, because
+// `includeBatched: true` short-circuits that same count to 0 — so `hiddenBatched`
+// fails first however the fixture is seeded. Filter dropped, three runs each:
+// seeded in range at three, the row-list case PASSED 3/3, inert against a filter
+// deleted outright rather than merely weakened; seeded above the reveals it fails
+// 3/3 at seven and still 3/3 at one. Green and guarding nothing is the state this
+// keeps out, and no red run announces it. The `two deref reads disagree` control
+// below is what fails instead if this stops straddling.
 const BATCHED_DEREFS = 7;
 // BOTH batched reasons, alternating, so the trail carries each one. Asserting a
 // page excludes `view-render` proves nothing while every batched row seeded is a


### PR DESCRIPTION
## Summary

`web-ui/test/pages/vault-page.test.ts` guards the vault route's de-reference read in two halves:
the row list must exclude the batched `display` / `view-render` reasons, and `hiddenBatched` must
count them whole. The count half was robust. **The row-list half only just worked.**

The fixture seeded both reason kinds over the *same* timestamp range, with the batched rows at the
bottom of it. With 55 reveals spanning `BASE+0…BASE+54000` and 7 batched rows spanning only
`BASE+0…BASE+6000`, against `ORDER BY at DESC, id DESC LIMIT 50`, the newest batched row landed at
page position **49/50** — tied on `at` with a reveal and separated from it by a `randomUUID()`
tie-break. Deterministic at the shipped count, and a coin flip one row below it.

Nothing in the file connected the batched-row count to the page limit, so trimming it for seed cost
was an obvious, apparently safe edit that half-disarmed the guard **with no red run to warn anyone.**

## Changes

- **Seed the batched rows above every reveal.** The narrow read filters on reason, not time, so
  every existing assertion is unchanged — but a widened read now puts a batched row at the *head*
  of the first page whatever the count is. No dependence on where the cutoff falls, or on the
  tie-break for a row sitting exactly on it.
- **Add a control case**, `is a fixture the two deref reads disagree on`, matching the two control
  cases the file already carries. It pins the disagreement from both sides *and* asserts strict
  time separation, so a future offset change that reintroduces a tie fails deterministically
  instead of turning the control into a 50/50 flake.
- **Seed both batched reasons.** The fixture previously wrote only `display`, so the sibling
  assertion that the page excludes `view-render` was inert — it passed for want of a candidate.

## Verification

All measured in this session on arm64 macOS / Node 24. Command throughout:

```
pnpm --filter @akasecurity/web-ui exec vitest run test/pages/vault-page.test.ts
```

**The defect.** The probe is the mutation the row-list assertion is the *only* guard against:
dropping `listDerefs`' row filter while leaving its `hiddenBatched` count alone. Those are two
independent statements (`secret-vault.ts:612-615` and `:648-653`), so the count still reads
`BATCHED_DEREFS` and nothing but `not.toContain` can notice.

Filter dropped, `-t "hides the batched render reasons"`, three runs each:

```
old seeding,  BATCHED_DEREFS=3  -> passed 3/3   (guard fully inert)
this seeding, BATCHED_DEREFS=7  -> failed 3/3
this seeding, BATCHED_DEREFS=1  -> failed 3/3
```

So the old fixture was not merely fragile at the page boundary — it was green with the filter
**deleted outright**. The new one holds at the weakest count the knob can take.

> An earlier revision of this description measured a *widened* route read instead. That probe is
> confounded and is no longer cited: `includeBatched: true` short-circuits `hiddenBatched` to `0`
> as well, so the count assertion fails first however the fixture is seeded, and the experiment
> cannot separate the two halves. Caught in review; the in-code comment now names the isolating
> mutation instead.

**The control is non-vacuous**, proved three ways with the route read *unmutated*:

- seeding reverted in-range at 6 (where the row-list half was a coin flip) — control fires **3/3**;
- degenerate fixture, no batched rows at all — control is the **only** failure while the other
  seven tests pass vacuously;
- batched rows forced to *tie* with the newest reveal — the strict-separation assertion fires
  **3/3** while the reason check stays silent, which is exactly the flake it backstops.

**The `view-render` assertion is now non-vacuous.** Dropping `'view-render'` from the repository's
`reason NOT IN (...)` filter reds it:

```
AssertionError: expected [ 'view-render', 'view-render', …(48) ] to not include 'view-render'
```

Before this change that mutation left the whole file green.

**Gates:**

```
prettier      clean            lint          exit 0
typecheck     exit 0           portability   no violations
web-ui        28 files / 505 tests passed
persistence   82 files / 1213 passed, 3 skipped
```

Test-only change — no product code touched.

