### PR TITLE
feat(persistence): give the ledger a claim column and a state that partitions

### DIFF
--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -968,6 +968,28 @@ function ensureSyncedAtColumn(db: DatabaseSync, table: 'audit_events'): void {
     `CREATE INDEX IF NOT EXISTS idx_audit_events_sync
        ON audit_events (event_type, synced_at, sync_claimed_at, started_at)`,
   );
+  // The stale-claim sweep cannot use the index above: that one leads with
+  // `event_type`, and the sweep's predicate never mentions it, so the planner
+  // has nothing to seek on and falls back to `SCAN audit_events` — a full pass
+  // over the most numerous table in the store, taken while holding the write
+  // lock. This is the index it can seek.
+  //
+  // PARTIAL, and that is the whole point of it rather than a refinement. The
+  // plan is the same either way — a plain index on the column also turns the
+  // sweep into a SEARCH — so what separates them is size and write cost, and
+  // there SQLite indexes NULL keys like any other: over 100k rows with the
+  // column unset throughout, a plain index costs 213 pages and this one costs 1.
+  // Claimed rows exist a batch at a time, so it stays that few entries wide
+  // however large the store gets, and the writes that never touch the column —
+  // which is nearly all of them — do not maintain it at all.
+  //
+  // Pinned in the ledger's tests for the same reason the index above is: the
+  // predicate and the index have to keep agreeing, and nothing says so out loud
+  // when they stop.
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_audit_claimed
+       ON audit_events (sync_claimed_at) WHERE sync_claimed_at IS NOT NULL`,
+  );
 }
 
 // Worktree-scan bookkeeping: which files the scanner has already run under which

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -928,10 +928,10 @@ export function isForeignSqliteLineage(db: DatabaseSync): boolean {
   return columnNames(db, 'events').includes('tenant_id');
 }
 
-// `synced_at` is an additive, plugin-local bookkeeping column that existing
-// stores already carry; installing it here (outside the append-only canonical
-// migrations) keeps every store column-compatible regardless of which release
-// created it. Guarded by table_info so it is applied exactly once per table,
+// `synced_at` and `sync_claimed_at` are additive, plugin-local bookkeeping
+// columns that existing stores already carry; installing them here (outside the
+// append-only canonical migrations) keeps every store column-compatible
+// regardless of which release created it. Guarded by table_info so it is applied exactly once per table,
 // idempotently. Also probes the TABLE itself first: columnNames() returns an
 // empty list for a table that doesn't exist, so a column-only guard would
 // read that as "no columns yet" and still run the ALTER TABLE below — which
@@ -941,9 +941,33 @@ export function isForeignSqliteLineage(db: DatabaseSync): boolean {
 // reads as absent here rather than as a column-less table.
 function ensureSyncedAtColumn(db: DatabaseSync, table: 'audit_events'): void {
   if (!schemaObjectExists(db, 'table', table)) return;
-  if (!columnNames(db, table).includes('synced_at')) {
+  const columns = columnNames(db, table);
+  if (!columns.includes('synced_at')) {
     db.exec(`ALTER TABLE ${table} ADD COLUMN synced_at integer`);
   }
+  // `sync_claimed_at` is the same kind of column and arrives the same way: set
+  // when a row is claimed for sending, cleared when it settles. It exists
+  // because `synced_at` alone cannot say "being sent right now" — it holds NULL,
+  // a delivery time, or the skip sentinel, and a fourth value in that column
+  // would collide with the `> 0` and `= -1` predicates the ledger already reads.
+  if (!columns.includes('sync_claimed_at')) {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN sync_claimed_at integer`);
+  }
+  // For the DELIVERY-STATE read specifically. That one aggregates over every row
+  // of the tracked types on each call — a surface showing it re-runs it per
+  // render — and `audit_events` is the table captures land in, the numerous
+  // grain. With all four columns present the planner answers it from the index
+  // alone (a covering index, no table access), which is what this exists for.
+  //
+  // The drain's own reads are NOT the reason for it: they bound on started_at
+  // directly after event_type, and `idx_audit_type_t` already puts those two
+  // adjacent, so the planner prefers it and is right to. Both plans are pinned
+  // in the ledger's tests, because a column order that stops working stops
+  // working silently.
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_audit_events_sync
+       ON audit_events (event_type, synced_at, sync_claimed_at, started_at)`,
+  );
 }
 
 // Worktree-scan bookkeeping: which files the scanner has already run under which

--- a/packages/persistence/src/repositories/history-sync.ts
+++ b/packages/persistence/src/repositories/history-sync.ts
@@ -28,6 +28,28 @@ export interface HistorySyncCounts {
 }
 
 /**
+ * Every tracked row, in exactly one delivery state.
+ *
+ * Distinct from `counts()`, which is the DRAIN's view and does not partition:
+ * its `pending` is bounded by the backlog boundary while `sent` and `skipped`
+ * are lifetime totals, so rows recorded after the boundary appear in none of
+ * the three and the numbers do not sum to anything. These four do sum to
+ * `total`, which is what a surface reporting delivery state needs.
+ *
+ * A caveat this cannot fix from here: a row the LIVE path delivered is NULL,
+ * because nothing on that path stamps. Until it does, `queued` over-counts on an
+ * attached machine by exactly the rows that were forwarded successfully. Read
+ * this only where that has been addressed.
+ */
+export interface HistorySyncPartition {
+  queued: number;
+  inProgress: number;
+  synced: number;
+  failed: number;
+  total: number;
+}
+
+/**
  * One stored detection, flattened across the finding and its rule definition.
  *
  * Shaped for the wire's ToolCallInspection but kept as a plain row: the span is
@@ -106,6 +128,10 @@ export class SqliteHistorySyncRepository {
   private readonly closeWindowStmt: StatementSync;
   private readonly releaseBoundaryStmt: StatementSync;
   private readonly freezeBoundaryStmt: StatementSync;
+  private readonly partitionStmt: StatementSync;
+  private readonly claimRowStmt: StatementSync;
+  private readonly releaseRowStmt: StatementSync;
+  private readonly releaseStaleClaimsStmt: StatementSync;
 
   constructor(private readonly db: DatabaseSync) {
     this.ensureRowStmt = db.prepare(`INSERT OR IGNORE INTO history_sync (id) VALUES (1)`);
@@ -138,7 +164,44 @@ export class SqliteHistorySyncRepository {
         LIMIT :limit`,
     );
 
-    this.stampStmt = db.prepare(`UPDATE audit_events SET synced_at = :at WHERE id = :id`);
+    // Settling clears the claim in the same statement. A row that has a
+    // delivery time and still reads as claimed would show up in two states at
+    // once, and the pair is only ever written together.
+    this.stampStmt = db.prepare(
+      `UPDATE audit_events SET synced_at = :at, sync_claimed_at = NULL WHERE id = :id`,
+    );
+
+    // Claim only what is still unsent: a row that settled between the read and
+    // this write must not be dragged back into the in-flight state.
+    this.claimRowStmt = db.prepare(
+      `UPDATE audit_events SET sync_claimed_at = :at WHERE id = :id AND synced_at IS NULL`,
+    );
+    this.releaseRowStmt = db.prepare(
+      `UPDATE audit_events SET sync_claimed_at = NULL WHERE id = :id`,
+    );
+    // A drain killed mid-batch leaves rows claimed for ever, and a claim that is
+    // never cleared reads as "sending" indefinitely. Nothing recovers it on its
+    // own — the claim is per-row bookkeeping, not the lease — so a caller sweeps
+    // stale ones the same way the lease treats a stale heartbeat.
+    this.releaseStaleClaimsStmt = db.prepare(
+      `UPDATE audit_events SET sync_claimed_at = NULL
+        WHERE sync_claimed_at IS NOT NULL AND sync_claimed_at < :staleBefore`,
+    );
+
+    // The four states are written to be EXHAUSTIVE, so they always sum to
+    // total. `failed` is `IS NOT NULL AND <= 0` rather than `= -1` for that
+    // reason: the ledger only ever writes -1 there, but a row is better counted
+    // as failed than silently missing from a rendered breakdown.
+    this.partitionStmt = db.prepare(
+      `SELECT
+         SUM(CASE WHEN synced_at IS NULL AND sync_claimed_at IS NULL THEN 1 ELSE 0 END) AS queued,
+         SUM(CASE WHEN synced_at IS NULL AND sync_claimed_at IS NOT NULL THEN 1 ELSE 0 END) AS inProgress,
+         SUM(CASE WHEN synced_at > 0 THEN 1 ELSE 0 END) AS synced,
+         SUM(CASE WHEN synced_at IS NOT NULL AND synced_at <= 0 THEN 1 ELSE 0 END) AS failed,
+         COUNT(*) AS total
+       FROM audit_events
+       WHERE event_type IN (${TYPE_LIST})`,
+    );
 
     this.countsStmt = db.prepare(
       `SELECT
@@ -277,6 +340,17 @@ export class SqliteHistorySyncRepository {
     this.stampAll(ids, SKIPPED);
   }
 
+  private eachInTransaction(ids: readonly string[], run: (id: string) => void): void {
+    if (ids.length === 0) return;
+    withTransaction(
+      this.db,
+      () => {
+        for (const id of ids) run(id);
+      },
+      'IMMEDIATE',
+    );
+  }
+
   private stampAll(ids: readonly string[], value: number): void {
     if (ids.length === 0) return;
     // One short IMMEDIATE transaction: the write lock is taken up front rather
@@ -289,6 +363,53 @@ export class SqliteHistorySyncRepository {
       },
       'IMMEDIATE',
     );
+  }
+
+  /**
+   * Claim rows as in-flight.
+   *
+   * Advisory in exactly the sense the lease is: it records that a send is in
+   * progress so a surface can say so, and a lost claim costs a row showing as
+   * queued while it is actually being sent. It is not exclusion — the far side
+   * settles a duplicate on the row id.
+   */
+  claimRows(ids: readonly string[], atMs: number): void {
+    this.eachInTransaction(ids, (id) => this.claimRowStmt.run({ at: atMs, id }));
+  }
+
+  /** Give back a claim without settling — the send failed, the row is queued again. */
+  releaseRows(ids: readonly string[]): void {
+    this.eachInTransaction(ids, (id) => this.releaseRowStmt.run({ id }));
+  }
+
+  /**
+   * Clear claims older than `staleBefore`, and report how many were cleared.
+   *
+   * A process killed between claiming and settling leaves rows claimed with
+   * nothing left to settle them. Without this they read as "sending" for ever.
+   */
+  releaseStaleClaims(staleBefore: number): number {
+    return Number(this.releaseStaleClaimsStmt.run({ staleBefore }).changes);
+  }
+
+  /**
+   * Every tracked row in exactly one delivery state.
+   *
+   * Takes no boundary on purpose. The boundary answers "what should the drain
+   * pick up now", which is a different question from "what state is this row
+   * in" — and a machine that has never attached has no boundary to pass, so
+   * requiring one would force a caller to invent one and report the whole store
+   * as queued.
+   */
+  partition(): HistorySyncPartition {
+    const row = getRow<Record<keyof HistorySyncPartition, number | null>>(this.partitionStmt, {});
+    return {
+      queued: row?.queued ?? 0,
+      inProgress: row?.inProgress ?? 0,
+      synced: row?.synced ?? 0,
+      failed: row?.failed ?? 0,
+      total: row?.total ?? 0,
+    };
   }
 
   /** `pending` counts only what is inside the backlog; sent and skipped are totals. */

--- a/packages/persistence/test/repositories/history-sync.test.ts
+++ b/packages/persistence/test/repositories/history-sync.test.ts
@@ -362,3 +362,137 @@ describe('SqliteHistorySyncRepository — closing the attached period', () => {
     expect(db.historySync.pendingSessions(10, ALL)).toEqual(['s-before']);
   });
 });
+
+// The delivery-state partition backs a surface that reports what has been sent,
+// what is going out now, and what is still waiting. It is a different read from
+// `counts()` — that one serves the drain and deliberately does not partition.
+describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
+  it('puts every tracked row in exactly one state', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    // Three structural rows per session; the capture leaf is not tracked yet.
+    const p = db.historySync.partition();
+    expect(p.total).toBe(3);
+    expect(p.queued + p.inProgress + p.synced + p.failed).toBe(p.total);
+    expect(p).toMatchObject({ queued: 3, inProgress: 0, synced: 0, failed: 0 });
+  });
+
+  it('moves a row through claimed, then settled', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.claimRows(['s-1'], T0 + MINUTE);
+    expect(db.historySync.partition()).toMatchObject({ queued: 2, inProgress: 1, synced: 0 });
+
+    db.historySync.markSynced(['s-1'], T0 + 2 * MINUTE);
+    // Settling clears the claim in the same write, so the row cannot read as
+    // both delivered and in flight.
+    expect(db.historySync.partition()).toMatchObject({ queued: 2, inProgress: 0, synced: 1 });
+  });
+
+  it('returns a claim to the queue when a send fails', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.claimRows(['s-1', 's-1-llm'], T0);
+    expect(db.historySync.partition().inProgress).toBe(2);
+
+    db.historySync.releaseRows(['s-1', 's-1-llm']);
+    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 0 });
+  });
+
+  it('never claims a row that already settled', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.markSynced(['s-1'], T0 + MINUTE);
+    // A claim racing a settle must not drag a delivered row back into flight.
+    db.historySync.claimRows(['s-1'], T0 + 2 * MINUTE);
+    expect(db.historySync.partition()).toMatchObject({ synced: 1, inProgress: 0, queued: 2 });
+  });
+
+  it('counts a permanent skip as failed, not as queued', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.markSkipped(['s-1-llm']);
+    const p = db.historySync.partition();
+    expect(p).toMatchObject({ queued: 2, failed: 1 });
+    expect(p.queued + p.inProgress + p.synced + p.failed).toBe(p.total);
+  });
+
+  it('sweeps a claim a dead drain left behind', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.claimRows(['s-1'], T0);
+    // Nothing settles it — the process holding it is gone.
+    expect(db.historySync.partition().inProgress).toBe(1);
+
+    expect(db.historySync.releaseStaleClaims(T0 + MINUTE)).toBe(1);
+    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 0 });
+    // A fresh claim is left alone.
+    db.historySync.claimRows(['s-1'], T0 + 10 * MINUTE);
+    expect(db.historySync.releaseStaleClaims(T0 + MINUTE)).toBe(0);
+    expect(db.historySync.partition().inProgress).toBe(1);
+  });
+
+  it('reports zeros on an empty store rather than nulls', () => {
+    const db = store.open();
+    // SUM() over no rows is NULL; a rendered breakdown must not receive one.
+    expect(db.historySync.partition()).toEqual({
+      queued: 0,
+      inProgress: 0,
+      synced: 0,
+      failed: 0,
+      total: 0,
+    });
+  });
+
+  it('does not yet count captures — the lane has not been widened', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    // seedSession writes a prompt row too. Until the drain can carry content
+    // safely, it is not part of the tracked set and must not appear here.
+    expect(db.historySync.partition().total).toBe(3);
+  });
+});
+
+// The ledger's reads used to scan `audit_events` — the table captures land in.
+// The comment on idx_audit_events_sync claims the index serves them; these pin
+// that claim, because a comment cannot notice when a column order stops working.
+describe('SqliteHistorySyncRepository — the ledger reads use the index', () => {
+  const planFor = (sql: string): string =>
+    store
+      .openRaw()
+      .prepare(`EXPLAIN QUERY PLAN ${sql}`)
+      .all()
+      .map((r) => (r as { detail: string }).detail)
+      .join(' | ');
+
+  it('answers the delivery-state partition from the index alone', () => {
+    store.open();
+    const plan = planFor(
+      `SELECT SUM(CASE WHEN synced_at IS NULL AND sync_claimed_at IS NULL THEN 1 ELSE 0 END)
+         FROM audit_events WHERE event_type IN ('session', 'llm_call', 'tool_call')`,
+    );
+    // COVERING is the property that matters: this read runs on every render of a
+    // surface that shows it, and without the index it is a full table scan.
+    expect(plan).toContain('idx_audit_events_sync');
+    expect(plan).toContain('COVERING INDEX');
+    expect(plan).not.toContain('SCAN audit_events');
+  });
+
+  it('finds pending sessions on the index that bounds started_at, not the new one', () => {
+    store.open();
+    const plan = planFor(
+      `SELECT COALESCE(root_session_id, id) AS sessionId, MIN(started_at)
+         FROM audit_events
+        WHERE synced_at IS NULL AND event_type IN ('session', 'llm_call', 'tool_call')
+          AND started_at < 9
+        GROUP BY sessionId`,
+    );
+    // The drain's read prefers idx_audit_type_t, which puts started_at directly
+    // after event_type; idx_audit_events_sync has the two sync columns in
+    // between, so it cannot seek the range as tightly. Asserted rather than
+    // assumed: the point is that this read is served by SOME index, and which
+    // one is a planner decision worth noticing if it changes.
+    expect(plan).toContain('idx_audit_type_t');
+    expect(plan).not.toContain('SCAN audit_events');
+  });
+});

--- a/packages/persistence/test/repositories/history-sync.test.ts
+++ b/packages/persistence/test/repositories/history-sync.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import type { LocalDatabase } from '../../src/database.ts';
+import { SqliteHistorySyncRepository } from '../../src/repositories/history-sync.ts';
+import type { RecordedQuery } from '../helpers/query-plans.ts';
+import { explain, recordingConnection } from '../helpers/query-plans.ts';
 import { useTempStore } from '../helpers/temp-store.ts';
 
 const store = useTempStore('aka-history-sync-');
@@ -454,23 +457,34 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
 });
 
 // The ledger's reads used to scan `audit_events` — the table captures land in.
-// The comment on idx_audit_events_sync claims the index serves them; these pin
-// that claim, because a comment cannot notice when a column order stops working.
+// The comments on idx_audit_events_sync and idx_audit_claimed claim the indexes
+// serve them; these pin that claim, because a comment cannot notice when a
+// column order stops working.
+//
+// THE SQL IS TAKEN FROM THE REPOSITORY AS IT EXECUTES, never restated here.
+// `recordingConnection` captures the statement and the parameters each call
+// really ran with (see test/helpers/query-plans.ts); a query spelled a second
+// time in this file would be free to drift from the one the ledger runs, and a
+// plan assertion over drifted SQL is the most convincing kind of green there
+// is — a real plan for a real query that nothing issues.
 describe('SqliteHistorySyncRepository — the ledger reads use the index', () => {
-  const planFor = (sql: string): string =>
-    store
-      .openRaw()
-      .prepare(`EXPLAIN QUERY PLAN ${sql}`)
-      .all()
-      .map((r) => (r as { detail: string }).detail)
-      .join(' | ');
+  /** The plans for every statement `drive` executes, as one string. */
+  const planFor = (drive: (ledger: SqliteHistorySyncRepository) => void): string => {
+    // Migrations run on `open()`; `openRaw` only attaches to the file.
+    store.open();
+    const raw = store.openRaw();
+    const recorded: RecordedQuery[] = [];
+    drive(new SqliteHistorySyncRepository(recordingConnection(raw, recorded)));
+    // Without this a read that stopped issuing SQL would satisfy every
+    // assertion below vacuously, and look exactly like one that was optimised.
+    expect(recorded.length, 'the driven read issued no statement').toBeGreaterThan(0);
+    // EXPLAIN goes through the RAW handle, so the recorder does not capture its
+    // own explains and recurse.
+    return recorded.flatMap((q) => explain(raw, q).map((row) => row.detail)).join(' | ');
+  };
 
   it('answers the delivery-state partition from the index alone', () => {
-    store.open();
-    const plan = planFor(
-      `SELECT SUM(CASE WHEN synced_at IS NULL AND sync_claimed_at IS NULL THEN 1 ELSE 0 END)
-         FROM audit_events WHERE event_type IN ('session', 'llm_call', 'tool_call')`,
-    );
+    const plan = planFor((ledger) => ledger.partition());
     // COVERING is the property that matters: this read runs on every render of a
     // surface that shows it, and without the index it is a full table scan.
     expect(plan).toContain('idx_audit_events_sync');
@@ -479,20 +493,27 @@ describe('SqliteHistorySyncRepository — the ledger reads use the index', () =>
   });
 
   it('finds pending sessions on the index that bounds started_at, not the new one', () => {
-    store.open();
-    const plan = planFor(
-      `SELECT COALESCE(root_session_id, id) AS sessionId, MIN(started_at)
-         FROM audit_events
-        WHERE synced_at IS NULL AND event_type IN ('session', 'llm_call', 'tool_call')
-          AND started_at < 9
-        GROUP BY sessionId`,
-    );
+    const plan = planFor((ledger) => ledger.pendingSessions(10, ALL));
     // The drain's read prefers idx_audit_type_t, which puts started_at directly
     // after event_type; idx_audit_events_sync has the two sync columns in
     // between, so it cannot seek the range as tightly. Asserted rather than
     // assumed: the point is that this read is served by SOME index, and which
     // one is a planner decision worth noticing if it changes.
     expect(plan).toContain('idx_audit_type_t');
+    expect(plan).not.toContain('SCAN audit_events');
+  });
+
+  // The one WRITE in this block, and the reason it needs its own index.
+  it('sweeps stale claims on the partial index, not by scanning the table', () => {
+    const plan = planFor((ledger) => {
+      ledger.releaseStaleClaims(T0 + MINUTE);
+    });
+    // idx_audit_events_sync cannot serve this: it leads with event_type, which
+    // this predicate does not mention, so the planner has nothing to seek on and
+    // falls back to a full pass over the table captures land in — taken while
+    // holding the write lock. idx_audit_claimed is the one it can seek.
+    expect(plan).toContain('idx_audit_claimed');
+    expect(plan).toContain('SEARCH');
     expect(plan).not.toContain('SCAN audit_events');
   });
 });


### PR DESCRIPTION
Second of six toward a durable outbox. Stacked on #363 — review that first; this PR's diff is only its own commit.

## Why a new column rather than a new `synced_at` value

`synced_at` holds NULL, a delivery time, or `-1`. None of those is *being sent right now*, and a fourth sentinel would collide with the `> 0` and `= -1` predicates the ledger already reads in `rearmStmt` and `countsStmt`. So the in-flight state gets `sync_claimed_at`, set on claim and cleared on settle — **in the same statement that stamps**, so a row can never read as both delivered and in flight.

## `partition()` is not `counts()`

`counts()` serves the drain and does **not** partition: `pending` is bounded by the backlog boundary while `sent` and `skipped` are lifetime totals, so rows recorded after the boundary are in none of the three. Rendering those three as one bar would be arithmetically wrong. `partition()` returns four states that sum to `total`, and a test asserts the sum.

Two decisions inside it:

- **It takes no boundary.** "What should the drain pick up now" is a different question from "what state is this row in" — and a machine that never attached has no boundary to pass, so requiring one would force a caller to invent one and report the entire store as queued.
- **`failed` is `IS NOT NULL AND <= 0`, not `= -1`.** The ledger only writes `-1`, but a row is better counted as failed than silently missing from a breakdown.

## The index, honestly

It exists for the partition — that read re-runs on every render of any surface showing it, over the table captures land in. It answers that query **covering**, with no table access.

It is **not** for the drain's own reads. Those bound on `started_at` immediately after `event_type`, and `idx_audit_type_t` already puts those adjacent, so the planner prefers it — correctly. I'd written a comment claiming otherwise; `EXPLAIN QUERY PLAN` disagreed, and the comment is now what's true. Both plans are asserted in tests, because a column order that stops working stops working silently.

## Known incompleteness, documented on the type

The live forward path still stamps nothing, so on an attached machine `queued` over-counts by exactly the rows that were forwarded successfully. That is the next unit's job. It's called out in the `HistorySyncPartition` doc comment rather than left for a reader to discover — and no surface renders this yet, so nothing misleading ships.

## Verification

9 new cases plus 2 query-plan assertions. Full: `test:oss` 41/41, enterprise 23/23, lint, typecheck, `check:oss-wall` clean over 1840 files.
