### PR TITLE
fix(persistence): compare both store sizes in the same WAL state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1456,6 +1456,33 @@ which is hundreds of megabytes. Nothing on the capture path does that (every
 `recordCapture` commits, and every hook is its own process), but a batch importer would.
 Do not "fix" the pragma without re-reading `store-growth.test.ts`.
 
+**That same property makes a two-size RATIO test compare two different states, and it has
+cost a red `main`.** `seedCaptureCorpus` commits its whole corpus in one transaction, so
+the log it leaves is the seed's entire page footprint rather than the steady state above —
+measured 4,132,392 B for 2,000 events against 17,637,752 B for 20,000, a factor of 4.27
+that belongs to the FIXTURE and to nothing the product does. Every measurement taken
+against those stores then carries a log-proportional cost on one side only. It reads as
+nothing while the pages are cached, which is why `scale-budgets.test.ts` reported a
+`openLocalDatabase` ratio of ~1.0 locally and on CI for months; on a runner executing the
+whole workspace suite in parallel those pages are not resident, and the same asymmetry
+arrived as a ratio of **3.619** (2.1464 ms against 7.7686 ms) against a ceiling of 3 — on a
+commit whose diff touched `CLAUDE.md`, a shell script and one unrelated test file, with no
+product code in it at all.
+
+So a file that seeds two sizes and divides one measurement by the other **checkpoints after
+seeding** (`PRAGMA wal_checkpoint(TRUNCATE)` through `corpusConnection`), which leaves both
+stores at the steady state — measured 4,148,872 and 4,144,752 B, i.e. equal — so the cost
+cancels in the ratio the way every other shared cost does. `scale-budgets.test.ts` and
+`security-page-scale.test.ts` both do this. It equalizes the LOG and not the DATABASE (2.2
+MB against 17.0 MB, still 7.7x apart), so a size-dependent cost in the thing under test
+survives it: verified by mutation, an index-defeated per-open scan fails at 4.14 with the
+checkpoint and 4.08 without. `store-growth.test.ts` is the deliberate exception — the
+unbounded log is what it measures, so it must NOT checkpoint.
+
+The failure this guards is quiet in the wrong direction: it reddens a tree whose diff
+cannot explain it, and the obvious-looking fix is to widen `FLATNESS_CEILING`. Widening it
+answers a state mismatch by weakening the one number that separates flat from linear.
+
 That WAL case is **skipped on Windows, on cost rather than on behaviour.** Demonstrating
 the bound needs 20,000 SEPARATE commits — a checkpoint cannot run inside a transaction, so
 batching them removes the property under test — and each one is an fsync on the platform

--- a/packages/persistence/test/performance/scale-budgets.test.ts
+++ b/packages/persistence/test/performance/scale-budgets.test.ts
@@ -182,7 +182,7 @@ import type { IngestEvent } from '@akasecurity/schema';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { openLocalDatabase } from '../../src/database.ts';
-import { CORPUS_EPOCH_MS, seedCaptureCorpus } from '../helpers/corpus.ts';
+import { CORPUS_EPOCH_MS, corpusConnection, seedCaptureCorpus } from '../helpers/corpus.ts';
 import type { OwnedTempStore } from '../helpers/temp-store.ts';
 import { createTempStore } from '../helpers/temp-store.ts';
 
@@ -305,6 +305,38 @@ function seedAndMeasure(store: OwnedTempStore, events: number): Measured {
     // pair again, which would raise the sensitivity floor a second time.
     findingRate: SEED_FINDING_RATE,
   });
+
+  // CHECKPOINT BEFORE MEASURING, or the two sizes are not compared in the same
+  // state and `openLocalDatabase` is charged for the difference.
+  //
+  // `seedCaptureCorpus` wraps the whole corpus in ONE transaction, and a
+  // checkpoint cannot run inside one — the same property `store-growth.test.ts`
+  // measures on purpose. So the log is not the ~4.2 MB steady state a real store
+  // settles at under `wal_autocheckpoint`; it holds the entire seed. Measured
+  // here: the 2,000-event store leaves a 4,132,392-byte WAL and the 20,000-event
+  // store 17,637,752 — a factor of 4.27 that is an artifact of the FIXTURE, not
+  // a property of the open.
+  //
+  // Every open then reads a log four times bigger on one side than the other.
+  // That costs nothing while the pages are in the page cache, which is why this
+  // reads ~1.0 locally and did so on every CI run for months. It is not free on a
+  // runner executing the whole workspace suite in parallel, where those pages are
+  // not resident — and it is charged in proportion to a size only one side has.
+  // CI failed at a ratio of 3.619 (2.1464 ms against 7.7686 ms), which is that
+  // 4.27 arriving with the cache cold, on a commit whose diff touched CLAUDE.md,
+  // a shell script and one unrelated test file.
+  //
+  // Truncating here leaves both stores at the steady state — measured 4,148,872
+  // and 4,144,752 bytes, i.e. equal — so a cost proportional to the log cancels
+  // in the ratio the way every other shared cost does. It does NOT paper over a
+  // real regression: a size-dependent cost in the open itself survives this,
+  // because it is the log rather than the database being equalized (2.2 MB
+  // against 17.0 MB, still 7.7x apart).
+  //
+  // Do not answer a future flake here by widening FLATNESS_CEILING. The ceiling
+  // separates flat from linear-in-the-table (~10); what went wrong was the two
+  // sides being in different states, and that is the thing to fix.
+  corpusConnection(db).exec('PRAGMA wal_checkpoint(TRUNCATE)');
 
   const captures: number[] = [];
   for (let i = 0; i < CAPTURE_SAMPLES; i += 1) {

--- a/packages/persistence/test/performance/security-page-scale.test.ts
+++ b/packages/persistence/test/performance/security-page-scale.test.ts
@@ -233,6 +233,16 @@ async function seedAndMeasure(store: OwnedTempStore, events: number): Promise<Sc
     resolutionRate: Math.min(1, RESOLUTION_TARGET / (events * TRACKABLE_PER_EVENT)),
   });
   const raw = corpusConnection(db);
+  // Both sizes measured in the same STATE. `seedCaptureCorpus` commits the whole
+  // corpus in one transaction and a checkpoint cannot run inside one, so the log
+  // is left holding the entire seed rather than the ~4.2 MB steady state a real
+  // store settles at — measured at 4.13 MB for 2,000 events against 17.64 MB for
+  // 20,000. Every read below then pays a log-proportional cost on one side only,
+  // which is free while those pages are cached and is not on a runner executing
+  // the whole workspace suite. Its sibling `scale-budgets.test.ts` failed CI on
+  // exactly that, at a ratio of 3.619 on a commit that touched no product code;
+  // the reasoning is written out there and not repeated.
+  raw.exec('PRAGMA wal_checkpoint(TRUNCATE)');
   const findings = new SqliteFindingsRepository(raw);
   // The corpus's own clock, never `Date.now()`: the corpus is stamped from a
   // fixed 2024 epoch, so on the wall clock every windowed read is years past its


### PR DESCRIPTION
## Summary

`main` is red. `scale-budgets.test.ts` fails its `openLocalDatabase` flatness case at a ratio of **3.619** (2.1464 ms at 2,000 events against 7.7686 ms at 20,000, ceiling 3) — on a commit whose entire diff is `CLAUDE.md`, a shell script and one unrelated test file, with **no product code in it at all** and nothing in `packages/persistence`.

The two sizes were not being compared in the same state, and this fixes that rather than widening the ceiling.

## What was actually wrong

`seedCaptureCorpus` commits its whole corpus in **one transaction**, and a checkpoint cannot run inside one — the same property `store-growth.test.ts` measures on purpose. So each store is left holding the seed's entire page footprint instead of the ~4.2 MB steady state `wal_autocheckpoint` settles at:

| corpus | WAL | db |
| --- | --- | --- |
| 2,000 events | 4,132,392 B | 2.2 MB |
| 20,000 events | 17,637,752 B | 17.0 MB |

That is a factor of **4.27** in the log, belonging to the *fixture* and to nothing the product does. Every open then reads a log four times bigger on one side.

It costs nothing while those pages are in the page cache — which is why this reads ~1.0 locally (measured 0.997 / 0.980 / 1.015 / 0.944 / 0.981 over five consecutive runs) and read that way on CI for months. It is not free on a runner executing the whole workspace suite in parallel, where those pages are not resident. **The 4.27 arriving cold is the 3.619.**

## The fix

Checkpoint after seeding, before measuring. Both stores then sit at the steady state — measured 4,148,872 B and 4,144,752 B, i.e. equal — so a log-proportional cost cancels in the ratio the way every other shared cost does.

**It equalizes the LOG, not the DATABASE** (2.2 MB against 17.0 MB, still 7.7x apart), so a size-dependent cost in the thing under test still fails. Verified by mutation rather than by reasoning — an index-defeated per-open scan:

| | ratio | result |
| --- | --- | --- |
| **with** the checkpoint | 4.141 | fails ✅ |
| **without** the checkpoint | 4.075 | fails ✅ |

Identical sensitivity. The fix removes the artifact, not the assertion.

The weaker mutation `CLAUDE.md` documents (`WHERE LENGTH(id) = 999`) sits under the ratio's own documented sensitivity floor at this pair and passes either way. That is the floor behaving exactly as written — *"the floor is proportional to the SMALL size, so cutting the pair by 2.5x raised it by 2.5x"* — not this change moving it.

## Changes

| File | Change |
| --- | --- |
| `packages/persistence/test/performance/scale-budgets.test.ts` | Checkpoint after seeding, with the measurements and the reasoning written down |
| `packages/persistence/test/performance/security-page-scale.test.ts` | Same generator, same 2k/20k pair, same ceiling of 3 — so the same latent asymmetry, and the same one line |
| `CLAUDE.md` | Records the gotcha beside the existing `wal_autocheckpoint` paragraph |

`security-page-scale.test.ts` had not failed yet, but it is the identical shape and would have failed the same way on a busy runner. Its **growth control** — `severitySummary`'s ratio must stay LARGE, or every flatness case in that file is vacuous — still passes, so the harness is still measuring growth.

`store-growth.test.ts` deliberately does **not** checkpoint: the unbounded log is the property it measures. Left alone.

## Why this is worth writing down rather than just fixing

The failure is quiet in the wrong direction. It reddens a tree whose own diff cannot explain it, so the obvious-looking fix is to widen `FLATNESS_CEILING` — which answers a *state mismatch* by weakening the one number that separates flat from linear-in-the-table. `CLAUDE.md` now says so at the point someone would reach for it.

## Test plan

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes — 43/43 tasks
- [x] `pnpm check:portability` passes
- [x] `packages/persistence`: 87 files, 1323 passed, 2 skipped
- [x] `packages/eslint-config` (parses `CLAUDE.md`): 19 files, 1378 passed
- [x] Failing case re-run 3x on the fix — green each time
- [x] Mutation-tested both with and without the fix (table above)

## Checklist

- [x] `pnpm format:check` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] PR title follows Conventional Commits

### Detection-rule changes only (`rules/`)

Not applicable — no `rules/` changes.
