### PR TITLE
chore(ci): renew the postcss waivers and drop the resolved sharp one

### DIFF
--- a/.github/audit-waivers.json
+++ b/.github/audit-waivers.json
@@ -4,22 +4,15 @@
       "advisory": "GHSA-6g55-p6wh-862q",
       "scope": "artifact",
       "module": "postcss",
-      "reason": "The fix ships in postcss 8.5.12, but next 15.5.x pins postcss at exactly 8.4.31 and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
-      "expires": "2026-08-28"
+      "reason": "The fix ships in postcss 8.5.12, but next 15.5.x pins postcss at exactly 8.4.31 (re-checked at next 15.5.24, the newest stable; 15.6.0 is canary-only) and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
+      "expires": "2026-09-28"
     },
     {
       "advisory": "GHSA-r28c-9q8g-f849",
       "scope": "artifact",
       "module": "postcss",
-      "reason": "The fix ships in postcss 8.5.18, but next 15.5.x pins postcss at exactly 8.4.31 and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
-      "expires": "2026-08-28"
-    },
-    {
-      "advisory": "GHSA-f88m-g3jw-g9cj",
-      "scope": "artifact",
-      "module": "sharp",
-      "reason": "The fix ships in sharp 0.35.0, but next 15.5.x declares sharp ^0.34.x and an end-user install resolves next's own range, so neither a direct dependency nor a workspace override reaches it; the dashboard has no next/image usage, so sharp is never loaded at runtime. Bump next once it allows sharp >=0.35.0.",
-      "expires": "2026-08-28"
+      "reason": "The fix ships in postcss 8.5.18, but next 15.5.x pins postcss at exactly 8.4.31 (re-checked at next 15.5.24, the newest stable; 15.6.0 is canary-only) and an end-user install resolves next's own pin, so neither a direct dependency nor a workspace override reaches it; postcss runs only at build time, and the shipped dashboard is pre-built. Bump next once it requires a patched postcss.",
+      "expires": "2026-09-28"
     }
   ]
 }


### PR DESCRIPTION
## Why CI is red everywhere

All three artifact waivers in `.github/audit-waivers.json` expired **2026-08-28**, so the Dependency audit's artifact leg now fails on **every PR and the daily `main` run** — not just the branch that happened to surface it.

```
2026-08-28T20:06Z   last green main audit   (waivers still valid)
2026-08-28          waivers expire
2026-08-29T06:44Z   first red run           (nothing between them but the date)
```

## The two postcss advisories: renewed

`GHSA-6g55-p6wh-862q` and `GHSA-r28c-9q8g-f849`. CONTRIBUTING says raise the range first and waive only when no fixed release is reachable, so I re-checked rather than carrying the claim over:

| | postcss pin | fix lands in |
|---|---|---|
| next@15.5.23 (what `cli/package.json` asks for) | `8.4.31` exact | 8.5.12 / 8.5.18 |
| next@15.5.24 (newest stable) | `8.4.31` exact | — |
| next@15.6.0 | **canary only** | — |

Still unreachable through next's own pin, so the waivers' own stated condition — *"Bump next once it requires a patched postcss"* — is still unmet. Expiry moves to **2026-09-28**, matching the window this file has used before (added 2026-07-30 → expired 2026-08-28; the original set 2026-07-27 → 2026-08-26).

Each `reason` now names the release the claim was verified against, so the next renewal re-checks a version instead of re-deriving the argument from scratch.

## The sharp waiver: deleted, not renewed

`GHSA-f88m-g3jw-g9cj` is a resolved exposure rather than an accepted one, so it should not carry a waiver at all.

next@15.5.24 widened its sharp range to `^0.34.3 || ^0.35.3`, and `cli/package.json` asks for `^15.5.23` — so a fresh end-user install floats to 15.5.24 and resolves a patched sharp 0.35.x.

Two independent confirmations that this is resolution and not wishful thinking:

1. In the failing run it was **absent from the blocking set** — reported only as a stale waiver, while the two postcss ones were reported as `##[error]` high advisories.
2. The artifact leg **passes locally with the entry removed**, which a still-live high advisory would not allow.

Renewing it would carry a waiver for an exposure that no longer exists, and keep emitting a stale-waiver notice for it every run.

## Verification

Both legs run locally against the real registry:

```
Dependency audit (artifact)  passed: 2 waived, 2 below the gate.
Dependency audit (workspace) passed: 0 waived, 1 below the gate.
```

`tools/audit-gate` suite: **90/90**. Prettier clean.

## Note

This is split out of #355 deliberately — that PR is a UI change and this blocks the whole repo, so landing it here unblocks everything at once. #355 needs a rebase once this merges.