### PR TITLE
perf(persistence): skip the pre-drop snapshot when the store holds nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1995,12 +1995,21 @@ straddle the two windows and **pin the straddle itself** — with rows that all 
 both, the assertions pass whichever read the page used, and the suite proves nothing.
 
 An at-rest leak scan must read **every file in the data dir**, not `aka.db` plus a
-hardcoded `-wal`/`-shm` pair. This is not a corner case: a migration leaves an
-`aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the pre-migration store — in that
-directory on **every** run, and it is around 47% of the bytes there, so a name-list reader
-misses more of the store than a `-wal` pair ever covered. On top of that SQLite writes an
+hardcoded `-wal`/`-shm` pair. This is not a corner case: the legacy-drop migration leaves an
+`aka.db.pre-drop.<ts>.<rand>.bak` — a byte-for-byte copy of the pre-migration store, so
+roughly as many bytes again as the store itself — beside it, and a name-list reader misses
+more of the store there than a `-wal` pair ever covered. On top of that SQLite writes an
 `aka.db-journal` instead of the WAL pair wherever WAL silently no-ops (see `dbSidecars` in
 `packages/persistence/src/paths.ts`), and the foreign-lineage reset leaves its own `.bak`.
+
+**That `.bak` no longer appears on every run, and the change makes a name-list reader MORE
+dangerous rather than less.** `legacyDropNeedsBackup` in
+`packages/persistence/src/migrations.ts` skips the snapshot when the store
+demonstrably holds nothing the drop could destroy, which is every brand-new store — so a
+fresh-store fixture now produces no `.bak` at all. A hardcoded reader exercised only against
+one therefore looks complete while the single case that still writes the copy — a store
+carrying real legacy history, i.e. the one whose backup holds a real prompt corpus — is
+exactly the case it cannot see. Read the directory.
 `web-ui/test/helpers/store-bytes.ts` is that reader; import it rather than re-rolling one.
 Bind one call and assert against it — the positive control and the absence check must
 describe the same bytes, not two independent reads. Two rules keep it honest, because an

--- a/cli/test/commands/init.test.ts
+++ b/cli/test/commands/init.test.ts
@@ -87,9 +87,13 @@ afterEach(() => {
 });
 
 // Every path under `home`, the home itself included. A hardcoded list of the
-// paths init writes cannot cover what a later change adds — the migration's
-// `aka.db.pre-drop.<ts>.bak`, a byte-for-byte copy of the store, is already one
-// such file and no list here names it.
+// paths init writes rots in BOTH directions, and the legacy-drop migration's
+// `aka.db.pre-drop.<ts>.bak` — a byte-for-byte copy of the store — has now done
+// each in turn: it once landed on every fresh init while no list here named it,
+// and it no longer lands here at all (legacyDropNeedsBackup skips the snapshot
+// on a store that holds nothing the drop could destroy), so a list updated to
+// name it would now name a file that never appears. A walk is right whichever
+// way the next change goes.
 //
 // Deliberately its own walk rather than a call into looseStorePaths: a test that
 // reuses the implementation it is checking cannot catch a bug in that walk.

--- a/packages/persistence/src/db/migrations/introspection.ts
+++ b/packages/persistence/src/db/migrations/introspection.ts
@@ -74,6 +74,41 @@ export function columnNames(
   return columns.map((c) => c.name);
 }
 
+/**
+ * Every table the store carries, in sqlite_master order, excluding SQLite's own
+ * internal `sqlite_*` bookkeeping tables. Views are excluded too — the `type`
+ * filter is what keeps a dropped-then-viewed name (the legacy `events`/
+ * `findings` pair) out of the list once the compatibility views replace it.
+ */
+export function tableNames(db: DatabaseSync): string[] {
+  const rows = db
+    .prepare(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite\\_%' ESCAPE '\\'",
+    )
+    .all() as { name: string }[];
+  return rows.map((r) => r.name);
+}
+
+/**
+ * True when any of `names` holds at least one row.
+ *
+ * ONE prepared statement for the whole set rather than one per table: each
+ * probe is an `EXISTS`, which stops at the first row, and `OR` short-circuits,
+ * so a store with history answers without reading past its first non-empty
+ * table. An empty list is false — no table can hold a row.
+ *
+ * Names come from sqlite_master and cannot be bound as parameters; doubling any
+ * embedded quote keeps each identifier a single token.
+ */
+export function anyTableHasRows(db: DatabaseSync, names: readonly string[]): boolean {
+  if (names.length === 0) return false;
+  const probes = names
+    .map((name) => `EXISTS(SELECT 1 FROM "${name.replaceAll('"', '""')}")`)
+    .join(' OR ');
+  const row = db.prepare(`SELECT (${probes}) AS present`).get() as { present: number };
+  return Boolean(row.present);
+}
+
 export function evidenceExists(db: DatabaseSync, object: EvidenceObject): boolean {
   if (object.kind === 'column') {
     // table_xinfo, NOT table_info: generated columns are invisible to table_info,

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -4,12 +4,14 @@ import type { EventKind, EventMetadata, SourceTool } from '@akasecurity/schema';
 import { SQLITE_MIGRATIONS, toCaptureAttributes } from '@akasecurity/schema';
 
 import {
+  anyTableHasRows,
   columnNames,
   evidenceExists,
   type EvidenceObject,
   evidenceObjects,
   indexExists,
   schemaObjectExists,
+  tableNames,
 } from './db/migrations/introspection.ts';
 import { inspectionDefinitionId, sourceProjectId } from './ids.ts';
 import { bindParams } from './internal/rows.ts';
@@ -233,17 +235,18 @@ export function applyMigrations(db: DatabaseSync, file?: string): void {
 // Runs the legacy-drop migration's own DDL (dropping `events`/`findings` and
 // creating their compatibility views) and ledgers its tag — called ONLY once
 // runLegacyHistoryBackfill has reported both legacy tables fully drained.
-// Backs the live file up first (when a real path is known — a `:memory:` or
-// path-less caller, i.e. tests, has nothing durable to protect), mirroring
-// backupLegacyStore's shape in database.ts. A failed backup defers the drop
-// entirely rather than proceeding without one — history is never destroyed
-// on a best-effort basis.
+// Backs the live file up first — when a real path is known (a `:memory:` or
+// path-less caller, i.e. tests, has nothing durable to protect) AND the store
+// has something to protect (legacyDropNeedsBackup; a store this open just built
+// does not), mirroring backupLegacyStore's shape in database.ts. A failed
+// backup defers the drop entirely rather than proceeding without one — history
+// is never destroyed on a best-effort basis.
 export function applyLegacyDropMigration(db: DatabaseSync, file: string | undefined): void {
   const migration = SQLITE_MIGRATIONS.find((m) => m.tag === LEGACY_DROP_MIGRATION_TAG);
   // Should not happen in a released build (schema and persistence version
   // together), but a missing migration must never crash an open.
   if (!migration) return;
-  if (file) {
+  if (file && legacyDropNeedsBackup(db)) {
     try {
       backupBeforeLegacyDrop(db, file);
     } catch (error) {
@@ -284,6 +287,67 @@ export function applyLegacyDropMigration(db: DatabaseSync, file: string | undefi
     );
   } catch (error) {
     akaWarn(`legacy events/findings drop failed; deferring: ${String(error)}`);
+  }
+}
+
+// Tables whose rows a migration writes ITSELF, so rows in them say nothing
+// about whether the store carries user history. Both are written by
+// applyMigrations before the drop is reached: the ledger it keeps its own state
+// in, and the installed_packs write gate's single control row
+// (ensureWriteGateTrigger).
+//
+// The list is deliberately as short as the probe point requires, and it is
+// pinned as an EXACT set by legacy-compat-views.test.ts. An entry here is a table whose
+// contents STOP BEING EVIDENCE, so a wrong one skips a backup that was owed —
+// and nothing else in the suite notices, because every other case reaches its
+// verdict through some other table. `policies` is the worked example of what
+// does NOT belong: it looks seeded, but seedDefaults() runs in openLocalDatabase
+// AFTER applyMigrations, so the table is empty here and listing it would only
+// have hidden a user's customized rows from a later caller.
+export const MIGRATION_SEEDED_TABLES: ReadonlySet<string> = new Set([
+  'migration_ledger',
+  '_pack_write_gate',
+]);
+
+// Whether the pre-drop snapshot is owed, read ENTIRELY out of the open store.
+//
+// The snapshot exists so the irreversible `events`/`findings` drop can never
+// destroy history on a best-effort basis, and on a store that carries any it
+// always runs. But the drop is also reached on the FIRST open of a brand-new
+// store: the earlier migrations have just created the legacy pair empty, the
+// backfill drains nothing, and the snapshot copies a freshly built schema —
+// a second full copy of the store file, on every install, protecting nothing.
+//
+// One rule separates the two: every table the store holds must be empty, bar
+// the seeded pair. The table list is read from sqlite_master rather than
+// written down here, so a table a later migration adds counts as evidence by
+// default — the case nobody has thought about falls on the side that takes the
+// backup, and only an explicit entry in MIGRATION_SEEDED_TABLES can take a
+// table out of the reckoning.
+//
+// That general rule is also what covers the case worth naming: a store part-way
+// through — or just finished with — the legacy drain. `legacy_copy_watermark`
+// is a plain table, written inside the same transaction that copies each page
+// of legacy rows (see drainLegacyTable), so a store that ever drained a legacy
+// row carries a row there and is snapshotted here whatever else it now holds.
+// It needs no special case, but it does mean adding that table to the seeded
+// set above would quietly cost a genuinely-upgraded store its snapshot.
+//
+// Nothing here is threaded in from the caller. `applyLegacyDropMigration` is
+// exported and callable directly, so a parameter would be a way for a caller to
+// skip a backup that was owed; the question is asked of the store instead, and
+// a store cannot lie about its own rows.
+export function legacyDropNeedsBackup(db: DatabaseSync): boolean {
+  try {
+    const candidates = tableNames(db).filter((name) => !MIGRATION_SEEDED_TABLES.has(name));
+    return anyTableHasRows(db, candidates);
+  } catch (error) {
+    // A probe that could not run leaves the question unanswered, and the
+    // unanswered case is the one that takes the backup.
+    akaWarn(
+      `could not rule out legacy history before the drop; backing up anyway: ${String(error)}`,
+    );
+    return true;
   }
 }
 

--- a/packages/persistence/test/at-rest-surface.test.ts
+++ b/packages/persistence/test/at-rest-surface.test.ts
@@ -121,6 +121,13 @@ const DOCUMENTED_EXCLUSIONS: readonly {
     pattern: /\.bak$/,
     reason:
       'a snapshot copy of the store; the note covers these in their own paragraph rather than in the file list, because the name carries a timestamp',
+    // Unobservable to the walk below, and deliberately so: the only snapshot an
+    // ordinary store ever took was the pre-drop one on its very first open, and
+    // a brand-new store no longer takes it (legacyDropNeedsBackup — there is
+    // nothing in a store this open just built to protect). The copy is still
+    // written, on a store that carries legacy history, and is still owner-only.
+    coveredBy:
+      "test/database.test.ts — 'writes the pre-drop VACUUM INTO backup owner-only (0600), not the umask default'",
   },
   {
     pattern: new RegExp(`\\.bak${escapeRe(SNAPSHOT_STAGING_SUFFIX)}$`),

--- a/packages/persistence/test/database.test.ts
+++ b/packages/persistence/test/database.test.ts
@@ -16,6 +16,7 @@ import type { DetectedFinding, IngestEvent } from '@akasecurity/schema';
 import { DEFAULT_ACTIONS } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
+import { schemaObjectExists } from '../src/db/migrations/introspection.ts';
 import { captureId } from '../src/ids.ts';
 import { backupBeforeLegacyDrop } from '../src/migrations.ts';
 import { descriptorProbe } from './helpers/descriptors.ts';
@@ -341,7 +342,14 @@ describe('openLocalDatabase sweeps abandoned snapshot staging', () => {
    */
   function migratedStore(): void {
     store.open();
-    expect(readdirSync(store.dataDir).some((name) => name.endsWith('.bak'))).toBe(true); // the first open really did take its pre-drop snapshot
+    // The first open really did run the legacy drop: `events` is a view now,
+    // not a table. That used to be evidenced by the pre-drop `.bak` the open
+    // left behind, but a brand-new store no longer takes one — it holds nothing
+    // the drop could destroy (see legacyDropNeedsBackup). The drop itself is
+    // what these cases need to have happened, so assert that directly.
+    const raw = store.openRaw();
+    expect(schemaObjectExists(raw, 'view', 'events')).toBe(true);
+    expect(schemaObjectExists(raw, 'table', 'events')).toBe(false);
   }
 
   // A staging area exactly as a killed process leaves one: the directory, and

--- a/packages/persistence/test/legacy-compat-views.test.ts
+++ b/packages/persistence/test/legacy-compat-views.test.ts
@@ -28,8 +28,11 @@ import {
   applyLegacyDropMigration,
   backupBeforeLegacyDrop,
   LEGACY_BACKFILL_MAX_ROWS_PER_CALL,
+  legacyDropNeedsBackup,
+  MIGRATION_SEEDED_TABLES,
 } from '../src/migrations.ts';
-import { DB_FILENAME } from '../src/paths.ts';
+import { DB_FILENAME, dbSidecars } from '../src/paths.ts';
+import { corruptStore } from './helpers/fault-injection.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 import { assertNoOpenTransaction } from './helpers/transactions.ts';
 
@@ -80,6 +83,29 @@ function seedPreCutoverFile(): string {
     raw.exec(migration.sql);
   }
   raw.close();
+  return file;
+}
+
+// The state the drop is really reached in: every migration applied EXCEPT the
+// drop itself, so `legacy_copy_watermark` (0013) exists and the legacy pair is
+// still a pair of real tables. seedPreCutoverFile() freezes one migration
+// earlier, which is the right fixture for the drain but the wrong one for any
+// question about the store's own upgrade record.
+function seedPreDropFile(): string {
+  const file = seedPreCutoverFile();
+  const raw = new DatabaseSync(file);
+  // Same reasoning as seedPreCutoverFile's own pragmas: fixture durability is
+  // irrelevant, and the default DELETE journal's per-statement fsync is what
+  // pushes this file past its timeout on the Windows runner.
+  raw.exec('PRAGMA journal_mode = MEMORY');
+  raw.exec('PRAGMA synchronous = OFF');
+  try {
+    const sql = SQLITE_MIGRATIONS.find((m) => m.tag === MIGRATION_0013_TAG)?.sql;
+    if (sql === undefined) throw new Error(`missing migration ${MIGRATION_0013_TAG}`);
+    raw.exec(sql);
+  } finally {
+    raw.close();
+  }
   return file;
 }
 
@@ -630,6 +656,202 @@ describe('legacy events/findings compatibility views', () => {
     } finally {
       db.close();
     }
+  });
+
+  // --- the pre-drop snapshot is owed, or it is not -------------------------
+  // The drop is reached on the FIRST open of every brand-new store, where the
+  // legacy pair was created empty milliseconds earlier by this same open. The
+  // snapshot there copies a freshly built schema and nothing else — a second
+  // full copy of the store file on every install. legacyDropNeedsBackup is what
+  // separates that from a store carrying history; these pin both sides of it.
+
+  it('a brand-new store takes no pre-drop backup — there is nothing in it to protect', () => {
+    const db = store.open();
+    db.close();
+
+    // The drop really did run on this open (otherwise "no backup" would hold
+    // for the wrong reason — a deferred drop needs no backup either).
+    const raw = store.openRaw();
+    try {
+      expect(schemaObjectExists(raw, 'view', 'events')).toBe(true);
+      expect(schemaObjectExists(raw, 'table', 'events')).toBe(false);
+    } finally {
+      raw.close();
+    }
+
+    const entries = readdirSync(store.dataDir).sort();
+    // Positive control FIRST. The absence check below is a filter, and a filter
+    // over an empty directory is empty — so on its own it passes just as well
+    // against a store that was never written at all.
+    expect(entries).toContain(DB_FILENAME);
+    // Only the store itself and its own sidecars are on disk: no `.pre-drop.`
+    // copy, and no staging directory left behind by one either. Measured on
+    // arm64 macOS / Node 24 the list is exactly ['aka.db'] — every sidecar is
+    // checkpointed away by the close above — but the sidecars are part of the
+    // store rather than a copy of it, so they are allowed rather than pinned.
+    const allowed = new Set([DB_FILENAME, ...dbSidecars(DB_FILENAME)]);
+    expect(entries.filter((f) => !allowed.has(f))).toEqual([]);
+  });
+
+  it('a store carrying legacy rows is still snapshotted before the drop', () => {
+    const file = seedPreCutoverFile();
+    const raw = new DatabaseSync(file);
+    raw.exec('PRAGMA foreign_keys = ON');
+    insertLegacyEvent(raw, 'ev-keep', 1_000, null);
+    raw.close();
+
+    const db = store.open();
+    db.close();
+
+    expect(readdirSync(store.dataDir).filter((f) => f.includes('.pre-drop.'))).toHaveLength(1);
+
+    // And the snapshot was taken on the way THROUGH the drop, not because the
+    // drop deferred — a deferral leaves a backup behind too, so the count above
+    // does not distinguish them on its own.
+    const after = store.openRaw();
+    try {
+      expect(schemaObjectExists(after, 'view', 'events')).toBe(true);
+      expect(schemaObjectExists(after, 'table', 'events')).toBe(false);
+    } finally {
+      after.close();
+    }
+  });
+
+  it('a failed snapshot still defers the drop on a store carrying legacy rows', () => {
+    const file = seedPreDropFile();
+    const db = new DatabaseSync(file);
+    db.exec('PRAGMA foreign_keys = ON');
+    db.exec(
+      'CREATE TABLE IF NOT EXISTS migration_ledger (tag TEXT PRIMARY KEY, applied_at INTEGER NOT NULL)',
+    );
+    // Real legacy history, so the snapshot is unambiguously owed.
+    insertLegacyEvent(db, 'ev-doomed', 1_000, null);
+    try {
+      expect(legacyDropNeedsBackup(db)).toBe(true);
+
+      // Point the snapshot at a data dir that does not exist: staging the copy
+      // throws, on every platform and without needing a chmod or a privilege.
+      const unreachable = join(store.dataDir, 'no-such-dir', DB_FILENAME);
+      expect(() => {
+        applyLegacyDropMigration(db, unreachable);
+      }).not.toThrow();
+
+      // Deferred, not proceeded-without-one: the legacy pair is untouched, no
+      // view was created, and the tag is not ledgered — the next open retries.
+      expect(schemaObjectExists(db, 'table', 'events')).toBe(true);
+      expect(schemaObjectExists(db, 'view', 'events')).toBe(false);
+      expect(
+        db.prepare('SELECT 1 FROM migration_ledger WHERE tag = ?').get(MIGRATION_0014_TAG),
+      ).toBeUndefined();
+      expect((db.prepare('SELECT count(*) AS n FROM events').get() as { n: number }).n).toBe(1);
+      // A deferred drop must not leave its own transaction open behind it.
+      assertNoOpenTransaction(db);
+
+      // Positive control on the SAME store and the same call: the only thing
+      // that changes is whether the snapshot can be written. With a reachable
+      // path the drop completes and the copy lands — so the deferral above is
+      // attributable to the failed snapshot rather than to anything else about
+      // this fixture.
+      applyLegacyDropMigration(db, file);
+      expect(schemaObjectExists(db, 'view', 'events')).toBe(true);
+      expect(schemaObjectExists(db, 'table', 'events')).toBe(false);
+      expect(readdirSync(store.dataDir).filter((f) => f.includes('.pre-drop.'))).toHaveLength(1);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('a row anywhere outside the legacy pair still owes the backup — a mid-upgrade store', () => {
+    const file = seedPreDropFile();
+    const db = new DatabaseSync(file);
+    db.exec('PRAGMA foreign_keys = ON');
+    try {
+      // The legacy pair is empty, exactly as on a brand-new store...
+      expect((db.prepare('SELECT count(*) AS n FROM events').get() as { n: number }).n).toBe(0);
+      expect(legacyDropNeedsBackup(db)).toBe(false);
+
+      // ...but a store part-way through the upgrade carries its drained history
+      // in audit_events, and that is evidence the snapshot is owed.
+      db.prepare(
+        "INSERT INTO audit_events (id, event_type, started_at) VALUES ('sess-1', 'session', 1000)",
+      ).run();
+      expect(legacyDropNeedsBackup(db)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('a drained watermark owes the backup — the case the general rule has to cover', () => {
+    // The watermark is the store's own record that legacy rows were once copied
+    // out of it, and it is written atomically with those rows (drainLegacyTable).
+    // It gets no special case in legacyDropNeedsBackup: `legacy_copy_watermark`
+    // is a plain table, so a row in it is evidence under the general rule like
+    // any other. This is what would go red if it were ever added to
+    // MIGRATION_SEEDED_TABLES — which would cost a genuinely-upgraded store its
+    // snapshot the day `audit_events` gains a retention sweep and such a store
+    // can present as otherwise empty.
+    const file = seedPreDropFile();
+    const db = new DatabaseSync(file);
+    db.exec('PRAGMA foreign_keys = ON');
+    try {
+      expect(legacyDropNeedsBackup(db)).toBe(false);
+      db.prepare(
+        "INSERT INTO legacy_copy_watermark (source, last_rowid) VALUES ('events', 42)",
+      ).run();
+      expect(legacyDropNeedsBackup(db)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('an unanswerable probe backs up rather than assuming there is nothing to protect', () => {
+    // A store whose schema cannot be read at all answers neither way, and the
+    // unanswered case has to take the backup. Without the guard the throw would
+    // escape applyMigrations and fail the whole open, where today a store this
+    // damaged merely defers the drop.
+    // The store is left in the state the PRODUCTION caller probes: mid-open,
+    // before openLocalDatabase seeds the default policies. A fully-opened store
+    // is the wrong control here — its seeded `policies` rows are real evidence,
+    // so the probe rightly says "back up" and the assertion below would have to
+    // be bought with an allowlist entry the production path never needs.
+    const file = seedPreDropFile();
+
+    // Positive control on the very same store: healthy and carrying nothing,
+    // the probe says there is nothing to protect. Only the damage below can
+    // flip it, so the assertion after it cannot hold for the boring reason.
+    const healthy = new DatabaseSync(file);
+    try {
+      expect(legacyDropNeedsBackup(healthy)).toBe(false);
+    } finally {
+      healthy.close();
+    }
+
+    corruptStore(file, 'header', { store });
+    const damaged = new DatabaseSync(file);
+    try {
+      expect(legacyDropNeedsBackup(damaged)).toBe(true);
+    } finally {
+      damaged.close();
+    }
+  });
+
+  it('MIGRATION_SEEDED_TABLES is pinned exactly — widening it hides real evidence', () => {
+    // The ONE hand-maintained input to legacyDropNeedsBackup, and the only way
+    // to skip a backup that was owed. A table listed there stops counting as
+    // evidence, so adding one that holds user data — `exceptions`,
+    // `secret_vault`, `inspection_findings` — makes a store holding only that
+    // read as "nothing to protect". Measured: with those three added, every
+    // other test in this package still passed, so nothing but an exact set
+    // makes the widening loud.
+    //
+    // Both entries are written by applyMigrations itself, BEFORE the drop is
+    // reached: the ledger it records its own progress in, and the
+    // installed_packs write gate's single control row (ensureWriteGateTrigger).
+    // `policies` is the near miss and is deliberately absent — seedDefaults()
+    // runs in openLocalDatabase AFTER applyMigrations, so the table is empty at
+    // the probe point and listing it would only have hidden a user's
+    // customized rows.
+    expect([...MIGRATION_SEEDED_TABLES].sort()).toEqual(['_pack_write_gate', 'migration_ledger']);
   });
 
   it('pre-drop backup is a sidecar-free snapshot that includes WAL-resident committed rows', () => {


### PR DESCRIPTION
## Summary

Opening a brand-new store wrote a full byte-for-byte copy of itself to
`aka.db.pre-drop.<ts>.<rand>.bak` before doing anything with it.

Migration `0014` drops the legacy `events`/`findings` tables, and because that
drop is irreversible `applyLegacyDropMigration` snapshots the live store aside
first — deferring the drop entirely if the snapshot fails. That is right for a
store carrying history. But the drop is also reached on the **first open of
every new store**, where the earlier migrations created the legacy pair empty
milliseconds earlier, the backfill drains nothing, and the copy duplicates a
schema this same open just built. It cost every `aka init`, every first hook
run on a new machine, and the dashboard's and CLI's first open.

## Changes

- **`legacyDropNeedsBackup(db)`** gates the snapshot. One rule: every table the
  store holds must be empty, bar the two `applyMigrations` seeds itself
  (`migration_ledger`, `_pack_write_gate`). The table list is read from
  `sqlite_master` rather than written down, so a table a later migration adds
  counts as evidence **by default** — the unconsidered case falls on the side
  that takes the backup — and a store too damaged to probe still takes it.
- **Nothing is threaded in from the caller.** `applyLegacyDropMigration` is
  exported and directly callable, so a parameter would be a way for a caller to
  skip a backup that was owed; the question is asked of the store instead.
- **`MIGRATION_SEEDED_TABLES` is pinned as an exact set.** Widening it to a
  user-data table is the one edit that can skip an owed backup, and it left the
  whole package green — see "Review findings" below.
- **`'policies'` dropped from that set.** `seedDefaults()` runs in
  `openLocalDatabase` *after* `applyMigrations`, so the table is empty at the
  probe point; listing it only hid a user's customized rows.
- **`sqlite_master` probing moved to `db/migrations/introspection.ts`** (`tableNames`,
  `anyTableHasRows`) — the module that already owns that concern — and answered
  with one prepared statement rather than one per table.

Behaviour on a store carrying legacy history is unchanged: it is snapshotted
before the drop, and a failed snapshot still defers the drop rather than
proceeding without one.

## Verification

Byte counts, same command with the gate present and removed:

```
$ pnpm vitest run test/zz-bytes.test.ts   # with the fix
aka.db=479232
TOTAL=479232

$ pnpm vitest run test/zz-bytes.test.ts   # gate removed (pre-fix code)
aka.db=479232
aka.db.pre-drop.1787385862514.aed960c4.bak=479232
TOTAL=958464
```

Fresh-open cost, fastest of 40 with warm-up discarded, arm64 macOS 26.5.2 /
Node 24.18.0 on an otherwise-quiet machine:

```
with the fix:      n=40 fastest=9.02ms  median=10.03ms
gate removed:      n=40 fastest=11.62ms median=12.18ms
```

Both measured in the session that produced this branch; the throwaway
`zz-bytes` spec is not committed.

### Mutation testing

Each mutation applied to the real source, suite re-run, tree restored
byte-identically, green re-confirmed:

| Mutation | Red |
| --- | --- |
| invert the gate | 5, incl. `drains, backs up, and drops a populated pre-cutover store without losing a row` |
| remove the gate (pre-fix code) | **exactly 1** — `a brand-new store takes no pre-drop backup` |
| neuter the seeded-table filter | 4 |
| probe never reports rows (call site) | 6 |
| `anyTableHasRows` always false (helper) | 6 |
| unanswerable probe returns `false` | `an unanswerable probe backs up rather than assuming there is nothing to protect` |

That the pre-fix code reds *only* the new fresh-store test is the useful one:
every conservatism guard stays green under the old behaviour, so this removes
waste without weakening protection.

### Review findings fixed on this branch

- **The seeded-table allowlist had no guard.** Adding `exceptions`,
  `secret_vault` and `inspection_findings` to it left **all 1315 tests in the
  package passing**, while making a store whose only content is user secrets
  read as "nothing to protect". Now caught by the exact-set pin.
- **`'policies'` was dead weight** in that set (measured: removing it keeps the
  fresh-store test green), and existed only to satisfy a test that probed a
  fully-opened store rather than the state the production caller sees. Both
  fixed.

### Suites

`@akasecurity/persistence` 1316 passed / 2 skipped, coverage 94.53% (floor 94%)
· `pnpm lint` and `check:portability` clean · `pnpm typecheck` 24/24 ·
`turbo run test --force` 43/43 · lint + typecheck re-run with `--force` on the
touched packages (26/26, 0 cached) because the turbo cache is shared across
worktrees.

## Docs

Two comments cited the old behaviour and are corrected: `CLAUDE.md`'s at-rest
leak-scan rule (which claimed the `.bak` lands on every run at ~47% of the
bytes) and `cli/test/commands/init.test.ts`'s walk rationale. Both now note
that the copy is *rarer*, which makes a hardcoded name-list reader **more**
dangerous, not less — a fresh-store fixture produces none, so such a reader
looks complete while missing the one case whose backup holds a real prompt
corpus.
