### PR TITLE
refactor(dashboard-ui): look the tonal pairs up instead of spelling them

### DIFF
--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -206,7 +206,7 @@ export function SessionListView({
                   <span className="text-label font-semibold uppercase tracking-wider text-text-3">
                     {group.day}
                   </span>
-                  <span className="h-px flex-1 bg-text/6" />
+                  <span className="h-px flex-1 bg-hairline" />
                   <span className="text-label text-text-3">{group.items.length}</span>
                 </div>
                 <div className="flex flex-col gap-1">

--- a/packages/dashboard-ui/src/data-shares/atoms.tsx
+++ b/packages/dashboard-ui/src/data-shares/atoms.tsx
@@ -8,7 +8,7 @@ import type {
   ShareTrustLevel,
   Transport,
 } from '@akasecurity/schema';
-import { Badge, cn } from '@akasecurity/ui-kit';
+import { Badge, cn, type Tone, TONE_SOFT } from '@akasecurity/ui-kit';
 
 import { BracesIcon, BuildingIcon, PinIcon, ServerIcon } from '../shared/icons.tsx';
 import { CLASS_META, destMarkStyle, providerMark, TRANSPORT_META, TRUST_META } from './meta.ts';
@@ -17,20 +17,20 @@ import { CLASS_META, destMarkStyle, providerMark, TRANSPORT_META, TRUST_META } f
  * Colored method tag (mono, method-colored). 'SDK' and 'REF' are evidence tags
  * rather than verbs — see HttpMethod in @akasecurity/schema.
  */
-const METHOD_TONE: Record<HttpMethod, string> = {
-  GET: 'bg-sev-low-fill text-sev-low-ink',
-  POST: 'bg-ok-fill text-ok-ink',
-  PUT: 'bg-sev-high-fill text-sev-high-ink',
-  DELETE: 'bg-sev-critical-fill text-sev-critical-ink',
-  SDK: 'bg-ok-fill text-ok-ink',
-  REF: 'bg-sev-medium-fill text-sev-medium-ink',
+const METHOD_TONE: Record<HttpMethod, Tone> = {
+  GET: 'low',
+  POST: 'ok',
+  PUT: 'high',
+  DELETE: 'critical',
+  SDK: 'ok',
+  REF: 'medium',
 };
 export function MethodTag({ method }: { method: HttpMethod }) {
   return (
     <span
       className={cn(
         'inline-flex h-5 items-center rounded px-1.5 font-mono text-label leading-none font-bold py-0.5',
-        METHOD_TONE[method],
+        TONE_SOFT[METHOD_TONE[method]],
       )}
     >
       {method}

--- a/packages/dashboard-ui/src/data-shares/meta.ts
+++ b/packages/dashboard-ui/src/data-shares/meta.ts
@@ -11,7 +11,7 @@ import type {
   ShareTrustLevel,
   Transport,
 } from '@akasecurity/schema';
-import type { BadgeProps } from '@akasecurity/ui-kit';
+import { type BadgeProps, TONE_SOFT } from '@akasecurity/ui-kit';
 
 import type { IconComponent } from '../lib/icons.ts';
 import {
@@ -128,10 +128,9 @@ export function flagReason(reasons: ReviewReason[]): string {
  * reclassification cannot silently drop them to the internal tint.
  */
 export function destMarkStyle(d: { kind: DestinationKind; trust: ShareTrustLevel }): string {
-  if (d.kind === 'ip') return 'bg-sev-critical-fill text-sev-critical-ink';
-  if (d.kind === 'external' || d.trust === 'unverified')
-    return 'bg-sev-high-fill text-sev-high-ink';
-  return 'bg-primary-tint text-primary';
+  if (d.kind === 'ip') return TONE_SOFT.critical;
+  if (d.kind === 'external' || d.trust === 'unverified') return TONE_SOFT.high;
+  return TONE_SOFT.primary;
 }
 
 /** Colored lettermark for a provider destination. */

--- a/packages/dashboard-ui/src/findings/meta.ts
+++ b/packages/dashboard-ui/src/findings/meta.ts
@@ -10,6 +10,7 @@ import type {
   FindingStatus,
   Severity,
 } from '@akasecurity/schema';
+import { type Tone, TONE_SOFT } from '@akasecurity/ui-kit';
 
 import type { IconComponent } from '../lib/icons.ts';
 import {
@@ -60,18 +61,18 @@ export const CATEGORY_ICON: Record<FindingCategory, IconComponent> = {
   custom: KeyIcon,
 };
 
-/** Per-category icon-tile fill + text color (falls back to a neutral surface tone). */
-export const CATEGORY_STYLE: Record<FindingCategory, string> = {
-  secret: 'bg-sev-critical-fill text-sev-critical-ink',
-  pii: 'bg-sev-low-fill text-sev-low-ink',
-  source_code: 'bg-violet-fill text-violet-ink',
-  code_flaw: 'bg-sev-high-fill text-sev-high-ink',
-  external_share: 'bg-teal-fill text-teal-ink',
-  mcp_server: 'bg-sev-high-fill text-sev-high-ink',
-  customer_data: 'bg-sev-high-fill text-sev-high-ink',
-  financial: 'bg-sev-high-fill text-sev-high-ink',
-  phi: 'bg-sev-low-fill text-sev-low-ink',
-  custom: 'bg-surface-2 text-text-2',
+/** Per-category icon-tile tone (falls back to a neutral surface tone). */
+export const CATEGORY_TONE: Record<FindingCategory, Tone> = {
+  secret: 'critical',
+  pii: 'low',
+  source_code: 'violet',
+  code_flaw: 'high',
+  external_share: 'teal',
+  mcp_server: 'high',
+  customer_data: 'high',
+  financial: 'high',
+  phi: 'low',
+  custom: 'neutral',
 };
 
 // The maps are exhaustive over FindingCategory (adding a member is a compile
@@ -83,28 +84,26 @@ export const CATEGORY_STYLE: Record<FindingCategory, string> = {
 // (react-hooks/static-components) stays satisfied.
 export const CATEGORY_ICON_FALLBACK: Record<string, IconComponent | undefined> = CATEGORY_ICON;
 
+// Returns the CLASS pair rather than the tone: every caller feeds it straight
+// into `cn()` beside layout classes, and the off-enum fallback has to resolve
+// somewhere — doing it here keeps that one place.
 export const categoryStyle = (category: string): string =>
-  (CATEGORY_STYLE as Record<string, string | undefined>)[category] ?? 'bg-surface-2 text-text-2';
+  TONE_SOFT[(CATEGORY_TONE as Record<string, Tone | undefined>)[category] ?? 'neutral'];
 
 /** Per-action pill label + icon + tinted classes. */
 export const ACTION_META: Record<
   FindingAction,
   { label: string; icon: IconComponent; className: string }
 > = {
-  blocked: {
-    label: 'Blocked',
-    icon: SlashCircleIcon,
-    className: 'bg-sev-critical-fill text-sev-critical-ink',
-  },
-  redacted: { label: 'Redacted', icon: RedactIcon, className: 'bg-primary-tint text-primary' },
-  warned: { label: 'Warned', icon: AlertIcon, className: 'bg-sev-high-fill text-sev-high-ink' },
-  allowed: { label: 'Allowed', icon: CheckIcon, className: 'bg-ok-fill text-ok-ink' },
+  blocked: { label: 'Blocked', icon: SlashCircleIcon, className: TONE_SOFT.critical },
+  redacted: { label: 'Redacted', icon: RedactIcon, className: TONE_SOFT.primary },
+  warned: { label: 'Warned', icon: AlertIcon, className: TONE_SOFT.high },
+  allowed: { label: 'Allowed', icon: CheckIcon, className: TONE_SOFT.ok },
+  // The one pill that is NOT a tonal family: it sits a step deeper than
+  // `neutral` (surface-3, not surface-2) to read as the quietest action of the
+  // six. There is no -ink half to get wrong, so spelling it here is safe.
   monitored: { label: 'Monitored', icon: EyeIcon, className: 'bg-surface-3 text-text-2' },
-  quarantined: {
-    label: 'Quarantined',
-    icon: ShieldIcon,
-    className: 'bg-sev-critical-fill text-sev-critical-ink',
-  },
+  quarantined: { label: 'Quarantined', icon: ShieldIcon, className: TONE_SOFT.critical },
 };
 
 /**

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -95,7 +95,7 @@ export {
   CATEGORY_ICON,
   CATEGORY_ICON_FALLBACK,
   CATEGORY_LABEL,
-  CATEGORY_STYLE,
+  CATEGORY_TONE,
   categoryStyle,
   type ColumnVisibility,
   DEFAULT_FINDINGS_VIEW,
@@ -207,7 +207,7 @@ export {
   type FindingsTimeseriesView,
 } from './security/FindingsOverTimeCardView.tsx';
 export { formatMttrDuration } from './security/format.ts';
-export { ENFORCEMENT_META, SEVERITY_META, SEVERITY_TILE } from './security/meta.ts';
+export { ENFORCEMENT_META, SEVERITY_META } from './security/meta.ts';
 export {
   type MttrChartPoint,
   MttrTrendCardView,

--- a/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
@@ -9,11 +9,12 @@ import {
   CardTitle,
   cn,
   Skeleton,
+  TONE_SOFT,
 } from '@akasecurity/ui-kit';
 
 import { relativeTime } from '../lib/relativeTime.ts';
 import { CheckCircleIcon } from '../shared/icons.tsx';
-import { SEVERITY_META, SEVERITY_TILE } from './meta.ts';
+import { SEVERITY_META } from './meta.ts';
 import { WidgetEmpty, WidgetError } from './widget-shared.tsx';
 
 export interface RecentlyResolvedView {
@@ -65,7 +66,7 @@ function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) 
       <span
         className={cn(
           'z-10 grid size-8 shrink-0 place-items-center rounded-lg',
-          SEVERITY_TILE[item.severity],
+          TONE_SOFT[item.severity],
         )}
       >
         <CheckCircleIcon aria-hidden focusable={false} className="size-4" />

--- a/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
@@ -62,7 +62,7 @@ function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) 
   return (
     <div className={cn('relative flex gap-3', !last && 'pb-4')}>
       {/* Connector line to the next item — centered under the 32px icon tile. */}
-      {!last && <span className="absolute bottom-0 left-4 top-8 w-px bg-text/6" />}
+      {!last && <span className="absolute bottom-0 left-4 top-8 w-px bg-hairline" />}
       <span
         className={cn(
           'z-10 grid size-8 shrink-0 place-items-center rounded-lg',

--- a/packages/dashboard-ui/src/security/RecommendedActionsCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecommendedActionsCardView.tsx
@@ -14,6 +14,8 @@ import {
   cn,
   Skeleton,
   Tag,
+  type Tone,
+  TONE_SOFT,
 } from '@akasecurity/ui-kit';
 
 import type { IconComponent } from '../lib/icons.ts';
@@ -26,13 +28,7 @@ import {
 } from '../shared/icons.tsx';
 import { WidgetError } from './widget-shared.tsx';
 
-type RecommendationTone = 'critical' | 'primary' | 'teal';
-
-const TONE_TILE: Record<RecommendationTone, string> = {
-  critical: 'bg-sev-critical-fill text-sev-critical-ink',
-  primary: 'bg-primary-tint text-primary',
-  teal: 'bg-teal-fill text-teal-ink',
-};
+type RecommendationTone = Extract<Tone, 'critical' | 'primary' | 'teal'>;
 
 // `category` is an extensible string; map the known ones to a tile icon, falling
 // back to a generic alert for any new category.
@@ -75,7 +71,7 @@ export function RecommendedActionsCardView({
   return (
     <Card className="flex flex-col shadow-sm">
       <CardHeader>
-        <CardIcon className="bg-primary-tint text-primary">
+        <CardIcon tone="primary">
           <SparklesIcon aria-hidden focusable={false} className="size-4" />
         </CardIcon>
         <CardHeading>
@@ -117,7 +113,7 @@ export function RecommendedActionsCardView({
                   <span
                     className={cn(
                       'flex size-8 shrink-0 items-center justify-center rounded-lg',
-                      TONE_TILE[SEVERITY_TONE[a.severity]],
+                      TONE_SOFT[SEVERITY_TONE[a.severity]],
                     )}
                   >
                     <Icon aria-hidden focusable={false} className="size-4" />

--- a/packages/dashboard-ui/src/security/ScanCoverageCardView.tsx
+++ b/packages/dashboard-ui/src/security/ScanCoverageCardView.tsx
@@ -35,7 +35,7 @@ export function ScanCoverageCardView({
   return (
     <Card className="flex flex-col shadow-sm">
       <CardHeader>
-        <CardIcon className="bg-teal-fill text-teal-ink">
+        <CardIcon tone="teal">
           <ShieldCheckIcon aria-hidden focusable={false} className="size-4" />
         </CardIcon>
         <CardHeading>

--- a/packages/dashboard-ui/src/security/SeverityCardView.tsx
+++ b/packages/dashboard-ui/src/security/SeverityCardView.tsx
@@ -67,7 +67,7 @@ export function SeverityCardView({
   return (
     <Card className="flex flex-col shadow-sm">
       <CardHeader>
-        <CardIcon className="bg-sev-critical-fill text-sev-critical-ink">
+        <CardIcon tone="critical">
           <AlertOctagonIcon aria-hidden focusable={false} className="size-4" />
         </CardIcon>
         <CardHeading>

--- a/packages/dashboard-ui/src/security/meta.ts
+++ b/packages/dashboard-ui/src/security/meta.ts
@@ -16,13 +16,9 @@ export const SEVERITY_META: Record<Severity, { label: string; color: string }> =
   low: { label: 'Low', color: COLORS.sevLow },
 };
 
-// Tailwind classes for a severity-tinted icon tile (fill + foreground).
-export const SEVERITY_TILE: Record<Severity, string> = {
-  critical: 'bg-sev-critical-fill text-sev-critical-ink',
-  high: 'bg-sev-high-fill text-sev-high-ink',
-  medium: 'bg-sev-medium-fill text-sev-medium-ink',
-  low: 'bg-sev-low-fill text-sev-low-ink',
-};
+// A severity-tinted icon tile needs no lookup of its own: every Severity member
+// is also a tonal family name, so `TONE_SOFT[severity]` at the call site IS the
+// mapping.
 
 // `icon` is a concrete component (resolved here, not a string name), so the view
 // renders it directly and a missing mapping is a compile error.

--- a/packages/dashboard-ui/src/shared/SummaryStripView.tsx
+++ b/packages/dashboard-ui/src/shared/SummaryStripView.tsx
@@ -120,7 +120,7 @@ export function SummaryStripView({
     >
       {items.map((item, i) => (
         <Fragment key={item.label}>
-          {i > 0 && <span className="w-px shrink-0 self-stretch bg-text/6" />}
+          {i > 0 && <span className="w-px shrink-0 self-stretch bg-hairline" />}
           <SummaryStat {...item} isLoading={isLoading} />
         </Fragment>
       ))}

--- a/packages/dashboard-ui/src/updates/AvailablePluginsCardView.tsx
+++ b/packages/dashboard-ui/src/updates/AvailablePluginsCardView.tsx
@@ -33,7 +33,7 @@ export function AvailablePluginsCardView({
   return (
     <Card className="shadow-sm">
       <CardHeader>
-        <CardIcon className="bg-teal-fill text-teal-ink">
+        <CardIcon tone="teal">
           <SparklesIcon aria-hidden focusable={false} className="size-4" />
         </CardIcon>
         <CardHeading>

--- a/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
+++ b/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
@@ -59,7 +59,7 @@ export function UpdateStatusCardView({
   return (
     <Card className="shadow-sm">
       <CardHeader>
-        <CardIcon className="bg-primary-tint text-primary">
+        <CardIcon tone="primary">
           <RefreshIcon aria-hidden focusable={false} className="size-4" />
         </CardIcon>
         <CardHeading>

--- a/web-ui/app/components/AppShell.tsx
+++ b/web-ui/app/components/AppShell.tsx
@@ -2,7 +2,7 @@
 
 import type { IconComponent } from '@akasecurity/dashboard-ui';
 import { ThemeToggle } from '@akasecurity/dashboard-ui/theme/toggle';
-import { cn } from '@akasecurity/ui-kit';
+import { cn, TONE_SOFT } from '@akasecurity/ui-kit';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
@@ -94,7 +94,7 @@ function NavRow({ item, active }: { item: NavItem; active: boolean }) {
   const className = cn(
     'flex w-full items-center gap-3 rounded-lg px-3 h-10 text-left text-sm group font-medium transition-colors cursor-pointer',
     active
-      ? 'bg-primary-tint text-primary font-semibold'
+      ? cn(TONE_SOFT.primary, 'font-semibold')
       : 'text-text-2 hover:bg-surface-2 hover:text-text',
   );
 


### PR DESCRIPTION
Stacked on #337 — review that one first; this branch's base is `feat/ui-kit-tonal-pair-vocabulary`.

That PR added the vocabulary and left the call sites for a follow-up so the two diffs stayed reviewable. This is that follow-up: it moves `dashboard-ui` and `web-ui` onto `TONE_SOFT`.

## The change

Complete hand-spelled pairs across `dashboard-ui/src` and `web-ui` go from **43 to 7**.

Counted as *complete, adjacent* fill+ink pairs — both halves of one family, written as literals next to each other — and excluding the neutral surface pair, which is a surface rather than a tonal family. The rule matters because the figure moves with it: counting the neutral pair as well gives **45 → 7** instead, so a reader applying a slightly wider rule reproduces a different number and concludes one of us has miscounted.

The presentational meta maps each carried a fill/ink class pair per domain key, so the same eight pairings were written out across findings, security, data-shares and the update cards. Each is now a `Record<DomainKey, Tone>` and the classes come from `TONE_SOFT` where they are rendered:

- `CATEGORY_STYLE` → `CATEGORY_TONE`, and `ACTION_META`'s five family pills
- `METHOD_TONE` in the data-shares atoms
- `TONE_TILE` in `RecommendedActionsCardView`, now typed `Extract<Tone, …>`
- the three branches of `destMarkStyle`

Five `CardIcon` tiles that reached for `className` now pass `tone`, which is what the prop is for. Merged last-wins, the classes they produce are unchanged.

`SEVERITY_TILE` is **dropped** rather than converted. Every `Severity` member is also a tonal family name, so the map was an identity; `TONE_SOFT[severity]` at the one call site is the whole of it.

## What deliberately stays hand-spelled

`categoryStyle` and `destMarkStyle` still **return classes** rather than a `Tone`. Every caller feeds them straight into `cn()` beside layout classes, and `categoryStyle`'s off-enum fallback has to resolve somewhere; doing it inside keeps that in one place and leaves the contract untouched, so the existing literal assertions in `findings/meta.test.ts` pass unchanged.

`ACTION_META`'s `monitored` pill is **not** a tonal family. It sits a step deeper than the neutral tone — `surface-3`, not `surface-2` — to read as the quietest of the six actions. Folding it into `neutral` would be a silent colour change, and it has no `-ink` half to get wrong.

**Solid pairs are out of scope.** This PR consumes `TONE_SOFT` and not `TONE_SOLID`, which still has no caller. Eight sites are exactly its shape — `NeedsReviewStripView.tsx:28,32`, `BlockedLedgerView.tsx:117,121`, `ProjectPane.tsx:394`, `InventoryNav.tsx:311`, `AssetDetail.tsx:168`, `ProvenanceBlock.tsx:70` — all pre-existing and untouched here. The substitutions are mechanical (`text-on-accent` and `text-xs` are different tailwind-merge groups, so a chip keeps its size), which makes them a cheap follow-up rather than a reason to widen this diff. Saying so explicitly because this is the PR whose job is call sites, so silence would read as "there were none".

`activity/meta.ts`'s `EVENT_META` is the same refactor with the halves stored split (`{text, fill}`, joined at `AuditTimelineView.tsx:54-55`) and is likewise left alone. It hits the same wall as `ACTION_META.monitored`: 8 of its 11 rows are `TONE_SOFT` members and the other 3 are `bg-surface-3 text-text-2`, which the vocabulary has no name for. A second neutral member would absorb those three and `monitored` together — worth doing, but it is new vocabulary and belongs in the PR that owns the vocabulary rather than mid-stack here.

The seven remaining pairs are inline one-offs in detections, inventory and settings. They are already complete literals, so Tailwind and the tonal-ink rule both see them; they are verbose rather than unsafe, and three are entangled with a border half that no family names.

`shared/tones.ts` is untouched. It is a second tonal registry with a different key space and a split text/fill shape, and it derives the `var()` strings the detections and policies views set inline. Folding the two together is a larger change than this one and wants its own review — the names map 1:1 except that its `gray` is `surface-3` where `TONE_SOFT.neutral` is `surface-2`.

## Also: finishing the hairline token

#337 gave the 6%-of-text rule a name and converted the `border-` form. Three `bg-` sites were left behind — `RecentlyResolvedCardView.tsx:65`, `activity/SessionListView.tsx:209`, `shared/SummaryStripView.tsx:123` — one of them four lines from a hunk in this PR. They now use `bg-hairline`, and `bg-text/6` appears nowhere in the workspace.

Beyond consistency: `bg-hairline` compiles to a plain `border-color: var(--color-hairline)`, while `bg-text/6` sits behind an `@supports` gate whose fallback bakes the **light-theme literal**, so a browser without `color-mix` draws a near-black rule on a dark card. The token is strictly more robust, not merely tidier.

## Verification

`typecheck`, `lint` and `test` green in dashboard-ui (319) and web-ui (574).

Since the whole point is that nothing should move on screen, that was checked directly rather than by eye. A probe against the real `cn` and `TONE_SOFT` confirms all six `CardIcon` and `AppShell` sites emit byte-identical class strings, and a temporary parity test compared every migrated map value against its pre-change literal — 33 values, all identical. Mutating one tone turned it red, so it was not passing vacuously. The scaffold was removed rather than committed; keeping it would only re-duplicate what `TONE_SOFT` now owns.

The hairline conversion was checked at the compiled stylesheet rather than by eye, since an unemitted class is the silent failure this stack exists to prevent: `.bg-hairline` is emitted, resolving to `rgb(37 47 61 / 0.06)` in light and `rgb(255 255 255 / 0.06)` in dark — exactly 6% of `--color-text` (`#252f3d` / `#ffffff`) in each theme, so the change is colour-preserving in both.

