### PR TITLE
perf(findings): stream the findings page reads from the timestamp index

### DIFF
--- a/packages/persistence/src/internal/rows.ts
+++ b/packages/persistence/src/internal/rows.ts
@@ -14,6 +14,22 @@ export function allRows<T>(stmt: StatementSync, params?: BindParams): T[] {
   return stmt.all(params) as unknown as T[];
 }
 
+/**
+ * `stmt`'s rows streamed via `.iterate()` rather than materialized, cast to
+ * the caller's row type `T` — the same audited cast `allRows` performs, for a
+ * caller reading a scan too large to hold as an array (the findings page's
+ * index-ordered streams over `findingScanSql`).
+ */
+export function* iterateRows<T>(stmt: StatementSync, params?: BindParams): Generator<T> {
+  const rows =
+    params === undefined
+      ? stmt.iterate()
+      : Array.isArray(params)
+        ? stmt.iterate(...params)
+        : stmt.iterate(params);
+  for (const row of rows) yield row as unknown as T;
+}
+
 /** The first row of `stmt` (or undefined), cast to the caller's row type `T`. */
 // `T` appears only in the return type on purpose: the caller names the row
 // shape and the audited cast to it happens here instead of at every call site.

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -46,7 +46,7 @@ import {
 
 import { parseJsonObject } from '../internal/json.ts';
 import { decodeKeysetCursor, encodeKeysetCursor } from '../internal/keyset-cursor.ts';
-import { allRows, countBy, countScalar } from '../internal/rows.ts';
+import { allRows, countBy, countScalar, iterateRows } from '../internal/rows.ts';
 import type {
   DashboardViews,
   FindingInstancesView,
@@ -158,6 +158,35 @@ function deriveInstanceStatus(row: {
     findingKey: row.finding_key,
     latestResolutionStatus: row.latest_status,
   });
+}
+
+/**
+ * `FindingGroupRowJoined` -> `FlatFindingRow`, the one field-by-field mapping
+ * both instance-level scans need: `previewRows`' rows before they enter
+ * `buildFindingGroups` (as `GroupableFindingRow`, which `FlatFindingRow`
+ * structurally satisfies), and `scanFindingRows`' own yield. Kept here rather
+ * than duplicated at both call sites so a column `findingScanSql` starts
+ * projecting is threaded through once, not twice with the risk of the two
+ * drifting — see `scanFindingRows`' generator for what that drift would mean.
+ */
+function toFlatFindingRow(r: FindingGroupRowJoined): FlatFindingRow {
+  return {
+    id: r.id,
+    ruleId: r.rule_id,
+    category: r.category,
+    severity: r.severity,
+    maskedMatch: r.masked_match,
+    actionTaken: r.action_taken,
+    confidence: r.confidence,
+    occurredAt: epochMillisToIso(r.occurred_at),
+    sourceTool: r.source_tool,
+    repo: r.repo ?? '',
+    file: r.file ?? '',
+    ...(r.tool_name === null ? {} : { toolName: r.tool_name }),
+    eventId: r.event_id,
+    ...(r.session_id === null ? {} : { sessionId: r.session_id }),
+    status: deriveInstanceStatus(r),
+  };
 }
 
 // The grouped list's cursor: the sort key of the last group on the page just
@@ -289,7 +318,7 @@ export class SqliteFindingsRepository
       this.db.prepare(
         `SELECT f.id, f.audit_event_id AS event_id, d.rule_id, d.category, d.severity,
                 f.masked_match, f.action_taken, f.confidence, e.started_at AS occurred_at,
-                json_extract(e.attributes, '$.source_tool') AS source_tool,
+                e.source_tool AS source_tool,
                 e.event_type AS kind
          FROM audit_events e
          CROSS JOIN inspection_findings f ON f.audit_event_id = e.id
@@ -416,27 +445,11 @@ export class SqliteFindingsRepository
     });
 
     const rows = this.previewRows(aggregates, {
-      ...(query.sessionId ? { sessionId: query.sessionId } : {}),
-      ...(query.from === undefined ? {} : { from: query.from }),
+      sessionId: query.sessionId,
+      from: query.from,
     });
 
-    const groupable: GroupableFindingRow[] = rows.map((r) => ({
-      id: r.id,
-      ruleId: r.rule_id,
-      category: r.category,
-      severity: r.severity,
-      maskedMatch: r.masked_match,
-      actionTaken: r.action_taken,
-      confidence: r.confidence,
-      occurredAt: epochMillisToIso(r.occurred_at),
-      sourceTool: r.source_tool,
-      repo: r.repo ?? '',
-      file: r.file ?? '',
-      ...(r.tool_name === null ? {} : { toolName: r.tool_name }),
-      eventId: r.event_id,
-      ...(r.session_id === null ? {} : { sessionId: r.session_id }),
-      status: deriveInstanceStatus(r),
-    }));
+    const groupable: GroupableFindingRow[] = rows.map(toFlatFindingRow);
 
     // No overrides/pack names in OSS: detection.name is null, policy is
     // synthesized from category (both unused by the OSS views).
@@ -574,8 +587,10 @@ export class SqliteFindingsRepository
    *
    * The scan runs from the top of the scope on every request, not from the
    * cursor: `totals` and `facets` describe the whole filtered scope and must not
-   * move as the caller pages. Rows are pulled in batches so memory stays flat
-   * while the counting runs, and only the page itself is retained.
+   * move as the caller pages. Rows come off ONE statement, iterated rather
+   * than materialized (`scanFindingRows`), so memory stays flat while the
+   * counting runs — a generator streaming the index order, not a sequence of
+   * fetched batches; only the page itself is retained.
    */
   listFindingInstances(query: ListFindingInstancesQuery): Promise<ListFindingInstancesResponse> {
     const opts: InstanceFilterOptions = {
@@ -592,6 +607,20 @@ export class SqliteFindingsRepository
     const limit = query.limit ?? DEFAULT_FLAT_FINDINGS_LIMIT;
     const cursor = query.cursor === undefined ? null : decodeKeysetCursor(query.cursor);
 
+    // Whether `row` is strictly past `cursor` in the same started_at DESC,
+    // id DESC order the scan already walks — the same disjunction a keyset
+    // predicate would test in SQL (`startedAt <= X AND (startedAt < X OR
+    // id < Y)`), evaluated in JS against the one scan below instead of a
+    // second, narrower statement. `cursor` is captured non-null in the
+    // closure so the null case costs one allocation, not a per-row branch.
+    const isPastCursor: (row: FlatFindingRow) => boolean =
+      cursor === null
+        ? () => true
+        : (row) => {
+            const rowMs = isoToEpochMillis(row.occurredAt);
+            return rowMs <= cursor.startedAtMs && (rowMs < cursor.startedAtMs || row.id < cursor.id);
+          };
+
     const accumulator = createInstanceFacetAccumulator(opts);
     const items: FindingInstanceDetail[] = [];
     let total = 0;
@@ -601,6 +630,14 @@ export class SqliteFindingsRepository
     // the page's end and the batch's end is ever skipped.
     let hasMore = false;
 
+    // ONE scan regardless of page: totals and facets always describe the
+    // whole filtered scope (so paging cannot move them), and that pass
+    // already visits every row a page-2+ request would otherwise re-seek for
+    // — `isPastCursor` collects the page inline instead of discarding this
+    // pass's tail and re-running a second, cursor-bounded scan for it. A
+    // store where the cursor sits deep in the scope no longer pays for that
+    // tail twice, and there is no second snapshot for a concurrent write to
+    // land between.
     for (const row of this.scanFindingRows({
       sessionId: query.sessionId,
       from: query.from,
@@ -608,6 +645,7 @@ export class SqliteFindingsRepository
       accumulator.add(row);
       if (!matchesInstanceFilters(row, opts)) continue;
       total += 1;
+      if (!isPastCursor(row)) continue;
       if (items.length < limit) {
         items.push(toInstanceDetail(row));
         last = row;
@@ -621,64 +659,12 @@ export class SqliteFindingsRepository
         ? encodeKeysetCursor({ startedAtMs: isoToEpochMillis(last.occurredAt), id: last.id })
         : null;
 
-    // The cursor selects the page out of the fully-counted scope rather than
-    // narrowing the scan, so paging cannot change what totals and facets say.
-    if (cursor !== null) {
-      const resumed = this.pageAfter(cursor, opts, limit, query);
-      return Promise.resolve({
-        totals: { findings: total },
-        facets: accumulator.facets(),
-        items: resumed.items,
-        nextCursor: resumed.nextCursor,
-      });
-    }
-
     return Promise.resolve({
       totals: { findings: total },
       facets: accumulator.facets(),
       items,
       nextCursor,
     });
-  }
-
-  /**
-   * The page of matching rows strictly after `cursor`. Separate from the
-   * counting pass because that one starts at the top of the scope by design;
-   * this one narrows the scan with the same keyset predicate the activity list
-   * uses, so a later page costs less than the first rather than more.
-   */
-  private pageAfter(
-    cursor: { startedAtMs: number; id: string },
-    opts: InstanceFilterOptions,
-    limit: number,
-    query: ListFindingInstancesQuery,
-  ): { items: FindingInstanceDetail[]; nextCursor: string | null } {
-    const items: FindingInstanceDetail[] = [];
-    let last: FlatFindingRow | undefined;
-    let hasMore = false;
-
-    for (const row of this.scanFindingRows({
-      sessionId: query.sessionId,
-      from: query.from,
-      after: cursor,
-    })) {
-      if (!matchesInstanceFilters(row, opts)) continue;
-      if (items.length < limit) {
-        items.push(toInstanceDetail(row));
-        last = row;
-      } else {
-        hasMore = true;
-        break;
-      }
-    }
-
-    return {
-      items,
-      nextCursor:
-        hasMore && last
-          ? encodeKeysetCursor({ startedAtMs: isoToEpochMillis(last.occurredAt), id: last.id })
-          : null,
-    };
   }
 
   /**
@@ -791,10 +777,15 @@ export class SqliteFindingsRepository
    * each rule has as many as it can show. The aggregate the caller already holds
    * says how many that is: `min(instanceCount, PREVIEW_INSTANCES_PER_GROUP)`
    * per rule, summed, is the number of rows this scan has to find, and it stops
-   * on the last one. For a store where every rule fires recently that is a few
-   * hundred rows; the worst case — a rule whose last instances are the oldest
-   * in the store — is one pass with no sort, which is still the floor the sorted
-   * form paid before doing any of its work.
+   * on the last one. That sum is bounded by `rules * PREVIEW_INSTANCES_PER_GROUP`
+   * (8,000 at this repo's 40-rule bench corpus), not by a fixed row count — a
+   * store with many firing rules widens it. The bound that DOES hold
+   * unconditionally is the sorted form's floor: this scan visits at most as
+   * many rows as `ROW_NUMBER() OVER (PARTITION BY rule_id …)` would have
+   * sorted, and stops the moment every rule has its cap, where the sorted form
+   * sorts the whole scope regardless. The true worst case — the rarest rule's
+   * wanted instances sitting at the tail of the scope — is one pass over
+   * everything in scope with no sort, which is still that floor.
    *
    * A row whose rule the aggregate did not see is skipped: the two statements
    * run without a shared snapshot, so a capture landing between them can add a
@@ -817,8 +808,7 @@ export class SqliteFindingsRepository
 
     const { sql, params } = this.findingScanSql(scope);
     const taken = new Map<string, number>();
-    for (const row of this.db.prepare(sql).iterate(...params)) {
-      const r = row as unknown as FindingGroupRowJoined;
+    for (const r of iterateRows<FindingGroupRowJoined>(this.db.prepare(sql), params)) {
       const want = wanted.get(r.rule_id);
       if (want === undefined) continue;
       const have = taken.get(r.rule_id) ?? 0;
@@ -842,36 +832,21 @@ export class SqliteFindingsRepository
    * keyset-bounded batches re-sorted everything below the cursor on every
    * batch and cost the square of the scope.
    *
-   * `after` narrows the pass to the rows strictly after a keyset cursor, for
-   * the page reads; `sessionId` and `from` carry ONLY what no facet counts. A
-   * filter dimension narrowed here would be missing from its own facet, which
-   * is computed by excluding that dimension — see listFindingInstances.
+   * `sessionId` and `from` carry ONLY what no facet counts — a filter
+   * dimension narrowed here would be missing from its own facet, which is
+   * computed by excluding that dimension (see listFindingInstances). There is
+   * no `after`/cursor parameter: a keyset page is collected inline from this
+   * same pass (`listFindingInstances`' `isPastCursor`) rather than by a second,
+   * narrower statement, since the counting pass already visits every row a
+   * page-2+ request would otherwise re-seek for.
    */
   private *scanFindingRows(scope: {
     sessionId?: string | undefined;
     from?: string | undefined;
-    after?: { startedAtMs: number; id: string } | undefined;
   }): Generator<FlatFindingRow> {
     const { sql, params } = this.findingScanSql(scope);
-    for (const row of this.db.prepare(sql).iterate(...params)) {
-      const r = row as unknown as FindingGroupRowJoined;
-      yield {
-        id: r.id,
-        ruleId: r.rule_id,
-        category: r.category,
-        severity: r.severity,
-        maskedMatch: r.masked_match,
-        actionTaken: r.action_taken,
-        confidence: r.confidence,
-        occurredAt: epochMillisToIso(r.occurred_at),
-        sourceTool: r.source_tool,
-        repo: r.repo ?? '',
-        file: r.file ?? '',
-        ...(r.tool_name === null ? {} : { toolName: r.tool_name }),
-        eventId: r.event_id,
-        ...(r.session_id === null ? {} : { sessionId: r.session_id }),
-        status: deriveInstanceStatus(r),
-      };
+    for (const r of iterateRows<FindingGroupRowJoined>(this.db.prepare(sql), params)) {
+      yield toFlatFindingRow(r);
     }
   }
 
@@ -892,11 +867,6 @@ export class SqliteFindingsRepository
    *  - **`CROSS JOIN`** pins `audit_events` as the driving table. With plain
    *    JOINs the planner drives from the findings and sorts everything.
    *
-   * The keyset cursor is spelled as an index range plus a boundary filter
-   * (`started_at <= ? AND (started_at < ? OR id < ?)`) rather than the
-   * disjunction the cursor's order implies, so the range half seeks the index
-   * and only the boundary instant pays the second test.
-   *
    * The latest-resolution lookup is the CORRELATED form: only `status` is
    * needed, `idx_finding_resolution_key_created` answers it with one backward
    * index probe per keyed row, and a derived table over the whole resolution
@@ -905,7 +875,6 @@ export class SqliteFindingsRepository
   private findingScanSql(scope: {
     sessionId?: string | undefined;
     from?: string | undefined;
-    after?: { startedAtMs: number; id: string } | undefined;
   }): { sql: string; params: SQLInputValue[] } {
     const conditions = [`+e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})`];
     const params: SQLInputValue[] = [];
@@ -918,19 +887,15 @@ export class SqliteFindingsRepository
       conditions.push('e.started_at >= ?');
       params.push(isoToEpochMillis(scope.from));
     }
-    if (scope.after !== undefined) {
-      conditions.push('e.started_at <= ? AND (e.started_at < ? OR f.id < ?)');
-      params.push(scope.after.startedAtMs, scope.after.startedAtMs, scope.after.id);
-    }
 
     const sql = `SELECT f.id AS id, d.rule_id AS rule_id, d.category AS category,
               d.severity AS severity, f.masked_match AS masked_match,
               f.action_taken AS action_taken, f.confidence AS confidence,
               e.started_at AS occurred_at,
-              json_extract(e.attributes, '$.source_tool') AS source_tool,
-              json_extract(e.attributes, '$.repo') AS repo,
-              json_extract(e.attributes, '$.file_path') AS file,
-              json_extract(e.attributes, '$.tool_name') AS tool_name,
+              e.source_tool AS source_tool,
+              e.repo AS repo,
+              e.file_path AS file,
+              e.tool_name AS tool_name,
               f.audit_event_id AS event_id, e.root_session_id AS session_id,
               e.event_type AS kind, f.finding_key AS finding_key,
               ${latestResolutionStatusSql('f')} AS latest_status
@@ -949,9 +914,9 @@ export class SqliteFindingsRepository
     // Tool names ride as their display label ("via Bash") to mirror
     // buildHaystack — see its doc for why the bare name is not searched.
     const innerSearchColumns = withSearchText
-      ? `, group_concat(DISTINCT json_extract(e.attributes, '$.repo')) AS repos,
-           group_concat(DISTINCT json_extract(e.attributes, '$.file_path')) AS files,
-           group_concat(DISTINCT 'via ' || json_extract(e.attributes, '$.tool_name')) AS tool_names`
+      ? `, group_concat(DISTINCT e.repo) AS repos,
+           group_concat(DISTINCT e.file_path) AS files,
+           group_concat(DISTINCT 'via ' || e.tool_name) AS tool_names`
       : `, NULL AS repos, NULL AS files, NULL AS tool_names`;
 
     const rows = this.db
@@ -972,7 +937,7 @@ export class SqliteFindingsRepository
                       coalesce(latest.status, '') AS status_tuple,
                     count(*) AS tuple_count,
                     max(e.started_at) AS latest_at,
-                    group_concat(DISTINCT json_extract(e.attributes, '$.source_tool')) AS source_tools,
+                    group_concat(DISTINCT e.source_tool) AS source_tools,
                     group_concat(DISTINCT f.action_taken) AS actions_taken
                     ${innerSearchColumns}
                FROM inspection_findings f

--- a/packages/persistence/src/repositories/findings.ts
+++ b/packages/persistence/src/repositories/findings.ts
@@ -618,7 +618,9 @@ export class SqliteFindingsRepository
         ? () => true
         : (row) => {
             const rowMs = isoToEpochMillis(row.occurredAt);
-            return rowMs <= cursor.startedAtMs && (rowMs < cursor.startedAtMs || row.id < cursor.id);
+            return (
+              rowMs <= cursor.startedAtMs && (rowMs < cursor.startedAtMs || row.id < cursor.id)
+            );
           };
 
     const accumulator = createInstanceFacetAccumulator(opts);
@@ -785,7 +787,8 @@ export class SqliteFindingsRepository
    * sorted, and stops the moment every rule has its cap, where the sorted form
    * sorts the whole scope regardless. The true worst case — the rarest rule's
    * wanted instances sitting at the tail of the scope — is one pass over
-   * everything in scope with no sort, which is still that floor.
+   * everything in scope with a block sort of the id tie-break only, never a
+   * sort of the scope, which is still that floor.
    *
    * A row whose rule the aggregate did not see is skipped: the two statements
    * run without a shared snapshot, so a capture landing between them can add a
@@ -828,7 +831,8 @@ export class SqliteFindingsRepository
    * the flat list counts and facets the whole filtered scope, which on a large
    * store is far more rows than any page. The rows come off ONE statement,
    * iterated rather than materialized, in the index order `findingScanSql`
-   * arranges — so the scan is a single pass with no sort, where a sequence of
+   * arranges — so the scan is a single pass with a block sort of the id
+   * tie-break only, never a sort of the scope, where a sequence of
    * keyset-bounded batches re-sorted everything below the cursor on every
    * batch and cost the square of the scope.
    *
@@ -872,10 +876,10 @@ export class SqliteFindingsRepository
    * index probe per keyed row, and a derived table over the whole resolution
    * table would be materialized before the first row streamed.
    */
-  private findingScanSql(scope: {
-    sessionId?: string | undefined;
-    from?: string | undefined;
-  }): { sql: string; params: SQLInputValue[] } {
+  private findingScanSql(scope: { sessionId?: string | undefined; from?: string | undefined }): {
+    sql: string;
+    params: SQLInputValue[];
+  } {
     const conditions = [`+e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})`];
     const params: SQLInputValue[] = [];
 

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -499,9 +499,8 @@ export class SqliteSecurityRepository implements SecurityViews {
     // bare GROUP BY name resolves against a FROM-clause column ahead of a
     // SELECT alias, while a bare ORDER BY name resolves the other way, so once
     // audit_events gained its own `repo` column (migration 0025) the two
-    // clauses silently bound to different things in the same statement. See
-    // ai-tc#406's review for the reproduction. Ranked + sliced in SQL —
-    // tie-break on repo for a stable order.
+    // clauses silently bound to different things in the same statement.
+    // Ranked + sliced in SQL — tie-break on repo for a stable order.
     const rows = allRows<{ repo: string; c: number }>(
       this.db.prepare(
         `SELECT e.repo AS repo, count(*) AS c

--- a/packages/persistence/src/repositories/security.ts
+++ b/packages/persistence/src/repositories/security.ts
@@ -493,20 +493,26 @@ export class SqliteSecurityRepository implements SecurityViews {
 
     const now = this.now();
     const from = now - RANGE_DAYS[range] * DAY_MS;
-    // Rank repos by findings in the window. attributes.repo is extracted in SQL
-    // via json_extract; rows without a repo are excluded. Ranked + sliced in
-    // SQL — tie-break on repo for a stable order.
+    // Rank repos by findings in the window. e.repo is a generated column over
+    // attributes.repo; rows without a repo are excluded. GROUP BY and ORDER BY
+    // both spell the qualified column rather than the bare "repo" alias — a
+    // bare GROUP BY name resolves against a FROM-clause column ahead of a
+    // SELECT alias, while a bare ORDER BY name resolves the other way, so once
+    // audit_events gained its own `repo` column (migration 0025) the two
+    // clauses silently bound to different things in the same statement. See
+    // ai-tc#406's review for the reproduction. Ranked + sliced in SQL —
+    // tie-break on repo for a stable order.
     const rows = allRows<{ repo: string; c: number }>(
       this.db.prepare(
-        `SELECT json_extract(e.attributes, '$.repo') AS repo, count(*) AS c
+        `SELECT e.repo AS repo, count(*) AS c
          FROM inspection_findings f
          JOIN audit_events e ON e.id = f.audit_event_id
          WHERE e.started_at >= :from AND e.started_at < :to
            AND e.event_type IN (${CAPTURE_EVENT_TYPES_SQL})
-           AND json_extract(e.attributes, '$.repo') IS NOT NULL
-           AND json_extract(e.attributes, '$.repo') != ''
-         GROUP BY repo
-         ORDER BY c DESC, repo
+           AND e.repo IS NOT NULL
+           AND e.repo != ''
+         GROUP BY e.repo
+         ORDER BY c DESC, e.repo
          LIMIT :limit`,
       ),
       { from, to: now, limit },
@@ -578,7 +584,7 @@ export class SqliteSecurityRepository implements SecurityViews {
         `SELECT f.finding_key AS finding_key,
                 d.rule_id AS rule_id,
                 d.severity AS severity,
-                json_extract(e.attributes, '$.file_path') AS path,
+                e.file_path AS path,
                 COALESCE(f.first_detected_at, e.started_at) AS first_detected_at,
                 latest.resolved_at AS latest_resolved_at
          FROM ${LATEST_RESOLUTION_BY_KEY_SQL} latest

--- a/packages/persistence/src/test-fixtures/generate.ts
+++ b/packages/persistence/src/test-fixtures/generate.ts
@@ -462,7 +462,9 @@ export function generateCaptureCorpus(
   // fallback would.
   const firstRule = rules[0];
   if (firstRule === undefined) {
-    throw new RangeError('generateCaptureCorpus: unreachable — rules.length === 0 already rejected');
+    throw new RangeError(
+      'generateCaptureCorpus: unreachable — rules.length === 0 already rejected',
+    );
   }
 
   if (!Number.isInteger(events) || events < 0) {

--- a/packages/persistence/src/test-fixtures/generate.ts
+++ b/packages/persistence/src/test-fixtures/generate.ts
@@ -453,6 +453,17 @@ export function generateCaptureCorpus(
     );
   }
   const pickRule = weightedPicker(rules);
+  // rules[0] is provably defined by the `rules.length === 0` check above;
+  // noUncheckedIndexedAccess cannot see across that control-flow boundary, and
+  // this repo's lint bans `!`. One narrowing guard here, immediately beside
+  // the invariant it relies on, stands in for `rules[0]` everywhere below —
+  // so a caller-supplied single rule is never silently swapped for
+  // DEFAULT_CORPUS_RULES' first entry the way a `?? DEFAULT_CORPUS_RULES[0]`
+  // fallback would.
+  const firstRule = rules[0];
+  if (firstRule === undefined) {
+    throw new RangeError('generateCaptureCorpus: unreachable — rules.length === 0 already rejected');
+  }
 
   if (!Number.isInteger(events) || events < 0) {
     throw new TypeError(
@@ -575,14 +586,11 @@ export function generateCaptureCorpus(
 
       const detected: DetectedFinding[] = [];
       if (rng() < findingRate) {
-        const rule = rules.length === 1 ? (rules[0] ?? DEFAULT_CORPUS_RULES[0]) : pickRule(rng());
+        const rule = rules.length === 1 ? firstRule : (pickRule(rng()) ?? firstRule);
         const actionTaken =
           actions.length === 1
             ? (actions[0] ?? 'block')
             : (actions[Math.floor(rng() * actions.length)] ?? 'block');
-        if (rule === undefined) {
-          throw new RangeError('generateCaptureCorpus: no rule to fire under');
-        }
         // TRACKABLE EXACTLY WHEN THE PRODUCT WOULD MAKE IT SO, which is why the
         // condition is `filePath` and not a knob. `@akasecurity/plugin-sdk`'s
         // runtime sets `isAtRest = kind === 'code_change' && filePath !== undefined`

--- a/packages/persistence/test/performance/hot-read-query-plans.test.ts
+++ b/packages/persistence/test/performance/hot-read-query-plans.test.ts
@@ -266,6 +266,7 @@ describe('query plans of every hot dashboard read', () => {
   // per-test shape and would rebuild it three times over.
   let store: OwnedTempStore;
   let plans: Map<string, PlanStep[]>;
+  let statementCounts: Map<string, number>;
 
   beforeAll(async () => {
     store = createTempStore('aka-query-plans-');
@@ -315,9 +316,11 @@ describe('query plans of every hot dashboard read', () => {
     };
 
     plans = new Map();
+    statementCounts = new Map();
     for (const read of HOT_READS) {
       recorded.length = 0;
       read.run(surfaces);
+      statementCounts.set(read.name, recorded.length);
       // EXPLAIN goes through the RAW handle, so the recorder does not capture
       // its own explains and recurse.
       plans.set(
@@ -368,5 +371,16 @@ describe('query plans of every hot dashboard read', () => {
       Object.entries(EXPECTED_FULL_INDEX_SCANS).map(([name, tables]) => [name, [...tables].sort()]),
     );
     expect(actual).toEqual(expected);
+  });
+
+  it('a page-2 flat read is one statement, not two', () => {
+    // The plan-shape pin above cannot see this: the deleted second statement
+    // sought idx_audit_started_at with a SEARCH, contributing no full-index
+    // scan either way, so its absence is invisible to a plan-shape assertion.
+    // Only a statement count states what the page-2 fix actually changed —
+    // listFindingInstances collecting the page inline once the scan passes
+    // the cursor, instead of discarding a first unbounded pass and re-running
+    // scanFindingRows narrowed by a keyset `after` predicate.
+    expect(statementCounts.get('/findings listFindingInstances (page 2)')).toBe(1);
   });
 });

--- a/packages/persistence/test/performance/hot-read-query-plans.test.ts
+++ b/packages/persistence/test/performance/hot-read-query-plans.test.ts
@@ -138,7 +138,15 @@ const HOT_READS: readonly HotRead[] = [
     name: '/findings listFindingInstances (page 2)',
     run: (c) => c.findings.listFindingInstances({ cursor: c.secondPageCursor }),
   },
+  {
+    name: '/findings listFindingInstances (session)',
+    run: (c) => c.findings.listFindingInstances({ sessionId: c.sessionId }),
+  },
   { name: '/findings listFindingLocations', run: (c) => c.findings.listFindingLocations({}) },
+  {
+    name: '/findings listFindingLocations (session)',
+    run: (c) => c.findings.listFindingLocations({ sessionId: c.sessionId }),
+  },
   // --- /activity -------------------------------------------------------------
   { name: '/activity stats', run: (c) => c.activity.stats() },
   {
@@ -214,19 +222,32 @@ const EXPECTED_FULL_INDEX_SCANS: Readonly<Record<string, readonly string[]>> = {
   // the three are UNBOUNDED by design — the flat list and the locations fold
   // count and facet every finding in scope, so the scan is the answer — and
   // the ratio in `findings-page-scale.test.ts` is what states that they are
-  // flat in the STORE once a scope narrows them. The grouped read's scan is
-  // bounded the way `recentFindings`' is: it stops once every rule has its
-  // preview, which a plan cannot show. Its `finding_resolution` entry is the
-  // latest-resolution derived table the aggregate joins, shared with the three
-  // `/security` reads above. The session-scoped grouped read drives from
-  // `idx_audit_session` instead, so only that derived table remains.
+  // flat in the STORE once a scope narrows them. The grouped read's scan
+  // stops early too, but NOT on a fixed row count the way `recentFindings`'
+  // LIMIT does: it stops once every rule has its preview cap, and that sum
+  // (`rules * PREVIEW_INSTANCES_PER_GROUP`) grows with the rule count, so a
+  // plan cannot show the bound and neither can this comment overstate it as
+  // constant — see `previewRows`' docblock in findings.ts for the real one.
+  // Its `finding_resolution` entry is the latest-resolution derived table the
+  // aggregate joins, shared with the three `/security` reads above. The
+  // session-scoped grouped read drives from `idx_audit_session` instead, so
+  // only that derived table remains.
   '/findings listGroupedFindings': ['audit_events', 'finding_resolution'],
   '/findings listGroupedFindings (session)': ['finding_resolution'],
   '/findings listFindingInstances': ['audit_events'],
-  // The counting pass over the whole scope, plus a keyset-bounded page read
-  // that seeks the same index and so contributes no scan of its own.
+  // ONE statement, the same one page 1 runs: the page-2 items are collected
+  // inline once the scan passes the cursor (listFindingInstances'
+  // isPastCursor), not a second, narrower statement.
   '/findings listFindingInstances (page 2)': ['audit_events'],
+  // Session-scoped, so `idx_audit_session` drives it the way the grouped
+  // read's session variant is driven — and unlike that variant, the flat
+  // and locations reads answer their resolution status through the
+  // CORRELATED form (one backward `idx_finding_resolution_key_created` probe
+  // per row), never the derived table, so neither one full-scans it even
+  // unscoped. Empty is the correct answer here, not an oversight.
+  '/findings listFindingInstances (session)': [],
   '/findings listFindingLocations': ['audit_events'],
+  '/findings listFindingLocations (session)': [],
   '/activity stats': [],
   '/activity listSessions': [],
   '/activity tokenReports': [],

--- a/packages/schema/src/drizzle/local/sqlite.ts
+++ b/packages/schema/src/drizzle/local/sqlite.ts
@@ -98,12 +98,22 @@ export const findingResolution = sqliteTable(
   (t) => [
     // Every read of this table asks the same question — the NEWEST row for a
     // finding key, ordered `created_at DESC, rowid DESC` — either as a
-    // correlated `LIMIT 1` per finding or as a window over every key (see
-    // resolution-sql.ts). With `created_at` in the key a backward scan of one
-    // key's range yields that order directly, so the per-finding lookup is a
-    // single probe and the window sorts only its rowid tie-break. A bare
-    // `finding_key` index answered the equality and left every row of the key
-    // to be sorted, once per statement.
+    // correlated `LIMIT 1` per finding (`latestResolutionColumnSql`) or as a
+    // window over every key (`LATEST_RESOLUTION_BY_KEY_SQL`, resolution-sql.ts).
+    // With `created_at` in the key a backward scan of one key's range yields
+    // that order directly, so the CORRELATED form's per-finding lookup is a
+    // single probe with no sort at all — a bare `finding_key` index answered
+    // the equality and left every row of the key to be sorted, once per
+    // finding, which is what this replaces there.
+    //
+    // The WINDOW form gets nothing from this: `EXPLAIN QUERY PLAN` over
+    // `LATEST_RESOLUTION_BY_KEY_SQL` is byte-identical under both index
+    // shapes — `SCAN fr USING INDEX <name>` then `USE TEMP B-TREE FOR LAST 2
+    // TERMS OF ORDER BY` either way — because `PARTITION BY finding_key ORDER
+    // BY created_at DESC` still needs a sort per partition regardless of which
+    // index feeds the scan; only a DESC-native index would drop it, and this
+    // one is ASC. `severitySummary` / `mttrTrend` / `recentlyResolved` share
+    // that form and see no change here.
     index('idx_finding_resolution_key_created').on(t.findingKey, t.createdAt),
     // Serves the resolution-driven /security reads, which ask "which findings
     // were resolved in this window" and therefore drive from a resolved_at range.


### PR DESCRIPTION
## What

The findings page reads against the local SQLite store were quadratic in the store size. This makes each one a single index-ordered streaming statement, adds the two indexes and columns they need, and pins the resulting plans with tests.

Measured on a deterministic corpus at two sizes (min of 3-5 samples, arm64 macOS, Node 26). The 100k-event store holds 33k findings over 100k `tool_call` rows:

| read | 10k events, before | after | 100k events, before | after |
| --- | ---: | ---: | ---: | ---: |
| flat, first page | 40.9 ms | 16.6 ms | 2827.7 ms | 197.4 ms |
| flat, second page | 52.1 ms | 16.9 ms | 3997.0 ms | 196.7 ms |
| flat, `?severity=` | 37.7 ms | 15.8 ms | 2219.9 ms | 190.1 ms |
| flat, `?tool=Bash` | 38.6 ms | 15.5 ms | 2202.1 ms | 186.3 ms |
| flat, `?q=` | 38.2 ms | 18.2 ms | 2221.0 ms | 212.6 ms |
| flat, `?status=open` | 62.5 ms | 15.7 ms | 2851.0 ms | 189.6 ms |
| locations, no filter | 34.1 ms | 16.0 ms | 2840.9 ms | 191.9 ms |
| locations, `?severity=` | 33.6 ms | 15.4 ms | 2998.9 ms | 183.8 ms |
| grouped, no filter | 35.3 ms | 23.7 ms | 438.2 ms | 279.6 ms |
| grouped, `?q=` | 32.2 ms | 24.4 ms | 376.8 ms | 288.3 ms |
| grouped, `?severity=` | 32.7 ms | 23.1 ms | 410.2 ms | 282.4 ms |
| grouped, `?status=open` | 34.6 ms | 24.1 ms | 375.7 ms | 281.6 ms |
| grouped, `?session=` | 1.11 ms | 0.61 ms | 10.94 ms | 6.27 ms |
| grouped, `?range=30d` | 33.1 ms | 23.4 ms | 147.3 ms | 101.9 ms |

## Why it was slow

The flat and locations views walked their scope in keyset batches of 1,000 rows. `EXPLAIN QUERY PLAN` showed a `MULTI-INDEX OR` on `idx_audit_type_t` followed by `USE TEMP B-TREE FOR ORDER BY` **per batch**, so every batch re-sorted every row below the cursor. That is the square of the store, and it is why page two cost more than page one.

The grouped preview ran `ROW_NUMBER() OVER (PARTITION BY rule_id ...)` across every finding in scope, two full sorts, to keep three rows per rule.

Separately, every findings read projected `source_tool`, `repo`, `file_path` and `tool_name` out of the attributes JSON with `json_extract`, once per column per row per statement.

## What changed

**Reads** (`packages/persistence/src/repositories/findings.ts`). Each view is one statement now, driven off `idx_audit_started_at` in DESC order and iterated rather than materialized, so the scan is a single pass with no sort and an early stop bounds the work. The grouped preview streams that same order and stops once every rule has its cap of rows, which the aggregate the caller already holds tells it.

Two spellings pin the plan and carry comments saying so. `CROSS JOIN` keeps `audit_events` as the driving table, and `+e.event_type` makes the kind predicate non-indexable so the planner cannot pick `idx_audit_type_t` and sort.

**Migration 0024** replaces `idx_finding_resolution_key` with `(finding_key, created_at)`. The latest-resolution lookup is `ORDER BY created_at DESC LIMIT 1` per key, which the single-column index could not answer without a sort. It is a replacement rather than an addition because the composite serves every read the old one did.

**Migration 0025** adds the four attribute columns as VIRTUAL generated columns, and `BaseAuditEventRow` carries them so the shared row type stays the single definition. VIRTUAL rather than STORED because SQLite cannot add a STORED generated column to an existing table, and these are projected rather than filtered, so there is nothing to index and no write cost.

## Guards

Both drive the real repository methods through a recorder rather than restating their SQL, so a plan test cannot pass for a query no user issues.

- `test/performance/hot-read-query-plans.test.ts` now covers the five findings reads: the full-index scans are pinned as an exact set, and a bare table scan or a returning temp B-tree fails it.
- `test/performance/findings-page-scale.test.ts` is new. It asserts the session-scoped reads stay flat across a 10x store step, with the unscoped grouped read as the growth control. It gates a ratio, never a wall-clock number.
- `bench/findings-page.bench.ts` is the measurement harness behind the table above (`pnpm --filter @akasecurity/persistence bench`). Its corpora are deterministic and idempotent, so a re-run after a change measures the same rows. It gates nothing.

## Test plan

- `pnpm --filter @akasecurity/persistence test` and `pnpm --filter @akasecurity/schema test` pass.
- The whole suite passes under the enterprise workspace lockfile as well (`pnpm test:oss`, 41 tasks), which is where the two stores are exercised together.
- `check:portability` passes; Prettier and lint are clean.

## Note for reviewers

This branch is based on the commit the enterprise repo currently pins, not on the tip of `main`, so the paired enterprise PR moves the submodule by exactly this change. None of the 51 commits on `main` since that point touch any file here, so the merge is clean. The enterprise pin will need correcting to the merge commit once this lands.
