### PR TITLE
fix(ui-kit): retone neutral to the deeper surface, and drop the second name

### DIFF
--- a/packages/dashboard-ui/src/activity/meta.ts
+++ b/packages/dashboard-ui/src/activity/meta.ts
@@ -68,15 +68,15 @@ interface EventMeta {
 
 /** Node glyph + tone for each audit event type on the timeline. */
 export const EVENT_META: Record<AuditEventKind, EventMeta> = {
-  session: { label: 'Session', icon: TerminalIcon, ...TONE_PARTS.muted },
+  session: { label: 'Session', icon: TerminalIcon, ...TONE_PARTS.neutral },
   prompt: { label: 'Prompt', icon: UserIcon, ...TONE_PARTS.primary },
   response: { label: 'Response', icon: SparklesIcon, ...TONE_PARTS.violet },
-  tool: { label: 'Tool', icon: TerminalIcon, ...TONE_PARTS.muted },
+  tool: { label: 'Tool', icon: TerminalIcon, ...TONE_PARTS.neutral },
   hook: { label: 'Hook', icon: RouteIcon, ...TONE_PARTS.low },
   detection: { label: 'Detection', icon: ShieldCheckIcon, ...TONE_PARTS.critical },
   share: { label: 'Egress', icon: ExternalShareIcon, ...TONE_PARTS.teal },
   permission: { label: 'Permission', icon: LockIcon, ...TONE_PARTS.high },
-  commit: { label: 'Commit', icon: BranchIcon, ...TONE_PARTS.muted },
+  commit: { label: 'Commit', icon: BranchIcon, ...TONE_PARTS.neutral },
   error: { label: 'Error', icon: AlertIcon, ...TONE_PARTS.critical },
   active: { label: 'In progress', icon: BoltIcon, ...TONE_PARTS.primary },
 };

--- a/packages/dashboard-ui/src/detections/PolicyPicker.tsx
+++ b/packages/dashboard-ui/src/detections/PolicyPicker.tsx
@@ -29,10 +29,10 @@ export function PolicyPicker({
         const m = policyMeta(k);
         const on = value === k;
         const [fg, bg] = toneColors(m.tone);
-        // The muted tone's tint (surface-3) barely contrasts with this control's
+        // The neutral tone's tint (surface-3) barely contrasts with this control's
         // surface-2 track, so a selected "Monitor" looks unselected. Fall back to a
         // white pill for it — the shadow then makes the selection read clearly.
-        const selBg = m.tone === 'muted' ? 'var(--color-surface)' : bg;
+        const selBg = m.tone === 'neutral' ? 'var(--color-surface)' : bg;
         const Icon = m.icon;
         return (
           <button

--- a/packages/dashboard-ui/src/detections/meta.ts
+++ b/packages/dashboard-ui/src/detections/meta.ts
@@ -93,7 +93,7 @@ export const POLICY_META: Record<BuiltinPolicyId, PolicyMeta> = {
     id: 'monitor',
     label: 'Monitor',
     icon: EyeIcon,
-    tone: 'muted',
+    tone: 'neutral',
     desc: 'Log every match for audit. The request is allowed through untouched.',
   },
   warn: {
@@ -150,7 +150,7 @@ export function policyMeta(id: string): PolicyMeta {
   // every call site. Read through a widened view after the hasOwn guard.
   const table: Partial<Record<string, PolicyMeta>> = POLICY_META;
   const known = Object.hasOwn(POLICY_META, id) ? table[id] : undefined;
-  return known ?? { id, label: id, icon: PolicyIcon, tone: 'muted', desc: '' };
+  return known ?? { id, label: id, icon: PolicyIcon, tone: 'neutral', desc: '' };
 }
 
 // ─── Category metadata ────────────────────────────────────────────────────────
@@ -196,7 +196,7 @@ export interface PublisherMeta {
 export const PUBLISHER_META: Record<PublisherKind, PublisherMeta> = {
   labs: { label: 'AKA Labs', icon: ShieldCheckIcon, tone: 'teal', verified: true },
   org: { label: 'Your org', icon: BuildingIcon, tone: 'violet', verified: false },
-  user: { label: 'Community', icon: UserIcon, tone: 'muted', verified: false },
+  user: { label: 'Community', icon: UserIcon, tone: 'neutral', verified: false },
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/dashboard-ui/src/findings/meta.ts
+++ b/packages/dashboard-ui/src/findings/meta.ts
@@ -99,10 +99,9 @@ export const ACTION_META: Record<
   redacted: { label: 'Redacted', icon: RedactIcon, className: TONE_SOFT.primary },
   warned: { label: 'Warned', icon: AlertIcon, className: TONE_SOFT.high },
   allowed: { label: 'Allowed', icon: CheckIcon, className: TONE_SOFT.ok },
-  // The one pill that is NOT a tonal family: it sits a step deeper than
-  // `neutral` (surface-3, not surface-2) to read as the quietest action of the
-  // six. There is no -ink half to get wrong, so spelling it here is safe.
-  monitored: { label: 'Monitored', icon: EyeIcon, className: 'bg-surface-3 text-text-2' },
+  // The quietest of the six, and the only one carrying no family colour:
+  // `neutral` is the untinted pair.
+  monitored: { label: 'Monitored', icon: EyeIcon, className: TONE_SOFT.neutral },
   quarantined: { label: 'Quarantined', icon: ShieldIcon, className: TONE_SOFT.critical },
 };
 

--- a/packages/dashboard-ui/src/policies/PoliciesView.tsx
+++ b/packages/dashboard-ui/src/policies/PoliciesView.tsx
@@ -52,7 +52,7 @@ export function PolicyStatsView({
       icon: ShieldCheckIcon,
       value: statValue(stats?.builtin),
       label: 'Built-in',
-      tone: 'muted',
+      tone: 'neutral',
     },
     {
       icon: TerminalIcon,

--- a/packages/dashboard-ui/src/shared/SummaryStripView.tsx
+++ b/packages/dashboard-ui/src/shared/SummaryStripView.tsx
@@ -22,7 +22,7 @@ import type { IconComponent } from '../lib/icons.ts';
  * the union to the families the strip actually uses; note it does NOT reject an
  * unknown name, which evaluates to `never` here and only errors at a call site.
  */
-export type StatTone = Extract<Tone, 'primary' | 'muted' | 'violet' | 'ok' | 'critical' | 'teal'>;
+export type StatTone = Extract<Tone, 'primary' | 'neutral' | 'violet' | 'ok' | 'critical' | 'teal'>;
 
 export interface SummaryStatItem {
   icon: IconComponent;

--- a/packages/dashboard-ui/test/activity/tone-parity.test.ts
+++ b/packages/dashboard-ui/test/activity/tone-parity.test.ts
@@ -8,9 +8,9 @@ import { EVENT_META } from '../../src/activity/meta.ts';
 // written out here; this is where they are, so re-toning a row is a deliberate
 // edit rather than something a spread quietly carries.
 const EXPECTED = {
-  session: 'muted', prompt: 'primary', response: 'violet', tool: 'muted',
+  session: 'neutral', prompt: 'primary', response: 'violet', tool: 'neutral',
   hook: 'low', detection: 'critical', share: 'teal', permission: 'high',
-  commit: 'muted', error: 'critical', active: 'primary',
+  commit: 'neutral', error: 'critical', active: 'primary',
 } as const;
 
 describe('the timeline node tones', () => {

--- a/packages/dashboard-ui/test/detections/meta.test.ts
+++ b/packages/dashboard-ui/test/detections/meta.test.ts
@@ -55,7 +55,7 @@ describe('policyMeta', () => {
   it('falls back to a neutral entry for an unknown id (keeping the id as label)', () => {
     const m = policyMeta('mystery');
     expect(m.label).toBe('mystery');
-    expect(m.tone).toBe('muted');
+    expect(m.tone).toBe('neutral');
   });
 
   it('defaults unassigned detections to monitor', () => {
@@ -72,7 +72,7 @@ describe('policyMeta', () => {
     (id) => {
       const m = policyMeta(id);
       expect(m.label).toBe(id);
-      expect(m.tone).toBe('muted');
+      expect(m.tone).toBe('neutral');
       // The destructure that crashed the page must succeed on the fallback tone.
       expect(toneColors(m.tone)).toHaveLength(2);
     },

--- a/packages/dashboard-ui/test/findings/meta.test.ts
+++ b/packages/dashboard-ui/test/findings/meta.test.ts
@@ -32,7 +32,7 @@ describe('categoryStyle', () => {
   });
 
   it('falls back to a neutral surface tone for an off-enum category', () => {
-    expect(categoryStyle('not-a-category')).toBe('bg-surface-2 text-text-2');
+    expect(categoryStyle('not-a-category')).toBe('bg-surface-3 text-text-2');
   });
 });
 

--- a/packages/ui-kit/src/badge.tsx
+++ b/packages/ui-kit/src/badge.tsx
@@ -9,15 +9,15 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        // `default` is the one tonal variant with no TONE_SOFT member: the
-        // vocabulary's `neutral` is bg-surface-2, and this is the step deeper.
-        default: 'bg-surface-3 text-text-2',
-        outline: 'border border-border text-text-2',
-        // The rest ARE vocabulary members, so they are read from it rather than
-        // respelled — a second copy of a pair is a second place to get the
+        // Every TINTED variant reads its pair from the vocabulary rather than
+        // respelling it — a second copy of a pair is a second place to get the
         // fill/ink halves wrong, which is the failure tone.ts exists to remove.
-        // The variant NAMES stay as they are: `variant` is public API, and
-        // `success` is spelled across consumers outside this repo.
+        // `default` is `neutral`, the untinted pair; `outline` is the one variant
+        // with no vocabulary member, because it carries no fill at all. The
+        // variant NAMES stay as they are: `variant` is public API, and `success`
+        // is spelled across consumers outside this repo.
+        default: TONE_SOFT.neutral,
+        outline: 'border border-border text-text-2',
         critical: TONE_SOFT.critical,
         high: TONE_SOFT.high,
         medium: TONE_SOFT.medium,

--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -66,7 +66,9 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
 const TONE_SOFT_FALLBACK: Record<string, string | undefined> = TONE_SOFT;
 
 function toneClasses(tone: string): string {
-  return (Object.hasOwn(TONE_SOFT, tone) ? TONE_SOFT_FALLBACK[tone] : undefined) ?? TONE_SOFT.neutral;
+  return (
+    (Object.hasOwn(TONE_SOFT, tone) ? TONE_SOFT_FALLBACK[tone] : undefined) ?? TONE_SOFT.neutral
+  );
 }
 
 export function CardIcon({

--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -58,7 +58,16 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
 // `undefined`, leaving the tile with no background AND no foreground rather than
 // falling back to neutral. This string-keyed view is what makes that fallback
 // reachable to the type system rather than dead code the compiler prunes.
+// `Object.hasOwn` rather than a bare `TONE_SOFT_FALLBACK[tone] ?? …`: a tone of
+// '__proto__' or 'constructor' resolves an INHERITED Object member, which is
+// truthy, so the `??` never fires and the tile renders with no tonal classes at
+// all — the very outcome the fallback exists to prevent. The widened view is
+// read only once the guard has said the key is the map's own.
 const TONE_SOFT_FALLBACK: Record<string, string | undefined> = TONE_SOFT;
+
+function toneClasses(tone: string): string {
+  return (Object.hasOwn(TONE_SOFT, tone) ? TONE_SOFT_FALLBACK[tone] : undefined) ?? TONE_SOFT.neutral;
+}
 
 export function CardIcon({
   className,
@@ -70,7 +79,7 @@ export function CardIcon({
       data-slot="card-icon"
       className={cn(
         'flex size-7.5 shrink-0 items-center justify-center rounded-lg',
-        TONE_SOFT_FALLBACK[tone] ?? TONE_SOFT.neutral,
+        toneClasses(tone),
         className,
       )}
       {...props}

--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -42,7 +42,8 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
 
 /**
  * Tinted square that holds a leading icon. `tone` names the tonal family and
- * defaults to `neutral`, the tile's own surface.
+ * defaults to `neutral`, the untinted pair — a tile that still reads against
+ * the card it sits on without claiming a family colour.
  *
  * Prefer it over spelling the fill/ink pair into `className`: the pairing is
  * irregular (primary's tint is `-tint`, and its bare token is already the ink),

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -46,18 +46,16 @@
 /**
  * A tonal family that can tint a surface.
  *
- * `neutral` and `muted` are two different tokens, not two names for one.
- * theme.css calls `--color-surface-2` "row hover / subtle inset" and
- * `--color-surface-3` "deeper inset, neutral solid fill": the first is a state a
- * CONTAINER enters, the second is an OBJECT's own fill. In light, surface-2 is
- * byte-identical to `--color-canvas`, so a `neutral` tile is invisible on the
- * page and near-invisible on a card — which is what it is for. `muted` is the
- * quiet tile that still has to READ on whatever it sits on, and is what Badge's
- * `default` variant and Button's solid `neutral` already fill with.
+ * `neutral` is the untinted one: a tile carrying no family colour at all. Its
+ * fill is `--color-surface-3`, which theme.css annotates "deeper inset, neutral
+ * solid fill" — an object's own fill, as against `--color-surface-2`'s "row
+ * hover / subtle inset", which is a state a CONTAINER enters and is applied
+ * directly rather than through this registry. Badge's `default` variant and
+ * Button's solid `neutral` fill with surface-3 too, so the word means one thing
+ * across the package.
  */
 export type Tone =
   | 'neutral'
-  | 'muted'
   | 'critical'
   | 'high'
   | 'medium'
@@ -86,11 +84,10 @@ export interface TonePair {
  * complete class names, so a half built from a family name emits no rule at all.
  */
 export const TONE_PARTS: Record<Tone, TonePair> = {
-  neutral: { fill: 'bg-surface-2', text: 'text-text-2' },
-  // The deeper of the two neutrals — see the note on `Tone`. Neither half names a
-  // tonal family, so there is no `-ink` here for the tonal-ink rule to check:
-  // this row is one the tests have to hold, because nothing else can.
-  muted: { fill: 'bg-surface-3', text: 'text-text-2' },
+  // Neither half names a tonal family, so there is no `-ink` here for the
+  // tonal-ink rule to check: this row is one the tests have to hold, because
+  // nothing else can.
+  neutral: { fill: 'bg-surface-3', text: 'text-text-2' },
   critical: { fill: 'bg-sev-critical-fill', text: 'text-sev-critical-ink' },
   high: { fill: 'bg-sev-high-fill', text: 'text-sev-high-ink' },
   medium: { fill: 'bg-sev-medium-fill', text: 'text-sev-medium-ink' },

--- a/packages/ui-kit/src/tone.ts
+++ b/packages/ui-kit/src/tone.ts
@@ -55,15 +55,7 @@
  * across the package.
  */
 export type Tone =
-  | 'neutral'
-  | 'critical'
-  | 'high'
-  | 'medium'
-  | 'low'
-  | 'ok'
-  | 'teal'
-  | 'violet'
-  | 'primary';
+  'neutral' | 'critical' | 'high' | 'medium' | 'low' | 'ok' | 'teal' | 'violet' | 'primary';
 
 /**
  * The families that also carry a SOLID fill. Only the alert tones do: a solid

--- a/packages/ui-kit/test/badge.test.ts
+++ b/packages/ui-kit/test/badge.test.ts
@@ -2,16 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import { Badge, type BadgeProps } from '../src/badge.tsx';
 
-// Seven of the nine variants read their pair from TONE_SOFT rather than
+// Eight of the nine variants read their pair from TONE_SOFT rather than
 // respelling it, so a change to the vocabulary now reaches Badge. That is the
 // point — one spelling per pair — but it also means an edit in tone.ts can move
-// what Badge renders without touching this file. These are the exact strings, so
-// such a change has to be deliberate.
+// what Badge renders without touching this file. These are the exact strings
+// rather than a second reference to TONE_SOFT, which would be true by
+// construction and would move with it; so such a change has to be deliberate.
 //
-// `default` is pinned for the opposite reason: it is the one tonal variant with
-// NO vocabulary member (neutral is bg-surface-2; this is the step deeper), so
-// "convert the last one too" is a real temptation and would darken every neutral
-// chip in the product.
+// `outline` is the ninth and is not a pair at all — it carries a border and no
+// fill, so there is no vocabulary member for it to read.
 const EXPECTED: Record<NonNullable<BadgeProps['variant']>, string> = {
   default: 'bg-surface-3 text-text-2',
   outline: 'border border-border text-text-2',
@@ -47,6 +46,6 @@ describe('Badge renders each variant unchanged', () => {
   // once, which is the shape a broken cva config actually produces.
   it('does not leak another variant onto a variant', () => {
     expect(classOf('success').split(' ')).not.toContain('bg-teal-fill');
-    expect(classOf('default').split(' ')).not.toContain('bg-surface-2');
+    expect(classOf('default').split(' ')).not.toContain('bg-sev-critical-fill');
   });
 });

--- a/packages/ui-kit/test/card.test.tsx
+++ b/packages/ui-kit/test/card.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { CardIcon } from '../src/card.tsx';
+import { type Tone, TONE_SOFT } from '../src/tone.ts';
+
+// `tone` is optional on a component this package ships to hosts outside this
+// repo, so a stale or plain-JS caller can pass a value outside the union. An
+// unguarded index yields `undefined`, `cn` drops it, and the tile renders with
+// no background AND no foreground — worse than a wrong colour, because it reads
+// as a layout bug rather than a data one.
+function classesOf(tone?: string): string[] {
+  const el = CardIcon({ tone: tone as Tone }) as { props: { className: string } };
+  return el.props.className.split(' ');
+}
+
+describe('CardIcon resolves its tone', () => {
+  // The positive control: without it every fallback case below would also pass
+  // on a CardIcon that had stopped emitting a tonal pair at all.
+  it.each(Object.keys(TONE_SOFT) as Tone[])('carries %s’s own pair', (tone) => {
+    for (const cls of TONE_SOFT[tone].split(' ')) expect(classesOf(tone)).toContain(cls);
+  });
+
+  it('defaults to neutral when no tone is given', () => {
+    for (const cls of TONE_SOFT.neutral.split(' ')) expect(classesOf()).toContain(cls);
+  });
+
+  // 'muted' was a real member until the neutral retone, so a stale caller can
+  // still send it; the prototype members are the pair that defeats a bare
+  // `?? TONE_SOFT.neutral`, since each resolves a truthy INHERITED value.
+  it.each(['not-a-tone', '', 'muted', '__proto__', 'constructor', 'toString'])(
+    'falls back to the neutral pair for %j',
+    (tone) => {
+      for (const cls of TONE_SOFT.neutral.split(' ')) expect(classesOf(tone)).toContain(cls);
+    },
+  );
+
+  it('never emits an object or an empty slot as a class', () => {
+    const classes = classesOf('__proto__');
+
+    expect(classes).not.toContain('');
+    expect(classes.join(' ')).not.toContain('[object');
+  });
+});

--- a/packages/ui-kit/test/tone.test.ts
+++ b/packages/ui-kit/test/tone.test.ts
@@ -19,8 +19,7 @@ import {
 // this replaced, and it would read as perfectly reasonable code.
 
 const FAMILIES: Record<Tone, [fill: string, text: string]> = {
-  neutral: ['bg-surface-2', 'text-text-2'],
-  muted: ['bg-surface-3', 'text-text-2'],
+  neutral: ['bg-surface-3', 'text-text-2'],
   critical: ['bg-sev-critical-fill', 'text-sev-critical-ink'],
   high: ['bg-sev-high-fill', 'text-sev-high-ink'],
   medium: ['bg-sev-medium-fill', 'text-sev-medium-ink'],
@@ -33,9 +32,9 @@ const FAMILIES: Record<Tone, [fill: string, text: string]> = {
 
 const TONES = Object.keys(FAMILIES) as Tone[];
 
-// The two families whose halves name no tonal family, so the tonal-ink lint rule
-// has nothing to match on them and only this file can hold their pairs.
-const SURFACE_FAMILIES: Tone[] = ['neutral', 'muted'];
+// The one family whose halves name no tonal family, so the tonal-ink lint rule
+// has nothing to match on it and only this file can hold its pair.
+const SURFACE_FAMILIES: Tone[] = ['neutral'];
 
 describe('the tonal registry', () => {
   it('covers every family exactly, with no extras', () => {
@@ -43,13 +42,6 @@ describe('the tonal registry', () => {
     // cannot see a family REMOVED from the union along with its row.
     expect(Object.keys(TONE_PARTS).sort()).toEqual([...TONES].sort());
     expect(Object.keys(TONE_SOFT).sort()).toEqual([...TONES].sort());
-  });
-
-  it('keeps the two neutrals distinct', () => {
-    // The whole reason `muted` exists. Collapsing these is a silent visual change:
-    // in light, surface-2 equals the canvas, so a `neutral` tile is invisible on
-    // the page, while `muted` is the tile that still has to read on what it sits on.
-    expect(TONE_PARTS.neutral.fill).not.toBe(TONE_PARTS.muted.fill);
   });
 
   for (const tone of TONES) {
@@ -172,13 +164,12 @@ describe('the tonal pairs resolve in theme.css', () => {
 
 describe('the tonal pairs are shaped as fill + ink', () => {
   // Catches the half that resolves but is the wrong half — `bg-ok` names a real
-  // token (the HUE), so the resolution check above passes on it. Three families
+  // token (the HUE), so the resolution check above passes on it. Two families
   // are irregular and are named rather than inferred: `primary`'s bare token IS
-  // the ink and its tint is `-tint`, and `neutral`/`muted` are surfaces rather
-  // than tonal families.
+  // the ink and its tint is `-tint`, and `neutral` is a surface rather than a
+  // tonal family.
   const IRREGULAR: Partial<Record<Tone, string>> = {
-    neutral: 'bg-surface-2 text-text-2',
-    muted: 'bg-surface-3 text-text-2',
+    neutral: 'bg-surface-3 text-text-2',
     primary: 'bg-primary-tint text-primary',
   };
 

--- a/web-ui/app/(app)/activity/page.tsx
+++ b/web-ui/app/(app)/activity/page.tsx
@@ -99,7 +99,7 @@ export default async function ActivityPage({
       icon: TerminalIcon,
       value: stats.sessionsToday.toLocaleString(),
       label: 'Sessions today',
-      tone: 'muted',
+      tone: 'neutral',
     },
     {
       icon: BoltIcon,
@@ -111,7 +111,7 @@ export default async function ActivityPage({
       icon: ListIcon,
       value: stats.toolCallsToday.toLocaleString(),
       label: 'Tool calls',
-      tone: 'muted',
+      tone: 'neutral',
     },
     {
       icon: ShieldCheckIcon,

--- a/web-ui/app/(app)/detections/page.tsx
+++ b/web-ui/app/(app)/detections/page.tsx
@@ -90,7 +90,7 @@ export default async function DetectionsPage({
       icon: ActivityIcon,
       value: stats.findingsLast30d.toLocaleString(),
       label: 'Findings · 30d',
-      tone: 'muted',
+      tone: 'neutral',
     },
   ];
   return (


### PR DESCRIPTION
Stacked on #341 — review that one first; this branch's base is `refactor/unify-tonal-registry`.

#341 said the retone was "a real question and deliberately not settled here". This settles it.

## The defect

`neutral` filled with `--color-surface-2`. In light that is **byte-identical to `--color-canvas`** (`#f9fafb`), and it is also the row-hover fill in both themes. Computed contrast (WCAG relative luminance):

| tile fill | on a card | on the canvas | on a hovered row |
|---|---|---|---|
| **surface-2** (before) | 1.045:1 | **1.000:1** | **1.000:1** *(both themes)* |
| **surface-3** (after) | 1.120:1 | 1.072:1 | 1.171:1 dark / 1.072:1 light |

The findings table's `custom` category tile is the sharp case: it sits on a row that hovers to exactly its own fill, so it vanishes under the pointer. My earlier note called this a light-mode problem — that was wrong, and the table shows why: surface-2 *is* the hover, so the collision is theme-independent.

**This is not a WCAG fix and the commit says so.** Neither fill reaches the 3:1 a UI boundary wants; these tiles are quiet by design and the glyph carries legibility. `text-2` on the new fill is 5.25:1 light / 6.69:1 dark — comfortably past 4.5, and slightly *down* from 5.63/7.83, which is a real if small cost. What changes is that three of those readings stop being the same colour twice.

## Why `muted` goes

`muted` was added in #341 for exactly one reason: the two neutrals differed and the deeper one had no name. With `neutral` at surface-3 it is a second name for one pair — the duplication #341 exists to remove. So it is deleted and its call sites move back to `neutral`; **none of them changes appearance**, since both were already surface-3.

`neutral` is the name that survives because `badge.tsx`'s `default` variant and `button.tsx`'s solid `neutral` were *already* `bg-surface-3`. After this, the word means one thing across the package.

**surface-2 is not orphaned.** Its role is a container *state* — row hover, the policy picker's track — always applied directly, never through the registry. The emitted stylesheet still carries it (verified below).

## What moves, and what does not

Moves: 11 bare `<CardIcon>` headers (all reach the default by *omission* — no call site passes `tone="neutral"`), the findings `custom` tile, and the off-enum category fallback.

Does **not** move: the timeline's node tones and the `monitored` action pill. `monitored` had been hand-spelled `bg-surface-3 text-text-2` precisely because it wanted to sit deeper than `neutral` did; it now folds into the family it was imitating, byte-for-byte.

One landmine worth flagging for review: `PolicyPicker` compares the family name at *runtime* (`m.tone === 'muted'`) to give a selected Monitor a white pill, because a surface-3 pill on a surface-2 track only reaches 1.072:1. Renaming carries it — TypeScript catches this one, but it is the kind of thing that regresses silently.

## Verification

`pnpm test:oss` green (41 tasks), workspace `lint` green (35), `typecheck` green (14).

The pixel claim is measured, not argued: the registry, every `CardIcon` tone, `categoryStyle` over each category plus the off-enum paths, the action pills and the timeline pairs were dumped before the change and diffed after. **The diff is exactly the sites listed above and nothing else** — `EVENT_META` and `ACTION_META` do not appear in it at all. All 19 tonal utilities still emit in a production CSS build (`vite build`, grepped against the built stylesheet with a negative control), `bg-surface-2` included.

## Noted in passing, not fixed here

`categoryStyle('__proto__')` and `('constructor')` return `undefined` rather than the fallback — those lookups hit truthy prototype members, so `?? 'neutral'` never fires. Visible in the dumps above and **unchanged by this PR**. `detections/meta.ts` already guards the same class with `Object.hasOwn`; a separate change is fixing `findings/meta.ts` to match.


---

## Follow-up commit: a guard that did not hold, and Badge's last pair

Writing the `CardIcon` test for this PR turned up a real defect in the fallback added upstream:

    TONE_SOFT_FALLBACK[tone] ?? TONE_SOFT.neutral

A tone of `'__proto__'` or `'constructor'` resolves an **inherited** `Object` member, which is truthy, so the `??` never fires. Verified by rendering: `CardIcon tone="__proto__"` emitted **no tonal classes at all** — the exact outcome the fallback exists to prevent — while `tone="not-a-tone"` fell back correctly, which is why it reads as working.

Now guarded with `Object.hasOwn`, the shape `policyMeta` in dashboard-ui already uses for the same reason. `test/card.test.tsx` pins it and was mutation-checked: it reds on the bare `??` form for exactly the three prototype members and is green otherwise, so it measures the guard rather than the component. The union's own members are the positive control.

Separately, Badge's `default` variant was the last hand-spelled pair in the package — spelled out only because the vocabulary had no member for surface-3. `neutral` is that member now, so it reads from `TONE_SOFT` like the other tinted variants, and `outline` is the only one left with no pair to read. **No rendered value changes**: `default` was already byte-identical to the pair it now reads.

Both files' comments asserted the opposite and are rewritten. The badge suite's `default` case had also gone vacuous — it asserted the absence of a class no variant can carry any more — and now names a real neighbouring fill.
