### PR TITLE
docs(ui-kit): put CardIcon's doc block back on CardIcon

### DIFF
--- a/packages/ui-kit/src/card.tsx
+++ b/packages/ui-kit/src/card.tsx
@@ -40,17 +40,6 @@ export function CardHeader({ className, ...props }: ComponentPropsWithRef<'div'>
   );
 }
 
-/**
- * Tinted square that holds a leading icon. `tone` names the tonal family and
- * defaults to `neutral`, the untinted pair — a tile that still reads against
- * the card it sits on without claiming a family colour.
- *
- * Prefer it over spelling the fill/ink pair into `className`: the pairing is
- * irregular (primary's tint is `-tint`, and its bare token is already the ink),
- * and getting it wrong fails silently — an undefined theme variable emits no
- * utility, so the glyph just inherits its color. `className` still wins, for the
- * one-off tile whose color is not a family theme.css names.
- */
 // The neutral pair used to be part of the base literal, so it applied no matter
 // what. Indexing makes it data-driven, and `tone` is optional on a component
 // this package ships to hosts outside this repo — where a stale or plain-JS
@@ -71,6 +60,17 @@ function toneClasses(tone: string): string {
   );
 }
 
+/**
+ * Tinted square that holds a leading icon. `tone` names the tonal family and
+ * defaults to `neutral`, the untinted pair — a tile that still reads against
+ * the card it sits on without claiming a family colour.
+ *
+ * Prefer it over spelling the fill/ink pair into `className`: the pairing is
+ * irregular (primary's tint is `-tint`, and its bare token is already the ink),
+ * and getting it wrong fails silently — an undefined theme variable emits no
+ * utility, so the glyph just inherits its color. `className` still wins, for the
+ * one-off tile whose color is not a family theme.css names.
+ */
 export function CardIcon({
   className,
   tone = 'neutral',


### PR DESCRIPTION
One file, comment placement only — no behaviour change.

## What happened

ai-tc#344 added a prototype-member guard to `CardIcon` and inserted it **between** the component's JSDoc block and its declaration. The block therefore attaches to a private const, and every consumer hovering `CardIcon` loses the guidance about preferring `tone` over `className` and about why the pairing is irregular.

Nothing goes red for this: a detached doc comment is still a valid comment, and no lint rule or test looks at what a JSDoc block is attached to.

## Why it is a separate PR

It was caught by a reviewer on the paired enterprise PR and fixed on #344's branch — but #344 had already merged (`047c9751`, 14:29:00Z), so the fix landed on a closed PR's branch and would never have reached `main`. This carries it across.

## The direction of the fix

The helper moves **above** the block rather than the block moving down. The line comments explaining the fallback belong next to the fallback, and the JSDoc belongs on the exported thing.

## Verification

`@akasecurity/ui-kit` 103 tests pass, package `lint` clean, `prettier --check` clean tree-wide. The diff is one file.
