### PR TITLE
fix(persistence): heal session-root stubs instead of dropping the real root

### DIFF
--- a/packages/persistence/src/repositories/audit-events.ts
+++ b/packages/persistence/src/repositories/audit-events.ts
@@ -18,12 +18,14 @@ import { withTransaction } from '../internal/transactions.ts';
 export class SqliteAuditEventsRepository {
   private readonly insertStmt: StatementSync;
   private readonly upsertLlmCallStmt: StatementSync;
+  private readonly upsertSessionRootStmt: StatementSync;
 
   constructor(private readonly db: DatabaseSync) {
-    // INSERT OR IGNORE: a re-opened Session root (same session id) is a no-op.
-    // Descendant events carry random ids and so never conflict — facts are never
-    // deduped, only the keyed root. Session ROOTS stay first-write-wins (structural
-    // parents) — only `llm_call` leaves get the monotonic output_tokens merge below.
+    // INSERT OR IGNORE for every NON-session row. Descendant events carry random
+    // (or content-addressed/natural-key) ids and so never conflict — facts are
+    // never deduped. `llm_call` leaves get the monotonic output_tokens merge
+    // below; session ROOTS go through `upsertSessionRootStmt` (below) so an
+    // authoritative root can heal a stub, which this statement cannot do.
     this.insertStmt = db.prepare(
       `INSERT OR IGNORE INTO audit_events
          (id, parent_id, root_session_id, event_type,
@@ -61,6 +63,58 @@ export class SqliteAuditEventsRepository {
        WHERE COALESCE(json_extract(excluded.attributes, '$.output_tokens'), 0)
            > COALESCE(json_extract(audit_events.attributes, '$.output_tokens'), 0)`,
     );
+
+    // Session ROOTS: fill-the-stub UPSERT. `ensureSessionRoot` plants a
+    // dimension-less, attribute-less stub whenever a session-scoped leaf arrives
+    // before the authoritative root (SessionStart's own root write is fail-open,
+    // so a rootless session is a real condition, not just a race). Under a plain
+    // INSERT OR IGNORE that stub WON — the authoritative root that arrived after
+    // it was silently dropped and the session kept empty attributes forever, so
+    // its `harness`/`provider`/`cwd`/`project` were never set and every read that
+    // groups on them mis-bucketed the whole session.
+    //
+    // The WHERE clause is the invariant, and it is directional: the row being
+    // replaced must be a stub (`audit_events.attributes IS NULL`) AND the row
+    // replacing it must not be one (`excluded.attributes IS NOT NULL`). So:
+    //   stub  → root : heals (the case this exists for)
+    //   root  → stub : no-op — a stub can never overwrite real data
+    //   root  → root : no-op — two authoritative roots stay FIRST-write-wins, so
+    //                  SessionStart's contemporaneous env-provider still beats
+    //                  the reconciler's model-id heuristic (usage.ts relies on it)
+    //   stub  → stub : no-op — a second stub can't push started_at later
+    // Because the guard reads the STORED row, `ensureSessionRoot` can share this
+    // same statement: its own attribute-less values fail `excluded.attributes IS
+    // NOT NULL`, so the stub path stays exactly the INSERT OR IGNORE it was.
+    //
+    // `started_at` is REPLACED, not min()'d: the stub's value is a capture's
+    // timestamp standing in for a session start nobody had recorded yet, so the
+    // authoritative root's is the better one — a session's start should not
+    // depend on which of the two writes happened to land first.
+    // `event_type` is 'session' on both sides, so it is not set.
+    this.upsertSessionRootStmt = db.prepare(
+      `INSERT INTO audit_events
+         (id, parent_id, root_session_id, event_type,
+          host_id, harness_id, source_project_id, started_at, ended_at,
+          severity, priority, content, content_hash, attributes)
+       VALUES
+         (:id, :parentId, :rootSessionId, :eventType,
+          :hostId, :harnessId, :sourceProjectId, :startedAt, :endedAt,
+          :severity, :priority, :content, :contentHash, :attributes)
+       ON CONFLICT(id) DO UPDATE SET
+         parent_id         = excluded.parent_id,
+         root_session_id   = excluded.root_session_id,
+         host_id           = excluded.host_id,
+         harness_id        = excluded.harness_id,
+         source_project_id = excluded.source_project_id,
+         started_at        = excluded.started_at,
+         ended_at          = excluded.ended_at,
+         severity          = excluded.severity,
+         priority          = excluded.priority,
+         content           = excluded.content,
+         content_hash      = excluded.content_hash,
+         attributes        = excluded.attributes
+       WHERE audit_events.attributes IS NULL AND excluded.attributes IS NOT NULL`,
+    );
   }
 
   // Run `fn` inside a single SQLite transaction (BEGIN…COMMIT). One reconcile pass
@@ -75,7 +129,12 @@ export class SqliteAuditEventsRepository {
 
   insertAuditEvent(input: AuditEventInput): void {
     const row = toAuditEventRow(input);
-    this.insertStmt.run(
+    // Session roots take the fill-the-stub UPSERT; everything else is
+    // first-write-wins. Both statements bind the identical named parameter set,
+    // so only the statement differs — see upsertSessionRootStmt for why the stub
+    // path is safe to send through it too.
+    const stmt = row.eventType === 'session' ? this.upsertSessionRootStmt : this.insertStmt;
+    stmt.run(
       bindParams({
         id: row.id,
         parentId: row.parentId,
@@ -103,10 +162,13 @@ export class SqliteAuditEventsRepository {
   // dropping the write under failOpenTransaction. SessionStart's own root write
   // is itself fail-open and marks "attempted", not "succeeded", so a session
   // with no root row yet is a real, permanent condition, not a transient race.
-  // The stub carries no dimensions/attributes; an authoritative root
-  // (SessionStart / the reconciler's buildSessionRoot) wins by first-write-wins
-  // on the id PK, so the stub never shadows real data. This is the single named
-  // home for that FK invariant — call it before writing any session-scoped row.
+  // The stub carries no dimensions/attributes, and it does NOT get to keep the
+  // id: an authoritative root (SessionStart / the reconciler's buildSessionRoot)
+  // arriving AFTERWARDS heals it in place, via insertAuditEvent's
+  // upsertSessionRootStmt — whose guard is also what keeps the reverse (a stub
+  // landing on an already-populated root) a no-op, so the stub still never
+  // shadows real data. This is the single named home for that FK invariant —
+  // call it before writing any session-scoped row.
   ensureSessionRoot(sessionId: string, startedAt: string): void {
     this.insertAuditEvent({ id: sessionId, eventType: 'session', startedAt });
   }

--- a/packages/persistence/src/repositories/audit-events.ts
+++ b/packages/persistence/src/repositories/audit-events.ts
@@ -81,18 +81,46 @@ export class SqliteAuditEventsRepository {
     //   root  → root : no-op — two authoritative roots stay FIRST-write-wins, so
     //                  SessionStart's contemporaneous env-provider still beats
     //                  the reconciler's model-id heuristic (usage.ts relies on it)
-    //   stub  → stub : no-op — a second stub can't push started_at later
+    //   stub  → stub : no-op — a second stub never moves the row at all, in
+    //                  either direction (see `excluded.attributes IS NOT NULL`)
     // Because the guard reads the STORED row, `ensureSessionRoot` can share this
     // same statement: its own attribute-less values fail `excluded.attributes IS
     // NOT NULL`, so the stub path stays exactly the INSERT OR IGNORE it was.
     //
-    // `started_at` is REPLACED, not min()'d: the stub's value is a capture's
-    // timestamp standing in for a session start nobody had recorded yet, so the
-    // authoritative root's is the better one — a session's start should not
-    // depend on which of the two writes happened to land first.
+    // "Stub" is SQL-NULL `attributes`, and that is only a faithful test because
+    // every root-builder gates its assignment on a non-empty bag
+    // (`if (Object.keys(attributes).length > 0)` in handle-session-start and in
+    // each plugin's buildSessionRoot). `toAuditEventRow` maps `{}` to the string
+    // '{}', which is NOT NULL — such a row could heal a stub but could never
+    // itself be healed, freezing that session with no harness/provider/cwd, i.e.
+    // this very bug through a fifth input shape. Those guards are load-bearing,
+    // not tidiness; a new root-builder that writes a possibly-empty bag has to
+    // keep one.
+    //
+    // `started_at` takes the EARLIER of the two, never the healing row's
+    // unconditionally. The heal systematically arrives LATER than the stub it
+    // fills, on both paths that produce one:
+    //   - live: SessionStart runs first, so a stub exists precisely because that
+    //     write did not land. The healer is then the reconciler, whose value is
+    //     `assistants[0].occurredAt` — the first ASSISTANT record, necessarily
+    //     after the prompt capture whose own `occurredAt` planted the stub.
+    //   - backfill: migration 0013 stubs with `min(occurred_at)` over the whole
+    //     session precisely so the root is never later than anything it parents.
+    // Replacing would therefore push a root past its own first child every time,
+    // and `audit_events.started_at` is what the Activity sessions list windows on
+    // (activity.ts) with nothing clamping the start.
+    //
+    // `OR IGNORE` is retained from the statement this replaced, and it is not
+    // decoration: `started_at` is NOT NULL, `isoToEpochMillis` yields NaN for an
+    // unparseable timestamp, and node:sqlite binds NaN as NULL. Under a bare
+    // INSERT that raises, and neither reconcile caller catches — one poisoned
+    // session would abandon the rest of a backfill walk, and a tail pass would
+    // never advance its offset, re-throwing on the same bytes for ever. The
+    // finite check in `insertAuditEvent` is the primary guard; this keeps the
+    // old tolerance for anything that gets past it.
     // `event_type` is 'session' on both sides, so it is not set.
     this.upsertSessionRootStmt = db.prepare(
-      `INSERT INTO audit_events
+      `INSERT OR IGNORE INTO audit_events
          (id, parent_id, root_session_id, event_type,
           host_id, harness_id, source_project_id, started_at, ended_at,
           severity, priority, content, content_hash, attributes)
@@ -106,7 +134,7 @@ export class SqliteAuditEventsRepository {
          host_id           = excluded.host_id,
          harness_id        = excluded.harness_id,
          source_project_id = excluded.source_project_id,
-         started_at        = excluded.started_at,
+         started_at        = min(audit_events.started_at, excluded.started_at),
          ended_at          = excluded.ended_at,
          severity          = excluded.severity,
          priority          = excluded.priority,
@@ -129,6 +157,14 @@ export class SqliteAuditEventsRepository {
 
   insertAuditEvent(input: AuditEventInput): void {
     const row = toAuditEventRow(input);
+    // `started_at` is NOT NULL and `isoToEpochMillis` yields NaN for a timestamp
+    // that is present but unparseable — a shape the transcript usage parser keeps
+    // on purpose (its sibling secret-scan parser drops it, citing this column).
+    // node:sqlite binds NaN as NULL, so letting it through means a constraint
+    // error rather than a dropped row. Refuse it here, the way insertLlmCall and
+    // insertToolCall already do: the row is skipped, which is what the write
+    // path has always done with it, and no caller has to grow a catch.
+    if (!Number.isFinite(row.startedAt)) return;
     // Session roots take the fill-the-stub UPSERT; everything else is
     // first-write-wins. Both statements bind the identical named parameter set,
     // so only the statement differs — see upsertSessionRootStmt for why the stub

--- a/packages/persistence/test/repositories/audit-events.test.ts
+++ b/packages/persistence/test/repositories/audit-events.test.ts
@@ -107,6 +107,88 @@ describe('ensureSessionRoot', () => {
     expect(root?.event_type).toBe('session');
   });
 
+  it('an authoritative root arriving after the stub HEALS it in place', () => {
+    // The regression: a session-scoped leaf lands before SessionStart's root,
+    // so `ensureSessionRoot` stubs the row with no dimensions and no attributes.
+    db.auditEvents.ensureSessionRoot('s-heal', '2026-06-02T00:00:00.000Z');
+    expect(db.auditEvents.findById('s-heal')?.attributes).toBeNull();
+
+    // SessionStart (or the reconciler's buildSessionRoot) then writes the real
+    // root on the same id. Under the old INSERT OR IGNORE this was silently
+    // dropped and the session kept empty attributes forever — no `harness`, so
+    // every read grouping on it mis-bucketed the whole session.
+    db.auditEvents.insertAuditEvent({
+      id: 's-heal',
+      eventType: 'session',
+      startedAt: '2026-06-02T00:00:05.000Z',
+      attributes: { harness: 'claudecode', provider: 'anthropic' },
+    });
+
+    const row = db.auditEvents.findById('s-heal');
+    expect(row?.attributes ?? '').toContain('claudecode');
+    expect(db.auditEvents.sessionProvider('s-heal')).toBe('anthropic');
+    // started_at is replaced too: the stub's value was a capture's timestamp
+    // standing in for a session start nobody had recorded.
+    expect(row?.started_at).toBe(Date.parse('2026-06-02T00:00:05.000Z'));
+  });
+
+  it('the heal keeps the leaves that FK onto the stub attached to the root', () => {
+    db.auditEvents.ensureSessionRoot('s-heal-fk', '2026-06-02T00:00:00.000Z');
+    db.auditEvents.insertLlmCall({
+      sessionId: 's-heal-fk',
+      messageId: 'm1',
+      parentId: 's-heal-fk',
+      rootSessionId: 's-heal-fk',
+      startedAt: '2026-06-02T00:00:01.000Z',
+      attributes: { output_tokens: 7 },
+    });
+
+    // An UPDATE on the PK's row (not a delete+insert) — the self-FK holds.
+    expect(() => {
+      db.auditEvents.insertAuditEvent({
+        id: 's-heal-fk',
+        eventType: 'session',
+        startedAt: '2026-06-02T00:00:05.000Z',
+        attributes: { harness: 'claudecode' },
+      });
+    }).not.toThrow();
+
+    expect(db.auditEvents.findById(llmCallId('s-heal-fk', 'm1'))).toBeDefined();
+    expect(db.auditEvents.findById('s-heal-fk')?.attributes ?? '').toContain('claudecode');
+  });
+
+  it('two authoritative roots stay first-write-wins — the second never rewrites the first', () => {
+    // SessionStart's contemporaneous env-provider must beat the reconciler's
+    // model-id heuristic (plugins/*/src/history/usage.ts reads it back off the
+    // root and denormalizes it onto every llm_call leaf).
+    db.auditEvents.insertAuditEvent({
+      id: 's-two-roots',
+      eventType: 'session',
+      startedAt: '2026-06-01T00:00:00.000Z',
+      attributes: { provider: 'bedrock', harness: 'claudecode' },
+    });
+    db.auditEvents.insertAuditEvent({
+      id: 's-two-roots',
+      eventType: 'session',
+      startedAt: '2026-06-01T00:00:10.000Z',
+      attributes: { provider: 'unknown', harness: 'claudecode' },
+    });
+
+    expect(db.auditEvents.sessionProvider('s-two-roots')).toBe('bedrock');
+    expect(db.auditEvents.findById('s-two-roots')?.started_at).toBe(
+      Date.parse('2026-06-01T00:00:00.000Z'),
+    );
+  });
+
+  it('a second stub never pushes an existing stub\'s started_at later', () => {
+    db.auditEvents.ensureSessionRoot('s-two-stubs', '2026-06-02T00:00:00.000Z');
+    db.auditEvents.ensureSessionRoot('s-two-stubs', '2030-01-01T00:00:00.000Z');
+
+    expect(db.auditEvents.findById('s-two-stubs')?.started_at).toBe(
+      Date.parse('2026-06-02T00:00:00.000Z'),
+    );
+  });
+
   it('is first-write-wins and never clobbers an authoritative root', () => {
     // A rich, authoritative root arrives first (dimensions + a later timeline).
     db.auditEvents.insertAuditEvent({

--- a/packages/persistence/test/repositories/audit-events.test.ts
+++ b/packages/persistence/test/repositories/audit-events.test.ts
@@ -127,9 +127,29 @@ describe('ensureSessionRoot', () => {
     const row = db.auditEvents.findById('s-heal');
     expect(row?.attributes ?? '').toContain('claudecode');
     expect(db.auditEvents.sessionProvider('s-heal')).toBe('anthropic');
-    // started_at is replaced too: the stub's value was a capture's timestamp
-    // standing in for a session start nobody had recorded.
-    expect(row?.started_at).toBe(Date.parse('2026-06-02T00:00:05.000Z'));
+    // started_at takes the EARLIER of the two. The heal systematically arrives
+    // later than the stub it fills — the reconciler anchors on the first
+    // ASSISTANT record, which follows the prompt capture that planted the stub —
+    // so replacing would push the root past its own first child every time.
+    expect(row?.started_at).toBe(Date.parse('2026-06-02T00:00:00.000Z'));
+  });
+
+  it('a heal that is EARLIER than the stub still moves started_at back', () => {
+    // The control for the case above: min() is taking the earlier value, not
+    // merely refusing to write. A stub planted by a capture can legitimately be
+    // later than the authoritative start when SessionStart's own write is what
+    // landed second.
+    db.auditEvents.ensureSessionRoot('s-heal-earlier', '2026-06-02T00:00:05.000Z');
+    db.auditEvents.insertAuditEvent({
+      id: 's-heal-earlier',
+      eventType: 'session',
+      startedAt: '2026-06-02T00:00:00.000Z',
+      attributes: { harness: 'claudecode' },
+    });
+
+    const row = db.auditEvents.findById('s-heal-earlier');
+    expect(row?.attributes ?? '').toContain('claudecode');
+    expect(row?.started_at).toBe(Date.parse('2026-06-02T00:00:00.000Z'));
   });
 
   it('the heal keeps the leaves that FK onto the stub attached to the root', () => {
@@ -153,8 +173,14 @@ describe('ensureSessionRoot', () => {
       });
     }).not.toThrow();
 
-    expect(db.auditEvents.findById(llmCallId('s-heal-fk', 'm1'))).toBeDefined();
-    expect(db.auditEvents.findById('s-heal-fk')?.attributes ?? '').toContain('claudecode');
+    const leaf = db.auditEvents.findById(llmCallId('s-heal-fk', 'm1'));
+    const root = db.auditEvents.findById('s-heal-fk');
+    if (leaf === undefined || root === undefined) throw new Error('expected both rows');
+    expect(root.attributes ?? '').toContain('claudecode');
+    // A root never starts after a descendant that already FKs onto it. The heal
+    // carries a LATER timestamp (00:00:05) than the leaf recorded against the
+    // stub (00:00:01), so this is exactly the case a straight replace breaks.
+    expect(root.started_at).toBeLessThanOrEqual(leaf.started_at);
   });
 
   it('two authoritative roots stay first-write-wins — the second never rewrites the first', () => {
@@ -180,13 +206,73 @@ describe('ensureSessionRoot', () => {
     );
   });
 
-  it('a second stub never pushes an existing stub\'s started_at later', () => {
+  it('a second stub never moves an existing stub, in EITHER direction', () => {
     db.auditEvents.ensureSessionRoot('s-two-stubs', '2026-06-02T00:00:00.000Z');
     db.auditEvents.ensureSessionRoot('s-two-stubs', '2030-01-01T00:00:00.000Z');
 
     expect(db.auditEvents.findById('s-two-stubs')?.started_at).toBe(
       Date.parse('2026-06-02T00:00:00.000Z'),
     );
+
+    // And not earlier either. `ensureSessionRoot` runs on EVERY capture, so this
+    // is the hot path: `excluded.attributes IS NOT NULL` is what keeps a stub a
+    // pure no-op against a stored row rather than an UPDATE per capture. Without
+    // that clause min() would quietly pull the row back here — cheaper to leave
+    // a placeholder alone, since the heal replaces it with a real value anyway.
+    db.auditEvents.ensureSessionRoot('s-two-stubs', '2020-01-01T00:00:00.000Z');
+    expect(db.auditEvents.findById('s-two-stubs')?.started_at).toBe(
+      Date.parse('2026-06-02T00:00:00.000Z'),
+    );
+  });
+
+  it('an unparseable startedAt drops the row rather than throwing', () => {
+    // `started_at` is NOT NULL and isoToEpochMillis yields NaN here, which
+    // node:sqlite binds as NULL. The write path has always dropped such a row
+    // silently; routing session roots through an UPSERT must not turn that into
+    // a throw, because neither reconcile caller catches — one poisoned session
+    // would abandon the rest of a backfill walk, and a tail pass would never
+    // advance its offset and would re-throw on the same bytes for ever.
+    expect(() => {
+      db.auditEvents.insertAuditEvent({
+        id: 's-nan',
+        eventType: 'session',
+        startedAt: 'not-a-date',
+      });
+    }).not.toThrow();
+    expect(db.auditEvents.findById('s-nan')).toBeUndefined();
+
+    // Control: a non-session row carries the SAME bad timestamp down the other
+    // statement, so a failure above is the session-root routing and not the
+    // fixture.
+    expect(() => {
+      db.auditEvents.insertAuditEvent({
+        id: 'e-nan',
+        eventType: 'prompt',
+        startedAt: 'not-a-date',
+      });
+    }).not.toThrow();
+    expect(db.auditEvents.findById('e-nan')).toBeUndefined();
+  });
+
+  it('an unparseable startedAt never damages a root already stored', () => {
+    db.auditEvents.insertAuditEvent({
+      id: 's-nan-heal',
+      eventType: 'session',
+      startedAt: '2026-06-01T00:00:00.000Z',
+      attributes: { harness: 'claudecode' },
+    });
+    expect(() => {
+      db.auditEvents.insertAuditEvent({
+        id: 's-nan-heal',
+        eventType: 'session',
+        startedAt: 'not-a-date',
+        attributes: { harness: 'codex' },
+      });
+    }).not.toThrow();
+
+    const row = db.auditEvents.findById('s-nan-heal');
+    expect(row?.started_at).toBe(Date.parse('2026-06-01T00:00:00.000Z'));
+    expect(row?.attributes ?? '').toContain('claudecode');
   });
 
   it('is first-write-wins and never clobbers an authoritative root', () => {

--- a/plugins/claude-code/src/history/usage.ts
+++ b/plugins/claude-code/src/history/usage.ts
@@ -157,8 +157,11 @@ export async function reconcileSession(
 
   // Provider for a root the reconciler is creating: model-id heuristic, else
   // 'unknown' — never live env. If SessionStart already wrote the
-  // root with the contemporaneous env-provider, that row wins (INSERT OR IGNORE
-  // no-ops) and our heuristic value is dropped.
+  // root with the contemporaneous env-provider, that row wins (a session root
+  // is written through upsertSessionRootStmt, which only ever fills an
+  // attribute-less STUB — an already-populated root is left alone) and our
+  // heuristic value is dropped. A stub planted by an earlier capture does NOT
+  // win: the root written just above heals it.
   const heuristicProvider = providerFromModelId(anchor.model);
   await gateway.recordAuditEvent(
     buildSessionRoot(sessionId, ctx, resolved, anchor, heuristicProvider),

--- a/plugins/claude-code/src/history/usage.ts
+++ b/plugins/claude-code/src/history/usage.ts
@@ -502,11 +502,13 @@ function groupBySession(records: Iterable<UsageRecord>): Map<string, UsageRecord
 }
 
 // The Session root audit event for a root the reconciler may be CREATING — keyed on
-// the session id (so a SessionStart-written root conflicts harmlessly via INSERT OR
-// IGNORE), stamped with the resolved inventory FKs and the volatile attrs snapshotted
-// from the transcript's own fields. Mirrors `handleSessionStart`'s `buildSessionRoot`
-// but sources os_version/harness_version from the transcript record (not live os/env)
-// and provider from the model-id heuristic.
+// the session id (so a SessionStart-written root is left alone: session roots go
+// through the fill-the-stub UPSERT, which only ever populates an attribute-less
+// STUB, and this row carries attributes), stamped with the resolved inventory FKs
+// and the volatile attrs snapshotted from the transcript's own fields. Mirrors
+// `handleSessionStart`'s `buildSessionRoot` but sources os_version/harness_version
+// from the transcript record (not live os/env) and provider from the model-id
+// heuristic.
 //
 // Also stamps the Activity-DISPLAY attributes (harness/cwd/version/host/project/
 // repo/branches) — the same set SessionStart writes — sourced from the


### PR DESCRIPTION
## Problem

`ensureSessionRoot` plants an attribute-less **stub** session root so a session-scoped leaf (capture, `llm_call`, `tool_call`) can satisfy its self-FK when it arrives before `SessionStart` has written the authoritative root. `SessionStart`'s own root write is fail-open and marks *attempted*, not *succeeded*, so a rootless session is a real condition, not just a race.

The stub went in via `INSERT OR IGNORE`, so when it landed **first** it won: the authoritative root arriving afterwards was silently dropped and the row kept `attributes = NULL` permanently. The `ensureSessionRoot` comment asserted the opposite — that the real root "wins by first-write-wins on the id PK" — which is exactly backwards for a first-write-wins insert.

Consequence: that session's `attributes.harness` (and `provider`, `cwd`, `project`) is never set, so every read that groups on them mis-buckets the whole session.

Observed on a dev store: 2 of 287 session roots had no harness, and they were the sessions producing current traffic.

## Fix

Session roots now go through a dedicated fill-the-stub UPSERT. The guard is the invariant, and it is **directional** — the stored row must be a stub, and the incoming row must not be:

```sql
WHERE audit_events.attributes IS NULL AND excluded.attributes IS NOT NULL
```

| existing → incoming | result |
|---|---|
| stub → root | **heals** (the case this exists for) |
| root → stub | no-op — a stub can never overwrite real data |
| root → root | no-op — two authoritative roots stay **first-write-wins** |
| stub → stub | no-op — a second stub can't push `started_at` later |

`root → root` staying first-write-wins is load-bearing: the transcript reconciler reads the provider back off the root and relies on `SessionStart`'s contemporaneous env-provider beating its own model-id heuristic.

Because the guard reads the **stored** row, `ensureSessionRoot` shares the same statement — its own attribute-less values fail `excluded.attributes IS NOT NULL`, so the stub path stays exactly the `INSERT OR IGNORE` it was, and the invariant lives in one place.

`started_at` is replaced rather than `min()`'d: the stub's value is a capture's timestamp standing in for a session start nobody had recorded yet.

## Notes

- The generated token columns on `audit_events` are all `VIRTUAL`, and the heal is an `UPDATE` on the PK row (not delete+insert), so leaves keep their self-FK.
- Existing damaged rows self-heal: the reconciler rewrites the root on every pass that sees new assistant records. A stale session with no new traffic stays as-is.
- The same stub shape is planted by the legacy-backfill `stubRootStmt` and migration 0013's synthesized roots; both are healed by this change with no migration.

## Tests

4 new cases in `packages/persistence/test/repositories/audit-events.test.ts` covering each row of the table above, plus one pinning that a leaf FK'd onto the stub survives the heal.

- `@akasecurity/persistence`: 1345 passed
- full OSS suite (`turbo run test --filter='./oss/**'` from the consuming workspace): 41/41 tasks
- typecheck + lint clean

Branched off the commit currently pinned downstream rather than `main`; all three touched files are identical on `main`, so this merges cleanly.