### PR TITLE
feat(plugin-runtime,persistence,plugin-sdk): stamp the structural forward

### DIFF
--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -3,6 +3,7 @@ import { dirname, join, sep } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 
 import type {
+  AuditEventInput,
   ConfigInventoryReport,
   ConfigScanRecord,
   DetectedFindingWithKey,
@@ -179,6 +180,12 @@ export interface LocalDatabase {
   // delivery paths leave a row in one indistinguishable state. Attached mode
   // only — nothing forwards in standalone, so nothing stamps. Fail-open.
   markCaptureDelivered(event: IngestEvent, atMs: number): void;
+  // Stamp structural events the LIVE forward already delivered — the sibling of
+  // markCaptureDelivered for the lane `partition()` counts. Without it a
+  // successfully forwarded session/llm_call/tool_call row is indistinguishable
+  // from one that was dropped. Settled through the same statement a drain uses.
+  // Attached mode only. Fail-open.
+  markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void;
   // Idempotent upsert of the session's host/harness/account/project dimensions
   // by content-addressed id, in one transaction. Returns the resolved ids to
   // stamp onto the Session audit row. Fail-open: returns {} if the DB is
@@ -486,6 +493,26 @@ export function openLocalDatabase(dir: string): LocalDatabase {
     });
   }
 
+  // Record that the LIVE path already delivered these structural events.
+  //
+  // No id derivation: `AuditEventInput.id` is the primary key the local write
+  // used and the id `pgAuditValues` stores verbatim, so the row, the wire and
+  // this stamp share one id space. Batched into a single transaction because a
+  // forwarded batch settles as a unit and N transactions on the store's most
+  // numerous table is a cost the session pays.
+  //
+  // Fail-open like every other write here: a stamp that does not land costs a
+  // redundant resend the receiver's id-dedup absorbs, never the session.
+  function markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void {
+    if (events.length === 0) return;
+    failOpenTransaction(db, () => {
+      historySync.markSynced(
+        events.map((event) => event.id),
+        atMs,
+      );
+    });
+  }
+
   function recordCapture(event: IngestEvent, detected: DetectedFindingWithKey[]): void {
     // Fail-open: dropping telemetry is acceptable; breaking the host session
     // is not. A locked/corrupt DB or a bad row leaves the session untouched.
@@ -755,6 +782,7 @@ export function openLocalDatabase(dir: string): LocalDatabase {
     inspectionFindings,
     recordCapture,
     markCaptureDelivered,
+    markAuditEventsDelivered,
     ensureInventory,
     recordConfigScan,
     recordProjectFiles,

--- a/packages/persistence/src/database.ts
+++ b/packages/persistence/src/database.ts
@@ -16,12 +16,22 @@ import type {
 } from '@akasecurity/schema';
 import {
   captureDefinitionVersion,
+  EventKind,
   isoToEpochMillis,
   toCaptureAttributes,
   toCaptureDefinitionInput,
 } from '@akasecurity/schema';
 
 import { captureId } from './ids.ts';
+
+/**
+ * The capture GRAIN — the event kinds whose row carries `content`.
+ *
+ * Read only by `markAuditEventsDelivered`, to keep the structural stamp off the
+ * capture lane's rows. Built from `EventKind.options` so it cannot drift from
+ * the enum the capture path is defined by.
+ */
+const CAPTURE_GRAIN: ReadonlySet<string> = new Set<string>(EventKind.options);
 import {
   backupPath,
   discardStore,
@@ -504,10 +514,27 @@ export function openLocalDatabase(dir: string): LocalDatabase {
   // Fail-open like every other write here: a stamp that does not land costs a
   // redundant resend the receiver's id-dedup absorbs, never the session.
   function markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void {
-    if (events.length === 0) return;
+    // CAPTURE-GRAIN ROWS ARE REFUSED, and this is the guard rather than a
+    // convention. `synced_at` serves two disjoint lanes off one column —
+    // `pendingRows` reads the structural types, `pendingCaptureRows` reads the
+    // capture ones — and both filter `synced_at IS NULL`. `recordAuditEvent`
+    // accepts any `AuditEventType`, so a capture-grain event routed through it
+    // would be stamped here on a forward that carried no `content`, and the
+    // capture drain would never offer that row again: silent, permanent loss of
+    // the text, with no error and a row that reads healthy. That is precisely
+    // why `markCaptureDelivered` is a separate method, and this is what keeps
+    // the two as separable as their docblocks claim.
+    //
+    // Derived from `EventKind` rather than from the drain's own
+    // `OUTBOX_CAPTURE_EVENT_TYPES`: that one is module-private and deliberately
+    // three kinds, while capture GRAIN is all four. Excluding by grain is the
+    // wider, safer side of that difference — `code_change` is in neither lane
+    // today, and a stamp on it would be exactly as wrong the day it joins one.
+    const stampable = events.filter((event) => !CAPTURE_GRAIN.has(event.eventType));
+    if (stampable.length === 0) return;
     failOpenTransaction(db, () => {
       historySync.markSynced(
-        events.map((event) => event.id),
+        stampable.map((event) => event.id),
         atMs,
       );
     });

--- a/packages/persistence/src/repositories/history-sync.ts
+++ b/packages/persistence/src/repositories/history-sync.ts
@@ -100,12 +100,19 @@ export interface HistorySyncCounts {
  * rows, so the stamp is invisible to it by construction. The stamp exists for a
  * capture drain to read; it is not a fix for this read.
  *
- * `queued` therefore still OVER-COUNTS on an attached machine, and by the same
- * rows it always did: a structural row the live path forwarded successfully
- * (`recordToolCalls`) is never stamped by anything, so it stays NULL and reads
- * as owed. Closing that needs a stamp on the structural forward, which no path
- * does today. Read `queued` as "not known to have been delivered", not as
- * "undelivered".
+ * `queued` no longer over-counts the rows it used to. A structural row the live
+ * path forwarded successfully is now stamped at the forward site through
+ * `markAuditEventsDelivered`, so it leaves this bucket; what stays is what the
+ * deployment genuinely has not been given — including every row the batch
+ * budget discarded (`forwardBatch`), which is the case this read exists to make
+ * visible and which nothing else on the device can see.
+ *
+ * Two caveats survive, and neither is closed here. `inProgress` is structurally
+ * always 0 until `claimRows`/`releaseStaleClaims` gain a caller — they have
+ * none. And `failed` counts a SKIP, not a failed attempt: `classify` returns
+ * `'skip'` for both a local rebuild defect and a deployment's 400/413/422, while
+ * a transient network failure leaves the row NULL and reads as queued, which is
+ * correct — it is still owed.
  */
 export interface HistorySyncPartition {
   queued: number;

--- a/packages/persistence/src/repositories/history-sync.ts
+++ b/packages/persistence/src/repositories/history-sync.ts
@@ -102,10 +102,24 @@ export interface HistorySyncCounts {
  *
  * `queued` no longer over-counts the rows it used to. A structural row the live
  * path forwarded successfully is now stamped at the forward site through
- * `markAuditEventsDelivered`, so it leaves this bucket; what stays is what the
- * deployment genuinely has not been given — including every row the batch
- * budget discarded (`forwardBatch`), which is the case this read exists to make
- * visible and which nothing else on the device can see.
+ * `markAuditEventsDelivered`, so it leaves this bucket — including, by its
+ * absence, every row the batch budget discarded (`forwardBatch`), which is the
+ * case this read exists to make visible and which nothing else on the device
+ * can see.
+ *
+ * STILL READ IT AS "not known to have been delivered", NOT as "undelivered".
+ * The stamp closed the largest residue, not the last one, and three survive it:
+ *   - A forward that TIMED OUT BUT LANDED. `withTimeout` is a bare
+ *     `Promise.race` with no abort, and the transport's own deadline is far
+ *     longer than `FORWARD_BUDGET_MS`, so `run` can return `{ok:false}` while
+ *     the request is still in flight and still acceptable.
+ *   - `ensureSessionRoot` STUBS. `recordCapture` and the standalone
+ *     `recordAuditEvent` both plant a `session` row — structural, counted here —
+ *     that no forward path ever sends, so this stamp never reaches it. It leaves
+ *     `queued` only when an authoritative root later forwards successfully.
+ *   - A permanent `invalid-request`. Deterministic, and the structural drain
+ *     bounds on `started_at < backlogBefore`, so a post-attach row is never
+ *     re-offered by anything: undeliverable for ever, yet reading as queued.
  *
  * Two caveats survive, and neither is closed here. `inProgress` is structurally
  * always 0 until `claimRows`/`releaseStaleClaims` gain a caller — they have

--- a/packages/persistence/test/record-capture.test.ts
+++ b/packages/persistence/test/record-capture.test.ts
@@ -7,11 +7,11 @@
 import { randomUUID } from 'node:crypto';
 import type { DatabaseSync } from 'node:sqlite';
 
-import type { DetectedFindingWithKey, IngestEvent } from '@akasecurity/schema';
+import type { DetectedFindingWithKey, IngestEvent, LlmCallInput } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { schemaObjectExists } from '../src/db/migrations/introspection.ts';
-import { captureId } from '../src/ids.ts';
+import { captureId, llmCallId } from '../src/ids.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
 const store = useTempStore('aka-record-capture-', { migrated: true });
@@ -678,6 +678,140 @@ describe('recordCapture — at-rest path disambiguation', () => {
     ).toBe(1);
     r.close();
     db.close();
+  });
+});
+
+// The STRUCTURAL half of the same seam. Kept beside markCaptureDelivered
+// deliberately: the two stamps share one column across two disjoint drains, and
+// the boundary between them is only testable where both are in view.
+describe('markAuditEventsDelivered', () => {
+  const syncedAt = (db: DatabaseSync, id: string): number | null =>
+    (
+      db.prepare(`SELECT synced_at AS s FROM audit_events WHERE id = ?`).get(id) as {
+        s: number | null;
+      }
+    ).s;
+
+  const llmCall = (sessionId: string, messageId: string): LlmCallInput => ({
+    sessionId,
+    messageId,
+    parentId: sessionId,
+    rootSessionId: sessionId,
+    startedAt: '2026-01-01T00:00:00.000Z',
+    attributes: { model: 'claude-opus-5', provider: 'anthropic' },
+  });
+
+  it('stamps the row insertLlmCall wrote, found by the same derivation', () => {
+    // THE PREMISE THE WHOLE FEATURE RESTS ON, and the only place it is executed
+    // against a real row. The attached gateway builds the forwarded event's id
+    // with `llmCallId(sessionId, messageId)`; `insertLlmCall` derives the local
+    // primary key from the same function. If those ever diverge the UPDATE
+    // matches nothing — and a SQLite UPDATE matching no rows is not an error, so
+    // every fake-backed suite would stay green while the outbox silently went on
+    // over-counting. Derived here rather than read back from the insert, so a
+    // change to either side fails HERE.
+    const db = store.open();
+    db.auditEvents.ensureSessionRoot('s-llm', '2026-01-01T00:00:00.000Z');
+    db.auditEvents.insertLlmCall(llmCall('s-llm', 'm-1'));
+    const id = llmCallId('s-llm', 'm-1');
+
+    expect(syncedAt(raw(), id)).toBeNull();
+    db.markAuditEventsDelivered(
+      [{ id, eventType: 'llm_call', startedAt: '2026-01-01T00:00:00.000Z' }],
+      1_700_000_000_000,
+    );
+    expect(syncedAt(raw(), id)).toBe(1_700_000_000_000);
+  });
+
+  it('leaves every other structural row outstanding', () => {
+    // Scoped to the events handed in, not the session: a batch whose head landed
+    // and whose tail the budget dropped must stamp only the head.
+    const db = store.open();
+    db.auditEvents.ensureSessionRoot('s-batch', '2026-01-01T00:00:00.000Z');
+    db.auditEvents.insertLlmCall(llmCall('s-batch', 'm-a'));
+    db.auditEvents.insertLlmCall(llmCall('s-batch', 'm-b'));
+
+    db.markAuditEventsDelivered(
+      [
+        {
+          id: llmCallId('s-batch', 'm-a'),
+          eventType: 'llm_call',
+          startedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      1_700_000_000_000,
+    );
+    expect(syncedAt(raw(), llmCallId('s-batch', 'm-a'))).toBe(1_700_000_000_000);
+    expect(syncedAt(raw(), llmCallId('s-batch', 'm-b'))).toBeNull();
+  });
+
+  it('moves the row out of `queued` and into `synced` in the partition', () => {
+    // The read this exists to make honest. Asserted through partition() rather
+    // than through the column, because the column being set is not the claim —
+    // the claim is that the bucket a surface renders actually moves.
+    const db = store.open();
+    db.auditEvents.ensureSessionRoot('s-part', '2026-01-01T00:00:00.000Z');
+    db.auditEvents.insertLlmCall(llmCall('s-part', 'm-1'));
+    // The session root is structural too, so it is counted alongside the leaf.
+    expect(db.historySync.partition()).toMatchObject({ queued: 2, synced: 0 });
+
+    db.markAuditEventsDelivered(
+      [
+        {
+          id: llmCallId('s-part', 'm-1'),
+          eventType: 'llm_call',
+          startedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      1_700_000_000_000,
+    );
+    expect(db.historySync.partition()).toMatchObject({ queued: 1, synced: 1 });
+  });
+
+  it('REFUSES a capture-grain row, leaving it for the capture drain', () => {
+    // The lane boundary, and the reason this method filters at all.
+    // `recordAuditEvent` accepts any AuditEventType, so a capture routed through
+    // it would otherwise be stamped on a forward that carried no `content` — and
+    // `pendingCaptureRows` filters `synced_at IS NULL`, so the capture drain
+    // would never offer that row again. Silent, permanent loss of the text.
+    const db = store.open();
+    const ev = event({ metadata: { sessionId: 's-cap' }, contentHash: 'hash-cap' });
+    db.recordCapture(ev, []);
+    const id = captureId('s-cap', 'hash-cap', null);
+
+    db.markAuditEventsDelivered(
+      [{ id, eventType: 'prompt', startedAt: '2026-01-01T00:00:00.000Z' }],
+      1_700_000_000_000,
+    );
+    expect(syncedAt(raw(), id)).toBeNull();
+  });
+
+  it('stamps the structural rows of a MIXED batch and refuses the capture ones', () => {
+    // The partial case the filter has to get right: an all-capture batch is
+    // caught by the early return, so only a mixed one drives the predicate.
+    const db = store.open();
+    db.auditEvents.ensureSessionRoot('s-mix', '2026-01-01T00:00:00.000Z');
+    db.auditEvents.insertLlmCall(llmCall('s-mix', 'm-1'));
+    const cap = event({ metadata: { sessionId: 's-mix' }, contentHash: 'hash-mix' });
+    db.recordCapture(cap, []);
+
+    db.markAuditEventsDelivered(
+      [
+        {
+          id: llmCallId('s-mix', 'm-1'),
+          eventType: 'llm_call',
+          startedAt: '2026-01-01T00:00:00.000Z',
+        },
+        {
+          id: captureId('s-mix', 'hash-mix', null),
+          eventType: 'prompt',
+          startedAt: '2026-01-01T00:00:00.000Z',
+        },
+      ],
+      1_700_000_000_000,
+    );
+    expect(syncedAt(raw(), llmCallId('s-mix', 'm-1'))).toBe(1_700_000_000_000);
+    expect(syncedAt(raw(), captureId('s-mix', 'hash-mix', null))).toBeNull();
   });
 });
 

--- a/packages/plugin-runtime/src/attached/forward-policy.ts
+++ b/packages/plugin-runtime/src/attached/forward-policy.ts
@@ -250,8 +250,8 @@ export type ForwardFailureReason = ControlPlaneFailure | 'breaker-open' | 'inval
  * `ok: false` is still not an error. G1 is unchanged and is the reason this is a
  * RESULT and not a throw: every caller has already completed its local write and
  * must return that result whatever the control plane did. The union widens what a
- * caller MAY observe; it obliges none of them to observe anything, and six of
- * the seven call sites in `attached-gateway.ts` still discard it outright.
+ * caller MAY observe; it obliges none of them to observe anything, and several
+ * call sites in `attached-gateway.ts` still discard it outright.
  */
 export type ForwardResult<T> =
   | { readonly ok: true; readonly value: T }
@@ -399,7 +399,7 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
       } catch (err) {
         // The one place the failure is still in hand. Classified HERE rather
         // than by the caller, because this is also the only place that can
-        // write it down — six of the seven call sites drop the result, and the
+        // write it down — most call sites drop the result, and the
         // reader that needs it (`/aka:status`) runs in a different process
         // minutes or days later.
         //

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -580,9 +580,15 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
     event: AuditEventInput & { inspections?: ToolCallInspection[] },
   ): Promise<void> {
     await this.deps.local.recordAuditEvent(event);
-    await this.deps.forward.run(() =>
+    const forwarded = await this.deps.forward.run(() =>
       this.deps.client.recordAuditEvent(reKeyForForward(event, this.remoteInventory)),
     );
+    // The stamp is outside the local write's transaction, for the reason
+    // `recordCapture` gives: the write is authoritative and commits whatever the
+    // network does; only once the forward settles is there anything true to
+    // record. `recordAuditEvent` resolves void, so `ok` IS the settlement — the
+    // client throws on any non-2xx and `run` converts that to `ok: false`.
+    if (forwarded.ok) this.deps.local.markAuditEventsDelivered([event], Date.now());
   }
 
   // Attached `llm_call` is written locally by the inner gateway, then routed to
@@ -592,11 +598,15 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
   // which would write the event to the local store a second time.
   async recordLlmCall(input: LlmCallInput): Promise<void> {
     await this.deps.local.recordLlmCall(input);
-    await this.deps.forward.run(() =>
-      this.deps.client.recordAuditEvent(
-        reKeyForForward(llmAuditEvent(input), this.remoteInventory),
-      ),
+    // Built ONCE and used for both the wire and the stamp. Two calls to
+    // `llmAuditEvent` would be two derivations of the same id, which is the
+    // drift `markAuditEventsDelivered` takes the event rather than an id to
+    // prevent.
+    const event = llmAuditEvent(input);
+    const forwarded = await this.deps.forward.run(() =>
+      this.deps.client.recordAuditEvent(reKeyForForward(event, this.remoteInventory)),
     );
+    if (forwarded.ok) this.deps.local.markAuditEventsDelivered([event], Date.now());
   }
 
   /**
@@ -624,17 +634,37 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
     toEvent: (input: T) => AuditEventInput & { inspections?: ToolCallInspection[] },
   ): Promise<void> {
     const deadline = Date.now() + BATCH_FORWARD_BUDGET_MS;
-    for (let i = 0; i < inputs.length; i += 1) {
-      const now = Date.now();
-      if (now >= deadline) {
-        // The remainder, not one item: everything from here on is discarded.
-        recordForwardDrops(this.deps.dataDir, inputs.length - i, now);
-        return;
+    // WHAT LANDED IS STAMPED, and stamped once for the whole batch rather than
+    // per item: `markSynced` takes the write lock for the set, and a serial loop
+    // that took it per row would pay that cost on the store's most numerous
+    // table while a hook waits. Accumulated rather than stamped inline because
+    // both exits below must settle it — the deadline exit especially, since a
+    // batch that drops its tail still delivered its head, and returning without
+    // stamping would leave exactly the rows that DID arrive reading as owed.
+    const delivered: AuditEventInput[] = [];
+    try {
+      for (let i = 0; i < inputs.length; i += 1) {
+        const now = Date.now();
+        if (now >= deadline) {
+          // The remainder, not one item: everything from here on is discarded.
+          recordForwardDrops(this.deps.dataDir, inputs.length - i, now);
+          return;
+        }
+        const input = inputs[i] as T;
+        // Built once per item, then shared by the wire and the stamp — see
+        // recordLlmCall for why a second derivation is the thing to avoid.
+        const event = toEvent(input);
+        const forwarded = await this.deps.forward.run(() =>
+          this.deps.client.recordAuditEvent(reKeyForForward(event, this.remoteInventory)),
+        );
+        if (forwarded.ok) delivered.push(event);
       }
-      const input = inputs[i] as T;
-      await this.deps.forward.run(() =>
-        this.deps.client.recordAuditEvent(reKeyForForward(toEvent(input), this.remoteInventory)),
-      );
+    } finally {
+      // `finally`, not a line before each exit: `forward.run` is documented never
+      // to throw, but this method's contract is that the caller's local write is
+      // already committed and correct, so a stamp lost to an unexpected throw
+      // here would silently re-offer rows the deployment already holds.
+      this.deps.local.markAuditEventsDelivered(delivered, Date.now());
     }
   }
 
@@ -954,6 +984,10 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
   // path that has nothing left to await.
   markCaptureDelivered(event: IngestEvent, atMs: number): void {
     this.deps.local.markCaptureDelivered(event, atMs);
+  }
+
+  markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void {
+    this.deps.local.markAuditEventsDelivered(events, atMs);
   }
 }
 

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -636,8 +636,11 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
     const deadline = Date.now() + BATCH_FORWARD_BUDGET_MS;
     // WHAT LANDED IS STAMPED, and stamped once for the whole batch rather than
     // per item: `markSynced` takes the write lock for the set, and a serial loop
-    // that took it per row would pay that cost on the store's most numerous
-    // table while a hook waits. Accumulated rather than stamped inline because
+    // would take and release it per row on the store's most numerous table. NOT
+    // because a hook is waiting — BATCH_FORWARD_BUDGET_MS's docblock retracts
+    // that claim explicitly, and this path runs in the detached reconcile child.
+    // What it buys is a shorter lock hold against the hooks writing CONCURRENTLY
+    // with that child. Accumulated rather than stamped inline because
     // both exits below must settle it — the deadline exit especially, since a
     // batch that drops its tail still delivered its head, and returning without
     // stamping would leave exactly the rows that DID arrive reading as owed.
@@ -660,11 +663,26 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
         if (forwarded.ok) delivered.push(event);
       }
     } finally {
-      // `finally`, not a line before each exit: `forward.run` is documented never
-      // to throw, but this method's contract is that the caller's local write is
-      // already committed and correct, so a stamp lost to an unexpected throw
-      // here would silently re-offer rows the deployment already holds.
-      this.deps.local.markAuditEventsDelivered(delivered, Date.now());
+      // `finally`, not a line before each exit: the deadline path RETURNS from
+      // inside the try, and a stamp after the loop would be skipped by exactly
+      // that return — leaving the rows that DID arrive reading as owed, on the
+      // slow-plane machine this all exists for.
+      //
+      // Caught, because this is now the only call on the path the "never throws"
+      // argument does not cover. `forward.run` is contracted not to throw and
+      // `toEvent`/`reKeyForForward` sit inside the try; a throw HERE would
+      // convert both exits — the deadline return included — into a rejection out
+      // of `recordLlmCalls`/`recordToolCalls`, which the reconciler reads as a
+      // failed local pass and drops. `deps.local` is typed as the interface, and
+      // `LocalStoreMaintenance.markAuditEventsDelivered` promises that it stamps,
+      // not that it swallows, so the guarantee has to be structural here rather
+      // than inherited from today's implementation.
+      try {
+        this.deps.local.markAuditEventsDelivered(delivered, Date.now());
+      } catch {
+        // A lost stamp costs a redundant resend the receiver's id-dedup absorbs.
+        // Breaking the pass costs the whole batch.
+      }
     }
   }
 
@@ -710,9 +728,16 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
   // local store.
   async recordConfigScan(record: ConfigScanRecord): Promise<void> {
     await this.deps.local.recordConfigScan(record);
-    await this.deps.forward.run(() =>
+    const forwarded = await this.deps.forward.run(() =>
       this.deps.client.recordAuditEvent(reKeyForForward(record.scanEvent, this.remoteInventory)),
     );
+    // Stamped like the other three, though `config_scan` is in NEITHER drain's
+    // type list today, so no read counts it and nothing re-offers it. That is
+    // exactly why it is stamped: the rule this class follows is that the write
+    // site records what was delivered and the READ decides what it counts, and a
+    // call site exempted because it happens to be inert is the one that reads as
+    // owed for ever on the day its type joins a lane.
+    if (forwarded.ok) this.deps.local.markAuditEventsDelivered([record.scanEvent], Date.now());
   }
 
   async recordBlockedDetection(entry: BlockedDetectionInput): Promise<void> {
@@ -946,10 +971,10 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
   //
   // Implementing these is what actually closes the skipped-local-maintenance
   // gap: the OSS structural guard `hasLocalStoreMaintenance()` is satisfied by
-  // any object carrying all five, so the composite qualifies and SessionStart
+  // any object carrying them all, so the composite qualifies and SessionStart
   // runs maintenance on the device's real store.
   //
-  // ⚠ Three of the six are SYNCHRONOUS and must stay that way. `handle-session-start`
+  // ⚠ Several of them are SYNCHRONOUS and must stay that way. `handle-session-start`
   // calls `capWarnEraEnforcement` without `await` and uses `staleBinaryNotice`'s
   // return value directly; declaring them `async` here would hand those call
   // sites a Promise and silently break both.

--- a/packages/plugin-runtime/src/handle-session-start.ts
+++ b/packages/plugin-runtime/src/handle-session-start.ts
@@ -119,8 +119,8 @@ export async function handleSessionStart(
       // just-written session root down with it.
       await recordConfigInventory(gateway, input.sessionId, input.cwd, input.homeDir);
       // Best-effort store maintenance. Each pass is gated on ITS OWN member
-      // rather than on the whole capability: the five are unrelated, so a
-      // gateway supplying four of them must still get those four run — gating
+      // rather than on the whole capability: they are unrelated, so a gateway
+      // supplying only some of them must still get those run — gating
       // the group would drop the retention purge because some unrelated member
       // is absent, and every pass here is swallowed, so nothing would say so.
       //

--- a/packages/plugin-runtime/src/standalone-gateway.ts
+++ b/packages/plugin-runtime/src/standalone-gateway.ts
@@ -440,9 +440,12 @@ export class StandaloneDataGateway implements DataGateway, LocalStoreMaintenance
     this.db.markCaptureDelivered(event, atMs);
   }
 
-  // Present so the standalone gateway still satisfies LocalStoreMaintenance,
-  // and a no-op in effect rather than by omission: nothing forwards here, so
-  // `delivered` is only ever the empty set the store returns early on.
+  // Implemented, not stubbed, for the same reason its sibling above is: the
+  // attached gateway is a DECORATOR over an instance of this class
+  // (`attached/factory.ts` builds one and passes it as `deps.local`), so every
+  // stamp the live forward makes lands here with a non-empty array. This is the
+  // production write path for that feature, not a shape-satisfying no-op — a
+  // machine that is merely standalone simply never calls it.
   markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void {
     this.db.markAuditEventsDelivered(events, atMs);
   }

--- a/packages/plugin-runtime/src/standalone-gateway.ts
+++ b/packages/plugin-runtime/src/standalone-gateway.ts
@@ -440,6 +440,13 @@ export class StandaloneDataGateway implements DataGateway, LocalStoreMaintenance
     this.db.markCaptureDelivered(event, atMs);
   }
 
+  // Present so the standalone gateway still satisfies LocalStoreMaintenance,
+  // and a no-op in effect rather than by omission: nothing forwards here, so
+  // `delivered` is only ever the empty set the store returns early on.
+  markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void {
+    this.db.markAuditEventsDelivered(events, atMs);
+  }
+
   staleBinaryNotice(currentVersion: string): string | null {
     try {
       // newestRecordedBinary() maxes across ALL recorders (plugin + aka-cli), and

--- a/packages/plugin-runtime/test/attached/gateway-exception-e2e.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway-exception-e2e.test.ts
@@ -120,6 +120,7 @@ function makeLocalStore(opts: {
     reconcileWorktreeProjects: () => Promise.resolve(),
     staleBinaryNotice: () => null,
     markCaptureDelivered: () => undefined,
+    markAuditEventsDelivered: () => undefined,
   };
 }
 

--- a/packages/plugin-runtime/test/attached/gateway-policy-e2e.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway-policy-e2e.test.ts
@@ -146,6 +146,7 @@ function makeLocalStore(bundle: PolicyBundle): DataGateway & LocalStoreMaintenan
     reconcileWorktreeProjects: () => Promise.resolve(),
     staleBinaryNotice: () => null,
     markCaptureDelivered: () => undefined,
+    markAuditEventsDelivered: () => undefined,
   };
 }
 

--- a/packages/plugin-runtime/test/attached/gateway.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway.test.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { toolCallId } from '@akasecurity/persistence';
 import type { DataGateway, LocalStoreMaintenance } from '@akasecurity/plugin-sdk';
 import { hasLocalStoreMaintenance } from '@akasecurity/plugin-sdk';
 import type {
@@ -725,6 +726,38 @@ describe('the batch budget records what it discards', () => {
 });
 
 describe('the live forward stamps what it delivered', () => {
+  it('stamps only the items that succeeded within a MIXED batch', async () => {
+    // The per-item half of the rule, which nothing else in this file reaches.
+    // `deadForward` short-circuits before the client, and the budget test's
+    // forward returns ok for every item — so `if (forwarded.ok)` is only ever
+    // driven with a CONSTANT predicate. Delete the `if` and push
+    // unconditionally, and both of those stay green. This alternates.
+    let call = 0;
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        call += 1;
+        const ok = call % 2 === 1;
+        if (ok) {
+          await op();
+          return { ok: true } as ForwardResult<unknown>;
+        }
+        return { ok: false, reason: 'unreachable' } as ForwardResult<unknown>;
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [] };
+    const { gateway } = build({ forward, local: makeLocal(calls) });
+    await gateway.recordToolCalls([
+      toolCallInput('odd-1'),
+      toolCallInput('even-2'),
+      toolCallInput('odd-3'),
+      toolCallInput('even-4'),
+    ]);
+
+    // Exactly the 1st and 3rd — the ones whose forward returned ok.
+    expect(calls.delivered).toEqual([toolCallId('s', 'odd-1'), toolCallId('s', 'odd-3')]);
+  });
+
   /**
    * The gap `HistorySyncPartition`'s docblock named: a structural row the live
    * path forwarded SUCCESSFULLY was never stamped by anything, so it stayed NULL
@@ -803,8 +836,11 @@ describe('the live forward stamps what it delivered', () => {
     // opposite bug.
     expect(seen.length).toBeGreaterThan(0);
     expect(seen.length).toBeLessThan(40);
-    // Exactly what landed, and nothing the deadline discarded.
-    expect(calls.delivered).toHaveLength(seen.length);
+    // IDENTITY, not count. `toHaveLength(seen.length)` would pass if the
+    // accumulator had stamped the wrong ids — the first N inputs rather than the
+    // N that came back `ok`. Those coincide here, which is exactly why a length
+    // assertion cannot tell them apart; this pins the join the whole PR rests on.
+    expect(calls.delivered).toEqual(seen.map((e) => (e as AuditEventInput).id));
   });
 });
 

--- a/packages/plugin-runtime/test/attached/gateway.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway.test.ts
@@ -8,6 +8,7 @@ import type {
   AuditEventInput,
   DetectionCategory,
   IngestEvent,
+  LlmCallInput,
   Policy,
   PolicyBundle,
   RecordProjectEgressInput,
@@ -69,6 +70,7 @@ const MAINTENANCE_METHODS = [
   'reconcileWorktreeProjects',
   'staleBinaryNotice',
   'markCaptureDelivered',
+  'markAuditEventsDelivered',
 ] as const;
 type MissingMaintenance = Exclude<
   keyof LocalStoreMaintenance,
@@ -82,10 +84,12 @@ void _maintenanceIsFullyListed;
 
 interface Calls {
   order: string[];
+  /** Ids handed to `markAuditEventsDelivered`, in the order they were stamped. */
+  delivered: string[];
 }
 
 /**
- * A recording stand-in for the inner local gateway. Three of the six maintenance
+ * A recording stand-in for the inner local gateway. Three of the maintenance
  * members are SYNCHRONOUS on the real port and are synchronous here too — a
  * fake that returned promises for them would hide exactly the bug the composite
  * has to avoid.
@@ -149,6 +153,10 @@ function makeLocal(calls: Calls, overrides: Partial<DataGateway & LocalStoreMain
   });
   base.markCaptureDelivered = vi.fn(() => {
     calls.order.push('local.markCaptureDelivered');
+  });
+  base.markAuditEventsDelivered = vi.fn((events: readonly { id: string }[]) => {
+    calls.order.push('local.markAuditEventsDelivered');
+    for (const event of events) calls.delivered.push(event.id);
   });
   return Object.assign(base, overrides) as unknown as DataGateway & LocalStoreMaintenance;
 }
@@ -250,7 +258,7 @@ afterEach(() => {
 });
 
 function build(overrides: Partial<AttachedDataGatewayDeps> = {}) {
-  const calls: Calls = { order: [] };
+  const calls: Calls = { order: [], delivered: [] };
   const local = overrides.local ?? makeLocal(calls);
   const client = overrides.client ?? makeClient(calls);
   const gateway = new AttachedDataGateway({
@@ -362,7 +370,7 @@ describe('writes are local-FIRST, then forwarded', () => {
   });
 
   it('a forward that never runs still returns the local result and does not throw', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const { gateway } = build({ forward: deadForward(calls) });
     await expect(
       gateway.recordCapture({ event: event('e'), findings: [] }),
@@ -392,7 +400,7 @@ describe('writes are local-FIRST, then forwarded', () => {
     // stamp would show up on the second. Both are asserted for the reason the
     // {0,0} case below spells out — a stamp that is missing because nothing was
     // forwarded proves nothing, so the forward is pinned as having been reached.
-    const forwardCalls: Calls = { order: [] };
+    const forwardCalls: Calls = { order: [], delivered: [] };
     const { gateway, calls } = build({ forward: deadForward(forwardCalls) });
     await gateway.recordCapture({ event: event('e1'), findings: [] });
     expect(forwardCalls.order).toContain('forward.skipped');
@@ -406,7 +414,7 @@ describe('writes are local-FIRST, then forwarded', () => {
     // outstanding for ever, resent on every pass and deduped every time.
     const { gateway, calls } = build({
       client: makeClient(
-        { order: [] },
+        { order: [], delivered: [] },
         {
           ingestEvents: vi.fn(() => Promise.resolve({ accepted: 0, duplicates: 1 })),
         },
@@ -423,7 +431,7 @@ describe('writes are local-FIRST, then forwarded', () => {
     // the direction the whole "queued is what is owed" invariant rests on.
     const { gateway, calls } = build({
       client: makeClient(
-        { order: [] },
+        { order: [], delivered: [] },
         {
           ingestEvents: vi.fn(() => Promise.resolve({ accepted: 0, duplicates: 0 })),
         },
@@ -441,7 +449,7 @@ describe('writes are local-FIRST, then forwarded', () => {
   });
 
   it('a forward that REJECTS is contained — the local write still stands', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const client = makeClient(calls, {
       ingestEvents: vi.fn(() => Promise.reject(new Error('backend down'))),
     });
@@ -472,7 +480,7 @@ describe('writes are local-FIRST, then forwarded', () => {
   });
 
   it('recordProjectEgress forward failure still returns the LOCAL summary and does not throw', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const client = makeClient(calls, {
       recordProjectEgress: vi.fn(() => Promise.reject(new Error('backend down'))),
     });
@@ -495,7 +503,7 @@ describe('consumeException is a fail-secure boundary', () => {
   });
 
   it('does NOT convert a local rejection into a granted bypass', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       consumeException: vi.fn(() => Promise.reject(new Error('store unreadable'))),
     });
@@ -510,7 +518,7 @@ describe('consumeException is a fail-secure boundary', () => {
 
 describe('ensureInventory and the two id spaces', () => {
   it('returns the LOCAL resolution, not the backend one', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       ensureInventory: vi.fn(() => Promise.resolve({ hostId: 'local-host' })),
     });
@@ -522,7 +530,7 @@ describe('ensureInventory and the two id spaces', () => {
   });
 
   it('re-keys a forwarded audit event into the BACKEND id space', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       ensureInventory: vi.fn(() => Promise.resolve({ hostId: 'local-host' })),
     });
@@ -548,7 +556,7 @@ describe('ensureInventory and the two id spaces', () => {
     // assert about — the point is only that the local write still ran and
     // nothing threw. The id-space cases below use a LIVE forward with a failing
     // inventory call, which is the state that actually reaches the wire.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const recordAuditEvent = vi.fn((event: AuditEventInput) => {
       void event;
       return Promise.resolve();
@@ -567,7 +575,7 @@ describe('ensureInventory and the two id spaces', () => {
     // insert is rejected, forward.run swallows it, and the session root plus
     // every descendant silently never reaches the tenant copy. Omitting the
     // field costs one degraded join instead.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const recordAuditEvent = vi.fn((event: AuditEventInput) => {
       void event;
       return Promise.resolve();
@@ -602,7 +610,7 @@ describe('ensureInventory and the two id spaces', () => {
     // would stamp B's events with A's host/harness/project — an insert that
     // SUCCEEDS while attributing a whole session to the wrong repository, which
     // is worse than not forwarding it.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const recordAuditEvent = vi.fn((event: AuditEventInput) => {
       void event;
       return Promise.resolve();
@@ -646,6 +654,16 @@ const toolCallInput = (id: string): ToolCallInput => ({
   inspections: [],
 });
 
+/** A minimal LlmCallInput; only its identity has to vary per item. */
+const llmCallInput = (id: string): LlmCallInput => ({
+  sessionId: 's',
+  messageId: id,
+  parentId: 'p',
+  rootSessionId: 'r',
+  startedAt: '2026-01-01T00:00:00.000Z',
+  attributes: { model: 'claude-opus-5', provider: 'anthropic' },
+});
+
 describe('the batch budget records what it discards', () => {
   /**
    * There was no coverage of the batch deadline at all, and the shape it guards
@@ -669,7 +687,7 @@ describe('the batch budget records what it discards', () => {
 
     const seen: unknown[] = [];
     const client = {
-      ...makeClient({ order: [] }),
+      ...makeClient({ order: [], delivered: [] }),
       recordAuditEvent: vi.fn((e: unknown) => {
         seen.push(e);
         return Promise.resolve();
@@ -706,6 +724,90 @@ describe('the batch budget records what it discards', () => {
   });
 });
 
+describe('the live forward stamps what it delivered', () => {
+  /**
+   * The gap `HistorySyncPartition`'s docblock named: a structural row the live
+   * path forwarded SUCCESSFULLY was never stamped by anything, so it stayed NULL
+   * and read as owed — indistinguishable from one the batch budget threw away.
+   * `queued` therefore measured "recorded since attach" rather than "not
+   * delivered", and every surface built on it would have inherited that.
+   */
+  it('stamps a single audit event once the forward settles', async () => {
+    const { gateway, calls } = build();
+    await gateway.recordAuditEvent({
+      id: 'evt-1',
+      eventType: 'session',
+      startedAt: '2026-01-01T00:00:00.000Z',
+    });
+    expect(calls.delivered).toEqual(['evt-1']);
+  });
+
+  it('stamps AFTER the forward, never before', async () => {
+    // Same ordering rule recordCapture follows: the local write is authoritative
+    // and commits whatever the network does, so there is nothing true to record
+    // until the forward has settled. A stamp written first would claim delivery
+    // the deployment never acknowledged.
+    const { gateway, calls } = build();
+    await gateway.recordLlmCall(llmCallInput('m1'));
+    expect(calls.order.indexOf('forward.run')).toBeLessThan(
+      calls.order.indexOf('local.markAuditEventsDelivered'),
+    );
+  });
+
+  it('stamps NOTHING when the forward fails', async () => {
+    // The bucket has to stay honest in the direction that matters: a row the
+    // deployment never received must keep reading as owed, or the outbox forgets
+    // it. This is the assertion that stops the stamp becoming unconditional.
+    const calls: Calls = { order: [], delivered: [] };
+    const { gateway } = build({ forward: deadForward(calls), local: makeLocal(calls) });
+    await gateway.recordLlmCall(llmCallInput('m1'));
+    expect(calls.delivered).toEqual([]);
+  });
+
+  it('stamps the DELIVERED HEAD of a batch whose tail the budget dropped', async () => {
+    // The case the accumulate-then-stamp shape exists for. `forwardBatch`
+    // returns early when the deadline passes, and a stamp written only after the
+    // loop would be skipped by that return — leaving the rows that DID arrive
+    // reading as owed, on exactly the slow-plane machine this is all for.
+    let clock = 1_000;
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        clock += 600;
+        await op();
+        return { ok: true } as ForwardResult<unknown>;
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [] };
+    const seen: unknown[] = [];
+    const client = {
+      ...makeClient(calls),
+      recordAuditEvent: vi.fn((e: unknown) => {
+        seen.push(e);
+        return Promise.resolve();
+      }),
+    } as unknown as AttachedClient;
+
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    try {
+      const { gateway } = build({ client, forward, local: makeLocal(calls) });
+      await gateway.recordToolCalls(
+        Array.from({ length: 40 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    // Partial on BOTH sides — the positive control. An assertion that only
+    // checked "some were stamped" would pass if all 40 were, which is the
+    // opposite bug.
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.length).toBeLessThan(40);
+    // Exactly what landed, and nothing the deadline discarded.
+    expect(calls.delivered).toHaveLength(seen.length);
+  });
+});
+
 describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   it('returns the local bundle untouched when the tenant cache is cold', async () => {
     const { gateway } = build({ readCachedBundle: () => Promise.resolve(null) });
@@ -720,7 +822,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('lets the tenant RAISE enforcement above the local policy', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'secret' }, 'warn')], { version: 'local' })),
@@ -753,7 +855,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
    */
   it('keeps one rule per id, and the local copy is the one that survives', async () => {
     const CONTESTED = 'marketplace/installed-secret';
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const localRule = wireRule(CONTESTED, 'secret');
     const remoteRule = { ...wireRule(CONTESTED, 'secret'), name: 'from-the-plane' };
     const local = makeLocal(calls, {
@@ -776,7 +878,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   it('still carries a rule only one side declares', async () => {
     // The positive control: dedup must not become "drop whatever the plane
     // adds", which would pass the case above while disabling the whole feature.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -802,7 +904,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // floor-only clamp while silently downgrading real enforcement. This is the
   // one merge bug that looks correct and disables protection.
   it('a WEAKER tenant policy can never win under first-write-wins', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'secret' }, 'block')], { version: 'local' })),
@@ -834,7 +936,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // cache-writer. What it could do is block the user's own sessions, which
     // anyone able to write into that directory can already do far more cheaply
     // by deleting the plugin.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -849,7 +951,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   it('leaves prohibitedModels absent when the organization prohibits nothing', async () => {
     // The control: a standalone bundle carries no prohibitions, so the merge
     // must not invent an empty list that reads as an enforced decision.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -859,7 +961,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('never takes rulesComplete from the cache — that would be a detection kill-switch', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -888,7 +990,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // the organization authored away quietly comes back.
 
   it('keeps the authored marker on a tenant-only policy that passes through', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -910,7 +1012,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // The first rebuild site: a tenant-only policy below the compiled-in floor
     // is re-emitted as `{ ...policy, action: floor }`. DEFAULT_ACTIONS.secret is
     // 'warn', so 'log' is rebuilt and the marker has to ride the spread.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -934,7 +1036,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // either, since a device that forgets which of its policies were authored
     // has lost the lock for all of them.
     const RULE = 'marketplace/authored-secret';
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -958,7 +1060,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('keeps it on the STRONGER side when both sides contend for one target', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'pii' }, 'warn')], { version: 'local' })),
@@ -984,7 +1086,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // The control. Every assertion above would also pass if the merge stamped
     // `provenance: 'authored'` onto everything it touched — which would lock a device
     // out of re-assigning packs no one ever authored a policy for.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'secret' }, 'warn')], { version: 'local' })),
@@ -1000,7 +1102,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('carries disabled policies through rather than dropping them', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'pii' }, 'warn', false)], { version: 'local' })),
@@ -1018,7 +1120,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // thing standing between an unsigned bundle and reduced enforcement.
 
   it('clamps a tenant-only policy UP to the compiled-in floor for its category', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -1034,7 +1136,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('leaves a tenant policy already AT or ABOVE the floor exactly as sent', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -1055,7 +1157,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // policy slips a real AWS key past at log-only. The bundled packs are seeded
   // LAST for exactly this reason, so they win every id collision.
   it("a tampered wire category cannot weaken a COMPILED-IN rule's clamp floor", async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -1075,7 +1177,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('a wire rule DOES supply a floor for a ruleId the plugin does not compile in', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -1095,7 +1197,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('leaves a policy for an UNRESOLVABLE ruleId unclamped rather than guessing', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
     });
@@ -1113,7 +1215,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it('keeps ruleId- and category-targeted policies in SEPARATE namespaces', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       // The user's own category-wide rule for secrets.
       getPolicyBundle: vi.fn(() =>
@@ -1147,7 +1249,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // ── the local bundle's OWN rules are a category source ─────────────────────
 
   it('a LOCALLY INSTALLED rule supplies a floor the plugin does not compile in', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       // A marketplace pack the user installed on this device: present in the
       // LOCAL bundle's rules, absent from the tenant's, absent from
@@ -1174,7 +1276,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   });
 
   it("the WIRE cannot redeclare a locally installed rule's category either", async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1210,7 +1312,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // the tenant's ruleId policy overrides the user's category policy. The
   // compiled-in floor cannot catch it — DEFAULT_ACTIONS tops out at 'warn'.
   it('a tenant ruleId policy cannot undercut the local CATEGORY policy', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'secret' }, 'block')], { version: 'local' })),
@@ -1229,7 +1331,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   it('…including for a rule only the LOCAL bundle declares', async () => {
     // Needs both halves: the category map must resolve the installed rule at
     // all before the local category policy can floor a policy targeting it.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1260,7 +1362,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // `secret -> block` to log-only — the fleet-wide failure this merge exists
   // to prevent, reached from the local side instead of the wire.
   it('a LOCAL ruleId policy cannot undercut the TENANT category policy', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1279,7 +1381,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   it('…including for a rule only the LOCAL bundle declares', async () => {
     // Same two halves as the tenant-side case: the category map has to resolve
     // a locally installed rule before any category policy can floor it.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1303,7 +1405,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // tenant's category-wide setting is raising enforcement, which is always
     // allowed — clamping it down to the tenant's action would be the same bug
     // in the opposite direction.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1323,7 +1425,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
     // The clamp is a floor, not an equalisation — the tenant tightening one
     // rule beyond the user's category-wide setting is the whole point of
     // attached mode and must survive.
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(bundle([policy({ category: 'secret' }, 'warn')], { version: 'local' })),
@@ -1349,7 +1451,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
       // guarantee and make the result depend on array order — the exact
       // property this merge exists to remove. With no local policy for
       // 'secret', the only floor is the compiled-in 'warn'.
-      const calls: Calls = { order: [] };
+      const calls: Calls = { order: [], delivered: [] };
       const local = makeLocal(calls, {
         getPolicyBundle: vi.fn(() => Promise.resolve(bundle([], { version: 'local' }))),
       });
@@ -1368,7 +1470,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   );
 
   it('resolves duplicate LOCAL targets first-write-wins, matching the runtime', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() =>
         Promise.resolve(
@@ -1389,7 +1491,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
   // ── the local store is the trusted side ───────────────────────────────────
 
   it("a CORRUPT local bundle read propagates — it never degrades to the tenant's", async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const local = makeLocal(calls, {
       getPolicyBundle: vi.fn(() => Promise.reject(new Error('local store corrupt'))),
     });
@@ -1412,7 +1514,7 @@ describe('getPolicyBundle merges the tenant bundle raise-only', () => {
 
 describe('posture reporting stays strictly after inventory settles', () => {
   it('runs prepare and send after the inventory call, never before', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const posture = {
       prepare: vi.fn(() => {
         calls.order.push('posture.prepare');
@@ -1434,7 +1536,7 @@ describe('posture reporting stays strictly after inventory settles', () => {
   });
 
   it('a throwing posture phase never reaches the session', async () => {
-    const calls: Calls = { order: [] };
+    const calls: Calls = { order: [], delivered: [] };
     const posture = {
       prepare: vi.fn(() => {
         throw new Error('sync boom');

--- a/packages/plugin-runtime/test/handle-session-start.test.ts
+++ b/packages/plugin-runtime/test/handle-session-start.test.ts
@@ -634,7 +634,7 @@ describe('handleSessionStart — local-store maintenance capability', () => {
     writeFileSync(join(cwd, 'main.ts'), '');
     const inner = new StandaloneDataGateway(dir, bundledDetections());
     const calls: string[] = [];
-    // Exactly ONE member omitted. Omitting all five makes every assertion below
+    // Exactly ONE member omitted. Omitting them all makes every assertion below
     // vacuous: a name that is not on the gateway can never reach `calls`, so
     // `not.toContain` holds whether the gate fires, is inverted, or is deleted.
     // With four still recording, the four positives bind the per-member gate

--- a/packages/plugin-sdk/src/data-gateway.ts
+++ b/packages/plugin-sdk/src/data-gateway.ts
@@ -241,11 +241,32 @@ export interface LocalStoreMaintenance {
    * derive it differently and stamp a row that does not exist.
    */
   markCaptureDelivered(event: IngestEvent, atMs: number): void;
+  /**
+   * Stamp structural events the live forward already delivered.
+   *
+   * The sibling of `markCaptureDelivered` for the lane the partition actually
+   * counts. Without it a `session`/`llm_call`/`tool_call` row the live path
+   * forwarded SUCCESSFULLY stays NULL — indistinguishable from one the batch
+   * budget discarded — so `queued` reads as "recorded since attach" rather than
+   * "owed", which is what `HistorySyncPartition`'s docblock says out loud.
+   *
+   * Takes the EVENTS, not row ids, for the same reason its sibling does: the
+   * caller hands over the very objects it forwarded, so no second derivation of
+   * an id exists to drift from the first. Unlike a capture the id needs no
+   * derivation at all — `AuditEventInput.id` IS the local row's primary key and
+   * the id the plane stores verbatim — but taking the event keeps the rule
+   * uniform across both stamps rather than making this one the exception.
+   *
+   * Deliberately NOT filtered by `eventType` here. This records what was
+   * delivered; which types a read COUNTS is `STRUCTURAL_EVENT_TYPES`' decision,
+   * and duplicating that list at the write site is how the two drift.
+   */
+  markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void;
 }
 
 // The member names, derived from the interface rather than restated: a
 // `Record` keyed on `keyof LocalStoreMaintenance` fails to compile until a
-// sixth member added above is listed here too, so the two cannot drift.
+// member added above is listed here too, so the two cannot drift.
 const LOCAL_STORE_MAINTENANCE_MEMBERS: Record<keyof LocalStoreMaintenance, true> = {
   sweepTerminalExceptions: true,
   capWarnEraEnforcement: true,
@@ -253,6 +274,7 @@ const LOCAL_STORE_MAINTENANCE_MEMBERS: Record<keyof LocalStoreMaintenance, true>
   reconcileWorktreeProjects: true,
   staleBinaryNotice: true,
   markCaptureDelivered: true,
+  markAuditEventsDelivered: true,
 };
 
 /**

--- a/packages/plugin-sdk/src/data-gateway.ts
+++ b/packages/plugin-sdk/src/data-gateway.ts
@@ -210,7 +210,7 @@ export interface DataGateway {
  * implementation with a store to maintain. A gateway that has none simply does
  * not provide them, and callers skip the work.
  *
- * Two members are synchronous — they complete inside a single store
+ * Some members are synchronous — they complete inside a single store
  * transaction and have nothing to await.
  */
 export interface LocalStoreMaintenance {
@@ -257,9 +257,17 @@ export interface LocalStoreMaintenance {
    * the id the plane stores verbatim — but taking the event keeps the rule
    * uniform across both stamps rather than making this one the exception.
    *
-   * Deliberately NOT filtered by `eventType` here. This records what was
-   * delivered; which types a read COUNTS is `STRUCTURAL_EVENT_TYPES`' decision,
-   * and duplicating that list at the write site is how the two drift.
+   * Which types a read COUNTS is `STRUCTURAL_EVENT_TYPES`' decision, and
+   * duplicating that list here is how the two drift — so this does not filter by
+   * the counting list. It does refuse ONE thing, and that is a lane boundary
+   * rather than a copy of a read's predicate: CAPTURE-GRAIN events are not
+   * stampable here. `synced_at` is one column serving two disjoint drains that
+   * both filter `synced_at IS NULL`, and `recordAuditEvent` accepts any
+   * `AuditEventType` — so a capture routed through it would be stamped on a
+   * forward that carried no `content`, and the capture drain would never offer
+   * that row again. That is silent, permanent loss of the text, and it is why
+   * `markCaptureDelivered` is a separate method. The implementation enforces it;
+   * a caller does not have to know.
    */
   markAuditEventsDelivered(events: readonly AuditEventInput[], atMs: number): void;
 }
@@ -284,7 +292,7 @@ const LOCAL_STORE_MAINTENANCE_MEMBERS: Record<keyof LocalStoreMaintenance, true>
  * the member qualifies, including a wrapper that forwards it to an inner
  * gateway.
  *
- * Per member rather than all-or-nothing, because the five passes are
+ * Per member rather than all-or-nothing, because the passes are
  * unrelated — a retention purge, a one-shot legacy cap, a file-tree commit, a
  * read-model repair, a version nudge — and an implementation that owns a store
  * has every reason to supply some and not others. Gating the group on the full

--- a/packages/plugin-sdk/test/local-store-maintenance.test.ts
+++ b/packages/plugin-sdk/test/local-store-maintenance.test.ts
@@ -10,6 +10,7 @@ const maintenance: LocalStoreMaintenance = {
   reconcileWorktreeProjects: () => Promise.resolve(),
   staleBinaryNotice: () => null,
   markCaptureDelivered: () => undefined,
+  markAuditEventsDelivered: () => undefined,
 };
 
 function gatewayWith(extra: object): DataGateway {
@@ -53,7 +54,7 @@ describe('offersMaintenance', () => {
 });
 
 describe('hasLocalStoreMaintenance', () => {
-  it('accepts a gateway offering all five members', () => {
+  it('accepts a gateway offering every member', () => {
     expect(hasLocalStoreMaintenance(gatewayWith(maintenance))).toBe(true);
   });
 


### PR DESCRIPTION
Closes the gap `HistorySyncPartition`'s own docblock names, in its words:

> `queued` therefore still OVER-COUNTS on an attached machine … a structural row the live path forwarded successfully (`recordToolCalls`) is never stamped by anything, so it stays NULL and reads as owed. **Closing that needs a stamp on the structural forward, which no path does today.**

## Why it matters

A delivered `session`/`llm_call`/`tool_call` was indistinguishable from one `forwardBatch` discarded past its deadline. Both are `synced_at IS NULL`. So `queued` measured *"recorded since attach"*, not *"not delivered"*, and every surface built on that read would have inherited it.

The drop it hides is not rare. `forwardBatch` (`attached/gateway.ts`) sends **serially, one HTTP request per event**, under a **3 s aggregate budget**, and discards the entire remainder when it lapses — at 200 ms RTT that admits ~15 items per batch. Nothing else on the device can see those rows; the breaker cannot, because the drop returns before `ForwardPolicy.run` is reached.

## What this does

Adds `markAuditEventsDelivered` beside `markCaptureDelivered` on `LocalStoreMaintenance`, settled through the **same `markSynced` statement a drain uses** — so a row delivered live and a row delivered by a drain end in one indistinguishable state, which is the property the outbox rests on.

Call sites: `recordAuditEvent`, `recordLlmCall`, and `forwardBatch` (covering `recordLlmCalls` and `recordToolCalls`).

## Three things worth review attention

1. **It takes the EVENTS, not row ids**, matching its sibling's stated rule. Unlike a capture the id needs no derivation — `AuditEventInput.id` *is* the local primary key and the id `pgAuditValues` stores verbatim — but each call site now builds its event **once** and shares it between the wire and the stamp, so no second derivation exists to drift.

2. **`forwardBatch` accumulates and stamps in a `finally`, not after the loop.** The deadline path `return`s early, and a stamp placed after the loop would be skipped by it — leaving exactly the rows that *did* arrive reading as owed, on the slow-plane machine this all exists for. This is the subtlest part of the change.

3. **Nothing is filtered by `eventType` at the write site.** This records what was delivered; which types a read *counts* stays `STRUCTURAL_EVENT_TYPES`' decision. Duplicating that list here is how the two drift.

## Verification

- `plugin-sdk` 564, `persistence` 1455 (+2 skipped), `plugin-runtime` 491 — all passing.
- Four new tests, and **both halves are mutation-tested**:
  - dropping the partial-batch stamp fails *"stamps the DELIVERED HEAD of a batch whose tail the budget dropped"*;
  - stamping unconditionally fails *"stamps NOTHING when the forward fails"*.
- Ordering is asserted (`forward.run` before the stamp), same rule `recordCapture` follows: the local write is authoritative and commits whatever the network does, so there is nothing true to record until the forward settles.

## What this deliberately does NOT close

- **`inProgress` is still structurally always 0** — `claimRows`/`releaseRows`/`releaseStaleClaims` still have no product caller.
- **`failed` still counts a SKIP, not a failed attempt** — `classify` returns `'skip'` for both a local rebuild defect and a deployment's 400/413/422, while a transient failure leaves the row NULL (correctly — it is still owed).

The `partition()` docblock is updated to say both out loud rather than imply otherwise.

## Related

- Plan: akasecurity/engineering#196 §15, unit U7 (smallest valuable slice is U7 + U11).
- The batch-budget drop itself is **still unfixed in any repo** — a 50-per-request bulk route (`POST /v1/audit-events/batch`) exists end to end and the live lane does not use it. This PR makes those drops visible; it does not prevent them.
