### PR TITLE
fix(ci): assert the no-network privilege drop-back landed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1582,17 +1582,19 @@ covering child processes, and its whole value is a positive control that refuses
 vacuously — which is worthless if nothing exercises it. The same suite drives
 `tools/ci/no-network-test.sh` with a `PATH` of hand-written stubs and pins every
 outcome: probe tooling missing, DNS still resolving, the target still answering, the
-probe reporting itself broken, the probe file gone, started as root, the privilege
-drop-back not having landed, and the one green path where the command actually runs.
+probe reporting itself broken, the probe file gone, no command to run, started as root,
+the privilege drop-back not having landed, and the one green path where the command
+actually runs.
 Change a probe and a case fails; delete one and the case that covered it fails.
 
-The last of those guards the only **silent** outcome on that path, which is why it is
-a control rather than a comment. The script drops back to the unprivileged caller
-because root ignores the 0444 mode `fault-injection.ts` builds a read-only store with,
-so as root the read-only cases in `packages/persistence` report `effective: false` and
-**skip** — a green run that quietly lost them. Refusing to START as root guards only the
-front door; nothing checked that the drop-back actually landed, so a broken `setpriv`
-was invisible. Phase 3 now asserts it.
+The drop-back case guards the only **silent** outcome on that path: as root the
+read-only-store cases in `packages/persistence` report `effective: false` and **skip**,
+so the run stays green having quietly lost them. Refusing to START as root guards the
+front door only, which is why phase 3 asserts the drop-back landed as well — and why
+`id` is demanded before any of it, since a missing `id` makes every one of those checks
+evaluate false without checking. The full reasoning is in the script's own header and
+phase-3 comment; it is not restated here, because a rationale kept in two places is one
+that goes out of step.
 
 ### The PATH shim, and why it fails OPEN
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1582,9 +1582,17 @@ covering child processes, and its whole value is a positive control that refuses
 vacuously — which is worthless if nothing exercises it. The same suite drives
 `tools/ci/no-network-test.sh` with a `PATH` of hand-written stubs and pins every
 outcome: probe tooling missing, DNS still resolving, the target still answering, the
-probe reporting itself broken, the probe file gone, started as root, and the one green
-path where the command actually runs. Change a probe and a case fails; delete one and
-the case that covered it fails.
+probe reporting itself broken, the probe file gone, started as root, the privilege
+drop-back not having landed, and the one green path where the command actually runs.
+Change a probe and a case fails; delete one and the case that covered it fails.
+
+The last of those guards the only **silent** outcome on that path, which is why it is
+a control rather than a comment. The script drops back to the unprivileged caller
+because root ignores the 0444 mode `fault-injection.ts` builds a read-only store with,
+so as root the read-only cases in `packages/persistence` report `effective: false` and
+**skip** — a green run that quietly lost them. Refusing to START as root guards only the
+front door; nothing checked that the drop-back actually landed, so a broken `setpriv`
+was invisible. Phase 3 now asserts it.
 
 ### The PATH shim, and why it fails OPEN
 

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -757,6 +757,33 @@ describe('the CI script refuses to run vacuously', { timeout: CI_SCRIPT_TIMEOUT_
     expect(run.status).not.toBe(127);
   });
 
+  it('refuses when the privilege drop-back did not land', (ctx) => {
+    requirePosixShell(ctx);
+    // The sibling of the case above, and the half that was missing. That one
+    // covers the FRONT door — started as root, there is no unprivileged
+    // identity to drop back to. This one covers the drop-back having silently
+    // failed to happen: phase 2's `setpriv` broke, or a future edit skipped it,
+    // and the command is about to run as root anyway.
+    //
+    // Why it matters more than it looks. Root ignores the 0444 mode
+    // `fault-injection.ts` builds a read-only store with, so the read-only
+    // cases in packages/persistence report `effective: false` and SKIP. A skip
+    // is not a failure — the job stays GREEN while quietly losing them. That is
+    // the one silent outcome on this path, and nothing asserted against it.
+    //
+    // The phase markers stay SET, which is what distinguishes this from the
+    // front-door case: both phases are already behind us, so the script is at
+    // the point of handing over. Exit 1 (a control failed) rather than 2 (bad
+    // invocation) for the same reason.
+    const run = runCiScript({ stubs: { ...blockedStubs(), id: prints('0') } });
+    expect(run.status).toBe(1);
+    expect(run.stderr).toContain('privilege drop-back did not happen');
+    // It must refuse BEFORE handing over, or the suite runs as root anyway and
+    // the message is just a log line. Both spellings, per the constants above.
+    expect(run.stdout).not.toContain(MARKER);
+    expect(run.stdout).not.toContain(RAN);
+  });
+
   it('refuses with no command to run', (ctx) => {
     requirePosixShell(ctx);
     const run = runCiScript({ stubs: blockedStubs(), args: [] });

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -20,6 +20,8 @@ import { Linter } from 'eslint';
 import tseslint from 'typescript-eslint';
 import { describe, expect, it } from 'vitest';
 
+import { CONVENTIONS_DOC, readConventions, sectionOf } from './helpers/claude-md.js';
+
 import { spawnViaNamedImport, spawnViaNamespace } from './helpers/product-worker.js';
 import { networkGuard } from '../src/index.js';
 import {
@@ -759,21 +761,16 @@ describe('the CI script refuses to run vacuously', { timeout: CI_SCRIPT_TIMEOUT_
 
   it('refuses when the privilege drop-back did not land', (ctx) => {
     requirePosixShell(ctx);
-    // The sibling of the case above, and the half that was missing. That one
-    // covers the FRONT door — started as root, there is no unprivileged
-    // identity to drop back to. This one covers the drop-back having silently
-    // failed to happen: phase 2's `setpriv` broke, or a future edit skipped it,
-    // and the command is about to run as root anyway.
+    // The sibling of the case above: that one covers the FRONT door (started as
+    // root, so there is no unprivileged identity to drop back to), this one
+    // covers the drop-back having silently failed to happen. Why a root run is
+    // the one SILENT outcome on this path is argued in the script's phase-3
+    // comment and not repeated here.
     //
-    // Why it matters more than it looks. Root ignores the 0444 mode
-    // `fault-injection.ts` builds a read-only store with, so the read-only
-    // cases in packages/persistence report `effective: false` and SKIP. A skip
-    // is not a failure — the job stays GREEN while quietly losing them. That is
-    // the one silent outcome on this path, and nothing asserted against it.
-    //
-    // The phase markers stay SET, which is what distinguishes this from the
-    // front-door case: both phases are already behind us, so the script is at
-    // the point of handing over. Exit 1 (a control failed) rather than 2 (bad
+    // What is specific to this case is how it is distinguished from the
+    // front-door one, since both turn on the same uid: the phase markers stay
+    // SET, so both earlier phases are already behind us and the script is at the
+    // point of handing over. Exit 1 (a control failed) rather than 2 (bad
     // invocation) for the same reason.
     const run = runCiScript({ stubs: { ...blockedStubs(), id: prints('0') } });
     expect(run.status).toBe(1);
@@ -782,6 +779,12 @@ describe('the CI script refuses to run vacuously', { timeout: CI_SCRIPT_TIMEOUT_
     // the message is just a log line. Both spellings, per the constants above.
     expect(run.stdout).not.toContain(MARKER);
     expect(run.stdout).not.toContain(RAN);
+    // …and before the egress probes, which is a separate claim the two
+    // assertions above cannot make: `blockedStubs` makes the probes PASS, so
+    // moving this control below them leaves every assertion here green while a
+    // root run does DNS and TCP work before refusing. This line is the only
+    // thing pinning the order the comment claims.
+    expect(run.stdout).not.toContain('verifying egress is actually blocked');
   });
 
   it('refuses with no command to run', (ctx) => {
@@ -793,11 +796,20 @@ describe('the CI script refuses to run vacuously', { timeout: CI_SCRIPT_TIMEOUT_
 
   // `it.for`, not `it.each`: only `for` passes the TestContext these cases skip
   // through. See requirePosixShell.
-  it.for(['getent', 'node'])('fails when the probe tool %s is missing', (missing, ctx) => {
+  it.for(['getent', 'node', 'id'])('fails when the tool %s is missing', (missing, ctx) => {
     requirePosixShell(ctx);
     // A probe whose own tooling is absent reports "not blocked = false" and the
     // control passes having probed nothing. This is the exact vacuous pass the
     // tool check exists to prevent, so each tool is pinned by name.
+    //
+    // `id` is here for the same reason and was the case that was missing. It is
+    // not a probe tool — it is what every privilege check reads — and its
+    // absence fails in the worse direction: `[ "$(id -u)" -eq 0 ]` with no `id`
+    // substitutes the empty string, and `[ "" -eq 0 ]` is an ERROR (exit 2),
+    // which `if` reads as FALSE. `set -e` does not fire inside an `if`
+    // condition, so the start-as-root refusal stops refusing and the phase-3
+    // drop-back control waves a root run through. Measured before the fix: the
+    // script ran the command and exited 0.
     const stubs = blockedStubs();
     delete stubs[missing];
     const run = runCiScript({ stubs });
@@ -897,6 +909,104 @@ function closeServer(server) {
     });
   });
 }
+
+// CLAUDE.md enumerates the outcomes this block pins, and prose is guarded by
+// nothing on its own. That file makes the point against itself in §1 — the
+// `emit()` sentence "claimed four shapes while six were reaching stdout", and
+// the fix it names is `hook-output-shapes.test.ts`, which reads the prose and
+// drives it against the thing it describes. This is that, for this sentence.
+//
+// The MAP is the hand-written half, because pairing a phrase with a case is a
+// judgement no derivation carries. Both SIDES are derived: the phrases are
+// checked against the real document, and the titles against the real cases
+// parsed out of this file. So a case added without a phrase fails, a phrase
+// without a case fails, and the count word fails with either.
+//
+// It found one on the first run: the enumeration had never listed the
+// no-command outcome, so it claimed to pin every outcome while omitting one of
+// nine.
+const PINNED_OUTCOMES = [
+  ['probe tooling missing', 'fails when the tool'],
+  ['DNS still resolving', 'fails when DNS still resolves'],
+  ['the target still answering', 'reports the target answered'],
+  ['probe reporting itself broken', 'reports itself broken'],
+  ['the probe file gone', 'fails when the probe file is missing'],
+  ['no command to run', 'refuses with no command to run'],
+  ['started as root', 'refuses to start as root'],
+  [
+    'the privilege drop-back not having landed',
+    'refuses when the privilege drop-back did not land',
+  ],
+  [
+    'the one green path where the command actually runs',
+    'runs the command when egress is genuinely gone',
+  ],
+];
+
+const VACUITY_BLOCK = "describe('the CI script refuses to run vacuously'";
+
+/**
+ * The case titles declared in that block, read from this file's own source.
+ *
+ * Derived rather than listed: a listed copy is a second thing to update, which
+ * is the drift being guarded against one level down. The slice ends at the next
+ * top-level `describe(` so a case added to a LATER block is not miscounted here.
+ */
+function pinnedCaseTitles() {
+  const src = readFileSync(fileURLToPath(import.meta.url), 'utf8');
+  const start = src.indexOf(VACUITY_BLOCK);
+  if (start === -1) {
+    throw new Error(
+      `this file no longer contains ${VACUITY_BLOCK}, so the enumeration guard would ` +
+        'compare against nothing and pass. Update the anchor.',
+    );
+  }
+  const after = src.slice(start + VACUITY_BLOCK.length);
+  const end = after.indexOf('\ndescribe(');
+  const block = end === -1 ? after : after.slice(0, end);
+  // `it('…'` and `it.for([…])('…'` alike; the title is the first string literal
+  // of the call that declares the case.
+  return [...block.matchAll(/\n {2}it(?:\.for\([^)]*\))?\(\s*'([^']+)'/g)].map((m) => m[1]);
+}
+
+describe("CLAUDE.md's enumeration of what this suite pins", () => {
+  // Whitespace-normalised, because the doc is prose wrapped at a column and a
+  // phrase spans the wrap wherever it happens to fall. Matching the raw text
+  // makes this guard fail on a REFLOW — which it did, on the first run, for the
+  // one phrase the wrap landed inside. A guard that reddens when a paragraph is
+  // rewrapped is one people learn to edit around.
+  const section = sectionOf(readConventions(), '### The no-network guard').replace(/\s+/g, ' ');
+
+  it.for(PINNED_OUTCOMES)('names the %s outcome', ([phrase], ctx) => {
+    if (typeof ctx?.skip !== 'function') throw new TypeError('needs a TestContext');
+    expect(section).toContain(phrase.replace(/\s+/g, ' '));
+  });
+
+  it('names every outcome the block actually pins, and no others', () => {
+    const titles = pinnedCaseTitles();
+    // Non-vacuity: an empty parse agrees with an empty map, and both would be
+    // the failure this guard exists to catch rather than a clean run.
+    expect(titles.length).toBeGreaterThan(0);
+    expect(titles).toHaveLength(PINNED_OUTCOMES.length);
+
+    const unmatched = titles.filter(
+      (t) => !PINNED_OUTCOMES.some(([, needle]) => t.includes(needle)),
+    );
+    expect(
+      unmatched,
+      `${CONVENTIONS_DOC} claims this block pins every outcome, but these cases are in no ` +
+        'entry of PINNED_OUTCOMES. Add the phrase to the doc and the pair here.',
+    ).toEqual([]);
+
+    const uncovered = PINNED_OUTCOMES.filter(
+      ([, needle]) => !titles.some((t) => t.includes(needle)),
+    ).map(([phrase]) => phrase);
+    expect(
+      uncovered,
+      `${CONVENTIONS_DOC} names these outcomes but no case in this block pins them.`,
+    ).toEqual([]);
+  });
+});
 
 describe('the egress probe', () => {
   it('reports a reachable target as NOT blocked', async () => {

--- a/tools/ci/no-network-test.sh
+++ b/tools/ci/no-network-test.sh
@@ -96,6 +96,25 @@ fi
 
 # Phase 3: inside the namespace, unprivileged.
 #
+# THE PRIVILEGE CONTROL, which is the other half of the positive control below
+# and guards a quieter failure. Phase 2 drops back to the caller because root
+# ignores the 0444 mode `fault-injection.ts` builds a read-only store with, so
+# the read-only cases in packages/persistence would report `effective: false`
+# and SKIP. A skip is not a failure: the suite would still report green, with
+# those cases silently uncovered. That hazard is why this script refuses to
+# START as root — but the refusal only guards the front door. Nothing checked
+# that the drop-back actually landed, so a `setpriv` that stopped working, or a
+# future edit to phase 2, would be invisible: green run, quieter suite, no
+# signal anywhere. Assert it instead of assuming it. Cheap, and it converts the
+# one silent failure on this path into a loud one.
+if [ "$(id -u)" -eq 0 ]; then
+  echo "no-network: FAILED — still root at the point the command runs, so the" >&2
+  echo "no-network: privilege drop-back did not happen. The read-only-store cases" >&2
+  echo "no-network: in packages/persistence would report 'effective: false' and" >&2
+  echo "no-network: skip, and the run would report green having quietly lost them." >&2
+  exit 1
+fi
+
 # The positive control. An empty network stack and a broken command look
 # identical from a green run, so prove the block is real before trusting the
 # result — the same reason the fault injectors in packages/persistence refuse to

--- a/tools/ci/no-network-test.sh
+++ b/tools/ci/no-network-test.sh
@@ -39,6 +39,26 @@ if [ "$#" -eq 0 ]; then
   exit 2
 fi
 
+# `id` is demanded before anything reads a uid, for the same reason the probe
+# tools are demanded before the egress control runs: a check whose own tooling is
+# missing does not fail, it passes without checking. `[ "$(id -u)" -eq 0 ]` with
+# no `id` on PATH substitutes the empty string, and `[ "" -eq 0 ]` is not false —
+# it is an ERROR, exit 2, which `if` reads as false. `set -e` does not fire
+# inside an `if` condition, so every privilege decision below would silently
+# invert: the start-as-root refusal would not refuse, the drop-back would carry
+# an empty uid, and the phase-3 control would wave a root run through. Measured,
+# not reasoned: with `id` off PATH the script ran the command and exited 0.
+if ! command -v id >/dev/null 2>&1; then
+  echo "no-network: FAILED — 'id' is not installed, so every privilege check below" >&2
+  echo "no-network: would evaluate to false without checking anything and the suite" >&2
+  echo "no-network: could run as root with its read-only-store cases skipping." >&2
+  exit 1
+fi
+
+# Captured once. The value cannot change within one exec of this script, and a
+# single reader is also a single place for the failure handling above to cover.
+SELF_UID="$(id -u)"
+
 # Phase 1: outside the namespace. Re-enter as root in a fresh network namespace,
 # carrying the caller's identity and the environment the toolchain needs. `sudo
 # env VAR=...` is used rather than `sudo -E` because preserving the whole
@@ -49,7 +69,7 @@ if [ "${AKA_NO_NETWORK_INSIDE:-}" != "1" ]; then
   # root the drop-back below is a no-op, and the read-only-store cases skip
   # instead of asserting. That is a quieter suite still reporting green, so it
   # fails here and there is deliberately no override.
-  if [ "$(id -u)" -eq 0 ]; then
+  if [ "$SELF_UID" -eq 0 ]; then
     echo "no-network: FAILED — started as root. This script elevates itself; running" >&2
     echo "no-network: it as root leaves no unprivileged identity to drop back to, and" >&2
     echo "no-network: the read-only-store cases in packages/persistence would skip" >&2
@@ -58,7 +78,7 @@ if [ "${AKA_NO_NETWORK_INSIDE:-}" != "1" ]; then
   fi
   exec sudo env \
     AKA_NO_NETWORK_INSIDE=1 \
-    "AKA_NO_NETWORK_UID=$(id -u)" \
+    "AKA_NO_NETWORK_UID=$SELF_UID" \
     "AKA_NO_NETWORK_GID=$(id -g)" \
     "PATH=$PATH" \
     "HOME=$HOME" \
@@ -75,7 +95,7 @@ fi
 # interface but leaves it DOWN, and the suite genuinely uses loopback (the CLI's
 # isPortFree bind probe, the dashboard boot test). Bring it up, then drop back to
 # the caller and re-enter this script one last time.
-if [ "$(id -u)" -eq 0 ] && [ "${AKA_NO_NETWORK_DROPPED:-}" != "1" ]; then
+if [ "$SELF_UID" -eq 0 ] && [ "${AKA_NO_NETWORK_DROPPED:-}" != "1" ]; then
   if [ -z "${AKA_NO_NETWORK_UID:-}" ] || [ -z "${AKA_NO_NETWORK_GID:-}" ]; then
     echo "no-network: no caller identity to drop back to. Run this script as the" >&2
     echo "no-network: unprivileged user; it re-enters itself under sudo." >&2
@@ -107,7 +127,7 @@ fi
 # future edit to phase 2, would be invisible: green run, quieter suite, no
 # signal anywhere. Assert it instead of assuming it. Cheap, and it converts the
 # one silent failure on this path into a loud one.
-if [ "$(id -u)" -eq 0 ]; then
+if [ "$SELF_UID" -eq 0 ]; then
   echo "no-network: FAILED — still root at the point the command runs, so the" >&2
   echo "no-network: privilege drop-back did not happen. The read-only-store cases" >&2
   echo "no-network: in packages/persistence would report 'effective: false' and" >&2


### PR DESCRIPTION
`tools/ci/no-network-test.sh` runs in three phases. Phase 2 drops back to the unprivileged caller before the suite runs, and the script's own header says why:

> root ignores the 0444 mode that `packages/persistence/test/helpers/fault-injection.ts` uses to build a read-only store, so those cases would report `effective: false` and skip.

**A skip is not a failure.** The job stays green while quietly losing those cases, which makes this the only *silent* outcome on that path — every other way the script can go wrong exits non-zero and is pinned by a test.

The script already refuses to **start** as root for exactly this reason, and that refusal is tested. But it guards the front door only. Nothing checked that the drop-back actually *landed*, so a `setpriv` that stopped working — or a future edit to phase 2 — would have been invisible: green run, quieter suite, no signal anywhere.

## The change

Phase 3 asserts it before handing over, beside the existing egress control and for the same stated reason (*"an empty network stack and a broken command look identical from a green run"*). A control that cannot fail loudly is a comment.

```bash
if [ "$(id -u)" -eq 0 ]; then
  echo "no-network: FAILED — still root at the point the command runs, so the" >&2
  ...
  exit 1
fi
```

Nineteen lines including the rationale, three of them executable.

## What this does *not* close

The two phases in front of it — the `unshare --net` re-entry, `ip link set lo up`, and the `setpriv` call itself — are still exercised only by the real ubuntu job. Covering them needs Linux plus privileges, so they would run on one leg at best.

That gap is unchanged and deliberate. What changes is that its **consequence** is now loud rather than silent, which is the part that was actually costing coverage: an untested mechanism whose failure reddens CI is a much smaller problem than one whose failure reports green.

## Verification

**Mutation-tested, because an absence assertion that cannot go red is worth nothing.** The control's condition was changed from `-eq 0` to `-eq 99999` so it can never fire. The edit was diffed against a pristine copy rather than grepped, since my first grep pattern was malformed and reported 0 matches for a mutation that had landed:

```
$ diff no-network-test.sh.pristine tools/ci/no-network-test.sh
110c110
< if [ "$(id -u)" -eq 0 ]; then
---
> if [ "$(id -u)" -eq 99999 ]; then
```

Exactly one case goes red, and for the right reason — the script exited 0, having handed over as root, rather than refusing:

```
× refuses when the privilege drop-back did not land
AssertionError: expected +0 to be 1 // Object.is equality
 Tests  1 failed | 60 passed (61)
```

Restored from the backup copy (not `git checkout`, which would have reverted to the index and taken the new control with it):

```
$ pnpm --filter @akasecurity/eslint-config test
 Test Files  19 passed (19)
      Tests  1367 passed (1367)
```

1366 before this branch, so **+1 and no other case moved**.

```
$ pnpm check:portability
Portability check passed: no violations found.

$ pnpm --filter @akasecurity/eslint-config lint
(clean)
```

The new case keeps the phase markers **set**, which is what distinguishes it from the existing front-door case: both phases are already behind us, so the script is at the point of handing over. It asserts exit **1** (a control failed) rather than 2 (bad invocation), and that neither `MARKER` nor `RAN` reached stdout — the two spellings that separate *"the script announced it was about to hand over"* from *"the command actually ran"*.

## `CLAUDE.md`

Its enumeration of the outcomes that suite pins gains the new one, plus a short paragraph on why this particular control exists. That file records an enumeration drifting inside the commit that fixed the previous drift as its own §1 lesson — so leaving it at seven while the suite pinned eight is the documented defect, not a nit.
