### PR TITLE
feat(ui-kit): name the tonal pairs instead of spelling them

### DIFF
--- a/packages/dashboard-ui/src/security/RecommendedActionsCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecommendedActionsCardView.tsx
@@ -111,7 +111,7 @@ export function RecommendedActionsCardView({
                   key={a.id}
                   className={cn(
                     'flex gap-3 py-3',
-                    i < items.length - 1 && 'border-b border-text/6',
+                    i < items.length - 1 && 'border-b border-hairline',
                   )}
                 >
                   <span

--- a/packages/dashboard-ui/src/updates/AvailablePluginsCardView.tsx
+++ b/packages/dashboard-ui/src/updates/AvailablePluginsCardView.tsx
@@ -46,7 +46,7 @@ export function AvailablePluginsCardView({
           {plugins.map((p, i) => {
             const outcome = outcomes[p.id];
             return (
-              <div key={p.id} className={cn('py-3', i > 0 && 'border-t border-text/6')}>
+              <div key={p.id} className={cn('py-3', i > 0 && 'border-t border-hairline')}>
                 <div className="flex items-center gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold text-text">{p.name}</div>

--- a/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
+++ b/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
@@ -83,7 +83,7 @@ export function UpdateStatusCardView({
           {statuses.map((s, i) => {
             const outcome = outcomes[s.id];
             return (
-              <div key={s.id} className={cn('py-3', i > 0 && 'border-t border-text/6')}>
+              <div key={s.id} className={cn('py-3', i > 0 && 'border-t border-hairline')}>
                 <div className="flex items-center gap-3">
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold text-text">{s.name}</div>

--- a/packages/ui-kit/src/badge.tsx
+++ b/packages/ui-kit/src/badge.tsx
@@ -2,22 +2,29 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import type { ReactNode } from 'react';
 
 import { cn } from './lib/cn.ts';
+import { TONE_SOFT } from './tone.ts';
 
 const badgeVariants = cva(
   'inline-flex items-center gap-1.5 whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-semibold',
   {
     variants: {
       variant: {
+        // `default` is the one tonal variant with no TONE_SOFT member: the
+        // vocabulary's `neutral` is bg-surface-2, and this is the step deeper.
         default: 'bg-surface-3 text-text-2',
         outline: 'border border-border text-text-2',
-        critical: 'bg-sev-critical-fill text-sev-critical-ink',
-        high: 'bg-sev-high-fill text-sev-high-ink',
-        medium: 'bg-sev-medium-fill text-sev-medium-ink',
-        low: 'bg-sev-low-fill text-sev-low-ink',
-        // Tonal (non-severity) variants for status/category chips.
-        success: 'bg-ok-fill text-ok-ink',
-        teal: 'bg-teal-fill text-teal-ink',
-        primary: 'bg-primary-tint text-primary',
+        // The rest ARE vocabulary members, so they are read from it rather than
+        // respelled — a second copy of a pair is a second place to get the
+        // fill/ink halves wrong, which is the failure tone.ts exists to remove.
+        // The variant NAMES stay as they are: `variant` is public API, and
+        // `success` is spelled across consumers outside this repo.
+        critical: TONE_SOFT.critical,
+        high: TONE_SOFT.high,
+        medium: TONE_SOFT.medium,
+        low: TONE_SOFT.low,
+        success: TONE_SOFT.ok,
+        teal: TONE_SOFT.teal,
+        primary: TONE_SOFT.primary,
       },
     },
     defaultVariants: { variant: 'default' },

--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -1,13 +1,14 @@
 import { type ComponentPropsWithRef } from 'react';
 
 import { cn } from './lib/cn.ts';
+import { type Tone, TONE_SOFT } from './tone.ts';
 
 /**
  * Composable card primitives. Compose instead of passing header props:
  *
  *   <Card>
  *     <CardHeader>
- *       <CardIcon className="bg-sev-critical-fill text-sev-critical-ink"><Icon /></CardIcon>
+ *       <CardIcon tone="critical"><Icon /></CardIcon>
  *       <CardHeading>
  *         <CardTitle>Open by severity</CardTitle>
  *         <CardDescription>131 findings</CardDescription>
@@ -39,13 +40,27 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
   );
 }
 
-/** Tinted square that holds a leading icon. Override the tile color via className. */
-export function CardIcon({ className, ...props }: ComponentPropsWithRef<'span'>) {
+/**
+ * Tinted square that holds a leading icon. `tone` names the tonal family and
+ * defaults to `neutral`, the tile's own surface.
+ *
+ * Prefer it over spelling the fill/ink pair into `className`: the pairing is
+ * irregular (primary's tint is `-tint`, and its bare token is already the ink),
+ * and getting it wrong fails silently — an undefined theme variable emits no
+ * utility, so the glyph just inherits its color. `className` still wins, for the
+ * one-off tile whose color is not a family theme.css names.
+ */
+export function CardIcon({
+  className,
+  tone = 'neutral',
+  ...props
+}: ComponentPropsWithRef<'span'> & { tone?: Tone }) {
   return (
     <span
       data-slot="card-icon"
       className={cn(
-        'flex size-7.5 shrink-0 items-center justify-center rounded-lg bg-surface-2 text-text-2',
+        'flex size-7.5 shrink-0 items-center justify-center rounded-lg',
+        TONE_SOFT[tone],
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -50,6 +50,15 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
  * utility, so the glyph just inherits its color. `className` still wins, for the
  * one-off tile whose color is not a family theme.css names.
  */
+// The neutral pair used to be part of the base literal, so it applied no matter
+// what. Indexing makes it data-driven, and `tone` is optional on a component
+// this package ships to hosts outside this repo — where a stale or plain-JS
+// caller can pass a value outside the union, and `cn` would drop the resulting
+// `undefined`, leaving the tile with no background AND no foreground rather than
+// falling back to neutral. This string-keyed view is what makes that fallback
+// reachable to the type system rather than dead code the compiler prunes.
+const TONE_SOFT_FALLBACK: Record<string, string | undefined> = TONE_SOFT;
+
 export function CardIcon({
   className,
   tone = 'neutral',
@@ -60,7 +69,7 @@ export function CardIcon({
       data-slot="card-icon"
       className={cn(
         'flex size-7.5 shrink-0 items-center justify-center rounded-lg',
-        TONE_SOFT[tone],
+        TONE_SOFT_FALLBACK[tone] ?? TONE_SOFT.neutral,
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -90,3 +90,4 @@ export {
   type TabsTriggerProps,
 } from './tabs.tsx';
 export { Tag, type TagProps } from './tag.tsx';
+export { type SolidTone, type Tone, TONE_SOFT, TONE_SOLID } from './tone.ts';

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -14,11 +14,24 @@
   --color-border: #e3e5e8;
   --color-border-strong: #d6d8dc;
 
-  /* field boundary. --color-border is a hairline tuned to separate a card from the
+  /* the lightest separator weight: the rule BETWEEN rows inside a card, where
+     --color-border is already drawing the card's own edge and repeating it per row
+     would draw a table. Its own token because it is the one separator that has to
+     stay under the container it sits in — the two above are container edges and
+     read as too heavy for a row.
+
+     The value is --color-text at 6% in each theme, which is what these rows spelled
+     inline before this token existed. Written out rather than derived, because the
+     alpha rides on a token that INVERTS between themes: 6% of the near-black light
+     ink and 6% of the white dark ink are opposite colors, and only writing both
+     keeps the pair honest if either text value is ever retuned. */
+  --color-hairline: rgb(37 47 61 / 0.06);
+
+  /* field boundary. --color-border is a thin rule tuned to separate a card from the
      page, where the two surfaces already differ and the line is reinforcement. A
      text field is the opposite case: it renders bg-surface inside a panel that is
      also bg-surface, so the border is the ONLY thing saying where the control
-     begins, and 1.4.11 asks that boundary for 3:1 rather than the hairline's 1.26:1.
+     begins, and 1.4.11 asks that boundary for 3:1 rather than that rule's 1.26:1.
      Its own token because widening --color-border to clear 3:1 would put that weight
      on every card and divider in the product, which is a different design decision
      than making inputs findable. Set against the LIGHTEST surface a field lands on
@@ -183,6 +196,10 @@
   --color-surface-3: #3d4653; /* deeper inset, neutral solid fill */
   --color-border: #3d4653;
   --color-border-strong: #5d6572;
+
+  /* 6% of this theme's --color-text (#ffffff), so the row rule lifts off the card
+     here where the light theme's sinks into it. */
+  --color-hairline: rgb(255 255 255 / 0.06);
 
   /* the same boundary in dark, set against the surfaces it actually lands on rather
      than against the canvas: 3.94:1 on --color-surface, 3.26:1 on --color-surface-2.

--- a/packages/ui-kit/src/table.tsx
+++ b/packages/ui-kit/src/table.tsx
@@ -74,7 +74,7 @@ export function TableRow({
       onClick={onClick}
       onKeyDown={isInteractive ? handleKeyDown : onKeyDown}
       className={cn(
-        'border-b border-text/6 transition-colors',
+        'border-b border-hairline transition-colors',
         isInteractive &&
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/40',
         className,

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -1,0 +1,65 @@
+// The tonal-pair vocabulary.
+//
+// Every tonal family in theme.css carries two foregrounds: `--color-X` is the HUE
+// (chart series, status dots, bar segments) and `--color-X-ink` is TEXT on that
+// family's tint. A tinted surface therefore pairs the family's `-fill` with its
+// `-ink`, and a solid surface pairs its `-ink` with `--color-on-accent`.
+//
+// Nothing in the names says which half belongs where, and `primary` reads the
+// inverse of every other family — it IS the ink, and pairs with `-tint` rather
+// than `-fill`. So every site that spells a pair by hand is a site that can spell
+// it wrong, and the failure is silent: an undefined theme variable generates no
+// utility at all, so the element simply inherits its color. In dark the two halves
+// are equal, which hides the mistake in one theme while it ships broken in the
+// other.
+//
+// Spelling each pair once, here, buys two things a hand-written className cannot.
+// Tailwind only emits classes it can see as complete literals, so a pair assembled
+// as `bg-sev-${severity}-fill` generates no CSS. And the tonal-ink guard in
+// @akasecurity/eslint-config needs the family name inside one static quasi to match
+// — a dynamically assembled pair is its documented blind spot, which is exactly how
+// a bare hue reached `text-*` undetected.
+
+/** A tonal family that can tint a surface. */
+export type Tone =
+  | 'neutral'
+  | 'critical'
+  | 'high'
+  | 'medium'
+  | 'low'
+  | 'ok'
+  | 'teal'
+  | 'violet'
+  | 'primary';
+
+/**
+ * The families that also carry a SOLID fill. Only the alert tones do: a solid
+ * fill is an escalation, and teal/violet/primary are categorical rather than
+ * urgent. `primary` has its own solid pair (`--color-primary-solid` with
+ * `--color-text-inv`) that is the button's, not a tile's, so it stays out.
+ */
+export type SolidTone = Extract<Tone, 'critical' | 'high' | 'medium' | 'low' | 'ok'>;
+
+/** Tinted surface plus the ink that reads on it. */
+export const TONE_SOFT: Record<Tone, string> = {
+  neutral: 'bg-surface-2 text-text-2',
+  critical: 'bg-sev-critical-fill text-sev-critical-ink',
+  high: 'bg-sev-high-fill text-sev-high-ink',
+  medium: 'bg-sev-medium-fill text-sev-medium-ink',
+  low: 'bg-sev-low-fill text-sev-low-ink',
+  ok: 'bg-ok-fill text-ok-ink',
+  teal: 'bg-teal-fill text-teal-ink',
+  violet: 'bg-violet-fill text-violet-ink',
+  // The inverse of every line above: primary's bare token is the ink, and its
+  // tint is spelled -tint rather than -fill.
+  primary: 'bg-primary-tint text-primary',
+};
+
+/** Saturated fill carrying `--color-on-accent`. */
+export const TONE_SOLID: Record<SolidTone, string> = {
+  critical: 'bg-sev-critical-ink text-on-accent',
+  high: 'bg-sev-high-ink text-on-accent',
+  medium: 'bg-sev-medium-ink text-on-accent',
+  low: 'bg-sev-low-ink text-on-accent',
+  ok: 'bg-ok-ink text-on-accent',
+};

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -5,6 +5,12 @@
 // family's tint. A tinted surface therefore pairs the family's `-fill` with its
 // `-ink`, and a solid surface pairs its `-ink` with `--color-on-accent`.
 //
+// The ink is calibrated to clear 4.5:1 over `--color-surface`, and that bound is
+// NOT unconditional: in dark the fills are 12% alpha, so a pair's contrast
+// depends on what sits beneath it. Over `--color-surface-2` critical, low and
+// violet fall under 4.5, and a tinted chip on a tinted row is outside what these
+// pairs promise — reach for a solid pair, or an untinted row, where that happens.
+//
 // Nothing in the names says which half belongs where, and `primary` reads the
 // inverse of every other family — it IS the ink, and pairs with `-tint` rather
 // than `-fill`. So every site that spells a pair by hand is a site that can spell

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -22,15 +22,7 @@
 
 /** A tonal family that can tint a surface. */
 export type Tone =
-  | 'neutral'
-  | 'critical'
-  | 'high'
-  | 'medium'
-  | 'low'
-  | 'ok'
-  | 'teal'
-  | 'violet'
-  | 'primary';
+  'neutral' | 'critical' | 'high' | 'medium' | 'low' | 'ok' | 'teal' | 'violet' | 'primary';
 
 /**
  * The families that also carry a SOLID fill. Only the alert tones do: a solid

--- a/packages/ui-kit/test/badge.test.ts
+++ b/packages/ui-kit/test/badge.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { Badge, type BadgeProps } from '../src/badge.tsx';
+
+// Seven of the nine variants read their pair from TONE_SOFT rather than
+// respelling it, so a change to the vocabulary now reaches Badge. That is the
+// point — one spelling per pair — but it also means an edit in tone.ts can move
+// what Badge renders without touching this file. These are the exact strings, so
+// such a change has to be deliberate.
+//
+// `default` is pinned for the opposite reason: it is the one tonal variant with
+// NO vocabulary member (neutral is bg-surface-2; this is the step deeper), so
+// "convert the last one too" is a real temptation and would darken every neutral
+// chip in the product.
+const EXPECTED: Record<NonNullable<BadgeProps['variant']>, string> = {
+  default: 'bg-surface-3 text-text-2',
+  outline: 'border border-border text-text-2',
+  critical: 'bg-sev-critical-fill text-sev-critical-ink',
+  high: 'bg-sev-high-fill text-sev-high-ink',
+  medium: 'bg-sev-medium-fill text-sev-medium-ink',
+  low: 'bg-sev-low-fill text-sev-low-ink',
+  success: 'bg-ok-fill text-ok-ink',
+  teal: 'bg-teal-fill text-teal-ink',
+  primary: 'bg-primary-tint text-primary',
+};
+
+/** The className Badge would render, without a DOM. */
+function classOf(variant: BadgeProps['variant']): string {
+  const el = Badge({ variant, children: null }) as { props: { className: string } };
+  return el.props.className;
+}
+
+describe('Badge renders each variant unchanged', () => {
+  it.each(Object.entries(EXPECTED))('%s carries exactly its pair', (variant, pair) => {
+    const rendered = classOf(variant as BadgeProps['variant']);
+
+    for (const cls of pair.split(' ')) expect(rendered.split(' ')).toContain(cls);
+  });
+
+  it('keeps the shared base classes on every variant', () => {
+    for (const variant of Object.keys(EXPECTED) as NonNullable<BadgeProps['variant']>[]) {
+      expect(classOf(variant)).toContain('rounded-full');
+    }
+  });
+
+  // Without this the suite would pass on a Badge that emitted every class at
+  // once, which is the shape a broken cva config actually produces.
+  it('does not leak another variant onto a variant', () => {
+    expect(classOf('success').split(' ')).not.toContain('bg-teal-fill');
+    expect(classOf('default').split(' ')).not.toContain('bg-surface-2');
+  });
+});

--- a/packages/ui-kit/test/tone.test.ts
+++ b/packages/ui-kit/test/tone.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { type SolidTone, type Tone, TONE_SOFT, TONE_SOLID } from '../src/tone.ts';
+
+// `Record<Tone, string>` constrains the KEYS and says nothing about the values,
+// so every way a pair can be wrong is invisible to the compiler: a `bg-ok` that
+// should be `bg-ok-fill`, an ink borrowed from another family, a `-fill` where
+// the ink belongs. Each of those fails the way this module exists to prevent —
+// an undefined theme variable emits no utility at all, so the element inherits
+// its color rather than landing on something visibly wrong, and in dark the hue
+// and ink halves are equal, which hides a mistake in one theme while it ships
+// broken in the other.
+//
+// So the values are checked against theme.css itself rather than against a
+// second copy of the strings. A literal restated here would be true by
+// construction and would move with nothing.
+
+const THEME_CSS = readFileSync(new URL('../src/styles/theme.css', import.meta.url), 'utf8');
+
+// Dark is class-activated in this file (`[data-theme='dark']`), never
+// `prefers-color-scheme` — so the two themes are exactly two blocks, split at
+// that selector.
+const DARK_SELECTOR_AT = THEME_CSS.indexOf("[data-theme='dark']");
+const LIGHT_BLOCK = THEME_CSS.slice(0, DARK_SELECTOR_AT);
+const DARK_BLOCK = THEME_CSS.slice(DARK_SELECTOR_AT);
+
+/** `bg-sev-critical-fill` / `text-ok-ink` → `--color-sev-critical-fill`. */
+function tokenOf(className: string): string {
+  return `--color-${className.replace(/^(?:bg|text)-/, '')}`;
+}
+
+function definesToken(block: string, token: string): boolean {
+  return block.includes(`${token}:`);
+}
+
+/** The two halves of a pair, asserted to BE two halves before being read. */
+function halvesOf(pair: string): { fill: string; ink: string } {
+  const parts = pair.split(' ');
+  expect(parts, `${pair} is not exactly a background and a foreground`).toHaveLength(2);
+  const [fill, ink] = parts as [string, string];
+  expect(fill, `${pair} does not lead with its background half`).toMatch(/^bg-/);
+  expect(ink, `${pair} does not close with its foreground half`).toMatch(/^text-/);
+  return { fill, ink };
+}
+
+describe('the tonal pairs resolve in theme.css', () => {
+  // The strongest of the three: a token nothing defines generates no utility,
+  // which is the silent failure. Both themes are required because a token
+  // defined only in light leaves dark inheriting, and vice versa.
+  it.each(Object.entries(TONE_SOFT))('TONE_SOFT.%s is defined in both themes', (_tone, pair) => {
+    const { fill, ink } = halvesOf(pair);
+
+    for (const token of [tokenOf(fill), tokenOf(ink)]) {
+      expect(definesToken(LIGHT_BLOCK, token), `${token} is undefined in light`).toBe(true);
+      expect(definesToken(DARK_BLOCK, token), `${token} is undefined in dark`).toBe(true);
+    }
+  });
+
+  it.each(Object.entries(TONE_SOLID))('TONE_SOLID.%s is defined in both themes', (_tone, pair) => {
+    const { fill, ink } = halvesOf(pair);
+
+    for (const token of [tokenOf(fill), tokenOf(ink)]) {
+      expect(definesToken(LIGHT_BLOCK, token), `${token} is undefined in light`).toBe(true);
+      expect(definesToken(DARK_BLOCK, token), `${token} is undefined in dark`).toBe(true);
+    }
+  });
+
+  // A control: without it, a `definesToken` that always returned true would pass
+  // every case above.
+  it('reports a token theme.css does not define', () => {
+    expect(definesToken(LIGHT_BLOCK, '--color-not-a-family-fill')).toBe(false);
+    expect(definesToken(DARK_BLOCK, '--color-not-a-family-fill')).toBe(false);
+  });
+});
+
+describe('the tonal pairs are shaped as fill + ink', () => {
+  // Catches the half that resolves but is the wrong half — `bg-ok` names a real
+  // token (the HUE), so the resolution check above passes on it. Two families
+  // are irregular and are named rather than inferred: `primary`'s bare token IS
+  // the ink and its tint is `-tint`, and `neutral` is a surface rather than a
+  // tonal family.
+  const IRREGULAR: Partial<Record<Tone, string>> = {
+    neutral: 'bg-surface-2 text-text-2',
+    primary: 'bg-primary-tint text-primary',
+  };
+
+  it.each(Object.entries(TONE_SOFT))(
+    'TONE_SOFT.%s pairs a -fill with its own -ink',
+    (tone, pair) => {
+      const irregular = IRREGULAR[tone as Tone];
+      if (irregular !== undefined) {
+        expect(pair).toBe(irregular);
+        return;
+      }
+
+      const { fill, ink } = halvesOf(pair);
+      expect(fill, `${tone}'s background half is not a -fill`).toMatch(/-fill$/);
+      expect(ink, `${tone}'s foreground half is not an -ink`).toMatch(/-ink$/);
+
+      // The family must be the SAME on both halves: `bg-ok-fill text-teal-ink`
+      // satisfies every check above it.
+      expect(fill.replace(/^bg-/, '').replace(/-fill$/, '')).toBe(
+        ink.replace(/^text-/, '').replace(/-ink$/, ''),
+      );
+    },
+  );
+
+  it.each(Object.entries(TONE_SOLID))(
+    'TONE_SOLID.%s fills with its ink over on-accent',
+    (tone, pair) => {
+      const { fill, ink } = halvesOf(pair);
+
+      // A solid fill is the family's INK used as a background — the inverse of the
+      // soft pair, which is why it cannot be derived from TONE_SOFT by suffix.
+      expect(fill, `${tone}'s solid background is not its -ink`).toMatch(/-ink$/);
+      expect(ink).toBe('text-on-accent');
+      expect(fill.replace(/^bg-/, '')).toBe(
+        TONE_SOFT[tone as SolidTone].split(' ')[1]?.replace(/^text-/, ''),
+      );
+    },
+  );
+});

--- a/web-ui/app/components/AppShell.tsx
+++ b/web-ui/app/components/AppShell.tsx
@@ -69,7 +69,7 @@ export function AppShell({ children }: { children: ReactNode }) {
 function Sidebar({ pathname }: { pathname: string }) {
   return (
     <aside className="flex w-62 flex-col border-r border-border bg-surface shrink-0">
-      <div className="flex h-16 items-center border-b border-text/6 px-5">
+      <div className="flex h-16 items-center border-b border-hairline px-5">
         <AkaLogo aria-label="AKA" className="h-8 w-auto text-mark-fg" />
       </div>
       <nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-3 py-3.5">


### PR DESCRIPTION
Bottom of the stack #337 → #339. #336 has merged, so this now targets `main`; #339 builds on it.

## The problem

Every tonal family in `theme.css` carries two foregrounds. The bare token is the **hue** — chart series, status dots, bar segments, where the job is staying distinguishable from its neighbours. The `-ink` form is **text** on that family's tint, dark enough for 4.5:1. So a tinted surface pairs `-fill` with `-ink`, and a solid one pairs `-ink` with `--color-on-accent`.

Nothing in the names says which half belongs where, and `primary` reads the inverse of every other family: it is already the ink, and its tint is spelled `-tint` rather than `-fill`. Every site that spells a pair by hand is therefore a site that can spell it wrong.

The failure is silent in three separate ways, which is what makes it worth solving structurally rather than by remembering:

1. An undefined theme variable emits **no utility at all**, so the element inherits its colour rather than landing on something visibly wrong.
2. In dark the hue and ink halves are equal, so a mistake looks correct in one theme and ships broken in the other.
3. The existing tonal-ink lint rule catches the literal form, but its selector needs the family name inside a single static quasi. A pair assembled from a non-literal — `` `text-sev-${severity}` `` — matches nothing. Tailwind has the same requirement, so such a class is never emitted either. The rule's own docs already name this as a deliberate blind spot.

## The change

`TONE_SOFT` and `TONE_SOLID`, keyed by a `Tone` union, so each pair is written exactly once and always as a complete literal — visible to Tailwind, and to the lint rule.

`SolidTone` is deliberately narrower than `Tone`. A solid fill is an escalation, so only the alert families carry one; teal, violet and primary are categorical, and primary's solid pair belongs to buttons rather than tiles. Typing it that way keeps the lookup total without inventing entries no design calls for.

`CardIcon` gains a `tone` prop whose default reproduces the neutral pair it previously hard-coded, so **existing uses render identically**. `className` still wins, for a one-off tile whose colour is not a family `theme.css` names.

## Badge reads the vocabulary rather than respelling it

Seven of `badgeVariants`' nine entries were a second copy of a pair `TONE_SOFT` defines — six under the same name, and `bg-ok-fill text-ok-ink` under the name `success`. A module whose stated job is one spelling per pair should not ship beside seven duplicates of its own, so those seven now read from `TONE_SOFT`.

The variant **names** are deliberately unchanged. `variant` is public API, and `success` is spelled across consumers outside this repo, so renaming it to match `ok` would be a breaking change rather than the one-word fix it resembles — while renaming `TONE_SOFT.ok` to `success` would break the member-name/token-name correspondence with `--color-ok`, which is the property the vocabulary exists to hold. Reading the *value* from the vocabulary removes the half that can actually be got wrong; the two names remain, but neither can now drift from the other.

`default` is the exception and stays hand-spelled: it is `bg-surface-3 text-text-2`, a step deeper than the vocabulary's `neutral` (`surface-2`), so it has no member to read. That leaves it as the only hand-spelled tonal variant in the file, which is a fair marker of where a second neutral member would go — the same gap that forces `ACTION_META.monitored` and three `EVENT_META` rows to stay literal in #339. Adding one is a follow-up, not this PR.

## `CardIcon` keeps its neutral fallback

The neutral pair used to be part of the base literal, so it applied unconditionally; indexing `TONE_SOFT` made it droppable, and an off-union `tone` would leave the tile with no background *and* no foreground rather than falling back to neutral. TypeScript rules that out for in-repo callers, but this package is consumed from another repository, where a stale or plain-JS caller can pass anything.

It is reached through a string-keyed view (the idiom `findings/meta.ts` already uses for its off-enum fallback) rather than a bare `??`, because with `tone` typed as `Tone` the compiler believes the index can never be undefined and `@typescript-eslint/no-unnecessary-condition` prunes the guard as dead code — the type making a promise about callers it cannot see.

## Also: `--color-hairline`

The rule between rows inside a card was written inline as a 6% alpha on the text colour, in ui-kit, dashboard-ui and web-ui alike. It now has a name and sits beside the two container-edge weights it belongs with.

The value is unchanged in both themes. It is written out per theme rather than derived, because the alpha rides on a token that inverts: 6% of the near-black light ink and 6% of the white dark ink are opposite colours, and spelling both keeps the pair honest if either text value is ever retuned.

## Verification

`typecheck`, `lint` and `test` green in ui-kit, dashboard-ui and web-ui.

Because the whole point is which classes actually reach the stylesheet, that was checked at the bundle rather than by eye: all four `.text-sev-*-ink` rules are emitted, and the token resolves to `#252f3d0f` / `#ffffff0f` in light and dark respectively. Since the badge literals have now left `badge.tsx`, the same compile confirms all 16 of its classes are still emitted — from `tone.ts`, which is the only place they are written.

`Record<Tone, string>` constrains the keys and says nothing about the values, so a `bg-ok` that should be `bg-ok-fill`, an ink borrowed from another family, or a token nothing defines were all invisible. `tone.test.ts` checks the values against `theme.css` itself rather than a second copy of the strings — every token defined in *both* theme blocks, the fill half actually a `-fill`, the ink half from the same family. `badge.test.ts` pins all nine variants, since a `tone.ts` edit can now move what `Badge` renders without touching `badge.tsx`.

Both were mutation-checked rather than assumed green: `bg-ok` for `bg-ok-fill` reds one case, a cross-family ink reds two, an undefined token reds one, and pointing `TONE_SOFT.ok` at the teal pair reds three across both files. ui-kit's suite is 44 tests rather than 4, and coverage moves 2.13 → 4.16 against its floor of 1.

One claim in `tone.ts` was too strong and is now qualified: the ink clears 4.5:1 over `--color-surface`, but dark's fills are 12% alpha, so a pair's contrast depends on what sits beneath it — over `--color-surface-2`, critical, low and violet fall under. A tinted chip on a tinted row is outside what these pairs promise, and the header says so rather than stating the bound unconditionally.

