### PR TITLE
feat(findings): match a search against the attributed user

### DIFF
--- a/packages/schema/src/zod/findings-flat-build.ts
+++ b/packages/schema/src/zod/findings-flat-build.ts
@@ -54,9 +54,11 @@ export type InstanceFilterDimension = keyof InstanceFilterOptions;
 
 /**
  * The searchable text of one instance: rule id, category, masked value, repo,
- * file, its tool as the rendered "via Bash" label, and its id. Mirrors the
- * grouped path's haystack so the same `q` matches the same things in both
- * views — a tool searched as the bare name would collide with file paths.
+ * file, its tool as the rendered "via Bash" label, its id, and the label of
+ * the person it is attributed to (when the store attributes findings).
+ * Mirrors the grouped path's haystack so the same `q` matches the same things
+ * in both views — a tool searched as the bare name would collide with file
+ * paths.
  */
 function rowHaystack(row: FlatFindingRow): string {
   return [
@@ -67,6 +69,7 @@ function rowHaystack(row: FlatFindingRow): string {
     row.file,
     row.toolName ? `via ${row.toolName}` : '',
     row.id,
+    row.user?.name ?? '',
   ]
     .join(' ')
     .toLowerCase();

--- a/packages/schema/src/zod/findings-group-build.ts
+++ b/packages/schema/src/zod/findings-group-build.ts
@@ -526,6 +526,10 @@ function buildHaystack(g: FindingGroup, extra?: string): string {
     ...g.instances.map((i) => i.file),
     ...g.instances.map((i) => (i.toolName ? `via ${i.toolName}` : '')),
     ...g.instances.map((i) => i.id),
+    // The people: the whole group's list when the store folded one, plus the
+    // preview's own — the two overlap, and a haystack does not mind.
+    ...(g.users ?? []).map((u) => u.name),
+    ...g.instances.map((i) => i.user?.name ?? ''),
     ...(extra === undefined ? [] : [extra]),
   ]
     .join(' ')

--- a/packages/schema/test/zod/findings-flat-build.test.ts
+++ b/packages/schema/test/zod/findings-flat-build.test.ts
@@ -89,6 +89,12 @@ describe('matchesInstanceFilters', () => {
     expect(matchesInstanceFilters(withTool, { q: 'nothing-here' })).toBe(false);
   });
 
+  it('matches q against the attributed user label', () => {
+    const attributed = row({ user: { id: 'u1', name: 'Alice@example.com' } });
+    expect(matchesInstanceFilters(attributed, { q: 'alice@' })).toBe(true);
+    expect(matchesInstanceFilters(row(), { q: 'alice@' })).toBe(false);
+  });
+
   it('ignores the named dimension when one is excepted', () => {
     const opts = { severity: ['low'], subtype: ['aws-key'] };
     expect(matchesInstanceFilters(row(), opts)).toBe(false);

--- a/packages/schema/test/zod/findings-group-build.test.ts
+++ b/packages/schema/test/zod/findings-group-build.test.ts
@@ -253,6 +253,20 @@ describe('buildFindingGroups user attribution', () => {
     expect(groups[0]?.users).toEqual([alice, bob, carol]);
   });
 
+  it('matches q against the people, from the preview and from the aggregate', () => {
+    // Preview rows are Alice's; only the aggregate knows Carol is in the group.
+    const carol = { id: 'u-carol', name: 'carol@example.com' };
+    const preview: GroupableFindingRow[] = [{ ...statusRow('a1', 'aws-key'), user: alice }];
+    const groups = buildFindingGroups(preview, {
+      aggregates: new Map([['aws-key', { ...aggregate, users: [carol, alice] }]]),
+    });
+    expect(applyFindingFilters(groups, { q: 'ALICE@' })).toHaveLength(1);
+    expect(applyFindingFilters(groups, { q: 'carol@' })).toHaveLength(1);
+    expect(applyFindingFilters(groups, { q: 'bob@' })).toHaveLength(0);
+    // And with no aggregate the rows are the whole group.
+    expect(applyFindingFilters(buildFindingGroups(attributed), { q: 'bob@' })).toHaveLength(1);
+  });
+
   it('carries no users when the aggregate supplies none, rather than folding the preview', () => {
     const groups = buildFindingGroups(attributed, {
       aggregates: new Map([['aws-key', aggregate]]),


### PR DESCRIPTION
Stacked on #378 (N1 there). Merge #378 first; this PR's base is its branch.

## Summary

The User column is searchable: `q` now matches the attributed person's label in both findings haystacks.

- `rowHaystack` (flat) folds `row.user.name`.
- `buildHaystack` (grouped) folds the whole group's `users` — the list the store's aggregate supplied in #378 — plus the preview rows' own, so a person only the aggregate knows still matches, exactly as repos and files already do through `searchText`.

The local store attributes nothing, so its search is unchanged.

## Verification

- `findings-flat-build`: a row with a user matches `alice@`, a row without does not.
- `findings-group-build`: a group whose preview is Alice's and whose aggregate names Carol matches both, and not Bob; with no aggregate the rows are the whole group.
- Lint, typecheck and Prettier (this repo's) pass for `@akasecurity/schema`.

The consuming side (resolving `q` against member emails in the catalog and matching the ids in the tenant SQL) lands as the paired enterprise PR.
