### PR TITLE
feat(plugin): record a model refusal as an audit fact

### DIFF
--- a/packages/plugin-runtime/test/standalone-gateway.test.ts
+++ b/packages/plugin-runtime/test/standalone-gateway.test.ts
@@ -733,12 +733,14 @@ describe('per-detection policy drives enforcement (installed_packs.policy_id)', 
  * raw snake_case columns and the camelCase type is optimistic. Read what is
  * there rather than what the type claims.
  */
-function rawRow(
-  db: ReturnType<typeof openLocalDatabase>,
-  id: string,
-): { id: string; event_type: string; root_session_id: string | null } | undefined {
-  return db.auditEvents.findById(id) as unknown as
-    { id: string; event_type: string; root_session_id: string | null } | undefined;
+interface RawAuditRow {
+  id: string;
+  event_type: string;
+  root_session_id: string | null;
+}
+
+function rawRow(db: ReturnType<typeof openLocalDatabase>, id: string): RawAuditRow | undefined {
+  return db.auditEvents.findById(id);
 }
 
 describe('recordAuditEvent plants the session root it FKs onto', () => {

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -56,8 +56,9 @@ export {
 } from './isolated-scan.ts';
 export type { ScanFinding } from './mask.ts';
 export { maskText, scanText } from './mask.ts';
-export type { ModelFromRecord } from './model-governance.ts';
+export type { ModelFromRecord, RefusalSeam } from './model-governance.ts';
 export {
+  buildModelRefusalEvent,
   claudeCodeModelFromRecord,
   codexModelFromRecord,
   decideProhibitedModelTurn,

--- a/packages/plugin-sdk/src/model-governance.ts
+++ b/packages/plugin-sdk/src/model-governance.ts
@@ -300,3 +300,57 @@ export function decideProhibitedModelTurn(
   if (!isModelProhibited(model, prohibitedModels)) return null;
   return { decision: 'block', reason: prohibitedModelMessage(model, 'turn') };
 }
+
+/** Which seam refused: a model switch, or a turn already running on one. */
+export type RefusalSeam = 'switch' | 'turn';
+
+/**
+ * The audit row for one refusal.
+ *
+ * WHAT IT DELIBERATELY DOES NOT CARRY is the point: no prompt, no response, no
+ * content of any kind. A governance refusal is worth recording so an operator
+ * can see the control working and on which machines — that question is answered
+ * by the model, the seam and the session, and answering it does not require
+ * moving anything the user typed. `content` is left unset rather than set to a
+ * summary, so there is no field for text to creep into later.
+ *
+ * `id` is random rather than content-addressed: refusals are facts, and two
+ * identical refusals a minute apart are two events, not one recorded twice.
+ *
+ * The caller owns whether this is written at all — every call site is
+ * best-effort and swallows its own failure, because a refusal that cannot be
+ * recorded must still be a refusal.
+ */
+export function buildModelRefusalEvent(input: {
+  id: string;
+  sessionId: string | undefined;
+  model: string;
+  seam: RefusalSeam;
+  sourceTool: string;
+  occurredAt: string;
+}): {
+  id: string;
+  eventType: 'model_refusal';
+  startedAt: string;
+  rootSessionId?: string;
+  attributes: Record<string, unknown>;
+} {
+  return {
+    id: input.id,
+    eventType: 'model_refusal',
+    startedAt: input.occurredAt,
+    // Omitted rather than nulled when unknown: `root_session_id` is a self-FK,
+    // and a session id naming no row would fail the insert outright.
+    ...(input.sessionId === undefined || input.sessionId === ''
+      ? {}
+      : { rootSessionId: input.sessionId }),
+    attributes: {
+      // `model` is a generated column on audit_events, so the refused model is
+      // queryable without unpacking the bag — which is what lets the control
+      // plane group refusals by the same id the prohibition was keyed on.
+      model: input.model,
+      refusal_seam: input.seam,
+      source_tool: input.sourceTool,
+    },
+  };
+}

--- a/packages/plugin-sdk/test/index.test.ts
+++ b/packages/plugin-sdk/test/index.test.ts
@@ -87,6 +87,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'applySetupTriageSuppressions',
   'assertRawFree',
   'buildIngestEvent',
+  'buildModelRefusalEvent',
   'buildTokenReports',
   'bundledDetections',
   'childRel',

--- a/packages/plugin-sdk/test/model-governance.test.ts
+++ b/packages/plugin-sdk/test/model-governance.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  buildModelRefusalEvent,
   claudeCodeModelFromRecord,
   codexModelFromRecord,
   decideProhibitedModelTurn,
@@ -293,5 +294,45 @@ describe('decideProhibitedModelTurn', () => {
     ['an empty prohibition list', 'claude-opus-5', []],
   ])('allows a turn on %s', (_label, model, prohibited) => {
     expect(decideProhibitedModelTurn(model, prohibited)).toBeNull();
+  });
+});
+
+describe('buildModelRefusalEvent', () => {
+  const base = {
+    id: 'evt-1',
+    sessionId: 's1',
+    model: 'claude-opus-5',
+    seam: 'switch' as const,
+    sourceTool: 'claude-code',
+    occurredAt: '2026-09-02T10:30:00.000Z',
+  };
+
+  it('carries the model, the seam and the session, and nothing the user typed', () => {
+    const event = buildModelRefusalEvent(base);
+    expect(event.eventType).toBe('model_refusal');
+    expect(event.rootSessionId).toBe('s1');
+    expect(event.attributes).toEqual({
+      model: 'claude-opus-5',
+      refusal_seam: 'switch',
+      source_tool: 'claude-code',
+    });
+  });
+
+  it('has NO content field at all, not merely an empty one', () => {
+    // The property that keeps prompt text from creeping in later: there is no
+    // field for it. An empty string would be a slot someone fills.
+    expect(Object.keys(buildModelRefusalEvent(base))).not.toContain('content');
+    expect(Object.keys(buildModelRefusalEvent(base))).not.toContain('contentHash');
+  });
+
+  it('OMITS rootSessionId when the session is unknown, rather than nulling it', () => {
+    // `root_session_id` is a self-FK: an id naming no row fails the insert, and
+    // an explicit null would be a different (allowed) statement than omission.
+    const event = buildModelRefusalEvent({ ...base, sessionId: undefined });
+    expect('rootSessionId' in event).toBe(false);
+  });
+
+  it('records the turn seam distinctly from the switch seam', () => {
+    expect(buildModelRefusalEvent({ ...base, seam: 'turn' }).attributes.refusal_seam).toBe('turn');
   });
 });

--- a/packages/schema/src/drizzle/base-rows.ts
+++ b/packages/schema/src/drizzle/base-rows.ts
@@ -125,6 +125,11 @@ export interface BaseAuditEventRow<TTime = number> {
     | 'response'
     | 'code_change'
     | 'tool_use'
+    // Mirrors AuditEventType in ../zod/meta.ts. The two lists are restated
+    // rather than derived because the table below asserts against this one as
+    // LITERALS (drizzle/adherence.test.ts), and a type alias does not satisfy
+    // that comparison. Adding a member means editing both.
+    | 'model_refusal'
     | 'config_scan';
   hostId: string | null;
   harnessId: string | null;

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -330,6 +330,7 @@ export const auditEvents = sqliteTable(
         'response',
         'code_change',
         'tool_use',
+        'model_refusal',
         'config_scan',
       ],
     }).notNull(),

--- a/packages/schema/src/zod/meta.ts
+++ b/packages/schema/src/zod/meta.ts
@@ -50,6 +50,13 @@ export const AuditEventType = z
     // 'tool_call' is the reconciler's structural row for every call, while
     // 'tool_use' exists only where a hook enforced against the arguments.
     'tool_use',
+    // One row per model REFUSAL: a switch onto a prohibited model that was
+    // denied, or a turn refused because the session was already running on one.
+    // A structural row like the ones above rather than a capture — it carries
+    // the model that was refused and nothing the user typed, because what is
+    // worth recording about a governance decision is the decision, and prompt
+    // text is the thing this product exists to keep from travelling.
+    'model_refusal',
     // One row per config-inventory scan, hung off the session root. It is the
     // fact the posture inspection findings reference (findings require an
     // audit_event_id), and its started_at is the "scanned Nm ago" the read

--- a/plugins/claude-code/src/hooks/model-guard.ts
+++ b/plugins/claude-code/src/hooks/model-guard.ts
@@ -6,14 +6,18 @@
 //
 // The two refusals answer DIFFERENT hooks in DIFFERENT vocabularies, which is
 // the one thing to get right here — see each function's own note.
+import { randomUUID } from 'node:crypto';
+
 import type { DataGateway } from '@akasecurity/plugin-sdk';
 import {
+  buildModelRefusalEvent,
   decideProhibitedModelTurn,
   isModelProhibited,
   modelFromTranscript,
   prohibitedModelMessage,
   readSessionModel,
 } from '@akasecurity/plugin-sdk';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 // PreModelSwitch answers in the SAME permission vocabulary as PreToolUse —
 // `permissionDecision: 'deny'` with a reason — rather than UserPromptSubmit's
@@ -100,17 +104,20 @@ export async function refuseProhibitedTurn(
   dataDir: string,
   sessionId: string | undefined,
   transcriptPath: string | undefined,
-): Promise<{ decision: 'block'; reason: string } | null> {
+): Promise<{ decision: { decision: 'block'; reason: string }; model: string } | null> {
   try {
     const { prohibitedModels } = await gateway.getPolicyBundle();
     // Bundle FIRST: with no prohibition list there is nothing to enforce, and
     // resolving the model would be a transcript read spent to reach the same
     // allow.
     if (prohibitedModels === undefined || prohibitedModels.length === 0) return null;
-    return decideProhibitedModelTurn(
-      resolveSessionModel(dataDir, sessionId, transcriptPath),
-      prohibitedModels,
-    );
+    const model = resolveSessionModel(dataDir, sessionId, transcriptPath);
+    const decision = decideProhibitedModelTurn(model, prohibitedModels);
+    // The model rides back with the verdict so the caller records WHICH model
+    // was refused without resolving it twice — and so the audit row and the
+    // message the user sees can never disagree about it. `model` is defined
+    // whenever a decision exists: the decision returns null for an absent one.
+    return decision === null || model === undefined ? null : { decision, model };
   } catch {
     return null;
   }
@@ -129,7 +136,7 @@ export async function refuseProhibitedTurn(
  * stdout contract and testable without one.
  */
 export async function handleProhibitedTurn(
-  gateway: Pick<DataGateway, 'getPolicyBundle' | 'close'>,
+  gateway: Pick<DataGateway, 'getPolicyBundle' | 'recordAuditEvent' | 'close'>,
   dataDir: string,
   sessionId: string | undefined,
   transcriptPath: string | undefined,
@@ -137,9 +144,28 @@ export async function handleProhibitedTurn(
 ): Promise<boolean> {
   const blocked = await refuseProhibitedTurn(gateway, dataDir, sessionId, transcriptPath);
   if (blocked === null) return false;
+  // Recorded while the gateway is still open, and best-effort: a refusal that
+  // cannot be written down is still a refusal, so a failed write must not reach
+  // the entry's outer catch and turn this block into a fail-open allow — the one
+  // way an audit trail could leave a session LESS governed than before it
+  // existed.
+  try {
+    await gateway.recordAuditEvent(
+      buildModelRefusalEvent({
+        id: randomUUID(),
+        sessionId,
+        model: blocked.model,
+        seam: 'turn',
+        sourceTool: SOURCE_TOOL.ClaudeCode,
+        occurredAt: new Date().toISOString(),
+      }),
+    );
+  } catch {
+    // Swallowed on purpose — see above.
+  }
   // Closed here rather than left to the caller's runtime `finally`, which the
   // refusal path never reaches.
   await gateway.close();
-  await emit(blocked);
+  await emit(blocked.decision);
   return true;
 }

--- a/plugins/claude-code/src/hooks/model-switch-run.ts
+++ b/plugins/claude-code/src/hooks/model-switch-run.ts
@@ -6,8 +6,11 @@
 //
 // The seams are the gateway, the emitter and the clock. Everything else is
 // ordinary logic and is exercised directly.
+import { randomUUID } from 'node:crypto';
+
 import type { DataGateway, PluginConfig } from '@akasecurity/plugin-sdk';
-import { recordSessionModel } from '@akasecurity/plugin-sdk';
+import { buildModelRefusalEvent, recordSessionModel } from '@akasecurity/plugin-sdk';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 import { decidePreModelSwitch, type PreModelSwitchOutput } from './model-guard.ts';
 
@@ -18,6 +21,9 @@ export interface PreModelSwitchDeps {
   emit: (output: PreModelSwitchOutput) => Promise<void>;
   /** Surfaces a redirected (symlinked) home once per session, on stderr. */
   warnIfStoreRedirected: (config: PluginConfig, sessionId: string | undefined) => void;
+  /** Injected so a test can pin the recorded id and timestamp. */
+  newId?: () => string;
+  now?: () => Date;
 }
 
 /**
@@ -44,18 +50,41 @@ export async function runPreModelSwitch(
   const gateway = deps.openGateway();
   if (gateway === null) return false;
 
+  // Closed at each exit below rather than in a `finally` here: the refusal path
+  // needs the gateway still open to record the event it is about to emit.
   let prohibited: readonly string[] | undefined;
   try {
     prohibited = (await gateway.getPolicyBundle()).prohibitedModels;
-  } finally {
+  } catch {
     await gateway.close();
+    return false;
   }
 
   const decision = decidePreModelSwitch(toModel, prohibited);
   if (decision !== null) {
+    // Best-effort, and swallowed: a refusal that cannot be written down is still
+    // a refusal, so a failed write must not reach the entry's outer catch and
+    // turn this deny into a fail-open allow.
+    try {
+      await gateway.recordAuditEvent(
+        buildModelRefusalEvent({
+          id: (deps.newId ?? randomUUID)(),
+          sessionId,
+          model: toModel,
+          seam: 'switch',
+          sourceTool: SOURCE_TOOL.ClaudeCode,
+          occurredAt: (deps.now ?? (() => new Date()))().toISOString(),
+        }),
+      );
+    } catch {
+      // Swallowed on purpose — see above.
+    }
+    await gateway.close();
     await deps.emit(decision);
     return true;
   }
+
+  await gateway.close();
 
   // ALLOWED — so this is the authoritative moment the session's model becomes
   // `to_model`, and recording it here is what lets user-prompt-submit decide

--- a/plugins/claude-code/test/hooks/model-switch-run.test.ts
+++ b/plugins/claude-code/test/hooks/model-switch-run.test.ts
@@ -33,14 +33,55 @@ afterAll(() => {
 const config = (): PluginConfig => ({ dataDir: dir }) as unknown as PluginConfig;
 
 /** A gateway stubbed down to the one read these paths perform. */
-function gatewayWith(prohibited: string[] | undefined, onClose = vi.fn()): DataGateway {
+function gatewayWith(
+  prohibited: string[] | undefined,
+  onClose = vi.fn(),
+  recordAuditEvent: (event: unknown) => Promise<void> = () => Promise.resolve(),
+): DataGateway {
   return {
     getPolicyBundle: () =>
       Promise.resolve({ prohibitedModels: prohibited } as unknown as Awaited<
         ReturnType<DataGateway['getPolicyBundle']>
       >),
+    recordAuditEvent,
     close: onClose,
   } as unknown as DataGateway;
+}
+
+/** One recorded audit row, in the shape these assertions read. */
+interface RecordedEvent {
+  eventType: string;
+  attributes: Record<string, unknown>;
+}
+
+/**
+ * The one row a refusal is expected to record.
+ *
+ * Narrows by construction rather than by an assertion — both `!` and `as` are
+ * refused here — and states the cardinality while it is at it: two rows for one
+ * refusal would be a defect these assertions would otherwise read straight past.
+ */
+function onlyEvent(events: readonly RecordedEvent[]): RecordedEvent {
+  const [first, ...rest] = events;
+  if (first === undefined || rest.length > 0) {
+    throw new Error(`expected exactly one recorded event, got ${String(events.length)}`);
+  }
+  return first;
+}
+
+/** A recorder plus the rows it captured, typed so no mock tuple is indexed. */
+function recorder(): {
+  fn: (event: unknown) => Promise<void>;
+  events: RecordedEvent[];
+} {
+  const events: RecordedEvent[] = [];
+  return {
+    fn: (event: unknown) => {
+      events.push(event as RecordedEvent);
+      return Promise.resolve();
+    },
+    events,
+  };
 }
 
 describe('runPreModelSwitch', () => {
@@ -115,6 +156,55 @@ describe('runPreModelSwitch', () => {
   });
 });
 
+describe('runPreModelSwitch records the refusal', () => {
+  it('writes a model_refusal naming the model and the switch seam', async () => {
+    const rec = recorder();
+    await runPreModelSwitch({}, 'claude-opus-5', 's1', {
+      config: config(),
+      openGateway: () => gatewayWith(['claude-opus-5'], vi.fn(), rec.fn),
+      emit: vi.fn(() => Promise.resolve()),
+      warnIfStoreRedirected: vi.fn(),
+      newId: () => 'evt-1',
+      now: () => new Date('2026-09-02T10:30:00.000Z'),
+    });
+    const event = onlyEvent(rec.events);
+    expect(event.eventType).toBe('model_refusal');
+    expect(event.attributes.model).toBe('claude-opus-5');
+    expect(event.attributes.refusal_seam).toBe('switch');
+  });
+
+  it('records nothing when the switch is ALLOWED', async () => {
+    const rec = recorder();
+    await runPreModelSwitch({}, 'claude-sonnet-4-5', 's1', {
+      config: config(),
+      openGateway: () => gatewayWith(['claude-opus-5'], vi.fn(), rec.fn),
+      emit: vi.fn(() => Promise.resolve()),
+      warnIfStoreRedirected: vi.fn(),
+    });
+    expect(rec.events).toHaveLength(0);
+  });
+
+  it('still refuses when the refusal cannot be recorded', async () => {
+    // The failure this must never have: a write that throws reaching the entry's
+    // outer catch would turn a deny into a fail-open allow, leaving the session
+    // LESS governed than before the audit trail existed.
+    const emit = vi.fn(() => Promise.resolve());
+    const refused = await runPreModelSwitch({}, 'claude-opus-5', 's1', {
+      config: config(),
+      openGateway: () =>
+        gatewayWith(
+          ['claude-opus-5'],
+          vi.fn(),
+          vi.fn(() => Promise.reject(new Error('store gone'))),
+        ),
+      emit,
+      warnIfStoreRedirected: vi.fn(),
+    });
+    expect(refused).toBe(true);
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('runPostModelSwitch', () => {
   it('records the model the harness switched to', () => {
     runPostModelSwitch('s1', 'claude-opus-5', {
@@ -134,8 +224,11 @@ describe('refuseProhibitedTurn', () => {
   it('refuses a turn on a model the marker says is prohibited', async () => {
     recordSessionModel(dir, 's1', 'claude-opus-5');
     const out = await refuseProhibitedTurn(gatewayWith(['claude-opus-5']), dir, 's1', undefined);
-    expect(out?.decision).toBe('block');
-    expect(out?.reason).toContain('claude-opus-5');
+    expect(out?.decision.decision).toBe('block');
+    expect(out?.decision.reason).toContain('claude-opus-5');
+    // The model rides back with the verdict so the audit row and the message
+    // the user sees can never disagree about which model was refused.
+    expect(out?.model).toBe('claude-opus-5');
   });
 
   it('falls back to the transcript when no marker covers the session', async () => {
@@ -204,5 +297,52 @@ describe('handleProhibitedTurn', () => {
     expect(stop).toBe(false);
     expect(close).not.toHaveBeenCalled();
     expect(emit).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleProhibitedTurn records the refusal', () => {
+  it('writes a model_refusal naming the TURN seam', async () => {
+    recordSessionModel(dir, 's1', 'claude-opus-5');
+    const rec = recorder();
+    await handleProhibitedTurn(
+      gatewayWith(['claude-opus-5'], vi.fn(), rec.fn),
+      dir,
+      's1',
+      undefined,
+      () => Promise.resolve(),
+    );
+    const event = onlyEvent(rec.events);
+    expect(event.eventType).toBe('model_refusal');
+    expect(event.attributes.model).toBe('claude-opus-5');
+    // The seam is what separates this from the switch refusal in the same
+    // session — an operator asking "was it prevented, or contained?" reads it.
+    expect(event.attributes.refusal_seam).toBe('turn');
+  });
+
+  it('still refuses when the refusal cannot be recorded', async () => {
+    // A write that throws must not reach the entry's outer catch, which would
+    // turn the block into a fail-open allow.
+    recordSessionModel(dir, 's1', 'claude-opus-5');
+    const emitted: unknown[] = [];
+    const stop = await handleProhibitedTurn(
+      gatewayWith(['claude-opus-5'], vi.fn(), () => Promise.reject(new Error('store gone'))),
+      dir,
+      's1',
+      undefined,
+      (output) => {
+        emitted.push(output);
+        return Promise.resolve();
+      },
+    );
+    expect(stop).toBe(true);
+    expect(emitted).toHaveLength(1);
+  });
+
+  it('records nothing when the turn is allowed', async () => {
+    const rec = recorder();
+    await handleProhibitedTurn(gatewayWith([], vi.fn(), rec.fn), dir, 's1', undefined, () =>
+      Promise.resolve(),
+    );
+    expect(rec.events).toHaveLength(0);
   });
 });

--- a/plugins/codex/src/hooks/model-guard.ts
+++ b/plugins/codex/src/hooks/model-guard.ts
@@ -8,8 +8,12 @@
 // cannot be refused before it takes effect; what is left is refusing a TURN
 // whose session is already on a prohibited model. A user who switches keeps the
 // model for the rest of the current turn and is refused from the next one.
+import { randomUUID } from 'node:crypto';
+
 import type { DataGateway } from '@akasecurity/plugin-sdk';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 import {
+  buildModelRefusalEvent,
   codexModelFromRecord,
   decideProhibitedModelTurn,
   modelFromTranscriptTail,
@@ -58,17 +62,19 @@ export async function refuseProhibitedTurn(
   dataDir: string,
   sessionId: string | undefined,
   transcriptPath: string | undefined,
-): Promise<{ decision: 'block'; reason: string } | null> {
+): Promise<{ decision: { decision: 'block'; reason: string }; model: string } | null> {
   try {
     const { prohibitedModels } = await gateway.getPolicyBundle();
     // Bundle FIRST: with no prohibition list there is nothing to enforce, and
     // resolving the model would be a transcript read spent to reach the same
     // allow.
     if (prohibitedModels === undefined || prohibitedModels.length === 0) return null;
-    return decideProhibitedModelTurn(
-      resolveCodexSessionModel(dataDir, sessionId, transcriptPath),
-      prohibitedModels,
-    );
+    const model = resolveCodexSessionModel(dataDir, sessionId, transcriptPath);
+    const decision = decideProhibitedModelTurn(model, prohibitedModels);
+    // The model rides back with the verdict so the caller records WHICH model
+    // was refused without resolving it twice — and so the audit row and the
+    // message the user sees can never disagree about it.
+    return decision === null || model === undefined ? null : { decision, model };
   } catch {
     return null;
   }
@@ -82,7 +88,7 @@ export async function refuseProhibitedTurn(
  * stdout contract and testable without one.
  */
 export async function handleProhibitedTurn(
-  gateway: Pick<DataGateway, 'getPolicyBundle' | 'close'>,
+  gateway: Pick<DataGateway, 'getPolicyBundle' | 'recordAuditEvent' | 'close'>,
   dataDir: string,
   sessionId: string | undefined,
   transcriptPath: string | undefined,
@@ -90,9 +96,26 @@ export async function handleProhibitedTurn(
 ): Promise<boolean> {
   const blocked = await refuseProhibitedTurn(gateway, dataDir, sessionId, transcriptPath);
   if (blocked === null) return false;
+  // Recorded while the gateway is still open, and best-effort: a refusal that
+  // cannot be written down is still a refusal, so a failed write must not reach
+  // the entry's outer catch and turn this block into a fail-open allow.
+  try {
+    await gateway.recordAuditEvent(
+      buildModelRefusalEvent({
+        id: randomUUID(),
+        sessionId,
+        model: blocked.model,
+        seam: 'turn',
+        sourceTool: SOURCE_TOOL.Codex,
+        occurredAt: new Date().toISOString(),
+      }),
+    );
+  } catch {
+    // Swallowed on purpose — see above.
+  }
   // Closed here rather than left to the caller's runtime `finally`, which the
   // refusal path never reaches.
   await gateway.close();
-  await emit(blocked);
+  await emit(blocked.decision);
   return true;
 }

--- a/plugins/codex/src/hooks/model-guard.ts
+++ b/plugins/codex/src/hooks/model-guard.ts
@@ -11,7 +11,6 @@
 import { randomUUID } from 'node:crypto';
 
 import type { DataGateway } from '@akasecurity/plugin-sdk';
-import { SOURCE_TOOL } from '@akasecurity/schema';
 import {
   buildModelRefusalEvent,
   codexModelFromRecord,
@@ -19,6 +18,7 @@ import {
   modelFromTranscriptTail,
   readSessionModel,
 } from '@akasecurity/plugin-sdk';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 /**
  * The model this Codex session is running on, or undefined when it cannot be


### PR DESCRIPTION
**Stacked on #374**, which is stacked on #372. The diff shown is only this PR's work; it will retarget as the stack merges.

A refusal was visible only to the user it stopped. An operator who prohibited a model could watch usage of it fall away, and could not see the control *working* — on which machines, at which seam, how often. The one question governance actually asks had no answer.

## The shape

`model_refusal` is a structural audit row, written at all three refusal seams: the denied switch on Claude Code, and the refused turn on both Claude Code and Codex.

**No migration.** `event_type` is plain `TEXT` with no CHECK constraint, and the legacy compatibility views filter to the four capture kinds, so a structural row cannot leak into a legacy reader's result set.

## What it does not carry is the point

No prompt, no response, no content of any kind. The question is answered by **the model, the seam and the session**, and answering it does not require moving anything the user typed.

`content` is left unset rather than filled with a summary, so there is no field for text to creep into later — and that is asserted as the **absence of the key**, not as an empty value, because an empty string is a slot someone fills.

Two smaller decisions in the same spirit:

- `model` rides the attribute bag, which is a **generated column** on `audit_events` — so refusals are queryable by the same id the prohibition was keyed on, without unpacking JSON.
- `rootSessionId` is **omitted** rather than nulled when the session is unknown: it is a self-FK, so an id naming no row fails the insert outright.

## The failure mode this had to avoid

Every write is best-effort and swallows its own failure. A refusal that cannot be recorded is still a refusal — and letting the write reach the hook's outer `catch` would turn a **deny into a fail-open allow**, which is the one way this feature could leave a session *less* governed than before it existed.

The gateway is now closed at each exit rather than in a `finally`, because the refusal path needs it open to record the event it is about to emit.

## Note for review

The event type is restated in three places (Zod enum, `base-rows.ts`, the SQLite table). I tried deriving `base-rows.ts` from the Zod vocabulary to stop that drifting; the table asserts against it as **literals** (`drizzle/adherence.test.ts`) and a type alias does not satisfy that comparison, so it stays restated with a comment saying so.

## Verification

`pnpm test:oss` 41/41, lint and prettier clean across schema, plugin-sdk, claude-code and codex (run from inside `oss/` — the enterprise `format:check` ignores the submodule).
