### PR TITLE
chore(deps): raise the fast-uri override past four host-confusion advisories

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
       "brace-expansion@5": "^5.0.9",
       "browserslist": "^4.28.7",
       "esbuild": "^0.28.2",
-      "fast-uri": "^3.1.5",
+      "fast-uri": "^3.1.6",
       "js-yaml": "^4.3.1",
       "nanoid": "^3.3.17",
       "postcss": "^8.5.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   brace-expansion@5: ^5.0.9
   browserslist: ^4.28.7
   esbuild: ^0.28.2
-  fast-uri: ^3.1.5
+  fast-uri: ^3.1.6
   js-yaml: ^4.3.1
   nanoid: ^3.3.17
   postcss: ^8.5.18
@@ -3372,8 +3372,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6452,7 +6452,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7117,7 +7117,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:


### PR DESCRIPTION
Four high advisories were published against `fast-uri` today at ~15:44 UTC, all inside the version window this workspace already resolved to. The audit gate blocks all four, so **main and every open PR fail on it** — the last green audit on main (16:23) simply predates the advisory data reaching the feed.

| Advisory | Issue |
|---|---|
| GHSA-5jgf-p345-68v8 | host confusion via skipped IDN canonicalization on scheme-relative references |
| GHSA-jqff-g426-hqxp | host confusion via percent-encoded scheme normalization |
| GHSA-f65p-4m7j-42xc | SSRF via malformed IPv6 normalization |
| GHSA-fph4-wmhf-6fwf | SSRF via repeated hostname percent-decoding |

All four name `>= 3.1.3, < 3.1.6` for the 3.x line; the workspace was on 3.1.5.

## The change

One line. `fast-uri` is not a direct dependency — it arrives transitively under commitlint's `ajv`:

```
fast-uri@3.1.5
└─┬ ajv@8.20.0
  └─┬ @commitlint/config-validator@21.2.0
    └─┬ @commitlint/load@21.2.2
      └─┬ @commitlint/cli@21.2.2
        └── ai-tc (devDependencies)
```

A `fast-uri: ^3.1.5` pnpm override was already present from an **earlier** advisory in the same package, so this raises that same floor to `^3.1.6` rather than introducing a new mechanism. It resolves to 3.1.7.

A waiver would have been the wrong instrument here: the fix is published and inside the major already pinned, so there is nothing to accept risk about.

## Verification

`node tools/audit-gate/src/audit-dependencies.ts` — *Dependency audit (workspace) passed: 0 waived, 1 below the gate.*

Split out of #398 deliberately: a security bump does not belong inside a feature change, and this unblocks every PR rather than only that one.
