### PR TITLE
fix(cli): verify archive-sea's Compress-Archive output is actually a zip

### DIFF
--- a/cli/scripts/archive-sea.mjs
+++ b/cli/scripts/archive-sea.mjs
@@ -5,7 +5,15 @@
 // cli.mjs + package.json + web-ui), so extracting yields a ready-to-run tree.
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  readSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -25,6 +33,32 @@ const archiveName = `aka-${version}-${triple}.${isWin ? 'zip' : 'tar.gz'}`;
 const archivePath = join(seaDist, archiveName);
 rmSync(archivePath, { force: true });
 
+/**
+ * Compress-Archive can exit 0 via a non-terminating error record having
+ * written nothing or a partial file, so prove the bytes are actually a zip
+ * before they get hashed into SHA256SUMS.
+ */
+function assertZipWritten(path) {
+  let fd;
+  try {
+    fd = openSync(path, 'r');
+  } catch {
+    throw new Error(`Compress-Archive reported success but wrote no ${path}`);
+  }
+  try {
+    const buf = Buffer.alloc(4);
+    const read = readSync(fd, buf, 0, 4, 0);
+    if (read < 4 || buf.toString('hex') !== '504b0304') {
+      throw new Error(
+        `Compress-Archive reported success but ${path} is not a zip — ` +
+          `read ${String(read)} byte(s), starting ${buf.subarray(0, read).toString('hex')}`,
+      );
+    }
+  } finally {
+    closeSync(fd);
+  }
+}
+
 if (isWin) {
   execFileSync(
     'powershell',
@@ -36,6 +70,7 @@ if (isWin) {
     ],
     { stdio: 'inherit' },
   );
+  assertZipWritten(archivePath);
 } else {
   execFileSync('tar', ['-czf', archivePath, '-C', seaDist, stagedName], { stdio: 'inherit' });
 }

--- a/cli/scripts/archive-sea.mjs
+++ b/cli/scripts/archive-sea.mjs
@@ -42,8 +42,14 @@ function assertZipWritten(path) {
   let fd;
   try {
     fd = openSync(path, 'r');
-  } catch {
-    throw new Error(`Compress-Archive reported success but wrote no ${path}`);
+  } catch (err) {
+    // Only "file genuinely doesn't exist" gets the friendly rewrite — any
+    // other errno (a permissions or descriptor-limit failure, say) means real
+    // bytes are sitting on disk and the crafted sentence would misdescribe them.
+    if (err.code !== 'ENOENT') throw err;
+    throw new Error(`Compress-Archive reported success but wrote nothing to ${path}`, {
+      cause: err,
+    });
   }
   try {
     const buf = Buffer.alloc(4);


### PR DESCRIPTION
## Summary
- `Compress-Archive` can exit 0 via a non-terminating error record while writing nothing or a partial file, so `archive-sea.mjs` could hash a broken/missing archive straight into `SHA256SUMS` — a release that verifies against itself and proves nothing.
- Adds a post-write check after the Windows `Compress-Archive` call (before hashing): open the archive, read the first 4 bytes, and require the zip magic number `504b0304`. Distinguishes "wrote nothing" (no file) from "wrote a non-zip" (bad/short magic) in the error message.
- Mirrors `assertZipWritten` from `tools/installer/test/helpers/release-fixture.ts` (added in [#351](https://github.com/akasecurity/ai-tc/pull/351), flagged there by review as an exposure the real packaging script shares but doesn't guard against). Scoped to `archive-sea.mjs` only — the fixture is untouched.
- The POSIX `tar` path is unaffected: `tar` doesn't have the same silent-partial-success behavior, so it's out of scope here.

## Review follow-ups
- **ENOENT narrowing.** The initial commit ported a bare `catch` that treated every `openSync` failure as "wrote nothing" — including a real, on-disk archive that merely couldn't be opened right now (permissions, descriptor-limit). Narrowed to `err.code !== 'ENOENT'` rethrowing untouched, with the original error attached as `cause`. #351 landed the identical narrowing on the fixture's copy independently — both were in flight at the same time, and #351 has since merged into `main`.
- **Docblock, not a message branch, for the empty-zip case.** A zero-entry zip is a real, structurally valid archive (EOCD record alone, `504b0506`) that still correctly fails this check (it isn't `504b0304`), which is right — an empty archive means `Compress-Archive` staged nothing. An intermediate commit gave that case its own message; #351's own final commit on the fixture took the other approach — leave the check as-is, since it already fails correctly and names the bytes, and just correct the docblock to say so plainly. Matched that here instead of diverging on a call review had explicitly left either way.
- One commit message from the first round claimed the fixture fix had "landed" while #351 was still open — accurate about the target, not about sequencing at the time. It's merged now, so the claim holds; noting it here since the commit text itself can't be corrected after the fact.
- Filed #354 to track whether `archive-sea.mjs`'s Windows leg (`powershell`, i.e. Windows PowerShell 5.1) needs the CLR-abort retry #351 added to the fixture's `pwsh`-on-Linux path — kept out of this PR since the evidence for whether it even applies to this interpreter is unresolved.

## Test plan
- [x] `node --check cli/scripts/archive-sea.mjs`
- [x] `eslint --no-config-lookup -c eslint.scripts.config.mjs scripts` (the pass that actually covers this file) — exit 0
- [x] `prettier --check cli/scripts/archive-sea.mjs` — passes
- [x] Manually proved each ported/changed branch RED then GREEN in an isolated harness (missing/empty/partial/wrong-magic/valid-zip, plus EISDIR and a chmod-0o000 unreadable-but-real-bytes case for the ENOENT narrowing), then diffed the shipped function byte-for-byte against the verified version each round — `cli/scripts/*.mjs` has no vitest coverage anywhere in this repo (these are CI-invoked release scripts, verified by workflow execution per CLAUDE.md), so this stands in for an automated test
- [ ] CI: `release-binaries.yml`'s Windows leg exercises the real `Compress-Archive` path