### PR TITLE
chore(release): merge release/0.9.8 back to main

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/antigravity/package.json
+++ b/plugins/antigravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-antigravity",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Antigravity CLI",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "aka-antigravity",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control — inspect and govern AI prompts in Antigravity. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks.json",
   "skills": "./skills",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka-codex",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-codex",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Merge the tagged release/0.9.8 branch back to main.

All five artifacts shipped from `94cc75d9`:

| Artifact | Tag | Result |
|---|---|---|
| `@akasecurity/cli` | `cli-v0.9.8` | npm `latest` |
| `@akasecurity/ai-tc-claude-code` | `plugin-claude-v0.9.8` | npm `latest` |
| `@akasecurity/ai-tc-codex` | `plugin-codex-v0.9.8` | npm `latest` |
| `@akasecurity/ai-tc-antigravity` | `plugin-antigravity-v0.9.8` | npm `latest` |
| `aka` binaries (SEA) | `bin-v0.9.8` | in flight |

The only change on this branch is the seven-file version bump 0.9.7 → 0.9.8.