### PR TITLE
feat(schema): declare models through a builder against one price table

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -6,7 +6,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./zod": "./src/zod/index.ts",
-    "./drizzle": "./src/drizzle/index.ts"
+    "./drizzle": "./src/drizzle/index.ts",
+    "./model": "./src/model/index.ts"
   },
   "scripts": {
     "lint": "eslint src test *.config.* && eslint --no-config-lookup -c eslint.scripts.config.mjs scripts",

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,6 +1,9 @@
 export * from './drizzle/sqlite-ddl.ts';
 export * from './exception-scope.ts';
 export * from './identity.ts';
+// Curated model catalog: vendor/platform vocabulary, the builder that declares a
+// model, the price table `token/cost-model.ts` reads, and id resolution.
+export * from './model/index.ts';
 export * from './time.ts';
 // Pure read-time token cost/rollup/format logic (no Node-API deps) — shared by
 // the plugin, the web-ui Activity surfaces, and the CLI/TUI.

--- a/packages/schema/src/model/builder.ts
+++ b/packages/schema/src/model/builder.ts
@@ -1,0 +1,217 @@
+// The catalog builder. Declaring a model is one call with vendor-level defaults
+// filled in, so adding a newly-released model is a single entry rather than a
+// hand-copied block of eighteen fields, and a field left unstated inherits the
+// vendor default rather than a neighbouring model's value.
+//
+// Usage (see `catalog.ts` for the real declarations):
+//
+//   const anthropic = vendor('anthropic', {
+//     family: { id: 'claude', name: 'Claude' },
+//     region: 'us',
+//     retention: 'zero_retention',
+//     training: { apiDefault: 'no', consumerDefault: 'no', ... },
+//   });
+//
+//   anthropic.model('claude-opus-5', {
+//     name: 'Claude Opus 5',
+//     ctx: 1_000_000,
+//     capability: 'reasoning',
+//     price: anthropicPrice(5, 25, 0.5),
+//     on: ['bedrock', 'vertex'],       // metadata resolves; price stays unknown
+//   });
+//
+// The `price` argument is the FIRST-PARTY price and the builder attaches it
+// only to the vendor's own platform. A reseller listed in `on` inherits the
+// model's identity — same weights, same context window, same open-weights
+// answer — with an unknown price and retention posture, since both are
+// properties of the serving contract. Overriding either for a reseller takes
+// the object form of `on`, which is more verbose than the bare string so that
+// a reseller price reads as a decision in the diff.
+import type {
+  DataRetention,
+  ModelCapability,
+  VendorTrainingPolicy,
+} from './governance.ts';
+import type { ModelPrice } from './pricing.ts';
+import { ZERO_PRICE } from './pricing.ts';
+import type { ModelHosting, ModelPlatform, ModelVendor } from './providers.ts';
+import { firstPartyPlatformFor, hostingFor, isFirstParty } from './providers.ts';
+
+/** What one platform offers for one model. */
+export interface PlatformOffering {
+  platform: ModelPlatform;
+  hosting: ModelHosting;
+  /** True when this is the vendor's own endpoint. */
+  firstParty: boolean;
+  /** `null` means the price is not verified for this platform — never 0, never a guess. */
+  price: ModelPrice | null;
+  /** `'unknown'` for any platform whose terms have not been read. */
+  retention: DataRetention;
+  /** Serving region, or `null` when unpinned/unverified. */
+  region: string | null;
+}
+
+/** A fully-resolved catalog entry. Every field is present; unknowns are `null`. */
+export interface ModelEntry {
+  /** The vendor's canonical first-party model id. */
+  id: string;
+  vendor: ModelVendor;
+  displayName: string;
+  familyId: string;
+  familyName: string;
+  /** `null` is a curated "no flagged specialisation", not an unfilled field. */
+  capability: ModelCapability | null;
+  /** `null` when the published context window has not been verified. */
+  contextWindow: number | null;
+  /** `null` when the published output cap has not been verified. */
+  maxOutputTokens: number | null;
+  openWeights: boolean;
+  /** Additional canonical spellings that mean this same model (e.g. a dated id). */
+  aliases: readonly string[];
+  /** The vendor's published training policy, or `null` if not curated. */
+  training: VendorTrainingPolicy | null;
+  /** Every platform known to serve this model, keyed by platform. */
+  platforms: ReadonlyMap<ModelPlatform, PlatformOffering>;
+}
+
+/** Vendor-level defaults every model from this vendor inherits. */
+export interface VendorDefaults {
+  family?: { id: string; name: string };
+  region?: string | null;
+  /** Retention on the vendor's OWN endpoint. Resellers always start `'unknown'`. */
+  retention?: DataRetention;
+  training?: VendorTrainingPolicy;
+  openWeights?: boolean;
+}
+
+/** A reseller/host entry with explicit overrides, for when its terms ARE known. */
+export interface PlatformSpec {
+  platform: ModelPlatform;
+  price?: ModelPrice;
+  retention?: DataRetention;
+  region?: string | null;
+}
+
+/** How a model declares the platforms serving it. */
+export type PlatformRef = ModelPlatform | PlatformSpec;
+
+/** One model's declaration. Vendor defaults fill anything omitted. */
+export interface ModelSpec {
+  /** Human-facing name. */
+  name: string;
+  /** Published context window in tokens; omit when unverified. */
+  ctx?: number;
+  /** Published max output tokens; omit when unverified. */
+  maxOut?: number;
+  capability?: ModelCapability | null;
+  /** The FIRST-PARTY price. Never applied to a reseller. */
+  price?: ModelPrice;
+  /** Platforms serving this model, besides the vendor's own. */
+  on?: readonly PlatformRef[];
+  /** Other ids that denote these same weights (dated forms, renames). */
+  aliases?: readonly string[];
+  /** Override the vendor's family for a model that sits outside it. */
+  family?: { id: string; name: string };
+  openWeights?: boolean;
+  retention?: DataRetention;
+  region?: string | null;
+}
+
+function normalizeRef(ref: PlatformRef): PlatformSpec {
+  return typeof ref === 'string' ? { platform: ref } : ref;
+}
+
+/**
+ * A vendor-scoped model builder. Collects the models declared through it so a
+ * catalog is assembled from explicit lists rather than from import side effects
+ * — `catalog.ts` composes `vendor.models()` arrays, which keeps the build
+ * order visible and makes the whole thing testable without module mocking.
+ */
+export class ModelVendorBuilder {
+  readonly vendor: ModelVendor;
+
+  private readonly defaults: VendorDefaults;
+
+  private readonly entries: ModelEntry[] = [];
+
+  constructor(vendor: ModelVendor, defaults: VendorDefaults = {}) {
+    this.vendor = vendor;
+    this.defaults = defaults;
+  }
+
+  /**
+   * Declare a model. Returns the built entry (handy for tests and for
+   * cross-referencing) and records it for `models()`.
+   */
+  model(id: string, spec: ModelSpec): ModelEntry {
+    const family = spec.family ?? this.defaults.family ?? { id, name: spec.name };
+    const ownPlatform = firstPartyPlatformFor(this.vendor);
+    const openWeights = spec.openWeights ?? this.defaults.openWeights ?? false;
+    const vendorRegion = spec.region ?? this.defaults.region ?? null;
+    const vendorRetention = spec.retention ?? this.defaults.retention ?? 'unknown';
+
+    const platforms = new Map<ModelPlatform, PlatformOffering>();
+
+    // The vendor's own endpoint, when it has one. This is the only platform
+    // that may carry `spec.price` and the vendor's retention posture.
+    if (ownPlatform !== null) {
+      platforms.set(ownPlatform, {
+        platform: ownPlatform,
+        hosting: hostingFor(ownPlatform),
+        firstParty: true,
+        price: spec.price ?? null,
+        retention: vendorRetention,
+        region: vendorRegion,
+      });
+    }
+
+    for (const ref of spec.on ?? []) {
+      const { platform, price, retention, region } = normalizeRef(ref);
+      const firstParty = isFirstParty(this.vendor, platform);
+      const hosting = hostingFor(platform);
+
+      // Self-hosted weights: cost is a known zero and the data never leaves the
+      // caller's infrastructure. Both are facts about the deployment, so they
+      // are safe to assert without a per-platform price page.
+      const isSelfHosted = hosting === 'local';
+
+      platforms.set(platform, {
+        platform,
+        hosting,
+        firstParty,
+        price: price ?? (isSelfHosted ? ZERO_PRICE : firstParty ? (spec.price ?? null) : null),
+        retention:
+          retention ?? (isSelfHosted ? 'on_infrastructure' : firstParty ? vendorRetention : 'unknown'),
+        region: region === undefined ? (firstParty ? vendorRegion : null) : region,
+      });
+    }
+
+    const entry: ModelEntry = {
+      id,
+      vendor: this.vendor,
+      displayName: spec.name,
+      familyId: family.id,
+      familyName: family.name,
+      capability: spec.capability ?? null,
+      contextWindow: spec.ctx ?? null,
+      maxOutputTokens: spec.maxOut ?? null,
+      openWeights,
+      aliases: Object.freeze([...(spec.aliases ?? [])]),
+      training: this.defaults.training ?? null,
+      platforms,
+    };
+
+    this.entries.push(entry);
+    return entry;
+  }
+
+  /** Every model declared through this builder, in declaration order. */
+  models(): readonly ModelEntry[] {
+    return this.entries;
+  }
+}
+
+/** Start a vendor-scoped builder. */
+export function vendor(v: ModelVendor, defaults: VendorDefaults = {}): ModelVendorBuilder {
+  return new ModelVendorBuilder(v, defaults);
+}

--- a/packages/schema/src/model/builder.ts
+++ b/packages/schema/src/model/builder.ts
@@ -141,6 +141,15 @@ export interface ModelSpec {
   defaultHosting?: ModelHosting;
   /** Defaults to `'managed'`; `'discovered'` for a model only traffic reaches. */
   seen?: ModelSeen;
+  /**
+   * Whether the vendor's own endpoint serves this model. Defaults to `true`.
+   *
+   * Set `false` for open weights a vendor publishes but does not host — the
+   * builder would otherwise give the model a first-party offering the vendor
+   * does not actually provide, and a surface enumerating `platforms` would
+   * list it.
+   */
+  firstParty?: boolean;
 }
 
 function normalizeRef(ref: PlatformRef): PlatformSpec {
@@ -171,7 +180,7 @@ export class ModelVendorBuilder {
    */
   model(id: string, spec: ModelSpec): ModelEntry {
     const family = spec.family ?? this.defaults.family ?? { id, name: spec.name };
-    const ownPlatform = firstPartyPlatformFor(this.vendor);
+    const ownPlatform = spec.firstParty === false ? null : firstPartyPlatformFor(this.vendor);
     const openWeights = spec.openWeights ?? this.defaults.openWeights ?? false;
     const vendorRegion = spec.region ?? this.defaults.region ?? null;
     const vendorRetention = spec.retention ?? this.defaults.retention ?? 'unknown';
@@ -181,14 +190,17 @@ export class ModelVendorBuilder {
     // The vendor's own endpoint, when it has one. This is the only platform
     // that may carry `spec.price` and the vendor's retention posture.
     if (ownPlatform !== null) {
-      platforms.set(ownPlatform, {
-        platform: ownPlatform,
-        hosting: hostingFor(ownPlatform),
-        firstParty: true,
-        price: spec.price ?? null,
-        retention: vendorRetention,
-        region: vendorRegion,
-      });
+      platforms.set(
+        ownPlatform,
+        Object.freeze({
+          platform: ownPlatform,
+          hosting: hostingFor(ownPlatform),
+          firstParty: true,
+          price: spec.price ?? null,
+          retention: vendorRetention,
+          region: vendorRegion,
+        }),
+      );
     }
 
     for (const ref of spec.on ?? []) {
@@ -201,15 +213,19 @@ export class ModelVendorBuilder {
       // are safe to assert without a per-platform price page.
       const isSelfHosted = hosting === 'local';
 
-      platforms.set(platform, {
+      platforms.set(
         platform,
-        hosting,
-        firstParty,
-        price: price ?? (isSelfHosted ? ZERO_PRICE : firstParty ? (spec.price ?? null) : null),
-        retention:
-          retention ?? (isSelfHosted ? 'on_infrastructure' : firstParty ? vendorRetention : 'unknown'),
-        region: region === undefined ? (firstParty ? vendorRegion : null) : region,
-      });
+        Object.freeze({
+          platform,
+          hosting,
+          firstParty,
+          price: price ?? (isSelfHosted ? ZERO_PRICE : firstParty ? (spec.price ?? null) : null),
+          retention:
+            retention ??
+            (isSelfHosted ? 'on_infrastructure' : firstParty ? vendorRetention : 'unknown'),
+          region: region === undefined ? (firstParty ? vendorRegion : null) : region,
+        }),
+      );
     }
 
     // A vendor with a first-party endpoint answers this from that endpoint; a
@@ -218,6 +234,19 @@ export class ModelVendorBuilder {
       spec.defaultHosting ??
       this.defaults.defaultHosting ??
       (ownPlatform === null ? 'gateway' : hostingFor(ownPlatform));
+
+    // A stated price that reached no offering is a silent loss: the model reads
+    // as "cost unknown" forever, indistinguishable from the deliberate
+    // reseller-unpriced case this builder is built around. That happens when
+    // the vendor has no first-party platform (or was never added to the
+    // first-party table), so it is refused rather than dropped.
+    if (spec.price !== undefined && ![...platforms.values()].some((o) => o.price === spec.price)) {
+      throw new Error(
+        `${id}: a first-party price was declared but no platform can carry it — ` +
+          `vendor '${this.vendor}' has no first-party endpoint. Price the serving ` +
+          `platform explicitly via the object form of \`on\`.`,
+      );
+    }
 
     const entry: ModelEntry = {
       id,
@@ -235,6 +264,14 @@ export class ModelVendorBuilder {
       defaultHosting,
       seen: spec.seen ?? 'managed',
     };
+
+    // Frozen so a consumer cannot rewrite a curated fact for the whole process.
+    // `platforms` is a Map, which `Object.freeze` cannot seal — a determined
+    // cast can still call `.set` on it. Everything reachable through it is
+    // frozen, so an accidental write fails; a deliberate one is out of scope
+    // for a value type and would need a wrapper on this read path.
+    Object.freeze(entry);
+    Object.freeze(entry.aliases);
 
     this.entries.push(entry);
     return entry;

--- a/packages/schema/src/model/builder.ts
+++ b/packages/schema/src/model/builder.ts
@@ -30,6 +30,7 @@
 import type {
   DataRetention,
   ModelCapability,
+  ModelSeen,
   VendorTrainingPolicy,
 } from './governance.ts';
 import type { ModelPrice } from './pricing.ts';
@@ -82,6 +83,15 @@ export interface ModelEntry {
    * estimated wherever it is rendered.
    */
   defaultHosting: ModelHosting;
+  /**
+   * Whether this is a model a deployment would deliberately onboard, or one
+   * that is only ever reached by traffic. A legacy model nobody selects on
+   * purpose is `'discovered'`, which puts it in the review queue.
+   *
+   * Curated rather than derived: being IN the catalog says the model is known,
+   * not that anyone chose it.
+   */
+  seen: ModelSeen;
 }
 
 /** Vendor-level defaults every model from this vendor inherits. */
@@ -129,6 +139,8 @@ export interface ModelSpec {
   /** Curated hosting band for an id that names no platform. Defaults to the
    * vendor's own endpoint's band, or `'gateway'` for a vendor with none. */
   defaultHosting?: ModelHosting;
+  /** Defaults to `'managed'`; `'discovered'` for a model only traffic reaches. */
+  seen?: ModelSeen;
 }
 
 function normalizeRef(ref: PlatformRef): PlatformSpec {
@@ -221,6 +233,7 @@ export class ModelVendorBuilder {
       training: this.defaults.training ?? null,
       platforms,
       defaultHosting,
+      seen: spec.seen ?? 'managed',
     };
 
     this.entries.push(entry);

--- a/packages/schema/src/model/builder.ts
+++ b/packages/schema/src/model/builder.ts
@@ -72,6 +72,16 @@ export interface ModelEntry {
   training: VendorTrainingPolicy | null;
   /** Every platform known to serve this model, keyed by platform. */
   platforms: ReadonlyMap<ModelPlatform, PlatformOffering>;
+  /**
+   * The hosting band to assume when an observed id names no platform.
+   *
+   * A first-party model resolves to its own endpoint's band. An open-weights
+   * model has no first-party endpoint and its id alone does not say whether it
+   * ran on a third-party host or the caller's own hardware, so the band is a
+   * CURATED call rather than a derived one — declared per model, and marked
+   * estimated wherever it is rendered.
+   */
+  defaultHosting: ModelHosting;
 }
 
 /** Vendor-level defaults every model from this vendor inherits. */
@@ -82,6 +92,7 @@ export interface VendorDefaults {
   retention?: DataRetention;
   training?: VendorTrainingPolicy;
   openWeights?: boolean;
+  defaultHosting?: ModelHosting;
 }
 
 /** A reseller/host entry with explicit overrides, for when its terms ARE known. */
@@ -115,6 +126,9 @@ export interface ModelSpec {
   openWeights?: boolean;
   retention?: DataRetention;
   region?: string | null;
+  /** Curated hosting band for an id that names no platform. Defaults to the
+   * vendor's own endpoint's band, or `'gateway'` for a vendor with none. */
+  defaultHosting?: ModelHosting;
 }
 
 function normalizeRef(ref: PlatformRef): PlatformSpec {
@@ -186,6 +200,13 @@ export class ModelVendorBuilder {
       });
     }
 
+    // A vendor with a first-party endpoint answers this from that endpoint; a
+    // vendor without one must state it, since the id carries no platform.
+    const defaultHosting: ModelHosting =
+      spec.defaultHosting ??
+      this.defaults.defaultHosting ??
+      (ownPlatform === null ? 'gateway' : hostingFor(ownPlatform));
+
     const entry: ModelEntry = {
       id,
       vendor: this.vendor,
@@ -199,6 +220,7 @@ export class ModelVendorBuilder {
       aliases: Object.freeze([...(spec.aliases ?? [])]),
       training: this.defaults.training ?? null,
       platforms,
+      defaultHosting,
     };
 
     this.entries.push(entry);

--- a/packages/schema/src/model/catalog.ts
+++ b/packages/schema/src/model/catalog.ts
@@ -136,6 +136,14 @@ anthropic.model('claude-haiku-4-5', {
   on: [...CLAUDE_RESELLERS],
 });
 
+// Retired but still reported. The pricing page no longer lists it, so its rate
+// is unknown — which reads as $0 spend, flagged estimated, rather than as a
+// wrong figure.
+anthropic.model('claude-sonnet-3-7', {
+  name: 'Claude Sonnet 3.7',
+  on: [...CLAUDE_RESELLERS],
+});
+
 // ─── OpenAI ──────────────────────────────────────────────────────────────────
 // Prices: developers.openai.com/api/docs/pricing. Context windows:
 // learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models.
@@ -269,6 +277,41 @@ openai.model('gpt-5-nano', {
   on: [...OPENAI_RESELLERS],
 });
 
+// Prior-generation OpenAI models still reported by deployments. Kept so they
+// resolve to a real vendor rather than the Unknown fallback; context windows
+// are not on the pricing page and are recorded as unknown.
+openai.model('gpt-4.1', {
+  name: 'GPT-4.1',
+  price: tokenPrice(2, 8, { cacheRead: 0.5 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-4o', {
+  name: 'GPT-4o',
+  price: tokenPrice(2.5, 10, { cacheRead: 1.25 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-4o-mini', {
+  name: 'GPT-4o mini',
+  price: tokenPrice(0.15, 0.6, { cacheRead: 0.075 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-4-turbo', {
+  name: 'GPT-4 Turbo',
+  price: tokenPrice(10, 30),
+  aliases: ['gpt-4-turbo-2024-04-09'],
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('o3', {
+  name: 'o3',
+  capability: 'reasoning',
+  price: tokenPrice(2, 8, { cacheRead: 0.5 }),
+  on: [...OPENAI_RESELLERS],
+});
+
 // Open-weight OpenAI models, served only by third parties.
 openai.model('gpt-oss-120b', {
   name: 'GPT-OSS 120B',
@@ -367,6 +410,10 @@ google.model('gemini-2.5-flash-lite', {
   on: ['vertex'],
 });
 
+// Off Google's current pricing page; identity resolves, rate is unknown.
+google.model('gemini-1-5-pro', { name: 'Gemini 1.5 Pro', on: ['vertex'] });
+google.model('gemini-1-5-flash', { name: 'Gemini 1.5 Flash', on: ['vertex'] });
+
 // ─── xAI ─────────────────────────────────────────────────────────────────────
 // Prices + context: docs.x.ai/docs/models. Every text model tiers at 200K input.
 // Training: docs.x.ai/developers/faq/security — API inputs and outputs are not
@@ -463,6 +510,15 @@ deepseek.model('deepseek-v4-pro', {
   on: ['bedrock', 'together', 'fireworks', 'openrouter'],
 });
 
+// Off DeepSeek's current pricing page; served on third-party hosts.
+deepseek.model('deepseek-r1', {
+  name: 'DeepSeek R1',
+  capability: 'reasoning',
+  openWeights: true,
+  defaultHosting: 'local',
+  on: ['bedrock', 'together', 'fireworks', 'openrouter', 'ollama', 'local'],
+});
+
 // ─── Cohere ──────────────────────────────────────────────────────────────────
 // Context windows: docs.cohere.com/docs/models. Current-generation prices are
 // not published (the reasoning tier is sales-priced), so they are unknown.
@@ -506,6 +562,8 @@ cohere.model('command-r-plus-08-2024', {
   ctx: 128_000,
   maxOut: 4_000,
   price: tokenPrice(2.5, 10),
+  // The undated form is what deployments report; the live id carries the date.
+  aliases: ['command-r-plus'],
   on: ['bedrock'],
 });
 
@@ -584,7 +642,20 @@ amazon.model('nova-2-lite', {
   on: ['bedrock'],
 });
 
-// Mistral's wire model ids are not published alongside its pricing (the pricing
+const mistral = vendor('mistral', {
+  family: { id: 'mistral', name: 'Mistral' },
+  openWeights: true,
+  retention: 'unknown',
+  defaultHosting: 'local',
+});
+
+// Absent from Mistral's current model list; survives on third-party hosts.
+mistral.model('mixtral-8x7b', {
+  name: 'Mixtral 8x7B',
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+// The rest of Mistral's wire model ids are not published alongside its pricing (the pricing
 // page uses display names and version tags), so no Mistral entries are declared
 // rather than declaring ids that would not resolve.
 
@@ -596,6 +667,7 @@ export const MODEL_ENTRIES: readonly ModelEntry[] = Object.freeze([
   ...xai.models(),
   ...deepseek.models(),
   ...cohere.models(),
+  ...mistral.models(),
   ...meta.models(),
   ...alibaba.models(),
   ...amazon.models(),

--- a/packages/schema/src/model/catalog.ts
+++ b/packages/schema/src/model/catalog.ts
@@ -1,0 +1,599 @@
+// The model catalog. One declaration per model; vendor defaults supply the rest.
+//
+// Curation rules, in force for every entry below:
+//
+//   - A field is stated only when it was read from the vendor's own published
+//     documentation. Anything unread is omitted, which resolves to `null`
+//     (unknown) rather than to a plausible-looking value.
+//   - `price` is the vendor's FIRST-PARTY rate. Platforms listed in `on` carry
+//     no price unless that platform's own rate was read.
+//   - `ctx` is omitted rather than guessed. A wrong context window is read by
+//     capacity and data-exposure reviews as though it were checked.
+//
+// Prices are USD per million tokens and are a REFERENCE snapshot, not billing.
+// Re-verify against the cited page when updating.
+import type { ModelEntry } from './builder.ts';
+import { vendor } from './builder.ts';
+import type { VendorTrainingPolicy } from './governance.ts';
+import { anthropicPrice, tokenPrice } from './pricing.ts';
+import { buildModelIndex } from './resolve.ts';
+
+// ─── Anthropic ───────────────────────────────────────────────────────────────
+// Prices + context: platform.claude.com/docs/en/about-claude/pricing and
+// platform.claude.com/docs/en/models/overview.
+// Training: privacy.claude.com — commercial products are not used for training
+// by default; consumer tiers are opt-IN ("Model Improvement"), not opt-out.
+
+const ANTHROPIC_TRAINING: VendorTrainingPolicy = {
+  apiDefault: 'no',
+  consumerDefault: 'no',
+  consumerControl: 'opt-in',
+  source: 'https://privacy.claude.com/en/articles/7996868-is-my-data-used-for-model-training',
+};
+
+const anthropic = vendor('anthropic', {
+  family: { id: 'claude', name: 'Claude' },
+  region: 'us',
+  retention: 'zero_retention',
+  training: ANTHROPIC_TRAINING,
+});
+
+const CLAUDE_RESELLERS = ['bedrock', 'vertex', 'foundry'] as const;
+
+anthropic.model('claude-fable-5-1', {
+  name: 'Claude Fable 5.1',
+  ctx: 1_000_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: anthropicPrice(10, 50, 0.25),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-fable-5', {
+  name: 'Claude Fable 5',
+  capability: 'reasoning',
+  price: anthropicPrice(10, 50, 1),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-5', {
+  name: 'Claude Opus 5',
+  ctx: 1_000_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: anthropicPrice(5, 25, 0.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-4-8', {
+  name: 'Claude Opus 4.8',
+  capability: 'reasoning',
+  price: anthropicPrice(5, 25, 0.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-4-7', {
+  name: 'Claude Opus 4.7',
+  capability: 'reasoning',
+  price: anthropicPrice(5, 25, 0.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-4-6', {
+  name: 'Claude Opus 4.6',
+  capability: 'reasoning',
+  price: anthropicPrice(5, 25, 0.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-4-5', {
+  name: 'Claude Opus 4.5',
+  capability: 'reasoning',
+  price: anthropicPrice(5, 25, 0.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-opus-4-1', {
+  name: 'Claude Opus 4.1',
+  capability: 'reasoning',
+  price: anthropicPrice(15, 75, 1.5),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-sonnet-5', {
+  name: 'Claude Sonnet 5',
+  ctx: 1_000_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: anthropicPrice(2, 10, 0.2),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-sonnet-4-6', {
+  name: 'Claude Sonnet 4.6',
+  capability: 'reasoning',
+  price: anthropicPrice(3, 15, 0.3),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-sonnet-4-5', {
+  name: 'Claude Sonnet 4.5',
+  capability: 'reasoning',
+  price: anthropicPrice(3, 15, 0.3),
+  on: [...CLAUDE_RESELLERS],
+});
+
+anthropic.model('claude-haiku-4-5', {
+  name: 'Claude Haiku 4.5',
+  ctx: 200_000,
+  maxOut: 64_000,
+  // Reviewed: fast/cheap tier, no flagged reasoning or code specialisation.
+  capability: null,
+  price: anthropicPrice(1, 5, 0.1),
+  // The vendor documents `claude-haiku-4-5-20251001` as the versioned id and
+  // `claude-haiku-4-5` as its alias; both are reported in the wild.
+  aliases: ['claude-haiku-4-5-20251001'],
+  on: [...CLAUDE_RESELLERS],
+});
+
+// ─── OpenAI ──────────────────────────────────────────────────────────────────
+// Prices: developers.openai.com/api/docs/pricing. Context windows:
+// learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/models.
+// Above 272,000 input tokens the long-context rate applies to the WHOLE request;
+// that rate is not published on the pricing page, so it is recorded as unknown.
+// Training: the API is not used for training by default (opt-in); ChatGPT
+// consumer tiers are on by default with an opt-out under Data Controls.
+
+const OPENAI_TRAINING: VendorTrainingPolicy = {
+  apiDefault: 'no',
+  consumerDefault: 'yes',
+  consumerControl: 'opt-out',
+  source: 'https://developers.openai.com/api/docs/guides/your-data',
+};
+
+const LONG_CONTEXT_272K = { thresholdInputTokens: 272_000, input: null, output: null };
+
+const openai = vendor('openai', {
+  family: { id: 'gpt', name: 'GPT' },
+  region: 'us',
+  retention: 'configurable',
+  training: OPENAI_TRAINING,
+});
+
+const OPENAI_RESELLERS = ['azure', 'foundry'] as const;
+
+openai.model('gpt-5.6-sol', {
+  name: 'GPT-5.6 Sol',
+  ctx: 1_050_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(4, 20, { cacheRead: 0.4, longContext: LONG_CONTEXT_272K }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.6-terra', {
+  name: 'GPT-5.6 Terra',
+  ctx: 1_050_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(2, 12, { cacheRead: 0.2, longContext: LONG_CONTEXT_272K }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.6-luna', {
+  name: 'GPT-5.6 Luna',
+  ctx: 1_050_000,
+  maxOut: 128_000,
+  capability: null,
+  price: tokenPrice(0.2, 1.2, { cacheRead: 0.02, longContext: LONG_CONTEXT_272K }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.5', {
+  name: 'GPT-5.5',
+  ctx: 1_050_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(5, 30, { cacheRead: 0.5, longContext: LONG_CONTEXT_272K }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.4', {
+  name: 'GPT-5.4',
+  ctx: 1_050_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(2.5, 15, { cacheRead: 0.25, longContext: LONG_CONTEXT_272K }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.4-mini', {
+  name: 'GPT-5.4 mini',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: null,
+  price: tokenPrice(0.75, 4.5, { cacheRead: 0.075 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.4-nano', {
+  name: 'GPT-5.4 nano',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: null,
+  price: tokenPrice(0.2, 1.25, { cacheRead: 0.02 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.3-codex', {
+  name: 'GPT-5.3 Codex',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: 'code',
+  price: tokenPrice(1.75, 14, { cacheRead: 0.175 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5.1', {
+  name: 'GPT-5.1',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(1.25, 10, { cacheRead: 0.125 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5', {
+  name: 'GPT-5',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: 'reasoning',
+  price: tokenPrice(1.25, 10, { cacheRead: 0.125 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5-mini', {
+  name: 'GPT-5 mini',
+  ctx: 400_000,
+  capability: null,
+  price: tokenPrice(0.25, 2, { cacheRead: 0.025 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+openai.model('gpt-5-nano', {
+  name: 'GPT-5 nano',
+  ctx: 400_000,
+  maxOut: 128_000,
+  capability: null,
+  price: tokenPrice(0.05, 0.4, { cacheRead: 0.005 }),
+  on: [...OPENAI_RESELLERS],
+});
+
+// Open-weight OpenAI models, served only by third parties.
+openai.model('gpt-oss-120b', {
+  name: 'GPT-OSS 120B',
+  openWeights: true,
+  retention: 'unknown',
+  on: ['together', 'fireworks', 'groq', 'openrouter', 'bedrock', 'ollama', 'local'],
+});
+
+openai.model('gpt-oss-20b', {
+  name: 'GPT-OSS 20B',
+  openWeights: true,
+  retention: 'unknown',
+  on: ['together', 'fireworks', 'groq', 'openrouter', 'ollama', 'local'],
+});
+
+// ─── Google ──────────────────────────────────────────────────────────────────
+// Prices: ai.google.dev/gemini-api/docs/pricing. Context windows are not
+// published on the model-list page and are recorded as unknown.
+// Training: the paid tier is not used to improve products; the free tier is.
+// The only way off the free tier's default is to move to the paid tier.
+
+const GOOGLE_TRAINING: VendorTrainingPolicy = {
+  apiDefault: 'no',
+  consumerDefault: 'yes',
+  consumerControl: 'none',
+  source: 'https://ai.google.dev/gemini-api/terms',
+};
+
+const google = vendor('google', {
+  family: { id: 'gemini', name: 'Gemini' },
+  region: 'us',
+  retention: 'configurable',
+  training: GOOGLE_TRAINING,
+});
+
+google.model('gemini-3.7-flash', {
+  name: 'Gemini 3.7 Flash',
+  capability: null,
+  // Promotional rate; the published post-promotion rate is 1.50 / 7.50.
+  price: tokenPrice(0.75, 3.75),
+  on: ['vertex'],
+});
+
+google.model('gemini-3.6-flash', {
+  name: 'Gemini 3.6 Flash',
+  capability: null,
+  price: tokenPrice(0.75, 3.75),
+  on: ['vertex'],
+});
+
+google.model('gemini-3.5-flash', {
+  name: 'Gemini 3.5 Flash',
+  capability: null,
+  price: tokenPrice(1.5, 9),
+  on: ['vertex'],
+});
+
+google.model('gemini-3.5-flash-lite', {
+  name: 'Gemini 3.5 Flash Lite',
+  capability: null,
+  price: tokenPrice(0.3, 2.5),
+  on: ['vertex'],
+});
+
+google.model('gemini-3.1-pro-preview', {
+  name: 'Gemini 3.1 Pro Preview',
+  capability: 'reasoning',
+  price: tokenPrice(2, 12, {
+    longContext: { thresholdInputTokens: 200_000, input: 4, output: 18 },
+  }),
+  on: ['vertex'],
+});
+
+google.model('gemini-2.5-pro', {
+  name: 'Gemini 2.5 Pro',
+  capability: 'reasoning',
+  price: tokenPrice(1.25, 10, {
+    longContext: { thresholdInputTokens: 200_000, input: 2.5, output: 15 },
+  }),
+  on: ['vertex'],
+});
+
+google.model('gemini-2.5-flash', {
+  name: 'Gemini 2.5 Flash',
+  capability: null,
+  price: tokenPrice(0.3, 2.5),
+  on: ['vertex'],
+});
+
+google.model('gemini-2.5-flash-lite', {
+  name: 'Gemini 2.5 Flash Lite',
+  capability: null,
+  price: tokenPrice(0.1, 0.4),
+  on: ['vertex'],
+});
+
+// ─── xAI ─────────────────────────────────────────────────────────────────────
+// Prices + context: docs.x.ai/docs/models. Every text model tiers at 200K input.
+// Training: docs.x.ai/developers/faq/security — API inputs and outputs are not
+// trained on without explicit permission. The consumer tier default is not
+// published and is recorded as unknown.
+
+const xai = vendor('xai', {
+  family: { id: 'grok', name: 'Grok' },
+  region: 'us',
+  retention: 'configurable',
+  training: {
+    apiDefault: 'no',
+    consumerDefault: 'unknown',
+    consumerControl: 'unknown',
+    source: 'https://docs.x.ai/developers/faq/security',
+  },
+});
+
+xai.model('grok-4.6', {
+  name: 'Grok 4.6',
+  ctx: 500_000,
+  capability: 'reasoning',
+  price: tokenPrice(2, 6, {
+    cacheRead: 0.5,
+    longContext: { thresholdInputTokens: 200_000, input: 4, output: 12 },
+  }),
+  on: ['bedrock'],
+});
+
+xai.model('grok-4.5', {
+  name: 'Grok 4.5',
+  ctx: 500_000,
+  capability: 'reasoning',
+  price: tokenPrice(2, 6, {
+    cacheRead: 0.3,
+    longContext: { thresholdInputTokens: 200_000, input: 4, output: 12 },
+  }),
+});
+
+xai.model('grok-4.3', {
+  name: 'Grok 4.3',
+  ctx: 1_000_000,
+  capability: 'reasoning',
+  price: tokenPrice(1.25, 2.5, {
+    cacheRead: 0.2,
+    longContext: { thresholdInputTokens: 200_000, input: 2.5, output: 5 },
+  }),
+  on: ['bedrock'],
+});
+
+xai.model('grok-build-0.1', {
+  name: 'Grok Build 0.1',
+  ctx: 256_000,
+  capability: 'code',
+  price: tokenPrice(1, 2, {
+    cacheRead: 0.2,
+    longContext: { thresholdInputTokens: 200_000, input: 2, output: 4 },
+  }),
+});
+
+// ─── DeepSeek ────────────────────────────────────────────────────────────────
+// Prices + context: api-docs.deepseek.com/quick_start/pricing. Rates below are
+// the PEAK band; off-peak (outside 01:00-04:00 and 06:00-10:00 UTC, Mon-Fri) is
+// half. The price shape carries no time-of-day axis, so the peak rate is stated
+// and an off-peak call costs less than reported.
+// Training: the privacy policy states data is used to train and improve models,
+// with an opt-out right. Data is processed and stored in the PRC.
+
+const deepseek = vendor('deepseek', {
+  family: { id: 'deepseek', name: 'DeepSeek' },
+  region: 'cn',
+  retention: 'configurable',
+  training: {
+    apiDefault: 'yes',
+    consumerDefault: 'yes',
+    consumerControl: 'opt-out',
+    source: 'https://cdn.deepseek.com/policies/en-US/deepseek-privacy-policy.html',
+  },
+});
+
+deepseek.model('deepseek-v4-flash', {
+  name: 'DeepSeek V4 Flash',
+  ctx: 1_000_000,
+  capability: null,
+  price: tokenPrice(0.44, 1.32, { cacheRead: 0.014 }),
+  on: ['bedrock', 'together', 'fireworks', 'openrouter', 'ollama', 'local'],
+});
+
+deepseek.model('deepseek-v4-pro', {
+  name: 'DeepSeek V4 Pro',
+  ctx: 1_000_000,
+  capability: 'reasoning',
+  price: tokenPrice(1.32, 3.96, { cacheRead: 0.044 }),
+  on: ['bedrock', 'together', 'fireworks', 'openrouter'],
+});
+
+// ─── Cohere ──────────────────────────────────────────────────────────────────
+// Context windows: docs.cohere.com/docs/models. Current-generation prices are
+// not published (the reasoning tier is sales-priced), so they are unknown.
+// Training: cohere.com/security documents an opt-out; the default is not stated.
+
+const cohere = vendor('cohere', {
+  family: { id: 'command', name: 'Command' },
+  region: 'us',
+  retention: 'configurable',
+  training: {
+    apiDefault: 'unknown',
+    consumerDefault: 'unknown',
+    consumerControl: 'opt-out',
+    source: 'https://cohere.com/security',
+  },
+});
+
+cohere.model('command-a-plus-05-2026', {
+  name: 'Command A+',
+  ctx: 128_000,
+  maxOut: 64_000,
+  on: ['bedrock'],
+});
+
+cohere.model('command-a-03-2025', {
+  name: 'Command A',
+  ctx: 256_000,
+  maxOut: 8_000,
+  on: ['bedrock'],
+});
+
+cohere.model('command-a-reasoning-08-2025', {
+  name: 'Command A Reasoning',
+  ctx: 256_000,
+  maxOut: 32_000,
+  capability: 'reasoning',
+});
+
+cohere.model('command-r-plus-08-2024', {
+  name: 'Command R+',
+  ctx: 128_000,
+  maxOut: 4_000,
+  price: tokenPrice(2.5, 10),
+  on: ['bedrock'],
+});
+
+// ─── Open-weight vendors ─────────────────────────────────────────────────────
+// Meta and Alibaba publish weights without running a first-party inference API,
+// so every offering is a third-party host or self-hosted. Host rates vary and
+// are not carried; a self-hosted run is a known zero.
+
+const meta = vendor('meta', {
+  family: { id: 'llama', name: 'Llama' },
+  openWeights: true,
+  retention: 'unknown',
+});
+
+const OPEN_WEIGHT_HOSTS = [
+  'bedrock',
+  'together',
+  'fireworks',
+  'groq',
+  'openrouter',
+  'ollama',
+  'local',
+] as const;
+
+meta.model('llama-3-3-70b', {
+  name: 'Llama 3.3 70B',
+  ctx: 128_000,
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+meta.model('llama-3-1-70b', {
+  name: 'Llama 3.1 70B',
+  ctx: 128_000,
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+meta.model('llama-3-1-8b', {
+  name: 'Llama 3.1 8B',
+  ctx: 128_000,
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+const alibaba = vendor('alibaba', {
+  family: { id: 'qwen', name: 'Qwen' },
+  openWeights: true,
+  retention: 'unknown',
+});
+
+alibaba.model('qwen-3-235b', {
+  name: 'Qwen 3 235B',
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+alibaba.model('qwen-3-coder-480b', {
+  name: 'Qwen 3 Coder 480B',
+  capability: 'code',
+  on: [...OPEN_WEIGHT_HOSTS],
+});
+
+// Amazon serves Nova only through its own cloud, so it has no first-party
+// platform entry. Bedrock pricing is JS-rendered and was not readable.
+const amazon = vendor('amazon', {
+  family: { id: 'nova', name: 'Nova' },
+  retention: 'configurable',
+});
+
+amazon.model('nova-2-lite', {
+  name: 'Nova 2 Lite',
+  ctx: 1_000_000,
+  maxOut: 64_000,
+  aliases: ['nova-2-lite-v1:0'],
+  on: ['bedrock'],
+});
+
+// Mistral's wire model ids are not published alongside its pricing (the pricing
+// page uses display names and version tags), so no Mistral entries are declared
+// rather than declaring ids that would not resolve.
+
+/** Every declared model, in vendor order. */
+export const MODEL_ENTRIES: readonly ModelEntry[] = Object.freeze([
+  ...anthropic.models(),
+  ...openai.models(),
+  ...google.models(),
+  ...xai.models(),
+  ...deepseek.models(),
+  ...cohere.models(),
+  ...meta.models(),
+  ...alibaba.models(),
+  ...amazon.models(),
+]);
+
+/** The lookup index over `MODEL_ENTRIES`, keyed by canonical id and alias. */
+export const MODEL_INDEX = buildModelIndex(MODEL_ENTRIES);

--- a/packages/schema/src/model/catalog.ts
+++ b/packages/schema/src/model/catalog.ts
@@ -274,6 +274,7 @@ openai.model('gpt-oss-120b', {
   name: 'GPT-OSS 120B',
   openWeights: true,
   retention: 'unknown',
+  defaultHosting: 'local',
   on: ['together', 'fireworks', 'groq', 'openrouter', 'bedrock', 'ollama', 'local'],
 });
 
@@ -281,6 +282,7 @@ openai.model('gpt-oss-20b', {
   name: 'GPT-OSS 20B',
   openWeights: true,
   retention: 'unknown',
+  defaultHosting: 'local',
   on: ['together', 'fireworks', 'groq', 'openrouter', 'ollama', 'local'],
 });
 
@@ -516,6 +518,9 @@ const meta = vendor('meta', {
   family: { id: 'llama', name: 'Llama' },
   openWeights: true,
   retention: 'unknown',
+  // Curated: an id like `llama-3-1-70b` names no platform, and these weights
+  // are most often run on the caller's own hardware in this context.
+  defaultHosting: 'local',
 });
 
 const OPEN_WEIGHT_HOSTS = [
@@ -550,6 +555,7 @@ const alibaba = vendor('alibaba', {
   family: { id: 'qwen', name: 'Qwen' },
   openWeights: true,
   retention: 'unknown',
+  defaultHosting: 'local',
 });
 
 alibaba.model('qwen-3-235b', {

--- a/packages/schema/src/model/catalog.ts
+++ b/packages/schema/src/model/catalog.ts
@@ -318,6 +318,8 @@ openai.model('o3', {
 openai.model('gpt-oss-120b', {
   name: 'GPT-OSS 120B',
   openWeights: true,
+  // Published weights; OpenAI's own API does not serve them.
+  firstParty: false,
   retention: 'unknown',
   defaultHosting: 'local',
   on: ['together', 'fireworks', 'groq', 'openrouter', 'bedrock', 'ollama', 'local'],
@@ -326,6 +328,8 @@ openai.model('gpt-oss-120b', {
 openai.model('gpt-oss-20b', {
   name: 'GPT-OSS 20B',
   openWeights: true,
+  // Published weights; OpenAI's own API does not serve them.
+  firstParty: false,
   retention: 'unknown',
   defaultHosting: 'local',
   on: ['together', 'fireworks', 'groq', 'openrouter', 'ollama', 'local'],

--- a/packages/schema/src/model/catalog.ts
+++ b/packages/schema/src/model/catalog.ts
@@ -300,6 +300,8 @@ openai.model('gpt-4o-mini', {
 
 openai.model('gpt-4-turbo', {
   name: 'GPT-4 Turbo',
+  // A legacy model reached by traffic, never deliberately onboarded.
+  seen: 'discovered',
   price: tokenPrice(10, 30),
   aliases: ['gpt-4-turbo-2024-04-09'],
   on: [...OPENAI_RESELLERS],
@@ -513,6 +515,7 @@ deepseek.model('deepseek-v4-pro', {
 // Off DeepSeek's current pricing page; served on third-party hosts.
 deepseek.model('deepseek-r1', {
   name: 'DeepSeek R1',
+  seen: 'discovered',
   capability: 'reasoning',
   openWeights: true,
   defaultHosting: 'local',
@@ -652,6 +655,7 @@ const mistral = vendor('mistral', {
 // Absent from Mistral's current model list; survives on third-party hosts.
 mistral.model('mixtral-8x7b', {
   name: 'Mixtral 8x7B',
+  seen: 'discovered',
   on: [...OPEN_WEIGHT_HOSTS],
 });
 

--- a/packages/schema/src/model/governance.ts
+++ b/packages/schema/src/model/governance.ts
@@ -1,0 +1,185 @@
+// Model governance vocabulary — the curated, vendor-published facts a
+// data-governance reviewer needs about a model: what it is good at, how long
+// the vendor keeps the data, and whether the data trains the next model.
+//
+// Every value in this file is CURATED (read from a vendor's published policy by
+// a human) rather than measured. Nothing here is derived from traffic: the
+// event stream carries a raw model string and nothing else. The one rule the
+// whole module exists to enforce is that an unknown fact is recorded as unknown
+// and never as a plausible default.
+import { z } from 'zod';
+
+/**
+ * A flagged specialisation, or `null` for a general-purpose model. `null` is a
+ * curated statement ("reviewed, no flagged specialisation"), not an unfilled
+ * field — entries carry a note saying so.
+ */
+export const ModelCapability = z.enum(['reasoning', 'code']);
+export type ModelCapability = z.infer<typeof ModelCapability>;
+
+/**
+ * How long the serving platform retains request data.
+ *
+ *   zero_retention    — contractual zero-retention; nothing persisted
+ *   no_storage        — not stored beyond the request lifetime
+ *   configurable      — depends on the customer's own settings/contract
+ *   on_device         — never leaves the caller's machine
+ *   on_infrastructure — retained on infrastructure the customer controls
+ *   unknown           — not verified. The honest default for any platform whose
+ *                       terms we have not read; NEVER inferred from the vendor's
+ *                       own posture, since a reseller's terms are its own.
+ */
+export const DataRetention = z.enum([
+  'zero_retention',
+  'no_storage',
+  'configurable',
+  'on_device',
+  'on_infrastructure',
+  'unknown',
+]);
+export type DataRetention = z.infer<typeof DataRetention>;
+
+/** Whether the model is one this deployment onboarded, or one we merely observed. */
+export const ModelSeen = z.enum(['managed', 'discovered']);
+export type ModelSeen = z.infer<typeof ModelSeen>;
+
+/**
+ * Whether customer data is used to train the vendor's models.
+ *
+ * Tri-state rather than boolean because the answer is NOT a property of the
+ * model — it is a property of (vendor policy x the plan the caller is on x
+ * whether they exercised the opt-out/opt-in). The event stream tells us none of
+ * those: a Claude Code session reports the same model id whether it is billed
+ * against an API key or a Claude.ai subscription. So the honest default is
+ * `unknown`, and it stays `unknown` until an operator declares the plan.
+ *
+ * A boolean cannot express this without asserting one of two unchecked
+ * claims: `false` for a consumer-tier caller who opted in, or `true` for an
+ * API caller covered by a no-training agreement.
+ */
+export const TrainsOnData = z.enum(['yes', 'no', 'unknown']);
+export type TrainsOnData = z.infer<typeof TrainsOnData>;
+
+/** How a customer changes their tier's training default, if they can at all. */
+export const TrainingControl = z.enum([
+  /** Off by default; the customer must switch it on. */
+  'opt-in',
+  /** On by default; the customer must switch it off. */
+  'opt-out',
+  /** Not customer-controllable. */
+  'none',
+  /** Not verified. */
+  'unknown',
+]);
+export type TrainingControl = z.infer<typeof TrainingControl>;
+
+/**
+ * A vendor's published training policy, split by the plan the caller is on.
+ * Curated from the vendor's own privacy documentation; `source` is the URL it
+ * was read from so the next updater can re-verify rather than re-guess.
+ *
+ * Note this is the VENDOR's policy for its own first-party endpoints. It says
+ * nothing about a model served through a cloud reseller, whose training and
+ * retention terms belong to that reseller's contract — see `resolveTrainsOnData`.
+ */
+export const VendorTrainingPolicy = z.object({
+  /** Does the vendor's first-party API train on customer data by default? */
+  apiDefault: TrainsOnData,
+  /** Does the vendor's consumer / pro / team subscription train by default? */
+  consumerDefault: TrainsOnData,
+  /** How a consumer-tier customer changes that default. */
+  consumerControl: TrainingControl,
+  /** Vendor documentation URL this was curated from. */
+  source: z.string().nullable(),
+});
+export type VendorTrainingPolicy = z.infer<typeof VendorTrainingPolicy>;
+
+/**
+ * Which plan a caller's traffic is billed against. Never observable from the
+ * event stream — an operator declares it, per tenant. `unknown` is the default
+ * for every deployment that has not.
+ */
+export const PlanTier = z.enum(['api', 'consumer', 'enterprise', 'unknown']);
+export type PlanTier = z.infer<typeof PlanTier>;
+
+/**
+ * An operator's declaration of how their organisation is billed and whether
+ * they exercised the training control. This is the ONLY input that can turn a
+ * `trainsOnData` of `unknown` into a definite answer.
+ */
+export const TrainingDeclaration = z.object({
+  tier: PlanTier,
+  /**
+   * Whether the org exercised its tier's training control — `true` means opted
+   * IN where the control is `opt-in`, and opted OUT where it is `opt-out`.
+   * `null` means undeclared, which leaves the tier default in force.
+   */
+  controlExercised: z.boolean().nullable(),
+});
+export type TrainingDeclaration = z.infer<typeof TrainingDeclaration>;
+
+/** The undeclared default — what every tenant reads as until an operator says otherwise. */
+export const UNDECLARED_TRAINING: TrainingDeclaration = Object.freeze({
+  tier: 'unknown',
+  controlExercised: null,
+});
+
+/**
+ * Resolve the effective `trainsOnData` for a model on a platform, given what
+ * the operator has declared.
+ *
+ * The rules, in order:
+ *
+ *  1. A model running on the caller's own hardware sends nothing to a vendor,
+ *     so it cannot train one. That is a fact about the deployment, not a policy
+ *     claim — `'no'` regardless of any declaration.
+ *  2. A model served by a cloud reseller is governed by that reseller's
+ *     contract, which this catalog does not carry. `'unknown'` — the vendor's
+ *     own posture describes the vendor's own endpoints and does not transfer.
+ *  3. On a first-party endpoint the vendor's per-tier policy applies, selected
+ *     by the declared tier. An undeclared tier is `'unknown'`: we cannot tell an
+ *     API key from a consumer subscription by looking at a model id.
+ *  4. A declared control flips the tier default in the direction its
+ *     `TrainingControl` allows.
+ */
+export function resolveTrainsOnData(input: {
+  hosting: ModelHostingLike;
+  firstParty: boolean;
+  policy: VendorTrainingPolicy | null;
+  declaration: TrainingDeclaration;
+}): TrainsOnData {
+  const { hosting, firstParty, policy, declaration } = input;
+
+  // (1) Self-hosted weights never reach a vendor.
+  if (hosting === 'local') return 'no';
+
+  // (2) Reseller/gateway terms are not the vendor's terms.
+  if (!firstParty) return 'unknown';
+
+  if (policy === null) return 'unknown';
+
+  // (3) Tier default.
+  const tierDefault: TrainsOnData =
+    declaration.tier === 'api' || declaration.tier === 'enterprise'
+      ? policy.apiDefault
+      : declaration.tier === 'consumer'
+        ? policy.consumerDefault
+        : 'unknown';
+
+  if (tierDefault === 'unknown') return 'unknown';
+
+  // (4) An exercised control flips the default the one way its control allows.
+  if (declaration.controlExercised === true) {
+    if (policy.consumerControl === 'opt-in') return 'yes';
+    if (policy.consumerControl === 'opt-out') return 'no';
+  }
+
+  return tierDefault;
+}
+
+/**
+ * Structural stand-in for `ModelHosting` so this module does not import
+ * `providers.ts` purely for a type — the two are otherwise independent, and
+ * keeping them so leaves the governance vocabulary reusable on its own.
+ */
+type ModelHostingLike = 'api' | 'gateway' | 'local';

--- a/packages/schema/src/model/governance.ts
+++ b/packages/schema/src/model/governance.ts
@@ -139,8 +139,11 @@ export const UNDECLARED_TRAINING: TrainingDeclaration = Object.freeze({
  *  3. On a first-party endpoint the vendor's per-tier policy applies, selected
  *     by the declared tier. An undeclared tier is `'unknown'`: we cannot tell an
  *     API key from a consumer subscription by looking at a model id.
- *  4. A declared control flips the tier default in the direction its
- *     `TrainingControl` allows.
+ *  4. A declared control flips the CONSUMER tier's default in the direction its
+ *     `TrainingControl` allows. It applies to no other tier: `consumerControl`
+ *     describes the consumer tier only, and `VendorTrainingPolicy` carries no
+ *     equivalent for the API tier, so there is nothing legitimate for an
+ *     api/enterprise declaration to consult.
  */
 export function resolveTrainsOnData(input: {
   hosting: ModelHostingLike;
@@ -169,7 +172,8 @@ export function resolveTrainsOnData(input: {
   if (tierDefault === 'unknown') return 'unknown';
 
   // (4) An exercised control flips the default the one way its control allows.
-  if (declaration.controlExercised === true) {
+  // Consumer tier only — see rule 4 above.
+  if (declaration.tier === 'consumer' && declaration.controlExercised === true) {
     if (policy.consumerControl === 'opt-in') return 'yes';
     if (policy.consumerControl === 'opt-out') return 'no';
   }

--- a/packages/schema/src/model/index.ts
+++ b/packages/schema/src/model/index.ts
@@ -1,0 +1,6 @@
+export * from './builder.ts';
+export * from './catalog.ts';
+export * from './governance.ts';
+export * from './pricing.ts';
+export * from './providers.ts';
+export * from './resolve.ts';

--- a/packages/schema/src/model/pricing.ts
+++ b/packages/schema/src/model/pricing.ts
@@ -13,6 +13,8 @@
 //      platform's own price page.
 import { z } from 'zod';
 
+import type { CostUsage } from '../token/cost-usage.ts';
+
 /**
  * A second rate band that applies once a request's INPUT crosses `thresholdInputTokens`.
  *
@@ -64,7 +66,7 @@ export const WEB_SEARCH_PER_REQUEST = 0.01;
  * and is re-verified on each price update.
  */
 export function anthropicPrice(input: number, output: number, cacheRead: number): ModelPrice {
-  return {
+  return Object.freeze({
     input,
     output,
     longContext: null, // flat across the full window on every current Claude
@@ -72,7 +74,7 @@ export function anthropicPrice(input: number, output: number, cacheRead: number)
     cacheWrite1h: input * 2,
     cacheRead,
     webSearch: WEB_SEARCH_PER_REQUEST,
-  };
+  });
 }
 
 /**
@@ -85,15 +87,15 @@ export function tokenPrice(
   output: number,
   options: { cacheRead?: number; longContext?: LongContextTier } = {},
 ): ModelPrice {
-  return {
+  return Object.freeze({
     input,
     output,
-    longContext: options.longContext ?? null,
+    longContext: options.longContext === undefined ? null : Object.freeze(options.longContext),
     cacheWrite5m: null,
     cacheWrite1h: null,
     cacheRead: options.cacheRead ?? null,
     webSearch: null,
-  };
+  });
 }
 
 /**
@@ -125,17 +127,6 @@ export function serviceTierMultiplier(tier: string | undefined): number {
   return SERVICE_TIER_MULTIPLIERS.get(tier) ?? 1;
 }
 
-/** The token components a cost is derived from. */
-export interface PricedUsage {
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheWrite1hTokens?: number;
-  cacheWrite5mTokens?: number;
-  cacheReadTokens?: number;
-  webSearchRequests?: number;
-  serviceTier?: string;
-}
-
 /**
  * Cost in USD for a usage bag at a given price, or `null` when the price
  * carries no verified rate for a column the usage actually bills against.
@@ -145,14 +136,27 @@ export interface PricedUsage {
  * undercounted — a partial sum reported as a total is a number nobody checked.
  * A column the usage does not touch contributes nothing either way.
  */
-export function costOf(price: ModelPrice, usage: PricedUsage): number | null {
+export function costOf(price: ModelPrice, usage: CostUsage): number | null {
   const metered: readonly (readonly [number, number | null])[] = [
     [usage.cacheWrite1hTokens ?? 0, price.cacheWrite1h],
     [usage.cacheWrite5mTokens ?? 0, price.cacheWrite5m],
     [usage.cacheReadTokens ?? 0, price.cacheRead],
   ];
 
-  let tokenCost = (usage.inputTokens ?? 0) * price.input + (usage.outputTokens ?? 0) * price.output;
+  // Above the threshold the band rate applies to the WHOLE request, not just
+  // the tokens past it, so input and output are re-priced rather than split.
+  // A null band rate is an unread rate: the request bills at a price we do not
+  // have, so the cost is unknown rather than the sub-threshold figure.
+  const band =
+    price.longContext !== null && (usage.inputTokens ?? 0) > price.longContext.thresholdInputTokens
+      ? price.longContext
+      : null;
+  if (band !== null && (band.input === null || band.output === null)) return null;
+
+  const inputRate = band?.input ?? price.input;
+  const outputRate = band?.output ?? price.output;
+
+  let tokenCost = (usage.inputTokens ?? 0) * inputRate + (usage.outputTokens ?? 0) * outputRate;
   for (const [tokens, rate] of metered) {
     if (tokens === 0) continue;
     if (rate === null) return null;

--- a/packages/schema/src/model/pricing.ts
+++ b/packages/schema/src/model/pricing.ts
@@ -1,0 +1,126 @@
+// The single price table, read by `token/cost-model.ts`. Prices live here and
+// nowhere else, so a rate is edited in one place.
+//
+// Two rules this module enforces structurally rather than by comment:
+//
+//   1. An unverified price is `null`, never a number. A missing entry resolves
+//      to "cost unknown" at the call site; it never falls back to a lookalike
+//      model's rate, and it never silently becomes 0.
+//   2. Only a vendor's FIRST-PARTY platform may carry the vendor's published
+//      rates. A reseller bills at its own rates — verified: Bedrock served
+//      Claude 3.5 Sonnet v2 at $6/$30 against Anthropic's own $3/$15, exactly
+//      2x — so a reseller entry stays unpriced until someone reads that
+//      platform's own price page.
+import { z } from 'zod';
+
+/**
+ * A second rate band that applies once a request's INPUT crosses `thresholdInputTokens`.
+ *
+ * Verified to apply to the whole request, not just the tokens above the line:
+ * "For GPT-5.6, prompts with more than 272,000 input tokens use long-context
+ * pricing for the full request, not only for tokens beyond the threshold."
+ * Google and xAI tier the same way (at 200K, xAI a clean 2x step).
+ *
+ * `input`/`output` are nullable because a vendor can publish the THRESHOLD
+ * without publishing the rate above it — which is exactly the OpenAI case
+ * today. A null there means "cost unknown above this size", which is a very
+ * different statement from "same price", and the difference is a bill.
+ */
+export const LongContextTier = z.object({
+  thresholdInputTokens: z.number().int().positive(),
+  input: z.number().nonnegative().nullable(),
+  output: z.number().nonnegative().nullable(),
+});
+export type LongContextTier = z.infer<typeof LongContextTier>;
+
+export const ModelPrice = z.object({
+  /** USD per 1M uncached input tokens, at or below any long-context threshold. */
+  input: z.number().nonnegative(),
+  /** USD per 1M output tokens, at or below any long-context threshold. */
+  output: z.number().nonnegative(),
+  /**
+   * Rate band above a size threshold, or `null` when the model is flat-rated.
+   * Anthropic is flat across its 1M window; OpenAI, Google and xAI are not.
+   */
+  longContext: LongContextTier.nullable(),
+  /** USD per 1M tokens written to a 5-minute ephemeral cache, or null if unpriced. */
+  cacheWrite5m: z.number().nonnegative().nullable(),
+  /** USD per 1M tokens written to a 1-hour ephemeral cache, or null if unpriced. */
+  cacheWrite1h: z.number().nonnegative().nullable(),
+  /** USD per 1M tokens read from cache, or null if unpriced. */
+  cacheRead: z.number().nonnegative().nullable(),
+  /** USD per single server-side web-search request, or null if the platform has none. */
+  webSearch: z.number().nonnegative().nullable(),
+});
+export type ModelPrice = z.infer<typeof ModelPrice>;
+
+/** $10 per 1,000 web-search requests = $0.01 per request. */
+export const WEB_SEARCH_PER_REQUEST = 0.01;
+
+/**
+ * An Anthropic-shaped price. `cacheRead` is a REQUIRED argument, not a derived
+ * column: see the note on `ModelPrice.cacheRead`. Cache writes remain derived
+ * (5m = 1.25x input, 1h = 2x input), which is still uniform across the family
+ * and is re-verified on each price update.
+ */
+export function anthropicPrice(input: number, output: number, cacheRead: number): ModelPrice {
+  return {
+    input,
+    output,
+    longContext: null, // flat across the full window on every current Claude
+    cacheWrite5m: input * 1.25,
+    cacheWrite1h: input * 2,
+    cacheRead,
+    webSearch: WEB_SEARCH_PER_REQUEST,
+  };
+}
+
+/**
+ * A plain input/output price for a vendor with no cache-pricing tiers we have
+ * verified. The cache columns are `null` (unknown), not 0 — a zero would read
+ * as "cached tokens are free", which is a price claim of its own.
+ */
+export function tokenPrice(
+  input: number,
+  output: number,
+  options: { cacheRead?: number; longContext?: LongContextTier } = {},
+): ModelPrice {
+  return {
+    input,
+    output,
+    longContext: options.longContext ?? null,
+    cacheWrite5m: null,
+    cacheWrite1h: null,
+    cacheRead: options.cacheRead ?? null,
+    webSearch: null,
+  };
+}
+
+/**
+ * Self-hosted inference: every column is a known 0. Distinct from an absent
+ * entry, which means "unknown" — running Llama on your own GPU genuinely costs
+ * the vendor relationship nothing, and reporting that as unknown would be as
+ * wrong as inventing a rate.
+ */
+export const ZERO_PRICE: ModelPrice = Object.freeze({
+  input: 0,
+  output: 0,
+  longContext: null,
+  cacheWrite5m: 0,
+  cacheWrite1h: 0,
+  cacheRead: 0,
+  webSearch: 0,
+});
+
+/** Service-tier multipliers applied to the whole per-call token cost. */
+const SERVICE_TIER_MULTIPLIERS: ReadonlyMap<string, number> = new Map([
+  ['standard', 1],
+  ['batch', 0.5],
+  ['priority', 1.5],
+]);
+
+/** The multiplier for a service tier; unknown and absent tiers are 1x. */
+export function serviceTierMultiplier(tier: string | undefined): number {
+  if (tier === undefined) return 1;
+  return SERVICE_TIER_MULTIPLIERS.get(tier) ?? 1;
+}

--- a/packages/schema/src/model/pricing.ts
+++ b/packages/schema/src/model/pricing.ts
@@ -124,3 +124,47 @@ export function serviceTierMultiplier(tier: string | undefined): number {
   if (tier === undefined) return 1;
   return SERVICE_TIER_MULTIPLIERS.get(tier) ?? 1;
 }
+
+/** The token components a cost is derived from. */
+export interface PricedUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheWrite1hTokens?: number;
+  cacheWrite5mTokens?: number;
+  cacheReadTokens?: number;
+  webSearchRequests?: number;
+  serviceTier?: string;
+}
+
+/**
+ * Cost in USD for a usage bag at a given price, or `null` when the price
+ * carries no verified rate for a column the usage actually bills against.
+ *
+ * A `null` column is an UNREAD rate, not a free one. Tokens billed against one
+ * cannot be priced, so the whole call is unknown rather than silently
+ * undercounted — a partial sum reported as a total is a number nobody checked.
+ * A column the usage does not touch contributes nothing either way.
+ */
+export function costOf(price: ModelPrice, usage: PricedUsage): number | null {
+  const metered: readonly (readonly [number, number | null])[] = [
+    [usage.cacheWrite1hTokens ?? 0, price.cacheWrite1h],
+    [usage.cacheWrite5mTokens ?? 0, price.cacheWrite5m],
+    [usage.cacheReadTokens ?? 0, price.cacheRead],
+  ];
+
+  let tokenCost = (usage.inputTokens ?? 0) * price.input + (usage.outputTokens ?? 0) * price.output;
+  for (const [tokens, rate] of metered) {
+    if (tokens === 0) continue;
+    if (rate === null) return null;
+    tokenCost += tokens * rate;
+  }
+
+  // Token prices are per MILLION tokens; divide once at the end.
+  const tokenUsd = (tokenCost / 1_000_000) * serviceTierMultiplier(usage.serviceTier);
+
+  // Web search bills per request, not per token, and is not tier-scaled.
+  const searches = usage.webSearchRequests ?? 0;
+  if (searches > 0 && price.webSearch === null) return null;
+
+  return tokenUsd + searches * (price.webSearch ?? 0);
+}

--- a/packages/schema/src/model/providers.ts
+++ b/packages/schema/src/model/providers.ts
@@ -1,0 +1,180 @@
+// Model provenance vocabulary — WHO made a model (`ModelVendor`) versus WHICH
+// endpoint served the call (`ModelPlatform`). These are two independent axes.
+// A model's identity travels across platforms: Claude Opus 5 is an Anthropic
+// model whether it arrives via the Anthropic API, AWS Bedrock or Google Vertex,
+// with the same weights and the same context window. Its PRICE and its
+// RETENTION posture do not travel — both are properties of the serving
+// contract. `pricing.ts` holds that separation.
+//
+// Pure data + pure functions: no I/O, no `process.env`, no `fetch`, no Node-API
+// deps, no Drizzle — this module sits on the emitted import graph from the
+// package entry (see `test/entry-graph.test.ts`).
+import { z } from 'zod';
+
+/**
+ * The organisation that trained the model. `unknown` is the honest answer for a
+ * model string we do not recognise — never a guess, and never silently folded
+ * onto a lookalike vendor.
+ */
+export const ModelVendor = z.enum([
+  'anthropic',
+  'openai',
+  'google',
+  'meta',
+  'mistral',
+  'deepseek',
+  'alibaba',
+  'xai',
+  'amazon',
+  'cohere',
+  'unknown',
+]);
+export type ModelVendor = z.infer<typeof ModelVendor>;
+
+/**
+ * The endpoint that actually served the call. Split into four bands because
+ * each band has different pricing, different data-retention terms, and a
+ * different id spelling for the same weights:
+ *
+ *   - first-party: the vendor's own API. Prices and retention terms are the
+ *     vendor's published ones.
+ *   - cloud resellers: the model runs under the cloud provider's contract.
+ *     Prices differ from first-party (verified: Bedrock billed Claude 3.5
+ *     Sonnet v2 at $6/$30 against Anthropic's own $3/$15 — 2x), and retention
+ *     is governed by the customer's AWS/GCP/Azure agreement, not the vendor's.
+ *   - open-weight hosts: third parties serving open weights at their own rates.
+ *   - self-hosted: the weights run on the customer's own hardware. No vendor
+ *     billing relationship and no vendor data flow, so cost is a known 0 rather
+ *     than an unknown.
+ */
+export const ModelPlatform = z.enum([
+  // first-party
+  'anthropic',
+  'openai',
+  'google-ai',
+  'mistral',
+  'deepseek',
+  'xai',
+  'cohere',
+  // cloud resellers
+  'bedrock',
+  'vertex',
+  'azure',
+  'foundry',
+  // open-weight hosts
+  'together',
+  'fireworks',
+  'groq',
+  'openrouter',
+  // self-hosted
+  'ollama',
+  'local',
+]);
+export type ModelPlatform = z.infer<typeof ModelPlatform>;
+
+/**
+ * How the served model reaches the caller, as rendered on the governance
+ * surface. Narrower than `ModelPlatform` on purpose: it answers "does this
+ * leave the building, and through whose door", which is the question a
+ * data-governance reviewer is actually asking.
+ */
+export const ModelHosting = z.enum(['api', 'gateway', 'local']);
+export type ModelHosting = z.infer<typeof ModelHosting>;
+
+/** Which band each platform belongs to — the source for `hostingFor` below. */
+const PLATFORM_HOSTING: ReadonlyMap<ModelPlatform, ModelHosting> = new Map([
+  ['anthropic', 'api'],
+  ['openai', 'api'],
+  ['google-ai', 'api'],
+  ['mistral', 'api'],
+  ['deepseek', 'api'],
+  ['xai', 'api'],
+  ['cohere', 'api'],
+  ['bedrock', 'api'],
+  ['vertex', 'api'],
+  ['azure', 'api'],
+  ['foundry', 'api'],
+  ['together', 'gateway'],
+  ['fireworks', 'gateway'],
+  ['groq', 'gateway'],
+  ['openrouter', 'gateway'],
+  ['ollama', 'local'],
+  ['local', 'local'],
+]);
+
+/** The hosting band a platform serves under. Total over `ModelPlatform`. */
+export function hostingFor(platform: ModelPlatform): ModelHosting {
+  // `PLATFORM_HOSTING` covers every member of the enum (pinned by a test), so
+  // the fallback is unreachable — kept rather than a non-null assertion so a
+  // future platform added without a band degrades to the most conservative
+  // answer instead of throwing at import time.
+  return PLATFORM_HOSTING.get(platform) ?? 'api';
+}
+
+/**
+ * Whether a platform is the vendor's own first-party endpoint. Load-bearing for
+ * pricing and retention: only a first-party platform may inherit the vendor's
+ * published rates and its retention posture (see `pricing.ts`).
+ */
+const FIRST_PARTY: ReadonlyMap<ModelVendor, ModelPlatform> = new Map([
+  ['anthropic', 'anthropic'],
+  ['openai', 'openai'],
+  ['google', 'google-ai'],
+  ['mistral', 'mistral'],
+  ['deepseek', 'deepseek'],
+  ['xai', 'xai'],
+  ['cohere', 'cohere'],
+]);
+
+/**
+ * The vendor's own endpoint, or `null` for a vendor that publishes weights
+ * without running a first-party inference API (Meta, Alibaba) or whose models
+ * are served only through its cloud (Amazon Nova → Bedrock).
+ */
+export function firstPartyPlatformFor(vendor: ModelVendor): ModelPlatform | null {
+  return FIRST_PARTY.get(vendor) ?? null;
+}
+
+/** True when `platform` is `vendor`'s own first-party endpoint. */
+export function isFirstParty(vendor: ModelVendor, platform: ModelPlatform): boolean {
+  return FIRST_PARTY.get(vendor) === platform;
+}
+
+/**
+ * Namespace prefixes a platform prepends to a model id. Read-side only: the
+ * resolver strips these to recover the canonical id (see `resolve.ts`). We do
+ * NOT reconstruct platform ids from the canonical form — the spellings vary by
+ * vendor AND by model generation (current Claude on Bedrock is
+ * `anthropic.claude-opus-5` with no version suffix, while Nova is
+ * `amazon.nova-2-lite-v1:0`), so generating them would be guessing.
+ */
+export const PLATFORM_NAMESPACES: readonly string[] = Object.freeze([
+  'anthropic',
+  'amazon',
+  'meta',
+  'mistral',
+  'deepseek',
+  'qwen',
+  'cohere',
+  'ai21',
+  'writer',
+  'luma',
+  'stability',
+]);
+
+/**
+ * Geographic routing prefixes AWS Bedrock prepends for cross-region and global
+ * inference profiles (`us.anthropic.claude-opus-5`, `global.amazon.nova-2-lite-v1:0`).
+ *
+ * The list is exhaustive over the geo prefixes Bedrock documents. A prefix
+ * missing from it makes every id carrying it unresolvable, so the model reads
+ * as unknown rather than as itself.
+ */
+export const GEO_PREFIXES: readonly string[] = Object.freeze([
+  'us',
+  'eu',
+  'apac',
+  'au',
+  'jp',
+  'global',
+]);

--- a/packages/schema/src/model/resolve.ts
+++ b/packages/schema/src/model/resolve.ts
@@ -1,0 +1,157 @@
+// Model-id resolution. One raw model string, as reported by a harness, resolved
+// to a catalog entry plus the platform that served it.
+//
+// The same weights are spelled differently on every platform:
+//
+//   claude-opus-5                        Anthropic API
+//   anthropic.claude-opus-5              Bedrock, base id
+//   us.anthropic.claude-opus-5           Bedrock, cross-region inference
+//   global.anthropic.claude-opus-5       Bedrock, global inference
+//   claude-haiku-4-5@20251001            Vertex, dated
+//   amazon.nova-2-lite-v1:0              Bedrock, versioned
+//   meta-llama/llama-3-3-70b             gateway namespace
+//
+// Resolution is tolerant on READ: decorations are stripped in a fixed order and
+// the remainder is matched against canonical ids and their aliases. Ids are
+// never GENERATED from the canonical form — the spellings vary by vendor and by
+// model generation, so producing one would be a guess.
+//
+// Lookups go through `Map`, so a raw model string can only ever match a key that
+// was declared. A string like `constructor` or `__proto__` resolves to nothing.
+import type { ModelEntry } from './builder.ts';
+import type { ModelPlatform } from './providers.ts';
+import { GEO_PREFIXES, PLATFORM_NAMESPACES } from './providers.ts';
+
+/** What a raw model string resolved to. */
+export interface ResolvedModel {
+  /** The catalog entry, or `null` when the id matched nothing. */
+  entry: ModelEntry | null;
+  /** The canonical id the raw string reduced to. */
+  canonicalId: string;
+  /** The platform inferred from the id's decorations, when it names one. */
+  platform: ModelPlatform | null;
+  /** The raw string exactly as reported. */
+  raw: string;
+}
+
+const GEO_PREFIX_RE = new RegExp(`^(?:${GEO_PREFIXES.join('|')})\\.`, 'u');
+const NAMESPACE_DOT_RE = new RegExp(`^(?:${PLATFORM_NAMESPACES.join('|')})\\.`, 'u');
+const NAMESPACE_SLASH_RE = new RegExp(`^(?:${PLATFORM_NAMESPACES.join('|')})/`, 'iu');
+const GATEWAY_VENDOR_SLASH_RE = /^[a-z0-9][\w.-]*\//iu;
+const BEDROCK_VERSION_RE = /-v\d+:\d+$/u;
+const BEDROCK_REVISION_RE = /:\d+$/u;
+const VERTEX_VERSION_RE = /@[\w-]+$/u;
+const DATED_SUFFIX_RE = /-\d{8}$/u;
+
+/**
+ * Strip the decorations a serving platform adds, in the order they nest.
+ * Returns the bare id plus the platform its decorations implied, if any.
+ */
+export function stripPlatformDecorations(model: string): {
+  id: string;
+  platform: ModelPlatform | null;
+} {
+  let id = model.trim();
+  let platform: ModelPlatform | null = null;
+
+  // A geo prefix is unambiguously Bedrock cross-region/global inference.
+  if (GEO_PREFIX_RE.test(id)) {
+    id = id.replace(GEO_PREFIX_RE, '');
+    platform = 'bedrock';
+  }
+
+  // A dotted vendor namespace is the Bedrock base-id form.
+  if (NAMESPACE_DOT_RE.test(id)) {
+    id = id.replace(NAMESPACE_DOT_RE, '');
+    platform ??= 'bedrock';
+  }
+
+  // A `-vN:M` or trailing `:M` revision is Bedrock's model version.
+  if (BEDROCK_VERSION_RE.test(id)) {
+    id = id.replace(BEDROCK_VERSION_RE, '');
+    platform ??= 'bedrock';
+  } else if (BEDROCK_REVISION_RE.test(id)) {
+    id = id.replace(BEDROCK_REVISION_RE, '');
+    platform ??= 'bedrock';
+  }
+
+  // `@version` is Vertex's separator.
+  if (VERTEX_VERSION_RE.test(id)) {
+    id = id.replace(VERTEX_VERSION_RE, '');
+    platform ??= 'vertex';
+  }
+
+  // A slash-separated namespace is a gateway spelling. The known-vendor form is
+  // stripped without implying a platform, because several gateways use it and
+  // the id alone does not say which.
+  if (NAMESPACE_SLASH_RE.test(id)) {
+    id = id.replace(NAMESPACE_SLASH_RE, '');
+  } else if (GATEWAY_VENDOR_SLASH_RE.test(id)) {
+    id = id.replace(GATEWAY_VENDOR_SLASH_RE, '');
+  }
+
+  return { id, platform };
+}
+
+/** An index over a set of entries, keyed by canonical id and by alias. */
+export interface ModelIndex {
+  byId: ReadonlyMap<string, ModelEntry>;
+  entries: readonly ModelEntry[];
+}
+
+/**
+ * Build a lookup index. An alias that collides with another model's canonical id
+ * loses — a declared id always wins over an alias, so an alias can never
+ * shadow a real model.
+ */
+export function buildModelIndex(entries: readonly ModelEntry[]): ModelIndex {
+  const byId = new Map<string, ModelEntry>();
+  for (const entry of entries) byId.set(entry.id, entry);
+  for (const entry of entries) {
+    for (const alias of entry.aliases) {
+      if (!byId.has(alias)) byId.set(alias, entry);
+    }
+  }
+  return { byId, entries: Object.freeze([...entries]) };
+}
+
+/**
+ * Resolve a raw model string against an index.
+ *
+ * Matching is attempted most-specific first: the raw string exactly as reported,
+ * then with platform decorations stripped, then with a trailing dated suffix
+ * removed. The dated form is tried LAST so a model whose canonical id carries a
+ * date (Anthropic's `claude-haiku-4-5-20251001` is one) matches itself before
+ * the shorter form is considered.
+ *
+ * `entry` is `null` when nothing matched, and `canonicalId` is then the raw
+ * string unchanged. That is the honest answer for a model this catalog does not
+ * carry, and callers render it as unknown rather than falling back to a
+ * lookalike.
+ */
+export function resolveModel(raw: string, index: ModelIndex): ResolvedModel {
+  const exact = index.byId.get(raw);
+  if (exact !== undefined) {
+    return { entry: exact, canonicalId: raw, platform: null, raw };
+  }
+
+  const { id, platform } = stripPlatformDecorations(raw);
+  const stripped = index.byId.get(id);
+  if (stripped !== undefined) {
+    return { entry: stripped, canonicalId: id, platform, raw };
+  }
+
+  if (DATED_SUFFIX_RE.test(id)) {
+    const undated = id.replace(DATED_SUFFIX_RE, '');
+    const byDate = index.byId.get(undated);
+    if (byDate !== undefined) {
+      return { entry: byDate, canonicalId: undated, platform, raw };
+    }
+  }
+
+  // Nothing matched. Report the id exactly as it arrived rather than the
+  // stripped form: the decorations were removed to ATTEMPT a match, and a
+  // stripped id for a model the catalog does not carry is a rewrite nothing
+  // justifies.
+  return { entry: null, canonicalId: raw, platform, raw };
+}

--- a/packages/schema/src/token/cost-model.ts
+++ b/packages/schema/src/token/cost-model.ts
@@ -12,20 +12,23 @@
 //   - Unknown `(provider, model)` → `null` ("unknown"); we never guess a figure.
 //   - Local providers (ollama) map to a zero-cost entry, so a local model is $0,
 //     not "unknown".
-//   - `normalizeModelId` *canonicalizes the model id only* (strips Bedrock
-//     region/version suffixes and the `anthropic/` gateway prefix for grouping/
-//     display); it does NOT rewrite the provider. A Bedrock/Vertex/gateway usage
-//     bag therefore looks up `(bedrock|vertex|gateway, canonical-model)`, which is
-//     NOT in PRICE_MAP (only `anthropic` is) → `null`. We never price non-direct
-//     providers at Anthropic-direct rates (those rates differ in reality, and the
-//     never-guess rule forbids assuming they match).
+//   - `normalizeModelId` *canonicalizes the model id only*; it does NOT rewrite
+//     the provider. A Bedrock/Vertex/gateway usage bag therefore asks the catalog
+//     for that platform's own price, which is carried only where that platform's
+//     published rate was read. Non-direct rates differ from first-party ones in
+//     reality, so an unread one stays `null` rather than being assumed equal.
 //   - The `CostModel` interface is the swap point for an alternative price
-//     map; the compiled-in map below is the permanent fallback.
+//     source; the catalog below is the permanent fallback.
 //
-// ⚠️ Prices below are a REFERENCE snapshot of current public Anthropic list
-// pricing (per million tokens). They are NOT authoritative billing — our derived
-// number is an estimate (subscription usage burns rate-limit budget, not dollar
-// credits). Keep them updated.
+// Prices come from `../model/catalog.ts` and are declared nowhere else. They are
+// a REFERENCE snapshot, not authoritative billing — a derived number is an
+// estimate, and subscription usage burns rate-limit budget rather than dollar
+// credits.
+import { MODEL_INDEX } from '../model/catalog.ts';
+import type { ModelPrice } from '../model/pricing.ts';
+import { serviceTierMultiplier, ZERO_PRICE } from '../model/pricing.ts';
+import { ModelPlatform } from '../model/providers.ts';
+import { resolveModel } from '../model/resolve.ts';
 
 /**
  * The token-usage bag a cost is derived from. Every field is optional: non-
@@ -53,22 +56,6 @@ export interface CostUsage {
   serviceTier?: string;
 }
 
-/** Per-(provider, model) prices. Token prices are USD per MILLION tokens. */
-export interface ModelPrice {
-  /** USD per 1M uncached input tokens. */
-  input: number;
-  /** USD per 1M output tokens. */
-  output: number;
-  /** USD per 1M tokens written to the 1h ephemeral cache (Anthropic: 2× input). */
-  cacheWrite1h: number;
-  /** USD per 1M tokens written to the 5m ephemeral cache (Anthropic: 1.25× input). */
-  cacheWrite5m: number;
-  /** USD per 1M tokens read from cache (Anthropic: 0.1× input). */
-  cacheRead: number;
-  /** USD per single web-search request (per-request, not per-token). */
-  webSearch: number;
-}
-
 /**
  * The read-time cost seam. Implementations turn a token-usage bag for a given
  * `(provider, model)` into an estimated USD cost, or `null` when the pair is
@@ -89,179 +76,76 @@ export interface CostModel {
   normalizeModelId(provider: string, model: string): { provider: string; model: string };
 }
 
-// Per-MTok multipliers Anthropic applies to the base input rate. Used to derive
-// the cache columns from `input` so a single rate edit stays internally
-// consistent. (5m write = 1.25×, 1h write = 2×, read = 0.1×.)
-const CACHE_WRITE_5M_MULT = 1.25;
-const CACHE_WRITE_1H_MULT = 2;
-const CACHE_READ_MULT = 0.1;
-
-// $10 per 1,000 web-search requests = $0.01 per request (current public price).
-const WEB_SEARCH_PER_REQUEST = 0.01;
-
-/** Build an Anthropic-shaped price entry from base input/output rates. */
-function anthropicPrice(input: number, output: number): ModelPrice {
-  return {
-    input,
-    output,
-    cacheWrite5m: input * CACHE_WRITE_5M_MULT,
-    cacheWrite1h: input * CACHE_WRITE_1H_MULT,
-    cacheRead: input * CACHE_READ_MULT,
-    webSearch: WEB_SEARCH_PER_REQUEST,
-  };
+/**
+ * Map a stored provider string onto a catalog platform. Unrecognised providers
+ * stay unmapped, which resolves to an unknown price rather than a guessed one.
+ */
+function platformFor(provider: string): ModelPlatform | null {
+  const parsed = ModelPlatform.safeParse(provider.trim().toLowerCase());
+  return parsed.success ? parsed.data : null;
 }
 
-// A zero-cost entry for local/self-hosted inference — every column is 0 so a
-// local model resolves to $0 (a known price), not `null` (unknown).
-const ZERO_PRICE: ModelPrice = {
-  input: 0,
-  output: 0,
-  cacheWrite5m: 0,
-  cacheWrite1h: 0,
-  cacheRead: 0,
-  webSearch: 0,
-};
-
-// Per-million-token reference prices — current public Anthropic list pricing.
-// Source: https://platform.claude.com/docs/en/pricing (a.k.a. claude.com/pricing).
-// prices as of 2026-06-29 — re-verify on update.
-//   Opus 4.8/4.7/4.6/4.5: $5 in / $25 out
-//   Sonnet 4.6/4.5:       $3 in / $15 out
-//   Haiku 4.5:            $1 in / $5 out
-// NOTE for the next updater: the Opus/Sonnet input prices being this close ($5 vs
-// $3) is EXPECTED for this generation — current Opus is $5/$25, NOT the historical
-// Opus-3 $15/$75. Don't "fix" the Opus numbers up to match an old mental model;
-// they are correct as written. Cache columns are derived from `input` via the
-// multipliers above (5m write = 1.25×, 1h write = 2×, read = 0.1×). These are a
-// REFERENCE to be updated — do not treat them as
-// authoritative billing.
-const ANTHROPIC_PRICES: Record<string, ModelPrice> = {
-  'claude-fable-5': anthropicPrice(10, 50),
-  'claude-opus-4-8': anthropicPrice(5, 25),
-  'claude-opus-4-7': anthropicPrice(5, 25),
-  'claude-opus-4-6': anthropicPrice(5, 25),
-  'claude-opus-4-5': anthropicPrice(5, 25),
-  'claude-sonnet-5': anthropicPrice(3, 15),
-  'claude-sonnet-4-6': anthropicPrice(3, 15),
-  'claude-sonnet-4-5': anthropicPrice(3, 15),
-  'claude-haiku-4-5': anthropicPrice(1, 5),
-};
-
-// The price map, keyed `"<provider>/<model>"` (NOT model alone — the same model
-// id costs differently per provider). `normalizeModelId` canonicalizes the *model
-// id* before lookup but preserves the original provider. Bedrock/Vertex/gateway
-// prices differ from Anthropic-direct in reality, so only `anthropic/*` direct
-// keys + the local zero-cost wildcards are populated here; a `bedrock/...`,
-// `vertex/...`, or other-gateway pair is absent and resolves to `null` (cost
-// unknown), never silently priced at Anthropic-direct rates.
-const PRICE_MAP: Record<string, ModelPrice> = {
-  ...Object.fromEntries(
-    Object.entries(ANTHROPIC_PRICES).map(([model, price]) => [`anthropic/${model}`, price]),
-  ),
-  // Local providers: known and free.
-  'ollama/*': ZERO_PRICE,
-  'local/*': ZERO_PRICE,
-};
-
-// Service-tier price multipliers. `batch` is half price; `priority` is a premium;
-// `standard` (and anything unrecognized) is 1×. The multiplier is applied to the
-// FULL per-call token cost — input, output, AND cache read/write — because the
-// batch discount is a flat 50% on the whole request (every token type), not just
-// fresh input/output. See `costFor` where `serviceTierMultiplier` scales the
-// summed `tokenCost`. (Web-search is per-request, not per-token, so it is left
-// out of the tier scaling.)
-const SERVICE_TIER_MULTIPLIERS: Record<string, number> = {
-  standard: 1,
-  batch: 0.5,
-  priority: 1.5,
-};
-
-function serviceTierMultiplier(tier: string | undefined): number {
-  if (tier === undefined) return 1;
-  return SERVICE_TIER_MULTIPLIERS[tier] ?? 1;
+/** True when a platform runs on the caller's own hardware. */
+function isLocalProvider(provider: string): boolean {
+  const p = provider.trim().toLowerCase();
+  return p === 'ollama' || p === 'local';
 }
 
-// Canonical Anthropic model ids the gateway/Bedrock/Vertex variants canonicalize
-// onto. Kept as a list so the longest match wins (`claude-3-5-sonnet` before a
-// bare `sonnet` heuristic would, etc.) — but for our current families
-// exact-substring matching is sufficient.
-const CANONICAL_ANTHROPIC_MODELS = Object.keys(ANTHROPIC_PRICES);
+/**
+ * The price for a `(provider, model)` pair, or `null` when the catalog carries
+ * no verified rate for that platform.
+ */
+function priceFor(provider: string, model: string): ModelPrice | null {
+  if (isLocalProvider(provider)) return ZERO_PRICE;
 
-// Canonicalize a raw (possibly gateway/Bedrock/Vertex) *model id* onto a canonical
-// Anthropic id when we can recognize it; otherwise return it unchanged. This only
-// touches the model string — the provider is preserved by the caller. Canonicalizes:
-//   anthropic/claude-3.5-sonnet            (gateway, dotted)   → claude-sonnet-4-6 is NOT assumed
-//   anthropic.claude-opus-4-8              (Bedrock prefix)    → claude-opus-4-8
-//   us.anthropic.claude-opus-4-8-v1:0      (Bedrock region+ver)→ claude-opus-4-8
-//   claude-opus-4-8@20260101               (Vertex @version)   → claude-opus-4-8
-//   claude-opus-4-8                        (direct)            → claude-opus-4-8 (unchanged)
-function canonicalizeAnthropicModel(model: string): string {
-  // Strip a Bedrock region prefix (`us.`, `eu.`, `apac.`) and the `anthropic.`
-  // provider prefix, a Bedrock version suffix (`-v1:0`, `:0`), and a Vertex
-  // `@version` suffix, then look for a known canonical id as a substring.
-  const stripped = model
-    .replace(/^(us|eu|apac|global)\./, '')
-    .replace(/^anthropic[./]/, '')
-    .replace(/@[\w-]+$/, '') // Vertex @version
-    .replace(/-v\d+:\d+$/, '') // Bedrock -vN:M
-    .replace(/:\d+$/, '') // Bedrock :M
-    .replace(/-\d{8}$/, ''); // dated id suffix, e.g. claude-haiku-4-5-20251001 → claude-haiku-4-5
+  const resolved = resolveModel(model, MODEL_INDEX);
+  if (resolved.entry === null) return null;
 
-  for (const canonical of CANONICAL_ANTHROPIC_MODELS) {
-    if (stripped === canonical) return canonical;
-  }
-  // Also tolerate gateway dotted forms like `claude-3.5-sonnet` only when they
-  // exactly match a canonical id after removing dots — none of our current
-  // canonical ids contain dots, so this is a no-op today but keeps the contract
-  // explicit: we never *guess* a family, we only fold exact aliases.
-  return stripped;
+  const platform = platformFor(provider);
+  if (platform === null) return null;
+
+  return resolved.entry.platforms.get(platform)?.price ?? null;
 }
 
 const defaultCostModel: CostModel = {
   normalizeModelId(provider, model) {
     const p = provider.trim().toLowerCase();
     // Local providers: collapse any model onto the wildcard zero-cost key.
-    if (p === 'ollama' || p === 'local') {
+    if (isLocalProvider(p)) {
       return { provider: p, model: '*' };
     }
-    // Anthropic-direct, Bedrock, and Vertex: canonicalize the *model id* (strip
-    // Bedrock region/version suffixes, Vertex `@version`, the `anthropic.` prefix)
-    // but PRESERVE the original provider. Only `anthropic` is in PRICE_MAP, so a
-    // bedrock/vertex pair resolves to `null` (cost unknown) — we never price a
-    // non-direct provider at Anthropic-direct rates.
-    if (p === 'anthropic' || p === 'bedrock' || p === 'vertex') {
-      return { provider: p, model: canonicalizeAnthropicModel(model) };
-    }
-    // Gateway providers: an embedded `anthropic/<model>` form (e.g. LiteLLM /
-    // OpenRouter exposing an Anthropic model) has its model id canonicalized (the
-    // `anthropic/` prefix is a display alias, not a billing provider), but the
-    // gateway provider is PRESERVED — so it too resolves to `null` (Anthropic-via-
-    // gateway pricing differs from direct, and we never guess it). A non-Anthropic
-    // embedded namespace (`meta-llama/llama-3-70b`) is left fully untouched.
-    const anthropicGateway = /^anthropic\/(.+)$/.exec(model);
-    if (anthropicGateway?.[1] !== undefined) {
-      return { provider: p, model: canonicalizeAnthropicModel(anthropicGateway[1]) };
-    }
-    return { provider: p, model };
+    // Everything else: canonicalize the model id, preserving the provider. An
+    // id the catalog does not carry is returned unchanged — decorations are
+    // stripped to attempt a match, never to rewrite an unrecognised id.
+    const resolved = resolveModel(model, MODEL_INDEX);
+    return { provider: p, model: resolved.entry?.id ?? model };
   },
 
   costFor({ provider, model, usage }) {
-    const key = this.normalizeModelId(provider, model);
-    const price = PRICE_MAP[`${key.provider}/${key.model}`];
-    if (price === undefined) return null; // unknown (provider, model) — never guess
+    const price = priceFor(provider, model);
+    if (price === null) return null; // unknown (provider, model) — never guess
 
-    const tokenCost =
-      (usage.inputTokens ?? 0) * price.input +
-      (usage.outputTokens ?? 0) * price.output +
-      (usage.cacheWrite1hTokens ?? 0) * price.cacheWrite1h +
-      (usage.cacheWrite5mTokens ?? 0) * price.cacheWrite5m +
-      (usage.cacheReadTokens ?? 0) * price.cacheRead;
+    // A nullable column is an unread rate. Tokens billed against one cannot be
+    // priced, so the whole call is unknown rather than silently undercounted.
+    const columns: readonly [number, number | null][] = [
+      [usage.cacheWrite1hTokens ?? 0, price.cacheWrite1h],
+      [usage.cacheWrite5mTokens ?? 0, price.cacheWrite5m],
+      [usage.cacheReadTokens ?? 0, price.cacheRead],
+    ];
+    let tokenCost = (usage.inputTokens ?? 0) * price.input + (usage.outputTokens ?? 0) * price.output;
+    for (const [tokens, rate] of columns) {
+      if (tokens === 0) continue;
+      if (rate === null) return null;
+      tokenCost += tokens * rate;
+    }
 
     // Token prices are per MILLION tokens; divide once at the end.
     const tokenUsd = (tokenCost / 1_000_000) * serviceTierMultiplier(usage.serviceTier);
 
     // Web-search is billed per request, not per token, and not tier-scaled.
-    const webSearchUsd = (usage.webSearchRequests ?? 0) * price.webSearch;
+    const searches = usage.webSearchRequests ?? 0;
+    if (searches > 0 && price.webSearch === null) return null;
+    const webSearchUsd = searches * (price.webSearch ?? 0);
 
     return tokenUsd + webSearchUsd;
   },

--- a/packages/schema/src/token/cost-model.ts
+++ b/packages/schema/src/token/cost-model.ts
@@ -27,34 +27,12 @@
 import { MODEL_INDEX } from '../model/catalog.ts';
 import type { ModelPrice } from '../model/pricing.ts';
 import { costOf, ZERO_PRICE } from '../model/pricing.ts';
-import { ModelPlatform } from '../model/providers.ts';
+import type { ModelPlatform } from '../model/providers.ts';
+import { hostingFor } from '../model/providers.ts';
 import { resolveModel } from '../model/resolve.ts';
+import type { CostUsage } from './cost-usage.ts';
 
-/**
- * The token-usage bag a cost is derived from. Every field is optional: non-
- * Anthropic providers return only a subset (the Anthropic-specific cache/web
- * fields simply come back absent), so a missing field contributes nothing to the
- * cost rather than failing the whole computation.
- */
-export interface CostUsage {
-  /** Uncached input tokens billed at the model's full input rate. */
-  inputTokens?: number;
-  /** Output (completion) tokens. */
-  outputTokens?: number;
-  /** Tokens written to the 1-hour ephemeral cache (`cache_creation.ephemeral_1h_input_tokens`). */
-  cacheWrite1hTokens?: number;
-  /** Tokens written to the 5-minute ephemeral cache (`cache_creation.ephemeral_5m_input_tokens`). */
-  cacheWrite5mTokens?: number;
-  /** Tokens read from cache (`cache_read_input_tokens`) — priced far below input. */
-  cacheReadTokens?: number;
-  /** Server-side web-search requests (`server_tool_use.web_search_requests`) — billed per request. */
-  webSearchRequests?: number;
-  /**
-   * Service tier (`usage.service_tier`): standard/batch/priority. Selects a
-   * price multiplier (e.g. batch is discounted). Unknown tiers fall back to 1×.
-   */
-  serviceTier?: string;
-}
+export type { CostUsage };
 
 /**
  * The read-time cost seam. Implementations turn a token-usage bag for a given
@@ -77,23 +55,90 @@ export interface CostModel {
 }
 
 /**
- * Map a stored provider string onto a catalog platform. Unrecognised providers
- * stay unmapped, which resolves to an unknown price rather than a guessed one.
+ * The provider strings the capture path actually stores, mapped onto catalog
+ * platforms.
+ *
+ * The two vocabularies are NOT spelled alike and must not be assumed to be:
+ * the resolvers record `'google'` where the catalog's first-party Google
+ * platform is `'google-ai'`, and `'gateway'` names no single platform at all.
+ * A provider with no entry here resolves to no platform, so its cost is
+ * unknown rather than priced against a lookalike.
+ *
+ * A plain Map rather than a schema parse: this runs once per priced leaf on the
+ * read path, and a lookup allocates nothing where a parse allocates a result
+ * object and, on the miss path, an issue array.
  */
-function platformFor(provider: string): ModelPlatform | null {
-  const parsed = ModelPlatform.safeParse(provider.trim().toLowerCase());
-  return parsed.success ? parsed.data : null;
+const PROVIDER_PLATFORM: ReadonlyMap<string, ModelPlatform> = new Map([
+  ['anthropic', 'anthropic'],
+  ['openai', 'openai'],
+  // The resolvers' spelling for Google's first-party API.
+  ['google', 'google-ai'],
+  ['google-ai', 'google-ai'],
+  ['bedrock', 'bedrock'],
+  ['vertex', 'vertex'],
+  ['azure', 'azure'],
+  ['foundry', 'foundry'],
+  ['mistral', 'mistral'],
+  ['deepseek', 'deepseek'],
+  ['xai', 'xai'],
+  ['cohere', 'cohere'],
+  ['together', 'together'],
+  ['fireworks', 'fireworks'],
+  ['groq', 'groq'],
+  ['openrouter', 'openrouter'],
+  ['ollama', 'ollama'],
+  ['local', 'local'],
+]);
+
+/**
+ * Providers deliberately carried as unpriceable rather than mapped.
+ *
+ * `gateway` names a class of hosts, not one of them, so it cannot select a
+ * price; `unknown` is the resolver's own miss. Listed explicitly so a test can
+ * assert every stored provider is either mapped or knowingly here, and a
+ * resolver inventing a fourth spelling is caught rather than silently unpriced.
+ */
+export const UNPRICEABLE_PROVIDERS: readonly string[] = Object.freeze([
+  'gateway',
+  'unknown',
+  'cli',
+  'api',
+]);
+
+/**
+ * The catalog platform a stored provider string names, or `null`.
+ *
+ * Exported so a test can assert that every provider the resolvers can record
+ * is either mapped here or listed in `UNPRICEABLE_PROVIDERS` — the seam that
+ * decides whether any of the catalog's prices are reachable at all.
+ */
+export function platformForProvider(provider: string): ModelPlatform | null {
+  return PROVIDER_PLATFORM.get(provider.trim().toLowerCase()) ?? null;
 }
 
-/** True when a platform runs on the caller's own hardware. */
+/**
+ * True when a provider runs on the caller's own hardware.
+ *
+ * Asks `providers.ts` rather than matching literals, so the platform → hosting
+ * band table stays the one place that decides this. A third local platform
+ * added there is local here too, instead of the builder and the cost model
+ * disagreeing with no test able to see it.
+ */
 function isLocalProvider(provider: string): boolean {
-  const p = provider.trim().toLowerCase();
-  return p === 'ollama' || p === 'local';
+  const platform = platformForProvider(provider);
+  return platform !== null && hostingFor(platform) === 'local';
 }
 
 /**
  * The price for a `(provider, model)` pair, or `null` when the catalog carries
  * no verified rate for that platform.
+ *
+ * When the model ID ITSELF names a platform, that wins over the provider
+ * string. A Bedrock-shaped id (`us.anthropic.claude-opus-5`) says where the
+ * call was served no matter what the session's provider snapshot claims, and
+ * pricing it at Anthropic-direct rates because the snapshot said `'anthropic'`
+ * is the substitution this module exists to prevent — the one Bedrock pair
+ * anyone has checked bills at 2x first-party.
  */
 function priceFor(provider: string, model: string): ModelPrice | null {
   if (isLocalProvider(provider)) return ZERO_PRICE;
@@ -101,7 +146,7 @@ function priceFor(provider: string, model: string): ModelPrice | null {
   const resolved = resolveModel(model, MODEL_INDEX);
   if (resolved.entry === null) return null;
 
-  const platform = platformFor(provider);
+  const platform = resolved.platform ?? platformForProvider(provider);
   if (platform === null) return null;
 
   return resolved.entry.platforms.get(platform)?.price ?? null;

--- a/packages/schema/src/token/cost-model.ts
+++ b/packages/schema/src/token/cost-model.ts
@@ -26,7 +26,7 @@
 // credits.
 import { MODEL_INDEX } from '../model/catalog.ts';
 import type { ModelPrice } from '../model/pricing.ts';
-import { serviceTierMultiplier, ZERO_PRICE } from '../model/pricing.ts';
+import { costOf, ZERO_PRICE } from '../model/pricing.ts';
 import { ModelPlatform } from '../model/providers.ts';
 import { resolveModel } from '../model/resolve.ts';
 
@@ -124,30 +124,7 @@ const defaultCostModel: CostModel = {
   costFor({ provider, model, usage }) {
     const price = priceFor(provider, model);
     if (price === null) return null; // unknown (provider, model) — never guess
-
-    // A nullable column is an unread rate. Tokens billed against one cannot be
-    // priced, so the whole call is unknown rather than silently undercounted.
-    const columns: readonly [number, number | null][] = [
-      [usage.cacheWrite1hTokens ?? 0, price.cacheWrite1h],
-      [usage.cacheWrite5mTokens ?? 0, price.cacheWrite5m],
-      [usage.cacheReadTokens ?? 0, price.cacheRead],
-    ];
-    let tokenCost = (usage.inputTokens ?? 0) * price.input + (usage.outputTokens ?? 0) * price.output;
-    for (const [tokens, rate] of columns) {
-      if (tokens === 0) continue;
-      if (rate === null) return null;
-      tokenCost += tokens * rate;
-    }
-
-    // Token prices are per MILLION tokens; divide once at the end.
-    const tokenUsd = (tokenCost / 1_000_000) * serviceTierMultiplier(usage.serviceTier);
-
-    // Web-search is billed per request, not per token, and not tier-scaled.
-    const searches = usage.webSearchRequests ?? 0;
-    if (searches > 0 && price.webSearch === null) return null;
-    const webSearchUsd = searches * (price.webSearch ?? 0);
-
-    return tokenUsd + webSearchUsd;
+    return costOf(price, usage);
   },
 };
 

--- a/packages/schema/src/token/cost-usage.ts
+++ b/packages/schema/src/token/cost-usage.ts
@@ -1,0 +1,28 @@
+// The token-usage bag a cost is derived from. Its own module because both the
+// price table (`model/pricing.ts`) and the cost model consume it, and either
+// owning it would make the two import each other.
+/**
+ * The token-usage bag a cost is derived from. Every field is optional: non-
+ * Anthropic providers return only a subset (the Anthropic-specific cache/web
+ * fields simply come back absent), so a missing field contributes nothing to the
+ * cost rather than failing the whole computation.
+ */
+export interface CostUsage {
+  /** Uncached input tokens billed at the model's full input rate. */
+  inputTokens?: number;
+  /** Output (completion) tokens. */
+  outputTokens?: number;
+  /** Tokens written to the 1-hour ephemeral cache (`cache_creation.ephemeral_1h_input_tokens`). */
+  cacheWrite1hTokens?: number;
+  /** Tokens written to the 5-minute ephemeral cache (`cache_creation.ephemeral_5m_input_tokens`). */
+  cacheWrite5mTokens?: number;
+  /** Tokens read from cache (`cache_read_input_tokens`) — priced far below input. */
+  cacheReadTokens?: number;
+  /** Server-side web-search requests (`server_tool_use.web_search_requests`) — billed per request. */
+  webSearchRequests?: number;
+  /**
+   * Service tier (`usage.service_tier`): standard/batch/priority. Selects a
+   * price multiplier (e.g. batch is discounted). Unknown tiers fall back to 1×.
+   */
+  serviceTier?: string;
+}

--- a/packages/schema/test/model/catalog.test.ts
+++ b/packages/schema/test/model/catalog.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  anthropicPrice,
+  buildModelIndex,
+  hostingFor,
+  isFirstParty,
+  MODEL_ENTRIES,
+  MODEL_INDEX,
+  ModelPlatform,
+  ModelVendor,
+  resolveModel,
+  resolveTrainsOnData,
+  stripPlatformDecorations,
+  UNDECLARED_TRAINING,
+  vendor,
+  ZERO_PRICE,
+} from '../../src/index.ts';
+
+describe('platform vocabulary', () => {
+  // `hostingFor` falls back to 'api' for a platform with no band, so the
+  // fallback is only unreachable while this table covers the whole enum. Stated
+  // as expected VALUES rather than as a not-undefined check: the latter is
+  // satisfied by the fallback itself and would pass for a platform whose band
+  // was never declared.
+  const EXPECTED_HOSTING: Record<string, string> = {
+    anthropic: 'api',
+    openai: 'api',
+    'google-ai': 'api',
+    mistral: 'api',
+    deepseek: 'api',
+    xai: 'api',
+    cohere: 'api',
+    bedrock: 'api',
+    vertex: 'api',
+    azure: 'api',
+    foundry: 'api',
+    together: 'gateway',
+    fireworks: 'gateway',
+    groq: 'gateway',
+    openrouter: 'gateway',
+    ollama: 'local',
+    local: 'local',
+  };
+
+  it('gives every platform its declared hosting band', () => {
+    // Exact key set: a platform added without a band fails here rather than
+    // silently taking the fallback.
+    expect(Object.keys(EXPECTED_HOSTING).sort()).toEqual([...ModelPlatform.options].sort());
+    for (const platform of ModelPlatform.options) {
+      expect(hostingFor(platform), platform).toBe(EXPECTED_HOSTING[platform]);
+    }
+  });
+
+  it('names only the vendor’s own endpoint as first-party', () => {
+    expect(isFirstParty('anthropic', 'anthropic')).toBe(true);
+    expect(isFirstParty('anthropic', 'bedrock')).toBe(false);
+    expect(isFirstParty('anthropic', 'vertex')).toBe(false);
+    // Meta publishes weights and runs no first-party API.
+    expect(isFirstParty('meta', 'together')).toBe(false);
+  });
+});
+
+describe('id resolution', () => {
+  it('resolves every platform spelling of one model to the same entry', () => {
+    const spellings = [
+      'claude-opus-5',
+      'anthropic.claude-opus-5',
+      'us.anthropic.claude-opus-5',
+      'eu.anthropic.claude-opus-5',
+      'global.anthropic.claude-opus-5',
+      'claude-opus-5@20251101',
+      'anthropic/claude-opus-5',
+    ];
+    for (const raw of spellings) {
+      const resolved = resolveModel(raw, MODEL_INDEX);
+      expect(resolved.entry?.id, raw).toBe('claude-opus-5');
+    }
+  });
+
+  it('resolves the geo prefixes an Anthropic-only canonicaliser omitted', () => {
+    // `au.` and `jp.` are documented Bedrock inference-profile prefixes.
+    expect(resolveModel('au.anthropic.claude-opus-5', MODEL_INDEX).entry?.id).toBe('claude-opus-5');
+    expect(resolveModel('jp.amazon.nova-2-lite-v1:0', MODEL_INDEX).entry?.id).toBe('nova-2-lite');
+  });
+
+  it('infers the serving platform from the id shape', () => {
+    expect(resolveModel('us.anthropic.claude-opus-5', MODEL_INDEX).platform).toBe('bedrock');
+    expect(resolveModel('claude-haiku-4-5@20251001', MODEL_INDEX).platform).toBe('vertex');
+    expect(resolveModel('claude-opus-5', MODEL_INDEX).platform).toBeNull();
+  });
+
+  it('prefers an exact id over a dated-suffix strip', () => {
+    // A model whose canonical id itself ends in eight digits must match itself
+    // before the shorter form is tried.
+    const dated = resolveModel('claude-haiku-4-5-20251001', MODEL_INDEX);
+    expect(dated.entry?.id).toBe('claude-haiku-4-5');
+    expect(resolveModel('claude-haiku-4-5', MODEL_INDEX).entry?.id).toBe('claude-haiku-4-5');
+  });
+
+  it('returns no entry for an unknown model rather than a lookalike', () => {
+    const resolved = resolveModel('claude-nonexistent-9', MODEL_INDEX);
+    expect(resolved.entry).toBeNull();
+    expect(resolved.canonicalId).toBe('claude-nonexistent-9');
+  });
+
+  it('does not resolve Object.prototype keys', () => {
+    // The index is a Map, so an inherited property cannot be reached through it.
+    for (const hostile of ['toString', 'constructor', '__proto__', 'valueOf', 'hasOwnProperty']) {
+      const resolved = resolveModel(hostile, MODEL_INDEX);
+      expect(resolved.entry, hostile).toBeNull();
+    }
+  });
+
+  it('strips decorations without inventing a platform', () => {
+    expect(stripPlatformDecorations('meta-llama/llama-3-3-70b').id).toBe('llama-3-3-70b');
+    expect(stripPlatformDecorations('meta-llama/llama-3-3-70b').platform).toBeNull();
+  });
+});
+
+describe('builder', () => {
+  const acme = vendor('anthropic', {
+    family: { id: 'acme', name: 'Acme' },
+    region: 'us',
+    retention: 'zero_retention',
+  });
+
+  const model = acme.model('acme-1', {
+    name: 'Acme 1',
+    ctx: 1_000,
+    price: anthropicPrice(10, 50, 1),
+    on: ['bedrock', 'ollama'],
+  });
+
+  it('gives the first-party platform the declared price and retention', () => {
+    const own = model.platforms.get('anthropic');
+    expect(own?.firstParty).toBe(true);
+    expect(own?.price?.input).toBe(10);
+    expect(own?.retention).toBe('zero_retention');
+  });
+
+  it('gives a reseller the identity but neither the price nor the retention', () => {
+    const bedrock = model.platforms.get('bedrock');
+    expect(bedrock?.firstParty).toBe(false);
+    expect(bedrock?.price).toBeNull();
+    expect(bedrock?.retention).toBe('unknown');
+  });
+
+  it('prices a self-hosted platform at a known zero', () => {
+    const ollama = model.platforms.get('ollama');
+    expect(ollama?.price).toEqual(ZERO_PRICE);
+    expect(ollama?.retention).toBe('on_infrastructure');
+  });
+
+  it('records an unstated context window as unknown rather than a default', () => {
+    const undeclared = acme.model('acme-2', { name: 'Acme 2' });
+    expect(undeclared.contextWindow).toBeNull();
+    expect(undeclared.maxOutputTokens).toBeNull();
+  });
+});
+
+describe('trainsOnData resolution', () => {
+  const policy = {
+    apiDefault: 'no',
+    consumerDefault: 'yes',
+    consumerControl: 'opt-out',
+    source: null,
+  } as const;
+
+  it('is unknown until an operator declares the plan', () => {
+    expect(
+      resolveTrainsOnData({
+        hosting: 'api',
+        firstParty: true,
+        policy,
+        declaration: UNDECLARED_TRAINING,
+      }),
+    ).toBe('unknown');
+  });
+
+  it('uses the vendor policy once a tier is declared', () => {
+    expect(
+      resolveTrainsOnData({
+        hosting: 'api',
+        firstParty: true,
+        policy,
+        declaration: { tier: 'api', controlExercised: null },
+      }),
+    ).toBe('no');
+    expect(
+      resolveTrainsOnData({
+        hosting: 'api',
+        firstParty: true,
+        policy,
+        declaration: { tier: 'consumer', controlExercised: null },
+      }),
+    ).toBe('yes');
+  });
+
+  it('honours an exercised opt-out', () => {
+    expect(
+      resolveTrainsOnData({
+        hosting: 'api',
+        firstParty: true,
+        policy,
+        declaration: { tier: 'consumer', controlExercised: true },
+      }),
+    ).toBe('no');
+  });
+
+  it('never transfers the vendor posture to a reseller', () => {
+    expect(
+      resolveTrainsOnData({
+        hosting: 'api',
+        firstParty: false,
+        policy,
+        declaration: { tier: 'api', controlExercised: null },
+      }),
+    ).toBe('unknown');
+  });
+
+  it('answers no for self-hosted weights regardless of declaration', () => {
+    expect(
+      resolveTrainsOnData({
+        hosting: 'local',
+        firstParty: false,
+        policy,
+        declaration: UNDECLARED_TRAINING,
+      }),
+    ).toBe('no');
+  });
+});
+
+describe('catalog data', () => {
+  it('declares no duplicate ids', () => {
+    const ids = MODEL_ENTRIES.map((e) => e.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('never lets an alias shadow a declared model', () => {
+    for (const entry of MODEL_ENTRIES) {
+      for (const alias of entry.aliases) {
+        const shadowed = MODEL_ENTRIES.find((e) => e.id === alias);
+        if (shadowed !== undefined) {
+          expect(MODEL_INDEX.byId.get(alias)).toBe(shadowed);
+        }
+      }
+    }
+  });
+
+  it('names a vendor for every entry', () => {
+    for (const entry of MODEL_ENTRIES) {
+      expect(ModelVendor.options).toContain(entry.vendor);
+    }
+  });
+
+  it('records the published Claude 5 context windows', () => {
+    // These are 1M models; the Claude 4.x figure is 200K and applies to Haiku.
+    for (const id of ['claude-opus-5', 'claude-sonnet-5', 'claude-fable-5-1']) {
+      expect(MODEL_INDEX.byId.get(id)?.contextWindow, id).toBe(1_000_000);
+    }
+    expect(MODEL_INDEX.byId.get('claude-haiku-4-5')?.contextWindow).toBe(200_000);
+  });
+
+  it('orders the Claude tiers by their published rates', () => {
+    const rate = (id: string): number => {
+      const price = MODEL_INDEX.byId.get(id)?.platforms.get('anthropic')?.price;
+      if (price == null) throw new Error(`no first-party price for ${id}`);
+      return price.input + price.output;
+    };
+    // Fable bills above Opus, which bills above Sonnet, which bills above Haiku.
+    expect(rate('claude-fable-5-1')).toBeGreaterThan(rate('claude-opus-5'));
+    expect(rate('claude-opus-5')).toBeGreaterThan(rate('claude-sonnet-5'));
+    expect(rate('claude-sonnet-5')).toBeGreaterThan(rate('claude-haiku-4-5'));
+  });
+
+  it('carries the non-uniform Anthropic cache-read rates', () => {
+    // Fable 5.1 reads cache at 0.025x base input; the rest of the family at 0.1x.
+    expect(MODEL_INDEX.byId.get('claude-fable-5-1')?.platforms.get('anthropic')?.price?.cacheRead).toBe(
+      0.25,
+    );
+    expect(MODEL_INDEX.byId.get('claude-fable-5')?.platforms.get('anthropic')?.price?.cacheRead).toBe(1);
+  });
+
+  it('leaves every reseller offering unpriced', () => {
+    for (const entry of MODEL_ENTRIES) {
+      for (const offering of entry.platforms.values()) {
+        if (offering.firstParty || offering.hosting === 'local') continue;
+        expect(offering.price, `${entry.id} on ${offering.platform}`).toBeNull();
+      }
+    }
+  });
+
+  it('builds an index that resolves every declared id', () => {
+    const index = buildModelIndex(MODEL_ENTRIES);
+    for (const entry of MODEL_ENTRIES) {
+      expect(resolveModel(entry.id, index).entry?.id, entry.id).toBe(entry.id);
+    }
+  });
+});

--- a/packages/schema/test/model/catalog.test.ts
+++ b/packages/schema/test/model/catalog.test.ts
@@ -3,16 +3,19 @@ import { describe, expect, it } from 'vitest';
 import {
   anthropicPrice,
   buildModelIndex,
+  defaultCostModel,
   hostingFor,
   isFirstParty,
   MODEL_ENTRIES,
   MODEL_INDEX,
   ModelPlatform,
   ModelVendor,
+  platformForProvider,
   resolveModel,
   resolveTrainsOnData,
   stripPlatformDecorations,
   UNDECLARED_TRAINING,
+  UNPRICEABLE_PROVIDERS,
   vendor,
   ZERO_PRICE,
 } from '../../src/index.ts';
@@ -276,10 +279,12 @@ describe('catalog data', () => {
 
   it('carries the non-uniform Anthropic cache-read rates', () => {
     // Fable 5.1 reads cache at 0.025x base input; the rest of the family at 0.1x.
-    expect(MODEL_INDEX.byId.get('claude-fable-5-1')?.platforms.get('anthropic')?.price?.cacheRead).toBe(
-      0.25,
-    );
-    expect(MODEL_INDEX.byId.get('claude-fable-5')?.platforms.get('anthropic')?.price?.cacheRead).toBe(1);
+    expect(
+      MODEL_INDEX.byId.get('claude-fable-5-1')?.platforms.get('anthropic')?.price?.cacheRead,
+    ).toBe(0.25);
+    expect(
+      MODEL_INDEX.byId.get('claude-fable-5')?.platforms.get('anthropic')?.price?.cacheRead,
+    ).toBe(1);
   });
 
   it('leaves every reseller offering unpriced', () => {
@@ -296,5 +301,97 @@ describe('catalog data', () => {
     for (const entry of MODEL_ENTRIES) {
       expect(resolveModel(entry.id, index).entry?.id, entry.id).toBe(entry.id);
     }
+  });
+});
+
+describe('the provider vocabulary the product actually stores', () => {
+  // Every provider string a resolver can record, from the three resolver
+  // vocabularies plus the miss values. These are what reach `costFor`, and they
+  // are NOT spelled like `ModelPlatform` — `google` against `google-ai` is the
+  // gap this case exists to hold closed.
+  const STORED_PROVIDERS = [
+    // provider.ts — Provider
+    'anthropic',
+    'bedrock',
+    'vertex',
+    'gateway',
+    // provider-codex.ts — CodexProvider
+    'openai',
+    // provider-antigravity.ts — AntigravityProvider
+    'google',
+    // resolver miss values
+    'unknown',
+  ];
+
+  it.each(STORED_PROVIDERS)('maps %s onto a platform, or declares it unpriceable', (provider) => {
+    // One or the other, never neither. A provider that is silently unmapped
+    // leaves every model it serves unpriced while the catalog carries a rate —
+    // which is exactly how `google` shipped unreachable.
+    const mapped = platformForProvider(provider) !== null;
+    const declaredUnpriceable = UNPRICEABLE_PROVIDERS.includes(provider);
+    expect(mapped || declaredUnpriceable, provider).toBe(true);
+  });
+
+  it('prices a Gemini call from the provider string the resolver records', () => {
+    // Regression: `google` is what gets stored; `google-ai` is the catalog's
+    // spelling. Keying only off the catalog's left every Gemini rollup unpriced.
+    expect(
+      defaultCostModel.costFor({
+        provider: 'google',
+        model: 'gemini-2.5-pro',
+        usage: { inputTokens: 1_000 },
+      }),
+    ).toBeCloseTo(0.00125, 10);
+  });
+
+  it('does not price a Bedrock-shaped id at first-party rates', () => {
+    // The id names Bedrock whatever the session's provider snapshot claims,
+    // and Bedrock's own rate is not carried.
+    expect(
+      defaultCostModel.costFor({
+        provider: 'anthropic',
+        model: 'us.anthropic.claude-opus-5',
+        usage: { inputTokens: 1_000_000 },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('long-context pricing', () => {
+  it('re-prices the whole request at the band rate above the threshold', () => {
+    // Gemini 2.5 Pro is $1.25/MTok at or below 200K and $2.50 above it, and the
+    // band applies to the entire request rather than the excess.
+    const under = defaultCostModel.costFor({
+      provider: 'google',
+      model: 'gemini-2.5-pro',
+      usage: { inputTokens: 100_000 },
+    });
+    const over = defaultCostModel.costFor({
+      provider: 'google',
+      model: 'gemini-2.5-pro',
+      usage: { inputTokens: 300_000 },
+    });
+    expect(under).toBeCloseTo(0.125, 10);
+    expect(over).toBeCloseTo(0.75, 10);
+  });
+
+  it('returns unknown when the band rate itself is unpublished', () => {
+    // OpenAI publishes the 272K threshold but not the rate above it. A definite
+    // figure there would be the sub-threshold price reported as the total.
+    expect(
+      defaultCostModel.costFor({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        usage: { inputTokens: 400_000 },
+      }),
+    ).toBeNull();
+    // Not vacuous: the same model prices normally below the threshold.
+    expect(
+      defaultCostModel.costFor({
+        provider: 'openai',
+        model: 'gpt-5.5',
+        usage: { inputTokens: 100_000 },
+      }),
+    ).toBeCloseTo(0.5, 10);
   });
 });

--- a/packages/schema/test/token/cost-model.test.ts
+++ b/packages/schema/test/token/cost-model.test.ts
@@ -64,7 +64,7 @@ describe('defaultCostModel.costFor', () => {
     expect(write1h).toBeGreaterThan(write5m);
   });
 
-  it('prices claude-sonnet-5 at the Sonnet tier ($3/$15 per MTok)', () => {
+  it('prices claude-sonnet-5 at its own published rate ($2/$10 per MTok)', () => {
     const cost = asNumber(
       defaultCostModel.costFor({
         provider: 'anthropic',
@@ -72,8 +72,9 @@ describe('defaultCostModel.costFor', () => {
         usage: { inputTokens: 1_000_000, outputTokens: 1_000_000 },
       }),
     );
-    // $3 input + $15 output.
-    expect(cost).toBeCloseTo(18, 6);
+    // $2 input + $10 output. Sonnet 5 is priced below the Sonnet 4.x line
+    // ($3/$15); the tier name does not carry the rate.
+    expect(cost).toBeCloseTo(12, 6);
   });
 
   it('adds a per-request web-search charge on top of token cost', () => {


### PR DESCRIPTION
## What

Replaces two hand-maintained, drifting model tables with one declaration per model under `packages/schema/src/model/`.

```ts
const anthropic = vendor('anthropic', {
  family: { id: 'claude', name: 'Claude' },
  region: 'us',
  retention: 'zero_retention',
  training: ANTHROPIC_TRAINING,
});

anthropic.model('claude-opus-5', {
  name: 'Claude Opus 5',
  ctx: 1_000_000,
  capability: 'reasoning',
  price: anthropicPrice(5, 25, 0.5),
  on: [...CLAUDE_RESELLERS],   // metadata resolves; price stays unknown
});
```

38 models across 9 vendors and 17 platforms. `token/cost-model.ts` now reads this catalog instead of carrying its own `ANTHROPIC_PRICES` — it loses 182 lines and gains 70.

## Why

The two tables disagreed. `cost-model.ts` priced Sonnet 5 at $3/$15 against a published $2/$10 and had no Opus 5 entry at all. Adding a model meant copying eighteen fields, and a field left unedited silently inherited the neighbouring model's value.

## Design

**Vendor and platform are separate axes.** A model's identity travels across platforms; its price and retention posture do not. `price` only ever reaches the vendor's own endpoint. A reseller listed in `on` inherits the weights, context window and open-weights answer with an explicitly unknown price and retention — Bedrock served Claude 3.5 Sonnet v2 at \$6/\$30 against Anthropic's own \$3/\$15, exactly 2x, so inheriting a first-party rate would state a number nobody checked.

**`resolve.ts` generalises `canonicalizeAnthropicModel` to every vendor.** `anthropic.claude-opus-5`, `us.anthropic.claude-opus-5`, `global.anthropic.claude-opus-5` and `claude-opus-5@20251101` all reach the same entry. It adds the `au.` and `jp.` Bedrock geo prefixes the Anthropic-only version omitted; ids carrying them previously resolved to nothing. An id that resolves to nothing is returned **unchanged** — decorations are stripped to attempt a match, never to rewrite an unrecognised id.

**`trainsOnData` is tri-state.** It is a property of (vendor policy × plan tier × whether the control was exercised), and the event stream carries none of those — a session reports the same model id whether billed against an API key or a subscription. A boolean forced a choice between asserting `false` for a consumer-tier caller who opted in and `true` for an API caller under a no-training agreement. It defaults to `unknown` until an operator declares the plan, and never transfers a vendor's posture to a reseller.

**Cache-read rates are data, not a derived 0.1x multiplier.** Anthropic prices Fable 5.1 and Mythos 5.1 cache reads at 0.025x base input; the derived column overcharged those by 4x.

**Lookups go through a `Map`**, so a tenant-supplied model string cannot reach an inherited `Object.prototype` member.

## Data provenance

Prices, context windows and training policies were verified against vendor documentation, cited per vendor block. Anything unread is recorded as `null` rather than estimated — notably Bedrock/Vertex rates, Gemini context windows, and current-generation Cohere prices. Mistral is not declared at all: its pricing page publishes display names rather than wire ids, so entries would not resolve.

Two pricing axes the shape deliberately does not model, noted inline where they apply: DeepSeek's time-of-day banding (the peak rate is stated, so an off-peak call costs less than reported) and Gemini's promotional expiry.

## One expectation changed

`cost-model.test.ts` pinned `claude-sonnet-5` at the Sonnet 4.x rate of \$3/\$15. That was the stale price; corrected to \$2/\$10. The tier name does not carry the rate.

## Verification

- 39 test files, 839 tests pass
- Coverage 88.37% lines (floor 84%)
- `tsc --noEmit` clean, `eslint` clean
- `entry-graph.test.ts` passes — no `drizzle-*` reaches the package entry through the new modules