### PR TITLE
fix(attached): let a widened bundle shape survive a conditional pull

### DIFF
--- a/packages/plugin-runtime/src/attached/policy-store.ts
+++ b/packages/plugin-runtime/src/attached/policy-store.ts
@@ -83,7 +83,17 @@ export function createPolicyStore(dir: string = dataDir()) {
       // organization's raise-only floor until a sync lands — enforcement lost in
       // order to repair enforcement — and a body missing a field this build
       // understands is still every rule and policy the device had a moment ago.
-      const etag = record.shapeId === POLICY_BUNDLE_SHAPE_ID ? stored : undefined;
+      //
+      // A stamp naming MORE than this build is replayable, not a mismatch. Such
+      // a record was written by a wider build and already carries everything
+      // this one declares, so its validator describes a representation this
+      // build has no reason to refetch — and treating it as a mismatch would
+      // make the narrower build pull the whole bundle unconditionally every
+      // window for the life of the install, which is the cheap-poll-into-full-
+      // transfer cost the transport refuses at length.
+      const replayable =
+        record.shapeId === POLICY_BUNDLE_SHAPE_ID || knowsMoreThanThisBuild(record.shapeId);
+      const etag = replayable ? stored : undefined;
       return { bundle, fetchedAtMs, ...(etag === undefined ? {} : { etag }) };
     } catch {
       // Fail-open: an unreadable or corrupt cache behaves like no cache
@@ -91,15 +101,6 @@ export function createPolicyStore(dir: string = dataDir()) {
     }
   }
 
-  /**
-   * Persist the bundle and the validator that confirmed it.
-   *
-   * `etag` is a second parameter rather than the caller handing over a whole
-   * `StoredPolicyBundle` so that `fetchedAtMs` keeps a single writer here —
-   * every caller stamping its own clock is how two cache entries end up
-   * disagreeing about what "fresh" means. The 304 arm expresses itself by
-   * passing the bundle it already holds back in with the new etag.
-   */
   /**
    * Whether `shapeId` names strictly MORE bundle fields than this build has.
    *
@@ -115,55 +116,25 @@ export function createPolicyStore(dir: string = dataDir()) {
     return theirs.size > ours.length && ours.every((key) => theirs.has(key));
   }
 
-  async function write(bundle: PolicyBundle, etag?: string): Promise<void> {
-    await ensureDataDir(dir);
-    // A build that understands FEWER fields does not get to flatten a record a
-    // wider one wrote.
-    //
-    // One `~/.aka` serves every host plugin on the machine — the data dir has no
-    // per-host segment — and they are separately published packages that upgrade
-    // on their own schedules, so a narrower build sharing this cache is the
-    // ordinary state of a machine during a rollout, not an edge case. Its pull
-    // parses the full body with its own schema, drops what it has never heard
-    // of, and would write that back; the wider build then reads a body missing
-    // a field it does understand and has to spend another pull recovering it,
-    // which the shared sync throttle can hold off for the length of its window.
-    // Two builds then take turns narrowing and repairing the same file.
-    //
-    // Skipping the write outright — rather than writing this bundle under the
-    // older stamp, or keeping the old body with the new validator — is what
-    // keeps the record self-consistent: the stored etag goes on describing the
-    // stored bytes, so the wider build's next pull replays a validator that
-    // still matches what it holds and the control plane answers 200 the moment
-    // there is anything new. Nothing is lost by returning here, because the
-    // caller cannot represent the fields already on disk.
-    //
-    // Two overlapping children can still interleave read and publish. That race
-    // is benign and is not worth a lock: the publish below is atomic, so the
-    // loser's bytes are whole, and a narrowing that does slip through is exactly
-    // what `read` above withholds the validator for.
+  /** The record currently on disk, unvalidated, or null when there is none. */
+  async function priorRecord(): Promise<Record<string, unknown> | null> {
     try {
-      const prior: unknown = JSON.parse(await readFile(file, 'utf8'));
-      if (
-        typeof prior === 'object' &&
-        prior !== null &&
-        knowsMoreThanThisBuild((prior as { shapeId?: unknown }).shapeId)
-      ) {
-        return;
-      }
+      const parsed: unknown = JSON.parse(await readFile(file, 'utf8'));
+      return typeof parsed === 'object' && parsed !== null
+        ? (parsed as Record<string, unknown>)
+        : null;
     } catch {
-      // No cache, or one this build cannot read — either way there is nothing
-      // wider to protect, and the write proceeds.
+      return null;
     }
-    const stored: StoredPolicyBundle = {
-      bundle,
-      fetchedAtMs: Date.now(),
-      // Stamped on EVERY write, the 304 arm's included: that arm hands back the
-      // bundle it already holds, and the point of the stamp is to describe the
-      // build that last narrowed those bytes, which is this one.
-      shapeId: POLICY_BUNDLE_SHAPE_ID,
-      ...(etag === undefined ? {} : { etag }),
-    };
+  }
+
+  /**
+   * Publish one record atomically.
+   *
+   * Shared by both arms of `write` so the tmp-and-rename reasoning below is
+   * stated once and neither arm can drift into a plain overwrite.
+   */
+  async function publishRecord(record: StoredPolicyBundle): Promise<void> {
     // Per-write suffix, not a fixed `${file}.tmp` — the same reasoning as
     // posture-store.ts and forward-policy.ts, which this file was the last in
     // the package not to follow. Two sync children can overlap (the throttle
@@ -180,7 +151,7 @@ export function createPolicyStore(dir: string = dataDir()) {
     const tmp = `${file}.${randomUUID()}.tmp`;
     try {
       // 0600: the policy bundle can carry org-specific rules and custom keywords
-      await writeFile(tmp, JSON.stringify(stored), {
+      await writeFile(tmp, JSON.stringify(record), {
         encoding: 'utf8',
         mode: DATA_FILE_MODE,
         flag: 'wx',
@@ -197,6 +168,74 @@ export function createPolicyStore(dir: string = dataDir()) {
       await rm(tmp, { force: true }).catch(() => undefined);
       throw err;
     }
+  }
+
+  /**
+   * Persist the bundle and the validator that confirmed it.
+   *
+   * `etag` is a second parameter rather than the caller handing over a whole
+   * `StoredPolicyBundle` so that `fetchedAtMs` keeps a single writer here —
+   * every caller stamping its own clock is how two cache entries end up
+   * disagreeing about what "fresh" means. The 304 arm expresses itself by
+   * passing the bundle it already holds back in with the new etag.
+   */
+  async function write(bundle: PolicyBundle, etag?: string): Promise<void> {
+    await ensureDataDir(dir);
+
+    // A build that understands FEWER fields does not get to flatten a record a
+    // wider one wrote.
+    //
+    // One `~/.aka` serves every host plugin on the machine — the data dir has no
+    // per-host segment — and they are separately published packages that upgrade
+    // on their own schedules, so a narrower build sharing this cache is the
+    // ordinary state of a machine during a rollout, not an edge case. Its pull
+    // parses the full body with its own schema, drops what it has never heard
+    // of, and would write that back; the wider build would then have to spend
+    // another pull recovering a field it does understand, which the shared sync
+    // throttle can hold off for a whole window. Two builds would take turns
+    // narrowing and repairing one file.
+    //
+    // Two overlapping children can still interleave this read and the publish.
+    // That race is benign and is not worth a lock: the publish is atomic, so the
+    // loser's bytes are whole, and a narrowing that does slip through is exactly
+    // what `read` withholds the validator for.
+    const prior = await priorRecord();
+    if (prior !== null && knowsMoreThanThisBuild(prior.shapeId)) {
+      // The wider body STAYS. What still advances is freshness, and only when
+      // the representation is the one this pull just confirmed: an equal
+      // `version` means the bytes already on disk ARE what this validator
+      // describes, so pairing them is self-consistent rather than the stale
+      // body under a fresh tag that would strand the wider build on a 304.
+      //
+      // Without this the record is never rewritten at all, and `fetchedAtMs`
+      // freezes the moment the wider plugin is removed — status would render an
+      // ever-growing "fetched N ago" and the posture report would tell the
+      // control plane the device had stopped syncing while it was in fact
+      // syncing successfully every window.
+      //
+      // When the versions differ the prior etag is stale anyway and pairing it
+      // with the old body would be exactly that mistake, so nothing is written
+      // and the wider build's own conditional pull repairs it.
+      const priorVersion = (prior.bundle as { version?: unknown } | undefined)?.version;
+      if (priorVersion === bundle.version) {
+        await publishRecord({
+          ...(prior as unknown as StoredPolicyBundle),
+          fetchedAtMs: Date.now(),
+          ...(etag === undefined ? {} : { etag }),
+        });
+      }
+      return;
+    }
+
+    await publishRecord({
+      bundle,
+      fetchedAtMs: Date.now(),
+      // Stamped on EVERY write, the 304 arm's included: that arm hands back the
+      // bundle it already holds, and the point of the stamp is to describe the
+      // build that last narrowed those bytes, which is this one.
+      shapeId: POLICY_BUNDLE_SHAPE_ID,
+      ...(etag === undefined ? {} : { etag }),
+    });
   }
 
   return { read, write, file };

--- a/packages/plugin-runtime/src/attached/policy-store.ts
+++ b/packages/plugin-runtime/src/attached/policy-store.ts
@@ -111,9 +111,13 @@ export function createPolicyStore(dir: string = dataDir()) {
    */
   function knowsMoreThanThisBuild(shapeId: unknown): boolean {
     if (typeof shapeId !== 'string' || shapeId === '') return false;
+    // Both sides as SETS. The derivation cannot produce a duplicate today —
+    // the top-level keys are unprefixed and the nested ones are prefixed — so a
+    // size-against-length comparison happens to be right, and would stop being
+    // right on a derivation change that was not otherwise wrong.
     const theirs = new Set(shapeId.split(','));
-    const ours = POLICY_BUNDLE_SHAPE_ID.split(',');
-    return theirs.size > ours.length && ours.every((key) => theirs.has(key));
+    const ours = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
+    return theirs.size > ours.size && [...ours].every((key) => theirs.has(key));
   }
 
   /** The record currently on disk, unvalidated, or null when there is none. */

--- a/packages/plugin-runtime/src/attached/policy-store.ts
+++ b/packages/plugin-runtime/src/attached/policy-store.ts
@@ -3,7 +3,7 @@ import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import { DATA_FILE_MODE, dataDir, ensureDataDir } from '@akasecurity/plugin-sdk';
-import { PolicyBundle } from '@akasecurity/schema';
+import { POLICY_BUNDLE_SHAPE_ID, PolicyBundle } from '@akasecurity/schema';
 
 import { publishByRename } from './atomic-publish.ts';
 
@@ -25,6 +25,16 @@ export interface StoredPolicyBundle {
    * stays tolerant of that two-member shape rather than failing closed on it.
    */
   etag?: string;
+  /**
+   * Which bundle fields the build that wrote this record understood, as
+   * `POLICY_BUNDLE_SHAPE_ID` reported them.
+   *
+   * Optional because a record written before this was stamped carries none —
+   * which reads as a mismatch, so every cache already on disk gives up its
+   * validator once and is refilled in full. That is the repair, not a
+   * concession to it.
+   */
+  shapeId?: string;
 }
 
 /**
@@ -43,13 +53,37 @@ export function createPolicyStore(dir: string = dataDir()) {
       const raw = await readFile(file, 'utf8');
       const parsed: unknown = JSON.parse(raw);
       if (typeof parsed !== 'object' || parsed === null) return null;
-      const record = parsed as { bundle?: unknown; fetchedAtMs?: unknown; etag?: unknown };
+      const record = parsed as {
+        bundle?: unknown;
+        fetchedAtMs?: unknown;
+        etag?: unknown;
+        shapeId?: unknown;
+      };
       const bundle = PolicyBundle.parse(record.bundle);
       const fetchedAtMs = typeof record.fetchedAtMs === 'number' ? record.fetchedAtMs : 0;
       // Tolerant, not strict: a pre-B3 cache has no etag and must still be
       // usable. Omitting the key rather than storing `undefined` is what
       // exactOptionalPropertyTypes wants.
-      const etag = typeof record.etag === 'string' ? record.etag : undefined;
+      const stored = typeof record.etag === 'string' ? record.etag : undefined;
+      // The VALIDATOR is dropped — and only the validator — when this record was
+      // written by a build that understood a different set of bundle fields.
+      //
+      // `PolicyBundle.parse` above strips any key this build does not declare,
+      // so a record an older build wrote is missing whatever that build had
+      // never heard of, while still carrying the `version` of a representation
+      // that carried it. Replaying that etag earns a 304, and the sync's
+      // not-modified arm rewrites the same narrowed body with a fresh validator
+      // — so the absent field can never arrive, and upgrading the plugin does
+      // not help, because the etag still matches. Handing the puller no
+      // validator makes the next request unconditional, and the control plane
+      // answers it with the whole bundle, which this build parses with the
+      // fields it does know about.
+      //
+      // The BUNDLE itself is kept. Returning null here instead would drop the
+      // organization's raise-only floor until a sync lands — enforcement lost in
+      // order to repair enforcement — and a body missing a field this build
+      // understands is still every rule and policy the device had a moment ago.
+      const etag = record.shapeId === POLICY_BUNDLE_SHAPE_ID ? stored : undefined;
       return { bundle, fetchedAtMs, ...(etag === undefined ? {} : { etag }) };
     } catch {
       // Fail-open: an unreadable or corrupt cache behaves like no cache
@@ -66,11 +100,68 @@ export function createPolicyStore(dir: string = dataDir()) {
    * disagreeing about what "fresh" means. The 304 arm expresses itself by
    * passing the bundle it already holds back in with the new etag.
    */
+  /**
+   * Whether `shapeId` names strictly MORE bundle fields than this build has.
+   *
+   * `POLICY_BUNDLE_SHAPE_ID` is a sorted comma-joined key list, so this is a set
+   * comparison. An absent, empty or unrecognisable stamp is deliberately NOT a
+   * superset: those are the records the shape check exists to replace, and
+   * treating them as wider would freeze every cache written before stamping.
+   */
+  function knowsMoreThanThisBuild(shapeId: unknown): boolean {
+    if (typeof shapeId !== 'string' || shapeId === '') return false;
+    const theirs = new Set(shapeId.split(','));
+    const ours = POLICY_BUNDLE_SHAPE_ID.split(',');
+    return theirs.size > ours.length && ours.every((key) => theirs.has(key));
+  }
+
   async function write(bundle: PolicyBundle, etag?: string): Promise<void> {
     await ensureDataDir(dir);
+    // A build that understands FEWER fields does not get to flatten a record a
+    // wider one wrote.
+    //
+    // One `~/.aka` serves every host plugin on the machine — the data dir has no
+    // per-host segment — and they are separately published packages that upgrade
+    // on their own schedules, so a narrower build sharing this cache is the
+    // ordinary state of a machine during a rollout, not an edge case. Its pull
+    // parses the full body with its own schema, drops what it has never heard
+    // of, and would write that back; the wider build then reads a body missing
+    // a field it does understand and has to spend another pull recovering it,
+    // which the shared sync throttle can hold off for the length of its window.
+    // Two builds then take turns narrowing and repairing the same file.
+    //
+    // Skipping the write outright — rather than writing this bundle under the
+    // older stamp, or keeping the old body with the new validator — is what
+    // keeps the record self-consistent: the stored etag goes on describing the
+    // stored bytes, so the wider build's next pull replays a validator that
+    // still matches what it holds and the control plane answers 200 the moment
+    // there is anything new. Nothing is lost by returning here, because the
+    // caller cannot represent the fields already on disk.
+    //
+    // Two overlapping children can still interleave read and publish. That race
+    // is benign and is not worth a lock: the publish below is atomic, so the
+    // loser's bytes are whole, and a narrowing that does slip through is exactly
+    // what `read` above withholds the validator for.
+    try {
+      const prior: unknown = JSON.parse(await readFile(file, 'utf8'));
+      if (
+        typeof prior === 'object' &&
+        prior !== null &&
+        knowsMoreThanThisBuild((prior as { shapeId?: unknown }).shapeId)
+      ) {
+        return;
+      }
+    } catch {
+      // No cache, or one this build cannot read — either way there is nothing
+      // wider to protect, and the write proceeds.
+    }
     const stored: StoredPolicyBundle = {
       bundle,
       fetchedAtMs: Date.now(),
+      // Stamped on EVERY write, the 304 arm's included: that arm hands back the
+      // bundle it already holds, and the point of the stamp is to describe the
+      // build that last narrowed those bytes, which is this one.
+      shapeId: POLICY_BUNDLE_SHAPE_ID,
       ...(etag === undefined ? {} : { etag }),
     };
     // Per-write suffix, not a fixed `${file}.tmp` — the same reasoning as

--- a/packages/plugin-runtime/src/attached/policy-store.ts
+++ b/packages/plugin-runtime/src/attached/policy-store.ts
@@ -196,36 +196,52 @@ export function createPolicyStore(dir: string = dataDir()) {
     // narrowing and repairing one file.
     //
     // Two overlapping children can still interleave this read and the publish.
-    // That race is benign and is not worth a lock: the publish is atomic, so the
-    // loser's bytes are whole, and a narrowing that does slip through is exactly
-    // what `read` withholds the validator for.
+    // That race is benign and is not worth a lock. What can slip through is a
+    // LOST UPDATE rather than a narrowing — the branch below republishes a
+    // record read a moment earlier, so a wider build's newer record can be
+    // clobbered by an older one CARRYING THE WIDER STAMP, which `read` will
+    // therefore not withhold a validator for. It still converges: the pair it
+    // republishes is internally consistent, so the wider build's next
+    // conditional pull answers 200 and rewrites it.
     const prior = await priorRecord();
-    if (prior !== null && knowsMoreThanThisBuild(prior.shapeId)) {
-      // The wider body STAYS. What still advances is freshness, and only when
-      // the representation is the one this pull just confirmed: an equal
-      // `version` means the bytes already on disk ARE what this validator
-      // describes, so pairing them is self-consistent rather than the stale
-      // body under a fresh tag that would strand the wider build on a 304.
+    const priorVersion = (prior?.bundle as { version?: unknown } | undefined)?.version;
+    if (
+      prior !== null &&
+      knowsMoreThanThisBuild(prior.shapeId) &&
+      priorVersion === bundle.version
+    ) {
+      // SAME VERSION, wider body: flattening it would destroy fields this build
+      // cannot even name, to land bytes the device already has. So the body and
+      // the stamp both stay, and only freshness moves.
       //
-      // Without this the record is never rewritten at all, and `fetchedAtMs`
-      // freezes the moment the wider plugin is removed — status would render an
-      // ever-growing "fetched N ago" and the posture report would tell the
-      // control plane the device had stopped syncing while it was in fact
-      // syncing successfully every window.
+      // Freshness has to move, because `fetchedAtMs` advances nowhere else. Left
+      // frozen, status renders an ever-growing "fetched N ago" and the posture
+      // report tells the control plane the device stopped syncing while it is in
+      // fact syncing successfully every window.
       //
-      // When the versions differ the prior etag is stale anyway and pairing it
-      // with the old body would be exactly that mistake, so nothing is written
-      // and the wider build's own conditional pull repairs it.
-      const priorVersion = (prior.bundle as { version?: unknown } | undefined)?.version;
-      if (priorVersion === bundle.version) {
-        await publishRecord({
-          ...(prior as unknown as StoredPolicyBundle),
-          fetchedAtMs: Date.now(),
-          ...(etag === undefined ? {} : { etag }),
-        });
-      }
+      // The VALIDATOR is deliberately not adopted. Pairing bytes with an etag
+      // this build never held for them would rest on the control plane bumping
+      // `version` for every representation it serves — true of the deployment
+      // this ships against, and not a property this package owns or can check.
+      // Keeping the etag already on disk costs at most one conditional round
+      // trip and assumes nothing.
+      await publishRecord({
+        ...(prior as unknown as StoredPolicyBundle),
+        fetchedAtMs: Date.now(),
+      });
       return;
     }
+
+    // A DIFFERENT version falls through and is written, narrowed. That is the
+    // whole point of scoping the guard to an equal version: the organization has
+    // published a new policy, and a device that refuses to adopt it because it
+    // cannot represent one field of the old one is worse off than one that adopts
+    // it narrowed. Declining here instead would deadlock — `read` hands the wider
+    // record's validator back on the next pass, the pull returns the same 200,
+    // and the write declines again, every window, forever, while `pullPolicyBundle`
+    // reports `ok`. Writing it stamps THIS build's narrower shape, which is
+    // exactly what makes the wider build's next read withhold its validator and
+    // restore the fields in one unconditional pull.
 
     await publishRecord({
       bundle,

--- a/packages/plugin-runtime/src/attached/policy-store.ts
+++ b/packages/plugin-runtime/src/attached/policy-store.ts
@@ -227,8 +227,12 @@ export function createPolicyStore(dir: string = dataDir()) {
       // this build never held for them would rest on the control plane bumping
       // `version` for every representation it serves — true of the deployment
       // this ships against, and not a property this package owns or can check.
-      // Keeping the etag already on disk costs at most one conditional round
-      // trip and assumes nothing.
+      // Keeping the etag already on disk assumes nothing. It costs a full
+      // transfer per window rather than one round trip, because nothing on this
+      // path ever advances the stored validator — but that only happens where
+      // the plane serves a changed representation under an unchanged `version`,
+      // which is precisely the case adopting the etag would answer by stranding
+      // the wider build on a 304 against bytes the server has moved past.
       await publishRecord({
         ...(prior as unknown as StoredPolicyBundle),
         fetchedAtMs: Date.now(),

--- a/packages/plugin-runtime/test/attached/policy-store.test.ts
+++ b/packages/plugin-runtime/test/attached/policy-store.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, readdir, stat, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type { Policy, PolicyBundle } from '@akasecurity/schema';
+import { POLICY_BUNDLE_SHAPE_ID } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
 import { createPolicyStore } from '../../src/attached/policy-store.ts';
@@ -138,5 +139,148 @@ describe('the policy cache publishes atomically', () => {
     const got = await store.read();
     expect(got?.bundle.policies).toHaveLength(1);
     expect(got?.bundle.policies[0]?.provenance).toBeUndefined();
+  });
+});
+
+// The cache is the only copy of the organization's decisions a hook ever reads,
+// and `PolicyBundle.parse` narrows it to the fields THIS build declares. A
+// record an older build wrote is therefore missing whatever that build had
+// never heard of, while still carrying the `version` of a representation that
+// carried it — so replaying its validator earns a 304 forever and the missing
+// field can never arrive. The stamp is what separates a device that recovers a
+// governance decision from one that is told "nothing has changed" for the life
+// of the install.
+describe('the policy cache records which bundle shape wrote it', () => {
+  const CACHE = 'policy-cache.json';
+
+  async function restamp(d: string, shapeId: string | undefined): Promise<void> {
+    const file = join(d, CACHE);
+    const record = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    if (shapeId === undefined) delete record.shapeId;
+    else record.shapeId = shapeId;
+    await writeFile(file, JSON.stringify(record), 'utf8');
+  }
+
+  it('stamps every write with the shape this build understands', async () => {
+    const d = await dir();
+    await createPolicyStore(d).write(bundle('v1'), 'W/"e"');
+    const record = JSON.parse(await readFile(join(d, CACHE), 'utf8')) as Record<string, unknown>;
+    expect(record.shapeId).toBe(POLICY_BUNDLE_SHAPE_ID);
+  });
+
+  it("replays the validator when the stamp is this build's", async () => {
+    // The positive control, and it is load-bearing: without it every assertion
+    // below is satisfied by a read() that returns no etag at all, which would
+    // cost each device a full bundle download on every single poll.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"e"');
+    expect((await store.read())?.etag).toBe('W/"e"');
+  });
+
+  it("withholds the validator when the stamp is another build's", async () => {
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"e"');
+    await restamp(d, 'customKeywords,fetchedAt,policies,version');
+    expect((await store.read())?.etag).toBeUndefined();
+  });
+
+  it('withholds the validator when there is no stamp at all', async () => {
+    // Every cache written before the stamp existed looks like this, and those
+    // are the ones actually on disk. An absent stamp has to read as a mismatch
+    // or none of them is ever repaired.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"e"');
+    await restamp(d, undefined);
+    expect((await store.read())?.etag).toBeUndefined();
+  });
+
+  it('keeps the BUNDLE whatever the stamp says', async () => {
+    // Only the validator is withheld. Returning null instead would take the
+    // organization's raise-only floor with it until a sync lands — enforcement
+    // lost in order to repair enforcement.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(authored('v1'), 'W/"e"');
+    await restamp(d, 'a-shape-this-build-does-not-have');
+    const got = await store.read();
+    expect(got?.bundle.version).toBe('v1');
+    expect(got?.bundle.policies[0]?.provenance).toBe('authored');
+  });
+});
+
+// One ~/.aka serves every host plugin on the machine, and they are separately
+// published packages that upgrade on their own schedules — so during a rollout a
+// build that understands fewer bundle fields is routinely sharing this cache
+// with one that understands more. The read check above repairs a narrowed
+// record; this is what stops the narrowing from being written in the first
+// place, so the two builds do not take turns flattening and repairing the file.
+describe('a narrower build does not flatten a wider record', () => {
+  const CACHE = 'policy-cache.json';
+
+  // This build's own key set plus one it has never heard of: what a LATER
+  // build's stamp looks like from here.
+  const WIDER = [...POLICY_BUNDLE_SHAPE_ID.split(','), 'zzzFutureField'].sort().join(',');
+
+  async function record(d: string): Promise<Record<string, unknown>> {
+    return JSON.parse(await readFile(join(d, CACHE), 'utf8')) as Record<string, unknown>;
+  }
+
+  async function restamp(d: string, shapeId: string): Promise<void> {
+    const file = join(d, CACHE);
+    const r = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    r.shapeId = shapeId;
+    await writeFile(file, JSON.stringify(r), 'utf8');
+  }
+
+  it('leaves a record stamped by a build that knows MORE fields alone', async () => {
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('wide'), 'W/"wide"');
+    await restamp(d, WIDER);
+
+    await store.write(bundle('narrowed'), 'W/"narrowed"');
+
+    const got = await record(d);
+    expect((got.bundle as { version: string }).version, 'the wider body survived').toBe('wide');
+    expect(got.shapeId, "and so did the wider build's stamp").toBe(WIDER);
+    expect(got.etag, 'the validator still describes the body beside it').toBe('W/"wide"');
+  });
+
+  it('still replaces a record with NO stamp — the repair must keep working', async () => {
+    // The control that keeps the guard from swallowing its own fix. Every cache
+    // written before stamping has no shapeId, and an absent stamp is not a
+    // superset of anything.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"e1"');
+    const file = join(d, CACHE);
+    const r = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    delete r.shapeId;
+    await writeFile(file, JSON.stringify(r), 'utf8');
+
+    await store.write(bundle('v2'), 'W/"e2"');
+    expect((await store.read())?.bundle.version).toBe('v2');
+  });
+
+  it('replaces a record stamped by a build that knows FEWER fields', async () => {
+    // The repair direction: a wider build overwrites what a narrower one left.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('narrow'), 'W/"e1"');
+    await restamp(d, 'customKeywords,fetchedAt,policies,version');
+
+    await store.write(bundle('wide'), 'W/"e2"');
+    expect((await store.read())?.bundle.version).toBe('wide');
+  });
+
+  it('replaces a record stamped by this same build', async () => {
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"e1"');
+    await store.write(bundle('v2'), 'W/"e2"');
+    expect((await store.read())?.bundle.version).toBe('v2');
   });
 });

--- a/packages/plugin-runtime/test/attached/policy-store.test.ts
+++ b/packages/plugin-runtime/test/attached/policy-store.test.ts
@@ -236,12 +236,14 @@ describe('a narrower build does not flatten a wider record', () => {
   }
 
   it('leaves a record stamped by a build that knows MORE fields alone', async () => {
+    // Same version on both sides: flattening would destroy fields this build
+    // cannot name in order to land bytes the device already has.
     const d = await dir();
     const store = createPolicyStore(d);
     await store.write(bundle('wide'), 'W/"wide"');
     await restamp(d, WIDER);
 
-    await store.write(bundle('narrowed'), 'W/"narrowed"');
+    await store.write(bundle('wide'), 'W/"narrowed"');
 
     const got = await record(d);
     expect((got.bundle as { version: string }).version, 'the wider body survived').toBe('wide');
@@ -318,32 +320,48 @@ describe('a narrower build stays a good citizen of a wider record', () => {
     expect((await store.read())?.etag).toBe('W/"wide"');
   });
 
-  it('advances freshness when the version it fetched is the one on disk', async () => {
-    // The wider body stays and the record still moves: an equal `version` means
-    // the bytes on disk ARE what this validator describes. Without it
-    // `fetchedAtMs` freezes the moment the wider plugin is removed, and the
-    // device reports itself as having stopped syncing while it is syncing.
+  it('advances freshness, keeps the wider body, and adopts NO new validator', async () => {
+    // The wider record carries a field this build does not declare. Without it
+    // the "body stays" assertion is true by construction — prior and incoming
+    // would be the same bundle — and flattening would pass the case.
     const d = await dir();
     const store = createPolicyStore(d);
     await store.write(bundle('same'), 'W/"old"');
-    await restamp(d, WIDER);
+    const file = join(d, CACHE);
+    {
+      const r = JSON.parse(await readFile(file, 'utf8')) as {
+        shapeId: string;
+        bundle: Record<string, unknown>;
+      };
+      r.shapeId = WIDER;
+      r.bundle.zzzFutureField = 'only the wider build understands this';
+      await writeFile(file, JSON.stringify(r), 'utf8');
+    }
     const before = (await record(d)).fetchedAtMs as number;
     await new Promise((r) => setTimeout(r, 2));
 
     await store.write(bundle('same'), 'W/"new"');
 
     const after = await record(d);
+    expect(
+      (after.bundle as Record<string, unknown>).zzzFutureField,
+      'the field only the wider build understands survived',
+    ).toBe('only the wider build understands this');
     expect(after.shapeId, "the wider build's stamp is untouched").toBe(WIDER);
-    expect((after.bundle as { version: string }).version, 'the wider body stays').toBe('same');
-    expect(after.etag, 'the confirmed validator is adopted').toBe('W/"new"');
     expect(after.fetchedAtMs as number, 'freshness advanced').toBeGreaterThan(before);
+    // Not adopted: pairing these bytes with a validator this build never held
+    // for them would rest on the plane bumping `version` for every
+    // representation it serves, which this package cannot check.
+    expect(after.etag, 'the validator already on disk is kept').toBe('W/"old"');
   });
 
-  it('writes NOTHING when the version it fetched differs from the one on disk', async () => {
-    // Pairing a stale body with a fresh validator is the one mistake that would
-    // strand the wider build on a 304 against bytes the server has moved past.
-    // Leaving the record alone keeps it self-consistent, and the wider build's
-    // own conditional pull repairs it.
+  it('WRITES a different version through, narrowed, rather than deadlocking', async () => {
+    // The organization published a new policy. Declining because this build
+    // cannot represent one field of the OLD one would strand the device: `read`
+    // hands the wider validator back next pass, the pull returns the same 200,
+    // and the write declines again every window, forever, while the sync
+    // reports `ok`. Adopting it narrowed is strictly better — and the narrower
+    // stamp is what makes the wider build restore its own fields next pull.
     const d = await dir();
     const store = createPolicyStore(d);
     await store.write(bundle('old'), 'W/"old"');
@@ -352,7 +370,10 @@ describe('a narrower build stays a good citizen of a wider record', () => {
     await store.write(bundle('new'), 'W/"new"');
 
     const after = await record(d);
-    expect((after.bundle as { version: string }).version).toBe('old');
-    expect(after.etag, 'still describes the body beside it').toBe('W/"old"');
+    expect((after.bundle as { version: string }).version, 'the new policy landed').toBe('new');
+    expect(after.shapeId, "stamped with THIS build's shape, so the wider one refetches").toBe(
+      POLICY_BUNDLE_SHAPE_ID,
+    );
+    expect(after.etag).toBe('W/"new"');
   });
 });

--- a/packages/plugin-runtime/test/attached/policy-store.test.ts
+++ b/packages/plugin-runtime/test/attached/policy-store.test.ts
@@ -284,3 +284,75 @@ describe('a narrower build does not flatten a wider record', () => {
     expect((await store.read())?.bundle.version).toBe('v2');
   });
 });
+
+// Declining to narrow a record is only half the answer. The narrower build runs
+// every window for the life of the install, so what it does on the way past
+// decides whether the device keeps polling cheaply and keeps reporting itself
+// as alive — or downloads the whole bundle forever while its console says it
+// stopped syncing.
+describe('a narrower build stays a good citizen of a wider record', () => {
+  const CACHE = 'policy-cache.json';
+  const WIDER = [...POLICY_BUNDLE_SHAPE_ID.split(','), 'zzzFutureField'].sort().join(',');
+
+  async function record(d: string): Promise<Record<string, unknown>> {
+    return JSON.parse(await readFile(join(d, CACHE), 'utf8')) as Record<string, unknown>;
+  }
+
+  async function restamp(d: string, shapeId: string): Promise<void> {
+    const file = join(d, CACHE);
+    const r = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    r.shapeId = shapeId;
+    await writeFile(file, JSON.stringify(r), 'utf8');
+  }
+
+  it('REPLAYS the validator of a record that knows more than it does', async () => {
+    // Without this the narrower build sends no If-None-Match every window and
+    // the control plane answers with the whole bundle each time — the cheap
+    // poll turned into a scheduled full transfer. A wider record already
+    // carries everything this build declares, so its validator is one this
+    // build has no reason to refetch against.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('v1'), 'W/"wide"');
+    await restamp(d, WIDER);
+    expect((await store.read())?.etag).toBe('W/"wide"');
+  });
+
+  it('advances freshness when the version it fetched is the one on disk', async () => {
+    // The wider body stays and the record still moves: an equal `version` means
+    // the bytes on disk ARE what this validator describes. Without it
+    // `fetchedAtMs` freezes the moment the wider plugin is removed, and the
+    // device reports itself as having stopped syncing while it is syncing.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('same'), 'W/"old"');
+    await restamp(d, WIDER);
+    const before = (await record(d)).fetchedAtMs as number;
+    await new Promise((r) => setTimeout(r, 2));
+
+    await store.write(bundle('same'), 'W/"new"');
+
+    const after = await record(d);
+    expect(after.shapeId, "the wider build's stamp is untouched").toBe(WIDER);
+    expect((after.bundle as { version: string }).version, 'the wider body stays').toBe('same');
+    expect(after.etag, 'the confirmed validator is adopted').toBe('W/"new"');
+    expect(after.fetchedAtMs as number, 'freshness advanced').toBeGreaterThan(before);
+  });
+
+  it('writes NOTHING when the version it fetched differs from the one on disk', async () => {
+    // Pairing a stale body with a fresh validator is the one mistake that would
+    // strand the wider build on a 304 against bytes the server has moved past.
+    // Leaving the record alone keeps it self-consistent, and the wider build's
+    // own conditional pull repairs it.
+    const d = await dir();
+    const store = createPolicyStore(d);
+    await store.write(bundle('old'), 'W/"old"');
+    await restamp(d, WIDER);
+
+    await store.write(bundle('new'), 'W/"new"');
+
+    const after = await record(d);
+    expect((after.bundle as { version: string }).version).toBe('old');
+    expect(after.etag, 'still describes the body beside it').toBe('W/"old"');
+  });
+});

--- a/packages/plugin-runtime/test/attached/policy-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/policy-sync.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -115,6 +115,40 @@ describe('pullPolicyBundle', () => {
     await pullPolicyBundle({ connection: CONNECTION, credential: CREDENTIAL, store });
 
     expect(getPolicyBundle).toHaveBeenCalledWith('W/"aaa"');
+  });
+
+  it('sends NO validator when the cache was written by a different bundle shape', async () => {
+    // The gap this closes, end to end. `PolicyBundle.parse` strips a key this
+    // build does not declare, so a body cached by an older build is missing
+    // whatever that build had never heard of — while carrying the `version` of
+    // a representation that HAD it. Replaying that validator earns a 304, and
+    // the arm below rewrites the same narrowed bytes with a fresh tag, so the
+    // absent field can never arrive however long the device polls. Upgrading
+    // the plugin does not help either: the etag still matches.
+    //
+    // Reached in the field by adding a field to PolicyBundle — a governance
+    // decision the control plane was serving and no attached device could see.
+    const store = createPolicyStore(dataDir);
+    await store.write(bundle('v1'), 'W/"stale"');
+    const file = join(dataDir, 'policy-cache.json');
+    const record = JSON.parse(readFileSync(file, 'utf8')) as Record<string, unknown>;
+    record.shapeId = 'customKeywords,fetchedAt,policies,version';
+    writeFileSync(file, JSON.stringify(record), 'utf8');
+
+    getPolicyBundle.mockResolvedValue({
+      changed: true,
+      bundle: bundle('v2'),
+      etag: 'W/"fresh"',
+    });
+
+    await expect(
+      pullPolicyBundle({ connection: CONNECTION, credential: CREDENTIAL, store }),
+    ).resolves.toBe('ok');
+
+    expect(getPolicyBundle, 'the stale validator is not replayed').toHaveBeenCalledWith(undefined);
+    const after = await store.read();
+    expect(after?.bundle.version, 'the full body replaced the narrowed one').toBe('v2');
+    expect(after?.etag, 're-stamped, so the very next pull is conditional again').toBe('W/"fresh"');
   });
 
   it('sends no validator when there is no cache', async () => {

--- a/packages/schema/src/zod/policy.ts
+++ b/packages/schema/src/zod/policy.ts
@@ -158,11 +158,30 @@ export type PolicyBundle = z.infer<typeof PolicyBundle>;
  * narrowed, and pay a single unconditional refetch instead of being told
  * forever that nothing has changed.
  *
- * Keys, not their types. Fields here get ADDED; a field renamed to nothing or
- * retyped under an unchanged name is not a case this separates, and claiming
- * otherwise would make it read as a schema checksum, which it is not.
+ * NESTED KEYS ARE INCLUDED, and the top level alone would not have been enough.
+ * `Policy` and `ExceptionBundleEntry` are plain objects, so Zod narrows them
+ * exactly as it narrows the bundle — while `policies` and `exceptions` stay one
+ * unchanged key each. A build that widens `Policy` therefore moves no top-level
+ * key, its stamp reads as a match, and the same 304 replays the same narrowed
+ * policies: the identical trap one level down. `Policy.provenance` is the
+ * worked example, and it decides whether a device may locally re-assign a rule
+ * the deployment has authored.
+ *
+ * `Rule` is deliberately absent. It is a `strictObject`, so a widened rule
+ * fails the parse outright instead of being narrowed in silence — a loud
+ * failure needs no stamp to detect it.
+ *
+ * Keys, not their types. Fields here get ADDED; a field retyped under an
+ * unchanged name at a depth this does not walk is not a case it separates, and
+ * claiming otherwise would make it read as a schema checksum, which it is not.
  */
-export const POLICY_BUNDLE_SHAPE_ID: string = Object.keys(PolicyBundle.shape).sort().join(',');
+export const POLICY_BUNDLE_SHAPE_ID: string = [
+  ...Object.keys(PolicyBundle.shape),
+  ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
+  ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
+]
+  .sort()
+  .join(',');
 
 // Enforcement-coverage denominators use this, NOT DEFAULT_ACTIONS: 'config'
 // findings only observe (see above), so a config policy can never be "covered"

--- a/packages/schema/src/zod/policy.ts
+++ b/packages/schema/src/zod/policy.ts
@@ -138,6 +138,32 @@ export const PolicyBundle = z
   .meta({ id: 'PolicyBundle' });
 export type PolicyBundle = z.infer<typeof PolicyBundle>;
 
+/**
+ * Which bundle fields THIS build understands, as one stable string.
+ *
+ * Derived from the schema's own keys rather than written by hand. A field added
+ * above moves this value with no second edit, which is the entire point: a
+ * constant somebody has to remember to bump goes stale on exactly the commit
+ * that widened the shape, which is the one commit where it has to be right.
+ *
+ * It exists because "an older on-disk cache still parses" — said of every
+ * optional field above — is only half of what an older cache does. Zod drops a
+ * key the schema does not declare, so a body cached by a build that predated a
+ * field is missing it, while still carrying the `version` of a served
+ * representation that HAD it. The bundle is fetched conditionally, so the
+ * control plane answers every later poll with 304 Not Modified and the reader
+ * is handed back the same narrowed body: the field can never arrive, however
+ * often the device polls and however new the plugin gets. Stamping the cache
+ * lets a reader tell a body its own build produced from one an older build
+ * narrowed, and pay a single unconditional refetch instead of being told
+ * forever that nothing has changed.
+ *
+ * Keys, not their types. Fields here get ADDED; a field renamed to nothing or
+ * retyped under an unchanged name is not a case this separates, and claiming
+ * otherwise would make it read as a schema checksum, which it is not.
+ */
+export const POLICY_BUNDLE_SHAPE_ID: string = Object.keys(PolicyBundle.shape).sort().join(',');
+
 // Enforcement-coverage denominators use this, NOT DEFAULT_ACTIONS: 'config'
 // findings only observe (see above), so a config policy can never be "covered"
 // by enforcement and would permanently drag the coverage % down. Derived by

--- a/packages/schema/src/zod/policy.ts
+++ b/packages/schema/src/zod/policy.ts
@@ -167,6 +167,13 @@ export type PolicyBundle = z.infer<typeof PolicyBundle>;
  * worked example, and it decides whether a device may locally re-assign a rule
  * the deployment has authored.
  *
+ * `PolicyTarget` is walked through its UNION MEMBERS for the same reason, and
+ * it is the easiest of the three to overlook: `policies.target` is one key
+ * whatever the target holds, so widening either member moves nothing the other
+ * walks see. The comment above this schema records that a `{ packId }` variant
+ * was considered and expressed as per-rule policies instead — the kind of
+ * decision that gets revisited, which is exactly when this would matter.
+ *
  * `Rule` is deliberately absent. It is a `strictObject`, so a widened rule
  * fails the parse outright instead of being narrowed in silence — a loud
  * failure needs no stamp to detect it.
@@ -178,6 +185,9 @@ export type PolicyBundle = z.infer<typeof PolicyBundle>;
 export const POLICY_BUNDLE_SHAPE_ID: string = [
   ...Object.keys(PolicyBundle.shape),
   ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
+  ...PolicyTarget.options
+    .flatMap((member) => Object.keys(member.shape))
+    .map((key) => `policies.target.${key}`),
   ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
 ]
   .sort()

--- a/packages/schema/src/zod/policy.ts
+++ b/packages/schema/src/zod/policy.ts
@@ -186,7 +186,13 @@ export const POLICY_BUNDLE_SHAPE_ID: string = [
   ...Object.keys(PolicyBundle.shape),
   ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
   ...PolicyTarget.options
-    .flatMap((member) => Object.keys(member.shape))
+    // `shape` GUARDED, and the guard is the load-bearing half. This expression
+    // runs at module load in a package every hook script bundles, so a union
+    // member that is not a plain object would not merely go unstamped — it
+    // would throw on import and take every hook with it, which is the one thing
+    // this plugin may never do. A non-object member contributes nothing here
+    // and is a deliberate gap for whoever adds one to close.
+    .flatMap((member) => ('shape' in member ? Object.keys(member.shape) : []))
     .map((key) => `policies.target.${key}`),
   ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
 ]

--- a/packages/schema/test/zod/policy.test.ts
+++ b/packages/schema/test/zod/policy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import { ExceptionBundleEntry } from '../../src/zod/exception.ts';
 import { DetectionCategory } from '../../src/zod/finding.ts';
@@ -130,9 +131,24 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
     // strict, so Zod narrows both.
     const named = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
     const missing = PolicyTarget.options
-      .flatMap((member) => Object.keys(member.shape))
+      .flatMap((member) => ('shape' in member ? Object.keys(member.shape) : []))
       .filter((key) => !named.has(`policies.target.${key}`));
     expect(missing, 'target fields absent from the stamp').toEqual([]);
+  });
+
+  it('survives a union member that is not a plain object', () => {
+    // The `shape` guard is load-bearing, not defensive. This derivation runs at
+    // MODULE LOAD in a package every hook script bundles, so an unguarded
+    // `.shape` on a non-object member would not produce a narrower stamp — it
+    // would throw on import and take every hook with it, which is the one thing
+    // the plugin may never do. Driven on the pattern rather than on
+    // `PolicyTarget` itself, because the real union has no such member yet and
+    // the point is what happens when someone adds one.
+    const mixed = z.union([z.object({ ruleId: z.string() }), z.literal('everything')]);
+    const walk = (): string[] =>
+      mixed.options.flatMap((member) => ('shape' in member ? Object.keys(member.shape) : []));
+    expect(walk).not.toThrow();
+    expect(walk()).toEqual(['ruleId']);
   });
 
   it('carries the two fields whose loss this was built for', () => {
@@ -153,7 +169,9 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
       ...Object.keys(PolicyBundle.shape),
       ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
       ...PolicyTarget.options
-        .flatMap((member) => Object.keys(member.shape))
+        // Guarded exactly as the derivation is, or the two stop agreeing the
+        // moment a non-object member is added.
+        .flatMap((member) => ('shape' in member ? Object.keys(member.shape) : []))
         .map((key) => `policies.target.${key}`),
       ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
     ].sort();

--- a/packages/schema/test/zod/policy.test.ts
+++ b/packages/schema/test/zod/policy.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { DetectionCategory } from '../../src/zod/finding.ts';
-import { DEFAULT_ACTIONS, FULL_ENFORCEMENT_POSTURE, PolicyBundle } from '../../src/zod/policy.ts';
+import {
+  DEFAULT_ACTIONS,
+  FULL_ENFORCEMENT_POSTURE,
+  POLICY_BUNDLE_SHAPE_ID,
+  PolicyBundle,
+  Policy,
+} from '../../src/zod/policy.ts';
 
 describe('DEFAULT_ACTIONS — severity-floor cold-start values', () => {
   it('never hard-enforces (block) or silently rewrites payloads (redact) before onboarding', () => {
@@ -77,5 +83,46 @@ describe('PolicyBundle.ruleVersions', () => {
     if (result.success) {
       expect(result.data.ruleVersions).toEqual({ 'secrets/aws-access-key': '2.3.1' });
     }
+  });
+});
+
+// The stamp exists so a cache narrowed by an older build can be told apart from
+// one this build wrote. It is only worth anything if it actually tracks the
+// schema — a constant that drifted free of `PolicyBundle` would go on matching
+// every record forever, which is indistinguishable from not having it.
+describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
+  it('names every top-level bundle field', () => {
+    const named = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
+    const missing = Object.keys(PolicyBundle.shape).filter((key) => !named.has(key));
+    expect(missing, 'bundle fields absent from the stamp').toEqual([]);
+  });
+
+  it('names the NESTED policy fields too', () => {
+    // The top level alone is not enough, and this is the case that shows why:
+    // `Policy` is a plain object, so Zod narrows it exactly as it narrows the
+    // bundle, while `policies` stays one unchanged key. A build that widens
+    // `Policy` would move no top-level key, its stamp would read as a match,
+    // and the same 304 would replay the same narrowed policies.
+    const named = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
+    const missing = Object.keys(Policy.shape).filter((key) => !named.has(`policies.${key}`));
+    expect(missing, 'policy fields absent from the stamp').toEqual([]);
+  });
+
+  it('carries the two fields whose loss this was built for', () => {
+    // Named rather than derived, so the assertion is not satisfied by whatever
+    // the schema happens to say today. `prohibitedModels` is the governance
+    // decision that went missing; `provenance` is the nested field added one
+    // commit before the stamp existed, and the reason the nested half is here.
+    expect(POLICY_BUNDLE_SHAPE_ID.split(',')).toContain('prohibitedModels');
+    expect(POLICY_BUNDLE_SHAPE_ID.split(',')).toContain('policies.provenance');
+  });
+
+  it('is stable across reads and sorted', () => {
+    // A set comparison downstream splits on the comma, but the value is also
+    // written to disk and compared by equality, so an unstable order would make
+    // every record read as a foreign shape.
+    const parts = POLICY_BUNDLE_SHAPE_ID.split(',');
+    expect(parts).toEqual([...parts].sort());
+    expect(POLICY_BUNDLE_SHAPE_ID).toBe(POLICY_BUNDLE_SHAPE_ID);
   });
 });

--- a/packages/schema/test/zod/policy.test.ts
+++ b/packages/schema/test/zod/policy.test.ts
@@ -4,9 +4,9 @@ import { DetectionCategory } from '../../src/zod/finding.ts';
 import {
   DEFAULT_ACTIONS,
   FULL_ENFORCEMENT_POSTURE,
+  Policy,
   POLICY_BUNDLE_SHAPE_ID,
   PolicyBundle,
-  Policy,
 } from '../../src/zod/policy.ts';
 
 describe('DEFAULT_ACTIONS — severity-floor cold-start values', () => {

--- a/packages/schema/test/zod/policy.test.ts
+++ b/packages/schema/test/zod/policy.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { ExceptionBundleEntry } from '../../src/zod/exception.ts';
 import { DetectionCategory } from '../../src/zod/finding.ts';
 import {
   DEFAULT_ACTIONS,
@@ -108,6 +109,19 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
     expect(missing, 'policy fields absent from the stamp').toEqual([]);
   });
 
+  it('names the NESTED exception fields too', () => {
+    // The same argument as `policies` above, and it needs its own case: without
+    // it the entire `exceptions.*` half of the derivation could be deleted with
+    // every other assertion here still green. `ExceptionBundleEntry` is a pick
+    // of a plain object, so Zod narrows it exactly as it narrows `Policy` while
+    // `exceptions` stays one unchanged key.
+    const named = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
+    const missing = Object.keys(ExceptionBundleEntry.shape).filter(
+      (key) => !named.has(`exceptions.${key}`),
+    );
+    expect(missing, 'exception fields absent from the stamp').toEqual([]);
+  });
+
   it('carries the two fields whose loss this was built for', () => {
     // Named rather than derived, so the assertion is not satisfied by whatever
     // the schema happens to say today. `prohibitedModels` is the governance
@@ -117,12 +131,16 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
     expect(POLICY_BUNDLE_SHAPE_ID.split(',')).toContain('policies.provenance');
   });
 
-  it('is stable across reads and sorted', () => {
-    // A set comparison downstream splits on the comma, but the value is also
-    // written to disk and compared by equality, so an unstable order would make
-    // every record read as a foreign shape.
-    const parts = POLICY_BUNDLE_SHAPE_ID.split(',');
-    expect(parts).toEqual([...parts].sort());
-    expect(POLICY_BUNDLE_SHAPE_ID).toBe(POLICY_BUNDLE_SHAPE_ID);
+  it('is exactly the sorted union of those shapes, and nothing else', () => {
+    // Written to disk and compared by EQUALITY, so the property that matters is
+    // that it is reproducible from the shapes — not merely equal to itself,
+    // which a module-level const always is. Pins the composition too: an extra
+    // key, a missing half, or an unsorted join all fail here.
+    const expected = [
+      ...Object.keys(PolicyBundle.shape),
+      ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
+      ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
+    ].sort();
+    expect(POLICY_BUNDLE_SHAPE_ID.split(',')).toEqual(expected);
   });
 });

--- a/packages/schema/test/zod/policy.test.ts
+++ b/packages/schema/test/zod/policy.test.ts
@@ -8,6 +8,7 @@ import {
   Policy,
   POLICY_BUNDLE_SHAPE_ID,
   PolicyBundle,
+  PolicyTarget,
 } from '../../src/zod/policy.ts';
 
 describe('DEFAULT_ACTIONS — severity-floor cold-start values', () => {
@@ -122,6 +123,18 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
     expect(missing, 'exception fields absent from the stamp').toEqual([]);
   });
 
+  it('names the fields of BOTH PolicyTarget union members', () => {
+    // `policies.target` is one key whatever the target holds, so widening
+    // either member moves nothing the other walks can see — the same trap as
+    // `Policy`, one level further down and easier to miss. Neither member is
+    // strict, so Zod narrows both.
+    const named = new Set(POLICY_BUNDLE_SHAPE_ID.split(','));
+    const missing = PolicyTarget.options
+      .flatMap((member) => Object.keys(member.shape))
+      .filter((key) => !named.has(`policies.target.${key}`));
+    expect(missing, 'target fields absent from the stamp').toEqual([]);
+  });
+
   it('carries the two fields whose loss this was built for', () => {
     // Named rather than derived, so the assertion is not satisfied by whatever
     // the schema happens to say today. `prohibitedModels` is the governance
@@ -139,6 +152,9 @@ describe('POLICY_BUNDLE_SHAPE_ID tracks the schema it describes', () => {
     const expected = [
       ...Object.keys(PolicyBundle.shape),
       ...Object.keys(Policy.shape).map((key) => `policies.${key}`),
+      ...PolicyTarget.options
+        .flatMap((member) => Object.keys(member.shape))
+        .map((key) => `policies.target.${key}`),
       ...Object.keys(ExceptionBundleEntry.shape).map((key) => `exceptions.${key}`),
     ].sort();
     expect(POLICY_BUNDLE_SHAPE_ID.split(',')).toEqual(expected);


### PR DESCRIPTION
## The defect

A field added to `PolicyBundle` could never reach a device that already held a cache.

`PolicyBundle.parse` strips a key the running schema does not declare, so a body cached by an older build is missing whatever that build had never heard of — while still carrying the `version` of a served representation that *had* it. The pull is conditional, so replaying that validator earns a 304, and the not-modified arm (`policy-sync.ts:141`) rewrites the same narrowed bytes with a fresh tag. **The absent field can never arrive, and upgrading the plugin does not help, because the etag still matches.**

Every optional field on the bundle carries a comment saying "an older on-disk cache still parses". That is true, and it is only half of it: such a cache parses *and is never replaced*.

## How it was found

`prohibitedModels` is where the cost became visible. On a live deployment the control plane was serving

```
prohibitedModels = ["claude-haiku-4-5-20251001", "claude-sonnet-5"]
```

and the device's cache held **the same `version` hash with the field absent** — every other bundle field byte-identical. Verified against that deployment:

| request | result |
|---|---|
| conditional GET, device's stored ETag | `304` |
| unconditional GET | `200`, full body, field present |

So an organization had prohibited a model, the decision reached the device's own `version` hash, and the model went on being used. Dropping only the ETag and re-syncing brought the field down and both seams then refused correctly — which is the behaviour this change makes automatic.

## The change

Stamp the cache with the set of bundle fields the writing build understood, **derived from the schema's own keys** (`Object.keys(PolicyBundle.shape)`) so a field added tomorrow moves it with no second edit — a constant somebody has to remember to bump goes stale on exactly the commit where it has to be right.

**On read**, a record whose stamp is not this build's gives up its validator — and *only* its validator, never the bundle. Dropping the bundle would take the organization's raise-only floor with it until a sync landed: enforcement lost in order to repair enforcement. The next pull goes out unconditional, once, and the full body replaces the narrowed one. An **absent** stamp reads as a mismatch, which is what repairs the caches already on disk.

**On write**, a build that understands strictly fewer fields than the record on disk leaves it alone. One `~/.aka` serves every host plugin on the machine and they upgrade on their own schedules, so a narrower build sharing this cache is the ordinary state of a rollout — without this it would parse the full body, drop what it does not know, and write that back, leaving the wider build to spend another pull recovering a field the shared sync throttle can hold off for a whole window. Skipping the write keeps the stored etag describing the stored bytes.

## Deliberately unchanged

- Fail-open throughout: a corrupt cache still reads as no cache, and no path here can refuse a session.
- The 304 arm still carries the etag forward — dropping it there regresses into the alternating full-download/304 loop its own tests exist to prevent.
- `prohibitedModels` stays `undefined` when empty, never `[]`.

## Tests

+12 cases across `policy-store.test.ts` and `policy-sync.test.ts`, including the positive controls that keep them from passing vacuously (a `read()` that never returns an etag would otherwise satisfy every withholding assertion, at the cost of a full download on every poll).

Mutation-checked: reverting the read-side check turns 3 cases red, and defeating the write-side guard turns 1 red.

`schema` 858 · `plugin-runtime` 458 · all green. Typecheck, ESLint and Prettier clean.

## Note for the release

This ships the repair but does not backdate it: every device attached today stays stuck until a build carrying it runs. The operational workaround meanwhile is to remove the `etag` key from `~/.aka/data/policy-cache.json` and let the next sync run.