### PR TITLE
fix(web-ui): say when an attached machine has no usable credential

### DIFF
--- a/cli/src/commands/attach.ts
+++ b/cli/src/commands/attach.ts
@@ -5,6 +5,7 @@ import {
   isSafeEndpoint,
   ManagedFieldError,
   openLocalDatabase,
+  readControlPlaneCredentialFile,
   readControlPlaneCredentialState,
   readLocalHistoryPreview,
   readWorkspaceSettings,
@@ -217,7 +218,10 @@ export async function runAttach(argv: string[], deps: AttachDeps = {}): Promise<
   // already attached and working — and an unconditional rollback would take
   // that machine from "attached and forwarding" to "attached, no usable
   // credential" while printing that nothing was changed.
-  const previous = readControlPlaneCredentialState(settingsDirOf(base));
+  // The WIDE read, because a rollback writes back the exact bytes that were
+  // there. This runs in the CLI's own process; nothing here crosses to a
+  // browser, which is the boundary the narrow state exists to protect.
+  const previous = readControlPlaneCredentialFile(settingsDirOf(base));
 
   try {
     // The credential FIRST, then the descriptor. In the other order a machine

--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -1,5 +1,10 @@
 'use client';
-import type { ManagedContext, ManagedSettingKey, WorkspaceSettings } from '@akasecurity/schema';
+import type {
+  CredentialState,
+  ManagedContext,
+  ManagedSettingKey,
+  WorkspaceSettings,
+} from '@akasecurity/schema';
 import {
   controlPlaneName,
   isAttached,
@@ -431,6 +436,13 @@ export interface WorkspaceSettingsFormViewProps {
   // state read-only rather than offering an action that cannot complete.
   onAttach?: (endpoint: string, label: string, accessKey: string) => void;
   onDetach?: () => void;
+  // Whether the credential half of the attachment is usable, read locally by
+  // the host (`readControlPlaneCredentialState`). OPTIONAL, and its absence
+  // means "not reported" rather than "fine": a host that cannot read the file
+  // leaves the surface exactly as it was instead of accusing a working machine
+  // of being broken. Ignored entirely while standalone, where having no
+  // credential is the ordinary state and not a fault.
+  credentialState?: CredentialState;
   // Where "Configure detections" points. Injected rather than hardcoded so this
   // package stays router-agnostic.
   detectionsHref?: string;
@@ -454,6 +466,7 @@ export function WorkspaceSettingsFormView({
   onSave,
   onAttach,
   onDetach,
+  credentialState,
   detectionsHref = '/detections',
   busy,
   error,
@@ -504,6 +517,7 @@ export function WorkspaceSettingsFormView({
       <SettingGroup title="Connection">
         <ConnectionRow
           settings={settings}
+          credentialState={credentialState}
           managedLabel={lockOn('runMode')}
           onAttach={onAttach}
           onDetach={onDetach}
@@ -677,6 +691,69 @@ export const CONNECTION_UNAVAILABLE_NOTICE =
   'This view cannot change the connection. Attach from the AKA dashboard, or with `aka attach` in ' +
   'a terminal.';
 
+// ─── When the stored connection is not a working one ─────────────────────────
+//
+// `runMode: 'attached'` is half an attachment. The other half is a usable
+// credential file, and a machine that has lost one sends and receives nothing
+// while every stored field still says "Attached" — the state `canAttach` above
+// exists to stop a user creating, and which they can still arrive at by other
+// routes: a hand-edited settings.json, an administrator repointing the endpoint
+// through a managed overlay, a restored home directory.
+//
+// WHY THIS IS HONEST TO SHOW when a handshake would not be. Every other caution
+// in this section is about not claiming knowledge of the far end — see
+// CONNECTION_ATTACHED_DESCRIPTION, which deliberately says nothing about
+// whether the deployment is reachable. This is a different kind of fact: the
+// credential is a file on THIS disk, read locally, and "there is no usable key
+// here" is something the page can see for itself. It reports the local half and
+// still says nothing about the remote one.
+//
+// The badge follows VAULT_STALE_BADGE's precedent: the row's stored answer and
+// what is actually happening disagree, so the badge has to carry the
+// contradiction rather than repeat the stored answer as if it were the outcome.
+export const CONNECTION_INACTIVE_BADGE = 'Not connected';
+
+export const CONNECTION_CREDENTIAL_MISSING_NOTICE =
+  'This machine is registered, but there is no access key stored on it — so nothing is being ' +
+  'sent or received. Attach it again to restore the connection.';
+
+// ONE message for four reasons (`untrusted-file`, `unreadable`, `malformed`,
+// `unsafe-endpoint`). A user cannot act differently on any of them — the fix is
+// to attach again in every case — and naming the distinction would describe our
+// parser rather than their machine.
+export const CONNECTION_CREDENTIAL_UNUSABLE_NOTICE =
+  'This machine is registered, but the access key stored on it cannot be used — so nothing is ' +
+  'being sent or received. Attach it again to replace it.';
+
+/**
+ * The mismatch notice, which has to name both endpoints.
+ *
+ * The only unusable reason a user can act on in two directions: re-attach
+ * against the endpoint the settings now name, or put the old endpoint back.
+ * Neither instruction can be written without saying which endpoint is which, so
+ * this is a function where its neighbours are constants.
+ */
+export function connectionEndpointMismatchNotice(
+  credentialEndpoint: string,
+  settingsEndpoint: string,
+): string {
+  return (
+    `This machine is set to ${settingsEndpoint}, but the access key stored on it was issued for ` +
+    `${credentialEndpoint} — so nothing is being sent or received. Attach it again to ` +
+    `${settingsEndpoint}, or point it back at ${credentialEndpoint}.`
+  );
+}
+
+/** The notice for a state, or null when there is nothing wrong to report. */
+function credentialNotice(state: CredentialState | undefined): string | null {
+  if (state === undefined || state.usable) return null;
+  if (state.reason === 'absent') return CONNECTION_CREDENTIAL_MISSING_NOTICE;
+  if (state.reason === 'endpoint-mismatch') {
+    return connectionEndpointMismatchNotice(state.credentialEndpoint, state.settingsEndpoint);
+  }
+  return CONNECTION_CREDENTIAL_UNUSABLE_NOTICE;
+}
+
 export const DETACH_LABEL = 'Detach';
 
 export const DETACH_EXPLANATION =
@@ -745,12 +822,14 @@ export const DETACH_MANAGED_NOTICE =
 
 function ConnectionRow({
   settings,
+  credentialState,
   managedLabel,
   onAttach,
   onDetach,
   busy,
 }: {
   settings: WorkspaceSettings;
+  credentialState?: CredentialState | undefined;
   managedLabel?: string | undefined;
   onAttach?: ((endpoint: string, label: string, accessKey: string) => void) | undefined;
   onDetach?: (() => void) | undefined;
@@ -763,6 +842,10 @@ function ConnectionRow({
   const [accessKey, setAccessKey] = useState('');
   const attached = isAttached(settings);
   const locked = managedLabel !== undefined;
+  // Only meaningful for an attached machine: a standalone one is not missing a
+  // credential, it is not supposed to have one, and reporting absence there
+  // would turn the ordinary state into a fault.
+  const notice = attached ? credentialNotice(credentialState) : null;
 
   return (
     <div className="px-4 py-3" data-slot="connection-row">
@@ -781,14 +864,28 @@ function ConnectionRow({
         <span
           className={cn(
             'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
-            attached ? 'bg-teal-fill text-teal-ink' : 'bg-surface-2 text-text-3',
+            notice !== null
+              ? 'bg-sev-high-fill text-sev-high-ink'
+              : attached
+                ? 'bg-teal-fill text-teal-ink'
+                : 'bg-surface-2 text-text-3',
           )}
           data-slot="run-mode-badge"
         >
-          {attached ? CONNECTION_ATTACHED_LABEL : CONNECTION_STANDALONE_LABEL}
+          {notice !== null
+            ? CONNECTION_INACTIVE_BADGE
+            : attached
+              ? CONNECTION_ATTACHED_LABEL
+              : CONNECTION_STANDALONE_LABEL}
           {locked && ' · locked'}
         </span>
       </div>
+
+      {notice !== null && (
+        <p className="mt-3 text-xs text-sev-high-ink" data-slot="connection-credential-notice">
+          {notice}
+        </p>
+      )}
 
       {attached && (
         <p className="mt-3 text-xs text-text-3" data-slot="connection-forwarding">

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -1,4 +1,4 @@
-import type { WorkspaceSettings } from '@akasecurity/schema';
+import type { CredentialState, WorkspaceSettings } from '@akasecurity/schema';
 import {
   BUILTIN_POLICIES,
   KNOWN_BUILTIN_IDS,
@@ -13,7 +13,11 @@ import {
   ATTACH_KEY_HINT,
   canAttach,
   CONNECTION_ATTACHED_DESCRIPTION,
+  CONNECTION_ATTACHED_LABEL,
+  CONNECTION_CREDENTIAL_MISSING_NOTICE,
+  CONNECTION_CREDENTIAL_UNUSABLE_NOTICE,
   CONNECTION_FORWARDING_NOTICE,
+  CONNECTION_INACTIVE_BADGE,
   CONNECTION_STANDALONE_DESCRIPTION,
   CONNECTION_UNAVAILABLE_NOTICE,
   DETACH_EXPLANATION,
@@ -71,6 +75,8 @@ const FORM_COPY: Record<string, string> = {
   CONNECTION_ATTACHED_DESCRIPTION,
   CONNECTION_FORWARDING_NOTICE,
   CONNECTION_UNAVAILABLE_NOTICE,
+  CONNECTION_CREDENTIAL_MISSING_NOTICE,
+  CONNECTION_CREDENTIAL_UNUSABLE_NOTICE,
   DETACH_MANAGED_NOTICE,
   HISTORICAL_SECTION_LABEL,
   HISTORICAL_SECTION_DESCRIPTION,
@@ -700,5 +706,113 @@ describe('the enforcement pointer', () => {
       }),
     );
     expect(html).toContain('href="/app/detections"');
+  });
+});
+
+// ─── The credential half of an attachment ────────────────────────────────────
+//
+// `runMode: 'attached'` is only half of a working attachment. The other half is
+// a usable credential file, and when it is missing or was minted for a
+// different deployment the machine sends and receives nothing while every
+// surface still says "Attached". `aka status` has always been able to say so;
+// this view could not, because it renders from `WorkspaceSettings` alone.
+//
+// What makes this honest to show — where a live handshake would not be — is
+// that the credential is a LOCAL fact. The page is not claiming anything about
+// whether the deployment answered; it is reporting what is on this disk.
+describe('the connection section, credential state', () => {
+  const base: WorkspaceSettings = {
+    specVersion: 1,
+    runMode: 'standalone',
+    policy: 'redact',
+    historicalAccess: 'session-only',
+    dataSharesInPlace: true,
+    vaultKeyCustody: 'file',
+    vaultInlineReveal: 'masked',
+  };
+
+  const attached: WorkspaceSettings = {
+    ...base,
+    runMode: 'attached',
+    controlPlane: {
+      endpoint: 'https://aka.acme.internal',
+      label: 'Acme Prod',
+      attachedAt: '2026-02-02T00:00:00.000Z',
+    },
+  };
+
+  const render = (props: Partial<WorkspaceSettingsFormViewProps> = {}): string =>
+    renderToStaticMarkup(
+      createElement(WorkspaceSettingsFormView, {
+        settings: attached,
+        onSave: () => undefined,
+        ...props,
+      }),
+    );
+
+  const usable: CredentialState = {
+    usable: true,
+    credential: { specVersion: 1, endpoint: 'https://aka.acme.internal', apiKey: 'k' },
+  };
+
+  it('says nothing extra when the credential is usable', () => {
+    const html = render({ credentialState: usable });
+    expect(html).not.toContain('data-slot="connection-credential-notice"');
+    expect(html).toContain(CONNECTION_ATTACHED_LABEL);
+    expect(html).not.toContain(CONNECTION_INACTIVE_BADGE);
+  });
+
+  // The host may not supply the state at all — the CLI inlines this package and
+  // renders the same view. An absent prop must leave the surface exactly as it
+  // was rather than accusing a working machine of being broken.
+  it('says nothing extra when the host supplies no credential state', () => {
+    const html = render();
+    expect(html).not.toContain('data-slot="connection-credential-notice"');
+    expect(html).toContain(CONNECTION_ATTACHED_LABEL);
+  });
+
+  it('names a missing credential, and stops calling the machine attached', () => {
+    const html = render({ credentialState: { usable: false, reason: 'absent' } });
+    expect(html).toContain(CONNECTION_CREDENTIAL_MISSING_NOTICE);
+    expect(html).toContain(CONNECTION_INACTIVE_BADGE);
+  });
+
+  // Four different reasons, one message. A user cannot act differently on
+  // "malformed" than on "unreadable" — the fix is the same in every case — and
+  // naming the internal distinction would be describing our parser rather than
+  // their machine.
+  it.each(['untrusted-file', 'unreadable', 'malformed', 'unsafe-endpoint'] as const)(
+    'reports a %s credential as unusable',
+    (reason) => {
+      const html = render({ credentialState: { usable: false, reason } });
+      expect(html).toContain(CONNECTION_CREDENTIAL_UNUSABLE_NOTICE);
+      expect(html).toContain(CONNECTION_INACTIVE_BADGE);
+    },
+  );
+
+  // The one reason that carries data, and the only one a user can act on in two
+  // different directions — so both endpoints have to be on screen or the advice
+  // is unfollowable.
+  it('names both endpoints on a mismatch', () => {
+    const html = render({
+      credentialState: {
+        usable: false,
+        reason: 'endpoint-mismatch',
+        credentialEndpoint: 'https://old.acme.internal',
+        settingsEndpoint: 'https://aka.acme.internal',
+      },
+    });
+    expect(html).toContain('https://old.acme.internal');
+    expect(html).toContain('https://aka.acme.internal');
+    expect(html).toContain(CONNECTION_INACTIVE_BADGE);
+  });
+
+  // A standalone machine is not "missing" a credential — it is not supposed to
+  // have one. Reporting absence there would turn the ordinary state into a
+  // fault.
+  it('reports nothing on a standalone machine', () => {
+    const html = render({ settings: base, credentialState: { usable: false, reason: 'absent' } });
+    expect(html).not.toContain('data-slot="connection-credential-notice"');
+    expect(html).not.toContain(CONNECTION_INACTIVE_BADGE);
   });
 });

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -750,10 +750,12 @@ describe('the connection section, credential state', () => {
       }),
     );
 
-  const usable: CredentialState = {
-    usable: true,
-    credential: { specVersion: 1, endpoint: 'https://aka.acme.internal', apiKey: 'k' },
-  };
+  // A VERDICT AND NOTHING ELSE, which is the whole of the usable branch. This
+  // package is presentational and its props are handed across a client boundary
+  // by at least one host, so the type it takes cannot carry a credential — and
+  // the view has never read one: `credentialNotice` branches on `usable` and
+  // `reason`.
+  const usable: CredentialState = { usable: true };
 
   it('says nothing extra when the credential is usable', () => {
     const html = render({ credentialState: usable });

--- a/packages/persistence/src/control-plane-credential.ts
+++ b/packages/persistence/src/control-plane-credential.ts
@@ -72,6 +72,23 @@ export function isSafeEndpoint(endpoint: string): boolean {
 export type { CredentialState, CredentialUnusableReason };
 
 /**
+ * The same answer as `CredentialState`, WITH the credential.
+ *
+ * A separate type, and one that never leaves this package's server-side
+ * consumers, because the two questions are different: "can this machine talk to
+ * its control plane, and if not why" is a question a surface asks, and "give me
+ * the key" is one only a transport or a rollback asks. Fusing them made every
+ * holder of a state a holder of a bearer credential, which is how one reached a
+ * client component and got serialised to the browser.
+ *
+ * Reachable only by asking for it by name. That is the whole mechanism: the
+ * narrow state is what a caller gets by default, and the wide read is a visible
+ * act at the call site.
+ */
+export type CredentialFileRead =
+  { usable: true; credential: AttachedCredential } | Extract<CredentialState, { usable: false }>;
+
+/**
  * Repair a too-permissive mode, or refuse the file.
  *
  * Repair-and-continue rather than refuse-on-sight: a group-readable credential
@@ -163,6 +180,29 @@ export function readControlPlaneCredentialState(
   settingsDir: string,
   connection?: ControlPlaneConnection,
 ): CredentialState {
+  const read = readControlPlaneCredentialFile(settingsDir, connection);
+  // THE PROJECTION, and the one line that keeps the credential off every
+  // surface. `usable` is rebuilt rather than spread, so a field added to the
+  // wide read never arrives here by accident — a spread would carry the next
+  // one out the same way `credential` went.
+  return read.usable ? { usable: true } : read;
+}
+
+/**
+ * The full read, credential included.
+ *
+ * SERVER-SIDE CALLERS ONLY. Everything this returns on the usable branch is a
+ * bearer credential, so a value from here must never be handed to a component
+ * that renders in a browser — in a React Server Components tree, anything
+ * passed to a `'use client'` boundary is serialised into the payload the
+ * browser receives. Surfaces take `readControlPlaneCredentialState`.
+ *
+ * Never throws. Every failure is a `usable: false` state.
+ */
+export function readControlPlaneCredentialFile(
+  settingsDir: string,
+  connection?: ControlPlaneConnection,
+): CredentialFileRead {
   const file = controlPlaneCredentialPath(settingsDir);
 
   let raw: string;
@@ -221,8 +261,8 @@ export function readControlPlaneCredential(
   settingsDir: string,
   connection: ControlPlaneConnection,
 ): AttachedCredential | null {
-  const state = readControlPlaneCredentialState(settingsDir, connection);
-  return state.usable ? state.credential : null;
+  const read = readControlPlaneCredentialFile(settingsDir, connection);
+  return read.usable ? read.credential : null;
 }
 
 /**

--- a/packages/persistence/src/control-plane-credential.ts
+++ b/packages/persistence/src/control-plane-credential.ts
@@ -1,7 +1,12 @@
 import { chmodSync, lstatSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { AttachedCredential, ControlPlaneConnection } from '@akasecurity/schema';
+import type {
+  AttachedCredential,
+  ControlPlaneConnection,
+  CredentialState,
+  CredentialUnusableReason,
+} from '@akasecurity/schema';
 import {
   ATTACHED_CREDENTIAL_FILENAME,
   AttachedCredential as CredentialSchema,
@@ -55,38 +60,16 @@ export function isSafeEndpoint(endpoint: string): boolean {
   return parsed.protocol === 'http:' && LOOPBACK_HOSTS.has(parsed.hostname);
 }
 
-/**
- * Why a credential is not usable, for a surface that has to explain itself.
- *
- *   `absent`         — no file. The ordinary unattached state.
- *   `untrusted-file` — a symlink, a file owned by someone else, or one whose
- *                      mode could not be tightened. A planted credential rather
- *                      than a permissions accident.
- *   `unreadable`     — present but could not be read.
- *   `malformed`      — not JSON, or not an `AttachedCredential` (which includes
- *                      an unknown `specVersion`, a `z.literal`).
- *   `unsafe-endpoint`— minted against an endpoint this build will not send a
- *                      credential to.
- *   `endpoint-mismatch` — a valid credential for a DIFFERENT deployment than the
- *                      one settings names. See `readControlPlaneCredentialState`.
- */
-export type CredentialUnusableReason =
-  | 'absent'
-  | 'untrusted-file'
-  | 'unreadable'
-  | 'malformed'
-  | 'unsafe-endpoint'
-  | 'endpoint-mismatch';
-
-export type CredentialState =
-  | { usable: true; credential: AttachedCredential }
-  | { usable: false; reason: Exclude<CredentialUnusableReason, 'endpoint-mismatch'> }
-  | {
-      usable: false;
-      reason: 'endpoint-mismatch';
-      credentialEndpoint: string;
-      settingsEndpoint: string;
-    };
+// `CredentialUnusableReason` and `CredentialState` now live in
+// @akasecurity/schema, beside the `AttachedCredential` they describe, and are
+// re-exported here so this module's public surface is unchanged.
+//
+// They moved because a PRESENTATIONAL surface has to name these states without
+// depending on the module that reads the disk: @akasecurity/dashboard-ui may
+// reach @akasecurity/schema and must not reach this package, so while the union
+// lived here the local dashboard could not be handed one. Every consumer that
+// imports them from @akasecurity/persistence keeps working.
+export type { CredentialState, CredentialUnusableReason };
 
 /**
  * Repair a too-permissive mode, or refuse the file.

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -7,11 +7,16 @@ export {
   clearAttachmentDerivedState,
   POLICY_CACHE_FILENAME,
 } from './attached-derived.ts';
-export type { CredentialState, CredentialUnusableReason } from './control-plane-credential.ts';
+export type {
+  CredentialFileRead,
+  CredentialState,
+  CredentialUnusableReason,
+} from './control-plane-credential.ts';
 export {
   controlPlaneCredentialPath,
   isSafeEndpoint,
   readControlPlaneCredential,
+  readControlPlaneCredentialFile,
   readControlPlaneCredentialState,
   removeControlPlaneCredential,
   writeControlPlaneCredential,

--- a/packages/persistence/test/control-plane-credential.test.ts
+++ b/packages/persistence/test/control-plane-credential.test.ts
@@ -17,6 +17,7 @@ import {
   controlPlaneCredentialPath,
   isSafeEndpoint,
   readControlPlaneCredential,
+  readControlPlaneCredentialFile,
   readControlPlaneCredentialState,
   removeControlPlaneCredential,
   writeControlPlaneCredential,
@@ -72,8 +73,8 @@ describe('write then read', () => {
   it('round-trips the credential and stores it owner-only', () => {
     writeControlPlaneCredential(store.settingsDir, credential);
 
-    const state = readControlPlaneCredentialState(store.settingsDir, connection);
-    expect(state).toEqual({ usable: true, credential });
+    const read = readControlPlaneCredentialFile(store.settingsDir, connection);
+    expect(read).toEqual({ usable: true, credential });
 
     // Owner-only is the whole at-rest control for this file. Windows has no
     // POSIX modes, so the assertion is scoped to where the mode is real.
@@ -83,13 +84,48 @@ describe('write then read', () => {
     }
   });
 
+  // THE PROJECTION, ASSERTED AT ITS SOURCE.
+  //
+  // The two readers answer the same question and only one of them may carry the
+  // key. This is the property the whole split exists for: `CredentialState` is
+  // what surfaces take, and one of those surfaces hands its value across a
+  // `'use client'` boundary, where every prop is serialised into the payload the
+  // browser receives.
+  //
+  // Asserted over the SERIALISED state, not by naming the absent field, so it
+  // stays red for any future shape that reintroduces the value under another
+  // name or nested one level down — and paired with the wide read above, which
+  // proves the same bytes ARE reachable when a server-side caller asks for them
+  // by name. A test that only checked the narrow one would pass just as well
+  // against a reader that had stopped working.
+  it('keeps the key out of the state, while the file read still carries it', () => {
+    writeControlPlaneCredential(store.settingsDir, credential);
+
+    const state = readControlPlaneCredentialState(store.settingsDir, connection);
+    expect(state).toEqual({ usable: true });
+
+    const serialised = JSON.stringify(state);
+    expect(serialised).toContain('"usable":true');
+    for (const secret of [credential.apiKey, credential.apiKey.slice(0, 8)]) {
+      expect(serialised).not.toContain(secret);
+    }
+
+    // The other half: this is not the key becoming unreachable.
+    expect(readControlPlaneCredential(store.settingsDir, connection)?.apiKey).toBe(
+      credential.apiKey,
+    );
+  });
+
   it('overwrites silently, because re-attaching is how a credential rotates', () => {
     writeControlPlaneCredential(store.settingsDir, credential);
     const rotated = { ...credential, apiKey: 'rotated-8c1d5e7a2f9b' };
     writeControlPlaneCredential(store.settingsDir, rotated);
 
-    const state = readControlPlaneCredentialState(store.settingsDir, connection);
-    expect(state.usable && state.credential.apiKey).toBe('rotated-8c1d5e7a2f9b');
+    // Through the FULL read, because the rotated key is the thing being
+    // asserted. `readControlPlaneCredentialState` deliberately cannot answer
+    // this — its usable branch carries no credential.
+    const read = readControlPlaneCredentialFile(store.settingsDir, connection);
+    expect(read.usable && read.credential.apiKey).toBe('rotated-8c1d5e7a2f9b');
   });
 
   it('refuses to store a credential for an endpoint it would never present to', () => {

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -99,6 +99,10 @@ const PUBLIC_VALUE_EXPORTS = [
   'overlayManagedSettings',
   'promptId',
   'readControlPlaneCredential',
+  // The WIDE read. Exported deliberately and named so it cannot be reached by
+  // accident: it returns a bearer credential, unlike the state reader beside
+  // it, and belongs only to server-side callers.
+  'readControlPlaneCredentialFile',
   'readControlPlaneCredentialState',
   'readEffectiveSettings',
   'readFingerprintKey',

--- a/packages/plugin-runtime/src/attached/factory.ts
+++ b/packages/plugin-runtime/src/attached/factory.ts
@@ -1,6 +1,6 @@
 import { hostname } from 'node:os';
 
-import { readControlPlaneCredentialState } from '@akasecurity/persistence';
+import { readControlPlaneCredential } from '@akasecurity/persistence';
 import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
 import { bundledDetections } from '@akasecurity/plugin-sdk';
 import { createRemoteClient } from '@akasecurity/remote';
@@ -48,7 +48,7 @@ export interface GatewayMeta {
  * credential authenticates to it. Either alone is not an attachment: a
  * descriptor with no credential dials nothing, and a credential whose endpoint
  * does not match the descriptor is refused rather than presented to a host it
- * was not minted for — see `readControlPlaneCredentialState`.
+ * was not minted for — see `readControlPlaneCredentialFile`.
  *
  * FAIL-OPEN THROUGHOUT. Absent, malformed, untrusted or mismatched credential,
  * an endpoint this build will not send to, or any error at all while wiring the
@@ -64,12 +64,16 @@ export function resolveGatewayForConfig(config: PluginConfig, meta?: GatewayMeta
     const connection = config.settings.controlPlane;
     if (connection === undefined) return local;
 
-    const state = readControlPlaneCredentialState(config.settingsDir, connection);
-    if (!state.usable) return local;
+    // The transport's door: one value, no reasons, nothing to branch on. A
+    // gateway that could not build a client falls back to the local one either
+    // way, so the reason is of no use here — and asking for the credential by
+    // name is what keeps the narrow state the default everywhere else.
+    const credential = readControlPlaneCredential(config.settingsDir, connection);
+    if (credential === null) return local;
 
     const client = createRemoteClient({
       endpoint: connection.endpoint,
-      apiKey: state.credential.apiKey,
+      apiKey: credential.apiKey,
     });
     const store = createPolicyStore(config.dataDir);
     // settingsDir, not dataDir: the device identity has to outlive a wipe of

--- a/packages/plugin-runtime/src/attached/history-sync.ts
+++ b/packages/plugin-runtime/src/attached/history-sync.ts
@@ -4,7 +4,7 @@ import { hostname } from 'node:os';
 import type { HistorySyncCounts, LocalDatabase } from '@akasecurity/persistence';
 import {
   openLocalDatabase,
-  readControlPlaneCredentialState,
+  readControlPlaneCredentialFile,
   readWorkspaceSettings,
 } from '@akasecurity/persistence';
 import { createRemoteClient } from '@akasecurity/remote';
@@ -135,7 +135,9 @@ export async function runHistorySync(deps: RunHistorySyncDeps): Promise<HistoryS
     if (connection === undefined) return null;
     if (!isHistorySyncConsentValid(settings.historySyncConsent, connection.endpoint)) return null;
 
-    const state = readControlPlaneCredentialState(deps.settingsDir, connection);
+    // The WIDE read: the client below needs the key itself, and this runs in
+    // the plugin's own process rather than anywhere a browser can see.
+    const state = readControlPlaneCredentialFile(deps.settingsDir, connection);
     if (!state.usable) return null;
 
     // READ-ONLY. A long-running child must never write the breaker: its view of

--- a/packages/plugin-runtime/src/attached/policy-sync.ts
+++ b/packages/plugin-runtime/src/attached/policy-sync.ts
@@ -1,4 +1,4 @@
-import { readControlPlaneCredentialState, readWorkspaceSettings } from '@akasecurity/persistence';
+import { readControlPlaneCredentialFile, readWorkspaceSettings } from '@akasecurity/persistence';
 import { createRemoteClient } from '@akasecurity/remote';
 import type { AttachedCredential, ControlPlaneConnection } from '@akasecurity/schema';
 import { isAttached } from '@akasecurity/schema';
@@ -186,7 +186,7 @@ export async function runPolicySync(deps: RunPolicySyncDeps): Promise<PolicySync
   const now = deps.now ?? (() => Date.now());
   // BOTH HALVES, or there is nothing to sync against: the descriptor names the
   // deployment and the credential authenticates to it, and either alone is not
-  // an attachment. `readControlPlaneCredentialState` is given the descriptor so
+  // an attachment. `readControlPlaneCredentialFile` is given the descriptor so
   // a credential minted for a different endpoint counts as absent here rather
   // than being presented to a host it was not minted for.
   const settings = readWorkspaceSettings(deps.base);
@@ -194,7 +194,9 @@ export async function runPolicySync(deps: RunPolicySyncDeps): Promise<PolicySync
   const state =
     connection === undefined
       ? undefined
-      : readControlPlaneCredentialState(deps.settingsDir, connection);
+      : // The WIDE read: `pullPolicyBundle` presents the credential. Runs in
+        // the plugin's own process, never in a browser.
+        readControlPlaneCredentialFile(deps.settingsDir, connection);
   // Detached between the spawn and here — nothing to do, and NOT AN ERROR, so
   // nothing is recorded either. The narrow ordering that makes this matter:
   // SessionStart spawns the child, the user runs detach, `removeControlPlaneCredential`

--- a/packages/plugin-runtime/src/attached/status.ts
+++ b/packages/plugin-runtime/src/attached/status.ts
@@ -1,4 +1,4 @@
-import { readControlPlaneCredentialState, readWorkspaceSettings } from '@akasecurity/persistence';
+import { readControlPlaneCredentialFile, readWorkspaceSettings } from '@akasecurity/persistence';
 import type { WorkspaceSettings } from '@akasecurity/schema';
 import { controlPlaneName, isAttached, isHistorySyncConsentValid } from '@akasecurity/schema';
 
@@ -105,7 +105,10 @@ export function renderAttachedStatus(deps: RenderAttachedStatusDeps): string {
       return ['AKA: standalone (not attached)', '  no control plane configured'].join('\n');
     }
     const connection = settings.controlPlane;
-    const state = readControlPlaneCredentialState(deps.settingsDir, connection);
+    // The WIDE read: this block prints `keyPrefix`, which the narrow state
+    // deliberately does not carry. It is a TERMINAL surface — `aka status` — so
+    // nothing here crosses to a browser.
+    const state = readControlPlaneCredentialFile(deps.settingsDir, connection);
 
     const lines = [
       // The mismatch case earns its own headline. An administrator can repoint

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -115,13 +115,28 @@ export type CredentialUnusableReason =
 /**
  * The credential half of an attachment, as a surface should read it.
  *
+ * THE USABLE BRANCH CARRIES NO PAYLOAD, and that is the point of the type
+ * rather than an omission. `AttachedCredential` holds a bearer key; a state
+ * that carried one would mean every surface accepting a `CredentialState`
+ * accepts a credential — including a client component, where the value is
+ * serialised into the payload the browser receives on every render. This type's
+ * own name says what it is for: naming a state, which needs a verdict and not a
+ * secret.
+ *
+ * A caller that genuinely needs the credential is a server one, and asks for it
+ * by name — `readControlPlaneCredential` for the transport's door, or
+ * `readControlPlaneCredentialFile` for the full read. Having to name it is the
+ * property: the narrow type is what a surface gets by default, and reaching
+ * past it is a visible act.
+ *
  * `endpoint-mismatch` carries BOTH endpoints because it is the one reason a
  * user can act on: the answer is either to re-attach against the endpoint
  * settings now names, or to put the old one back, and neither instruction can
- * be written without saying which is which.
+ * be written without saying which is which. Neither is secret — the endpoints
+ * are in settings and on screen already.
  */
 export type CredentialState =
-  | { usable: true; credential: AttachedCredential }
+  | { usable: true }
   | { usable: false; reason: Exclude<CredentialUnusableReason, 'endpoint-mismatch'> }
   | {
       usable: false;

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -75,6 +75,61 @@ export const AttachedCredential = z.object({
 });
 export type AttachedCredential = z.infer<typeof AttachedCredential>;
 
+// ─── Whether that credential can actually be used ────────────────────────────
+
+// The two types below are PLAIN TYPESCRIPT, not Zod, and they describe a
+// derived answer rather than a stored or wire shape — so the `.meta({ id })`
+// rule in this file's header has nothing to say about them.
+//
+// They live here, beside `AttachedCredential`, because they are the vocabulary
+// for reading one: every reason names a way that file can exist and still not
+// authenticate. The reader itself is `readControlPlaneCredentialState` in
+// @akasecurity/persistence, which owns the file I/O and re-exports these; they
+// sit in this package so a PRESENTATIONAL surface can name a state without
+// depending on the module that reads the disk. @akasecurity/dashboard-ui is
+// exactly that case — it may reach this package and not that one.
+
+/**
+ * Why a credential is not usable, for a surface that has to explain itself.
+ *
+ *   `absent`         — no file. The ordinary unattached state.
+ *   `untrusted-file` — a symlink, a file owned by someone else, or one whose
+ *                      mode could not be tightened. A planted credential rather
+ *                      than a permissions accident.
+ *   `unreadable`     — present but could not be read.
+ *   `malformed`      — not JSON, or not an `AttachedCredential` (which includes
+ *                      an unknown `specVersion`, a `z.literal`).
+ *   `unsafe-endpoint`— minted against an endpoint this build will not send a
+ *                      credential to.
+ *   `endpoint-mismatch` — a valid credential for a DIFFERENT deployment than the
+ *                      one settings names.
+ */
+export type CredentialUnusableReason =
+  | 'absent'
+  | 'untrusted-file'
+  | 'unreadable'
+  | 'malformed'
+  | 'unsafe-endpoint'
+  | 'endpoint-mismatch';
+
+/**
+ * The credential half of an attachment, as a surface should read it.
+ *
+ * `endpoint-mismatch` carries BOTH endpoints because it is the one reason a
+ * user can act on: the answer is either to re-attach against the endpoint
+ * settings now names, or to put the old one back, and neither instruction can
+ * be written without saying which is which.
+ */
+export type CredentialState =
+  | { usable: true; credential: AttachedCredential }
+  | { usable: false; reason: Exclude<CredentialUnusableReason, 'endpoint-mismatch'> }
+  | {
+      usable: false;
+      reason: 'endpoint-mismatch';
+      credentialEndpoint: string;
+      settingsEndpoint: string;
+    };
+
 // ─── Bounds shared with the reference deployment's storage ───────────────────
 
 // The largest epoch-millis value that round-trips as a timestamp everywhere:

--- a/packages/schema/src/zod/local.ts
+++ b/packages/schema/src/zod/local.ts
@@ -78,9 +78,16 @@ export const HISTORY_SYNC_PAYLOAD_VERSION = 1;
 export const RunMode = z.enum(['standalone', 'attached']);
 export type RunMode = z.infer<typeof RunMode>;
 
-// Which deployment this machine is attached to. Opaque to this tree — nothing
+// Which deployment this machine is attached to. Opaque to THIS FILE — nothing
 // here parses, resolves or dials `endpoint`; it is stored so the dashboard can
 // name what the user is attached to and so a detach has something to clear.
+//
+// "This file", not "this tree", for the same reason the RunMode block above was
+// narrowed: @akasecurity/remote dials this endpoint, and the CLI and the local
+// dashboard both ask it to. The block above was corrected when that landed and
+// this one was not, which left the two neighbours disagreeing about the same
+// fact — the weaker claim is the true one, and it is the only one this file can
+// actually keep.
 //
 // DELIBERATELY CARRIES NO CREDENTIAL. A bearer token in settings.json would sit
 // in a file every local process can read for as long as the attachment lasts,

--- a/web-ui/app/(app)/settings/SettingsClient.tsx
+++ b/web-ui/app/(app)/settings/SettingsClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { WorkspaceSettingsFormView } from '@akasecurity/dashboard-ui';
-import type { ManagedContext, WorkspaceSettings } from '@akasecurity/schema';
+import type { CredentialState, ManagedContext, WorkspaceSettings } from '@akasecurity/schema';
 import { useState, useTransition } from 'react';
 
 import { attachToControlPlane, detachFromControlPlane, saveSettings } from './actions';
@@ -9,9 +9,13 @@ import { attachToControlPlane, detachFromControlPlane, saveSettings } from './ac
 export function SettingsClient({
   settings,
   managed,
+  credentialState,
 }: {
   settings: WorkspaceSettings;
   managed: ManagedContext;
+  // Read on the server (page.tsx) and forwarded verbatim. Carries a verdict and,
+  // on a mismatch, the two endpoints — never the key itself.
+  credentialState: CredentialState;
 }) {
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
@@ -43,6 +47,7 @@ export function SettingsClient({
     <WorkspaceSettingsFormView
       settings={settings}
       managed={managed}
+      credentialState={credentialState}
       busy={busy}
       error={error}
       saved={saved}

--- a/web-ui/app/(app)/settings/actions.ts
+++ b/web-ui/app/(app)/settings/actions.ts
@@ -7,7 +7,7 @@ import {
   isSafeEndpoint,
   ManagedFieldError,
   openLocalDatabase,
-  readControlPlaneCredentialState,
+  readControlPlaneCredentialFile,
   readWorkspaceSettings,
   removeControlPlaneCredential,
   settingsDir,
@@ -241,7 +241,11 @@ export async function attachToControlPlane(input: unknown): Promise<SaveSettings
     // rejects the whole Server Action and replaces the page with a framework
     // error, which is precisely the failure every action in this file is written
     // to return instead of raise.
-    previous = readControlPlaneCredentialState(dir);
+    // The FULL read, not the narrow state, and this is one of the two callers
+    // that is entitled to it: rolling a credential back means writing the exact
+    // bytes that were there. A Server Action runs only on the server, so
+    // nothing here crosses to a browser.
+    previous = readControlPlaneCredentialFile(dir);
     writeControlPlaneCredential(dir, {
       specVersion: 1,
       endpoint,
@@ -276,7 +280,7 @@ export async function attachToControlPlane(input: unknown): Promise<SaveSettings
       // locking the credential transaction inside @akasecurity/persistence so
       // the CLI is covered too; a lock taken only here would leave the CLI
       // racing and read as a fix. Flagged on the PR rather than half-done.
-      const current = readControlPlaneCredentialState(dir);
+      const current = readControlPlaneCredentialFile(dir);
       const ours = current.usable && current.credential.apiKey === accessKey;
       if (ours) {
         if (previous.usable) writeControlPlaneCredential(dir, previous.credential);

--- a/web-ui/app/(app)/settings/page.tsx
+++ b/web-ui/app/(app)/settings/page.tsx
@@ -30,9 +30,17 @@ export default function SettingsPage() {
   // that comparison is the only thing this argument enables.
   //
   // Read here, in the server component, because it touches the filesystem.
-  // Nothing secret crosses to the client: the state is a verdict plus, on a
-  // mismatch, the two endpoints — never the key. `dynamic = 'force-dynamic'`
-  // above already means this is re-read on every visit rather than baked in.
+  // `dynamic = 'force-dynamic'` above already means this is re-read on every
+  // visit rather than baked in.
+  //
+  // Nothing secret crosses to the client, and that is now a property of the
+  // TYPE rather than of this comment. `CredentialState`'s usable branch carries
+  // no payload at all — a server-side caller that needs the key asks for it by
+  // name — so what reaches `SettingsClient` below is a verdict plus, on a
+  // mismatch, the two endpoints, and there is no branch on which it could be
+  // more. That matters here specifically: `SettingsClient` is `'use client'`,
+  // so everything handed to it is serialised into the payload the browser
+  // receives on every settings render.
   const credentialState = readControlPlaneCredentialState(settingsDir(), settings.controlPlane);
 
   return (

--- a/web-ui/app/(app)/settings/page.tsx
+++ b/web-ui/app/(app)/settings/page.tsx
@@ -1,5 +1,9 @@
 import { PageHead } from '@akasecurity/dashboard-ui';
-import { readEffectiveSettings } from '@akasecurity/persistence';
+import {
+  readControlPlaneCredentialState,
+  readEffectiveSettings,
+  settingsDir,
+} from '@akasecurity/persistence';
 
 import { SettingsClient } from './SettingsClient';
 
@@ -15,10 +19,26 @@ export default function SettingsPage() {
   // editable control for a value the writer then refuses.
   const { settings, managed } = readEffectiveSettings();
 
+  // The other half of an attachment. `runMode: 'attached'` is a stored answer;
+  // whether this machine can actually use the connection also depends on a
+  // credential file, and without this read the page called a machine attached
+  // while it sent and received nothing. The CLI could always say so — this is
+  // the dashboard catching up to `aka status`.
+  //
+  // Passed the descriptor so an endpoint MISMATCH is detectable: a credential
+  // minted for another deployment parses perfectly and is still unusable, and
+  // that comparison is the only thing this argument enables.
+  //
+  // Read here, in the server component, because it touches the filesystem.
+  // Nothing secret crosses to the client: the state is a verdict plus, on a
+  // mismatch, the two endpoints — never the key. `dynamic = 'force-dynamic'`
+  // above already means this is re-read on every visit rather than baked in.
+  const credentialState = readControlPlaneCredentialState(settingsDir(), settings.controlPlane);
+
   return (
     <div className="px-8 pb-10 pt-7">
       <PageHead title="Settings" sub="Workspace configuration for this machine." />
-      <SettingsClient settings={settings} managed={managed} />
+      <SettingsClient settings={settings} managed={managed} credentialState={credentialState} />
     </div>
   );
 }

--- a/web-ui/test/pages/settings-page.test.ts
+++ b/web-ui/test/pages/settings-page.test.ts
@@ -14,6 +14,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SettingsPage from '../../app/(app)/settings/page.tsx';
 import { SettingsClient } from '../../app/(app)/settings/SettingsClient.tsx';
+import { expectNoEchoOf } from '../helpers/no-echo.ts';
 
 type ReadEffectiveArgs = Parameters<typeof Persistence.readEffectiveSettings>;
 
@@ -185,6 +186,38 @@ describe('the settings route', () => {
     });
     const state = renderPage().credentialState;
     expect(state.usable).toBe(true);
+  });
+
+  // THE KEY MUST NOT CROSS THIS BOUNDARY, and asserting `usable === true` above
+  // cannot see whether it did — which is exactly why it once did. `SettingsClient`
+  // is `'use client'`, so every prop reaching it is serialised into the payload
+  // the browser receives on each settings render; a `credentialState` whose
+  // usable branch carried an `AttachedCredential` put a bearer key in there on
+  // every visit.
+  //
+  // Asserted over the SERIALISED prop rather than by naming the field, so it
+  // stays red for any future shape that reintroduces the value under another
+  // name or nested one level down.
+  it('hands the client no part of the key, on the branch that used to carry it', () => {
+    const apiKey = 'zq7fvkxm2rjt9wbn4hdc6sylp3g8';
+    applyOnboarding(
+      {
+        runMode: 'attached',
+        controlPlane: { endpoint: 'https://aka.acme.internal', attachedAt: NOW },
+      },
+      akaHome(),
+    );
+    writeControlPlaneCredential(settingsDir(akaHome()), {
+      specVersion: 1,
+      endpoint: 'https://aka.acme.internal',
+      apiKey,
+    });
+    const serialised = JSON.stringify(renderPage().credentialState);
+    // A positive control first: `expectNoEchoOf` passes trivially over bytes
+    // that came back empty, and an empty serialisation is the one way this
+    // assertion could be green while proving nothing.
+    expect(serialised).toContain('"usable":true');
+    expectNoEchoOf(serialised, apiKey);
   });
 
   it('passes an administrator’s locks straight through to the form', () => {

--- a/web-ui/test/pages/settings-page.test.ts
+++ b/web-ui/test/pages/settings-page.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type * as Persistence from '@akasecurity/persistence';
-import { applyOnboarding } from '@akasecurity/persistence';
+import {
+  applyOnboarding,
+  settingsDir,
+  writeControlPlaneCredential,
+} from '@akasecurity/persistence';
 import type { ComponentProps, ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -55,7 +59,13 @@ vi.mock('@akasecurity/persistence', async (importActual) => {
   };
 });
 
+const NOW = '2026-02-02T00:00:00.000Z';
+
 let home: string;
+
+/** The AKA home inside the redirected HOME — what every writer here takes as
+ * its base, and what the page resolves for itself from `homedir()`. */
+const akaHome = (): string => join(home, '.aka');
 
 beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-settings-page-'));
@@ -104,6 +114,77 @@ describe('the settings route', () => {
     // unmanaged machine makes the two readers agree.
     renderPage();
     expect(managedSource.calls).toBe(1);
+  });
+
+  // ─── The credential half ───────────────────────────────────────────────────
+  //
+  // `runMode: 'attached'` is a stored answer; whether the machine can use the
+  // connection also depends on a credential file. Without this prop the form
+  // renders "Attached" for a machine that sends and receives nothing, which is
+  // the state `aka status` has always been able to name and this page could
+  // not.
+
+  it('hands the client the credential state', () => {
+    const props = renderPage();
+    // A fresh temp home has no credential file, which is the ordinary
+    // standalone answer — the form ignores it while standalone.
+    expect(props.credentialState).toEqual({ usable: false, reason: 'absent' });
+  });
+
+  it('reports a missing credential on a machine whose settings say attached', () => {
+    applyOnboarding(
+      {
+        runMode: 'attached',
+        controlPlane: { endpoint: 'https://aka.acme.internal', attachedAt: NOW },
+      },
+      akaHome(),
+    );
+    const props = renderPage();
+    expect(props.settings.runMode).toBe('attached');
+    expect(props.credentialState).toEqual({ usable: false, reason: 'absent' });
+  });
+
+  // The wiring assertion that nothing else can make. Passing the descriptor to
+  // the reader is the ONLY thing that makes a mismatch detectable: a credential
+  // minted for another deployment parses perfectly, so a page that read the
+  // credential without the descriptor would report it usable and every other
+  // case in this file would still pass.
+  it('detects a credential minted for a different deployment', () => {
+    applyOnboarding(
+      {
+        runMode: 'attached',
+        controlPlane: { endpoint: 'https://new.acme.internal', attachedAt: NOW },
+      },
+      akaHome(),
+    );
+    writeControlPlaneCredential(settingsDir(akaHome()), {
+      specVersion: 1,
+      endpoint: 'https://old.acme.internal',
+      apiKey: 'a-key-for-the-old-deployment',
+    });
+    expect(renderPage().credentialState).toEqual({
+      usable: false,
+      reason: 'endpoint-mismatch',
+      credentialEndpoint: 'https://old.acme.internal',
+      settingsEndpoint: 'https://new.acme.internal',
+    });
+  });
+
+  it('reports a matching credential as usable', () => {
+    applyOnboarding(
+      {
+        runMode: 'attached',
+        controlPlane: { endpoint: 'https://aka.acme.internal', attachedAt: NOW },
+      },
+      akaHome(),
+    );
+    writeControlPlaneCredential(settingsDir(akaHome()), {
+      specVersion: 1,
+      endpoint: 'https://aka.acme.internal',
+      apiKey: 'a-key-for-this-deployment',
+    });
+    const state = renderPage().credentialState;
+    expect(state.usable).toBe(true);
   });
 
   it('passes an administrator’s locks straight through to the form', () => {


### PR DESCRIPTION
## The gap

`runMode: 'attached'` is half an attachment. The other half is a usable
credential file, and a machine that has lost one sends and receives nothing
while the settings page still shows a teal **Attached** badge.

`aka status` has always been able to name this state. The dashboard could not,
because the connection row renders from `WorkspaceSettings` alone — and the
comment on `canAttach` in that same file already described the outcome
("attached-and-broken … forwarding silently does nothing") as something the
form existed to stop a user *creating*. Users can still arrive at it by other
routes: a hand-edited `settings.json`, an administrator repointing the endpoint
through a managed overlay, a restored home directory.

## What this adds

The settings page reads the credential state server-side and passes it to the
form, which now distinguishes four outcomes:

| State | What the row says |
|---|---|
| usable | unchanged — **Attached** |
| no key stored | **Not connected** + "there is no access key stored on it" |
| key unusable | **Not connected** + "the access key stored on it cannot be used" |
| key for another deployment | **Not connected** + both endpoints named |

Four internal reasons (`untrusted-file`, `unreadable`, `malformed`,
`unsafe-endpoint`) share one message: a user cannot act differently on any of
them — the fix is to attach again in every case — and naming the distinction
would describe our parser rather than their machine.

The mismatch case prints **both** endpoints because it is the one a user can act
on in two directions: re-attach against the endpoint the settings now name, or
point the machine back at the old one. Neither instruction can be written
without saying which is which.

## Why this is honest to show

Every other string in that section deliberately avoids claiming knowledge of the
far end — `CONNECTION_ATTACHED_DESCRIPTION` carries a comment explaining that a
successful attach an hour ago says nothing about now.

This does not acquire any such knowledge. The credential is a file on the local
disk, so "there is no usable key here" is something the page can see for itself.
It reports the local half and still says nothing about whether the deployment
would answer. The badge follows `VAULT_STALE_BADGE`'s precedent: when the stored
answer and what is actually happening disagree, the badge carries the
contradiction instead of repeating the stored answer as if it were the outcome.

## The type move

`CredentialState` and `CredentialUnusableReason` move from
`@akasecurity/persistence` to `@akasecurity/schema`, beside the
`AttachedCredential` they describe, and are re-exported from persistence so **no
consumer's imports change**.

They had to move for a presentational package to name these states at all:
`@akasecurity/dashboard-ui` depends on `@akasecurity/schema` and `@akasecurity/ui-kit`
only, and must not reach the module that reads the disk. They are plain
TypeScript rather than Zod — a derived answer, not a stored or wire shape — so
the `.meta({ id })` rule in that file's header does not apply, and the comment
says so.

## Compatibility

The prop is **optional**, and its absence means "not reported" rather than
"fine": a host that does not read the file leaves the surface exactly as it was
rather than accusing a working machine of being broken. That case is covered by
a test, because the CLI inlines this package and renders the same view.

A standalone machine is never reported as missing a credential — it is not
supposed to have one, and reporting absence there would turn the ordinary state
into a fault.

## Also

Corrects a comment the attach work left behind: the block describing
`ControlPlaneConnection` still said the endpoint was opaque to *this tree*,
while its neighbour had already been narrowed to *this file* when the transport
landed. The two neighbours were disagreeing about the same fact; the weaker
claim is the true one and the only one that file can keep.

## Verification

New copy is added to the form's existing honesty sweep. The page-wiring test is
a real guard, not a restatement: dropping the descriptor argument that makes a
mismatch detectable fails exactly one test (verified by mutation), and every
other case still passes — a credential minted for another deployment parses
perfectly, so nothing else could catch it.

Full workspace suite green: 41/41 packages.