### PR TITLE
fix(policy): a detection the control plane governs stays switched on

### DIFF
--- a/packages/dashboard-ui/src/detections/DetectionDetailView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionDetailView.tsx
@@ -15,18 +15,23 @@
 //   - policyError     : a write the store refused, in the user's words. Rendered
 //     at the control that produced it, because a refusal reported nowhere is
 //     indistinguishable from a picker that quietly ignores you.
+//   - enabledError    : the same, for the enable/disable toggle. Its own message
+//     rather than the picker's, because a refusal shown at the wrong control
+//     attributes the organization's constraint to a choice it never touched.
 //   - onOpenUpdate    : present + update available ⇒ Update button in the provenance
 import type { DetectionDetail, DetectionRule } from '@akasecurity/schema';
 import { Button, SeverityBadge, Switch, toneColors } from '@akasecurity/ui-kit';
-import type { ReactNode } from 'react';
+import { type ReactNode, useId } from 'react';
 
 import type { IconComponent } from '../lib/icons.ts';
 import { SectionLabel } from '../shared/DetailFields.tsx';
 import { ChevronRightIcon, MoreVertIcon, PlusIcon } from '../shared/icons.tsx';
 import { CATEGORY_LABEL, MATCHER_META, matcherSummary, policyMeta } from './meta.ts';
 import {
+  DETECTION_STAYS_ON_REASON,
   type DetectionPolicyFloor,
   effectivePolicyId,
+  isDisableRefused,
   unavailableUnderFloor,
 } from './policy-floor.ts';
 import { PolicyPicker } from './PolicyPicker.tsx';
@@ -84,6 +89,7 @@ export function DetectionDetailView({
   unavailablePolicies,
   policyFloor,
   policyError,
+  enabledError,
   onOpenUpdate,
   onRecheck,
   unknownHint,
@@ -107,6 +113,8 @@ export function DetectionDetailView({
   policyFloor?: DetectionPolicyFloor | null | undefined;
   /** A refused or failed policy write, already worded for the reader. */
   policyError?: string | null | undefined;
+  /** The same, for a refused or failed enable/disable write. */
+  enabledError?: string | null | undefined;
   onOpenUpdate?: (() => void) | undefined;
   // Re-read the update state in place (the OSS web-ui's "Check again" for the
   // unknown provenance state); omitted by apps with their own refresh flow.
@@ -131,6 +139,15 @@ export function DetectionDetailView({
     unavailablePolicies === undefined && floorRestrictions === undefined
       ? undefined
       : { ...unavailablePolicies, ...floorRestrictions };
+  // A governed detection may not be switched off — "not running" is below every
+  // archetype, so the organization naming it at all is what settles this (see
+  // isDisableRefused). Gated on the host having a write path at the toggle too:
+  // a read-only pane must not sprout a reason for a control it does not offer,
+  // exactly as the picker does not look restricted when it has no onChange.
+  const staysOn = onToggleEnabled !== undefined && isDisableRefused(d.enabled, policyFloor);
+  // Two panes on one page must not mint the same id; this one is the anchor the
+  // Switch's aria-describedby points at.
+  const staysOnId = useId();
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -159,7 +176,23 @@ export function DetectionDetailView({
               {onToggleEnabled && (
                 <Switch
                   checked={d.enabled}
-                  onCheckedChange={onToggleEnabled}
+                  // Inert rather than absent when the organization requires this
+                  // detection to keep running: the handler is omitted (spread
+                  // rather than passed as undefined, which the prop's type does
+                  // not take), so activation does nothing — but no NATIVE
+                  // `disabled` goes on, because that would take the control out
+                  // of the tab order, and the whole point of leaving it there is
+                  // that the reason reaches whoever reaches for it. Same
+                  // contract as the picker's unassignable archetypes.
+                  {...(staysOn ? {} : { onCheckedChange: onToggleEnabled })}
+                  aria-disabled={staysOn || undefined}
+                  // Points at the line below the header, so the reason is
+                  // announced AT the control rather than as prose to go and find.
+                  aria-describedby={staysOn ? staysOnId : undefined}
+                  // The reason travels with the control as well, so a pointer
+                  // user gets it without reading ahead.
+                  title={staysOn ? DETECTION_STAYS_ON_REASON : undefined}
+                  className={staysOn ? 'cursor-not-allowed opacity-50' : undefined}
                   aria-label={d.enabled ? 'Disable detection' : 'Enable detection'}
                 />
               )}
@@ -175,6 +208,24 @@ export function DetectionDetailView({
             </Button>
           </div>
         </div>
+        {staysOn && (
+          // Full width under the header rather than beside the toggle: a tooltip
+          // is invisible on touch and unreliable for assistive tech, and the
+          // sentence does not fit the shrink-0 column the control sits in. This
+          // is the accessible copy `aria-describedby` above points at.
+          <p id={staysOnId} className="mt-2 text-xs text-text-3" data-slot="enabled-locked-reason">
+            {DETECTION_STAYS_ON_REASON}
+          </p>
+        )}
+        {enabledError && (
+          // At the control that produced it, like the picker's own refusal —
+          // the toggle is where the user acted, and a message they have to go
+          // and find reads as the page failing rather than as this change being
+          // refused.
+          <p className="mt-2 text-xs text-sev-critical-ink" data-slot="enabled-write-error">
+            {enabledError}
+          </p>
+        )}
       </div>
 
       {/* scroll body */}

--- a/packages/dashboard-ui/src/detections/policy-floor.ts
+++ b/packages/dashboard-ui/src/detections/policy-floor.ts
@@ -134,3 +134,47 @@ export function isPolicyGoverned(
   if (!floor) return false;
   return floor.locked || effectivePolicyId(assigned, floor) !== (assigned ?? PLACEHOLDER_POLICY);
 }
+
+/**
+ * The sentence a user reads when switching a detection off is not theirs to
+ * decide.
+ *
+ * ONE sentence, where the picker's reason has two, because this constraint has
+ * one shape. A detection that does not run supplies no rules, no per-rule
+ * actions and no reversibility, which is weaker than every archetype the
+ * organization could have asked for — including the weakest — so whether it
+ * named a floor or authored the answer outright makes no difference to what may
+ * happen here.
+ *
+ * Worded beside the constraint it describes, like policyFloorReason, so the
+ * toggle that withholds the choice before the click and the refusal a write
+ * that got through anyway reports afterwards are one sentence rather than two
+ * descriptions of one rule.
+ */
+export const DETECTION_STAYS_ON_REASON =
+  'Your organization requires this detection to stay on, so it cannot be turned ' +
+  'off on this machine. You can still give it a stronger enforcement policy here.';
+
+/**
+ * Whether switching this detection off is a choice the machine no longer has.
+ *
+ * ANY floor forbids it, including a floor of Monitor — which is what makes this
+ * a different question from the picker's. There the floor names a rung and the
+ * archetypes below it are the restricted ones; here "off" sits below the whole
+ * ladder, so the question is not which rung the organization asked for but
+ * whether it spoke for this detection at all. A pack the organization's bundle
+ * never names carries no floor, so this constrains exactly the detections it
+ * speaks for and nothing else.
+ *
+ * Only what is currently ON, and deliberately: re-enabling is always allowed —
+ * it is the direction the floor exists to protect — and a store can hold a
+ * detection switched off before any of this existed, exactly as it can hold an
+ * assignment below the floor. Withholding the toggle there would leave a
+ * governed detection stuck off with nothing able to turn it back on.
+ */
+export function isDisableRefused(
+  enabled: boolean,
+  floor: DetectionPolicyFloor | null | undefined,
+): boolean {
+  return enabled && Boolean(floor);
+}

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -159,8 +159,10 @@ export {
   PUBLISHER_META,
 } from './detections/meta.ts';
 export {
+  DETECTION_STAYS_ON_REASON,
   type DetectionPolicyFloor,
   effectivePolicyId,
+  isDisableRefused,
   isPolicyGoverned,
   policyFloorReason,
   unavailableUnderFloor,

--- a/packages/dashboard-ui/test/detections/detection-floor-views.test.ts
+++ b/packages/dashboard-ui/test/detections/detection-floor-views.test.ts
@@ -7,7 +7,7 @@ import { DetectionDetailView } from '../../src/detections/DetectionDetailView.ts
 import { DetectionsListView } from '../../src/detections/DetectionsListView.tsx';
 import { policyMeta } from '../../src/detections/meta.ts';
 import type { DetectionPolicyFloor } from '../../src/detections/policy-floor.ts';
-import { policyFloorReason } from '../../src/detections/policy-floor.ts';
+import { DETECTION_STAYS_ON_REASON, policyFloorReason } from '../../src/detections/policy-floor.ts';
 
 // The two surfaces that used to disagree with enforcement, driven end to end
 // from the serializable floor a host hands them.
@@ -80,6 +80,23 @@ function buttonTags(html: string): string[] {
     .split('<button')
     .slice(1)
     .map((chunk) => chunk.slice(0, chunk.indexOf('>')));
+}
+
+/**
+ * The opening tag of the enable/disable Switch, which renders as a <button> of
+ * its own. Picked out by slot rather than by position: the pane carries other
+ * buttons — the picker's five archetypes, "Add rule" — and an assertion aimed
+ * at the wrong one would pass whatever this control emitted.
+ */
+function switchTag(html: string): string {
+  const tag = buttonTags(html).find((t) => t.includes('data-slot="switch"'));
+  expect(tag, 'the pane rendered no enable/disable switch at all').toBeDefined();
+  return tag ?? '';
+}
+
+/** The same pane with a host that can actually write the enabled state. */
+function toggleable(props: Partial<Parameters<typeof DetectionDetailView>[0]> = {}): string {
+  return detail({ onToggleEnabled: () => undefined, ...props });
 }
 
 function list(floorsById?: ReadonlyMap<string, DetectionPolicyFloor>): string {
@@ -175,6 +192,85 @@ describe('DetectionDetailView under a control-plane floor', () => {
     expect(html.match(/data-unavailable/g)?.length).toBe(2);
     expect(html).toContain('Not available on this machine.');
     expect(html).toContain(policyFloorReason(WARN_FLOOR));
+  });
+});
+
+describe('the enable toggle under a control-plane floor', () => {
+  it('renders byte-identically when no floor and no refusal are supplied', () => {
+    // The standalone machine again, at the other control. It must not pick up an
+    // aria-disabled switch, a reason line, or a message.
+    expect(toggleable({ policyFloor: null })).toBe(toggleable());
+    expect(toggleable({ enabledError: null })).toBe(toggleable());
+  });
+
+  it('withholds the switch-off without taking it out of the tab order', () => {
+    const html = toggleable({ policyFloor: WARN_FLOOR });
+    // aria, never the native attribute — the same contract the picker's
+    // unassignable archetypes keep, and for the same reason: a natively
+    // disabled control leaves the tab order, so the reason never reaches a
+    // keyboard or screen-reader user. Asserted precisely, because
+    // `toContain('disabled')` matches the aria form too.
+    expect(switchTag(html)).toContain('aria-disabled="true"');
+    expect(switchTag(html)).not.toContain(' disabled=""');
+    // Positive control on the same control: unconstrained, it carries neither.
+    expect(switchTag(toggleable())).not.toContain('aria-disabled');
+  });
+
+  it('says why, in a line the switch points at', () => {
+    const html = toggleable({ policyFloor: WARN_FLOOR });
+    expect(html).toContain(DETECTION_STAYS_ON_REASON);
+    expect(html).toContain('data-slot="enabled-locked-reason"');
+    // The reason travels on the control as well, for a pointer user.
+    expect(switchTag(html)).toContain(`title="${DETECTION_STAYS_ON_REASON}"`);
+    const describedBy = /aria-describedby="([^"]+)"/.exec(switchTag(html));
+    expect(describedBy, 'the withheld switch describes nothing').not.toBeNull();
+    // And it points at an element that is really in the markup — an id
+    // referencing nothing announces nothing, and reads identically here.
+    expect(html).toMatch(
+      new RegExp(`id="${describedBy?.[1] ?? ''}"[^>]*data-slot="enabled-locked-reason"`),
+    );
+  });
+
+  it('withholds it under a Monitor floor too, where the picker restricts nothing', () => {
+    // "Off" is below every archetype, so the weakest floor still forbids it.
+    // Both halves asserted on one rendering, so this cannot pass by the pane
+    // having rendered neither control.
+    const html = toggleable({ policyFloor: { floor: 'monitor', locked: false } });
+    expect(switchTag(html)).toContain('aria-disabled="true"');
+    expect(html).not.toContain('data-unavailable');
+  });
+
+  it('leaves a governed detection that is already off free to be turned back on', () => {
+    // Re-enabling moves toward what the organization asked for. A store can hold
+    // a detection switched off from before this refusal existed, and withholding
+    // the toggle there would leave it stuck off.
+    const html = toggleable({ d: { ...DETAIL, enabled: false }, policyFloor: LOCKED });
+    expect(switchTag(html)).not.toContain('aria-disabled');
+    expect(html).not.toContain('data-slot="enabled-locked-reason"');
+  });
+
+  it('does not make a read-only pane look restricted', () => {
+    // No onToggleEnabled is a different statement — this host offers no
+    // enable/disable at all, not that the organization withheld one. It must not
+    // sprout a reason for a control that is not there.
+    const html = detail({ policyFloor: LOCKED });
+    expect(html).not.toContain('data-slot="switch"');
+    expect(html).not.toContain('data-slot="enabled-locked-reason"');
+  });
+
+  it('renders a refused toggle at the toggle, not under the picker', () => {
+    // The two refusals are about different controls. Reporting this one under
+    // the picker would attribute the organization's constraint to a choice it
+    // never touched.
+    const message = 'That change was not saved.';
+    const html = toggleable({ enabledError: message });
+    expect(html).toContain('data-slot="enabled-write-error"');
+    expect(html).toContain(message);
+    expect(html).not.toContain('data-slot="policy-write-error"');
+    // And the picker's own refusal still lands at the picker.
+    const other = toggleable({ policyError: message });
+    expect(other).toContain('data-slot="policy-write-error"');
+    expect(other).not.toContain('data-slot="enabled-write-error"');
   });
 });
 

--- a/packages/dashboard-ui/test/detections/policy-floor.test.ts
+++ b/packages/dashboard-ui/test/detections/policy-floor.test.ts
@@ -4,7 +4,9 @@ import { describe, expect, it } from 'vitest';
 import { policyMeta } from '../../src/detections/meta.ts';
 import type { DetectionPolicyFloor } from '../../src/detections/policy-floor.ts';
 import {
+  DETECTION_STAYS_ON_REASON,
   effectivePolicyId,
+  isDisableRefused,
   isPolicyGoverned,
   policyFloorReason,
   unavailableUnderFloor,
@@ -175,5 +177,65 @@ describe('DetectionPolicyFloor', () => {
     // And the decisions actually run off that value, rather than off a shape
     // this test built for itself.
     expect(Object.keys(unavailableUnderFloor(asProp) ?? {}).sort()).toEqual(['monitor', 'warn']);
+  });
+});
+
+describe('isDisableRefused', () => {
+  it('refuses nothing on a machine nothing manages', () => {
+    // Every OSS install that has not attached. The toggle must come out of this
+    // module exactly as live as it was before any of it existed.
+    expect(isDisableRefused(true, null)).toBe(false);
+    expect(isDisableRefused(true, undefined)).toBe(false);
+  });
+
+  it('refuses the switch-off under EVERY floor, the weakest included', () => {
+    // The whole difference from the picker's question. There the floor names a
+    // rung and the archetypes below it are restricted; here "off" is below the
+    // ladder, so what matters is that the organization spoke for this detection
+    // at all.
+    for (const id of KNOWN_BUILTIN_IDS) {
+      expect(isDisableRefused(true, floor({ floor: id })), `a floor of '${id}'`).toBe(true);
+    }
+  });
+
+  it('parts company with the picker exactly at a Monitor floor', () => {
+    // The case that would be missed by reusing unavailableUnderFloor: a floor of
+    // Monitor forbids no ASSIGNMENT, and still forbids switching the detection
+    // off. Both halves asserted, so this cannot pass by both being empty.
+    expect(unavailableUnderFloor(floor({ floor: 'monitor' }))).toBeUndefined();
+    expect(isDisableRefused(true, floor({ floor: 'monitor' }))).toBe(true);
+  });
+
+  it('never refuses a re-enable, locked or not', () => {
+    // Re-enabling moves toward what the organization asked for. A store can hold
+    // a detection switched off from before any of this existed, and withholding
+    // the toggle there would leave it stuck off with nothing able to turn it
+    // back on.
+    for (const locked of [false, true]) {
+      expect(isDisableRefused(false, floor({ locked })), `locked: ${String(locked)}`).toBe(false);
+    }
+  });
+});
+
+describe('DETECTION_STAYS_ON_REASON', () => {
+  it('names whose decision it is and what is still open', () => {
+    // A user who is not told the organization decided this goes looking for a
+    // broken toggle; one who is not told enforcement can still be raised reads
+    // the whole detection as out of their hands.
+    expect(DETECTION_STAYS_ON_REASON).toMatch(/organization/i);
+    expect(DETECTION_STAYS_ON_REASON).toMatch(/stronger/i);
+  });
+
+  it('does not read as a fault to retry', () => {
+    expect(DETECTION_STAYS_ON_REASON).not.toMatch(/error|failed|try again/i);
+  });
+
+  it("is not the picker's sentence", () => {
+    // Different constraints with different remedies. Collapsing them would tell
+    // someone whose detection may not be switched off to go and pick a stronger
+    // archetype, which is not what was refused.
+    for (const locked of [false, true]) {
+      expect(DETECTION_STAYS_ON_REASON).not.toBe(policyFloorReason(floor({ locked })));
+    }
   });
 });

--- a/packages/persistence/src/index.ts
+++ b/packages/persistence/src/index.ts
@@ -89,6 +89,7 @@ export {
 export type { FloorRule, PackPolicyFloor, PolicyFloorRefusal } from './policy-floor.ts';
 export {
   controlPlanePolicyFloor,
+  packEnablementRefusal,
   policyAssignmentRefusal,
   PolicyFloorError,
   readCachedPolicyBundle,

--- a/packages/persistence/src/policy-floor.ts
+++ b/packages/persistence/src/policy-floor.ts
@@ -5,19 +5,23 @@
  * entirely the user's. On an attached one the organization's bundle is a FLOOR:
  * the device may raise a pack above what the control plane asks for, but never
  * set one below it, and a pack whose answer the organization has AUTHORED is not
- * locally re-assignable at all. Both constraints come from what the bundle
- * actually says — a pack it never reaches stays entirely the user's, exactly as
- * on a standalone machine.
+ * locally re-assignable at all. A pack the bundle governs at ALL may not be
+ * switched OFF either, whatever archetype it carries — switching a detection off
+ * sits below every one of them, so it is the one move no floor could ever
+ * permit. All three constraints come from what the bundle actually says — a pack
+ * it never reaches stays entirely the user's, exactly as on a standalone
+ * machine.
  *
  * Two properties make that floor honest rather than decorative:
  *
- *   It is computed HERE, below the one write path, not on the surface that
- *   renders the picker. A refusal that lived in the dashboard would leave the
- *   CLI and every other local caller writing whatever they liked, and the
+ *   It is computed HERE, below the device-local write paths, not on the surface
+ *   that renders the picker. A refusal that lived in the dashboard would leave
+ *   the CLI and every other local caller writing whatever they liked, and the
  *   attached runtime's raise-only merge would then be silently papering over a
  *   stored assignment the user believes is in force. That merge stays where it
  *   is — it is the second line of defence, and it is the only one that binds a
- *   store written before this refusal existed.
+ *   store written before this refusal existed. It does not reach the switch-off,
+ *   which is why that one is refused here or nowhere.
  *
  *   It refuses by THROWING (see PolicyFloorError). Writing a different value
  *   than the caller asked for would leave a user staring at a picker that
@@ -52,8 +56,20 @@ export interface FloorRule {
   readonly category: string;
 }
 
-/** Why an assignment was refused: the pack is below the floor, or it is locked. */
-export type PolicyFloorRefusal = 'floor' | 'lock';
+/**
+ * Why a device-local write to a governed pack was refused.
+ *
+ * Three members rather than two, because the three have different remedies and
+ * a reader who cannot tell them apart takes the wrong one. `floor` says the
+ * archetype asked for is too weak — pick a stronger one. `lock` says no
+ * archetype is available, because the organization wrote this detection's
+ * answer. `disable` is not about an archetype at all: the write was a switch-off
+ * of a governed detection, and the remedy is neither of the other two's. Folding
+ * it into `floor` would send someone to a picker they never opened; folding it
+ * into `lock` would claim the organization had set a policy it may only have
+ * stated a minimum for.
+ */
+export type PolicyFloorRefusal = 'floor' | 'lock' | 'disable';
 
 /**
  * What the control plane imposes on ONE installed pack.
@@ -65,8 +81,36 @@ export type PolicyFloorRefusal = 'floor' | 'lock';
 export type { PackPolicyFloor };
 
 /**
- * A refused pack-policy assignment, carrying everything a surface needs to say
- * why without re-deriving it.
+ * One sentence per refusal, each naming the organization as the author of the
+ * constraint. These reach a user — through a CLI's stderr as readily as through
+ * a page — so none of them may read as a product fault or as this machine
+ * having decided anything.
+ */
+function refusalMessage(
+  pack: string,
+  attempted: BuiltinPolicyId | null,
+  floor: BuiltinPolicyId,
+  refusal: PolicyFloorRefusal,
+): string {
+  switch (refusal) {
+    case 'lock':
+      return `refusing to re-assign '${pack}': its policy is set by the connected control plane`;
+    case 'disable':
+      // Deliberately says nothing about the floor: what forbids this is that
+      // the control plane governs the detection at all, and quoting a minimum
+      // here would invite the reader to satisfy it and try again.
+      return `refusing to disable '${pack}': it is governed by the connected control plane`;
+    case 'floor':
+      return (
+        `refusing to set '${pack}' to '${attempted ?? 'unassigned'}': the connected control ` +
+        `plane requires at least '${floor}'`
+      );
+  }
+}
+
+/**
+ * A refused device-local write to a governed pack, carrying everything a
+ * surface needs to say why without re-deriving it.
  *
  * Modelled on ManagedFieldError, and for the same reason: a caller that cannot
  * distinguish "you may not write this" from "the write failed" has to report
@@ -74,9 +118,12 @@ export type { PackPolicyFloor };
  * as a bug in the product rather than a decision by the user's own organization.
  */
 export class PolicyFloorError extends Error {
-  /** `namespace/packId` of the detection whose assignment was refused. */
+  /** `namespace/packId` of the detection whose write was refused. */
   readonly pack: string;
-  /** What the caller asked for; null is the "clear the assignment" write. */
+  /**
+   * The archetype the caller asked for, or null when the write named none —
+   * clearing the assignment, or switching the detection off.
+   */
   readonly attempted: BuiltinPolicyId | null;
   /** The weakest archetype the control plane permits for this pack. */
   readonly floor: BuiltinPolicyId;
@@ -88,12 +135,7 @@ export class PolicyFloorError extends Error {
     floor: BuiltinPolicyId,
     refusal: PolicyFloorRefusal,
   ) {
-    super(
-      refusal === 'lock'
-        ? `refusing to re-assign '${pack}': its policy is set by the connected control plane`
-        : `refusing to set '${pack}' to '${attempted ?? 'unassigned'}': the connected control ` +
-            `plane requires at least '${floor}'`,
-    );
+    super(refusalMessage(pack, attempted, floor, refusal));
     this.name = 'PolicyFloorError';
     this.pack = pack;
     this.attempted = attempted;
@@ -314,4 +356,35 @@ export function policyAssignmentRefusal(
   return isActionAtLeast(builtinPolicyToAction(effective), builtinPolicyToAction(floor.floor))
     ? null
     : 'floor';
+}
+
+/**
+ * Why a pack under `floor` may not be switched to `enabled`, or null when it
+ * may be.
+ *
+ * The asymmetry is the whole content: a DISABLE is refused for every governed
+ * pack, whatever archetype the floor names, and a RE-ENABLE is never refused.
+ * Disabling is not a weaker archetype, it is the absence of one — a disabled
+ * pack contributes no rules to the local bundle at all, so the per-rule actions
+ * the floor is stated over stop existing rather than being lowered. And what
+ * covers a stored assignment that slipped below the floor does not cover this:
+ * the attached runtime's raise-only merge re-supplies an ACTION for a rule, not
+ * the rule itself, so a bundle carrying policies but no rules (`rules` is
+ * optional on PolicyBundle) leaves a locally disabled detection simply not
+ * running, with nothing left to clamp. Re-enabling moves toward what the
+ * organization asked for and is therefore always the device's to do — including
+ * for a LOCKED pack, whose lock is over which archetype the pack carries and
+ * says nothing about whether it runs.
+ *
+ * Unlike `policyAssignmentRefusal` this also takes the ABSENCE of a floor and
+ * answers null for it, so a surface holding an optional floor per row need not
+ * spell that case out. Stated here rather than at the write path so what greys
+ * the switch out and what throws cannot disagree about which way is open.
+ */
+export function packEnablementRefusal(
+  enabled: boolean,
+  floor: PackPolicyFloor | null,
+): PolicyFloorRefusal | null {
+  if (floor === null || enabled) return null;
+  return 'disable';
 }

--- a/packages/persistence/src/repositories/installed-packs.ts
+++ b/packages/persistence/src/repositories/installed-packs.ts
@@ -18,6 +18,7 @@ import type { FloorRule, PackPolicyFloor } from '../policy-floor.ts';
 import {
   controlPlanePolicyFloor,
   openControlPlaneFloors,
+  packEnablementRefusal,
   policyAssignmentRefusal,
   PolicyFloorError,
 } from '../policy-floor.ts';
@@ -762,8 +763,27 @@ export class SqliteInstalledPacksRepository implements InstalledPacksReadPort {
     return Number(res.changes) > 0;
   }
 
-  /** Enable or disable one installed pack. */
+  /**
+   * Enable or disable one installed pack.
+   *
+   * On an ATTACHED machine a detection the organization's bundle governs at all
+   * may not be switched OFF here — see packEnablementRefusal for why that is not
+   * merely another point below the floor, and why re-enabling stays open. Like
+   * the assignment above, the check belongs at this write path rather than on a
+   * surface: this is the one device-local writer of the column, and a refusal
+   * that lived in a page would leave the CLI free.
+   */
   setEnabled(namespace: string, packId: string, enabled: boolean): boolean {
+    const floor = this.policyFloor(namespace, packId);
+    if (floor !== null) {
+      const refusal = packEnablementRefusal(enabled, floor);
+      if (refusal !== null) {
+        // No archetype was asked for, so `attempted` is null. The floor is
+        // still carried, because a surface reporting this wants to name what
+        // the organization requires of the detection it just kept switched on.
+        throw new PolicyFloorError(`${namespace}/${packId}`, null, floor.floor, refusal);
+      }
+    }
     const res = this.db
       .prepare(
         `UPDATE installed_packs SET enabled = :enabled, updated_at = :now

--- a/packages/persistence/test/index.test.ts
+++ b/packages/persistence/test/index.test.ts
@@ -101,6 +101,7 @@ const PUBLIC_VALUE_EXPORTS = [
   'normalizeHost',
   'openLocalDatabase',
   'overlayManagedSettings',
+  'packEnablementRefusal',
   'policyAssignmentRefusal',
   'promptId',
   'readCachedPolicyBundle',

--- a/packages/persistence/test/policy-floor.test.ts
+++ b/packages/persistence/test/policy-floor.test.ts
@@ -1,8 +1,8 @@
-// The control-plane floor at the ONE device-local write path for a detection's
-// policy assignment. Every case here drives a real store in a real temp `~/.aka`
-// with a real settings.json and a real policy-cache.json, because the whole
-// subject is how those three files combine — a stubbed reader would assert the
-// wiring this suite exists to check.
+// The control-plane floor at the device-local write paths a detection has: its
+// policy assignment, and whether it runs at all. Every case here drives a real
+// store in a real temp `~/.aka` with a real settings.json and a real
+// policy-cache.json, because the whole subject is how those three files combine
+// — a stubbed reader would assert the wiring this suite exists to check.
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -10,7 +10,11 @@ import type { InstalledPackInput, Policy, PolicyBundle, Rule } from '@akasecurit
 import { describe, expect, it } from 'vitest';
 
 import { POLICY_CACHE_FILENAME } from '../src/attached-derived.ts';
-import { controlPlanePolicyFloor, PolicyFloorError } from '../src/policy-floor.ts';
+import {
+  controlPlanePolicyFloor,
+  packEnablementRefusal,
+  PolicyFloorError,
+} from '../src/policy-floor.ts';
 import { SETTINGS_FILENAME } from '../src/settings.ts';
 import { useTempStore } from './helpers/temp-store.ts';
 
@@ -460,5 +464,190 @@ describe('controlPlanePolicyFloor', () => {
         store.home,
       ),
     ).toEqual({ floor: 'monitor', locked: false });
+  });
+});
+
+/** Whether the pack's row is switched on, read outside the repository. */
+function storedEnabled(packId: string): boolean {
+  const raw = store.openRaw();
+  const row = raw.prepare(`SELECT enabled FROM installed_packs WHERE pack_id = ?`).get(packId) as
+    { enabled: number } | undefined;
+  raw.close();
+  return row?.enabled === 1;
+}
+
+describe('control-plane floor on setEnabled', () => {
+  it('refuses to switch OFF a detection the control plane governs', () => {
+    // Disabling is not a weaker archetype, it is the absence of one: a disabled
+    // pack contributes no rules, so nothing is left for the floor to be stated
+    // over. And unlike a below-floor assignment, the runtime's raise-only merge
+    // cannot paper over it — a bundle carrying policies but no rules has no
+    // rule to re-supply.
+    writeAttachedSettings();
+    writePolicyCache([policy({ target: { category: 'secret' }, action: 'warn' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    let caught: unknown;
+    try {
+      db.installedPacks.setEnabled('aka', 'secrets', false);
+    } catch (err) {
+      caught = err;
+    }
+    db.close();
+
+    expect(caught).toBeInstanceOf(PolicyFloorError);
+    const error = caught as PolicyFloorError;
+    expect(error.pack).toBe('aka/secrets');
+    // No archetype was asked for, and the floor is carried so a surface can say
+    // what the organization requires of the detection it kept switched on.
+    expect(error.attempted).toBeNull();
+    expect(error.floor).toBe('warn');
+    expect(error.refusal).toBe('disable');
+    // A refusal, not a substitution: the row is exactly as it was.
+    expect(storedEnabled('secrets')).toBe(true);
+  });
+
+  it('refuses the switch-off even under a MONITOR floor, which forbids no assignment', () => {
+    // The weakest floor there is: every archetype satisfies it, so the
+    // assignment guard refuses nothing here. Not running is still below it, and
+    // that is the whole reason this constraint cannot be expressed as a point on
+    // the action ladder.
+    writeAttachedSettings();
+    writePolicyCache([policy({ target: { category: 'secret' }, action: 'log' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    expect(db.installedPacks.policyFloor('aka', 'secrets')).toEqual({
+      floor: 'monitor',
+      locked: false,
+    });
+    expect(db.installedPacks.setPolicy('aka', 'secrets', 'monitor')).toBe(true);
+    expect(() => db.installedPacks.setEnabled('aka', 'secrets', false)).toThrow(PolicyFloorError);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(true);
+  });
+
+  it('refuses to switch off a LOCKED detection', () => {
+    writeAttachedSettings();
+    writePolicyCache([
+      policy({ target: { ruleId: 'secrets/aws' }, action: 'redact', provenance: 'authored' }),
+    ]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    let caught: unknown;
+    try {
+      db.installedPacks.setEnabled('aka', 'secrets', false);
+    } catch (err) {
+      caught = err;
+    }
+    db.close();
+
+    // 'disable' rather than 'lock': what was refused is the switch-off, and a
+    // reader told their organization "set the policy" would go looking for a
+    // picker they never opened.
+    expect((caught as PolicyFloorError).refusal).toBe('disable');
+    expect(storedEnabled('secrets')).toBe(true);
+  });
+
+  it('leaves a detection the bundle never names free to be switched off', () => {
+    writeAttachedSettings();
+    writePolicyCache([policy({ target: { category: 'pii' }, action: 'block' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    expect(db.installedPacks.policyFloor('aka', 'secrets')).toBeNull();
+    expect(db.installedPacks.setEnabled('aka', 'secrets', false)).toBe(true);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(false);
+  });
+
+  it('always allows a RE-ENABLE, including of a locked detection', () => {
+    // The realistic route to a governed pack that is switched off: it was
+    // switched off while the machine was its own authority, and then attached.
+    // Re-enabling moves toward what the organization asked for, so it stays the
+    // device's to do — a lock is over which archetype the pack carries, not
+    // over whether it runs.
+    writeStandaloneSettings();
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+    expect(db.installedPacks.setEnabled('aka', 'secrets', false)).toBe(true);
+
+    writeAttachedSettings();
+    writePolicyCache([
+      policy({ target: { ruleId: 'secrets/aws' }, action: 'block', provenance: 'authored' }),
+    ]);
+    expect(db.installedPacks.policyFloor('aka', 'secrets')?.locked).toBe(true);
+
+    expect(db.installedPacks.setEnabled('aka', 'secrets', true)).toBe(true);
+    // …and it is still switched on afterwards, so the guard cannot be satisfied
+    // by refusing everything.
+    expect(() => db.installedPacks.setEnabled('aka', 'secrets', false)).toThrow(PolicyFloorError);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(true);
+  });
+
+  it('re-enabling a governed detection is not refused for being a write at all', () => {
+    writeAttachedSettings();
+    writePolicyCache([policy({ target: { category: 'secret' }, action: 'block' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    // Already on, so this is the no-op direction — it must still be permitted,
+    // and must still report that the row matched.
+    expect(db.installedPacks.setEnabled('aka', 'secrets', true)).toBe(true);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(true);
+  });
+
+  it('imposes nothing on a machine that is not attached, even with a cache left behind', () => {
+    writeStandaloneSettings();
+    writePolicyCache([policy({ target: { category: 'secret' }, action: 'block' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    expect(db.installedPacks.setEnabled('aka', 'secrets', false)).toBe(true);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(false);
+  });
+
+  it('imposes nothing when the machine has no cached bundle yet', () => {
+    writeAttachedSettings();
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    expect(db.installedPacks.setEnabled('aka', 'secrets', false)).toBe(true);
+    db.close();
+    expect(storedEnabled('secrets')).toBe(false);
+  });
+
+  it('still reports a no-such-detection rather than refusing it', () => {
+    // The guard runs first, and a pack that is not installed contributes no
+    // rules and so carries no floor — so the answer stays "nothing matched",
+    // which is what a caller distinguishes an edit from.
+    writeAttachedSettings();
+    writePolicyCache([policy({ target: { category: 'secret' }, action: 'block' })]);
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', [rule('secrets/aws')])]);
+
+    expect(db.installedPacks.setEnabled('aka', 'missing', false)).toBe(false);
+    db.close();
+  });
+});
+
+describe('packEnablementRefusal', () => {
+  it('refuses a disable under any floor and permits every enable', () => {
+    for (const locked of [false, true]) {
+      for (const floor of ['monitor', 'warn', 'redact', 'block', 'vault'] as const) {
+        expect(packEnablementRefusal(false, { floor, locked })).toBe('disable');
+        expect(packEnablementRefusal(true, { floor, locked })).toBeNull();
+      }
+    }
+  });
+
+  it('refuses nothing where there is no floor', () => {
+    expect(packEnablementRefusal(false, null)).toBeNull();
+    expect(packEnablementRefusal(true, null)).toBeNull();
   });
 });

--- a/packages/persistence/test/repositories/legacy-writers.test.ts
+++ b/packages/persistence/test/repositories/legacy-writers.test.ts
@@ -34,6 +34,13 @@
 //      runtime merges the control plane's bundle over the local one raise-only
 //      on every hook, so the weaker row is clamped back before it decides
 //      anything.
+//   5. installed_packs.enabled is APP-guarded, not gated, in the same shape and
+//      with a NARROWER bound: the current repository refuses to switch off a
+//      pack the control plane governs at all, and the trigger does not cover
+//      that column either. A raw pre-guard writer can still disable the row,
+//      and unlike the assignment above the raise-only merge cannot clamp it
+//      back — the merge re-supplies an ACTION for a rule, not the rule, and a
+//      disabled pack contributes no rules at all.
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
@@ -352,5 +359,79 @@ describe('legacy policy_id writer vs installed_packs (floor boundary)', () => {
     expect(db.installedPacks.setPolicy('aka', 'secrets', 'monitor')).toBe(true);
     db.close();
     expect(policyIdRow('secrets')).toBe('monitor');
+  });
+});
+
+// ─── Invariant 5: enabled is app-guarded, not gated ──────────────────────────
+
+// ╔═══════════════════════════════════════════════════════════════════════╗
+// ║ DO NOT EDIT — PINNED ARTIFACT. Vendored VERBATIM from setEnabled. The   ║
+// ║ guard added in front of it changed no byte of the statement, so this is ║
+// ║ what every shipped generation executes — pre-guard ones with nothing in ║
+// ║ front. Any reformat silently voids the guarantee while the test stays   ║
+// ║ green.                                                                  ║
+// ╚═══════════════════════════════════════════════════════════════════════╝
+const LEGACY_PACK_ENABLE = `UPDATE installed_packs SET enabled = :enabled, updated_at = :now
+         WHERE namespace = :namespace AND pack_id = :packId`;
+
+function enabledRow(packId: string): boolean {
+  const raw = new DatabaseSync(join(store.dataDir, DB_FILENAME));
+  const row = raw.prepare(`SELECT enabled FROM installed_packs WHERE pack_id = ?`).get(packId) as
+    { enabled: number } | undefined;
+  raw.close();
+  return row?.enabled === 1;
+}
+
+describe('legacy enabled writer vs installed_packs (governed-pack boundary)', () => {
+  it('the CURRENT repository refuses to switch off a governed detection', () => {
+    attachWithSecretBlockFloor();
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', '2.0.0', ['secrets/aws'])]);
+
+    expect(() => db.installedPacks.setEnabled('aka', 'secrets', false)).toThrow(PolicyFloorError);
+    // Re-enabling stays open, so the guard is a direction and not a freeze.
+    expect(db.installedPacks.setEnabled('aka', 'secrets', true)).toBe(true);
+    db.close();
+    expect(enabledRow('secrets')).toBe(true);
+  });
+
+  it('a RAW legacy switch-off can still disable the row — the documented, bounded gap', () => {
+    // The migration 0006 write gate is BEFORE UPDATE OF version, name,
+    // rules_json, so it does not cover this column either, and nothing at the
+    // database level stops a pre-guard writer. The bound is NARROWER than the
+    // policy_id one and worth stating plainly: a disabled pack contributes no
+    // rules to the local bundle, and the attached runtime's raise-only merge
+    // re-supplies an action for a rule rather than the rule itself — so where
+    // the cached bundle carries no rules of its own, this really does stop the
+    // detection firing until something switches it back on. What holds the line
+    // is that every current writer goes through the repository.
+    attachWithSecretBlockFloor();
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', '2.0.0', ['secrets/aws'])]);
+    db.close();
+
+    const legacy = new DatabaseSync(join(store.dataDir, DB_FILENAME));
+    try {
+      legacy.prepare(LEGACY_PACK_ENABLE).run({
+        enabled: 0,
+        now: Date.now(),
+        namespace: 'aka',
+        packId: 'secrets',
+      });
+    } finally {
+      legacy.close();
+    }
+    expect(enabledRow('secrets')).toBe(false); // the gap
+    // And the bound the gate does hold: the pack's content is untouched, so the
+    // rules are still there to be re-enabled.
+    expect(installedRow('secrets')).toEqual({ version: '2.0.0', rules: 1 });
+  });
+
+  it('a raw switch-off stays open on a machine no control plane governs', () => {
+    const db = store.open();
+    db.installedPacks.recordInventory([pack('secrets', '2.0.0', ['secrets/aws'])]);
+    expect(db.installedPacks.setEnabled('aka', 'secrets', false)).toBe(true);
+    db.close();
+    expect(enabledRow('secrets')).toBe(false);
   });
 });

--- a/web-ui/app/(app)/detections/DetectionsClient.tsx
+++ b/web-ui/app/(app)/detections/DetectionsClient.tsx
@@ -23,12 +23,13 @@ import {
 } from './actions';
 import { buildDetectionsParams } from './filters';
 
-// Fallbacks for the two ways a policy write can fail without the action naming
-// a reason: a result that says not-ok and carries no message, and a call that
+// Fallbacks for the two ways a write can fail without the action naming a
+// reason: a result that says not-ok and carries no message, and a call that
 // never returned one at all. Both are faults rather than refusals, so both say
-// what the user can do about it.
-const DEFAULT_POLICY_ERROR = 'That change could not be saved.';
-const TRANSPORT_POLICY_ERROR =
+// what the user can do about it. Shared by both writes on this page, which fail
+// in the same two ways.
+const DEFAULT_WRITE_ERROR = 'That change could not be saved.';
+const TRANSPORT_WRITE_ERROR =
   'That change could not be sent — check that the dashboard is still running and try again.';
 
 // Tabs: updates come from the available_packs mirror (what the running
@@ -90,6 +91,11 @@ export function DetectionsClient({
   // click can legitimately fail — and a picker that snaps back with nothing on
   // screen is the defect this state exists to close.
   const [policyError, setPolicyError] = useState<string | null>(null);
+  // The same for the enable/disable write, and separate from it: the two are
+  // different refusals about different controls, and one state would show the
+  // organization's reason for keeping a detection running underneath the
+  // picker, which never refused anything.
+  const [enabledError, setEnabledError] = useState<string | null>(null);
 
   // id → latest version, for the per-row amber update badges. Derived straight
   // from the list items (the store sets latestVersion only when a newer
@@ -156,10 +162,11 @@ export function DetectionsClient({
           }}
           onSelect={(id) => {
             setEditRuleId(null);
-            // The refusal belongs to the detection that produced it; carrying it
-            // to the next one would attribute an organization's constraint to a
-            // detection that is not under it.
+            // The refusals belong to the detection that produced them; carrying
+            // one to the next detection would attribute an organization's
+            // constraint to a detection that is not under it.
             setPolicyError(null);
+            setEnabledError(null);
             push({ filter, q: query, id });
           }}
           filterTabs={OSS_TABS}
@@ -184,24 +191,35 @@ export function DetectionsClient({
                 // would jump to a different detection and look like the toggle hit the
                 // wrong one.
                 push({ filter, q: query, id: detail.id });
-                startTransition(() => {
-                  void setDetectionEnabled(detail.id, !detail.enabled);
+                startTransition(async () => {
+                  try {
+                    const result = await setDetectionEnabled(detail.id, !detail.enabled);
+                    setEnabledError(result.ok ? null : (result.error ?? DEFAULT_WRITE_ERROR));
+                  } catch {
+                    // Same reasoning as the policy write below: the action
+                    // RETURNS its refusals, but the call itself can still
+                    // reject, and an unhandled rejection inside a transition
+                    // takes the page to the route error boundary over something
+                    // a retry would clear.
+                    setEnabledError(TRANSPORT_WRITE_ERROR);
+                  }
                 });
               }}
               policyFloor={floors[detail.id] ?? null}
               policyError={policyError}
+              enabledError={enabledError}
               onChangePolicy={(policyId) => {
                 startTransition(async () => {
                   try {
                     const result = await setDetectionPolicy(detail.id, policyId);
-                    setPolicyError(result.ok ? null : (result.error ?? DEFAULT_POLICY_ERROR));
+                    setPolicyError(result.ok ? null : (result.error ?? DEFAULT_WRITE_ERROR));
                   } catch {
                     // The action is written to RETURN a refusal rather than
                     // throw, but the CALL can still reject — a dropped
                     // connection, a framework fault — and an unhandled rejection
                     // inside a transition takes the page to the route error
                     // boundary over something a retry would clear.
-                    setPolicyError(TRANSPORT_POLICY_ERROR);
+                    setPolicyError(TRANSPORT_WRITE_ERROR);
                   }
                 });
               }}

--- a/web-ui/app/(app)/detections/actions.ts
+++ b/web-ui/app/(app)/detections/actions.ts
@@ -6,9 +6,12 @@ import { revalidatePath } from 'next/cache';
 import { db } from '../../lib/db';
 import {
   asPolicyFloorRefusal,
+  DETECTION_ID_INVALID,
+  DETECTION_MISSING,
   DETECTION_POLICY_INVALID,
-  DETECTION_POLICY_MISSING,
-  DETECTION_POLICY_WRITE_ERROR,
+  DETECTION_STAYS_ON_REFUSAL,
+  DETECTION_WRITE_ERROR,
+  isControlPlaneRefusal,
   policyFloorRefusal,
 } from '../../lib/detection-refusals';
 
@@ -21,17 +24,21 @@ import {
 // every 'use server' export to be async — hence the require-await disables below.
 
 /**
- * The outcome of a policy assignment, in terms the client can render.
+ * The outcome of a per-detection write, in terms the client can render.
  *
- * This RETURNS a refusal rather than throwing one, for the reason every
+ * These RETURN a refusal rather than throwing one, for the reason every
  * mutating action on this dashboard does: a rejected Server Action escalates to
- * the route error boundary and replaces the whole page. But it also no longer
- * returns NOTHING, which is what it used to do — a write refused by the control
- * plane's floor left the picker showing the choice the user made, the store
- * holding a different one, and enforcement applying a third. A refusal nobody
- * can see is indistinguishable from a picker that ignores you.
+ * the route error boundary and replaces the whole page. But they also no longer
+ * return NOTHING, which is what they used to do — a write refused by the control
+ * plane left the control showing the choice the user made, the store holding a
+ * different one, and enforcement applying a third. A refusal nobody can see is
+ * indistinguishable from a control that ignores you.
+ *
+ * One shape for both writes: they answer the same questions (did it land, and
+ * if not, what does the user read), and a second shape saying the same thing is
+ * how two controls on one page start reporting the same refusal differently.
  */
-export interface SetDetectionPolicyResult {
+export interface DetectionWriteResult {
   ok: boolean;
   error?: string;
 }
@@ -50,7 +57,7 @@ export interface SetDetectionPolicyResult {
 export async function setDetectionPolicy(
   id: string,
   policyId: string,
-): Promise<SetDetectionPolicyResult> {
+): Promise<DetectionWriteResult> {
   const parts = splitDetectionId(id);
   // Both malformed inputs answer with the same sentence: only a stale or
   // hand-made client sends either, the remedy for both is a reload, and neither
@@ -68,22 +75,53 @@ export async function setDetectionPolicy(
   } catch (error) {
     const refused = asPolicyFloorRefusal(error);
     if (refused !== null) return { ok: false, error: policyFloorRefusal(refused) };
-    return { ok: false, error: DETECTION_POLICY_WRITE_ERROR };
+    return { ok: false, error: DETECTION_WRITE_ERROR };
   }
   revalidatePath('/detections');
   // No row changed: the pack this page rendered is not installed any more. Said
   // plainly, because the revalidated page below is about to stop showing it and
   // an unexplained disappearance reads as the write having broken something.
-  return written ? { ok: true } : { ok: false, error: DETECTION_POLICY_MISSING };
+  return written ? { ok: true } : { ok: false, error: DETECTION_MISSING };
 }
 
-/** Enable or disable a detection. */
+/**
+ * Enable or disable a detection.
+ *
+ * On an ATTACHED machine the store refuses to switch OFF a detection the
+ * organization's bundle names at all — a detection that does not run supplies
+ * no rules and no actions, which is below every archetype the organization
+ * could have asked for, so the floor it set would be unreachable rather than
+ * merely lowered. Re-enabling is never refused.
+ *
+ * That refusal is recognised structurally (see isControlPlaneRefusal) and
+ * reported as the organization's decision, never as a failure: retrying cannot
+ * help and the user has done nothing wrong. It goes through the same result
+ * shape the assignment does, so a toggle that is somehow clicked anyway — a
+ * stale page, a second tab, a sync that landed between render and click — says
+ * why instead of snapping back in silence.
+ */
 // eslint-disable-next-line @typescript-eslint/require-await -- 'use server' exports must be async
-export async function setDetectionEnabled(id: string, enabled: boolean): Promise<void> {
+export async function setDetectionEnabled(
+  id: string,
+  enabled: boolean,
+): Promise<DetectionWriteResult> {
   const parts = splitDetectionId(id);
-  if (!parts) return;
-  db().installedPacks.setEnabled(parts.namespace, parts.packId, enabled);
+  // Only a stale or hand-made client sends this; the remedy is a reload, and
+  // the message may not quote what was sent.
+  if (!parts) return { ok: false, error: DETECTION_ID_INVALID };
+  let written: boolean;
+  try {
+    written = db().installedPacks.setEnabled(parts.namespace, parts.packId, enabled);
+  } catch (error) {
+    if (isControlPlaneRefusal(error)) return { ok: false, error: DETECTION_STAYS_ON_REFUSAL };
+    return { ok: false, error: DETECTION_WRITE_ERROR };
+  }
   revalidatePath('/detections');
+  // No row changed: the detection this page rendered is not installed any more.
+  // Said plainly, because the revalidated page below is about to stop showing
+  // it and an unexplained disappearance reads as the write having broken
+  // something.
+  return written ? { ok: true } : { ok: false, error: DETECTION_MISSING };
 }
 
 /**

--- a/web-ui/app/lib/detection-refusals.ts
+++ b/web-ui/app/lib/detection-refusals.ts
@@ -1,19 +1,20 @@
-import { policyFloorReason } from '@akasecurity/dashboard-ui';
+import { DETECTION_STAYS_ON_REASON, policyFloorReason } from '@akasecurity/dashboard-ui';
 import type { PolicyFloorError } from '@akasecurity/persistence';
 import { BuiltinPolicyId } from '@akasecurity/schema';
 
-// The wording a user reads when a per-detection enforcement-policy write does
-// not land.
+// The wording a user reads when a per-detection write — the enforcement policy,
+// or the enable/disable toggle — does not land.
 //
 // Here rather than inside the `'use server'` module for the same reason the
 // settings copy is (see action-refusals.ts): every export of that module must be
 // an async Server Action, so a formatter defined there is reachable only by
-// performing the whole write it describes — and the refusal these exist for
-// needs an attached machine with a cached control-plane bundle behind it.
+// performing the whole write it describes — and the refusals these exist for
+// need an attached machine with a cached control-plane bundle behind it.
 //
-// The four are kept distinguishable on purpose. They have different remedies —
-// pick something stronger, ask your administrator, reload, or the store is
-// broken — and a reader who cannot tell them apart takes the wrong one.
+// Every one of them is kept distinguishable on purpose. They have different
+// remedies — pick something stronger, raise it instead of switching it off, ask
+// your administrator, reload, or the store is broken — and a reader who cannot
+// tell them apart takes the wrong one.
 
 /**
  * The organization's policy forbids the assignment that was attempted.
@@ -36,27 +37,57 @@ export function policyFloorRefusal(error: Pick<PolicyFloorError, 'floor' | 'refu
 }
 
 /**
+ * The organization requires the detection to keep running, so it was not
+ * switched off.
+ *
+ * Built from the same sentence the toggle already withholds the choice with,
+ * behind the same lead as the assignment refusal above — one rule, one wording,
+ * and the reader learns first that nothing changed.
+ *
+ * A constant rather than a formatter because nothing about it varies: the
+ * constraint is "the organization named this detection at all", which carries
+ * no archetype to quote.
+ */
+export const DETECTION_STAYS_ON_REFUSAL = `That change was not saved. ${DETECTION_STAYS_ON_REASON}`;
+
+/**
+ * Whether a thrown value is the store's control-plane refusal at all.
+ *
+ * Read STRUCTURALLY — by `name`, never by `instanceof`. The store's error class
+ * reaches this page across a bundle boundary, and a prototype identity that
+ * survives one bundler configuration is not what should decide which sentence a
+ * user reads: were it ever to miss, the organization's decision would be
+ * reported as DETECTION_WRITE_ERROR — sending someone to fix a permission on
+ * `~/.aka` they do not have, and never telling them their organization set the
+ * policy.
+ *
+ * The name is the WHOLE test here, and that is the difference from
+ * asPolicyFloorRefusal below. Its sentence quotes the archetype the
+ * organization requires, so it has to validate the fields it is about to
+ * format; the enable refusal quotes none of them, because a detection the
+ * organization speaks for stays on whichever archetype it asked for. Demanding
+ * a discriminator the sentence has no opinion about would make the refusal turn
+ * on a value it never reads.
+ */
+export function isControlPlaneRefusal(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  return (error as Record<string, unknown>).name === 'PolicyFloorError';
+}
+
+/**
  * The two facts a floor refusal carries, or null for a failure that is not one.
  *
- * Read STRUCTURALLY — by `name` and by the fields themselves, never by
- * `instanceof`. The store's error class reaches this page across a bundle
- * boundary, and a prototype identity that survives one bundler configuration is
- * not what should decide which of these sentences a user reads: were it ever to
- * miss, the organization's decision would be reported as DETECTION_POLICY_WRITE_ERROR
- * — sending someone to fix a permission on `~/.aka` they do not have, and never
- * telling them their organization set the policy.
- *
- * The fields are validated as well as the name, because that is the half a name
- * check alone cannot do: a shape carrying the name without a usable floor would
+ * Structural for the reason isControlPlaneRefusal is, and strict on top of it:
+ * the fields are validated as well as the name, because that is the half a name
+ * check alone cannot do. A shape carrying the name without a usable floor would
  * otherwise format `undefined` into the sentence, and falling through to the
  * write error is the honest answer for something this cannot read.
  */
 export function asPolicyFloorRefusal(
   error: unknown,
 ): Pick<PolicyFloorError, 'floor' | 'refusal'> | null {
-  if (typeof error !== 'object' || error === null) return null;
-  const { name, floor, refusal } = error as Record<string, unknown>;
-  if (name !== 'PolicyFloorError') return null;
+  if (!isControlPlaneRefusal(error)) return null;
+  const { floor, refusal } = error as Record<string, unknown>;
   if (refusal !== 'floor' && refusal !== 'lock') return null;
   // The floor is stated in the archetype vocabulary the picker offers, so it is
   // checked against that same canonical enum rather than for any string.
@@ -74,10 +105,21 @@ export function asPolicyFloorRefusal(
 export const DETECTION_POLICY_INVALID =
   'That enforcement policy is not one this machine recognises, so nothing was changed. Reload the page and try again.';
 
+/**
+ * The request named something that is not a detection.
+ *
+ * Its own sentence rather than the one above: a toggle carries no archetype, so
+ * a message about enforcement policies would describe a control the user never
+ * touched. Same shape otherwise — only a stale or hand-made client gets here,
+ * the remedy is a reload, and nothing that was sent is quoted back.
+ */
+export const DETECTION_ID_INVALID =
+  'That detection is not one this machine recognises, so nothing was changed. Reload the page and try again.';
+
 /** The detection named by the request is not installed on this machine. */
-export const DETECTION_POLICY_MISSING =
+export const DETECTION_MISSING =
   'That detection is not installed on this machine any more, so nothing was changed. Reload the page to see what is.';
 
-/** The store could not be written at all — a fault, unlike the three above. */
-export const DETECTION_POLICY_WRITE_ERROR =
+/** The store could not be written at all — a fault, unlike every answer above. */
+export const DETECTION_WRITE_ERROR =
   'Could not save this change to the local store. Try again, and check that ~/.aka is writable.';

--- a/web-ui/test/actions/detection-enabled.test.ts
+++ b/web-ui/test/actions/detection-enabled.test.ts
@@ -1,0 +1,332 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { isDisableRefused } from '@akasecurity/dashboard-ui';
+import {
+  dataDir,
+  type LocalDatabase,
+  openLocalDatabase,
+  packEnablementRefusal,
+  POLICY_CACHE_FILENAME,
+  SETTINGS_FILENAME,
+  settingsDir,
+} from '@akasecurity/persistence';
+import type { ActionTaken, InstalledPackInput, Policy, PolicyBundle } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { removeTree } from '../../../test/helpers/remove-tree.ts';
+import { setDetectionEnabled } from '../../app/(app)/detections/actions.ts';
+import { db } from '../../app/lib/db.ts';
+import {
+  DETECTION_ID_INVALID,
+  DETECTION_MISSING,
+  DETECTION_STAYS_ON_REFUSAL,
+  DETECTION_WRITE_ERROR,
+} from '../../app/lib/detection-refusals.ts';
+import { ECHO_RUN, expectNoEchoOf } from '../helpers/no-echo.ts';
+import { expectNoRejection } from '../helpers/no-throw.ts';
+
+// The Detections page's OTHER write, driven against a real store in a real temp
+// `~/.aka` with a real settings.json and a real cached policy bundle.
+//
+// The defect this suite exists to keep closed: the floor governed which POLICY a
+// detection could carry and said nothing about whether it ran at all, so a user
+// could switch a governed detection off — and whether that reduced enforcement
+// turned on something invisible to them, since the organization's bundle
+// re-supplies an ACTION for a rule, never the rule itself. What only this level
+// can check is that the store's refusal REACHES the page in words, rather than
+// being swallowed into a silent no-op that looks exactly like the bug.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
+
+const NAMESPACE = 'aka';
+const PACK = 'floor-fixture';
+const DETECTION_ID = `${NAMESPACE}/${PACK}`;
+const RULE_ID = 'floor-fixture/one';
+
+let home: string;
+let base: string;
+
+function seedPack(): void {
+  const pack: InstalledPackInput = {
+    namespace: NAMESPACE,
+    packId: PACK,
+    version: '1.0.0',
+    name: 'Floor fixture',
+    rules: [
+      {
+        specVersion: 1,
+        id: RULE_ID,
+        name: 'Fixture rule',
+        category: 'secret',
+        severity: 'high',
+        matcher: { type: 'keyword', keywords: ['fixture'], caseSensitive: false },
+      },
+    ],
+  };
+  const db = openLocalDatabase(dataDir(base));
+  try {
+    db.installedPacks.recordInventory([pack]);
+  } finally {
+    db.close();
+  }
+}
+
+/** Both halves of an attachment, since `isAttached` demands both. */
+function attach(): void {
+  mkdirSync(settingsDir(base), { recursive: true });
+  writeFileSync(
+    join(settingsDir(base), SETTINGS_FILENAME),
+    JSON.stringify({
+      specVersion: 1,
+      runMode: 'attached',
+      controlPlane: {
+        endpoint: 'https://cp.example.internal',
+        attachedAt: new Date(0).toISOString(),
+      },
+    }),
+  );
+}
+
+/** The on-disk shape the sync child publishes: the bundle plus its freshness. */
+function governBy(action: ActionTaken, provenance?: Policy['provenance']): void {
+  const policy: Policy = {
+    // Policy.id is a guid, so a placeholder string fails the parse this fixture
+    // exists to get past.
+    id: '00000000-0000-4000-8000-000000000001',
+    scope: 'global',
+    enabled: true,
+    target: { ruleId: RULE_ID },
+    action,
+    ...(provenance === undefined ? {} : { provenance }),
+  };
+  const bundle: PolicyBundle = {
+    version: '1',
+    policies: [policy],
+    customKeywords: [],
+    fetchedAt: new Date(0).toISOString(),
+  };
+  mkdirSync(dataDir(base), { recursive: true });
+  writeFileSync(
+    join(dataDir(base), POLICY_CACHE_FILENAME),
+    JSON.stringify({ bundle, fetchedAtMs: 0 }),
+  );
+}
+
+/**
+ * Whether the detection is actually running, read on a fresh handle rather than
+ * the action's — and through the repository's own read rather than raw SQL, so
+ * this asserts what the page would render rather than a column the schema owns.
+ */
+async function storedEnabled(): Promise<boolean | undefined> {
+  const db = openLocalDatabase(dataDir(base));
+  try {
+    return (await db.detections.getDetectionDetail(DETECTION_ID))?.enabled;
+  } finally {
+    db.close();
+  }
+}
+
+function resetSingleton(): void {
+  const globals = globalThis as unknown as { __akaDb?: LocalDatabase };
+  globals.__akaDb?.close();
+  delete globals.__akaDb;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-detection-enabled-'));
+  osHome.dir = home;
+  base = join(home, '.aka');
+  resetSingleton();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetSingleton();
+  removeTree(home);
+});
+
+describe('setDetectionEnabled on a standalone machine', () => {
+  it('switches a detection off and says so', async () => {
+    seedPack();
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result).toEqual({ ok: true });
+    expect(await storedEnabled()).toBe(false);
+  });
+});
+
+describe('setDetectionEnabled on a detection the organization governs', () => {
+  beforeEach(() => {
+    attach();
+  });
+
+  it('refuses to switch it off and says whose decision that is', async () => {
+    seedPack();
+    governBy('block');
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe(DETECTION_STAYS_ON_REFUSAL);
+    // A refusal, not a silent no-op: the detection is still running, and the
+    // page is about to render it that way.
+    expect(await storedEnabled()).toBe(true);
+    // And it must not be reported as breakage — that message sends someone to
+    // fix a permission on ~/.aka they do not have, while never telling them
+    // their organization asked for this.
+    expect(result.error).not.toBe(DETECTION_WRITE_ERROR);
+  });
+
+  it('refuses under the WEAKEST floor too, where no assignment is restricted', async () => {
+    // The case that separates this constraint from the picker's. A control plane
+    // asking only for Monitor forbids no archetype, and still forbids the
+    // detection not running: "off" supplies no rules at all, so the floor it set
+    // would be unreachable rather than merely lowered.
+    seedPack();
+    governBy('log');
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result.error).toBe(DETECTION_STAYS_ON_REFUSAL);
+    expect(await storedEnabled()).toBe(true);
+  });
+
+  it('lets a detection that is already off be turned back on', async () => {
+    // The positive control the refusals above need, and a property in its own
+    // right: a store can hold a detection switched off from before this refusal
+    // existed, and re-enabling moves toward what the organization asked for.
+    seedPack();
+    expect(await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false))).toEqual({
+      ok: true,
+    });
+    resetSingleton();
+    governBy('block', 'authored');
+    expect(await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, true))).toEqual({
+      ok: true,
+    });
+    expect(await storedEnabled()).toBe(true);
+  });
+
+  it('constrains nothing the organization has not spoken for', async () => {
+    // Attached, with a bundle that reaches no rule of this pack. An attachment
+    // that constrained by itself would put a decision on screen that nobody made.
+    seedPack();
+    governBy('block');
+    // Same bundle, a rule id it does not name: the floor is null, so the write
+    // is the machine's own again.
+    const empty: PolicyBundle = {
+      version: '1',
+      policies: [],
+      customKeywords: [],
+      fetchedAt: new Date(0).toISOString(),
+    };
+    writeFileSync(
+      join(dataDir(base), POLICY_CACHE_FILENAME),
+      JSON.stringify({ bundle: empty, fetchedAtMs: 0 }),
+    );
+    expect(await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false))).toEqual({
+      ok: true,
+    });
+    expect(await storedEnabled()).toBe(false);
+  });
+
+  it('withholds the toggle for EXACTLY the writes the store refuses', async () => {
+    // The property the page rests on. The pane decides what to offer from the
+    // floor descriptor the Server Component hands down; the store decides what
+    // to accept from the same three files. If those two ever differ, the page is
+    // back to offering a switch that does not stick — or withholding one that
+    // would have worked.
+    seedPack();
+    governBy('redact');
+    const store = openLocalDatabase(dataDir(base));
+    const floor = store.installedPacks.policyFloor(NAMESPACE, PACK);
+    store.close();
+    expect(floor, 'the fixture produced no floor to compare against').not.toBeNull();
+
+    // The two read the same fact from opposite ends — the pane is handed the
+    // state the detection is IN, the store the state a write is asking FOR — so
+    // the comparison has to flip one of them. Getting that wrong is exactly how
+    // the two would come to disagree, which is why the write path is driven
+    // underneath as the tiebreaker rather than trusted to the pair above.
+    for (const current of [true, false]) {
+      const withheld = isDisableRefused(current, floor);
+      expect(withheld).toBe(packEnablementRefusal(!current, floor) !== null);
+      const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, !current));
+      expect(result.ok, `a detection that is on=${String(current)}`).toBe(!withheld);
+      resetSingleton();
+    }
+    // Non-vacuous: the loop has to have exercised both answers, or two matching
+    // constants would agree while proving nothing.
+    expect(isDisableRefused(true, floor)).toBe(true);
+    expect(isDisableRefused(false, floor)).toBe(false);
+  });
+});
+
+describe('setDetectionEnabled on input it cannot act on', () => {
+  it('answers a malformed detection id rather than returning silently', async () => {
+    seedPack();
+    const posted = 'no-slash-cGFzc3dvcmQ';
+    const result = await expectNoRejection(() => setDetectionEnabled(posted, false));
+    expect(result).toEqual({ ok: false, error: DETECTION_ID_INVALID });
+    // It reaches the page as untrusted input to an HTTP POST, so the message
+    // must not echo it — and not a truncated run of it either.
+    expectNoEchoOf(result.error, posted);
+    // Positive control on the same bytes: the run IS findable in a string that
+    // carries it, so the absence above is a property of the message.
+    expect(`${DETECTION_ID_INVALID} ${posted}`).toContain(posted.slice(0, ECHO_RUN));
+    // Nothing was written: the detection is still running.
+    expect(await storedEnabled()).toBe(true);
+  });
+
+  it('says so when the detection is not installed here', async () => {
+    // No pack seeded at all: the write changes no row.
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result).toEqual({ ok: false, error: DETECTION_MISSING });
+  });
+});
+
+/**
+ * A SECOND copy of the store's error class: same name, unrelated prototype —
+ * what the page sees once a bundler has handed it and the store their own
+ * copies of the module. The real store cannot be made to throw one, so it is
+ * thrown from the real store's own write method here; everything downstream of
+ * the throw is the production path.
+ */
+class ForeignPolicyFloorError extends Error {
+  readonly refusal = 'disable';
+
+  constructor() {
+    super('refusing to disable');
+    this.name = 'PolicyFloorError';
+  }
+}
+
+describe('setDetectionEnabled when the refusal arrives from another copy of the class', () => {
+  it("still reports it as the organization's decision, not a broken store", async () => {
+    // An identity check would fail here and answer DETECTION_WRITE_ERROR, which
+    // tells the user to retry and to check that ~/.aka is writable — a problem
+    // they do not have, while never learning that their organization asked for
+    // this detection to keep running.
+    seedPack();
+    vi.spyOn(db().installedPacks, 'setEnabled').mockImplementation(() => {
+      throw new ForeignPolicyFloorError();
+    });
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result).toEqual({ ok: false, error: DETECTION_STAYS_ON_REFUSAL });
+  });
+
+  it('still reports a genuine store fault as one', async () => {
+    // The other half of the same read: strictness. A write that failed for a
+    // real reason must keep the message that tells the user to retry, or the
+    // structural check would have turned every fault into somebody else's
+    // decision.
+    seedPack();
+    vi.spyOn(db().installedPacks, 'setEnabled').mockImplementation(() => {
+      throw new Error('SQLITE_BUSY: database is locked');
+    });
+    const result = await expectNoRejection(() => setDetectionEnabled(DETECTION_ID, false));
+    expect(result).toEqual({ ok: false, error: DETECTION_WRITE_ERROR });
+  });
+});

--- a/web-ui/test/actions/detection-policy.test.ts
+++ b/web-ui/test/actions/detection-policy.test.ts
@@ -20,9 +20,9 @@ import { removeTree } from '../../../test/helpers/remove-tree.ts';
 import { setDetectionPolicy } from '../../app/(app)/detections/actions.ts';
 import { db } from '../../app/lib/db.ts';
 import {
+  DETECTION_MISSING,
   DETECTION_POLICY_INVALID,
-  DETECTION_POLICY_MISSING,
-  DETECTION_POLICY_WRITE_ERROR,
+  DETECTION_WRITE_ERROR,
   policyFloorRefusal,
 } from '../../app/lib/detection-refusals.ts';
 import { ECHO_RUN, expectNoEchoOf } from '../helpers/no-echo.ts';
@@ -276,7 +276,7 @@ describe('setDetectionPolicy on input it cannot act on', () => {
   it('says so when the detection is not installed here', async () => {
     // No pack seeded at all: the write changes no row.
     const result = await expectNoRejection(() => setDetectionPolicy(DETECTION_ID, 'block'));
-    expect(result).toEqual({ ok: false, error: DETECTION_POLICY_MISSING });
+    expect(result).toEqual({ ok: false, error: DETECTION_MISSING });
   });
 });
 
@@ -301,7 +301,7 @@ class ForeignPolicyFloorError extends Error {
 
 describe('setDetectionPolicy when the refusal arrives from another copy of the class', () => {
   it("still reports it as the organization's decision, not a broken store", async () => {
-    // An identity check would fail here and answer DETECTION_POLICY_WRITE_ERROR,
+    // An identity check would fail here and answer DETECTION_WRITE_ERROR,
     // which tells the user to retry and to check that ~/.aka is writable — a
     // permission problem they do not have, while never learning that their
     // organization set the policy. The refusal is therefore read by its fields.
@@ -311,7 +311,7 @@ describe('setDetectionPolicy when the refusal arrives from another copy of the c
     });
     const result = await expectNoRejection(() => setDetectionPolicy(DETECTION_ID, 'monitor'));
     expect(result.error).toBe(policyFloorRefusal({ floor: 'block', refusal: 'floor' }));
-    expect(result.error).not.toBe(DETECTION_POLICY_WRITE_ERROR);
+    expect(result.error).not.toBe(DETECTION_WRITE_ERROR);
     expect(result.ok).toBe(false);
   });
 
@@ -325,6 +325,6 @@ describe('setDetectionPolicy when the refusal arrives from another copy of the c
       throw new Error('SQLITE_BUSY: database is locked');
     });
     const result = await expectNoRejection(() => setDetectionPolicy(DETECTION_ID, 'monitor'));
-    expect(result).toEqual({ ok: false, error: DETECTION_POLICY_WRITE_ERROR });
+    expect(result).toEqual({ ok: false, error: DETECTION_WRITE_ERROR });
   });
 });

--- a/web-ui/test/actions/detection-refusals.test.ts
+++ b/web-ui/test/actions/detection-refusals.test.ts
@@ -1,12 +1,15 @@
-import { policyFloorReason } from '@akasecurity/dashboard-ui';
+import { DETECTION_STAYS_ON_REASON, policyFloorReason } from '@akasecurity/dashboard-ui';
 import { PolicyFloorError } from '@akasecurity/persistence';
 import { describe, expect, it } from 'vitest';
 
 import {
   asPolicyFloorRefusal,
+  DETECTION_ID_INVALID,
+  DETECTION_MISSING,
   DETECTION_POLICY_INVALID,
-  DETECTION_POLICY_MISSING,
-  DETECTION_POLICY_WRITE_ERROR,
+  DETECTION_STAYS_ON_REFUSAL,
+  DETECTION_WRITE_ERROR,
+  isControlPlaneRefusal,
   policyFloorRefusal,
 } from '../../app/lib/detection-refusals.ts';
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
@@ -52,7 +55,7 @@ describe('policyFloorRefusal', () => {
     for (const refusal of ['floor', 'lock'] as const) {
       const message = policyFloorRefusal({ floor: 'block', refusal });
       expect(message).not.toMatch(/error|failed|try again/i);
-      expect(message).not.toBe(DETECTION_POLICY_WRITE_ERROR);
+      expect(message).not.toBe(DETECTION_WRITE_ERROR);
     }
   });
 
@@ -66,24 +69,54 @@ describe('policyFloorRefusal', () => {
   });
 });
 
-describe('the four refusals are distinguishable', () => {
+describe('DETECTION_STAYS_ON_REFUSAL', () => {
+  it('says the change was not saved', () => {
+    // The one fact the constraint itself does not carry. Without it the reader
+    // is left guessing whether the detection is now off.
+    expect(DETECTION_STAYS_ON_REFUSAL).toMatch(/not saved/i);
+  });
+
+  it('reuses the sentence the toggle already showed', () => {
+    // One rule, one wording — the toggle withholds the choice with this before
+    // the click, exactly as the picker does with the floor's own sentence.
+    expect(DETECTION_STAYS_ON_REFUSAL).toContain(DETECTION_STAYS_ON_REASON);
+  });
+
+  it('says the detection can still be raised', () => {
+    // The remedy this refusal leaves open, and the whole reason it is not the
+    // lock's sentence: enforcement may still be strengthened here.
+    expect(DETECTION_STAYS_ON_REFUSAL).toMatch(/stronger/i);
+  });
+
+  it('does not read as a fault the user should retry', () => {
+    // Retrying cannot help, and the user has done nothing wrong.
+    expect(DETECTION_STAYS_ON_REFUSAL).not.toMatch(/error|failed|try again/i);
+    expect(DETECTION_STAYS_ON_REFUSAL).not.toBe(DETECTION_WRITE_ERROR);
+  });
+});
+
+describe('every refusal is distinguishable', () => {
   it('no two produce the same message', () => {
     // They mean different things and have different remedies: pick something
-    // stronger, ask your administrator, reload, or the store is broken.
+    // stronger, raise it instead of switching it off, ask your administrator,
+    // reload, or the store is broken.
     const messages = new Set([
       policyFloorRefusal({ floor: 'warn', refusal: 'floor' }),
       policyFloorRefusal({ floor: 'warn', refusal: 'lock' }),
+      DETECTION_STAYS_ON_REFUSAL,
       DETECTION_POLICY_INVALID,
-      DETECTION_POLICY_MISSING,
-      DETECTION_POLICY_WRITE_ERROR,
+      DETECTION_ID_INVALID,
+      DETECTION_MISSING,
+      DETECTION_WRITE_ERROR,
     ]);
-    expect(messages.size).toBe(5);
+    expect(messages.size).toBe(7);
   });
 
-  it('the two faults tell the user what to do about them', () => {
+  it('the faults tell the user what to do about them', () => {
     expect(DETECTION_POLICY_INVALID).toMatch(/reload/i);
-    expect(DETECTION_POLICY_MISSING).toMatch(/reload/i);
-    expect(DETECTION_POLICY_WRITE_ERROR).toMatch(/try again/i);
+    expect(DETECTION_ID_INVALID).toMatch(/reload/i);
+    expect(DETECTION_MISSING).toMatch(/reload/i);
+    expect(DETECTION_WRITE_ERROR).toMatch(/try again/i);
   });
 });
 
@@ -106,6 +139,44 @@ class ForeignPolicyFloorError extends Error {
     this.refusal = refusal;
   }
 }
+
+describe('isControlPlaneRefusal', () => {
+  it("reads the store's own refusal, and a copy `instanceof` would miss", () => {
+    // The enable path asks only this question: was this the organization's
+    // decision? It quotes no archetype, so it validates none — and it must
+    // still see the refusal through a second copy of the class, for the same
+    // reason the assignment path does.
+    expect(
+      isControlPlaneRefusal(new PolicyFloorError('aka/pack', 'monitor', 'block', 'floor')),
+    ).toBe(true);
+    const copy = new ForeignPolicyFloorError('warn', 'lock');
+    expect(copy instanceof PolicyFloorError).toBe(false);
+    expect(isControlPlaneRefusal(copy)).toBe(true);
+  });
+
+  it('turns away a genuine store fault', () => {
+    // The other half of the same read. A write that failed for a real reason
+    // must keep the message that tells the user to retry, or every fault would
+    // come out as somebody else's decision.
+    for (const candidate of [
+      null,
+      undefined,
+      'PolicyFloorError',
+      new Error('SQLITE_BUSY: database is locked'),
+      { name: 'ManagedFieldError' },
+    ] as unknown[]) {
+      expect(isControlPlaneRefusal(candidate), JSON.stringify(candidate ?? null)).toBe(false);
+    }
+  });
+
+  it('accepts a refusal carrying no archetype at all', () => {
+    // Deliberately weaker than asPolicyFloorRefusal, and this is the case that
+    // says so: the enable refusal's sentence quotes nothing from the error, so
+    // demanding a floor it never reads would report the organization's decision
+    // as a broken store.
+    expect(isControlPlaneRefusal({ name: 'PolicyFloorError' })).toBe(true);
+  });
+});
 
 describe('asPolicyFloorRefusal', () => {
   it("reads the store's own refusal", () => {

--- a/web-ui/test/pages/detections-client-governed-toggle.test.ts
+++ b/web-ui/test/pages/detections-client-governed-toggle.test.ts
@@ -1,0 +1,124 @@
+// The detections route's own wiring of the enable/disable toggle to the floor.
+//
+// dashboard-ui pins that the pane withholds a switch-off for a detection under
+// a floor, and the page suite pins that the server computes the floor record and
+// hands it down. Neither can see the line that joins them, which lives here in a
+// client component: `policyFloor={floors[detail.id] ?? null}`. It is a lookup,
+// and getting it wrong is quiet — key the record by the wrong id and every
+// toggle comes back live, offering a switch-off the store will refuse.
+//
+// So this renders the component for real and reads the control.
+import type { DetectionPolicyFloor } from '@akasecurity/dashboard-ui';
+import type { DetectionDetail, ListDetectionsResponse } from '@akasecurity/schema';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+// DetectionsClient reaches the router through the shared navigation hook, which
+// throws outside a real Next app. Renders here are static — renderToStaticMarkup
+// runs no effects — so a no-op router is enough: nothing calls it.
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/detections',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}));
+
+const { DetectionsClient } = await import('../../app/(app)/detections/DetectionsClient.tsx');
+const { NavigationTransitionProvider } =
+  await import('../../app/components/NavigationTransition.tsx');
+
+const DETECTION_ID = 'aka/secrets';
+
+const DETAIL: DetectionDetail = {
+  id: DETECTION_ID,
+  name: 'Secrets',
+  version: '1.0.0',
+  enabled: true,
+  origin: 'library',
+  ruleCount: 1,
+  namespace: 'aka',
+  packId: 'secrets',
+  editedAt: '2026-01-01T00:00:00.000Z',
+  findingsLast30d: 0,
+  update: null,
+  modified: false,
+  policyId: 'monitor',
+  rules: [
+    {
+      id: 'secrets/example',
+      name: 'Example',
+      category: 'secret',
+      severity: 'high',
+      matcher: { type: 'keyword', keywords: ['example'], caseSensitive: false },
+    },
+  ],
+};
+
+const LIST: ListDetectionsResponse = {
+  items: [
+    {
+      id: DETECTION_ID,
+      name: 'Secrets',
+      version: '1.0.0',
+      enabled: true,
+      origin: 'library',
+      ruleCount: 1,
+      namespace: 'aka',
+      packId: 'secrets',
+      policyId: 'monitor',
+    },
+  ],
+  counts: { all: 1, library: 1, custom: 0, customized: 0, updates: 0 },
+};
+
+function render(floors: Record<string, DetectionPolicyFloor>): string {
+  return renderToStaticMarkup(
+    createElement(
+      NavigationTransitionProvider,
+      null,
+      createElement(DetectionsClient, {
+        list: LIST,
+        detail: DETAIL,
+        filter: 'all',
+        query: '',
+        selectedId: DETECTION_ID,
+        floors,
+      }),
+    ),
+  );
+}
+
+/** The opening tag of the enable/disable Switch, which renders as a <button>. */
+function switchTag(markup: string): string {
+  const tag = markup
+    .split('<button')
+    .slice(1)
+    .map((chunk) => chunk.slice(0, chunk.indexOf('>')))
+    .find((t) => t.includes('data-slot="switch"'));
+  expect(tag, 'the page rendered no enable/disable switch at all').toBeDefined();
+  return tag ?? '';
+}
+
+describe('the detections client hands the pane the floor for the selected detection', () => {
+  it('withholds the switch-off for a governed detection', () => {
+    const markup = render({ [DETECTION_ID]: { floor: 'warn', locked: false } });
+    expect(switchTag(markup)).toContain('aria-disabled="true"');
+    expect(markup).toContain('data-slot="enabled-locked-reason"');
+  });
+
+  it('leaves it live on a machine nothing manages', () => {
+    // The positive control the assertion above needs: an empty record is what
+    // every install that has not attached sends, and it must reach the pane as
+    // no constraint rather than as one nobody imposed.
+    const markup = render({});
+    expect(switchTag(markup)).not.toContain('aria-disabled');
+    expect(markup).not.toContain('data-slot="enabled-locked-reason"');
+  });
+
+  it("does not borrow another detection's floor", () => {
+    // The lookup is by detection id. Keyed on anything else — the pack id, the
+    // list position — this record would still be non-empty and the toggle would
+    // come out withheld for a detection nobody governs.
+    const markup = render({ 'aka/something-else': { floor: 'block', locked: true } });
+    expect(switchTag(markup)).not.toContain('aria-disabled');
+  });
+});


### PR DESCRIPTION
Follow-up to #385, which made a detection's assigned policy govern vaulting and at-rest masking, and made the control-plane bundle a floor the device cannot write below. This closes the way around that floor.

## The gap

The floor decided **which policy a detection may carry**. It said nothing about **whether the detection runs at all** — and the Enabled toggle writes `installed_packs.enabled` through a path that had no check on it.

Switching a pack off is weaker than every archetype. `installedRuleset()` opens with:

```ts
for (const row of rows) {
  if (!intToBool(row.enabled)) continue;
```

so a disabled pack contributes no rules, no per-rule actions and no reversibility. The floor is expressed as **actions on rules**, so once the rules stop being contributed there is nothing left for it to constrain.

Attached mode does not reliably save it, and the reason is worth stating precisely because it is easy to assume otherwise. The gateway merges `[...local.rules, ...cached.rules]` local-first, so when the organization's cached bundle carries the pack's rules they are re-supplied and `mergeRaiseOnly` still clamps their action — enforcement largely survives. But `rules` is **optional** on `PolicyBundle`. A bundle carrying policies without rules leaves nothing to re-supply and nothing to clamp: the detections stop firing, silently.

So the outcome of one click depended on something the person clicking cannot see.

## What changed

**A pack the control plane names may not be switched off locally.** Re-enabling is always allowed — it moves toward what the organization asked for, never away. A pack the bundle never names is untouched, so this reaches exactly the detections an organization actually speaks for and nothing else. (After #385's narrowing, `floor` is already `null` for anything unmentioned.)

**The guard is at the repository**, beside the one on `setPolicy`, because that is the single device-local write path. A refusal living on the dashboard would leave the CLI and every other local caller free to write whatever they liked.

**The refusal is its own reason**, not a reuse of the two that exist. Both of those describe an *assignment* — `floor` means the archetype asked for is too weak, `lock` means no archetype may be chosen. A switch-off is not an assignment, so reusing `floor` would send someone to a picker they never opened and imply a stronger archetype would satisfy it, and reusing `lock` would claim the organization set this detection's policy when it may only have stated a minimum.

**The toggle says so before it is clicked.** The Server Action was `Promise<void>` and swallowed everything, so a refusal would have reached the user as a toggle silently snapping back — indistinguishable from the defect being fixed. It now returns the same result shape the policy write uses, reading the refusal structurally by `name` rather than `instanceof` across a bundle boundary, and the toggle carries the same unavailable-affordance contract the policy picker already ships.

## Verification

`check:oss-wall` clean over 1892 files · format clean · typecheck + lint 70/70 · `pnpm test:oss` 41/41 · enterprise suite 23/23.

Every new test was confirmed to fail with the guard reverted. Two over-broad mutants were also driven, since the permissive half matters as much as the refusing half: one that refuses re-enables fails 4 cases, one that refuses a disable with no floor fails 13 across four suites.

Pairs with the enterprise PR that bumps the submodule.