### PR TITLE
feat(ui-kit): a field-border token, and a Sheet that can anchor left

### DIFF
--- a/packages/ui-kit/src/input.tsx
+++ b/packages/ui-kit/src/input.tsx
@@ -6,6 +6,12 @@ import { cn } from './lib/cn.ts';
  * A text input primitive. Styles a native `<input>` with the design tokens
  * (surface fill, border, primary focus ring) so forms across the dashboards
  * share one field look. `ref` flows through as a regular prop (React 19).
+ *
+ * The edge is `border-border-field`, not `border-border`. A field renders
+ * `bg-surface` inside panels that are also `bg-surface`, so its border is the
+ * only thing marking where the control starts — the hairline that separates a
+ * card from the page is 1.26:1 there and leaves the field almost invisible to a
+ * low-vision reader. See the token's note in theme.css.
  */
 export function Input({ className, type = 'text', ...props }: ComponentPropsWithRef<'input'>) {
   return (
@@ -13,7 +19,7 @@ export function Input({ className, type = 'text', ...props }: ComponentPropsWith
       type={type}
       data-slot="input"
       className={cn(
-        'h-9 w-full rounded-lg border border-border bg-surface px-3 text-sm text-text',
+        'h-9 w-full rounded-lg border border-border-field bg-surface px-3 text-sm text-text',
         'truncate placeholder:text-text-3 transition-colors',
         'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         'disabled:cursor-not-allowed disabled:opacity-50',

--- a/packages/ui-kit/src/sheet.tsx
+++ b/packages/ui-kit/src/sheet.tsx
@@ -5,8 +5,9 @@ import { cn } from './lib/cn.ts';
 
 /**
  * Slide-over panel built on @radix-ui/react-dialog — portalled, with overlay,
- * focus trap, and escape/outside-click dismissal. Anchored to the right edge.
- * Compound API mirrors Dialog:
+ * focus trap, and escape/outside-click dismissal. Anchored to the right edge by
+ * default; `side="left"` anchors it to the left and moves the divider with it,
+ * which is what a navigation drawer needs. Compound API mirrors Dialog:
  *
  *   <Sheet open={open} onOpenChange={setOpen}>
  *     <SheetContent>
@@ -22,9 +23,12 @@ export const Sheet = Dialog.Root;
 export const SheetTrigger = Dialog.Trigger;
 export const SheetClose = Dialog.Close;
 
-export type SheetContentProps = ComponentPropsWithRef<typeof Dialog.Content>;
+export type SheetContentProps = ComponentPropsWithRef<typeof Dialog.Content> & {
+  /** Which edge the panel is anchored to. Defaults to `'right'`. */
+  side?: 'left' | 'right';
+};
 
-export function SheetContent({ className, children, ...props }: SheetContentProps) {
+export function SheetContent({ className, children, side = 'right', ...props }: SheetContentProps) {
   return (
     <Dialog.Portal>
       <Dialog.Overlay
@@ -34,7 +38,11 @@ export function SheetContent({ className, children, ...props }: SheetContentProp
       <Dialog.Content
         data-slot="sheet-content"
         className={cn(
-          'fixed inset-y-0 right-0 z-50 flex h-full w-full max-w-md flex-col gap-4 overflow-y-auto border-l border-border bg-surface p-6 shadow-lg outline-none',
+          'fixed inset-y-0 z-50 flex h-full w-full max-w-md flex-col gap-4 overflow-y-auto border-border bg-surface p-6 shadow-lg outline-none',
+          // Chosen here rather than left to the caller: `left-0` does not displace
+          // `right-0` and `border-r` does not displace `border-l`, so a className
+          // can add the new edge without ever removing the old one.
+          side === 'left' ? 'left-0 border-r' : 'right-0 border-l',
           className,
         )}
         {...props}

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -14,6 +14,18 @@
   --color-border: #e3e5e8;
   --color-border-strong: #d6d8dc;
 
+  /* field boundary. --color-border is a hairline tuned to separate a card from the
+     page, where the two surfaces already differ and the line is reinforcement. A
+     text field is the opposite case: it renders bg-surface inside a panel that is
+     also bg-surface, so the border is the ONLY thing saying where the control
+     begins, and 1.4.11 asks that boundary for 3:1 rather than the hairline's 1.26:1.
+     Its own token because widening --color-border to clear 3:1 would put that weight
+     on every card and divider in the product, which is a different design decision
+     than making inputs findable. Set against the LIGHTEST surface a field lands on
+     (#ffffff, 3.34:1) and still clearing it on the canvas and surface-2 fills the
+     auth forms use (3.20:1). */
+  --color-border-field: #868d99;
+
   /* text. The three tiers sit closer together than they look like they should: on a
      light background everything at 4.5:1 or better is crowded into a narrow dark band,
      so the tertiary tier cannot be as faint as the eye expects. It is set against
@@ -171,6 +183,12 @@
   --color-surface-3: #3d4653; /* deeper inset, neutral solid fill */
   --color-border: #3d4653;
   --color-border-strong: #5d6572;
+
+  /* the same boundary in dark, set against the surfaces it actually lands on rather
+     than against the canvas: 3.94:1 on --color-surface, 3.26:1 on --color-surface-2.
+     It reads lighter than --color-border-strong on purpose — strong is a divider that
+     wants to recede, this is a control edge that has to be found. */
+  --color-border-field: #828b9b;
 
   /* text */
   --color-text: #ffffff;


### PR DESCRIPTION
Two additions to the shared primitives, each independently useful.

## `--color-border-field`

`Input` renders `bg-surface` inside panels that are also `bg-surface`, so its
border is the only thing marking where the control begins — and at **1.26:1**
in light and **1.42:1** in dark, that boundary sits far under the 3:1 WCAG
1.4.11 asks of it. The field is close to invisible to a low-vision reader.

The new token is measured against every surface a field actually lands on,
rather than against one and assumed for the rest:

| | value | on `surface` | on `canvas` / `surface-2` |
|---|---|---|---|
| light | `#868d99` | 3.34:1 | 3.20:1 |
| dark | `#828b9b` | 3.94:1 | 3.26:1 |

It is its own token rather than a widened `--color-border` on purpose: that
hairline is tuned to separate a card from the page, where the two surfaces
already differ and the line is reinforcement. Widening it would put a 3:1
weight on every card and divider in the product, which is a different decision
from making inputs findable.

## `SheetContent side`

`side="left" | "right"`, defaulting to `right`, so every existing caller is
unaffected.

The edge is resolved inside the component rather than left to a `className`,
because a caller cannot express it from the outside: `left-0` does not displace
`right-0` and `border-r` does not displace `border-l`, so an override adds the
new edge without removing the old one and the panel is anchored to both.

## Verification

- `ui-kit` and `dashboard-ui` lint, typecheck and tests pass; the full
  workspace suite is green.
- Both contrast pairs re-measured in a running browser, not only computed —
  the values above are what `getComputedStyle` reports for a rendered field
  against its actual panel.
- The `side` behaviour was driven at 375px: the panel reports `left: 0` with
  the divider moved to `border-right`.
