### PR TITLE
feat(persistence): derive a capture's wire id from the row it is stored in

### DIFF
--- a/packages/persistence/src/ids.ts
+++ b/packages/persistence/src/ids.ts
@@ -163,19 +163,37 @@ function uuidFromDigest(digest: string): string {
 // renderings of ONE identity, and this is the function that makes them so.
 //
 // It replaces a `randomUUID()` minted per capture and then discarded, which had
-// three consequences worth stating because each is a bug the derivation removes:
+// two consequences worth stating because each is a bug the derivation removes:
 //
 //  1. A stored capture could not be matched to what was sent, because the wire
 //     id was never persisted. There was no id to mark delivered.
 //  2. A capture rebuilt from its row would be sent under a NEW id every attempt,
 //     so the receiver's id-dedup could not suppress a retry — the one mechanism
 //     that makes redelivery safe.
-//  3. Avoiding (2) meant reaching for content-hash dedup, which collapses
-//     genuinely distinct byte-identical prompts. Both belong on a timeline.
+//
+// What it does NOT do is keep byte-identical captures apart, and reading it that
+// way is the mistake to avoid. The tuple carries no timestamp and no nonce, so
+// identical content in one session at one path is ONE capture BY DEFINITION OF
+// THE KEY — and that is the point rather than a concession: `recordCapture` keys
+// the row on the same tuple with INSERT OR IGNORE, so the local timeline has
+// shown one for as long as this key has existed. Deriving the wire id from that
+// same tuple makes the wire AGREE with the store instead of diverging from it,
+// which is the property actually being bought — an id that means the same thing
+// on both sides. What the scoping adds is where the collapse STOPS: identical
+// content in two different sessions, or at two different paths, stays two
+// captures, which dedup on `contentHash` alone would not have preserved.
+//
+// One live-path behaviour changes with it, named here rather than left to be
+// discovered: a repeated identical prompt — `yes`, `continue`, `run the tests`,
+// the ordinary shape of a session — used to reach a deployment as two random-id
+// events, and now arrives as one. That matches what the local store has always
+// shown for it, which is why it is the correct outcome and not a lost capture.
 //
 // Callers must pass the SAME tuple `captureId` receives for that capture. The
-// two are derived from one digest here so that stays true by construction; the
-// round-trip is pinned by `capture wire id` in test/ids.test.ts.
+// two are derived from one digest here so that stays true by construction;
+// pinned by `is the SAME digest captureId returns, only re-rendered` in
+// test/ids.test.ts, and across the seam by `derives the id from the tuple the
+// local row is keyed on` in plugin-sdk's test/build-ingest-event.test.ts.
 export function captureWireId(
   sessionId: string | null,
   contentHash: string,

--- a/packages/persistence/src/ids.ts
+++ b/packages/persistence/src/ids.ts
@@ -140,6 +140,50 @@ export function captureId(
   );
 }
 
+// Renders 16 bytes of a hex digest as a UUIDv8 (RFC 9562 §5.8 — the version
+// reserved for custom, non-random layouts, which is exactly what a digest is).
+// The version and variant nibbles are overwritten rather than appended: a UUID
+// carries them at fixed positions, so a raw digest slice is NOT a valid UUID and
+// a validator that checks either field would reject it.
+function uuidFromDigest(digest: string): string {
+  const h = digest.slice(0, 32);
+  // Version 8 — says "derived, not random" to anyone reading the id.
+  const version = '8';
+  // Variant 10xx: keep the low two bits of the nibble, force the high two.
+  const variant = ((Number.parseInt(h.charAt(16), 16) & 0b0011) | 0b1000).toString(16);
+  // charAt/slice rather than indexing: an indexed read is `string | undefined`
+  // here, and neither escape from that (`!` or `as string`) is allowed by lint.
+  const b = h.slice(0, 12) + version + h.slice(13, 16) + variant + h.slice(17, 32);
+  return `${b.slice(0, 8)}-${b.slice(8, 12)}-${b.slice(12, 16)}-${b.slice(16, 20)}-${b.slice(20, 32)}`;
+}
+
+// The id a capture is SENT under, derived from the identity `captureId` already
+// keys its row on. Two ids for one capture is not duplication — the local row is
+// keyed by a 64-hex digest and the wire needs a `guid` — but they must be two
+// renderings of ONE identity, and this is the function that makes them so.
+//
+// It replaces a `randomUUID()` minted per capture and then discarded, which had
+// three consequences worth stating because each is a bug the derivation removes:
+//
+//  1. A stored capture could not be matched to what was sent, because the wire
+//     id was never persisted. There was no id to mark delivered.
+//  2. A capture rebuilt from its row would be sent under a NEW id every attempt,
+//     so the receiver's id-dedup could not suppress a retry — the one mechanism
+//     that makes redelivery safe.
+//  3. Avoiding (2) meant reaching for content-hash dedup, which collapses
+//     genuinely distinct byte-identical prompts. Both belong on a timeline.
+//
+// Callers must pass the SAME tuple `captureId` receives for that capture. The
+// two are derived from one digest here so that stays true by construction; the
+// round-trip is pinned by `capture wire id` in test/ids.test.ts.
+export function captureWireId(
+  sessionId: string | null,
+  contentHash: string,
+  filePath: string | null = null,
+): string {
+  return uuidFromDigest(captureId(sessionId, contentHash, filePath));
+}
+
 // Data Shares dimensions — id derivations for share destinations,
 // endpoints, and call-sites. Structurally stable (fixed prefixes, fixed
 // canonicalIdentity join order) so a future local-store egress scan derives

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -38,6 +38,7 @@ export type { LocalHistoryPreview } from './history-preview.ts';
 export { readLocalHistoryPreview } from './history-preview.ts';
 export {
   captureId,
+  captureWireId,
   classifiedDataId,
   inspectionDefinitionId,
   inspectionFindingId,

--- a/packages/persistence/test/ids.test.ts
+++ b/packages/persistence/test/ids.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   captureId,
+  captureWireId,
   classifiedDataId,
   inspectionDefinitionId,
   inspectionFindingId,
@@ -200,6 +201,54 @@ describe('shareEndpointId / shareCallSiteId', () => {
   it('shareCallSiteId is stable for the golden vector', () => {
     expect(shareCallSiteId('endpoint_abc', 'payments-api', 'src/lib/telemetry.ts', 42)).toBe(
       '40015cd85d9d172866157ec2c1c5414d90c29fedaf2a33468c0ba63704cf506c',
+    );
+  });
+});
+
+// `captureWireId` is the same identity as `captureId`, rendered as a UUID because
+// that is what `Event.id` accepts. The pair exists so a stored capture can
+// reproduce the id it was sent under — the property that makes redelivery
+// idempotent instead of duplicating the row on every retry.
+describe('captureWireId (the same identity as captureId, rendered as a guid)', () => {
+  it('is stable for the same (session, contentHash, path)', () => {
+    const id = captureWireId('sess_abc123', 'contenthash123');
+    expect(id).toBe('812cee34-ea16-843f-934a-565757076697');
+    expect(captureWireId('sess_abc123', 'contenthash123')).toBe(id);
+  });
+
+  it('is the SAME digest captureId returns, only re-rendered', () => {
+    // The invariant the whole design rests on. If these ever diverge, a drained
+    // capture is sent under an id its own row cannot derive, and delivery can no
+    // longer be recorded against it.
+    const digest = captureId('sess_abc123', 'contenthash123', 'src/a.ts');
+    const wire = captureWireId('sess_abc123', 'contenthash123', 'src/a.ts');
+    const flat = wire.replaceAll('-', '');
+    // Every nibble except the two the UUID format claims (version at 12,
+    // variant at 16) is carried across untouched.
+    for (let i = 0; i < 32; i += 1) {
+      if (i === 12 || i === 16) continue;
+      expect(flat.charAt(i)).toBe(digest.charAt(i));
+    }
+  });
+
+  it('sets the version and variant nibbles a UUID validator checks', () => {
+    const flat = captureWireId('sess_abc123', 'contenthash123').replaceAll('-', '');
+    // Version 8: derived, not random (RFC 9562 §5.8).
+    expect(flat[12]).toBe('8');
+    // Variant 10xx — the high two bits forced, the low two preserved.
+    expect(Number.parseInt(flat.charAt(16), 16) & 0b1100).toBe(0b1000);
+  });
+
+  it('distinguishes every component captureId distinguishes', () => {
+    expect(captureWireId(null, 'contenthash123')).toBe('68787b92-f533-8d97-854b-e0f5f56d043b');
+    expect(captureWireId('sess_abc123', 'contenthash456')).toBe(
+      '7a7a1bc5-f2bc-89f5-8615-aa418669072a',
+    );
+    expect(captureWireId('sess_abc123', 'contenthash123', 'src/a.ts')).toBe(
+      '90eef03a-6239-877d-b1c3-6f3b74b3f253',
+    );
+    expect(captureWireId('sess_abc123', 'contenthash123', 'src/a.ts')).not.toBe(
+      captureWireId('sess_abc123', 'contenthash123', 'src/b.ts'),
     );
   });
 });

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -63,6 +63,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'bindingInput',
   'capWarnEraEnforcementOnce',
   'captureId',
+  'captureWireId',
   'classifiedDataId',
   'clearAttachmentDerivedState',
   'compareBinaryVersions',

--- a/packages/plugin-sdk/src/events.ts
+++ b/packages/plugin-sdk/src/events.ts
@@ -1,5 +1,6 @@
 import { createHash, randomUUID } from 'node:crypto';
 
+import { captureWireId } from '@akasecurity/persistence';
 import type { EventKind, EventMetadata, IngestEvent, SourceTool } from '@akasecurity/schema';
 
 export interface BuildEventInput {
@@ -26,13 +27,30 @@ export function contentHashOf(text: string): string {
 
 // One place to construct a schema-valid IngestEvent so adapters never
 // hand-roll ids, timestamps, or hashes.
+//
+// `id` is DERIVED from (sessionId, contentHash, filePath) — the same tuple the
+// stored row is keyed on — and not random. That is what lets an undelivered
+// capture be retried: the row can reproduce the id it was sent under, so the
+// receiver's id-dedup recognises the retry instead of writing a second copy.
+// A random id would be unreproducible from the row and duplicate on every
+// attempt. See `captureWireId` for the full rationale.
+//
+// The tuple must match what the local write derives its row id from
+// (`recordCapture` → `captureId`), so the fields are read from `input.metadata`
+// exactly as that path reads them from `event.metadata`. `correlationId` stays
+// random: it identifies the REQUEST that produced the capture, not the capture.
 export function buildIngestEvent(input: BuildEventInput): IngestEvent {
+  const contentHash = input.contentHash ?? contentHashOf(input.content);
   return {
-    id: randomUUID(),
+    id: captureWireId(
+      input.metadata?.sessionId ?? null,
+      contentHash,
+      input.metadata?.filePath ?? null,
+    ),
     sourceTool: input.sourceTool,
     kind: input.kind,
     occurredAt: input.occurredAt ?? new Date().toISOString(),
-    contentHash: input.contentHash ?? contentHashOf(input.content),
+    contentHash,
     content: input.content,
     // Stamp a per-capture correlation id so a recorded event can be tied back to
     // its origin once synced — the lightweight plugin "trace propagation" (no OTel

--- a/packages/plugin-sdk/test/build-ingest-event.test.ts
+++ b/packages/plugin-sdk/test/build-ingest-event.test.ts
@@ -1,0 +1,84 @@
+import { captureId, captureWireId } from '@akasecurity/persistence';
+import { IngestEvent } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { buildIngestEvent, contentHashOf } from '../src/events.ts';
+
+// `buildIngestEvent` mints the id a capture is SENT under. It used to be a
+// `randomUUID()` that was discarded, which meant a stored capture could never be
+// matched to what was sent. It is now derived from the same tuple the stored row
+// is keyed on, so the row can always reproduce it.
+describe('buildIngestEvent — a derived, reproducible capture id', () => {
+  const base = {
+    kind: 'prompt',
+    sourceTool: 'claude-code',
+    content: 'hello world',
+  } as const;
+
+  it('mints an id the Event schema accepts', () => {
+    // The acceptance criterion for the derivation: `Event.id` is `z.guid()`, so a
+    // raw 64-hex digest would be rejected outright. This is what forces the UUID
+    // rendering rather than sending captureId itself.
+    const event = buildIngestEvent({ ...base, metadata: { sessionId: 'sess_1' } });
+    expect(() => IngestEvent.parse(event)).not.toThrow();
+  });
+
+  it('derives the same id for the same capture, twice', () => {
+    const input = { ...base, metadata: { sessionId: 'sess_1', filePath: 'src/a.ts' } };
+    // occurredAt and correlationId differ between these two calls; the id must not.
+    expect(buildIngestEvent(input).id).toBe(buildIngestEvent(input).id);
+  });
+
+  it('derives the id from the tuple the local row is keyed on', () => {
+    // The join that makes delivery recordable: given a stored row, re-deriving
+    // this id must land on the id the deployment was given. Both directions are
+    // spelled out here because a change to either side breaks retry idempotency
+    // silently — the send still succeeds, it just writes a second copy.
+    const hash = contentHashOf('hello world');
+    const event = buildIngestEvent({
+      ...base,
+      metadata: { sessionId: 'sess_1', filePath: 'src/a.ts' },
+    });
+    expect(event.contentHash).toBe(hash);
+    expect(event.id).toBe(captureWireId('sess_1', hash, 'src/a.ts'));
+    // …and that wire id is a rendering of the row's own key, not a parallel space.
+    expect(event.id.replaceAll('-', '').slice(0, 12)).toBe(
+      captureId('sess_1', hash, 'src/a.ts').slice(0, 12),
+    );
+  });
+
+  it('honours a caller-supplied contentHash, so a redacted copy still derives the original id', () => {
+    // Secrets-at-rest: `content` is the masked copy but `contentHash` is the hash
+    // of the ORIGINAL. The id must follow the hash, or a redacted capture and its
+    // unredacted twin would occupy different ids on the wire while sharing a row.
+    const original = contentHashOf('my-secret-value');
+    const event = buildIngestEvent({
+      ...base,
+      content: '***masked***',
+      contentHash: original,
+      metadata: { sessionId: 'sess_1' },
+    });
+    expect(event.id).toBe(captureWireId('sess_1', original, null));
+  });
+
+  it('separates captures that the row-level key separates', () => {
+    const mk = (metadata: Record<string, string>) => buildIngestEvent({ ...base, metadata }).id;
+    const inSession = mk({ sessionId: 'sess_1' });
+    expect(inSession).not.toBe(mk({ sessionId: 'sess_2' }));
+    expect(inSession).not.toBe(mk({ sessionId: 'sess_1', filePath: 'src/a.ts' }));
+    expect(mk({ sessionId: 'sess_1', filePath: 'src/a.ts' })).not.toBe(
+      mk({ sessionId: 'sess_1', filePath: 'src/b.ts' }),
+    );
+    // A session-less capture folds onto the sentinel rather than shortening the join.
+    expect(buildIngestEvent(base).id).toBe(captureWireId(null, contentHashOf(base.content), null));
+  });
+
+  it('keeps correlationId random — it identifies the request, not the capture', () => {
+    // Deriving this one too would collapse two separate requests that happened to
+    // carry identical text onto one correlation, losing the origin link.
+    const input = { ...base, metadata: { sessionId: 'sess_1' } };
+    expect(buildIngestEvent(input).metadata?.correlationId).not.toBe(
+      buildIngestEvent(input).metadata?.correlationId,
+    );
+  });
+});


### PR DESCRIPTION
First of six units toward letting the plugin **queue telemetry it cannot send and drain it later** instead of dropping it. This one is the unlock: without a reproducible id there is nothing to record delivery against.

## The problem

A capture is written locally under `captureId` — `sha256(session, contentHash, filePath)` — and sent under an id `buildIngestEvent` minted with `randomUUID()` and immediately discarded. The two spaces are disjoint by *format* as well as by value (64-hex vs a guid), and the wire id is persisted nowhere: not as a column, not in the attributes bag.

That costs nothing while an undelivered capture is dropped. It becomes three separate defects the moment one is meant to be retried:

1. **No id to stamp.** Delivery is recorded as `UPDATE … WHERE id = :id`, and neither id identifies the other side's row.
2. **Retries duplicate.** A capture rebuilt from its row would go out under a fresh id on every attempt, so id-dedup on the receiving side cannot recognise it as a retry — the one mechanism that makes redelivery safe.
3. **The obvious workaround loses data.** Reaching for content-hash dedup instead collapses genuinely distinct byte-identical prompts. Two identical prompts are two events and both belong on the timeline; the schema comment already says so.

## The change

`captureWireId` renders the digest `captureId` **already computes** as a UUIDv8 — the version reserved for non-random layouts. Same identity, two renderings, defined in one function so they cannot drift. `Event.id` is a `guid`, which is what forces a rendering rather than sending the digest itself.

`correlationId` stays random on purpose: it identifies the *request* that produced a capture, not the capture. Deriving it would collapse two separate requests that happened to carry identical text.

## What it does not do

**No local migration.** `captureId` is unchanged, so no stored row is re-keyed and no store needs to be rewritten.

**One-time id-space transition.** Captures already delivered under random ids will not match their derived ids. Bounded, and visible only as a duplicate timeline entry.

## Verification

New: 6 cases in `plugin-sdk/test/build-ingest-event.test.ts`, 4 in `persistence/test/ids.test.ts`. The load-bearing ones:

- the derived id **parses as `IngestEvent`** — the acceptance criterion, since a raw digest would be rejected
- every nibble except the version and variant positions is carried across from `captureId`'s digest unchanged
- a caller-supplied `contentHash` (the secrets-at-rest path, where `content` is masked but the hash is of the original) still derives the id of the original
- `correlationId` still differs between two builds of the same input

Full run: persistence 1382 passed, plugin-sdk 493 passed, `test:oss` 41/41 tasks, lint and typecheck clean.
