### PR TITLE
feat(shares): device-side egress ingest projection and wiring

### DIFF
--- a/packages/dashboard-ui/src/data-shares/DataShareDetailView.tsx
+++ b/packages/dashboard-ui/src/data-shares/DataShareDetailView.tsx
@@ -51,13 +51,15 @@ function CallSiteCard({ st }: { st: CallSite }) {
       <span className="font-mono text-xs text-text-3">
         {st.file}:<b className="text-text-2">{st.line}</b>
       </span>
-      <div className="overflow-x-auto whitespace-pre rounded-md bg-ink px-2.5 py-2 font-mono text-xs leading-relaxed text-white mt-0.5">
-        <span className="text-code-muted">
-          {st.file.split('/').pop()}:{st.line}
-          {'  '}
-        </span>
-        {st.snippet}
-      </div>
+      {st.snippet !== '' && (
+        <div className="overflow-x-auto whitespace-pre rounded-md bg-ink px-2.5 py-2 font-mono text-xs leading-relaxed text-white mt-0.5">
+          <span className="text-code-muted">
+            {st.file.split('/').pop()}:{st.line}
+            {'  '}
+          </span>
+          {st.snippet}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -149,8 +149,10 @@ export type { VaultDerefInsert, VaultRow, VaultRowInsert } from './repositories/
 export { SqliteSecretVaultRepository } from './repositories/secret-vault.ts';
 export { SqliteSecurityRepository } from './repositories/security.ts';
 export {
+  capHits,
   MAX_EGRESS_CALL_SITES_PER_PROJECT,
   SqliteSharesRepository,
+  withoutDroppedFiles,
 } from './repositories/shares.ts';
 export { SqliteSourceProjectRepository } from './repositories/source-project.ts';
 export { compareBinaryVersions } from './semver.ts';

--- a/packages/persistence/src/repositories/shares.ts
+++ b/packages/persistence/src/repositories/shares.ts
@@ -127,7 +127,7 @@ function parseNetwork(networkJson: string | null): ShareDestinationSummary['netw
  * dropped rather than half-kept: half a generated blob's destinations is not a
  * usable inventory of it, and storing it would ledger the file as done.
  */
-function capHits(
+export function capHits(
   all: readonly ResolvedEgressHit[],
   mode: EgressReconcile['mode'],
 ): { hits: ResolvedEgressHit[]; droppedFiles: string[]; truncated: boolean } {
@@ -164,7 +164,7 @@ function capHits(
  * deletes by path prefix and recomputes the whole subtree every run — so it is
  * returned unchanged and its truncation stays a plain per-write cap.
  */
-function withoutDroppedFiles(
+export function withoutDroppedFiles(
   reconcile: EgressReconcile,
   droppedFiles: readonly string[],
 ): EgressReconcile {

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -61,6 +61,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'base32Decode',
   'base32Encode',
   'bindingInput',
+  'capHits',
   'capWarnEraEnforcementOnce',
   'captureId',
   'captureWireId',
@@ -125,6 +126,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'toolCallId',
   'verifyPointerTag',
   'withFileLock',
+  'withoutDroppedFiles',
   'writeControlPlaneCredential',
   'writeOwnerOnlyFileSync',
 ];

--- a/packages/plugin-runtime/src/attached/egress-wire.ts
+++ b/packages/plugin-runtime/src/attached/egress-wire.ts
@@ -20,6 +20,20 @@ import type {
  * variants — there is no branch on prefix — which is what keeps `git:X` and
  * `path:X` from aliasing to the same digest while letting the same `git:`
  * identity converge to the same digest across every device that scanned it.
+ *
+ * WHAT THIS DOES NOT BUY. The digest is for stable cross-device identity, not
+ * concealment. Its inputs are low-entropy and enumerable — a repo URL, or a
+ * local filesystem path — so anyone holding the digests recovers the plaintext
+ * by hashing a candidate list. It keeps an absolute `path:` root (which on macOS
+ * embeds an OS username) out of request logs and off the wire in front of a
+ * passive observer; it does not hide it from the deployment receiving it.
+ *
+ * That trade is deliberate. The org running the control plane is entitled to
+ * know which repos its own devices scanned, and `site.file` crosses in plaintext
+ * anyway. But do not upgrade this in place if concealment from the RECIPIENT is
+ * ever wanted: that needs a keyed construction (HMAC under a per-tenant secret),
+ * and a per-tenant key destroys the cross-device convergence above. It is a
+ * contract change, not a one-line swap here.
  */
 export function hashProjectKey(projectKey: string): string {
   return createHash('sha256').update(projectKey, 'utf8').digest('hex');

--- a/packages/plugin-runtime/src/attached/egress-wire.ts
+++ b/packages/plugin-runtime/src/attached/egress-wire.ts
@@ -1,0 +1,68 @@
+// The device-side projection of a project's egress-recording unit onto the
+// wire-boundary-safe shape both attached gateways forward. This is the ONLY
+// place that builds an `EgressIngestRequest` — neither gateway hand-rolls the
+// payload, so the privacy boundary has exactly one implementation.
+import { createHash } from 'node:crypto';
+
+import { capHits, withoutDroppedFiles } from '@akasecurity/persistence';
+import type {
+  EgressIngestHit,
+  EgressIngestRequest,
+  RecordProjectEgressInput,
+  ResolvedEgressHit,
+} from '@akasecurity/schema';
+
+/**
+ * Digest a local `projectKey` for the wire.
+ *
+ * Unsalted SHA-256 over the FULL prefixed key (including its `git:` / `path:`
+ * prefix), rendered as 64 lowercase hex characters. Uniform across both
+ * variants — there is no branch on prefix — which is what keeps `git:X` and
+ * `path:X` from aliasing to the same digest while letting the same `git:`
+ * identity converge to the same digest across every device that scanned it.
+ */
+export function hashProjectKey(projectKey: string): string {
+  return createHash('sha256').update(projectKey, 'utf8').digest('hex');
+}
+
+function toIngestHit(hit: ResolvedEgressHit): EgressIngestHit {
+  return {
+    host: hit.host,
+    kind: hit.kind,
+    name: hit.name,
+    category: hit.category,
+    trust: hit.trust,
+    network: hit.network,
+    method: hit.method,
+    transport: hit.transport,
+    url: hit.url,
+    template: hit.template,
+    dataClass: hit.dataClass,
+    site: {
+      file: hit.site.file,
+      line: hit.site.line,
+      dynamic: hit.site.dynamic,
+      vendored: hit.site.vendored,
+    },
+  };
+}
+
+/**
+ * Build the outbound ingest payload for one project's egress-recording unit.
+ *
+ * Applies the same per-project cap the local write enforces (`capHits`), drops
+ * the corresponding files from the reconcile set (`withoutDroppedFiles`), then
+ * strips everything that must not leave the device: `site.snippet` (source
+ * text), the plaintext `projectKey` (replaced with its digest), and
+ * `projectId` (a device-local id the tenant's inventory cannot resolve).
+ */
+export function toEgressIngestRequest(input: RecordProjectEgressInput): EgressIngestRequest {
+  const { hits, droppedFiles } = capHits(input.hits, input.reconcile.mode);
+  const reconcile = withoutDroppedFiles(input.reconcile, droppedFiles);
+  return {
+    projectKey: hashProjectKey(input.projectKey),
+    project: input.project,
+    reconcile,
+    hits: hits.map(toIngestHit),
+  };
+}

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -51,7 +51,7 @@ import { REQUEST_TIMEOUT_MS, withTimeout } from './with-timeout.ts';
  *
  * WRITE-ONLY, plus the posture self-report. There are deliberately no reads:
  * every read is served from the local store, and the credential a machine holds
- * is scoped to the four writes plus the policy bundle and whoami — nothing
+ * is scoped to the five writes plus the policy bundle and whoami — nothing
  * else. A read added here would be a method that cannot work against the
  * credential this gateway actually holds.
  */

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -16,6 +16,7 @@ import type {
   ConfigScanRecord,
   DayActivity,
   DetectionCategory,
+  EgressIngestRequest,
   EgressWriteSummary,
   FindingView,
   HealthSummary,
@@ -38,6 +39,7 @@ import type {
 } from '@akasecurity/schema';
 import { DEFAULT_ACTIONS } from '@akasecurity/schema';
 
+import { toEgressIngestRequest } from './egress-wire.ts';
 import { recordForwardDrops } from './forward-drops.ts';
 import type { ForwardPolicy } from './forward-policy.ts';
 import { REQUEST_TIMEOUT_MS, withTimeout } from './with-timeout.ts';
@@ -63,6 +65,10 @@ export interface AttachedClient {
   // posture-reporter.ts). The response is unused — whether the promise settles
   // is all the throttle needs.
   reportStorePosture(snapshot: StorePostureSnapshot): Promise<unknown>;
+  // One project's egress-recording unit, already projected to the
+  // wire-boundary-safe shape by `toEgressIngestRequest`. The response is
+  // unused — see recordProjectEgress below for why.
+  recordProjectEgress(request: EgressIngestRequest): Promise<unknown>;
 }
 
 export interface AttachedDataGatewayDeps {
@@ -633,15 +639,22 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
   }
 
   /**
-   * LOCAL-ONLY, deliberately. The shares API is read-plus-decision-override
-   * with no egress ingest endpoint, so there is nothing to forward to; adding a
-   * forward here would be inventing a wire contract that does not exist. The
-   * local write is the whole operation, and its summary is the real one — the
-   * scanner reads a throw as a FAILED WRITE and skips its ledger commit, so
-   * returning the inner gateway's result keeps the retry semantics honest.
+   * Local write first, forward second, LOCAL summary returned.
+   *
+   * The scanner reads a throw as a FAILED WRITE and withholds its ledger
+   * commit, so the local write happens strictly first and its result — never
+   * a server-derived one — is what the caller gets back. The forward is
+   * built through `toEgressIngestRequest`, the one place that projects the
+   * payload onto the wire-boundary-safe shape (no snippet, hashed
+   * projectKey), and its result is discarded: `forward.run` never throws or
+   * rejects, so there is nothing here to act on.
    */
   async recordProjectEgress(input: RecordProjectEgressInput): Promise<EgressWriteSummary> {
-    return this.deps.local.recordProjectEgress(input);
+    const summary = await this.deps.local.recordProjectEgress(input);
+    await this.deps.forward.run(() =>
+      this.deps.client.recordProjectEgress(toEgressIngestRequest(input)),
+    );
+    return summary;
   }
 
   // ---------------------------------------------------------------------

--- a/packages/plugin-runtime/src/attached/index.ts
+++ b/packages/plugin-runtime/src/attached/index.ts
@@ -5,6 +5,7 @@
 // decorator only when both halves of an attachment are present and agree, so a
 // machine that has never attached — the overwhelming majority — constructs none
 // of it and behaves exactly as it did before this existed.
+export { hashProjectKey, toEgressIngestRequest } from './egress-wire.ts';
 export type { GatewayMeta } from './factory.ts';
 // The device identity, and ONLY that: `aka attach` has to tell a deployment
 // which machine is asking, and reading it through the same store the posture

--- a/packages/plugin-runtime/src/attached/policy-sync.ts
+++ b/packages/plugin-runtime/src/attached/policy-sync.ts
@@ -31,7 +31,7 @@ export const SYNC_REQUEST_TIMEOUT_MS = 30_000;
  * (G2).
  *
  * This module builds its own client rather than reusing the gateway's
- * `AttachedClient`. That interface declares exactly the four ingest writes, and
+ * `AttachedClient`. That interface declares exactly the five ingest writes, and
  * it is the seam that keeps the hook path off the network: putting a bundle
  * fetch on it would make "the gateway can reach the control plane for reads" true
  * again, which is the property local-first exists to remove. The cost is one

--- a/packages/plugin-runtime/test/attached/egress-wire.test.ts
+++ b/packages/plugin-runtime/test/attached/egress-wire.test.ts
@@ -1,0 +1,213 @@
+import type { RecordProjectEgressInput, ResolvedEgressHit } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { hashProjectKey, toEgressIngestRequest } from '../../src/attached/egress-wire.ts';
+
+const HEX_64 = /^[0-9a-f]{64}$/;
+
+const hit = (over: Partial<ResolvedEgressHit> = {}): ResolvedEgressHit => ({
+  host: 'api.stripe.com',
+  kind: 'provider',
+  name: 'Stripe',
+  category: 'payments',
+  trust: 'recognized',
+  network: null,
+  method: 'POST',
+  transport: 'https',
+  url: 'https://api.stripe.com/v1/charges',
+  template: false,
+  dataClass: 'customer',
+  site: {
+    file: 'src/billing/charge.ts',
+    line: 42,
+    snippet: 'const client = new Stripe(process.env.STRIPE_SECRET_KEY);',
+    dynamic: false,
+    vendored: false,
+  },
+  ...over,
+});
+
+const input = (over: Partial<RecordProjectEgressInput> = {}): RecordProjectEgressInput => ({
+  projectKey: 'git:github.com/acme/widgets',
+  project: 'widgets',
+  projectId: 'source-project-1',
+  reconcile: { mode: 'walk', walkedPrefix: '' },
+  hits: [hit()],
+  ...over,
+});
+
+// ─── hashProjectKey ────────────────────────────────────────────────────────
+
+describe('hashProjectKey', () => {
+  it('is deterministic for an identical key', () => {
+    const key = 'git:github.com/acme/widgets';
+    expect(hashProjectKey(key)).toBe(hashProjectKey(key));
+  });
+
+  it('produces 64 lowercase hex characters', () => {
+    expect(hashProjectKey('git:github.com/acme/widgets')).toMatch(HEX_64);
+    expect(hashProjectKey('path:/Users/alice/code/widgets')).toMatch(HEX_64);
+  });
+
+  it('does not alias git: and path: variants of the same suffix', () => {
+    const suffix = 'github.com/acme/widgets';
+    expect(hashProjectKey(`git:${suffix}`)).not.toBe(hashProjectKey(`path:${suffix}`));
+  });
+
+  it('hashes over the full prefixed key, not just the suffix', () => {
+    // Same suffix, different prefix — must not collide with a bare hash of the
+    // suffix alone (i.e. the prefix is genuinely part of what is hashed).
+    const suffix = 'github.com/acme/widgets';
+    expect(hashProjectKey(`git:${suffix}`)).not.toBe(hashProjectKey(suffix));
+  });
+});
+
+// ─── toEgressIngestRequest: projection shape ──────────────────────────────
+
+describe('toEgressIngestRequest', () => {
+  it('strips snippet from every hit site', () => {
+    const payload = toEgressIngestRequest(input());
+    for (const h of payload.hits) {
+      expect('snippet' in h.site).toBe(false);
+    }
+  });
+
+  it('hashes projectKey for both git: and path: variants', () => {
+    const gitPayload = toEgressIngestRequest(input({ projectKey: 'git:github.com/acme/widgets' }));
+    expect(gitPayload.projectKey).toMatch(HEX_64);
+    expect(gitPayload.projectKey).not.toBe('git:github.com/acme/widgets');
+
+    const pathPayload = toEgressIngestRequest(input({ projectKey: 'path:/Users/alice/widgets' }));
+    expect(pathPayload.projectKey).toMatch(HEX_64);
+    expect(pathPayload.projectKey).not.toBe('path:/Users/alice/widgets');
+  });
+
+  it('hashing is deterministic across two builds of the same key', () => {
+    const first = toEgressIngestRequest(input());
+    const second = toEgressIngestRequest(input());
+    expect(first.projectKey).toBe(second.projectKey);
+  });
+
+  it('keeps display project, and drops projectId entirely', () => {
+    const payload = toEgressIngestRequest(input({ project: 'widgets', projectId: 'source-1' }));
+    expect(payload.project).toBe('widgets');
+    expect('projectId' in payload).toBe(false);
+  });
+
+  it('preserves vendored: true rather than omitting or defaulting it', () => {
+    const payload = toEgressIngestRequest(
+      input({ hits: [hit({ site: { ...hit().site, vendored: true } })] }),
+    );
+    expect(payload.hits[0]?.site.vendored).toBe(true);
+  });
+
+  it('preserves the reconcile block for walk mode', () => {
+    const payload = toEgressIngestRequest(
+      input({ reconcile: { mode: 'walk', walkedPrefix: 'src' } }),
+    );
+    expect(payload.reconcile).toEqual({ mode: 'walk', walkedPrefix: 'src' });
+  });
+
+  it('preserves the reconcile block for ledger mode', () => {
+    const reconcile = {
+      mode: 'ledger' as const,
+      scannedFiles: ['a.ts', 'b.ts'],
+      deletedFiles: ['c.ts'],
+    };
+    const payload = toEgressIngestRequest(input({ reconcile }));
+    expect(payload.reconcile).toEqual(reconcile);
+  });
+
+  it('carries only the confirmed hit-level fields', () => {
+    const payload = toEgressIngestRequest(input());
+    expect(Object.keys(payload.hits[0] ?? {}).sort()).toEqual(
+      [
+        'category',
+        'dataClass',
+        'host',
+        'kind',
+        'method',
+        'name',
+        'network',
+        'site',
+        'template',
+        'transport',
+        'trust',
+        'url',
+      ].sort(),
+    );
+  });
+
+  it('carries only the confirmed site-level fields', () => {
+    const payload = toEgressIngestRequest(input());
+    expect(Object.keys(payload.hits[0]?.site ?? {}).sort()).toEqual(
+      ['dynamic', 'file', 'line', 'vendored'].sort(),
+    );
+  });
+
+  it('applies the per-project cap before serialization (walk mode drops whole files by count)', () => {
+    const many = Array.from({ length: 5001 }, (_, i) =>
+      hit({ site: { ...hit().site, file: `src/f${String(i)}.ts`, line: 1 } }),
+    );
+    const payload = toEgressIngestRequest(
+      input({ reconcile: { mode: 'walk', walkedPrefix: '' }, hits: many }),
+    );
+    expect(payload.hits.length).toBe(5000);
+  });
+
+  it('applies withoutDroppedFiles to a ledger-mode reconcile set when the cap drops whole files', () => {
+    // One file with 5001 hits alone exceeds the cap and is dropped wholesale.
+    const overflowing = Array.from({ length: 5001 }, (_, i) =>
+      hit({ site: { ...hit().site, file: 'src/generated.ts', line: i + 1 } }),
+    );
+    const payload = toEgressIngestRequest(
+      input({
+        reconcile: {
+          mode: 'ledger',
+          scannedFiles: ['src/generated.ts', 'src/other.ts'],
+          deletedFiles: [],
+        },
+        hits: overflowing,
+      }),
+    );
+    expect(payload.hits.length).toBe(0);
+    expect(payload.reconcile).toEqual({
+      mode: 'ledger',
+      scannedFiles: ['src/other.ts'],
+      deletedFiles: [],
+    });
+  });
+});
+
+// ─── Privacy assertions over the serialized payload ───────────────────────
+
+describe('egress-wire-privacy: serialized payload', () => {
+  it('contains no "snippet" key at any nesting level', () => {
+    const payload = toEgressIngestRequest(input());
+    expect(JSON.stringify(payload)).not.toContain('"snippet"');
+  });
+
+  it('contains no substring of any local snippet value', () => {
+    const secretSnippet = 'const client = new Stripe(process.env.STRIPE_SECRET_KEY);';
+    const payload = toEgressIngestRequest(
+      input({ hits: [hit({ site: { ...hit().site, snippet: secretSnippet } })] }),
+    );
+    expect(JSON.stringify(payload)).not.toContain(secretSnippet);
+    expect(JSON.stringify(payload)).not.toContain('STRIPE_SECRET_KEY');
+  });
+
+  it('projectKey matches the digest shape, never a path:/git: plaintext prefix', () => {
+    const payload = toEgressIngestRequest(input({ projectKey: 'git:github.com/acme/widgets' }));
+    expect(payload.projectKey).toMatch(HEX_64);
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('git:');
+    expect(serialized).not.toContain('path:');
+  });
+
+  it('contains no OS username substring for a path: projectKey', () => {
+    const payload = toEgressIngestRequest(input({ projectKey: 'path:/Users/alice/code/widgets' }));
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain('alice');
+    expect(serialized).not.toContain('/Users/alice');
+  });
+});

--- a/packages/plugin-runtime/test/attached/gateway-exception-e2e.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway-exception-e2e.test.ts
@@ -127,6 +127,7 @@ const noopClient = (): AttachedClient => ({
   ingestInventory: () => Promise.resolve({}),
   recordAuditEvent: () => Promise.resolve(),
   reportStorePosture: () => Promise.resolve({}),
+  recordProjectEgress: () => Promise.resolve({}),
 });
 
 /** The backend is irrelevant to this decision; run every forward, ignore it. */

--- a/packages/plugin-runtime/test/attached/gateway-policy-e2e.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway-policy-e2e.test.ts
@@ -153,6 +153,7 @@ const noopClient = (): AttachedClient => ({
   ingestInventory: () => Promise.resolve({}),
   recordAuditEvent: () => Promise.resolve(),
   reportStorePosture: () => Promise.resolve({}),
+  recordProjectEgress: () => Promise.resolve({}),
 });
 
 const passthrough = (): ForwardPolicy => ({

--- a/packages/plugin-runtime/test/attached/gateway.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway.test.ts
@@ -167,6 +167,10 @@ function makeClient(calls: Calls, overrides: Partial<AttachedClient> = {}): Atta
       calls.order.push('client.reportStorePosture');
       return Promise.resolve({});
     }),
+    recordProjectEgress: vi.fn(() => {
+      calls.order.push('client.recordProjectEgress');
+      return Promise.resolve({ ok: true });
+    }),
     ...overrides,
   };
 }
@@ -371,11 +375,12 @@ describe('writes are local-FIRST, then forwarded', () => {
     ).toHaveBeenCalled();
   });
 
-  it('recordProjectEgress is LOCAL-ONLY — there is no egress ingest endpoint to forward to', async () => {
+  it('recordProjectEgress writes locally, then attempts a forward', async () => {
     const { gateway, calls } = build();
     const summary = await gateway.recordProjectEgress(egressInput());
-    expect(calls.order).toContain('local.recordProjectEgress');
-    expect(calls.order).not.toContain('forward.run');
+    expect(calls.order.indexOf('local.recordProjectEgress')).toBeLessThan(
+      calls.order.indexOf('client.recordProjectEgress'),
+    );
     // The inner gateway's real summary is returned, not a zeroed stand-in: the
     // scanner reads a throw as a failed write and skips its ledger commit.
     expect(summary).toEqual({
@@ -385,6 +390,22 @@ describe('writes are local-FIRST, then forwarded', () => {
       truncated: false,
       droppedFiles: [],
     });
+  });
+
+  it('recordProjectEgress forward failure still returns the LOCAL summary and does not throw', async () => {
+    const calls: Calls = { order: [] };
+    const client = makeClient(calls, {
+      recordProjectEgress: vi.fn(() => Promise.reject(new Error('backend down'))),
+    });
+    const { gateway } = build({ client, forward: passthroughForward(calls) });
+    await expect(gateway.recordProjectEgress(egressInput())).resolves.toEqual({
+      destinations: 1,
+      endpoints: 2,
+      callSites: 3,
+      truncated: false,
+      droppedFiles: [],
+    });
+    expect(calls.order).toContain('forward.run');
   });
 });
 

--- a/packages/remote/src/client.ts
+++ b/packages/remote/src/client.ts
@@ -3,6 +3,7 @@ import type {
   AttachDeviceRequest as AttachDeviceRequestT,
   AttachTokenResponse as AttachTokenResponseT,
   AuditEventBatchAck as AuditEventBatchAckT,
+  EgressIngestRequest as EgressIngestRequestT,
   IngestAck as IngestAckT,
   IngestBatch,
   InventoryContext,
@@ -16,6 +17,7 @@ import {
   AttachDeviceGrant,
   AttachTokenResponse,
   AuditEventBatchAck,
+  EgressIngestRequest,
   IngestAck,
   PluginWhoami,
   PolicyBundle,
@@ -28,10 +30,10 @@ import type { z } from 'zod';
 import type { RemoteResponse } from './http.ts';
 import { RemoteRequestError, RemoteRequestInvalid, RemoteResponseInvalid, send } from './http.ts';
 
-// The seven routes an attached machine may call, and nothing else.
+// The eight routes an attached machine may call, and nothing else.
 //
 // The set is small on purpose and is the same set a deployment scopes a
-// credential to: five writes and two self-scoped reads. There is deliberately
+// credential to: six writes and two self-scoped reads. There is deliberately
 // no way to ask this client for anything organization-wide — a credential on a
 // laptop should not be able to read what other people's machines reported, and
 // a client that cannot express the request is a stronger guarantee than a
@@ -50,6 +52,7 @@ const ROUTES = {
   storePosture: '/v1/store-posture',
   policyBundle: '/v1/policy-bundle',
   whoami: '/v1/plugin/whoami',
+  shares: '/v1/shares',
 } as const;
 
 export interface RemoteClientOptions {
@@ -90,6 +93,11 @@ export interface RemoteClient {
   getPolicyBundle(etag?: string): Promise<ConditionalBundle>;
   /** GET /v1/plugin/whoami — who this credential belongs to. */
   whoami(): Promise<PluginWhoamiT>;
+  /**
+   * POST /v1/shares — one project's egress-recording unit, already projected
+   * to the wire-boundary-safe shape (no snippet, hashed projectKey).
+   */
+  recordProjectEgress(request: EgressIngestRequestT): Promise<void>;
 }
 
 /** Header value as a single string; Node reports repeats as an array. */
@@ -283,6 +291,23 @@ export function createRemoteClient(options: RemoteClientOptions): RemoteClient {
     async whoami() {
       const response = await send({ ...common, method: 'GET', url: url(ROUTES.whoami) });
       return parsed(PluginWhoami, okBody(response), ROUTES.whoami);
+    },
+
+    async recordProjectEgress(request) {
+      // Validated on the way OUT, not merely typed — the same discipline as
+      // recordAuditEvent, and for the same reason: a caller that counts
+      // failures toward a circuit breaker cannot tell a raw ZodError from a
+      // transport fault, so a deterministic local shape bug must not open
+      // the breaker and suppress every unrelated forward.
+      const validated = EgressIngestRequest.safeParse(request);
+      if (!validated.success) throw new RemoteRequestInvalid(ROUTES.shares, validated.error);
+      const response = await send({
+        ...common,
+        method: 'POST',
+        url: url(ROUTES.shares),
+        body: JSON.stringify(validated.data),
+      });
+      okBody(response);
     },
   };
 }

--- a/packages/remote/src/http.ts
+++ b/packages/remote/src/http.ts
@@ -274,7 +274,7 @@ export async function send(options: SendOptions): Promise<RemoteResponse> {
     // request.
     //
     // There is deliberately no 'connect' sibling. Node dispatches that event
-    // only when the REQUEST method was CONNECT, and the seven routes are GET and
+    // only when the REQUEST method was CONNECT, and the eight routes are GET and
     // POST — so a handler for it could never run, and an unreachable line reads
     // as a covered case while proving nothing. The 'close' backstop below is
     // the general answer, and it covers that shape too.

--- a/packages/remote/src/index.ts
+++ b/packages/remote/src/index.ts
@@ -1,7 +1,7 @@
 // The control-plane transport: the one OSS package that reaches a network, and
 // only the network a machine's own settings name.
 //
-// It is deliberately narrow. `createRemoteClient` speaks the seven routes an
+// It is deliberately narrow. `createRemoteClient` speaks the eight routes an
 // attached machine is scoped to and cannot express anything else; `send` is the
 // single module underneath that opens a socket. Nothing here decides WHETHER a
 // machine is attached, reads the credential, or holds a policy — those belong to
@@ -35,7 +35,7 @@ export { createAttachClient, createRemoteClient } from './client.ts';
 // only one a caller could step around: anything in the workspace could build a
 // `SendOptions.url` from a less-trusted source and put the credential on a
 // cleartext socket, with nothing here to refuse it. Narrowing the barrel closes
-// it by construction instead — the package's whole public surface is now seven
+// it by construction instead — the package's whole public surface is now eight
 // named routes against one endpoint, and there is no exported way to hand this
 // module an arbitrary URL. Nothing outside the package used `send`.
 export {

--- a/packages/remote/test/client.test.ts
+++ b/packages/remote/test/client.test.ts
@@ -506,6 +506,27 @@ describe('the shares-ingest submission', () => {
 
     expect(server.received).toHaveLength(before);
   });
+
+  it('rejects a malformed projectKey digest before it reaches the wire', async () => {
+    // The digest is the one field on this request derived from the machine's own
+    // filesystem: a non-git project keys on `path:<abs root>`, which embeds an OS
+    // username. Hashing is what makes that safe to send, so a value that is not a
+    // digest is the exact shape of a build that forgot to hash — and it must fail
+    // HERE, on the machine that still holds the plaintext, not as a remote 400.
+    //
+    // Each case is a different way to miss: too short, uppercase hex, right
+    // length but not hex, and something that never resembled a digest at all.
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    const before = server.received.length;
+
+    for (const bad of ['a'.repeat(63), 'A'.repeat(64), 'zz'.repeat(32), 'AKIA-not-a-digest']) {
+      await expect(
+        client.recordProjectEgress({ ...egressRequest, projectKey: bad }),
+      ).rejects.toThrow();
+    }
+
+    expect(server.received).toHaveLength(before);
+  });
 });
 
 describe('routes', () => {

--- a/packages/remote/test/client.test.ts
+++ b/packages/remote/test/client.test.ts
@@ -1,4 +1,4 @@
-import type { StorePostureSnapshot } from '@akasecurity/schema';
+import type { EgressIngestRequest, StorePostureSnapshot } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { createAttachClient, createRemoteClient } from '../src/client.ts';
@@ -30,6 +30,28 @@ const bundle = {
   rules: [],
   customKeywords: [],
   fetchedAt: '2026-08-24T10:00:00.000Z',
+};
+
+const egressRequest: EgressIngestRequest = {
+  projectKey: 'a'.repeat(64),
+  project: 'widgets',
+  reconcile: { mode: 'walk', walkedPrefix: '' },
+  hits: [
+    {
+      host: 'api.stripe.com',
+      kind: 'provider',
+      name: 'Stripe',
+      category: 'payments',
+      trust: 'recognized',
+      network: null,
+      method: 'POST',
+      transport: 'https',
+      url: 'https://api.stripe.com/v1/charges',
+      template: false,
+      dataClass: 'customer',
+      site: { file: 'src/billing/charge.ts', line: 42, dynamic: false, vendored: false },
+    },
+  ],
 };
 
 const json = (payload: unknown) => JSON.stringify(payload);
@@ -451,10 +473,45 @@ describe('the audit-event submission', () => {
   });
 });
 
+describe('the shares-ingest submission', () => {
+  const server = useLoopbackServer();
+
+  it('posts a well-formed submission', async () => {
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    server.reply((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(json({ ok: true }));
+    });
+
+    await client.recordProjectEgress(egressRequest);
+    expect(server.received.at(-1)?.url).toBe('/v1/shares');
+  });
+
+  it('refuses a malformed request before it reaches the network', async () => {
+    // Validated on the way out, the same discipline as recordAuditEvent: a
+    // deterministic local shape bug must not be indistinguishable from a
+    // transport fault to a caller counting failures toward a circuit breaker.
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    const before = server.received.length;
+
+    const [firstHit] = egressRequest.hits;
+    if (firstHit === undefined) throw new Error('fixture must carry at least one hit');
+
+    await expect(
+      client.recordProjectEgress({
+        ...egressRequest,
+        hits: [{ ...firstHit, site: { ...firstHit.site, line: -1 } }] as never,
+      }),
+    ).rejects.toThrow();
+
+    expect(server.received).toHaveLength(before);
+  });
+});
+
 describe('routes', () => {
   const server = useLoopbackServer();
 
-  it('addresses each of the seven, and tolerates trailing slashes on the endpoint', async () => {
+  it('addresses each of the eight, and tolerates trailing slashes on the endpoint', async () => {
     // SEVERAL slashes, not one. The normalization is a scan rather than a
     // `replace(/\/+$/, '')` — that regex is quadratic on an all-slash string,
     // since the engine retries from every position and each attempt walks to the
@@ -476,7 +533,9 @@ describe('routes', () => {
                   keyKind: 'plugin',
                   serverTime: '2026-08-24T10:00:00.000Z',
                 })
-              : json({ accepted: 1, duplicates: 0, ok: true }),
+              : req.url === '/v1/shares'
+                ? json({ ok: true })
+                : json({ accepted: 1, duplicates: 0, ok: true }),
       );
     });
 
@@ -499,6 +558,7 @@ describe('routes', () => {
     await client.reportStorePosture(snapshot);
     await client.getPolicyBundle();
     await client.whoami();
+    await client.recordProjectEgress(egressRequest);
 
     expect(server.received.map((r) => `${r.method ?? ''} ${r.url ?? ''}`)).toEqual([
       'POST /v1/events',
@@ -508,6 +568,7 @@ describe('routes', () => {
       'POST /v1/store-posture',
       'GET /v1/policy-bundle',
       'GET /v1/plugin/whoami',
+      'POST /v1/shares',
     ]);
   });
 });

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -1,8 +1,17 @@
 import { z } from 'zod';
 
+import { EgressReconcile } from './egress-extraction.ts';
 import type { ActionTaken } from './finding.ts';
 import { ACTION_TAKEN_KEYS } from './finding.ts';
 import { AuditEventInput, ToolCallInspection } from './meta.ts';
+import {
+  DataClass,
+  DestinationKind,
+  DestinationNetwork,
+  HttpMethod,
+  ShareTrustLevel,
+  Transport,
+} from './shares.ts';
 
 // The control-plane wire contract: what an ATTACHED machine sends to the
 // deployment named by `WorkspaceSettings.controlPlane` (see ./local.ts), and
@@ -334,6 +343,50 @@ export const RecordAuditEventBatch = z
   })
   .meta({ id: 'RecordAuditEventBatch' });
 export type RecordAuditEventBatch = z.infer<typeof RecordAuditEventBatch>;
+
+// ─── Shares ingest (request: POST /v1/shares) ─────────────────────────────
+//
+// The wire projection of a device's local `ResolvedEgressHit` (./egress-extraction.ts).
+// Deliberately narrower than the local shape: `site.snippet` is stripped before
+// the payload leaves the device (source text never crosses the wire), and the
+// caller hashes `projectKey` before sending it (the plaintext key never crosses
+// the wire either). See `toEgressIngestRequest` in
+// `@akasecurity/plugin-runtime`'s `src/attached/egress-wire.ts`, which is the
+// only place that builds this shape.
+export const EgressIngestHit = z
+  .object({
+    host: z.string(),
+    kind: DestinationKind,
+    name: z.string(),
+    category: z.string(),
+    trust: ShareTrustLevel,
+    network: DestinationNetwork.nullable(),
+    method: HttpMethod,
+    transport: Transport,
+    url: z.string(),
+    template: z.boolean(),
+    dataClass: DataClass,
+    site: z.object({
+      file: z.string(),
+      line: z.number().int().positive(),
+      dynamic: z.boolean(),
+      vendored: z.boolean(),
+    }),
+  })
+  .meta({ id: 'EgressIngestHit' });
+export type EgressIngestHit = z.infer<typeof EgressIngestHit>;
+
+export const EgressIngestRequest = z
+  .object({
+    /** Hash digest of the local `projectKey`, never the plaintext. */
+    projectKey: z.string().min(1),
+    /** Display name only — never keys reconciliation. */
+    project: z.string(),
+    reconcile: EgressReconcile,
+    hits: z.array(EgressIngestHit),
+  })
+  .meta({ id: 'EgressIngestRequest' });
+export type EgressIngestRequest = z.infer<typeof EgressIngestRequest>;
 
 // ─── Lenient response parsers (no ids — see the header) ──────────────────────
 

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -378,8 +378,19 @@ export type EgressIngestHit = z.infer<typeof EgressIngestHit>;
 
 export const EgressIngestRequest = z
   .object({
-    /** Hash digest of the local `projectKey`, never the plaintext. */
-    projectKey: z.string().min(1),
+    /**
+     * Hash digest of the local `projectKey`, never the plaintext.
+     *
+     * ENFORCED, not just documented: 64 lowercase hex. `.min(1)` let the
+     * sentence above be true only by convention, so a build that forgot to hash
+     * would put a `path:/Users/<name>/…` root on the wire and learn about it as
+     * a remote 400, if at all. The narrow shape makes the same mistake a local
+     * `RemoteRequestInvalid` at the validate-on-out boundary, on the machine
+     * that still has the plaintext to not send.
+     */
+    projectKey: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/, 'projectKey must be a 64-character lowercase hex digest'),
     /** Display name only — never keys reconciliation. */
     project: z.string(),
     reconcile: EgressReconcile,

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -347,12 +347,27 @@ export type RecordAuditEventBatch = z.infer<typeof RecordAuditEventBatch>;
 // ─── Shares ingest (request: POST /v1/shares) ─────────────────────────────
 //
 // The wire projection of a device's local `ResolvedEgressHit` (./egress-extraction.ts).
-// Deliberately narrower than the local shape: `site.snippet` is stripped before
-// the payload leaves the device (source text never crosses the wire), and the
-// caller hashes `projectKey` before sending it (the plaintext key never crosses
-// the wire either). See `toEgressIngestRequest` in
-// `@akasecurity/plugin-runtime`'s `src/attached/egress-wire.ts`, which is the
-// only place that builds this shape.
+// Deliberately narrower than the local shape in two ways, and they are NOT the
+// same strength of claim — do not read them as a pair:
+//
+//   1. `site.snippet` is stripped before the payload leaves the device. Source
+//      text does not cross, and nothing downstream can reconstruct it.
+//   2. `projectKey` is sent as a digest. That is for STABLE CROSS-DEVICE
+//      IDENTITY, not concealment. Its inputs are low-entropy and enumerable — a
+//      `git:` key is a repo URL, a `path:` key is a local filesystem path — so
+//      anyone holding the digests recovers the plaintext by hashing a candidate
+//      list. It resists a passive observer, NOT the recipient.
+//
+// (2) is a deliberate trade rather than an oversight: the deployment is entitled
+// to know which repos its own devices scanned, and `site.file` crosses in
+// plaintext regardless. Concealment FROM THE RECIPIENT would need a keyed
+// construction — HMAC under a per-tenant secret — and this shape cannot be
+// quietly upgraded to one, because a key that varies by tenant destroys the
+// cross-device convergence the digest exists to provide. Wanting that later
+// means changing the contract, not tightening this function.
+//
+// See `toEgressIngestRequest` in `@akasecurity/plugin-runtime`'s
+// `src/attached/egress-wire.ts`, which is the only place that builds this shape.
 export const EgressIngestHit = z
   .object({
     host: z.string(),


### PR DESCRIPTION
Adds the device side of forwarding data-shares (egress scan results) from an attached machine to a control plane. Until now `recordProjectEgress` was LOCAL-ONLY by design — two gateways carried byte-identical "LOCAL-ONLY, deliberately" comments and a test pinned the behaviour. This reverses that decision deliberately, and inverts the test that held it.

## The privacy boundary is the point of this PR

A new projection, `toEgressIngestRequest` in `packages/plugin-runtime/src/attached/egress-wire.ts`, is the only thing that decides what leaves the machine:

- **`snippet` never crosses the wire.** Call-site source text stays on the device. What travels is `file`, `line`, `dynamic`, `vendored` — enough to locate a call site, not to read one.
- **`projectKey` is hashed on the device**, unsalted SHA-256 over the full prefixed key, uniformly across both the `git:` and `path:` variants. The `path:` form is an absolute root, which on macOS embeds an OS username; hashing at the sender keeps the plaintext out of network hops and request logs. Uniform rather than conditional because an asymmetric rule is one a future contributor gets wrong, and `project` (display) already covers operator readability.
- The per-project cap runs on the device, before serialization.

The projection builds its output as an **allowlist**, not a spread-and-delete. A field added to `ResolvedEgressHit` upstream cannot leak by default; someone has to add it here on purpose.

`test/attached/egress-wire.test.ts` enforces this with negative assertions rather than shape checks:

```
expect('snippet' in h.site).toBe(false)
expect(JSON.stringify(payload)).not.toContain('"snippet"')
// and: no substring of any local snippet value appears anywhere in the payload
```

That last one is the one that matters — it catches snippet content escaping through some other field, not just a field named `snippet`.

For context on where this sits relative to the field: "path + line, no snippet" is the documented default across Snyk Code, Datadog SAST, Semgrep and GitGuardian. None of them upload raw snippets by default either.

## Also here

- `capHits` / `withoutDroppedFiles` exported from `@akasecurity/persistence` so the projection can apply the same cap the local write does
- a 7th `ROUTES` entry and `recordProjectEgress` in `@akasecurity/remote`, validating on the way out
- the OSS attached gateway flipped from local-only to local-write-then-forward, fail-open throughout: the local write remains the system of record, its `EgressWriteSummary` is what the caller receives, and a forward failure can never break a session
- `DataShareDetailView` hides the snippet panel when empty

## Verification

`@akasecurity/schema` 803/803 · `@akasecurity/persistence` 1402/1404 (2 skipped) · `@akasecurity/plugin-runtime` 433/433 · `@akasecurity/remote` 28/28 · `@akasecurity/dashboard-ui` 388/388.

## Note for reviewers

The forward targets `POST /v1/shares`, which does not exist on any deployed control plane until the enterprise counterpart lands. That is harmless and needs no flag: the 404 reaches `ForwardPolicy` as a transport failure, the breaker opens after 3 failures with a 30s cooldown, and the local write is untouched.
