### PR TITLE
fix(installer): build the win32 zip fixture without PowerShell off Windows

### DIFF
--- a/tools/installer/test/helpers/release-fixture.test.ts
+++ b/tools/installer/test/helpers/release-fixture.test.ts
@@ -332,12 +332,12 @@ describe('the release fixture', () => {
     expect(magicOf(path).startsWith(GZIP)).toBe(true);
   });
 
-  // Skipped only where no PowerShell exists, since Compress-Archive is what
-  // writes a zip. Both hosted Linux and macOS runners ship `pwsh`, so this runs
-  // on all three CI legs rather than only the Windows one — which is the whole
-  // point: the platform that gets this wrong is the platform that is NOT
-  // Windows.
-  it.skipIf(PS === undefined)('writes a real zip for a win32 triple on any host', () => {
+  // No longer gated on a PowerShell, and that is a real widening rather than
+  // tidying: off Windows the zip is written by stored-zip.ts, so this runs on
+  // every host including one with no pwsh at all. The platform that gets a
+  // win32 fixture wrong is the platform that is NOT Windows, so the case that
+  // catches it should be the one that never skips.
+  it('writes a real zip for a win32 triple on any host', () => {
     const path = writeArchive(root, {
       version: FIXTURE_VERSION,
       triple: 'win32-x64',

--- a/tools/installer/test/helpers/release-fixture.ts
+++ b/tools/installer/test/helpers/release-fixture.ts
@@ -30,6 +30,7 @@ import { join } from 'node:path';
 
 import { removeTree } from '../../../../test/helpers/remove-tree.ts';
 import { powershellEnv, powershellExe } from './run-installer.ts';
+import { writeStoredZip } from './stored-zip.ts';
 
 /** A version no real release carries, so a fixture can never be mistaken for one. */
 export const FIXTURE_VERSION = '0.0.0-fixture';
@@ -325,6 +326,12 @@ export function writeArchive(
   // with it because the interpreter is resolved here: without it the wiring
   // could only be checked on a host that has PowerShell, i.e. not on the legs
   // where the retry branch would otherwise be dead code.
+  //
+  // Passing EITHER also selects the PowerShell builder whatever the host, and
+  // that is the same argument rather than a second one: off Windows the default
+  // is now Node (see stored-zip.ts), so without this the wiring assertion would
+  // stop reaching `compressArchive` on exactly the hosts it was widened to
+  // cover, and would keep passing while proving nothing.
   { exe: exeOverride, run }: { exe?: string; run?: CompressRunner } = {},
 ): string {
   const archivePath = join(intoDir, archiveNameFor(version, triple));
@@ -338,17 +345,27 @@ export function writeArchive(
     writeFileSync(join(root, 'payload.txt'), `${banner}\n`);
     if (triple.startsWith('win32')) {
       writeWindowsPayload(root, banner, runnable);
-      // Whatever PowerShell this host has, rather than `powershell` — which is
-      // Windows-only, while `Compress-Archive` ships with pwsh everywhere. The
-      // ps1 suite skips outright without one, so a caller that got here has one.
-      const exe = exeOverride ?? powershellExe();
-      if (exe === undefined) {
-        throw new Error(
-          `cannot build ${archiveNameFor(version, triple)}: a zip fixture needs a PowerShell ` +
-            '(Compress-Archive), and this host has neither `powershell` nor `pwsh`',
-        );
+      // PowerShell builds this on Windows, and Node builds it everywhere else.
+      // The split is not a preference between two ways of writing a zip; see
+      // stored-zip.ts for the CI abort that motivates it and for why Windows
+      // deliberately keeps the cmdlet. An injected seam forces the PowerShell
+      // path whatever the host, because driving that path is the only thing
+      // those two options are for — without it the retry's wiring assertion
+      // would silently stop reaching the code it exists to pin.
+      if (process.platform === 'win32' || exeOverride !== undefined || run !== undefined) {
+        // Whatever PowerShell this host has, rather than `powershell` — which is
+        // Windows-only, while `Compress-Archive` ships with pwsh everywhere.
+        const exe = exeOverride ?? powershellExe();
+        if (exe === undefined) {
+          throw new Error(
+            `cannot build ${archiveNameFor(version, triple)}: a zip fixture needs a PowerShell ` +
+              '(Compress-Archive), and this host has neither `powershell` nor `pwsh`',
+          );
+        }
+        compressArchive(exe, root, archivePath, run);
+      } else {
+        writeStoredZip(archivePath, stage, rootName);
       }
-      compressArchive(exe, root, archivePath, run);
     } else {
       const stub = join(root, 'aka');
       writeFileSync(stub, `#!/bin/sh\necho "aka ${banner}"\n`);

--- a/tools/installer/test/helpers/stored-zip.test.ts
+++ b/tools/installer/test/helpers/stored-zip.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `writeStoredZip` writes the bytes off-Windows hosts hand to the installer, so
+ * what it produces has to be a zip by a reader's standard rather than by its
+ * own. Everything below is checked with `unzip` — a reader this repo did not
+ * write — because a zip validated by the code that wrote it proves only that
+ * the two agree.
+ *
+ * `Expand-Archive` would be the closer mirror of what `install.ps1` does, and
+ * it is deliberately NOT used: it is a PowerShell module autoload, which is the
+ * exact call this file exists to keep off non-Windows CI (see stored-zip.ts).
+ * Reaching for it here would put the flake back inside the test that proves the
+ * flake was removed. On Windows the writer is never the one building the
+ * archive, so `Expand-Archive`'s real agreement with it is not a thing that has
+ * to hold.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { removeTree } from '../../../../test/helpers/remove-tree.ts';
+import { writeStoredZip } from './stored-zip.ts';
+
+/** `unzip`, or undefined where the host has none — Windows, most often. */
+function unzipExe(): string | undefined {
+  try {
+    execFileSync('unzip', ['-v'], { stdio: 'pipe' });
+    return 'unzip';
+  } catch {
+    return undefined;
+  }
+}
+
+const UNZIP = unzipExe();
+const ROOT_NAME = 'aka-win32-x64';
+
+describe('writeStoredZip', () => {
+  let dir: string;
+  /** A staged `aka-win32-x64/` tree, the shape `writeArchive` hands over. */
+  let stage: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aka-stored-zip-'));
+    stage = join(dir, 'stage');
+    mkdirSync(join(stage, ROOT_NAME, 'nested'), { recursive: true });
+    writeFileSync(join(stage, ROOT_NAME, 'payload.txt'), 'the banner line\n');
+    writeFileSync(join(stage, ROOT_NAME, 'aka.exe'), 'not a PE — inert fixture payload\n');
+    writeFileSync(join(stage, ROOT_NAME, 'nested', 'deep.txt'), 'a nested file\n');
+  });
+  afterAll(() => {
+    removeTree(dir);
+  });
+
+  const write = (name: string): string => {
+    const at = join(dir, name);
+    writeStoredZip(at, stage, ROOT_NAME);
+    return at;
+  };
+
+  it('starts with a local file header, so a reader recognises it at all', () => {
+    // The floor `assertZipWritten` checks of the PowerShell path, checked of
+    // this one too — an empty zip is an EOCD alone (504b0506) and fails here.
+    expect(readFileSync(write('magic.zip')).subarray(0, 4).toString('hex')).toBe('504b0304');
+  });
+
+  it.skipIf(UNZIP === undefined)('passes a third-party integrity check', () => {
+    // `unzip -t` reads every entry and verifies its CRC against the stored one.
+    // A wrong length field, a wrong offset or a miscomputed CRC all surface
+    // here, and none of them would be visible in the magic number above.
+    const out = execFileSync('unzip', ['-t', write('integrity.zip')], { encoding: 'utf8' });
+    expect(out).toContain('No errors detected');
+  });
+
+  it.skipIf(UNZIP === undefined)('round-trips the tree, rooted at aka-<triple>/', () => {
+    // The root is what build-binaries.yml asserts of a real archive and what
+    // install.ps1 joins onto to find the binary, so it is pinned as a PATH and
+    // not merely as "some entries came back".
+    const into = join(dir, 'extracted');
+    execFileSync('unzip', ['-q', write('roundtrip.zip'), '-d', into], { stdio: 'pipe' });
+    expect(readFileSync(join(into, ROOT_NAME, 'payload.txt'), 'utf8')).toBe('the banner line\n');
+    expect(readFileSync(join(into, ROOT_NAME, 'nested', 'deep.txt'), 'utf8')).toBe(
+      'a nested file\n',
+    );
+  });
+
+  it('writes the same bytes for the same tree, and different bytes for different content', () => {
+    // The tampering case rebuilds one archive under one name and asserts the
+    // installer refuses the second copy, which rests entirely on the CONTENT
+    // moving the bytes. A wall-clock timestamp in the entries would move them
+    // on its own and let that case pass without any tampering — so the
+    // stability half of this is as load-bearing as the difference half.
+    const first = readFileSync(write('stable-a.zip'));
+    expect(readFileSync(write('stable-b.zip')).equals(first)).toBe(true);
+
+    writeFileSync(join(stage, ROOT_NAME, 'payload.txt'), 'a different banner\n');
+    expect(readFileSync(write('changed.zip')).equals(first)).toBe(false);
+    writeFileSync(join(stage, ROOT_NAME, 'payload.txt'), 'the banner line\n');
+  });
+});

--- a/tools/installer/test/helpers/stored-zip.test.ts
+++ b/tools/installer/test/helpers/stored-zip.test.ts
@@ -14,7 +14,7 @@
  * to hold.
  */
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -85,12 +85,36 @@ describe('writeStoredZip', () => {
     );
   });
 
+  it('stamps the fixed 1980 date rather than the wall clock', () => {
+    // Read out of the first local header, NOT inferred from two archives
+    // matching. That was the original shape of this case and it could not fail:
+    // a DOS time field has two-SECOND resolution, so two writes milliseconds
+    // apart land in the same tick whether the stamp is fixed or a wall clock,
+    // and the equality held either way. Worse, a wall-clock stamp would then be
+    // FLAKY rather than failing — red only on the ~0.4% of runs that straddle a
+    // tick boundary, which is the shape that gets re-run instead of read.
+    const zip = readFileSync(write('stamp.zip'));
+    expect(zip.readUInt16LE(10)).toBe(0); // time: 00:00:00
+    expect(zip.readUInt16LE(12)).toBe((1 << 5) | 1); // date: 1980-01-01
+  });
+
+  it('does not depend on the order the host lists the tree in', () => {
+    // The sort in `collect` is a determinism claim, and the host's own readdir
+    // order is usually sorted already — so observing one archive proves
+    // nothing. Driving a second one through a deliberately reversed listing
+    // does: with the sort, both orders yield the same bytes; without it, they
+    // cannot.
+    const forward = readFileSync(write('order-default.zip'));
+    const at = join(dir, 'order-reversed.zip');
+    writeStoredZip(at, stage, ROOT_NAME, (d) => readdirSync(d).sort().reverse());
+    expect(readFileSync(at).equals(forward)).toBe(true);
+  });
+
   it('writes the same bytes for the same tree, and different bytes for different content', () => {
     // The tampering case rebuilds one archive under one name and asserts the
     // installer refuses the second copy, which rests entirely on the CONTENT
-    // moving the bytes. A wall-clock timestamp in the entries would move them
-    // on its own and let that case pass without any tampering — so the
-    // stability half of this is as load-bearing as the difference half.
+    // moving the bytes. This is the difference half of that; the stability half
+    // it used to carry is the case above, which can actually fail.
     const first = readFileSync(write('stable-a.zip'));
     expect(readFileSync(write('stable-b.zip')).equals(first)).toBe(true);
 

--- a/tools/installer/test/helpers/stored-zip.ts
+++ b/tools/installer/test/helpers/stored-zip.ts
@@ -33,12 +33,15 @@
  * also keeps this file short enough to read in one sitting, which a fixture
  * builder has to be.
  *
- * SCOPE, so nobody reaches for it where it would be wrong: entries are held in
- * memory one at a time, and sizes are the classic 32-bit fields with no zip64
- * fallback. Both are fine for what this packs — off Windows a fixture root is a
- * line of text and an inert placeholder, because `writeWindowsPayload` only
- * copies the real ~115 MB PE when the host IS Windows — and neither would be
- * fine for a real release archive.
+ * SCOPE, so nobody reaches for it where it would be wrong. Entries are held in
+ * memory one at a time; sizes are the classic 32-bit fields with no zip64
+ * fallback; and entry names are written as UTF-8 with the UTF-8 flag CLEAR,
+ * which a reader is entitled to decode as CP437 — so a name outside ASCII would
+ * round-trip wrong, and nothing here stops one being passed. All three are fine
+ * for what this packs — off Windows a fixture root is a line of text and an
+ * inert placeholder, because `writeWindowsPayload` only copies the real ~115 MB
+ * PE when the host IS Windows, and the names are `aka-<triple>/`, `payload.txt`
+ * and `aka.exe` — and none of them would be fine for a real release archive.
  */
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -57,7 +60,7 @@ import { crc32 } from 'node:zlib';
 const DOS_TIME = 0;
 const DOS_DATE = (1 << 5) | 1;
 
-/** FILE_ATTRIBUTE_DIRECTORY, in the high half of `external file attributes`. */
+/** FILE_ATTRIBUTE_DIRECTORY, in the DOS attribute byte — the LOW half of `external file attributes`. */
 const DIR_ATTRS = 0x10;
 
 const LOCAL_HEADER = 0x04034b50;
@@ -74,16 +77,19 @@ interface Entry {
   readonly isDirectory: boolean;
 }
 
+/** How a directory is listed. Injectable — see the parameter on `writeStoredZip`. */
+export type DirLister = (dir: string) => string[];
+
 /** Every file and directory under `dir`, depth first, named relative to `prefix`. */
-function collect(dir: string, prefix: string): Entry[] {
+function collect(dir: string, prefix: string, list: DirLister): Entry[] {
   const out: Entry[] = [];
   // Sorted, so the archive does not depend on the order the filesystem happens
   // to hand back — the same determinism argument as the fixed timestamp.
-  for (const name of readdirSync(dir).sort()) {
+  for (const name of list(dir).sort()) {
     const full = join(dir, name);
     if (statSync(full).isDirectory()) {
       out.push({ name: `${prefix}${name}/`, data: Buffer.alloc(0), isDirectory: true });
-      out.push(...collect(full, `${prefix}${name}/`));
+      out.push(...collect(full, `${prefix}${name}/`, list));
       continue;
     }
     out.push({ name: `${prefix}${name}`, data: readFileSync(full), isDirectory: false });
@@ -97,10 +103,20 @@ function collect(dir: string, prefix: string): Entry[] {
  * what `build-binaries.yml` asserts of a real archive and what `install.ps1`
  * joins onto to find the binary.
  */
-export function writeStoredZip(archivePath: string, stage: string, rootName: string): void {
+export function writeStoredZip(
+  archivePath: string,
+  stage: string,
+  rootName: string,
+  // A seam, for the same reason the timestamp is fixed: the sort above is a
+  // DETERMINISM claim, and a claim nothing can falsify is not one. Removing the
+  // sort leaves every observation-based assertion green, because a host's own
+  // readdir order is usually sorted already — so the only way to pin it is to
+  // hand this an order that is deliberately not.
+  list: DirLister = readdirSync,
+): void {
   const entries = [
     { name: `${rootName}/`, data: Buffer.alloc(0), isDirectory: true },
-    ...collect(join(stage, rootName), `${rootName}/`),
+    ...collect(join(stage, rootName), `${rootName}/`, list),
   ];
 
   const local: Buffer[] = [];
@@ -117,7 +133,7 @@ export function writeStoredZip(archivePath: string, stage: string, rootName: str
     const header = Buffer.alloc(30);
     header.writeUInt32LE(LOCAL_HEADER, 0);
     header.writeUInt16LE(VERSION, 4);
-    header.writeUInt16LE(0, 6); // flags: none — names below are ASCII
+    header.writeUInt16LE(0, 6); // flags: none — bit 11 (UTF-8 names) clear, see SCOPE above
     header.writeUInt16LE(0, 8); // method: stored
     header.writeUInt16LE(DOS_TIME, 10);
     header.writeUInt16LE(DOS_DATE, 12);

--- a/tools/installer/test/helpers/stored-zip.ts
+++ b/tools/installer/test/helpers/stored-zip.ts
@@ -1,0 +1,166 @@
+/**
+ * A minimal STORED (uncompressed) zip writer, so building a win32 fixture
+ * archive off Windows needs no PowerShell.
+ *
+ * WHY THIS EXISTS AT ALL, given `Compress-Archive` already did it. On GitHub's
+ * `ubuntu-24.04-arm` runners `pwsh` intermittently aborts (SIGABRT) partway
+ * into that cmdlet with a `FileLoadException` naming an assembly whose name has
+ * been read truncated — see the note on `compressArchive`, which retries it.
+ * That retry is losing: three separate jobs in one day burned all three attempts
+ * on a command that is correct, one of them over six seconds, WHILE another
+ * `Compress-Archive` in the same job completed. So it is not a window to wait
+ * out, and a bigger retry budget is a guess rather than a fix.
+ *
+ * What the evidence does support is narrower and is what this acts on: every
+ * observed abort is in the `Compress-Archive` child, and NONE is in the
+ * `install.ps1` children the same suite spawns from the same helper with the
+ * same environment — those keep passing in the very runs where the fixture
+ * build dies. Resolving an unknown command name is what sends PowerShell
+ * through module auto-discovery, and that is the work the refusal path never
+ * does. Off Windows this file removes that call, so whichever assembly load is
+ * dying is no longer on the path at all.
+ *
+ * IT IS DELIBERATELY NOT USED ON WINDOWS. There the cmdlet is what
+ * `archive-sea.mjs` runs to build a real release, the fixture mirrors it on
+ * purpose, and it is the one host where the archive is EXPANDED again
+ * (`install.ps1` step 5) rather than only hashed. Nothing observed has ever
+ * aborted there. Off Windows the mirror buys nothing — no release is built on
+ * those hosts, and no case gets past step 4 to open the archive.
+ *
+ * STORED, never deflated, for the same reason `compressArchive` passes
+ * `-CompressionLevel NoCompression`: the installer hashes the archive and
+ * expands it, and neither step cares whether the entries were compressed. It
+ * also keeps this file short enough to read in one sitting, which a fixture
+ * builder has to be.
+ *
+ * SCOPE, so nobody reaches for it where it would be wrong: entries are held in
+ * memory one at a time, and sizes are the classic 32-bit fields with no zip64
+ * fallback. Both are fine for what this packs — off Windows a fixture root is a
+ * line of text and an inert placeholder, because `writeWindowsPayload` only
+ * copies the real ~115 MB PE when the host IS Windows — and neither would be
+ * fine for a real release archive.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { crc32 } from 'node:zlib';
+
+/**
+ * A fixed 1980-01-01 00:00:00 in DOS date/time, so the same tree always yields
+ * the same bytes.
+ *
+ * The tampering case builds one archive twice under one name and asserts the
+ * installer refuses the second, which rests on the CONTENT changing the bytes.
+ * A wall-clock stamp would change them on its own and let that case pass
+ * without the content ever differing. 1980 rather than 0 because a zero DATE is
+ * not a representable DOS date — the epoch of the format is 1980.
+ */
+const DOS_TIME = 0;
+const DOS_DATE = (1 << 5) | 1;
+
+/** FILE_ATTRIBUTE_DIRECTORY, in the high half of `external file attributes`. */
+const DIR_ATTRS = 0x10;
+
+const LOCAL_HEADER = 0x04034b50;
+const CENTRAL_HEADER = 0x02014b50;
+const END_OF_CENTRAL_DIR = 0x06054b50;
+
+/** Zip 2.0 — the version that stored and deflated entries need. */
+const VERSION = 20;
+
+interface Entry {
+  /** The path as it appears IN the archive, `/`-separated, `/`-suffixed for a directory. */
+  readonly name: string;
+  readonly data: Buffer;
+  readonly isDirectory: boolean;
+}
+
+/** Every file and directory under `dir`, depth first, named relative to `prefix`. */
+function collect(dir: string, prefix: string): Entry[] {
+  const out: Entry[] = [];
+  // Sorted, so the archive does not depend on the order the filesystem happens
+  // to hand back — the same determinism argument as the fixed timestamp.
+  for (const name of readdirSync(dir).sort()) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      out.push({ name: `${prefix}${name}/`, data: Buffer.alloc(0), isDirectory: true });
+      out.push(...collect(full, `${prefix}${name}/`));
+      continue;
+    }
+    out.push({ name: `${prefix}${name}`, data: readFileSync(full), isDirectory: false });
+  }
+  return out;
+}
+
+/**
+ * Write `<stage>/<rootName>` into `archivePath` as a stored zip, rooted at
+ * `rootName/` exactly as `Compress-Archive -Path <dir>` roots it — which is
+ * what `build-binaries.yml` asserts of a real archive and what `install.ps1`
+ * joins onto to find the binary.
+ */
+export function writeStoredZip(archivePath: string, stage: string, rootName: string): void {
+  const entries = [
+    { name: `${rootName}/`, data: Buffer.alloc(0), isDirectory: true },
+    ...collect(join(stage, rootName), `${rootName}/`),
+  ];
+
+  const local: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, 'utf8');
+    // `crc32` returns an unsigned 32-bit number already; a stored entry's
+    // compressed and uncompressed sizes are the same by definition.
+    const crc = crc32(entry.data);
+    const size = entry.data.length;
+
+    const header = Buffer.alloc(30);
+    header.writeUInt32LE(LOCAL_HEADER, 0);
+    header.writeUInt16LE(VERSION, 4);
+    header.writeUInt16LE(0, 6); // flags: none — names below are ASCII
+    header.writeUInt16LE(0, 8); // method: stored
+    header.writeUInt16LE(DOS_TIME, 10);
+    header.writeUInt16LE(DOS_DATE, 12);
+    header.writeUInt32LE(crc, 14);
+    header.writeUInt32LE(size, 18);
+    header.writeUInt32LE(size, 22);
+    header.writeUInt16LE(name.length, 26);
+    header.writeUInt16LE(0, 28); // extra field length
+    local.push(header, name, entry.data);
+
+    const record = Buffer.alloc(46);
+    record.writeUInt32LE(CENTRAL_HEADER, 0);
+    record.writeUInt16LE(VERSION, 4); // version made by
+    record.writeUInt16LE(VERSION, 6); // version needed
+    record.writeUInt16LE(0, 8);
+    record.writeUInt16LE(0, 10);
+    record.writeUInt16LE(DOS_TIME, 12);
+    record.writeUInt16LE(DOS_DATE, 14);
+    record.writeUInt32LE(crc, 16);
+    record.writeUInt32LE(size, 20);
+    record.writeUInt32LE(size, 24);
+    record.writeUInt16LE(name.length, 28);
+    record.writeUInt16LE(0, 30); // extra field length
+    record.writeUInt16LE(0, 32); // comment length
+    record.writeUInt16LE(0, 34); // disk number start
+    record.writeUInt16LE(0, 36); // internal attributes
+    record.writeUInt32LE(entry.isDirectory ? DIR_ATTRS : 0, 38);
+    record.writeUInt32LE(offset, 42);
+    central.push(record, name);
+
+    offset += header.length + name.length + size;
+  }
+
+  const directory = Buffer.concat(central);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(END_OF_CENTRAL_DIR, 0);
+  end.writeUInt16LE(0, 4); // this disk
+  end.writeUInt16LE(0, 6); // disk the central directory starts on
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(directory.length, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20); // comment length
+
+  writeFileSync(archivePath, Buffer.concat([...local, directory, end]));
+}


### PR DESCRIPTION
`pwsh` intermittently aborts partway into `Compress-Archive` on GitHub's `ubuntu-24.04-arm` runners, with a `FileLoadException` naming an assembly whose name was read truncated. The 3-attempt retry added for it (#057366da) is now losing — **three job failures in one day across two unrelated branches**, each burning all three attempts on a command that is correct.

## Why not just tune the retry

The retry cannot be tuned out of this. In the most recent failure one case spent **6.2 s across its three attempts and all aborted, while another `Compress-Archive` in the same job completed**. So it is not a time window to wait out, and a larger budget or a backoff would be a guess rather than a fix.

Passing and failing jobs also run the identical runner image (`ubuntu-24.04-arm` `20260823.101.1`), so this is not an image regression either.

## What the evidence does support

Every observed abort is in the `Compress-Archive` child. **None** is in the `install.ps1` children the same suite spawns, from the same helper, with the same environment — those keep passing in the very runs where the fixture build dies.

Resolving an unknown command name is what sends PowerShell through module auto-discovery; that is the work the refusal path never does. So off Windows this stops making the call at all, and a stored-zip writer replaces it.

## Why that is safe

Off Windows nothing ever *opens* the archive:

- `install.ps1` expands at step 5; both non-Windows cases exit at step 4's checksum refusal.
- The happy path is Windows-gated for an unrelated reason (`New-Item -ItemType Junction` silently no-ops under pwsh on Linux).
- The fixture root there is a line of text and an inert placeholder — `writeWindowsPayload` only copies the real ~115 MB PE when the host **is** Windows.

**Windows deliberately keeps the cmdlet, with its retry.** That is where the fixture mirrors what `archive-sea.mjs` runs to build a real release, where the archive is expanded again, and where nothing has ever aborted.

## Validation

Checked with `unzip` — a reader this repo did not write — for integrity and a byte-identical round-trip, rather than by the code that wrote it. `Expand-Archive` is deliberately **not** the validator: it is a module autoload, the exact call this removes from non-Windows CI, so using it would put the flake back inside the test that proves the flake was removed.

Both assertions were confirmed to fail against a deliberately corrupted CRC and a corrupted central-directory offset.

`writes a real zip for a win32 triple on any host` loses its PowerShell gate, so it now runs on hosts with no `pwsh` at all — a widening, since the platform that gets a win32 fixture wrong is the one that is not Windows.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)