### PR TITLE
fix(ui-kit): give every field a fill of its own, not just an edge

### DIFF
--- a/packages/dashboard-ui/src/activity/HarnessSelect.tsx
+++ b/packages/dashboard-ui/src/activity/HarnessSelect.tsx
@@ -54,7 +54,7 @@ export function HarnessSelect({
     <DropdownMenu>
       <DropdownMenuTrigger
         className={cn(
-          'group flex h-8.5 w-full items-center gap-2 rounded-lg border bg-surface-2 px-2.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          'group flex h-8.5 w-full items-center gap-2 rounded-lg border bg-surface-2 px-2.5 text-sm focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
           all ? 'border-border-field' : 'border-primary',
         )}
       >

--- a/packages/dashboard-ui/src/activity/HarnessSelect.tsx
+++ b/packages/dashboard-ui/src/activity/HarnessSelect.tsx
@@ -65,7 +65,7 @@ export function HarnessSelect({
         />
         <span className="flex-1 text-left font-medium text-text">{label}</span>
         {!all && (
-          <Badge variant="primary" className="px-1.5 py-0 text-label bg-surface">
+          <Badge variant="primary" className="px-1.5 py-0 text-label bg-surface-2">
             {value.length}
           </Badge>
         )}

--- a/packages/dashboard-ui/src/activity/HarnessSelect.tsx
+++ b/packages/dashboard-ui/src/activity/HarnessSelect.tsx
@@ -54,7 +54,7 @@ export function HarnessSelect({
     <DropdownMenu>
       <DropdownMenuTrigger
         className={cn(
-          'group flex h-8.5 w-full items-center gap-2 rounded-lg border bg-surface px-2.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+          'group flex h-8.5 w-full items-center gap-2 rounded-lg border bg-surface-2 px-2.5 text-sm outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
           all ? 'border-border-field' : 'border-primary',
         )}
       >

--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -160,7 +160,7 @@ export function SessionListView({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="shrink-0 border-b border-border p-3">
-        <div className="mb-2 flex h-8.5 items-center gap-2 rounded-lg border border-border-field bg-surface-2 px-2.5">
+        <div className="mb-2 flex h-8.5 items-center gap-2 rounded-lg border border-border-field bg-surface-2 px-2.5 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40">
           <SearchIcon aria-hidden focusable={false} className="size-3.5 shrink-0 text-text-3" />
           <input
             value={query}

--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -169,7 +169,7 @@ export function SessionListView({
             }}
             placeholder="Search sessions & events…"
             aria-label="Search sessions and events"
-            className="min-w-0 flex-1 bg-transparent text-sm text-text placeholder:text-text-3 focus:outline-none"
+            className="min-w-0 flex-1 bg-transparent text-sm text-text placeholder:text-text-3 focus:outline-hidden"
           />
         </div>
         <HarnessSelect

--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -160,7 +160,7 @@ export function SessionListView({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="shrink-0 border-b border-border p-3">
-        <div className="mb-2 flex h-8.5 items-center gap-2 rounded-lg border border-border bg-surface-2 px-2.5">
+        <div className="mb-2 flex h-8.5 items-center gap-2 rounded-lg border border-border-field bg-surface-2 px-2.5">
           <SearchIcon aria-hidden focusable={false} className="size-3.5 shrink-0 text-text-3" />
           <input
             value={query}

--- a/packages/dashboard-ui/src/detections/DetectionsListView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionsListView.tsx
@@ -114,7 +114,7 @@ export function DetectionsListView({
             }}
             spellCheck={false}
             placeholder="Search detections…"
-            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           />
         </div>
         <div className="mt-2.5 flex flex-wrap gap-1.5">

--- a/packages/dashboard-ui/src/detections/DetectionsListView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionsListView.tsx
@@ -114,7 +114,7 @@ export function DetectionsListView({
             }}
             spellCheck={false}
             placeholder="Search detections…"
-            className="h-9 w-full rounded-lg border border-border bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
           />
         </div>
         <div className="mt-2.5 flex flex-wrap gap-1.5">

--- a/packages/dashboard-ui/src/detections/DetectionsListView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionsListView.tsx
@@ -114,7 +114,7 @@ export function DetectionsListView({
             }}
             spellCheck={false}
             placeholder="Search detections…"
-            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
           />
         </div>
         <div className="mt-2.5 flex flex-wrap gap-1.5">

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -110,7 +110,7 @@ export function FindingsToolbarView({
           onChange={(e) => {
             onQueryChange(e.target.value);
           }}
-          className="h-9 w-full rounded-lg border border-border bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
         />
       </div>
       <MultiSelectFilter

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -110,7 +110,7 @@ export function FindingsToolbarView({
           onChange={(e) => {
             onQueryChange(e.target.value);
           }}
-          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
         />
       </div>
       <MultiSelectFilter

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -110,7 +110,7 @@ export function FindingsToolbarView({
           onChange={(e) => {
             onQueryChange(e.target.value);
           }}
-          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
         />
       </div>
       <MultiSelectFilter

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -147,7 +147,7 @@ export function InventoryNav(props: InventoryNavProps) {
               onQuery(e.target.value);
             }}
             placeholder="Search assets…"
-            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
           />
         </div>
 

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -147,7 +147,7 @@ export function InventoryNav(props: InventoryNavProps) {
               onQuery(e.target.value);
             }}
             placeholder="Search assets…"
-            className="h-8.5 w-full rounded-lg border border-border bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
           />
         </div>
 

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -147,7 +147,7 @@ export function InventoryNav(props: InventoryNavProps) {
               onQuery(e.target.value);
             }}
             placeholder="Search assets…"
-            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
           />
         </div>
 

--- a/packages/dashboard-ui/src/inventory/ProjectPane.tsx
+++ b/packages/dashboard-ui/src/inventory/ProjectPane.tsx
@@ -170,7 +170,7 @@ function SearchBox({ proj, query, onQueryChange }: ProjectPaneProps) {
           onQueryChange(e.target.value);
         }}
         placeholder={`Search files in ${proj.name}…`}
-        className="h-9 w-full rounded-lg border border-border bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
       />
       {query && (
         <button

--- a/packages/dashboard-ui/src/inventory/ProjectPane.tsx
+++ b/packages/dashboard-ui/src/inventory/ProjectPane.tsx
@@ -170,7 +170,7 @@ function SearchBox({ proj, query, onQueryChange }: ProjectPaneProps) {
           onQueryChange(e.target.value);
         }}
         placeholder={`Search files in ${proj.name}…`}
-        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none"
+        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
       />
       {query && (
         <button

--- a/packages/dashboard-ui/src/inventory/ProjectPane.tsx
+++ b/packages/dashboard-ui/src/inventory/ProjectPane.tsx
@@ -170,7 +170,7 @@ function SearchBox({ proj, query, onQueryChange }: ProjectPaneProps) {
           onQueryChange(e.target.value);
         }}
         placeholder={`Search files in ${proj.name}…`}
-        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
       />
       {query && (
         <button

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -86,12 +86,40 @@ function canvasCollisionFill(): string {
   return `bg-${twin}`;
 }
 
+/**
+ * A focus fragment matched as a DECISION rather than as today's spelling of it.
+ *
+ * Tailwind v4 split v3's `outline-none` in two: `outline-none` sets
+ * `outline-style: none` flat, while `outline-hidden` also re-emits a transparent
+ * outline under `forced-colors: active`, which the system then paints. Windows
+ * High Contrast Mode discards box-shadow rings and author border colours — which
+ * is exactly `ring-*` and `border-primary`, i.e. BOTH cues these six controls
+ * carry — so `outline-hidden` is the spelling that keeps an indicator there.
+ *
+ * Pinning either spelling literally makes the other fail, and a move from `none`
+ * to `hidden` is the REPAIR. A pin that reds on a repair reads as a regression and
+ * gets reverted — the same failure this file's header describes for the container
+ * premise, one property over: an assertion that mandates the state it exists to
+ * forbid. So the outline token alternates and every other token stays exact.
+ */
+function focusPattern(fragment: string): RegExp {
+  return new RegExp(
+    fragment
+      .split(' ')
+      .map((token) =>
+        /^(?:focus:)?outline-(?:none|hidden)$/.test(token)
+          ? '(?:focus:)?outline-(?:none|hidden)'
+          : token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+      )
+      .join(' '),
+  );
+}
+
 const FIELDS: {
   file: string;
   control: string;
   on: 'a Card' | 'the page canvas';
   edge: string;
-  fill: string;
   /** The whole focus treatment, pinned as one fragment — see the loop below. */
   focus: string;
   alsoContains?: string;
@@ -101,36 +129,32 @@ const FIELDS: {
     control: 'the findings search',
     on: 'the page canvas',
     edge: 'rounded-lg border border-border-field bg-surface pl-9 pr-3',
-    fill: 'bg-surface',
     focus:
-      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'detections/DetectionsListView.tsx',
     control: 'the detections search',
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
-    fill: 'bg-surface-2',
     focus:
-      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'inventory/InventoryNav.tsx',
     control: 'the assets search',
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
-    fill: 'bg-surface-2',
     focus:
-      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'inventory/ProjectPane.tsx',
     control: 'the project-files search',
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-8',
-    fill: 'bg-surface-2',
     focus:
-      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'activity/SessionListView.tsx',
@@ -139,7 +163,6 @@ const FIELDS: {
     // The border sits on the WRAPPER: the input inside it is bg-transparent, so
     // this element is the whole visible control and carries both decisions.
     edge: 'rounded-lg border border-border-field bg-surface-2 px-2.5',
-    fill: 'bg-surface-2',
     focus: 'focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
   },
   {
@@ -150,9 +173,8 @@ const FIELDS: {
     // once a subset is chosen — so the fragment carries the fill and the shape,
     // and the resting colour is pinned as the CONDITIONAL below, not as a token.
     edge: 'rounded-lg border bg-surface-2 px-2.5',
-    fill: 'bg-surface-2',
     alsoContains: "all ? 'border-border-field'",
-    focus: 'outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+    focus: 'focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
 ];
 
@@ -170,12 +192,18 @@ describe('the hand-rolled field boundary', () => {
   //
   // What this does NOT assert is that the indicator clears 3:1 between states. It
   // does not: the border swap is 2.070:1 light / 1.729:1 dark and the ring adds
-  // 2.019:1 / 2.157:1 on its own pixels, both under SC 2.4.13. These match the
-  // ui-kit primitives, and moving that bar is a change to --color-primary's alpha
-  // across both products. See theme.css's closing paragraph.
+  // 2.019:1 / 2.325:1 on its own pixels, both under SC 2.4.13. (2.157:1 is that
+  // dark figure taken over --color-surface-2 — the field's own fill, which is the
+  // one surface a ring painted OUTSIDE the border box never has behind it.) These
+  // match the ui-kit primitives, and moving that bar is a change to
+  // --color-primary's alpha across both products.
+  //
+  // Nor does it assert anything under FORCED COLORS, where the ring's box-shadow
+  // and the focused border colour are both discarded — see `focusPattern` and
+  // theme.css's closing paragraph.
   for (const { file, control, focus } of FIELDS) {
     it(`${control}: keeps a focus indicator`, () => {
-      expect(read(file)).toContain(focus);
+      expect(read(file)).toMatch(focusPattern(focus));
     });
   }
 
@@ -201,10 +229,16 @@ describe('the hand-rolled field boundary', () => {
   // the fill of the thing UNDER it, which is not in the class string. Both
   // container fills are resolved — ui-kit's Card, and the canvas/surface-2
   // same-hex identity in theme.css.
-  for (const { file, control, on, edge, fill } of FIELDS) {
+  for (const { file, control, on, edge } of FIELDS) {
     it(`${control}: its fill is not the same as ${on}`, () => {
       const container = on === 'a Card' ? cardFill() : canvasCollisionFill();
-      expect(read(file)).not.toContain(edge.replace(fill, container));
+      // The fill token is DERIVED from this control's own edge fragment, by the
+      // same regex `cardFill` uses, rather than restated in a second field that
+      // had to be edited in lockstep with it.
+      expect(edge, `${control}: no bg-surface* token in its edge fragment`).toMatch(
+        /\bbg-surface(?:-\d)?\b/,
+      );
+      expect(read(file)).not.toContain(edge.replace(/\bbg-surface(?:-\d)?\b/, container));
     });
   }
 });

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -1,4 +1,6 @@
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -9,34 +11,87 @@ import { describe, expect, it } from 'vitest';
 // 1.42:1 dark, under the 3:1 a control boundary is asked for. `bg-surface-2` (or
 // `bg-surface` on the page canvas) is the fill: a field whose fill equals the
 // fill under it leaves that edge drawing a rectangle against its own colour,
-// which is compliant and reads as a floating outline. Revert either half and the
-// control goes back to looking like an outline on nothing.
+// which is compliant and reads as a floating outline.
 //
 // ui-kit's `Input` and `SelectTrigger` carry both in one place, pinned by
 // border-field.test.ts there. The controls below are hand-rolled — a search
 // wrapper around a `bg-transparent` input, a DropdownMenu trigger — so each
 // spells the pair itself and nothing was pinning any of them. That is not a
-// hypothetical gap: four of these six sat on `border-border` for months while
-// ui-kit's two were correct, and the fifth and sixth were missed by a survey that
-// went looking for the other four, because one is `h-8.5` rather than `h-9` and
-// the other puts its border colour behind a conditional.
+// hypothetical gap: five of these six sat on `border-border` while ui-kit's two
+// were correct, and two were missed by a survey that went looking for the other
+// four. Neither miss was about size — `InventoryNav` is `h-8.5` like
+// `SessionListView` and was found. What hid them was SHAPE: SessionListView puts
+// its border on a WRAPPER around a `bg-transparent` input, so a search for
+// bordered `<input>` elements never saw it, and HarnessSelect puts its border
+// COLOUR behind a conditional, so a search for the literal pairing missed that.
+//
+// Both premises these assertions rest on are RESOLVED rather than restated: the
+// container fill is read from ui-kit's `card.tsx`, and the canvas collision from
+// `theme.css`. Written as literals, changing `card.tsx` to `bg-surface-2` left
+// this suite green while every field collided at 1.000:1 — and the positive pins
+// then REQUIRED the collision.
 //
 // Same precedent as border-field.test.ts: pin the exact string so a change is
 // deliberate. These files also carry legitimate `border-border` on cards,
 // dividers and chips, so the negative cases are built FROM each pinned fragment
 // rather than searching for a token — a bare token search cannot tell a field's
-// edge from the card it sits in.
+// edge from the card it sits in. Where a control's edge colour is CONDITIONAL,
+// the conditional expression is pinned, not the token: an unanchored whole-file
+// search for `'border-border-field'` passed while HarnessSelect's ternary arms
+// were swapped, putting its resting state on primary blue and its filtered state
+// on plain grey.
+
+const require_ = createRequire(import.meta.url);
+const UI_KIT_SRC = dirname(require_.resolve('@akasecurity/ui-kit'));
+
+const cache = new Map<string, string>();
+const readFile = (abs: string): string => {
+  const hit = cache.get(abs);
+  if (hit !== undefined) return hit;
+  const src = readFileSync(abs, 'utf8');
+  cache.set(abs, src);
+  return src;
+};
 
 const read = (rel: string): string =>
-  readFileSync(fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)), 'utf8');
+  readFile(fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)));
+
+/** ui-kit's `Card` fill — the surface every Card-hosted field renders on. */
+function cardFill(): string {
+  const line = readFile(join(UI_KIT_SRC, 'card.tsx'))
+    .split('\n')
+    .find((l) => l.includes('rounded-xl border border-border'));
+  if (line === undefined) throw new Error('card.tsx: no Card class string found');
+  const match = /\bbg-surface(?:-\d)?\b/.exec(line);
+  if (match === null) throw new Error('card.tsx: no bg-surface* token on the Card line');
+  return match[0];
+}
+
+/**
+ * The fill a CANVAS-level field must not take: in light, `--color-canvas` and
+ * `--color-surface-2` are the same hex, so a `bg-surface-2` field on the page has
+ * no fill of its own. Resolved from theme.css so the day those two stop matching,
+ * this stops asserting a collision that no longer exists.
+ */
+function canvasCollisionFill(): string {
+  const css = readFile(join(UI_KIT_SRC, 'styles/theme.css'));
+  const valueOf = (token: string): string => {
+    const match = new RegExp(`--color-${token}:\\s*#[0-9a-f]{3,8}`, 'i').exec(css);
+    if (match === null) throw new Error(`theme.css: --color-${token} not found`);
+    return match[0].slice(match[0].indexOf('#')).toLowerCase();
+  };
+  const canvas = valueOf('canvas');
+  const twin = (['surface-2', 'surface-3', 'surface'] as const).find((t) => valueOf(t) === canvas);
+  if (twin === undefined) throw new Error('theme.css: no surface token shares the canvas hex');
+  return `bg-${twin}`;
+}
 
 const FIELDS: {
   file: string;
   control: string;
-  on: string;
+  on: 'a Card' | 'the page canvas';
   edge: string;
   fill: string;
-  containerFill: string;
   alsoContains?: string;
 }[] = [
   {
@@ -45,9 +100,6 @@ const FIELDS: {
     on: 'the page canvas',
     edge: 'rounded-lg border border-border-field bg-surface pl-9 pr-3',
     fill: 'bg-surface',
-    // In light the canvas and --color-surface-2 are the same hex, so a
-    // bg-surface-2 field on the canvas is the collision, not the safe choice.
-    containerFill: 'bg-surface-2',
   },
   {
     file: 'detections/DetectionsListView.tsx',
@@ -55,7 +107,6 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
     fill: 'bg-surface-2',
-    containerFill: 'bg-surface',
   },
   {
     file: 'inventory/InventoryNav.tsx',
@@ -63,7 +114,6 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
     fill: 'bg-surface-2',
-    containerFill: 'bg-surface',
   },
   {
     file: 'inventory/ProjectPane.tsx',
@@ -71,7 +121,6 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-8',
     fill: 'bg-surface-2',
-    containerFill: 'bg-surface',
   },
   {
     file: 'activity/SessionListView.tsx',
@@ -81,7 +130,6 @@ const FIELDS: {
     // this element is the whole visible control and carries both decisions.
     edge: 'rounded-lg border border-border-field bg-surface-2 px-2.5',
     fill: 'bg-surface-2',
-    containerFill: 'bg-surface',
   },
   {
     file: 'activity/HarnessSelect.tsx',
@@ -89,11 +137,10 @@ const FIELDS: {
     on: 'a Card',
     // Its border COLOUR is conditional — border-border-field at rest, primary
     // once a subset is chosen — so the fragment carries the fill and the shape,
-    // and the resting colour is asserted separately.
+    // and the resting colour is pinned as the CONDITIONAL below, not as a token.
     edge: 'rounded-lg border bg-surface-2 px-2.5',
     fill: 'bg-surface-2',
-    containerFill: 'bg-surface',
-    alsoContains: "'border-border-field'",
+    alsoContains: "all ? 'border-border-field'",
   },
 ];
 
@@ -110,18 +157,20 @@ describe('the hand-rolled field boundary', () => {
   // matches the field and never the card or divider beside it.
   for (const { file, control, edge } of FIELDS) {
     const collided = edge.replace('border-border-field', 'border-border');
-    if (collided === edge) continue; // HarnessSelect: colour is not in the fragment
+    if (collided === edge) continue; // HarnessSelect: colour is pinned via alsoContains
     it(`${control}: its edge is not back on the ordinary border`, () => {
       expect(read(file)).not.toContain(collided);
     });
   }
 
   // The fill half, which no token search can express: what makes a fill wrong is
-  // the fill of the thing UNDER it, which is not in the class string.
-  for (const { file, control, on, edge, fill, containerFill } of FIELDS) {
-    const collided = edge.replace(fill, containerFill);
+  // the fill of the thing UNDER it, which is not in the class string. Both
+  // container fills are resolved — ui-kit's Card, and the canvas/surface-2
+  // same-hex identity in theme.css.
+  for (const { file, control, on, edge, fill } of FIELDS) {
     it(`${control}: its fill is not the same as ${on}`, () => {
-      expect(read(file)).not.toContain(collided);
+      const container = on === 'a Card' ? cardFill() : canvasCollisionFill();
+      expect(read(file)).not.toContain(edge.replace(fill, container));
     });
   }
 });

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+// A field is TWO decisions, and this package makes both by hand.
+//
+// `border-border-field` is the edge: `border-border` measures 1.26:1 light and
+// 1.42:1 dark, under the 3:1 a control boundary is asked for. `bg-surface-2` (or
+// `bg-surface` on the page canvas) is the fill: a field whose fill equals the
+// fill under it leaves that edge drawing a rectangle against its own colour,
+// which is compliant and reads as a floating outline. Revert either half and the
+// control goes back to looking like an outline on nothing.
+//
+// ui-kit's `Input` and `SelectTrigger` carry both in one place, pinned by
+// border-field.test.ts there. The controls below are hand-rolled — a search
+// wrapper around a `bg-transparent` input, a DropdownMenu trigger — so each
+// spells the pair itself and nothing was pinning any of them. That is not a
+// hypothetical gap: four of these six sat on `border-border` for months while
+// ui-kit's two were correct, and the fifth and sixth were missed by a survey that
+// went looking for the other four, because one is `h-8.5` rather than `h-9` and
+// the other puts its border colour behind a conditional.
+//
+// Same precedent as border-field.test.ts: pin the exact string so a change is
+// deliberate. These files also carry legitimate `border-border` on cards,
+// dividers and chips, so the negative cases are built FROM each pinned fragment
+// rather than searching for a token — a bare token search cannot tell a field's
+// edge from the card it sits in.
+
+const read = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)), 'utf8');
+
+const FIELDS: {
+  file: string;
+  control: string;
+  on: string;
+  edge: string;
+  fill: string;
+  containerFill: string;
+  alsoContains?: string;
+}[] = [
+  {
+    file: 'findings/FindingsToolbarView.tsx',
+    control: 'the findings search',
+    on: 'the page canvas',
+    edge: 'rounded-lg border border-border-field bg-surface pl-9 pr-3',
+    fill: 'bg-surface',
+    // In light the canvas and --color-surface-2 are the same hex, so a
+    // bg-surface-2 field on the canvas is the collision, not the safe choice.
+    containerFill: 'bg-surface-2',
+  },
+  {
+    file: 'detections/DetectionsListView.tsx',
+    control: 'the detections search',
+    on: 'a Card',
+    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
+    fill: 'bg-surface-2',
+    containerFill: 'bg-surface',
+  },
+  {
+    file: 'inventory/InventoryNav.tsx',
+    control: 'the assets search',
+    on: 'a Card',
+    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
+    fill: 'bg-surface-2',
+    containerFill: 'bg-surface',
+  },
+  {
+    file: 'inventory/ProjectPane.tsx',
+    control: 'the project-files search',
+    on: 'a Card',
+    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-8',
+    fill: 'bg-surface-2',
+    containerFill: 'bg-surface',
+  },
+  {
+    file: 'activity/SessionListView.tsx',
+    control: 'the sessions search',
+    on: 'a Card',
+    // The border sits on the WRAPPER: the input inside it is bg-transparent, so
+    // this element is the whole visible control and carries both decisions.
+    edge: 'rounded-lg border border-border-field bg-surface-2 px-2.5',
+    fill: 'bg-surface-2',
+    containerFill: 'bg-surface',
+  },
+  {
+    file: 'activity/HarnessSelect.tsx',
+    control: 'the harness filter',
+    on: 'a Card',
+    // Its border COLOUR is conditional — border-border-field at rest, primary
+    // once a subset is chosen — so the fragment carries the fill and the shape,
+    // and the resting colour is asserted separately.
+    edge: 'rounded-lg border bg-surface-2 px-2.5',
+    fill: 'bg-surface-2',
+    containerFill: 'bg-surface',
+    alsoContains: "'border-border-field'",
+  },
+];
+
+describe('the hand-rolled field boundary', () => {
+  for (const { file, control, on, edge, alsoContains } of FIELDS) {
+    it(`${control}: an edge that clears 3:1 and a fill a step off ${on}`, () => {
+      const source = read(file);
+      expect(source).toContain(edge);
+      if (alsoContains !== undefined) expect(source).toContain(alsoContains);
+    });
+  }
+
+  // The edge half. Built by swapping this control's own edge token back, so it
+  // matches the field and never the card or divider beside it.
+  for (const { file, control, edge } of FIELDS) {
+    const collided = edge.replace('border-border-field', 'border-border');
+    if (collided === edge) continue; // HarnessSelect: colour is not in the fragment
+    it(`${control}: its edge is not back on the ordinary border`, () => {
+      expect(read(file)).not.toContain(collided);
+    });
+  }
+
+  // The fill half, which no token search can express: what makes a fill wrong is
+  // the fill of the thing UNDER it, which is not in the class string.
+  for (const { file, control, on, edge, fill, containerFill } of FIELDS) {
+    const collided = edge.replace(fill, containerFill);
+    it(`${control}: its fill is not the same as ${on}`, () => {
+      expect(read(file)).not.toContain(collided);
+    });
+  }
+});

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -92,6 +92,8 @@ const FIELDS: {
   on: 'a Card' | 'the page canvas';
   edge: string;
   fill: string;
+  /** The whole focus treatment, pinned as one fragment — see the loop below. */
+  focus: string;
   alsoContains?: string;
 }[] = [
   {
@@ -100,6 +102,8 @@ const FIELDS: {
     on: 'the page canvas',
     edge: 'rounded-lg border border-border-field bg-surface pl-9 pr-3',
     fill: 'bg-surface',
+    focus:
+      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'detections/DetectionsListView.tsx',
@@ -107,6 +111,8 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
     fill: 'bg-surface-2',
+    focus:
+      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'inventory/InventoryNav.tsx',
@@ -114,6 +120,8 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
     fill: 'bg-surface-2',
+    focus:
+      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'inventory/ProjectPane.tsx',
@@ -121,6 +129,8 @@ const FIELDS: {
     on: 'a Card',
     edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-8',
     fill: 'bg-surface-2',
+    focus:
+      'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
   },
   {
     file: 'activity/SessionListView.tsx',
@@ -130,6 +140,7 @@ const FIELDS: {
     // this element is the whole visible control and carries both decisions.
     edge: 'rounded-lg border border-border-field bg-surface-2 px-2.5',
     fill: 'bg-surface-2',
+    focus: 'focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
   },
   {
     file: 'activity/HarnessSelect.tsx',
@@ -141,10 +152,33 @@ const FIELDS: {
     edge: 'rounded-lg border bg-surface-2 px-2.5',
     fill: 'bg-surface-2',
     alsoContains: "all ? 'border-border-field'",
+    focus: 'outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
   },
 ];
 
 describe('the hand-rolled field boundary', () => {
+  // The FOCUS half. Pinned separately from `edge` because it lives at the far end
+  // of the class string and one control expresses it through `focus-within` on a
+  // wrapper rather than `focus`/`focus-visible` on the control itself.
+  //
+  // It is pinned at all because it was the one property of these six that nothing
+  // reached: deleting the ring from all four search inputs passed 365/365, one
+  // property over from the gap this file's header diagnoses. And pinning it found
+  // a second defect — SessionListView's wrapper carried NO focus rule while its
+  // inner input suppressed the native outline, so focusing that search changed
+  // nothing on screen at all.
+  //
+  // What this does NOT assert is that the indicator clears 3:1 between states. It
+  // does not: the border swap is 2.070:1 light / 1.729:1 dark and the ring adds
+  // 2.019:1 / 2.157:1 on its own pixels, both under SC 2.4.13. These match the
+  // ui-kit primitives, and moving that bar is a change to --color-primary's alpha
+  // across both products. See theme.css's closing paragraph.
+  for (const { file, control, focus } of FIELDS) {
+    it(`${control}: keeps a focus indicator`, () => {
+      expect(read(file)).toContain(focus);
+    });
+  }
+
   for (const { file, control, on, edge, alsoContains } of FIELDS) {
     it(`${control}: an edge that clears 3:1 and a fill a step off ${on}`, () => {
       const source = read(file);

--- a/packages/ui-kit/src/input.tsx
+++ b/packages/ui-kit/src/input.tsx
@@ -42,7 +42,7 @@ export function Input({ className, type = 'text', ...props }: ComponentPropsWith
       className={cn(
         'h-9 w-full rounded-lg border border-border-field bg-surface-2 px-3 text-sm text-text',
         'truncate placeholder:text-text-3 transition-colors',
-        'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
         'disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}

--- a/packages/ui-kit/src/input.tsx
+++ b/packages/ui-kit/src/input.tsx
@@ -19,6 +19,17 @@ import { cn } from './lib/cn.ts';
  * The fill step is deliberately slight — 1.05:1 light, 1.21:1 dark. It is a hint,
  * not a boundary: the border still does all the contrast work.
  *
+ * `bg-surface-2` is not a free choice — theme.css annotates it `row hover /
+ * subtle inset`, and it is also the menu-highlight fill (`select.tsx`'s
+ * `data-[highlighted]`, `dropdown-menu.tsx`'s `focus:`). So a field now shares a
+ * fill with a read-only inset box and with a highlighted menu row: the 1.05:1
+ * gained against the panel is smaller than the 1.000:1 given up against those
+ * state fills. That trade is deliberate — the panel is what a field must be
+ * findable against, and the edge (3.20:1 here) is what separates it from an inset
+ * box, which carries none. Do not read the paragraph above as covering a DISABLED
+ * field: `disabled:opacity-50` collapses this fill step to 1.02:1 and the border
+ * to 1.71:1.
+ *
  * A field on the page CANVAS wants `bg-surface` instead — in light the canvas and
  * `--color-surface-2` are the same hex, so `bg-surface-2` there is the very
  * collision this fill exists to avoid. See the token's note in theme.css.

--- a/packages/ui-kit/src/input.tsx
+++ b/packages/ui-kit/src/input.tsx
@@ -7,11 +7,21 @@ import { cn } from './lib/cn.ts';
  * (surface fill, border, primary focus ring) so forms across the dashboards
  * share one field look. `ref` flows through as a regular prop (React 19).
  *
- * The edge is `border-border-field`, not `border-border`. A field renders
- * `bg-surface` inside panels that are also `bg-surface`, so its border is the
- * only thing marking where the control starts — the hairline that separates a
- * card from the page is 1.26:1 there and leaves the field almost invisible to a
- * low-vision reader. See the token's note in theme.css.
+ * The fill is `bg-surface-2` and the edge is `border-border-field`, and the two
+ * are one decision. Card, DialogContent and SheetContent are all `bg-surface`,
+ * which is where forms live — so a `bg-surface` field had a fill identical to the
+ * panel under it, leaving the border as the only thing marking the control. That
+ * is the case `border-border` fails at 1.26:1, which is near-invisible to a
+ * low-vision reader. `border-border-field` fixes the contrast half (3.20:1 on
+ * this fill); `bg-surface-2` fixes the other half, so the control reads as a
+ * field rather than an outline drawn on nothing.
+ *
+ * The fill step is deliberately slight — 1.05:1 light, 1.21:1 dark. It is a hint,
+ * not a boundary: the border still does all the contrast work.
+ *
+ * A field on the page CANVAS wants `bg-surface` instead — in light the canvas and
+ * `--color-surface-2` are the same hex, so `bg-surface-2` there is the very
+ * collision this fill exists to avoid. See the token's note in theme.css.
  */
 export function Input({ className, type = 'text', ...props }: ComponentPropsWithRef<'input'>) {
   return (
@@ -19,7 +29,7 @@ export function Input({ className, type = 'text', ...props }: ComponentPropsWith
       type={type}
       data-slot="input"
       className={cn(
-        'h-9 w-full rounded-lg border border-border-field bg-surface px-3 text-sm text-text',
+        'h-9 w-full rounded-lg border border-border-field bg-surface-2 px-3 text-sm text-text',
         'truncate placeholder:text-text-3 transition-colors',
         'focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         'disabled:cursor-not-allowed disabled:opacity-50',

--- a/packages/ui-kit/src/select.tsx
+++ b/packages/ui-kit/src/select.tsx
@@ -75,7 +75,7 @@ export function SelectTrigger({
       data-slot="select-trigger"
       className={cn(
         'flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-border-field bg-surface-2 px-3 text-sm text-text',
-        'transition-colors focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+        'transition-colors focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
         'data-[placeholder]:text-text-3 disabled:cursor-not-allowed disabled:opacity-50',
         '[&>span]:truncate',
         className,

--- a/packages/ui-kit/src/select.tsx
+++ b/packages/ui-kit/src/select.tsx
@@ -55,12 +55,12 @@ function CheckMark({ className }: { className?: string }) {
 /**
  * The select's own trigger.
  *
- * Its edge is `border-border-field`, not `border-border`, for the reason `Input`
- * gives: it renders `bg-surface` inside panels that are also `bg-surface`, so the
- * border is the only thing marking where the control begins, and `border-border`
- * is 1.26:1 there. Deliberately unlike `SelectContent` below, which is a floating
- * surface over a scrim and does not have that problem — the two differ on purpose
- * rather than by oversight. See the token's note in theme.css.
+ * Its fill and edge are `bg-surface-2` / `border-border-field`, for the reason
+ * `Input` gives: it renders inside panels that are `bg-surface`, so a
+ * `bg-surface` trigger had no fill of its own and `border-border` is 1.26:1
+ * there. Deliberately unlike `SelectContent` below, which is a floating surface
+ * over a scrim and does not have that problem — the two differ on purpose rather
+ * than by oversight. See the token's note in theme.css.
  */
 export function SelectTrigger({
   className,
@@ -71,7 +71,7 @@ export function SelectTrigger({
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       className={cn(
-        'flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-border-field bg-surface px-3 text-sm text-text',
+        'flex h-9 w-full cursor-pointer items-center justify-between gap-2 rounded-lg border border-border-field bg-surface-2 px-3 text-sm text-text',
         'transition-colors focus:border-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
         'data-[placeholder]:text-text-3 disabled:cursor-not-allowed disabled:opacity-50',
         '[&>span]:truncate',

--- a/packages/ui-kit/src/select.tsx
+++ b/packages/ui-kit/src/select.tsx
@@ -58,9 +58,12 @@ function CheckMark({ className }: { className?: string }) {
  * Its fill and edge are `bg-surface-2` / `border-border-field`, for the reason
  * `Input` gives: it renders inside panels that are `bg-surface`, so a
  * `bg-surface` trigger had no fill of its own and `border-border` is 1.26:1
- * there. Deliberately unlike `SelectContent` below, which is a floating surface
- * over a scrim and does not have that problem — the two differ on purpose rather
- * than by oversight. See the token's note in theme.css.
+ * there. Deliberately unlike `SelectContent` below, which keeps `bg-surface`
+ * because it is separated by ELEVATION rather than by a fill step — it is
+ * `Portal` + `Content` carrying `shadow-lg`, and the shadow is what marks its
+ * edge over whatever it opens on. (Not a scrim: Radix Select ships no overlay
+ * primitive, unlike Radix Dialog.) The two differ on purpose rather than by
+ * oversight. See the token's note in theme.css.
  */
 export function SelectTrigger({
   className,

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -37,17 +37,26 @@
      than making inputs findable.
 
      THE RULE, which is what a retune needs and a list of numbers is not: choose
-     it against the LIGHTEST surface a field lands on, and require 3:1 there. That
-     is --color-surface, where it measures 3.34:1 — and today that is the only
-     ratio this token renders at, because both consumers (Input, SelectTrigger)
-     hardcode bg-surface and no call site overrides the fill.
+     it against the LIGHTEST surface a field lands on, and require 3:1 there. In
+     light that is --color-surface at 3.34:1, with --color-surface-2 at 3.20:1.
+     Both are live, and which one a field takes follows from a second rule: A
+     FIELD'S FILL IS ALWAYS A STEP OFF THE FILL UNDER IT. Card, DialogContent and
+     SheetContent are all --color-surface, so a field inside one is bg-surface-2
+     — Input and SelectTrigger, and the Detections/Inventory/ProjectPane search
+     inputs. A field on the page CANVAS is bg-surface instead, because in light
+     the canvas and --color-surface-2 are the same hex.
 
-     --color-surface-2 and the canvas are quoted at 3.20:1 as headroom for a field
-     that lands there, not as a case that exists. Note what does NOT use this
-     token: the search inputs in Findings, Detections and Inventory are still
-     `border-border` on bg-surface-2 — 1.21:1 light, 1.17:1 dark — so they are
-     BELOW the floor this token was introduced to clear, and moving them is
-     outstanding work rather than something this value already fixed.
+     Why that step matters: a field whose fill equals the fill under it leaves
+     this border drawing a rectangle against its own colour — compliant, and
+     reading as a floating outline among the 1.26:1 hairlines beside it. Both
+     collisions have shipped. The step is deliberately slight, 1.05:1 light and
+     1.21:1 dark; it is a hint, not a boundary, and this token still does all the
+     contrast work.
+
+     There is almost no room above the floor. One perceptible step lighter than
+     this value measures 2.98:1 on --color-surface and fails. It reads far
+     heavier than --color-border beside it, and that is the cost of 3:1 against a
+     near-white surface, not a value waiting to be softened.
 
      --color-surface-3 is outside the rule's input set, which is why it does not
      constrain the value: nothing renders a field there. It measures 2.98:1 light
@@ -220,8 +229,9 @@
 
   /* the same boundary in dark, under the same rule: chosen against the lightest
      surface a field lands on and required to clear 3:1 there. 3.94:1 on
-     --color-surface, which is where both consumers render, and 3.26:1 on
-     --color-surface-2. It reads lighter than --color-border-strong on purpose —
+     --color-surface and 3.26:1 on --color-surface-2 — and note which of those
+     binds: dark inverts the order of the two, so --color-surface-2 is the
+     LIGHTER one here and 3.26:1 is the figure with the least room, not 3.94:1. It reads lighter than --color-border-strong on purpose —
      strong is a divider that wants to recede, this is a control edge that has to
      be found.
 

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -29,22 +29,34 @@
 
   /* field boundary. --color-border is a thin rule tuned to separate a card from the
      page, where the two surfaces already differ and the line is reinforcement. A
-     text field is the opposite case: it renders bg-surface inside a panel that is
-     also bg-surface, so the border is the ONLY thing saying where the control
-     begins, and 1.4.11 asks that boundary for 3:1 rather than that rule's 1.26:1.
-     Its own token because widening --color-border to clear 3:1 would put that weight
-     on every card and divider in the product, which is a different design decision
-     than making inputs findable.
+     field is the opposite case: it sits INSIDE a panel, one small fill step off
+     it, so nothing but the border states where the control begins — and 1.4.11
+     asks that boundary for 3:1 rather than that rule's 1.26:1. (Before this token
+     the step did not exist either: a field rendered bg-surface inside a bg-surface
+     panel, so the border carried the whole boundary at 1.26:1.) Its own token
+     because widening --color-border to clear 3:1 would put that weight on every
+     card and divider in the product, which is a different design decision than
+     making inputs findable.
 
-     THE RULE, which is what a retune needs and a list of numbers is not: choose
-     it against the LIGHTEST surface a field lands on, and require 3:1 there. In
-     light that is --color-surface at 3.34:1, with --color-surface-2 at 3.20:1.
-     Both are live, and which one a field takes follows from a second rule: A
-     FIELD'S FILL IS ALWAYS A STEP OFF THE FILL UNDER IT. Card, DialogContent and
-     SheetContent are all --color-surface, so a field inside one is bg-surface-2
-     — Input and SelectTrigger, and the Detections/Inventory/ProjectPane search
-     inputs. A field on the page CANVAS is bg-surface instead, because in light
-     the canvas and --color-surface-2 are the same hex.
+     THE RULE, which is what a retune needs and a list of numbers is not: require
+     3:1 against EVERY surface a field lands on — i.e. the MINIMUM over that set,
+     which is the surface closest in luminance, not the lightest. Naming "the
+     lightest" is wrong in light and right only by accident in dark: this token is
+     darker than every light surface, so contrast RISES with surface lightness and
+     the lightest surface is the LOOSEST case (3.34:1 on --color-surface against
+     3.20:1 on --color-surface-2, which is the one that binds). In dark the token
+     is lighter than both surfaces and the order inverts, so there the tighter
+     surface happens to be the lighter one too. A retune obeying "lightest"
+     literally could land 3.03:1 on #ffffff and 2.90:1 on #f9fafb — under the floor
+     on the fill that now carries most of the product's fields, with nothing in the
+     repo computing a ratio to catch it.
+
+     Which fill a field takes follows from a second rule: A FIELD'S FILL IS ALWAYS
+     A STEP OFF THE FILL UNDER IT. Card, DialogContent and SheetContent are all
+     --color-surface, so a field inside one is bg-surface-2 — Input, SelectTrigger,
+     and the Detections / Inventory / ProjectPane / Sessions search inputs and the
+     Activity harness filter. A field on the page CANVAS is bg-surface instead,
+     because in light the canvas and --color-surface-2 are the same hex.
 
      Why that step matters: a field whose fill equals the fill under it leaves
      this border drawing a rectangle against its own colour — compliant, and
@@ -52,6 +64,14 @@
      collisions have shipped. The step is deliberately slight, 1.05:1 light and
      1.21:1 dark; it is a hint, not a boundary, and this token still does all the
      contrast work.
+
+     WHAT THIS TOKEN DOES NOT YET REACH, so this block is not read as a finished
+     inventory: web-ui still has fields on the ordinary border, and two fail both
+     halves — the vault reveal-confirmation input (bg-surface inside a bg-surface
+     panel, 1.000:1 and 1.26:1) and the data-shares filter bar (bg-surface-2 on the
+     canvas, the same-hex collision named above). Neither is reachable from the two
+     suites that pin this, which cover ui-kit and dashboard-ui only. Moving them is
+     outstanding work rather than something this value already fixed.
 
      There is almost no room above the floor. One perceptible step lighter than
      this value measures 2.98:1 on --color-surface and fails. It reads far
@@ -227,21 +247,22 @@
      here where the light theme's sinks into it. */
   --color-hairline: rgb(255 255 255 / 0.06);
 
-  /* the same boundary in dark, under the same rule: chosen against the lightest
-     surface a field lands on and required to clear 3:1 there. 3.94:1 on
-     --color-surface and 3.26:1 on --color-surface-2 — and note which of those
-     binds: dark inverts the order of the two, so --color-surface-2 is the
-     LIGHTER one here and 3.26:1 is the figure with the least room, not 3.94:1. It reads lighter than --color-border-strong on purpose —
-     strong is a divider that wants to recede, this is a control edge that has to
-     be found.
+  /* the same boundary in dark, under the same rule: 3:1 against every surface a
+     field lands on. 3.94:1 on --color-surface and 3.26:1 on --color-surface-2, so
+     --color-surface-2 binds here as it does in light — but for the opposite
+     reason, which is why the light block spells the rule out: this token is
+     LIGHTER than both dark surfaces, so contrast falls as the surface lightens
+     and the tighter case is the lighter surface. It reads lighter than
+     --color-border-strong on purpose — strong is a divider that wants to recede,
+     this is a control edge that has to be found.
 
      Carried here as well as in the light block, for the reason --color-hairline
      gives two tokens up: a retune of THIS value, or of --color-surface-3, has to
      see the constraint locally. --color-surface-3 is 2.78:1 against this value,
      below the floor, and stays outside the rule's input set only while nothing
-     renders a field there. The light block's canvas figure has no counterpart
-     here — canvas and --color-surface-2 are the same hex in light and different
-     in dark, so that grouping does not carry across. */
+     renders a field there. The canvas is not in this block's figures at all:
+     canvas and --color-surface-2 are the same hex in light and different in dark,
+     so the light block's same-hex collision has no counterpart here. */
   --color-border-field: #828b9b;
 
   /* text */

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -80,15 +80,34 @@
      focused appearance, and 2.4.13 asks that change for 3:1. It does not clear it:
      swapping this token for --color-primary is 2.070:1 light and 1.729:1 dark, and
      the ring beside it (--color-primary at 40%, painted OUTSIDE the border box, so
-     its backdrop is the container rather than the field) adds 2.019:1 and 2.157:1.
+     its backdrop is the container rather than the field) adds 2.019:1 and 2.325:1.
+     Take those against the CONTAINER, which is what that sentence says and what
+     the ring actually paints on: 2.157:1 is the dark figure over --color-surface-2,
+     i.e. over the field's own fill, which is the one surface the ring never has
+     behind it. Light barely moves either way (the two surfaces are 1.05:1 apart
+     there); dark's 1.21:1 gap makes the two computations diverge.
      Two sub-threshold cues do not sum to a passing one. 1.4.11 is met and was never
      at risk — the focused border against the field fill is 6.620:1 light and
      5.628:1 dark — so what falls short is the AAA criterion, not the AA one. Every
      field in both products shares these figures because they all use the same ring;
      closing the gap means moving that alpha, not this value.
 
+     FORCED COLORS, where the loss is total rather than sub-threshold. Both cues
+     above are exactly what Windows High Contrast Mode discards: ring-* compiles
+     to a box-shadow, and --color-primary on a focused border is an author border
+     colour. Tailwind v4 split v3's outline-none in two — outline-none sets
+     outline-style:none flat, while outline-hidden also re-emits a transparent
+     outline under forced-colors: active, which the system then paints. So a
+     control spelling outline-none keeps NO focus indicator at all under HCM.
+     The eight controls the two suites pin spell outline-hidden for that reason.
+     Ten further ui-kit components still spell outline-none — including
+     SelectItem, in the same file as the SelectTrigger that moved — and are not
+     covered by either suite; moving them is outstanding work, and this token
+     cannot fix any of it.
+
      Both suites pin the focus fragment as PRESENT, which is a different claim from
-     clearing the bar. Do not read a green run as either.
+     clearing the bar — and PRESENT is asserted against the resting/focused change,
+     not against forced colors. Do not read a green run as either.
 
      There is almost no room above the floor. One perceptible step lighter than
      this value measures 2.98:1 on --color-surface and fails. It reads far

--- a/packages/ui-kit/src/styles/theme.css
+++ b/packages/ui-kit/src/styles/theme.css
@@ -66,12 +66,29 @@
      contrast work.
 
      WHAT THIS TOKEN DOES NOT YET REACH, so this block is not read as a finished
-     inventory: web-ui still has fields on the ordinary border, and two fail both
-     halves — the vault reveal-confirmation input (bg-surface inside a bg-surface
-     panel, 1.000:1 and 1.26:1) and the data-shares filter bar (bg-surface-2 on the
-     canvas, the same-hex collision named above). Neither is reachable from the two
-     suites that pin this, which cover ui-kit and dashboard-ui only. Moving them is
+     inventory. Two things:
+
+     Fields outside ui-kit and dashboard-ui. web-ui still has fields on the ordinary
+     border, and two fail both halves — the vault reveal-confirmation input
+     (bg-surface inside a bg-surface panel, 1.000:1 and 1.26:1) and the data-shares
+     filter bar (bg-surface-2 on the canvas, the same-hex collision named above).
+     Neither is reachable from the two suites that pin this. Moving them is
      outstanding work rather than something this value already fixed.
+
+     The FOCUSED state, which this token does not address and which no value here
+     can fix. A field's focus indicator is the change between its resting and
+     focused appearance, and 2.4.13 asks that change for 3:1. It does not clear it:
+     swapping this token for --color-primary is 2.070:1 light and 1.729:1 dark, and
+     the ring beside it (--color-primary at 40%, painted OUTSIDE the border box, so
+     its backdrop is the container rather than the field) adds 2.019:1 and 2.157:1.
+     Two sub-threshold cues do not sum to a passing one. 1.4.11 is met and was never
+     at risk — the focused border against the field fill is 6.620:1 light and
+     5.628:1 dark — so what falls short is the AAA criterion, not the AA one. Every
+     field in both products shares these figures because they all use the same ring;
+     closing the gap means moving that alpha, not this value.
+
+     Both suites pin the focus fragment as PRESENT, which is a different claim from
+     clearing the bar. Do not read a green run as either.
 
      There is almost no room above the floor. One perceptible step lighter than
      this value measures 2.98:1 on --color-surface and fails. It reads far

--- a/packages/ui-kit/test/border-field.test.ts
+++ b/packages/ui-kit/test/border-field.test.ts
@@ -3,17 +3,23 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
-// --color-border-field exists because `border-border` is 1.26:1 light and 1.42:1
-// dark against `bg-surface`, and a field's border is the only thing marking
-// where the control begins. Nothing pinned that choice, so a sweep normalising
-// these class strings against their neighbours would revert it with no signal —
-// and SelectContent one function below IS `border-border`, which makes the
-// trigger look like the inconsistency rather than the fix.
+// A field is TWO decisions that have to hold together, so both are pinned in one
+// fragment. `--color-border-field` exists because `border-border` is 1.26:1 light
+// and 1.42:1 dark; `bg-surface-2` exists because Card, DialogContent and
+// SheetContent are all `bg-surface`, so a `bg-surface` field had a fill identical
+// to the panel under it and the border was left drawing a rectangle against its
+// own colour. Revert either half and the control goes back to reading as a
+// floating outline.
+//
+// Nothing pinned either choice, so a sweep normalising these class strings
+// against their neighbours would revert them with no signal — and SelectContent
+// one function below IS `border-border bg-surface`, which makes the trigger look
+// like the inconsistency rather than the fix.
 //
 // Same precedent as badge.test.ts: pin the exact string so a change is
 // deliberate. The fragments are long enough that the prose in each file's own
-// docblock — which names both tokens while explaining the choice — cannot
-// satisfy them, which is the failure mode a bare token search would have.
+// docblock — which names the tokens while explaining the choice — cannot satisfy
+// them, which is the failure mode a bare token search would have.
 
 const read = (rel: string): string =>
   readFileSync(fileURLToPath(new URL(`../src/${rel}`, import.meta.url)), 'utf8');
@@ -22,13 +28,13 @@ const EXPECTED: { file: string; component: string; edge: string; why: string }[]
   {
     file: 'input.tsx',
     component: 'Input',
-    edge: 'rounded-lg border border-border-field bg-surface',
-    why: 'a field on a panel of its own colour; the border is the whole boundary',
+    edge: 'rounded-lg border border-border-field bg-surface-2',
+    why: 'a fill one step off the panel under it, and an edge that clears 3:1 on that fill',
   },
   {
     file: 'select.tsx',
     component: 'SelectTrigger',
-    edge: 'rounded-lg border border-border-field bg-surface',
+    edge: 'rounded-lg border border-border-field bg-surface-2',
     why: 'the same shape as Input, and it sits in the same forms',
   },
   {
@@ -46,12 +52,25 @@ describe('the field boundary', () => {
     });
   }
 
-  // The pairing that must not come back: a control edge on its own fill at
-  // 1.26:1. Written as the exact fragment rather than a token search, because
-  // `border-border` is a prefix of `border-border-field`.
-  it('leaves no field edge on the ordinary border', () => {
+  // The two pairings that must not come back, in either fill: a control edge on
+  // the ordinary border at 1.26:1. Written as exact fragments rather than a token
+  // search, because `border-border` is a prefix of `border-border-field`.
+  it.each(['bg-surface', 'bg-surface-2'])(
+    'leaves no field edge on the ordinary border (%s)',
+    (fill) => {
+      const offenders = ['input.tsx', 'select.tsx'].filter((file) =>
+        read(file).includes(`rounded-lg border border-border ${fill} px-3`),
+      );
+      expect(offenders).toEqual([]);
+    },
+  );
+
+  // The fill half, stated on its own: a field whose fill equals the panel under
+  // it. Card/DialogContent/SheetContent are all bg-surface, so `bg-surface` on
+  // these two controls is that collision by definition.
+  it('leaves no field on the same fill as its container', () => {
     const offenders = ['input.tsx', 'select.tsx'].filter((file) =>
-      read(file).includes('rounded-lg border border-border bg-surface px-3'),
+      read(file).includes('border-border-field bg-surface px-3'),
     );
     expect(offenders).toEqual([]);
   });

--- a/packages/ui-kit/test/border-field.test.ts
+++ b/packages/ui-kit/test/border-field.test.ts
@@ -59,17 +59,26 @@ const CONTAINERS = [
   { file: 'sheet.tsx', component: 'SheetContent', anchor: 'fixed inset-y-0' },
 ] as const;
 
-const EXPECTED: { file: string; component: string; edge: string; why: string }[] = [
+const EXPECTED: {
+  file: string;
+  component: string;
+  edge: string;
+  /** The focus indicator, where the component is one a user can focus. */
+  focus?: string;
+  why: string;
+}[] = [
   {
     file: 'input.tsx',
     component: 'Input',
     edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
+    focus: 'focus-visible:ring-2 focus-visible:ring-primary/40',
     why: 'a fill one step off the panel under it, and an edge that clears 3:1 on that fill',
   },
   {
     file: 'select.tsx',
     component: 'SelectTrigger',
     edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
+    focus: 'focus-visible:ring-2 focus-visible:ring-primary/40',
     why: 'the same shape as Input, and it sits in the same forms',
   },
   {
@@ -108,6 +117,23 @@ describe('the field boundary', () => {
   for (const { file, component, edge, why } of EXPECTED) {
     it(`${component}: ${why}`, () => {
       expect(read(file)).toContain(edge);
+    });
+  }
+
+  // The FOCUS half, pinned for the two components a user can focus. It sits at the
+  // far end of the class string, outside every `edge` fragment above, and nothing
+  // reached it — deleting the ring from the four dashboard-ui search inputs that
+  // were given it passed 365/365 there. SelectContent carries none by design: it
+  // is a popup, not a control.
+  //
+  // This asserts the ring is PRESENT, not that it clears 3:1 between states. It
+  // does not — `ring-primary/40` paints outside the border box, so its backdrop is
+  // the container, giving 2.019:1 light and 2.157:1 dark. Raising it means moving
+  // --color-primary's alpha for every focus ring in both products.
+  for (const { file, component, focus } of EXPECTED) {
+    if (focus === undefined) continue;
+    it(`${component}: keeps its focus ring`, () => {
+      expect(read(file)).toContain(focus);
     });
   }
 

--- a/packages/ui-kit/test/border-field.test.ts
+++ b/packages/ui-kit/test/border-field.test.ts
@@ -53,6 +53,36 @@ function containerFill(file: string, anchor: string): string {
   return match[0];
 }
 
+/**
+ * A focus fragment matched as a DECISION rather than as today's spelling of it.
+ *
+ * Tailwind v4 split v3's `outline-none` in two: `outline-none` sets
+ * `outline-style: none` flat, while `outline-hidden` also re-emits a transparent
+ * outline under `forced-colors: active`, which the system then paints. Windows
+ * High Contrast Mode discards box-shadow rings and author border colours — which
+ * is exactly `ring-*` and `border-primary` — so `outline-hidden` is the spelling
+ * that keeps an indicator there at all.
+ *
+ * Pinning either spelling literally makes the other fail this suite, and a move
+ * from `none` to `hidden` is the REPAIR. A pin that reds on a repair reads as a
+ * regression and gets reverted — the same failure this file's header describes
+ * for the container premise, one property over: an assertion that mandates the
+ * state it exists to forbid. So the outline token alternates and every other
+ * token stays exact.
+ */
+function focusPattern(fragment: string): RegExp {
+  return new RegExp(
+    fragment
+      .split(' ')
+      .map((token) =>
+        /^(?:focus:)?outline-(?:none|hidden)$/.test(token)
+          ? '(?:focus:)?outline-(?:none|hidden)'
+          : token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+      )
+      .join(' '),
+  );
+}
+
 const CONTAINERS = [
   { file: 'card.tsx', component: 'Card', anchor: 'rounded-xl border border-border' },
   { file: 'dialog.tsx', component: 'DialogContent', anchor: 'rounded-2xl border border-border' },
@@ -63,22 +93,29 @@ const EXPECTED: {
   file: string;
   component: string;
   edge: string;
-  /** The focus indicator, where the component is one a user can focus. */
-  focus?: string;
+  /**
+   * The focus indicator. REQUIRED, and `null` is how a component declares it has
+   * none — an optional key skipped with `continue` is the same silently-skips
+   * shape as the `alsoContains` hole this suite already closed once: a focusable
+   * component added below would get no pin and no complaint.
+   */
+  focus: string | null;
   why: string;
 }[] = [
   {
     file: 'input.tsx',
     component: 'Input',
     edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
-    focus: 'focus-visible:ring-2 focus-visible:ring-primary/40',
+    focus:
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
     why: 'a fill one step off the panel under it, and an edge that clears 3:1 on that fill',
   },
   {
     file: 'select.tsx',
     component: 'SelectTrigger',
     edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
-    focus: 'focus-visible:ring-2 focus-visible:ring-primary/40',
+    focus:
+      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
     why: 'the same shape as Input, and it sits in the same forms',
   },
   {
@@ -88,6 +125,7 @@ const EXPECTED: {
     // it is separated by ELEVATION rather than by a fill step. Radix Select ships
     // no overlay primitive, so there is no scrim doing that job.
     edge: 'rounded-lg border border-border bg-surface shadow-lg',
+    focus: null, // a popup, not a control — nothing to focus
     why: 'elevated rather than inset — it does NOT share the problem, and pinning it records that the difference is deliberate',
   },
 ];
@@ -104,13 +142,19 @@ describe('the field boundary', () => {
     expect(new Set(fills.map((f) => f.fill)).size, JSON.stringify(fills)).toBe(1);
   });
 
+  // Read from the SOURCE, not from `edge`. Comparing the resolved container against
+  // the fixture literal validates the fixture against itself: reverting input.tsx to
+  // `bg-surface` left this assertion green (it fails 2 others, so nothing was
+  // uncovered overall — but this one reads as a fill guard and was not one).
   it('the field fill is one step off that container fill, not equal to it', () => {
     const container = containerFill(CONTAINERS[0].file, CONTAINERS[0].anchor);
     for (const { component, file, edge } of EXPECTED) {
       if (component === 'SelectContent') continue; // elevated, deliberately equal
-      expect(edge, `${component} (${file}) must not sit on its container's own fill`).not.toContain(
-        `${container} px-`,
-      );
+      const shape = edge.replace(/\bbg-surface(?:-\d)?\b/, container);
+      expect(
+        read(file),
+        `${component} (${file}) must not sit on its container's own fill`,
+      ).not.toContain(shape);
     }
   });
 
@@ -128,12 +172,18 @@ describe('the field boundary', () => {
   //
   // This asserts the ring is PRESENT, not that it clears 3:1 between states. It
   // does not — `ring-primary/40` paints outside the border box, so its backdrop is
-  // the container, giving 2.019:1 light and 2.157:1 dark. Raising it means moving
-  // --color-primary's alpha for every focus ring in both products.
+  // the container, giving 2.019:1 light and 2.325:1 dark (2.157:1 is that figure
+  // over --color-surface-2, i.e. the field's own fill, which is the one surface the
+  // ring never has behind it). Raising it means moving --color-primary's alpha for
+  // every focus ring in both products.
+  //
+  // Nor does it assert anything about FORCED COLORS, where a `ring-*` box-shadow and
+  // an author border colour are both discarded. That is why the outline token is
+  // matched as a decision rather than as a spelling — see `focusPattern`.
   for (const { file, component, focus } of EXPECTED) {
-    if (focus === undefined) continue;
+    if (focus === null) continue; // declared above as having none
     it(`${component}: keeps its focus ring`, () => {
-      expect(read(file)).toContain(focus);
+      expect(read(file)).toMatch(focusPattern(focus));
     });
   }
 

--- a/packages/ui-kit/test/border-field.test.ts
+++ b/packages/ui-kit/test/border-field.test.ts
@@ -5,11 +5,17 @@ import { describe, expect, it } from 'vitest';
 
 // A field is TWO decisions that have to hold together, so both are pinned in one
 // fragment. `--color-border-field` exists because `border-border` is 1.26:1 light
-// and 1.42:1 dark; `bg-surface-2` exists because Card, DialogContent and
-// SheetContent are all `bg-surface`, so a `bg-surface` field had a fill identical
-// to the panel under it and the border was left drawing a rectangle against its
-// own colour. Revert either half and the control goes back to reading as a
-// floating outline.
+// and 1.42:1 dark; `bg-surface-2` exists because the containers a form lives in —
+// Card, DialogContent, SheetContent — are all `bg-surface`, so a `bg-surface`
+// field had a fill identical to the panel under it and the border was left
+// drawing a rectangle against its own colour. Revert either half and the control
+// goes back to reading as a floating outline.
+//
+// That container premise is RESOLVED from those three files rather than restated
+// here, and the difference is not cosmetic: with it written as a literal, changing
+// `card.tsx` to `bg-surface-2` collided every field at 1.000:1 and this suite
+// stayed green — worse, the positive pins below then REQUIRED `bg-surface-2` on
+// the fields, so the suite mandated the collision it exists to forbid.
 //
 // Nothing pinned either choice, so a sweep normalising these class strings
 // against their neighbours would revert them with no signal — and SelectContent
@@ -17,35 +23,88 @@ import { describe, expect, it } from 'vitest';
 // like the inconsistency rather than the fix.
 //
 // Same precedent as badge.test.ts: pin the exact string so a change is
-// deliberate. The fragments are long enough that the prose in each file's own
-// docblock — which names the tokens while explaining the choice — cannot satisfy
-// them, which is the failure mode a bare token search would have.
+// deliberate. Every pinned fragment ends on a DELIMITED token, because
+// `bg-surface` is a prefix of `bg-surface-2` exactly as `border-border` is of
+// `border-border-field`: an undelimited `…bg-surface` pin was satisfiable by
+// `…bg-surface-2`, and SelectContent passed this suite while wearing the
+// trigger's new fill.
 
-const read = (rel: string): string =>
-  readFileSync(fileURLToPath(new URL(`../src/${rel}`, import.meta.url)), 'utf8');
+const cache = new Map<string, string>();
+const read = (rel: string): string => {
+  const hit = cache.get(rel);
+  if (hit !== undefined) return hit;
+  const src = readFileSync(fileURLToPath(new URL(`../src/${rel}`, import.meta.url)), 'utf8');
+  cache.set(rel, src);
+  return src;
+};
+
+/**
+ * The fill of a container a form renders inside, read from the container itself.
+ * `anchor` picks the one class string that styles it, so a hover/child rule
+ * carrying its own `bg-*` cannot be mistaken for the container's own fill.
+ */
+function containerFill(file: string, anchor: string): string {
+  const line = read(file)
+    .split('\n')
+    .find((l) => l.includes(anchor));
+  if (line === undefined) throw new Error(`${file}: no line matching ${anchor}`);
+  const match = /\bbg-surface(?:-\d)?\b/.exec(line);
+  if (match === null) throw new Error(`${file}: no bg-surface* token on the ${anchor} line`);
+  return match[0];
+}
+
+const CONTAINERS = [
+  { file: 'card.tsx', component: 'Card', anchor: 'rounded-xl border border-border' },
+  { file: 'dialog.tsx', component: 'DialogContent', anchor: 'rounded-2xl border border-border' },
+  { file: 'sheet.tsx', component: 'SheetContent', anchor: 'fixed inset-y-0' },
+] as const;
 
 const EXPECTED: { file: string; component: string; edge: string; why: string }[] = [
   {
     file: 'input.tsx',
     component: 'Input',
-    edge: 'rounded-lg border border-border-field bg-surface-2',
+    edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
     why: 'a fill one step off the panel under it, and an edge that clears 3:1 on that fill',
   },
   {
     file: 'select.tsx',
     component: 'SelectTrigger',
-    edge: 'rounded-lg border border-border-field bg-surface-2',
+    edge: 'rounded-lg border border-border-field bg-surface-2 px-3',
     why: 'the same shape as Input, and it sits in the same forms',
   },
   {
     file: 'select.tsx',
     component: 'SelectContent',
-    edge: 'rounded-lg border border-border bg-surface',
-    why: 'a floating surface over a scrim — it does NOT share the problem, and pinning it records that the difference is deliberate',
+    // Delimited by `shadow-lg`, which is also the reason it keeps `bg-surface`:
+    // it is separated by ELEVATION rather than by a fill step. Radix Select ships
+    // no overlay primitive, so there is no scrim doing that job.
+    edge: 'rounded-lg border border-border bg-surface shadow-lg',
+    why: 'elevated rather than inset — it does NOT share the problem, and pinning it records that the difference is deliberate',
   },
 ];
 
 describe('the field boundary', () => {
+  // The premise every fill assertion rests on. Read from the containers, so a
+  // container that moves fails HERE with its own name rather than silently
+  // turning the pins below into a mandate for the collision.
+  it('every container a form renders in shares one fill', () => {
+    const fills = CONTAINERS.map(({ file, component, anchor }) => ({
+      component,
+      fill: containerFill(file, anchor),
+    }));
+    expect(new Set(fills.map((f) => f.fill)).size, JSON.stringify(fills)).toBe(1);
+  });
+
+  it('the field fill is one step off that container fill, not equal to it', () => {
+    const container = containerFill(CONTAINERS[0].file, CONTAINERS[0].anchor);
+    for (const { component, file, edge } of EXPECTED) {
+      if (component === 'SelectContent') continue; // elevated, deliberately equal
+      expect(edge, `${component} (${file}) must not sit on its container's own fill`).not.toContain(
+        `${container} px-`,
+      );
+    }
+  });
+
   for (const { file, component, edge, why } of EXPECTED) {
     it(`${component}: ${why}`, () => {
       expect(read(file)).toContain(edge);
@@ -66,11 +125,12 @@ describe('the field boundary', () => {
   );
 
   // The fill half, stated on its own: a field whose fill equals the panel under
-  // it. Card/DialogContent/SheetContent are all bg-surface, so `bg-surface` on
-  // these two controls is that collision by definition.
+  // it. The container fill is resolved, so this tracks card.tsx rather than a
+  // literal that would go on passing after card.tsx moved.
   it('leaves no field on the same fill as its container', () => {
+    const container = containerFill(CONTAINERS[0].file, CONTAINERS[0].anchor);
     const offenders = ['input.tsx', 'select.tsx'].filter((file) =>
-      read(file).includes('border-border-field bg-surface px-3'),
+      read(file).includes(`border-border-field ${container} px-3`),
     );
     expect(offenders).toEqual([]);
   });


### PR DESCRIPTION
## What this fixes

`--color-border-field` fixed the **contrast** half of a field's boundary and left the other half unmade.

`Card`, `DialogContent` and `SheetContent` are all `bg-surface` — which is where forms live — and `Input`/`SelectTrigger` were `bg-surface` too. So **30 of their 31 usages had a fill identical to the panel under them**, and the border was left drawing a rectangle against its own colour. Compliant at 3:1, and reading as a floating outline rather than a control.

## Why the token can't just be softened

Measured, not assumed:

| | current | one step lighter |
|---|---|---|
| light, on `--color-surface` | `#868d99` — 3.34:1 | `#8f96a1` — **2.98:1**, fails |

Dark looks like it has room at 3.94:1, but the token's own rule is "the lightest surface a field lands on", and **dark inverts the surface order** — `--color-surface-2` (`#313c4b`) is lighter than `--color-surface` (`#252f3d`). So **3.26:1 is the figure with the least room, not 3.94:1**. The block previously implied otherwise; that's corrected here.

## The rule instead

**A field's fill is always a step off the fill under it.**

```
inside a Card/Dialog/Sheet   bg-surface-2   3.20:1 light   3.26:1 dark
on the page canvas           bg-surface     3.34:1 light   3.94:1 dark
```

The canvas takes the other value because **in light the canvas and `--color-surface-2` are the same hex** — so `bg-surface-2` there is the collision, not the safe choice.

The fill step is deliberately slight (1.05:1 light, 1.21:1 dark). It's a hint, not a boundary — the border still does all the contrast work.

## What moved

- **`Input` + `SelectTrigger`** → `bg-surface-2`. Covers every form in the package at once. `SelectContent` is untouched: it floats over a scrim and never had the problem.
- **Six hand-rolled fields in dashboard-ui**, which spell the pair themselves: the Findings toolbar search (canvas-level, so `bg-surface`), and the Detections, Inventory, ProjectPane and Sessions searches plus the harness filter (all inside a Card).

Two of those six were missed by a sweep looking for the other four, which is why they're now pinned rather than described:

- **Sessions search** is `h-8.5` where the rest are `h-9`, and its border sits on the **wrapper** because the input inside is `bg-transparent` — so neither a height-shaped search nor a search for bordered `<input>`s found it. It was still on `border-border` at 1.21:1.
- **Harness filter** puts its border colour behind a conditional (`all ? 'border-border-field' : 'border-primary'`), so a search for the literal pairing missed it too. Its border was already right; its fill collided.

## Tests

Both halves are pinned, because reverting either brings the outline back.

- `border-field.test.ts` gains a fill assertion and runs its edge assertion over both fills.
- **New** `field-boundary.test.ts` covers the six hand-rolled controls (17 cases).

Each negative is built **from that control's own pinned fragment** rather than searching for a token: these files carry legitimate `border-border` on cards, dividers and chips, so a token search can't tell a field's edge from the card it sits in — and what makes a fill wrong is the fill of the thing *under* it, which isn't in the class string at all.

Both guards were mutation-tested rather than trusted green: reverting `Input`'s fill fails 2 cases in `border-field.test.ts`; reverting the sessions edge and the harness fill each fail 2 different cases in `field-boundary.test.ts`.

## Scope

Text fields and selects — the controls sharing the `Input`/`SelectTrigger` shape. Hand-rolled **clickable cards and list rows** (`HarnessOverview`, `FindingDetailView`, `BlockedLedgerView`) also carry `border-border`, and `PolicyPicker`'s segmented control does too. Those are a separate question about non-field controls and are deliberately not touched here.

## Verification

- `ui-kit` **105/105**, `dashboard-ui` **365/365**
- ESLint + Prettier clean on both packages
- Rebased onto current `main` (the branch point was 30 commits behind); no conflicts, and upstream's changes in these packages touched none of these files