### PR TITLE
feat(schema): the wire contract for attaching a machine by device code

### DIFF
--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -334,3 +334,162 @@ export const ControlPlaneErrorBody = z.object({
     .optional(),
 });
 export type ControlPlaneErrorBody = z.infer<typeof ControlPlaneErrorBody>;
+
+// ─── Attaching a machine without ferrying a key by hand ──────────────────────
+//
+// The shape of RFC 8628's Device Authorization Grant, for the same reason it
+// exists there: the terminal that wants a credential cannot receive a browser
+// redirect. It needs no local listener, so nothing here opens a socket, and it
+// works over SSH and on headless machines — the printed code completes on
+// whatever browser the user can reach.
+//
+// TWO ENDPOINTS, BOTH UNAUTHENTICATED, because the caller has no credential
+// yet — that is the whole point. Everything a device sends is therefore
+// attacker-chosen, so every field below is length-capped, and every field a
+// deployment sends back is `printable`: the CLI writes them straight into a
+// terminal, and this flow renders MORE server-authored text than any other
+// (a code, a URL, and a refusal message). The reasoning is the one on
+// `PluginWhoami` above and applies with more force here, since a caller reaches
+// these routes before it has established which deployment it is talking to.
+
+/**
+ * `POST /v1/attach/device` — start a grant.
+ *
+ * Everything here is REPORTED BY THE DEVICE and none of it is verified: this is
+ * an unauthenticated POST, so a caller says whatever it likes. It exists so the
+ * person approving in a browser can recognise their own machine, and an
+ * approval surface must present it as claimed rather than as fact — what the
+ * server actually observed (source address, timing) is the half that cannot be
+ * forged.
+ *
+ * Required rather than optional, so an approval page always has something to
+ * show: a caller that cannot determine its own hostname sends a placeholder,
+ * which is a decision the CLI makes visibly rather than an absence the server
+ * has to render as a blank.
+ */
+export const AttachDeviceRequest = z
+  .object({
+    hostname: printable(255).min(1),
+    os: printable(64).min(1),
+    cliVersion: printable(64).min(1),
+    // What to call this machine afterwards. Optional because the CLI's own
+    // `--label` is optional, and absent means "use the endpoint".
+    label: printable(200).optional(),
+  })
+  .meta({ id: 'AttachDeviceRequest' });
+export type AttachDeviceRequest = z.infer<typeof AttachDeviceRequest>;
+
+/**
+ * `POST /v1/attach/token` — the poll.
+ *
+ * `deviceCode` is the secret half of the grant and never leaves the machine
+ * that started it. It is the reason this endpoint can answer RFC-distinct
+ * states without leaking anything: every answer only ever confirms something
+ * about a grant the caller already holds the code for.
+ */
+export const AttachTokenRequest = z
+  .object({
+    deviceCode: printable(128).min(1),
+  })
+  .meta({ id: 'AttachTokenRequest' });
+export type AttachTokenRequest = z.infer<typeof AttachTokenRequest>;
+
+// ── The answers ──────────────────────────────────────────────────────────────
+//
+// Response parsers, so NO `.meta({ id })` on any of them — see this file's
+// header. On `AttachTokenIssued` that rule is not merely conventional: it
+// carries a bearer credential in `apiKey`, and an id would register the shape in
+// Zod's global registry for anything walking it to publish. Same rule, and the
+// same reason, as `AttachedCredential` at the top of this file.
+
+/** `POST /v1/attach/device` — what the terminal prints and then polls with. */
+export const AttachDeviceGrant = z.object({
+  // The secret. Long and high-entropy; the user never sees or types it.
+  deviceCode: printable(128),
+  // The short one a human reads off the terminal and types into a browser.
+  userCode: printable(32),
+  verificationUri: printable(512),
+  // The same page with the code already filled in. Optional because a
+  // deployment may decline to offer it, and a client must not require it.
+  verificationUriComplete: printable(512).optional(),
+  expiresIn: z.number().int().positive(),
+  // The deployment's requested poll spacing, in seconds. Advisory until the
+  // deployment says `slow_down`, which is not.
+  interval: z.number().int().positive(),
+});
+export type AttachDeviceGrant = z.infer<typeof AttachDeviceGrant>;
+
+/** Still waiting for someone to approve or deny it in a browser. */
+export const AttachTokenPending = z.object({ status: z.literal('pending') });
+
+/**
+ * Polling faster than the deployment will answer.
+ *
+ * Carries a new `interval` rather than leaving the client to guess a backoff,
+ * and is a distinct state from `pending` so a client can tell "nothing has
+ * happened yet" from "you are asking too often".
+ */
+export const AttachTokenSlowDown = z.object({
+  status: z.literal('slow_down'),
+  interval: z.number().int().positive(),
+});
+
+/**
+ * Decided, and the answer was no — a TERMINAL state, not a reason to keep
+ * polling.
+ *
+ * `message` is optional and server-authored, so a deployment can say WHY when
+ * the reason is actionable — a role that may not attach machines is the case
+ * this exists for, and one a user would otherwise experience as ten minutes of
+ * polling ending in a false "expired".
+ */
+export const AttachTokenDenied = z.object({
+  status: z.literal('denied'),
+  message: printable(500).optional(),
+});
+
+/** The grant ran out before anyone decided. Terminal; start again. */
+export const AttachTokenExpired = z.object({ status: z.literal('expired') });
+
+/**
+ * Approved and redeemed — the credential, exactly once.
+ *
+ * `endpoint` is echoed back rather than assumed from the URL the client dialled:
+ * the credential file binds a key to the endpoint it was minted for, and the
+ * deployment is the party that knows its own canonical origin.
+ */
+export const AttachTokenIssued = z.object({
+  status: z.literal('issued'),
+  apiKey: z.string().min(1).max(512),
+  endpoint: printable(512),
+  // What the deployment resolved the caller to, so the CLI can show who it is
+  // about to attach as before writing anything. Optional: a deployment that
+  // does not send it leaves the CLI to ask `whoami`, which it does anyway.
+  tenantName: printable(200).optional(),
+  userEmail: printable(320).optional(),
+});
+
+/**
+ * Every answer `POST /v1/attach/token` can give, parsed leniently.
+ *
+ * A plain union with an UNKNOWN-STATUS member last, rather than a
+ * discriminated union that would reject anything it has not been taught. A
+ * newer deployment adding a sixth state must not turn an older CLI's poll into
+ * a parse error — the client's own rule is to keep waiting for a state it does
+ * not recognise, which is only expressible if the parse succeeds.
+ *
+ * Order is load-bearing: `z.union` takes the first member that matches, so the
+ * catch-all has to be last. It also makes a MALFORMED known state degrade
+ * safely — an `issued` with no `apiKey` fails the first member and lands on the
+ * catch-all as an unrecognised status, so the client waits rather than
+ * attaching with nothing.
+ */
+export const AttachTokenResponse = z.union([
+  AttachTokenIssued,
+  AttachTokenPending,
+  AttachTokenSlowDown,
+  AttachTokenDenied,
+  AttachTokenExpired,
+  z.object({ status: printable(64) }),
+]);
+export type AttachTokenResponse = z.infer<typeof AttachTokenResponse>;

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -369,6 +369,14 @@ export type ControlPlaneErrorBody = z.infer<typeof ControlPlaneErrorBody>;
  */
 export const AttachDeviceRequest = z
   .object({
+    // This machine's own continuity id, so re-attaching ROTATES the credential
+    // on one machine record instead of producing a second one. Client-minted
+    // and losable — a wiped state file mints a fresh id and the deployment sees
+    // a new machine, which is benign precisely because the identity that
+    // matters is the credential, not this. Deliberately NOT a hardware
+    // fingerprint: nothing here should be a value a device could be tracked by
+    // across organizations.
+    deviceId: printable(128).min(1),
     hostname: printable(255).min(1),
     os: printable(64).min(1),
     cliVersion: printable(64).min(1),

--- a/packages/schema/test/zod/control-plane.test.ts
+++ b/packages/schema/test/zod/control-plane.test.ts
@@ -279,7 +279,12 @@ describe('response parsers', () => {
 // ─── The device-authorization attach flow ────────────────────────────────────
 
 describe('AttachDeviceRequest', () => {
-  const request = { hostname: 'dev-laptop', os: 'darwin 24.0.0', cliVersion: '0.9.8' };
+  const request = {
+    deviceId: 'd76504a1-fab2-4e28-af82-b5aab7212fdc',
+    hostname: 'dev-laptop',
+    os: 'darwin 24.0.0',
+    cliVersion: '0.9.8',
+  };
 
   it('accepts what the CLI reports about itself', () => {
     expect(AttachDeviceRequest.safeParse(request).success).toBe(true);
@@ -289,7 +294,7 @@ describe('AttachDeviceRequest', () => {
   // Required, so an approval page always has something to render. A caller that
   // cannot determine its hostname substitutes a placeholder — a visible
   // decision — rather than leaving the server to render a blank.
-  it.each(['hostname', 'os', 'cliVersion'])('refuses an empty %s', (field) => {
+  it.each(['deviceId', 'hostname', 'os', 'cliVersion'])('refuses an empty %s', (field) => {
     expect(AttachDeviceRequest.safeParse({ ...request, [field]: '' }).success).toBe(false);
   });
 
@@ -304,6 +309,9 @@ describe('AttachDeviceRequest', () => {
       false,
     );
     expect(AttachDeviceRequest.safeParse({ ...request, label: 'l'.repeat(201) }).success).toBe(
+      false,
+    );
+    expect(AttachDeviceRequest.safeParse({ ...request, deviceId: 'd'.repeat(129) }).success).toBe(
       false,
     );
   });

--- a/packages/schema/test/zod/control-plane.test.ts
+++ b/packages/schema/test/zod/control-plane.test.ts
@@ -3,9 +3,13 @@ import { z } from 'zod';
 
 import type { StorePostureSnapshot as StorePostureSnapshotT } from '../../src/zod/control-plane.ts';
 import {
+  AttachDeviceGrant,
+  AttachDeviceRequest,
   ATTACHED_CREDENTIAL_FILENAME,
   ATTACHED_CREDENTIAL_SPEC_VERSION,
   AttachedCredential,
+  AttachTokenIssued,
+  AttachTokenResponse,
   ControlPlaneErrorBody,
   IngestAck,
   PluginWhoami,
@@ -269,5 +273,142 @@ describe('response parsers', () => {
     expect(z.globalRegistry.get(IngestAck)).toBeUndefined();
     expect(z.globalRegistry.get(PluginWhoami)).toBeUndefined();
     expect(z.globalRegistry.get(ControlPlaneErrorBody)).toBeUndefined();
+  });
+});
+
+// ─── The device-authorization attach flow ────────────────────────────────────
+
+describe('AttachDeviceRequest', () => {
+  const request = { hostname: 'dev-laptop', os: 'darwin 24.0.0', cliVersion: '0.9.8' };
+
+  it('accepts what the CLI reports about itself', () => {
+    expect(AttachDeviceRequest.safeParse(request).success).toBe(true);
+    expect(AttachDeviceRequest.safeParse({ ...request, label: 'Work laptop' }).success).toBe(true);
+  });
+
+  // Required, so an approval page always has something to render. A caller that
+  // cannot determine its hostname substitutes a placeholder — a visible
+  // decision — rather than leaving the server to render a blank.
+  it.each(['hostname', 'os', 'cliVersion'])('refuses an empty %s', (field) => {
+    expect(AttachDeviceRequest.safeParse({ ...request, [field]: '' }).success).toBe(false);
+  });
+
+  // Unauthenticated, so every one of these is attacker-chosen. Length caps are
+  // what stop a grant row being an arbitrary-size write.
+  it('caps every device-supplied string', () => {
+    expect(AttachDeviceRequest.safeParse({ ...request, hostname: 'h'.repeat(256) }).success).toBe(
+      false,
+    );
+    expect(AttachDeviceRequest.safeParse({ ...request, os: 'o'.repeat(65) }).success).toBe(false);
+    expect(AttachDeviceRequest.safeParse({ ...request, cliVersion: 'v'.repeat(65) }).success).toBe(
+      false,
+    );
+    expect(AttachDeviceRequest.safeParse({ ...request, label: 'l'.repeat(201) }).success).toBe(
+      false,
+    );
+  });
+
+  // These strings are rendered on an approval page and echoed by the CLI. An
+  // escape sequence in a hostname would repaint the very block a user is
+  // reading to decide whether to approve.
+  it('refuses control characters in what the device claims', () => {
+    expect(AttachDeviceRequest.safeParse({ ...request, hostname: 'a\u001b[2Kb' }).success).toBe(
+      false,
+    );
+    expect(AttachDeviceRequest.safeParse({ ...request, label: 'two\nlines' }).success).toBe(false);
+  });
+});
+
+describe('AttachTokenResponse', () => {
+  it('reads each state the flow defines', () => {
+    for (const body of [
+      { status: 'pending' },
+      { status: 'slow_down', interval: 10 },
+      { status: 'denied' },
+      { status: 'denied', message: 'your role cannot attach machines' },
+      { status: 'expired' },
+      { status: 'issued', apiKey: 'aka_live_x', endpoint: 'https://aka.example.test' },
+    ]) {
+      expect(AttachTokenResponse.safeParse(body), JSON.stringify(body)).toMatchObject({
+        success: true,
+      });
+    }
+  });
+
+  // The leniency that lets the CLI ship ahead of a deployment, and outlive one.
+  // A sixth state must not turn a poll into a parse error — the client's rule is
+  // to keep waiting for a status it does not recognise, which it can only do if
+  // the parse succeeded.
+  it('accepts a status it has never heard of rather than failing', () => {
+    expect(AttachTokenResponse.safeParse({ status: 'authorization_pending' }).success).toBe(true);
+  });
+
+  // Order is load-bearing: the catch-all is last, so a WELL-FORMED known state
+  // must still parse as itself and keep its own fields.
+  it('prefers a known state over the catch-all', () => {
+    expect(AttachTokenResponse.parse({ status: 'slow_down', interval: 10 })).toEqual({
+      status: 'slow_down',
+      interval: 10,
+    });
+  });
+
+  // The safe degradation. An `issued` with no key fails the issued member and
+  // lands on the catch-all as an unrecognised status, so a client waits instead
+  // of attaching with nothing — never a shape that says "issued" and carries no
+  // credential.
+  it('does not read a keyless issued body as an issued credential', () => {
+    const parsed = AttachTokenResponse.parse({ status: 'issued' });
+    expect(parsed).not.toHaveProperty('apiKey');
+    expect(Object.keys(parsed)).toEqual(['status']);
+  });
+
+  it('rejects a body with no status at all', () => {
+    expect(AttachTokenResponse.safeParse({}).success).toBe(false);
+  });
+
+  // Same rule, and the same reason, as AttachedCredential: this member carries a
+  // bearer credential, and a meta id would register it in the global registry
+  // for anything walking that registry to publish.
+  it('carries NO meta id on the member that holds the credential', () => {
+    expect(z.globalRegistry.get(AttachTokenIssued)).toBeUndefined();
+    expect(z.globalRegistry.get(AttachTokenResponse)).toBeUndefined();
+    expect(z.globalRegistry.get(AttachDeviceGrant)).toBeUndefined();
+  });
+});
+
+describe('AttachDeviceGrant', () => {
+  const grant = {
+    deviceCode: 'd'.repeat(64),
+    userCode: 'ABCD-EFGH',
+    verificationUri: 'https://aka.example.test/attach',
+    expiresIn: 600,
+    interval: 5,
+  };
+
+  it('reads a grant, with or without the prefilled link', () => {
+    expect(AttachDeviceGrant.safeParse(grant).success).toBe(true);
+    expect(
+      AttachDeviceGrant.safeParse({
+        ...grant,
+        verificationUriComplete: 'https://aka.example.test/attach?code=ABCD-EFGH',
+      }).success,
+    ).toBe(true);
+  });
+
+  // Everything here is printed into a terminal by a client that has not yet
+  // established which deployment it is talking to.
+  it('refuses control characters in anything it will print', () => {
+    expect(AttachDeviceGrant.safeParse({ ...grant, userCode: 'AB\u001b[1;1H' }).success).toBe(
+      false,
+    );
+    expect(
+      AttachDeviceGrant.safeParse({ ...grant, verificationUri: 'https://x.test\nfake: line' })
+        .success,
+    ).toBe(false);
+  });
+
+  it('requires a positive expiry and interval', () => {
+    expect(AttachDeviceGrant.safeParse({ ...grant, expiresIn: 0 }).success).toBe(false);
+    expect(AttachDeviceGrant.safeParse({ ...grant, interval: -1 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## What this is

Attaching a machine today means ferrying two artifacts by hand: a user mints a
key in a browser, copies the plaintext out of a one-time reveal, and pastes it
into a terminal prompt on the machine being attached.

These are the shapes for doing it without the copy — the Device Authorization
Grant's, chosen because the terminal that wants a credential cannot receive a
browser redirect. It needs no local listener, so nothing here opens a socket,
and it works over SSH and on headless machines where the printed code completes
on any browser.

**Contracts only.** Two request bodies, the grant a deployment answers with, and
the five states a poll can return. Nothing sends anything yet — no client
method, no CLI command, no new egress path.

## Decisions worth reviewing

**Everything is capped and charset-constrained, in both directions.** Both
endpoints are unauthenticated, because the caller has no credential yet — that
is the point — so every device-supplied field is length-capped, and so is every
field a deployment sends back. This flow prints more server-authored text into a
terminal than any other in the tree (a code, a URL, a refusal message), and it
does so *before* the client has established which deployment it is talking to.
That is the reasoning already on `PluginWhoami`, applied where it bites harder.

**The poll answer is a plain union with an unknown-status member last, not a
discriminated union.** A deployment that adds a sixth state must not turn an
older client's poll into a parse error: the client's rule is to keep waiting for
a status it does not recognise, and it can only do that if the parse succeeded.

Order is load-bearing, and it buys a second property — safe degradation. An
`issued` body carrying no key fails the issued member and lands on the catch-all
as an unrecognised status, so a client **waits** instead of attaching with
nothing. There is no parse that yields "issued" with no credential.

**The issued member carries no `.meta({ id })`.** Same rule as
`AttachedCredential` at the top of that file and for the same reason: an id
registers the shape in Zod's global registry, and a consumer walking that
registry publishes every entry it finds. This one holds a bearer credential.
Pinned by a test rather than left to a comment.

**`deviceId` is client-minted and losable on purpose.** It exists so a machine
that attaches twice ends up with one record and one live credential rather than
two of each. A wiped state file produces a new id and the deployment sees a new
machine — harmless precisely because the id is not the identity; the credential
is. Deliberately not a hardware fingerprint: nothing here should be a value a
device could be tracked by across organizations.

## Tests

37 cases over the new shapes: the charset guard refusing control characters in
anything a terminal will print, the length caps, the unknown-status leniency,
the catch-all ordering (a known state still parses as itself), the
keyless-issued degradation, and the registry absence.

Test sources carry no literal control bytes — the escape-sequence cases spell
them as JavaScript unicode escapes, so the file exercises the guard without
containing what it tests for.

## Verification

Full workspace suite green (41/41 packages), plus typecheck, lint and Prettier.

## What comes next

The client method and an interactive `aka attach` are a follow-up on this
branch's contract; the server that answers these two endpoints is being built
separately and does not ship in this repo.
