### PR TITLE
fix: require the render instant at every time-label call site

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,6 +851,79 @@ variable string, since `iconColor="var(--color-ok)"` and `iconBg="var(--color-ok
 are the same node to a selector (`toneColors()` is the live example); and a class
 assembled from a non-literal.
 
+`tonalInkTokens` is no longer only the tonal ban: it is the WHOLE
+`no-restricted-syntax` value those three packages get, assembled by
+`reactSyntaxBans()` from four groups (network, drizzle, tonal, ambient clock)
+because a later entry replaces the rule's options rather than merging them. A
+per-file opt-out is therefore written as `reactSyntaxBans({ … })` with one group
+switched off, never as a hand-listed subset — the other three come along by
+construction, so lifting one ban cannot silently lift four.
+
+### A time label is a function of two instants, and a client component is given both
+
+A page under `'use client'` is rendered **twice** — once on the server, once when
+the browser hydrates it. A label derived from the ambient clock is therefore two
+different strings whenever a rounding boundary falls between those two renders,
+and React resolves that by discarding the server HTML for the subtree. It is not
+only cosmetic: `exceptionState` gates **structure**, since `ExceptionDetailView`
+renders its revoke form only while the state reads `active`, so the two renders
+can disagree about whether a whole subtree exists.
+
+The class is closed in the type system rather than site by site. `relativeTime`,
+`relativeTimeShort` and `exceptionState` take `now` as a **required** argument,
+and every time-derived view takes a required `renderedAt: number` prop — a
+DEFAULT would not do, because a default reads as safe at every call site that
+omits it, which is every call site until somebody remembers. Required, the
+compiler names each place that has to decide which instant it means, and a host
+that forgets one fails the build instead of shipping the defect.
+
+Where each instant comes from:
+
+- A **server component** captures one per request with `renderInstant()`
+  (`web-ui/app/lib/rendered-at.ts`) and passes it down. It is a function, not a
+  module constant: a constant is captured once when the module loads and then
+  served to every later request, so a long-lived dashboard process would render
+  every age against the instant it booted. `exceptions-page.test.ts` pins that
+  by rendering the route twice under two clocks.
+- A **client component** that must not go stale feeds it to `useRenderClock`,
+  which returns that instant for the render React compares against the server's
+  HTML and the live clock from the commit after. It is built on
+  `useSyncExternalStore`, whose third argument IS the server snapshot, so the
+  split is in the signature rather than in a comment about effect ordering.
+  Freezing is the floor everywhere; the refresh is applied where a derived
+  lifecycle decays — a temporary grant expires in 30 minutes and a dashboard tab
+  outlives that, so a frozen instant would label an expired grant `active` and go
+  on offering to revoke it.
+
+The remaining hole — satisfying the required argument with a fresh clock read at
+the call site, which typechecks perfectly — is closed by the ambient-clock
+selectors above. They are scoped by `Program:has(> ExpressionStatement[directive=
+'use client'])`, so they fire only where the directive is a real directive-prologue
+statement: a **server** component may still read the clock, which is what makes
+capturing an instant possible at all, and a file that merely mentions the string
+as a value is untouched. `Date.now()` and a zero-argument `new Date()` are clock
+reads; `new Date(iso)` and `Date.parse(iso)` parse a value the caller already had
+and are deliberately left alone.
+
+Two things about that ban are worth knowing before trusting it. It reaches what
+`react-hooks/purity` cannot — that rule reports a clock read inside a COMPONENT,
+so a module-level helper in a client file is invisible to it, and that is exactly
+where the one site this sweep did not find by hand was living
+(`HarnessOverview`'s `formatEvent`). And it cannot follow a binding, so a clock
+reached through an imported helper goes unseen; the required argument is what
+covers that direction. `packages/dashboard-ui/src/lib/useRenderClock.ts` is the
+one sanctioned reader, and its exemption is written in that package's
+`eslint.config.mjs` through `reactSyntaxBans({ allowAmbientClock: true })`.
+
+**What none of this reaches is a LOCALE-formatted string.** `toLocaleString` and
+its siblings render in the renderer's own locale and time zone, and the server's
+need not be the browser's, so passing one instant does not reconcile them. Two
+sites carry that honestly rather than pretending otherwise: `SessionListView`'s
+`title` keeps its `suppressHydrationWarning` for the locale half alone (the clock
+half is pinned now), and `HarnessOverview`'s `formatEvent` says so in its own
+doc comment. `suppressHydrationWarning` silences a warning without reconciling
+anything, so it is never a substitute for passing an instant.
+
 ## Detection rules
 
 See `skills/write-detection-rule/SKILL.md`. A rule PR carrying fewer than 2 positive or

--- a/packages/dashboard-ui/eslint.config.mjs
+++ b/packages/dashboard-ui/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
 import { reactSyntaxBans, rootConfigFiles } from '@akasecurity/eslint-config';
-import { reactUiPackage } from '@akasecurity/eslint-config/react';
+import { presentationalUiPackage } from '@akasecurity/eslint-config/react';
 
 export default [
-  ...reactUiPackage,
+  ...presentationalUiPackage,
   {
     languageOptions: {
       parserOptions: {

--- a/packages/dashboard-ui/eslint.config.mjs
+++ b/packages/dashboard-ui/eslint.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { rootConfigFiles } from '@akasecurity/eslint-config';
+import { reactSyntaxBans, rootConfigFiles } from '@akasecurity/eslint-config';
 import { reactUiPackage } from '@akasecurity/eslint-config/react';
 
 export default [
@@ -11,6 +11,16 @@ export default [
         tsconfigRootDir: import.meta.dirname,
       },
     },
+  },
+  {
+    // The one sanctioned reader of the ambient clock in this package. Every other
+    // client module takes the instant as a prop; this hook is what produces the
+    // live one they are given, after hydration has committed. Written through
+    // `reactSyntaxBans` rather than by hand so lifting THIS ban cannot lift the
+    // network, drizzle or tonal ones with it — a bare `no-restricted-syntax`
+    // entry here would replace all four.
+    files: ['src/lib/useRenderClock.ts'],
+    rules: { 'no-restricted-syntax': reactSyntaxBans({ allowAmbientClock: true }) },
   },
   ...rootConfigFiles,
 ];

--- a/packages/dashboard-ui/src/activity/SessionDetailView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionDetailView.tsx
@@ -75,6 +75,7 @@ function DetailBody({
   toolHref,
   onExpand,
   overlayClose = false,
+  renderedAt,
 }: {
   session: ActivitySession;
   tokenReport?: SessionTokenReport | null;
@@ -83,6 +84,13 @@ function DetailBody({
   toolHref?: (toolName: string) => string;
   onExpand?: () => void;
   overlayClose?: boolean;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   const harness = PROVIDERS[session.harness];
   const tools = toolEntries(session.tools);
@@ -157,10 +165,14 @@ function DetailBody({
             <MetaChips items={session.models} mono nowrap />
           </MetaItem>
           <MetaItem label="Started">
-            <MetaLine text={`${startLabel(session.startedAt)} · ${dayLabel(session.startedAt)}`} />
+            <MetaLine
+              text={`${startLabel(session.startedAt)} · ${dayLabel(session.startedAt, new Date(renderedAt))}`}
+            />
           </MetaItem>
           <MetaItem label="Duration">
-            <MetaLine text={durationLabel(session.startedAt, session.endedAt, session.status)} />
+            <MetaLine
+              text={durationLabel(session.startedAt, session.endedAt, session.status, renderedAt)}
+            />
           </MetaItem>
           <MetaItem label="Turns">{session.turns}</MetaItem>
           {/* In the Findings cell the tally is what yields when the column is
@@ -324,6 +336,7 @@ export function SessionDetailView({
   toolHref,
   onExpand,
   overlayClose,
+  renderedAt,
 }: {
   session: ActivitySession | null;
   isLoading: boolean;
@@ -350,6 +363,13 @@ export function SessionDetailView({
   /** The host paints a close control over this view's top-right corner (a
    * slide-over does) — reserve room for it in the header's action row. */
   overlayClose?: boolean;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   if (error) {
     return (
@@ -384,6 +404,7 @@ export function SessionDetailView({
       {...(toolHref ? { toolHref } : {})}
       {...(onExpand ? { onExpand } : {})}
       {...(overlayClose ? { overlayClose } : {})}
+      renderedAt={renderedAt}
     />
   );
 }

--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -26,10 +26,12 @@ function SessionRow({
   session,
   selected,
   onSelect,
+  renderedAt,
 }: {
   session: ActivitySessionSummary;
   selected: boolean;
   onSelect: () => void;
+  renderedAt: number;
 }) {
   const flagged = session.findings > 0;
   return (
@@ -63,15 +65,18 @@ function SessionRow({
         </span>
       </div>
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        {/* Relative time is "now"-relative + the tooltip is locale-formatted, so
-            server and client HTML legitimately differ — suppress the hydration
-            warning rather than freeze it to the server's clock/locale. */}
+        {/* The label reads `renderedAt`, so the clock half of this element now
+            matches across server and client. The `title` does not and cannot:
+            toLocaleString renders in the RENDERER's locale and time zone, and
+            the server's are not the browser's. suppressHydrationWarning is kept
+            for that half alone — it silences the warning without reconciling
+            the attribute, so it is not a substitute for passing an instant. */}
         <span
           className="text-xs font-semibold text-text-2"
           title={new Date(session.startedAt).toLocaleString()}
           suppressHydrationWarning
         >
-          {relativeTime(session.startedAt)}
+          {relativeTime(session.startedAt, renderedAt)}
         </span>
         <Metric icon={ClockIcon}>
           {durationLabel(session.startedAt, session.endedAt, session.status)}
@@ -116,6 +121,7 @@ export function SessionListView({
   emptyCount = 0,
   showEmpty = false,
   onToggleEmpty,
+  renderedAt,
 }: {
   sessions: ActivitySessionSummary[];
   selectedId: string;
@@ -136,6 +142,13 @@ export function SessionListView({
   showEmpty?: boolean;
   /** Flips showEmpty; omitted hides the toggle. */
   onToggleEmpty?: () => void;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   const days = groupSessionsByDay(sessions);
   const filtersActive = query.trim() !== '' || harness.length > 0;
@@ -214,6 +227,7 @@ export function SessionListView({
                     <SessionRow
                       key={session.id}
                       session={session}
+                      renderedAt={renderedAt}
                       selected={session.id === selectedId}
                       onSelect={() => {
                         onSelect(session.id);

--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -79,7 +79,7 @@ function SessionRow({
           {relativeTime(session.startedAt, renderedAt)}
         </span>
         <Metric icon={ClockIcon}>
-          {durationLabel(session.startedAt, session.endedAt, session.status)}
+          {durationLabel(session.startedAt, session.endedAt, session.status, renderedAt)}
         </Metric>
         <Metric icon={ListIcon}>{session.turns} turns</Metric>
         {flagged && (
@@ -150,7 +150,7 @@ export function SessionListView({
    */
   renderedAt: number;
 }) {
-  const days = groupSessionsByDay(sessions);
+  const days = groupSessionsByDay(sessions, new Date(renderedAt));
   const filtersActive = query.trim() !== '' || harness.length > 0;
 
   const noun = emptyCount === 1 ? 'background session' : 'background sessions';

--- a/packages/dashboard-ui/src/activity/format.ts
+++ b/packages/dashboard-ui/src/activity/format.ts
@@ -27,8 +27,15 @@ function startOfLocalDay(d: Date): number {
  * `Yesterday` / `Mon, Jun 8`. Computed from `startedAt` client-side — the API
  * returns the timestamp, never the label (see the activity API spec's "Day
  * grouping is computed client-side" note).
+ *
+ * `now` is required rather than defaulted to `new Date()` — see relativeTime.ts
+ * for why a default here is the same hydration hole with better manners. This
+ * decides whether a session buckets under `Today` or `Yesterday`, which is a
+ * STRUCTURAL label: it is also the React key groupSessionsByDay assigns each
+ * day section, so a server/hydration disagreement here doesn't just relabel a
+ * heading, it makes React discard and remount the whole section.
  */
-export function dayLabel(iso: string, now: Date = new Date()): string {
+export function dayLabel(iso: string, now: Date): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return '';
   const diffDays = Math.round((startOfLocalDay(now) - startOfLocalDay(d)) / DAY_MS);
@@ -66,12 +73,18 @@ export function eventTime(iso: string): string {
  * Human duration derived from the timestamp pair: `46m` / `1h 12m`. An open
  * (`active`) session has no `endedAt`, so it measures against `now` and gets a
  * `· live` suffix — matching the design's "46m · live" pill.
+ *
+ * `now` is required for the same reason as `dayLabel`'s: an open session
+ * measures its span against it, so a server render and the hydration render
+ * that follows disagree on the duration whenever they straddle a minute
+ * boundary — the same hydration-discard class `relativeTime`'s required
+ * argument closes, reached through a sibling helper.
  */
 export function durationLabel(
   startedAt: string,
   endedAt: string | null,
   status: SessionStatus,
-  now: number = Date.now(),
+  now: number,
 ): string {
   const start = Date.parse(startedAt);
   if (Number.isNaN(start)) return '';
@@ -111,11 +124,14 @@ export { formatCostTotal, formatUsd } from '@akasecurity/schema';
  * order — the server returns a flat `items[]`, the day headings are a view
  * concern (see `dayLabel`). A session with an unparseable `startedAt` falls
  * into an empty-label bucket rather than being dropped.
+ *
+ * `now` is required and threaded straight into `dayLabel` — this is the
+ * severe case of the class: `day` becomes each section's React key below, so a
+ * server/hydration disagreement here doesn't relabel a heading, it hands React
+ * a different key set and the whole day-section subtree is discarded and
+ * remounted rather than patched.
  */
-export function groupSessionsByDay(
-  items: ActivitySessionSummary[],
-  now: Date = new Date(),
-): SessionDay[] {
+export function groupSessionsByDay(items: ActivitySessionSummary[], now: Date): SessionDay[] {
   const groups: SessionDay[] = [];
   for (const session of items) {
     const day = dayLabel(session.startedAt, now);

--- a/packages/dashboard-ui/src/data-shares/DataShareDetailView.tsx
+++ b/packages/dashboard-ui/src/data-shares/DataShareDetailView.tsx
@@ -155,10 +155,12 @@ function EndpointDetail({
   d,
   ep,
   onBack,
+  renderedAt,
 }: {
   d: ShareDestinationDetail;
   ep: EndpointWithSites;
   onBack: () => void;
+  renderedAt: number;
 }) {
   return (
     <>
@@ -210,7 +212,7 @@ function EndpointDetail({
             <ClassTag cls={ep.dataClass} />
           </span>
         </MetaItem>
-        <MetaItem label="Last seen">{relativeTime(ep.lastSeen)}</MetaItem>
+        <MetaItem label="Last seen">{relativeTime(ep.lastSeen, renderedAt)}</MetaItem>
       </div>
 
       <div>
@@ -234,6 +236,13 @@ export interface DataShareDetailViewProps {
   /** Write the per-destination egress decision (`null` clears the override). */
   onSetDecision: (decision: EgressDecision | null) => void;
   isSettingDecision: boolean;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }
 
 export function DataShareDetailView({
@@ -243,6 +252,7 @@ export function DataShareDetailView({
   onBack,
   onSetDecision,
   isSettingDecision,
+  renderedAt,
 }: DataShareDetailViewProps) {
   // `status` (effective egress state) and `isCustom` (override differs from the
   // trust default) already ride on the destination — read them from there.
@@ -258,7 +268,7 @@ export function DataShareDetailView({
 
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4.5">
         {endpoint ? (
-          <EndpointDetail d={d} ep={endpoint} onBack={onBack} />
+          <EndpointDetail d={d} ep={endpoint} onBack={onBack} renderedAt={renderedAt} />
         ) : (
           <DestDetail d={d} onPick={onPick} />
         )}

--- a/packages/dashboard-ui/src/data-shares/DataSharesTableView.tsx
+++ b/packages/dashboard-ui/src/data-shares/DataSharesTableView.tsx
@@ -51,6 +51,13 @@ export interface DataSharesTableViewProps {
   onToggle: (id: string) => void;
   onOpenDest: (id: string) => void;
   onOpenEndpoint: (id: string, endpointId: string) => void;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }
 
 function ClassCell({ classes }: { classes: DataClass[] }) {
@@ -66,12 +73,14 @@ function ClassCell({ classes }: { classes: DataClass[] }) {
 
 function GroupRow({
   d,
+  renderedAt,
   expanded,
   selected,
   onToggle,
   onOpen,
 }: {
   d: ShareDestinationSummary;
+  renderedAt: number;
   expanded: boolean;
   selected: boolean;
   onToggle: () => void;
@@ -149,7 +158,7 @@ function GroupRow({
         {d.callSiteCount === 1 ? '' : 's'}
       </TableCell>
       <TableCell className="whitespace-nowrap text-xs text-text-3">
-        {relativeTime(d.lastSeen)}
+        {relativeTime(d.lastSeen, renderedAt)}
       </TableCell>
     </TableRow>
   );
@@ -157,10 +166,12 @@ function GroupRow({
 
 function EndpointRow({
   ep,
+  renderedAt,
   selected,
   onClick,
 }: {
   ep: EndpointSummary;
+  renderedAt: number;
   selected: boolean;
   onClick: () => void;
 }) {
@@ -196,7 +207,7 @@ function EndpointRow({
         <b className="text-text">{ep.callSiteCount}</b> call{ep.callSiteCount === 1 ? '' : 's'}
       </TableCell>
       <TableCell className="whitespace-nowrap text-xs text-text-3">
-        {relativeTime(ep.lastSeen)}
+        {relativeTime(ep.lastSeen, renderedAt)}
       </TableCell>
     </TableRow>
   );
@@ -211,6 +222,7 @@ export function DataSharesTableView({
   onToggle,
   onOpenDest,
   onOpenEndpoint,
+  renderedAt,
 }: DataSharesTableViewProps) {
   return (
     <Table>
@@ -234,6 +246,7 @@ export function DataSharesTableView({
             <Fragment key={d.id}>
               <GroupRow
                 d={d}
+                renderedAt={renderedAt}
                 expanded={isExp}
                 selected={groupSel}
                 onToggle={bindId(onToggle, d.id)}
@@ -244,6 +257,7 @@ export function DataSharesTableView({
                   <EndpointRow
                     key={ep.id}
                     ep={ep}
+                    renderedAt={renderedAt}
                     selected={
                       drawerOpen && selection?.id === d.id && selection.endpointId === ep.id
                     }

--- a/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
+++ b/packages/dashboard-ui/src/exceptions/BlockedLedgerView.tsx
@@ -89,10 +89,12 @@ export interface BlockedLedgerViewProps {
    */
   blockReason: (row: BlockedDetectionDescriptor) => string | null;
   /**
-   * Time captured by an SSR host for a stable initial render. Passing this
-   * prevents relative labels from crossing a boundary between SSR and hydration.
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
    */
-  renderedAt?: number;
+  renderedAt: number;
 }
 
 /**

--- a/packages/dashboard-ui/src/exceptions/ExceptionDetailView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionDetailView.tsx
@@ -23,8 +23,10 @@ export interface ExceptionDetailViewProps {
    * It reaches further here than on the list views: `exceptionState` gates the
    * revoke form below, so a grant whose `expiresAt` falls between the two
    * passes renders that whole block on the server and drops it on the client.
+   * Required rather than optional for exactly that reason — an omitted instant
+   * is not a smaller version of this bug, it is the bug.
    */
-  renderedAt?: number | undefined;
+  renderedAt: number;
 }
 
 /** Full grant detail — the web twin of `aka exception show <id>`. */

--- a/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
+++ b/packages/dashboard-ui/src/exceptions/ExceptionsTableView.tsx
@@ -13,11 +13,13 @@ export interface ExceptionsTableViewProps {
   includeTerminal: boolean;
   onSelect: (id: string) => void;
   /**
-   * Time captured by an SSR host for a stable initial render. Passing this
-   * prevents relative labels — and the expiry-derived state badge — from
-   * crossing a boundary between SSR and hydration.
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it — and the expiry-derived
+   * state badge with them. Required: a view that picks its own instant renders one
+   * string while the server renders it and another when the browser hydrates it.
+   * See ../lib/relativeTime.ts.
    */
-  renderedAt?: number;
+  renderedAt: number;
 }
 
 /**

--- a/packages/dashboard-ui/src/exceptions/atoms.tsx
+++ b/packages/dashboard-ui/src/exceptions/atoms.tsx
@@ -16,13 +16,13 @@ export function StateTag({ state }: { state: ExceptionState }) {
   return <Badge variant={STATE_TONE[state]}>{state}</Badge>;
 }
 
-export function StateTagFor({
-  exception,
-  now,
-}: {
-  exception: ExceptionDescriptor;
-  now?: number | undefined;
-}) {
+/**
+ * Lifecycle chip for a grant, derived at `now`. `now` is required for the reason
+ * {@link exceptionState}'s is — a chip that picks its own instant reads `active`
+ * on the server and `expired` in the browser whenever the two straddle
+ * `expiresAt`.
+ */
+export function StateTagFor({ exception, now }: { exception: ExceptionDescriptor; now: number }) {
   return <StateTag state={exceptionState(exception, now)} />;
 }
 

--- a/packages/dashboard-ui/src/exceptions/meta.ts
+++ b/packages/dashboard-ui/src/exceptions/meta.ts
@@ -23,7 +23,18 @@ export type Tone = NonNullable<BadgeProps['variant']>;
 // it is unrevoked, unexpired, and under its use budget.
 export type ExceptionState = 'active' | 'consumed' | 'expired' | 'revoked';
 
-export function exceptionState(ex: ExceptionDescriptor, now = Date.now()): ExceptionState {
+/**
+ * The lifecycle state a grant is in at `now`.
+ *
+ * `now` is required rather than defaulted, and this is the call that most needs
+ * it: the state gates STRUCTURE, not just a label. ExceptionDetailView renders
+ * the revoke form only while the state reads `active`, so a server render and a
+ * hydration that straddle `expiresAt` disagree about whether that whole subtree
+ * exists — a mismatch React resolves by throwing the server HTML away. See the
+ * note at the top of ../lib/relativeTime.ts; the same argument applies, one
+ * severity up.
+ */
+export function exceptionState(ex: ExceptionDescriptor, now: number): ExceptionState {
   if (ex.revokedAt !== null) return 'revoked';
   if (ex.maxUses !== null && ex.useCount >= ex.maxUses) return 'consumed';
   if (ex.expiresAt !== null && Date.parse(ex.expiresAt) <= now) return 'expired';

--- a/packages/dashboard-ui/src/findings/FindingDetailView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingDetailView.tsx
@@ -44,11 +44,19 @@ export function FindingDetailView({
   onSelectInstance,
   onBack,
   footer,
+  renderedAt,
 }: {
   selection: Selection;
   onSelectInstance: (instance: FindingInstance) => void;
   onBack: () => void;
   footer?: ReactNode;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   const { finding, instance } = selection;
   const Icon = CATEGORY_ICON_FALLBACK[finding.category] ?? KeyIcon;
@@ -89,7 +97,7 @@ export function FindingDetailView({
             <span className="text-xs text-text-3">
               {grouped
                 ? `${String(finding.instanceCount)} locations · ${String(providerCount)} tool${providerCount > 1 ? 's' : ''}`
-                : `${category} · ${instance.repo} · detected ${relativeTime(instance.detectedAt)}`}
+                : `${category} · ${instance.repo} · detected ${relativeTime(instance.detectedAt, renderedAt)}`}
             </span>
           </div>
         </div>
@@ -144,7 +152,7 @@ export function FindingDetailView({
             <MetaItem label="Action taken">
               <ActionTag action={instance.action} />
             </MetaItem>
-            <MetaItem label="Detected">{relativeTime(instance.detectedAt)}</MetaItem>
+            <MetaItem label="Detected">{relativeTime(instance.detectedAt, renderedAt)}</MetaItem>
             <MetaItem label="Confidence">
               <Confidence confidence={instance.confidence} />
             </MetaItem>

--- a/packages/dashboard-ui/src/findings/FindingsFlatTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsFlatTableView.tsx
@@ -73,6 +73,7 @@ export function FindingsFlatTableView({
   isLoading = false,
   emptyState,
   showUserColumn = false,
+  renderedAt,
 }: {
   items: FindingInstanceDetail[];
   /** The row rendered as selected ('' for none). */
@@ -96,6 +97,13 @@ export function FindingsFlatTableView({
   total?: number;
   isLoading?: boolean;
   emptyState?: ReactNode;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   return (
     <Card className="flex h-full min-h-0 flex-col overflow-hidden shadow-sm">
@@ -195,7 +203,7 @@ export function FindingsFlatTableView({
                     </TableCell>
                     <TableCell className={FINDING_COLUMN_CLASS.latest}>
                       <span className="text-text-3 text-xs">
-                        {relativeTime(instance.detectedAt)}
+                        {relativeTime(instance.detectedAt, renderedAt)}
                       </span>
                     </TableCell>
                   </TableRow>

--- a/packages/dashboard-ui/src/findings/FindingsLocationsView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsLocationsView.tsx
@@ -27,6 +27,7 @@ export function FindingsLocationsView({
   hasMore = false,
   isLoading = false,
   emptyState,
+  renderedAt,
 }: {
   items: FindingLocationRepo[];
   expandedRepos: ReadonlySet<string>;
@@ -36,6 +37,13 @@ export function FindingsLocationsView({
   hasMore?: boolean;
   isLoading?: boolean;
   emptyState?: ReactNode;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   return (
     <Card className="flex h-full min-h-0 flex-col overflow-hidden shadow-sm">
@@ -87,7 +95,7 @@ export function FindingsLocationsView({
                       {repo.files.length} {repo.files.length === 1 ? 'file' : 'files'}
                     </span>
                     <span className="shrink-0 text-xs text-text-3">
-                      {relativeTime(repo.latestDetectedAt)}
+                      {relativeTime(repo.latestDetectedAt, renderedAt)}
                     </span>
                   </button>
 
@@ -96,6 +104,7 @@ export function FindingsLocationsView({
                       <FileRow
                         key={`${repo.repo}\0${file.file}`}
                         file={file}
+                        renderedAt={renderedAt}
                         // The unnamed bucket has no filter that could name it,
                         // so its rows are informational rather than links.
                         onSelect={
@@ -136,8 +145,10 @@ function StatusBadge({ status }: { status: FindingLocationRepo['status'] }) {
 function FileRow({
   file,
   onSelect,
+  renderedAt,
 }: {
   file: FindingLocationFile;
+  renderedAt: number;
   // `| undefined` explicitly: the caller passes undefined for the unnamed
   // bucket, which exactOptionalPropertyTypes distinguishes from omitting it.
   onSelect?: (() => void) | undefined;
@@ -159,7 +170,9 @@ function FileRow({
         {file.ruleIds.join(', ')}
       </span>
       <span className="shrink-0 text-xs text-text-3">{file.instanceCount}</span>
-      <span className="shrink-0 text-xs text-text-3">{relativeTime(file.latestDetectedAt)}</span>
+      <span className="shrink-0 text-xs text-text-3">
+        {relativeTime(file.latestDetectedAt, renderedAt)}
+      </span>
     </div>
   );
 

--- a/packages/dashboard-ui/src/findings/FindingsTableView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsTableView.tsx
@@ -76,6 +76,7 @@ export function FindingsTableView({
   emptyState,
   sessionFirings,
   statusFilter,
+  renderedAt,
 }: {
   groups: FindingGroup[];
   /** Visible columns, in display order (caller applies column visibility). */
@@ -123,6 +124,13 @@ export function FindingsTableView({
    * preview window).
    */
   statusFilter?: readonly string[];
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }) {
   return (
     <Card className="flex flex-col overflow-hidden shadow-sm h-full">
@@ -187,7 +195,7 @@ export function FindingsTableView({
                       </TableCell>
                       {columns.map((col) => (
                         <TableCell key={col.id} className={FINDING_COLUMN_CLASS[col.id]}>
-                          {GROUP_CELL[col.id](group)}
+                          {GROUP_CELL[col.id](group, renderedAt)}
                         </TableCell>
                       ))}
                     </TableRow>
@@ -209,7 +217,7 @@ export function FindingsTableView({
                           <TableCell />
                           {columns.map((col) => (
                             <TableCell key={col.id} className={FINDING_COLUMN_CLASS[col.id]}>
-                              {INSTANCE_CELL[col.id](group, instance)}
+                              {INSTANCE_CELL[col.id](group, instance, renderedAt)}
                             </TableCell>
                           ))}
                         </TableRow>
@@ -330,21 +338,24 @@ function StatusCell({ status }: { status: FindingStatus | undefined }) {
 }
 
 /** Per-column renderers for a group row, keyed by column id. */
-const GROUP_CELL: Record<FindingColumn['id'], (g: FindingGroup) => ReactNode> = {
-  severity: (g) => <SeverityBadge severity={g.severity} />,
-  subtype: (g) => <TypeCell finding={g} />,
-  sources: (g) => <ProviderChips ids={g.providers} />,
-  user: (g) => <UsersCell users={g.users} />,
-  locations: (g) => <span className="text-text-3">{g.instanceCount} locations</span>,
-  action: (g) => <AggregateActionTag aggregateAction={g.aggregateAction} />,
-  status: (g) => <StatusCell status={g.status} />,
-  latest: (g) => <span className="text-text-3 text-xs">{relativeTime(g.latestDetectedAt)}</span>,
-};
+const GROUP_CELL: Record<FindingColumn['id'], (g: FindingGroup, renderedAt: number) => ReactNode> =
+  {
+    severity: (g) => <SeverityBadge severity={g.severity} />,
+    subtype: (g) => <TypeCell finding={g} />,
+    sources: (g) => <ProviderChips ids={g.providers} />,
+    user: (g) => <UsersCell users={g.users} />,
+    locations: (g) => <span className="text-text-3">{g.instanceCount} locations</span>,
+    action: (g) => <AggregateActionTag aggregateAction={g.aggregateAction} />,
+    status: (g) => <StatusCell status={g.status} />,
+    latest: (g, renderedAt) => (
+      <span className="text-text-3 text-xs">{relativeTime(g.latestDetectedAt, renderedAt)}</span>
+    ),
+  };
 
 /** Per-column renderers for an instance (sub-)row, keyed by column id. */
 const INSTANCE_CELL: Record<
   FindingColumn['id'],
-  (g: FindingGroup, i: FindingInstance) => ReactNode
+  (g: FindingGroup, i: FindingInstance, renderedAt: number) => ReactNode
 > = {
   severity: (g) => <SeverityBadge severity={g.severity} />,
   subtype: (_g, i) => (
@@ -363,5 +374,7 @@ const INSTANCE_CELL: Record<
   ),
   action: (_g, i) => <ActionTag action={i.action} />,
   status: (_g, i) => <StatusCell status={i.status} />,
-  latest: (_g, i) => <span className="text-text-3 text-xs">{relativeTime(i.detectedAt)}</span>,
+  latest: (_g, i, renderedAt) => (
+    <span className="text-text-3 text-xs">{relativeTime(i.detectedAt, renderedAt)}</span>
+  ),
 };

--- a/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
+++ b/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
@@ -14,6 +14,7 @@ import type {
 } from '@akasecurity/schema';
 import { Badge, cn } from '@akasecurity/ui-kit';
 
+import { dayLabel } from '../activity/format.ts';
 import { Provider } from '../shared/Provider.tsx';
 import { AccessBar, EmptyState, FlagChips, TrustPill, VisBadge } from './chips.tsx';
 import { ASSET_META, assetTile, EVENT_KIND, langColor } from './data.ts';
@@ -24,26 +25,20 @@ const EVENT_KINDS: HarnessEventKind[] = ['block', 'redact', 'warn'];
 /**
  * Format an ISO timestamp into the "Today · 09:19" day/time the row shows.
  *
- * `now` is the instant the day bucket is relative to, and it is a parameter for
- * the reason relativeTime's is: a server render and a hydration that straddle
- * local midnight would label the same event "Today" and "Yesterday". The clock
- * half is closed by passing one instant; the LOCALE half is not closeable here —
- * toLocaleTimeString renders in the renderer's own locale and time zone, and the
- * server's need not be the browser's.
+ * The day half is `dayLabel` from the Activity view's format module — this used
+ * to reimplement the same local-midnight bucketing locally, which is exactly
+ * the kind of divergence a rounding or DST fix to one copy and not the other
+ * would produce silently. `now` is required for the reason `dayLabel`'s own is:
+ * a server render and a hydration that straddle local midnight would label the
+ * same event "Today" and "Yesterday". The clock half is closed by passing one
+ * instant; the LOCALE half is not closeable here — toLocaleTimeString renders
+ * in the renderer's own locale and time zone, and the server's need not be the
+ * browser's.
  */
 function formatEvent(iso: string, now: number): { day: string; time: string } {
   const d = new Date(iso);
   const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const today = new Date(now);
-  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
-  const dayDiff = Math.round((startOf(today) - startOf(d)) / 86_400_000);
-  const day =
-    dayDiff === 0
-      ? 'Today'
-      : dayDiff === 1
-        ? 'Yesterday'
-        : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
-  return { day, time };
+  return { day: dayLabel(iso, new Date(now)), time };
 }
 
 export function HarnessOverview({

--- a/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
+++ b/packages/dashboard-ui/src/inventory/HarnessOverview.tsx
@@ -21,11 +21,20 @@ import { Ico } from './Ico.tsx';
 
 const EVENT_KINDS: HarnessEventKind[] = ['block', 'redact', 'warn'];
 
-/** Format an ISO timestamp into the "Today · 09:19" day/time the row shows. */
-function formatEvent(iso: string): { day: string; time: string } {
+/**
+ * Format an ISO timestamp into the "Today · 09:19" day/time the row shows.
+ *
+ * `now` is the instant the day bucket is relative to, and it is a parameter for
+ * the reason relativeTime's is: a server render and a hydration that straddle
+ * local midnight would label the same event "Today" and "Yesterday". The clock
+ * half is closed by passing one instant; the LOCALE half is not closeable here —
+ * toLocaleTimeString renders in the renderer's own locale and time zone, and the
+ * server's need not be the browser's.
+ */
+function formatEvent(iso: string, now: number): { day: string; time: string } {
   const d = new Date(iso);
   const time = d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-  const today = new Date();
+  const today = new Date(now);
   const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
   const dayDiff = Math.round((startOf(today) - startOf(d)) / 86_400_000);
   const day =
@@ -42,11 +51,19 @@ export function HarnessOverview({
   events,
   onSelect,
   onSelectProject,
+  renderedAt,
 }: {
   harness: HarnessSummary;
   events: HarnessEventsResponse | null;
   onSelect: (it: AssetSummary) => void;
   onSelectProject: (id: string) => void;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and the event rows' day buckets read it. Required: a view that
+   * picks its own instant can label an event "Today" on the server and
+   * "Yesterday" in the browser.
+   */
+  renderedAt: number;
 }) {
   const mcpItems = harness.categories.find((c) => c.type === 'mcp')?.assets ?? [];
   const unapproved = mcpItems.filter((it) => it.trust === 'unapproved').length;
@@ -99,7 +116,7 @@ export function HarnessOverview({
             <div className="flex flex-col gap-1.5">
               {items.map((x) => {
                 const m = EVENT_KIND[x.kind];
-                const { day, time } = formatEvent(x.occurredAt);
+                const { day, time } = formatEvent(x.occurredAt, renderedAt);
                 return (
                   <div
                     key={`${x.occurredAt}·${x.title}`}

--- a/packages/dashboard-ui/src/lib/relativeTime.ts
+++ b/packages/dashboard-ui/src/lib/relativeTime.ts
@@ -1,6 +1,18 @@
 // Presentation helper: humanize an ISO timestamp as a relative string. Lives in
 // @akasecurity/dashboard-ui so the shared findings views don't reach into an app;
 // every host renders the same "6 days ago" strings.
+//
+// Both helpers take the instant to measure against as a REQUIRED argument, and
+// that is the whole point of the signature rather than a convenience. A relative
+// label is a pure function of (timestamp, now); read `now` from the ambient clock
+// instead and the same component computes one string while the server renders it
+// and a different one when the browser hydrates it, whenever a rounding boundary
+// falls between the two. React reports that as a hydration mismatch and discards
+// the server HTML for the subtree. A default argument does not close this: it
+// reads as safe at every call site that omits it, which is every call site until
+// somebody remembers. Requiring the argument makes the compiler name each place
+// that has to decide which instant it means. `useRenderClock` is what a client
+// host passes; a server component passes one instant it captured itself.
 
 const RELATIVE = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
 const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
@@ -12,8 +24,15 @@ const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
   ['minute', 60],
 ];
 
-/** Humanize an ISO timestamp as a relative string ("6 days ago"). */
-export function relativeTime(iso: string | undefined, now = Date.now()): string {
+/**
+ * Humanize an ISO timestamp as a relative string ("6 days ago").
+ *
+ * @param iso the instant being described; a missing or unparseable value reads
+ *   as the empty string, so a caller never has to pre-check one.
+ * @param now the instant to measure against, in epoch milliseconds. Required —
+ *   see the note at the top of this file.
+ */
+export function relativeTime(iso: string | undefined, now: number): string {
   if (!iso) return '';
   const then = Date.parse(iso);
   if (Number.isNaN(then)) return '';
@@ -43,12 +62,20 @@ const SHORT_SUFFIX: Partial<Record<Intl.RelativeTimeFormatUnit, string>> = {
  * Weeks cap at "4w" — the `month` tier (30d) precedes `week`, so 30+ days read
  * as "1mo"+. Under a minute reads "now" (same 45s cutoff as {@link relativeTime}'s
  * "just now"). Floors to the whole unit — "1h" means at least an hour elapsed.
+ *
+ * @param iso the instant being described; a missing or unparseable value reads
+ *   as the empty string.
+ * @param now the instant to measure against, in epoch milliseconds. Required for
+ *   the reason {@link relativeTime}'s is — and this helper floors rather than
+ *   rounds, so it crosses a boundary on every whole unit rather than on every
+ *   half one, which makes a drifting `now` MORE likely to change its text, not
+ *   less.
  */
-export function relativeTimeShort(iso: string | undefined): string {
+export function relativeTimeShort(iso: string | undefined, now: number): string {
   if (!iso) return '';
   const then = Date.parse(iso);
   if (Number.isNaN(then)) return '';
-  const abs = Math.abs((then - Date.now()) / 1000);
+  const abs = Math.abs((then - now) / 1000);
   if (abs < 45) return 'now';
   for (const [unit, secs] of UNITS) {
     if (abs >= secs) return `${String(Math.floor(abs / secs))}${SHORT_SUFFIX[unit] ?? ''}`;

--- a/packages/dashboard-ui/src/lib/timeRanges.ts
+++ b/packages/dashboard-ui/src/lib/timeRanges.ts
@@ -43,10 +43,18 @@ const DAY_MS = 86_400_000;
 /**
  * A time-range chip → the ISO `from` lower bound (`now − N days`) an API filters
  * on. Shared by every page that turns a range into a session/activity query so
- * every host path derives the same
- * bound. `now` is injectable so the derived `from` is testable.
+ * every host path derives the same bound.
+ *
+ * `now` is required rather than defaulted to `Date.now()` — not because this
+ * bound is itself rendered (it never is; it only shapes which rows a query
+ * returns), but because the caller's own render instant is what every LABEL on
+ * the same page is measured against. A default here would let the query window
+ * and the page's labels each read the clock independently, a fraction of a
+ * second apart — invisible almost always, and a real skew exactly when a
+ * request lands on the boundary the window is drawn from. Pass the same
+ * `renderedAt` the page already captured.
  */
-export function rangeToFromIso(range: TimeRange, now: number = Date.now()): string {
+export function rangeToFromIso(range: TimeRange, now: number): string {
   return new Date(now - RANGE_DAYS[range] * DAY_MS).toISOString();
 }
 

--- a/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
+++ b/packages/dashboard-ui/src/security/RecentlyResolvedCardView.tsx
@@ -21,11 +21,23 @@ export interface RecentlyResolvedView {
   items: ResolvedFeedItem[];
   isLoading: boolean;
   error: string | null;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }
 
 /** The recently-resolved feed: a vertical timeline of findings moved to resolved,
  * newest first. */
-export function RecentlyResolvedCardView({ items, isLoading, error }: RecentlyResolvedView) {
+export function RecentlyResolvedCardView({
+  items,
+  isLoading,
+  error,
+  renderedAt,
+}: RecentlyResolvedView) {
   return (
     <Card className="flex h-full flex-col shadow-sm">
       <CardHeader>
@@ -50,7 +62,12 @@ export function RecentlyResolvedCardView({ items, isLoading, error }: RecentlyRe
           <WidgetEmpty message="No resolved findings yet." />
         ) : (
           items.map((item, i) => (
-            <ResolvedRow key={item.findingKey} item={item} last={i === items.length - 1} />
+            <ResolvedRow
+              key={item.findingKey}
+              item={item}
+              last={i === items.length - 1}
+              renderedAt={renderedAt}
+            />
           ))
         )}
       </CardContent>
@@ -58,7 +75,15 @@ export function RecentlyResolvedCardView({ items, isLoading, error }: RecentlyRe
   );
 }
 
-function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) {
+function ResolvedRow({
+  item,
+  last,
+  renderedAt,
+}: {
+  item: ResolvedFeedItem;
+  last: boolean;
+  renderedAt: number;
+}) {
   return (
     <div className={cn('relative flex gap-3', !last && 'pb-4')}>
       {/* Connector line to the next item — centered under the 32px icon tile. */}
@@ -77,7 +102,7 @@ function ResolvedRow({ item, last }: { item: ResolvedFeedItem; last: boolean }) 
             {item.ruleId}
           </span>
           <span className="ml-auto shrink-0 text-xs text-text-3">
-            {relativeTime(item.resolvedAt)}
+            {relativeTime(item.resolvedAt, renderedAt)}
           </span>
         </div>
         <div className="mt-1.5 flex items-center gap-1.5 text-xs text-text-3">

--- a/packages/dashboard-ui/src/vault/DerefAuditTableView.tsx
+++ b/packages/dashboard-ui/src/vault/DerefAuditTableView.tsx
@@ -36,6 +36,13 @@ export interface DerefAuditTableViewProps {
   loadingNextPage?: boolean;
   // 1-based position of this window's first row in the whole trail.
   pageStart?: number | undefined;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }
 
 // Model-target crossings are the anomaly signal this trail exists for, so both
@@ -73,6 +80,7 @@ export function DerefAuditTableView({
   onPreviousPage,
   loadingNextPage = false,
   pageStart,
+  renderedAt,
 }: DerefAuditTableViewProps) {
   const toggle =
     onToggleBatched === undefined ? null : (
@@ -139,7 +147,9 @@ export function DerefAuditTableView({
                 // distinguished line — the record that values were destroyed
                 // outlives the values.
                 <TableRow key={row.id} data-purge="" className="bg-surface-2">
-                  <TableCell className="text-xs text-text-2">{relativeTime(row.at)}</TableCell>
+                  <TableCell className="text-xs text-text-2">
+                    {relativeTime(row.at, renderedAt)}
+                  </TableCell>
                   <TableCell colSpan={5} className="text-xs font-medium text-text-2">
                     Vault purge —{' '}
                     {row.pointerCount === 1 ? 'a pointer' : `${String(row.pointerCount)} pointers`}{' '}
@@ -155,7 +165,9 @@ export function DerefAuditTableView({
                     isBatchedDerefReason(row.reason) && 'text-text-3',
                   )}
                 >
-                  <TableCell className="text-xs text-text-2">{relativeTime(row.at)}</TableCell>
+                  <TableCell className="text-xs text-text-2">
+                    {relativeTime(row.at, renderedAt)}
+                  </TableCell>
                   <TableCell className="text-xs">{DEREF_REASON_LABEL[row.reason]}</TableCell>
                   <TableCell className="text-xs">
                     {row.target === 'model' ? (

--- a/packages/dashboard-ui/src/vault/VaultInventoryView.tsx
+++ b/packages/dashboard-ui/src/vault/VaultInventoryView.tsx
@@ -39,6 +39,13 @@ export interface VaultInventoryViewProps {
   pageStart?: number | undefined;
   // Vaulted values across the whole store, not just this page.
   total?: number | undefined;
+  /**
+   * The instant this render is measured against, in epoch milliseconds. The host
+   * captures one and every relative label below reads it. Required: a view that
+   * picks its own instant renders one string while the server renders it and
+   * another when the browser hydrates it. See ../lib/relativeTime.ts.
+   */
+  renderedAt: number;
 }
 
 const COLUMN_CLASS: Record<string, string> = {
@@ -66,6 +73,7 @@ export function VaultInventoryView({
   loadingNextPage = false,
   pageStart,
   total,
+  renderedAt,
 }: VaultInventoryViewProps) {
   // An empty page the reader PAGED INTO keeps its pager, because Previous is the
   // only way back out — a later page can come back empty (a repeat detection
@@ -111,6 +119,7 @@ export function VaultInventoryView({
                 hasActions={hasActions}
                 onReveal={onReveal}
                 onRevoke={onRevoke}
+                renderedAt={renderedAt}
               />
             ))}
           </TableBody>
@@ -153,9 +162,11 @@ function VaultInventoryRow({
   hasActions,
   onReveal,
   onRevoke,
+  renderedAt,
 }: {
   entry: VaultInventoryEntry;
   hasActions: boolean;
+  renderedAt: number;
   onReveal?: ((pointerId: string) => void) | undefined;
   onRevoke?: ((grantId: string) => void) | undefined;
 }) {
@@ -171,10 +182,10 @@ function VaultInventoryRow({
           <span className="text-xs text-text-2">{String(entry.occurrences)}</span>
         </TableCell>
         <TableCell className={COLUMN_CLASS.firstSeen}>
-          <span className="text-xs text-text-2">{relativeTime(entry.firstSeen)}</span>
+          <span className="text-xs text-text-2">{relativeTime(entry.firstSeen, renderedAt)}</span>
         </TableCell>
         <TableCell className={COLUMN_CLASS.lastSeen}>
-          <span className="text-xs text-text-2">{relativeTime(entry.lastSeen)}</span>
+          <span className="text-xs text-text-2">{relativeTime(entry.lastSeen, renderedAt)}</span>
         </TableCell>
         <TableCell className={COLUMN_CLASS.grant}>
           {grantId === null ? null : <RevealToModelBadge />}
@@ -229,7 +240,9 @@ function VaultInventoryRow({
                     <div>
                       <SightingKindChip kind={sighting.kind} />
                     </div>
-                    <span className="text-text-3">{relativeTime(sighting.lastSeen)}</span>
+                    <span className="text-text-3">
+                      {relativeTime(sighting.lastSeen, renderedAt)}
+                    </span>
                   </li>
                 ))}
               </ul>

--- a/packages/dashboard-ui/test/activity/SessionDetailView.test.tsx
+++ b/packages/dashboard-ui/test/activity/SessionDetailView.test.tsx
@@ -1,0 +1,102 @@
+import type { ActivitySession } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SessionDetailView } from '../../src/activity/SessionDetailView.tsx';
+
+// SessionDetailView's "Started"/"Duration" meta lines read `dayLabel` and
+// `durationLabel` the same way SessionListView's row does — but this view had
+// no `renderedAt` prop at all before this PR, so both calls fell straight
+// through to format.ts's ambient-clock defaults. Confirmed live: the app-level
+// host (ActivityClient) builds a `detailProps` object shared by the docked
+// pane and the full-width inspector and never included `renderedAt` in it,
+// so opening either for an in-progress or midnight-adjacent session rendered
+// one string on the server and another at hydration.
+function session(over: Partial<ActivitySession> = {}): ActivitySession {
+  return {
+    id: 'sess-1',
+    harness: 'claudecode',
+    title: 'Refactor auth',
+    project: 'api',
+    repo: 'acme/api',
+    branches: ['main'],
+    startedAt: '2026-07-05T08:00:00.000Z',
+    endedAt: null,
+    status: 'active',
+    turns: 4,
+    findings: 0,
+    shares: 0,
+    host: 'dev-box',
+    cwd: '/Users/dev/api',
+    models: ['claude-opus-5'],
+    version: '1.0.0',
+    tokens: {
+      sessionId: 'sess-1',
+      model: 'claude-opus-5',
+      provider: 'anthropic',
+      inputTokens: 100,
+      outputTokens: 200,
+      cacheCreation: 0,
+      cacheRead: 0,
+      totalTokens: 300,
+      estimatedCostUsd: null,
+    },
+    tools: {},
+    files: [],
+    commits: 0,
+    events: [],
+    ...over,
+  };
+}
+
+function render(props: Partial<Parameters<typeof SessionDetailView>[0]> = {}) {
+  return renderToStaticMarkup(
+    <SessionDetailView
+      session={session()}
+      isLoading={false}
+      error={null}
+      renderedAt={Date.parse('2026-07-05T09:00:00.000Z')}
+      {...props}
+    />,
+  );
+}
+
+describe('SessionDetailView measures its Duration meta line against the instant it is handed', () => {
+  it('renders an active session duration against renderedAt, not the ambient clock', () => {
+    const html = render();
+
+    expect(html).toContain('1h 0m · live');
+  });
+
+  it('is a fixture the ambient clock could not produce', () => {
+    const ambientMs = Date.now() - Date.parse('2026-07-05T08:00:00.000Z');
+    expect(Math.abs(ambientMs)).toBeGreaterThan(30 * 24 * 60 * 60 * 1000);
+  });
+});
+
+describe('SessionDetailView measures its Started day label against the instant it is handed', () => {
+  // Local-part construction, matching SessionListView's suite — the boundary
+  // is local midnight, so a UTC literal buckets differently by the runner's
+  // own time zone.
+  function at(day: number, hour: number): string {
+    return new Date(2026, 6, day, hour, 30).toISOString();
+  }
+
+  it('labels Today when renderedAt is the same local day as startedAt', () => {
+    const html = render({
+      session: session({ startedAt: at(5, 20) }),
+      renderedAt: new Date(2026, 6, 5, 22, 0).getTime(),
+    });
+
+    expect(html).toContain('Today');
+  });
+
+  it('relabels the SAME session Yesterday once renderedAt crosses local midnight', () => {
+    const html = render({
+      session: session({ startedAt: at(5, 23) }),
+      renderedAt: new Date(2026, 6, 6, 1, 0).getTime(),
+    });
+
+    expect(html).toContain('Yesterday');
+  });
+});

--- a/packages/dashboard-ui/test/activity/SessionListView.test.tsx
+++ b/packages/dashboard-ui/test/activity/SessionListView.test.tsx
@@ -1,0 +1,106 @@
+import type { ActivitySessionSummary } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SessionListView } from '../../src/activity/SessionListView.tsx';
+
+// SessionListView reads the ambient clock through two paths beside the
+// `relativeTime` call this class of bug was first fixed for in the same
+// element: `durationLabel` for an in-progress session's "46m · live" chip, and
+// `groupSessionsByDay` for the Today/Yesterday day headings. Both default their
+// `now` parameter in format.ts, so a call site that forgot to pass `renderedAt`
+// still compiled — the required-argument guard only reaches a call that
+// SUPPLIES nothing, and TypeScript is silent about a caller relying on a
+// default it can still see.
+//
+// The day-heading case is the more severe of the two: `day` becomes the React
+// key groupSessionsByDay assigns each section, so getting it from the wrong
+// clock does not just relabel a heading, it hands React a different key set —
+// the SUBTREE gets discarded and remounted rather than patched, which is the
+// exact "structural, not textual" failure this PR's own exceptionState fix
+// exists to prevent.
+const noop = (): void => undefined;
+
+function session(over: Partial<ActivitySessionSummary> = {}): ActivitySessionSummary {
+  return {
+    id: 'sess-1',
+    harness: 'claudecode',
+    title: 'Refactor auth',
+    project: 'api',
+    repo: 'acme/api',
+    branches: ['main'],
+    startedAt: '2026-07-05T08:00:00.000Z',
+    endedAt: null,
+    status: 'active',
+    turns: 4,
+    findings: 0,
+    shares: 0,
+    ...over,
+  };
+}
+
+function render(props: Partial<Parameters<typeof SessionListView>[0]> = {}) {
+  return renderToStaticMarkup(
+    <SessionListView
+      sessions={[session()]}
+      selectedId=""
+      onSelect={noop}
+      query=""
+      onQuery={noop}
+      harness={[]}
+      onHarness={noop}
+      isLoading={false}
+      error={null}
+      renderedAt={Date.parse('2026-07-05T09:00:00.000Z')}
+      {...props}
+    />,
+  );
+}
+
+describe('SessionListView measures its duration chip against the instant it is handed', () => {
+  it('renders an active session duration against renderedAt, not the ambient clock', () => {
+    // One hour after the fixture's startedAt: the "· live" chip on an active
+    // session measures against `now`, so this pins that `now` is `renderedAt`.
+    const html = render();
+
+    expect(html).toContain('1h 0m · live');
+  });
+
+  it('is a fixture the ambient clock could not produce', () => {
+    // The control: a duration read against `Date.now()` would print a duration
+    // in the years, not "1h 0m" — pin that renderedAt sits far from now.
+    const ambientMs = Date.now() - Date.parse('2026-07-05T08:00:00.000Z');
+    expect(Math.abs(ambientMs)).toBeGreaterThan(30 * 24 * 60 * 60 * 1000);
+  });
+});
+
+// Local-part construction throughout, never a UTC literal — the boundary is
+// LOCAL midnight, so a fixture built from a UTC instant buckets differently
+// depending on the runner's own time zone (verified: the two cases below flip
+// their answer under Pacific/Kiritimati and Asia/Kolkata when built that way).
+function at(day: number, hour: number): string {
+  return new Date(2026, 6, day, hour, 30).toISOString();
+}
+
+describe('SessionListView day-groups sessions against the instant it is handed', () => {
+  it('buckets a session under Today when renderedAt is the same local day', () => {
+    const html = render({
+      sessions: [session({ startedAt: at(5, 20) })],
+      renderedAt: new Date(2026, 6, 5, 22, 0).getTime(),
+    });
+
+    expect(html).toContain('Today');
+  });
+
+  it('buckets the SAME session under Yesterday when renderedAt crosses local midnight', () => {
+    // Same session fixture as above, only the clock this render was handed
+    // moves — which is exactly what a server render and a late hydration are.
+    const html = render({
+      sessions: [session({ startedAt: at(5, 23) })],
+      renderedAt: new Date(2026, 6, 6, 1, 0).getTime(),
+    });
+
+    expect(html).toContain('Yesterday');
+    expect(html).not.toContain('>Today<');
+  });
+});

--- a/packages/dashboard-ui/test/data-shares/DataSharesTableView.test.tsx
+++ b/packages/dashboard-ui/test/data-shares/DataSharesTableView.test.tsx
@@ -4,9 +4,15 @@ import { describe, expect, it, vi } from 'vitest';
 import { DataSharesTableView } from '../../src/data-shares/DataSharesTableView.tsx';
 import { destination, endpoint, group } from './fixtures.ts';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 function render(props: Partial<Parameters<typeof DataSharesTableView>[0]> = {}) {
   return renderToStaticMarkup(
     <DataSharesTableView
+      renderedAt={RENDERED_AT}
       group={group()}
       expanded={{}}
       selection={null}

--- a/packages/dashboard-ui/test/exceptions/blocked-ledger-approvability.test.tsx
+++ b/packages/dashboard-ui/test/exceptions/blocked-ledger-approvability.test.tsx
@@ -27,6 +27,11 @@ import {
   BlockedLedgerView,
 } from '../../src/exceptions/BlockedLedgerView.tsx';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 const row = (reference: string, keyVersion: number): BlockedDetectionDescriptor => ({
   reference,
   ruleId: 'aws-access-key',
@@ -43,6 +48,7 @@ const REFERENCES = ['aaa111', 'bbb222'] as const;
 const render = (blockReason: (r: BlockedDetectionDescriptor) => string | null) =>
   renderToStaticMarkup(
     <BlockedLedgerView
+      renderedAt={RENDERED_AT}
       items={[row(REFERENCES[0], 1), row(REFERENCES[1], 7)]}
       onApprove={vi.fn()}
       blockedWindow="30m"

--- a/packages/dashboard-ui/test/exceptions/fingerprint-egress.test.tsx
+++ b/packages/dashboard-ui/test/exceptions/fingerprint-egress.test.tsx
@@ -36,6 +36,11 @@ import {
 } from '../../src/exceptions/ExceptionsTableView.tsx';
 import type { RotateKeyDialogProps } from '../../src/exceptions/RotateKeyDialog.tsx';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 // Distinctive hex so a fragment of it in markup is an echo, not a coincidence;
 // no other fixture value below shares a 6-character window with it.
 const FINGERPRINT = 'ba5eba11deadbea7f01dab1ecafed00dfeedface8badf00dca11ab1e0ddba11e';
@@ -99,7 +104,11 @@ function expectNoFingerprintEcho(markup: string): void {
 describe('exceptions views never render the valueFingerprint', () => {
   it('ExceptionDetailView renders a full grant row without any fingerprint fragment', () => {
     const markup = renderToStaticMarkup(
-      <ExceptionDetailView exception={asExceptionDescriptor(exceptionRow)} onRevoke={vi.fn()} />,
+      <ExceptionDetailView
+        renderedAt={RENDERED_AT}
+        exception={asExceptionDescriptor(exceptionRow)}
+        onRevoke={vi.fn()}
+      />,
     );
     // Positive control first — an empty render passes every absence check vacuously.
     expect(markup).toContain(exceptionRow.id.slice(0, 8));
@@ -111,6 +120,7 @@ describe('exceptions views never render the valueFingerprint', () => {
   it('ExceptionsTableView renders full grant rows without any fingerprint fragment', () => {
     const markup = renderToStaticMarkup(
       <ExceptionsTableView
+        renderedAt={RENDERED_AT}
         items={[asExceptionDescriptor(exceptionRow)]}
         includeTerminal={false}
         onSelect={vi.fn()}
@@ -124,6 +134,7 @@ describe('exceptions views never render the valueFingerprint', () => {
   it('BlockedLedgerView renders full ledger rows without any fingerprint fragment', () => {
     const markup = renderToStaticMarkup(
       <BlockedLedgerView
+        renderedAt={RENDERED_AT}
         items={[asBlockedDescriptor(blockedRow)]}
         onApprove={vi.fn()}
         blockedWindow="30m"
@@ -146,6 +157,7 @@ describe('exceptions views never render the valueFingerprint', () => {
     // here, so the guard has to see the path rendered rather than beside it.
     const markup = renderToStaticMarkup(
       <BlockedLedgerView
+        renderedAt={RENDERED_AT}
         items={[asBlockedDescriptor(blockedRow)]}
         onApprove={vi.fn()}
         blockedWindow="30m"

--- a/packages/dashboard-ui/test/exceptions/views.test.tsx
+++ b/packages/dashboard-ui/test/exceptions/views.test.tsx
@@ -6,6 +6,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ExceptionDetailView } from '../../src/exceptions/ExceptionDetailView.tsx';
 import { ExceptionsTableView } from '../../src/exceptions/ExceptionsTableView.tsx';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 // The capability presentation is asymmetric on purpose: a reveal-to-model
 // grant is flagged with a badge on every surface (it lets the raw value reach
 // the model), while suppression — the default — stays unlabelled. Rendered
@@ -51,6 +56,7 @@ describe('ExceptionsTableView capability badge', () => {
   it('flags a reveal-to-model row with the badge', () => {
     const html = renderToStaticMarkup(
       <ExceptionsTableView
+        renderedAt={RENDERED_AT}
         items={[exception({ capability: 'reveal_to_model' })]}
         includeTerminal={false}
         onSelect={noop}
@@ -61,7 +67,12 @@ describe('ExceptionsTableView capability badge', () => {
 
   it('leaves a suppress row unlabelled', () => {
     const html = renderToStaticMarkup(
-      <ExceptionsTableView items={[exception({})]} includeTerminal={false} onSelect={noop} />,
+      <ExceptionsTableView
+        renderedAt={RENDERED_AT}
+        items={[exception({})]}
+        includeTerminal={false}
+        onSelect={noop}
+      />,
     );
     expect(html).not.toContain(BADGE);
   });
@@ -185,7 +196,10 @@ describe('ExceptionDetailView threads renderedAt, not the ambient clock', () => 
 describe('ExceptionDetailView capability presentation', () => {
   it('shows the badge and the consequence callout for a reveal grant', () => {
     const html = renderToStaticMarkup(
-      <ExceptionDetailView exception={exception({ capability: 'reveal_to_model' })} />,
+      <ExceptionDetailView
+        renderedAt={RENDERED_AT}
+        exception={exception({ capability: 'reveal_to_model' })}
+      />,
     );
     expect(html).toContain(BADGE);
     // The consequence must be stated, not implied.
@@ -194,8 +208,79 @@ describe('ExceptionDetailView capability presentation', () => {
   });
 
   it('renders a suppress grant without any capability labelling', () => {
-    const html = renderToStaticMarkup(<ExceptionDetailView exception={exception({})} />);
+    const html = renderToStaticMarkup(
+      <ExceptionDetailView renderedAt={RENDERED_AT} exception={exception({})} />,
+    );
     expect(html).not.toContain(BADGE);
     expect(html).not.toContain('raw form at tool boundaries');
+  });
+});
+
+// The instant these views are given is not just a label input: `exceptionState`
+// derives a grant's lifecycle from it, and ExceptionDetailView renders the
+// revoke form ONLY while that reads `active`. So the two renders of a page —
+// the server's and the browser's hydration of it — can disagree about whether a
+// whole subtree exists, which React resolves by throwing the server's markup
+// away. That is why the argument is required rather than defaulted, and these
+// are what fail if a view goes back to picking its own instant.
+//
+// Each case drives two renders that differ ONLY in `renderedAt`, straddling the
+// fixture's `expiresAt`. Two renders of one input, one boundary between them —
+// which is exactly the shape of the defect.
+describe('the exceptions views read the instant they are given', () => {
+  const EXPIRES = '2026-07-05T00:30:00.000Z';
+  const BEFORE = Date.parse('2026-07-05T00:00:00.000Z');
+  const AFTER = Date.parse('2026-07-05T01:00:00.000Z');
+  const expiring = () => exception({ scope: 'temporary', expiresAt: EXPIRES });
+
+  it('labels the same grant differently on either side of its expiry', () => {
+    const before = renderToStaticMarkup(
+      <ExceptionsTableView
+        items={[expiring()]}
+        includeTerminal
+        onSelect={noop}
+        renderedAt={BEFORE}
+      />,
+    );
+    const after = renderToStaticMarkup(
+      <ExceptionsTableView
+        items={[expiring()]}
+        includeTerminal
+        onSelect={noop}
+        renderedAt={AFTER}
+      />,
+    );
+
+    expect(before).toContain('in 30 minutes');
+    expect(before).toContain('>active<');
+    expect(after).toContain('30 minutes ago');
+    expect(after).toContain('>expired<');
+  });
+
+  it('gates the revoke form on the instant, so the two renders differ in STRUCTURE', () => {
+    // The severe case: not a differing label but a differing tree. The form is
+    // present at BEFORE and absent at AFTER, from the same props.
+    const before = renderToStaticMarkup(
+      <ExceptionDetailView exception={expiring()} onRevoke={noop} renderedAt={BEFORE} />,
+    );
+    const after = renderToStaticMarkup(
+      <ExceptionDetailView exception={expiring()} onRevoke={noop} renderedAt={AFTER} />,
+    );
+
+    expect(before).toContain('Revoke this grant');
+    expect(after).not.toContain('Revoke this grant');
+    // And the chip agrees with the form it gates, at both instants.
+    expect(before).toContain('>active<');
+    expect(after).toContain('>expired<');
+  });
+
+  it('threads the instant into the detail view own labels too', () => {
+    const html = renderToStaticMarkup(
+      <ExceptionDetailView
+        exception={exception({ createdAt: '2026-07-04T23:30:00.000Z' })}
+        renderedAt={BEFORE}
+      />,
+    );
+    expect(html).toContain('30 minutes ago');
   });
 });

--- a/packages/dashboard-ui/test/findings/FindingsFlatTableView.test.tsx
+++ b/packages/dashboard-ui/test/findings/FindingsFlatTableView.test.tsx
@@ -4,6 +4,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { FindingsFlatTableView } from '../../src/findings/FindingsFlatTableView.tsx';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 function instance(over: Partial<FindingInstanceDetail> = {}): FindingInstanceDetail {
   return {
     id: 'fnd-1',
@@ -27,7 +32,12 @@ function instance(over: Partial<FindingInstanceDetail> = {}): FindingInstanceDet
 
 function render(props: Partial<Parameters<typeof FindingsFlatTableView>[0]> = {}) {
   return renderToStaticMarkup(
-    <FindingsFlatTableView items={[instance()]} onSelect={vi.fn()} {...props} />,
+    <FindingsFlatTableView
+      renderedAt={RENDERED_AT}
+      items={[instance()]}
+      onSelect={vi.fn()}
+      {...props}
+    />,
   );
 }
 

--- a/packages/dashboard-ui/test/findings/FindingsTableView.test.tsx
+++ b/packages/dashboard-ui/test/findings/FindingsTableView.test.tsx
@@ -1,0 +1,98 @@
+import type { FindingGroup, FindingInstance } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FindingsTableView } from '../../src/findings/FindingsTableView.tsx';
+import { FINDINGS_COLUMNS } from '../../src/findings/meta.ts';
+
+// The grouped table renders its `latest` column twice over — once from
+// GROUP_CELL for the group row, once from INSTANCE_CELL for each expanded
+// instance row — and each reaches `relativeTime` with an instant of its own.
+// The sibling flat view's suite cannot see either: it renders a different
+// component.
+//
+// Both cells are pinned here against a fixed instant far from the fixtures, so
+// a cell that fell back to the ambient clock reads a five-figure age rather
+// than the hours the assertions name.
+const RENDERED_AT = Date.parse('2026-07-05T12:00:00.000Z');
+
+// Three hours and two days before RENDERED_AT. The two differ so a cell that
+// rendered the wrong row's timestamp is caught as well as one that read the
+// wrong clock.
+const GROUP_LATEST = '2026-07-05T09:00:00.000Z';
+const INSTANCE_DETECTED = '2026-07-03T12:00:00.000Z';
+
+function instance(over: Partial<FindingInstance> = {}): FindingInstance {
+  return {
+    id: 'fnd-1',
+    provider: 'claudecode',
+    repo: 'acme/api',
+    file: 'src/db.ts',
+    action: 'blocked',
+    detectedAt: INSTANCE_DETECTED,
+    confidence: 0.9,
+    status: 'handled',
+    ...over,
+  };
+}
+
+function group(over: Partial<FindingGroup> = {}): FindingGroup {
+  return {
+    id: 'aws-key',
+    category: 'secret',
+    subtype: 'aws-key',
+    severity: 'critical',
+    match: { maskedValue: 'AKIA****', contextPrefix: '' },
+    detection: { id: 'aws-key', name: null },
+    policy: { id: 'category:secret', name: 'secret' },
+    instanceCount: 1,
+    providers: ['claudecode'],
+    aggregateAction: 'blocked',
+    latestDetectedAt: GROUP_LATEST,
+    instances: [instance()],
+    status: 'handled',
+    ...over,
+  };
+}
+
+function render(props: Partial<Parameters<typeof FindingsTableView>[0]> = {}) {
+  return renderToStaticMarkup(
+    <FindingsTableView
+      renderedAt={RENDERED_AT}
+      groups={[group()]}
+      columns={FINDINGS_COLUMNS}
+      selection={null}
+      expandedIds={new Set<string>()}
+      onToggleExpand={vi.fn()}
+      onSelectGroup={vi.fn()}
+      onSelectInstance={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe('FindingsTableView measures both latest columns against the instant it is handed', () => {
+  it('renders the group row age against renderedAt, not the ambient clock', () => {
+    const html = render();
+
+    expect(html).toContain('3 hours ago');
+  });
+
+  it('renders an expanded instance row age against the same instant', () => {
+    const html = render({ expandedIds: new Set(['aws-key']) });
+
+    // The group's own cell is still there; the instance's is the second.
+    expect(html).toContain('3 hours ago');
+    expect(html).toContain('2 days ago');
+  });
+
+  it('is a fixture the ambient clock could not produce', () => {
+    // The control for the two cases above. Both assert a SHORT age, which is
+    // exactly what a view reading `Date.now()` would stop producing the moment
+    // the fixtures aged — so pin that the fixtures really are far from now.
+    // Without this, a regression to the ambient clock reads "3h ago" on any
+    // machine whose date happens to sit near the fixture, and both cases pass.
+    const ageFromRealClock = Date.now() - Date.parse(GROUP_LATEST);
+    expect(Math.abs(ageFromRealClock)).toBeGreaterThan(30 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/packages/dashboard-ui/test/inventory/harness-overview.test.tsx
+++ b/packages/dashboard-ui/test/inventory/harness-overview.test.tsx
@@ -1,0 +1,88 @@
+import type { HarnessEventsResponse, HarnessSummary } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HarnessOverview } from '../../src/inventory/HarnessOverview.tsx';
+
+// The enforcement-event rows bucket each event as "Today" / "Yesterday" / a
+// date, and that bucket is relative to an instant. It is the same hydration
+// defect the relative-time labels have, in a shape a search for `relativeTime`
+// does not find: the derivation lives in a module-level helper, so it is also
+// invisible to `react-hooks/purity`, which reports a clock read inside a
+// component. The `use client`-scoped clock ban is what found it, and this is
+// what keeps it found.
+//
+// The boundary here is local midnight rather than a rounding tier, so the
+// fixtures are built from local parts — a UTC literal would bucket differently
+// depending on the runner's time zone and make this test's own answer a
+// property of the machine.
+const noop = (): void => undefined;
+
+function at(day: number, hour: number): string {
+  return new Date(2026, 6, day, hour, 30).toISOString();
+}
+
+function harness(): HarnessSummary {
+  return {
+    id: 'claudecode',
+    label: 'Claude Code',
+    kind: 'cli',
+    version: '1.0.0',
+    sessions: 1,
+    assetCount: 0,
+    flagCount: 0,
+    projects: [],
+    categories: [],
+  };
+}
+
+function events(occurredAt: string): HarnessEventsResponse {
+  return {
+    counts: { block: 1, redact: 0, warn: 0 },
+    items: [{ kind: 'block', title: 'aws-access-key', detail: 'blocked', occurredAt }],
+  };
+}
+
+describe('HarnessOverview buckets its event rows against the instant it is given', () => {
+  // A clock a long way from either fixture instant, so a helper that reached for
+  // it would bucket every row as a bare date and fail both cases below.
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2027, 11, 25, 12, 0));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function render(occurredAt: string, renderedAt: number): string {
+    return renderToStaticMarkup(
+      <HarnessOverview
+        harness={harness()}
+        events={events(occurredAt)}
+        onSelect={noop}
+        onSelectProject={noop}
+        renderedAt={renderedAt}
+      />,
+    );
+  }
+
+  it('labels one event two different ways on either side of local midnight', () => {
+    // The same event, rendered at 23:00 on the 5th and again at 01:00 on the
+    // 6th. Two renders of one input across a boundary — which is exactly what a
+    // server render and a late hydration are.
+    const event = at(5, 22);
+    const before = render(event, new Date(2026, 6, 5, 23, 0).getTime());
+    const after = render(event, new Date(2026, 6, 6, 1, 0).getTime());
+
+    expect(before).toContain('Today');
+    expect(before).not.toContain('Yesterday');
+    expect(after).toContain('Yesterday');
+  });
+
+  it('falls back to a dated bucket beyond yesterday', () => {
+    const html = render(at(1, 12), new Date(2026, 6, 5, 12, 0).getTime());
+    expect(html).not.toContain('Today');
+    expect(html).not.toContain('Yesterday');
+    expect(html).toContain('Jul');
+  });
+});

--- a/packages/dashboard-ui/test/lib/relativeTime.test.ts
+++ b/packages/dashboard-ui/test/lib/relativeTime.test.ts
@@ -11,35 +11,81 @@ const HOUR = 60 * MIN;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 
-describe('relativeTimeShort', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(NOW);
-  });
-  afterEach(() => {
-    vi.useRealTimers();
-  });
+// Both helpers take the instant as a required argument, so every case below
+// passes NOW explicitly. The fake clock is still set — deliberately, and to a
+// DIFFERENT instant — because it is what makes each case double as a guard: a
+// helper that reached for Date.now() would measure against an ambient clock a
+// year and a half out, and no assertion here could still hold. Set the ambient
+// clock to NOW and this whole file goes on passing with the argument ignored.
+const AMBIENT = new Date('2027-12-25T00:00:00Z');
 
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(AMBIENT);
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('relativeTimeShort', () => {
   it('reads "now" under the 45s cutoff', () => {
-    expect(relativeTimeShort(ago(0))).toBe('now');
-    expect(relativeTimeShort(ago(44 * SEC))).toBe('now');
+    expect(relativeTimeShort(ago(0), NOW.getTime())).toBe('now');
+    expect(relativeTimeShort(ago(44 * SEC), NOW.getTime())).toBe('now');
   });
 
   it('floors to the largest whole unit with a terse suffix', () => {
-    expect(relativeTimeShort(ago(2 * MIN))).toBe('2m');
-    expect(relativeTimeShort(ago(38 * MIN))).toBe('38m');
-    expect(relativeTimeShort(ago(90 * MIN))).toBe('1h'); // floors, not rounds
-    expect(relativeTimeShort(ago(2 * HOUR))).toBe('2h');
-    expect(relativeTimeShort(ago(3 * DAY))).toBe('3d');
-    expect(relativeTimeShort(ago(2 * WEEK))).toBe('2w');
-    expect(relativeTimeShort(ago(29 * DAY))).toBe('4w'); // weeks cap here — month tier starts at 30d
-    expect(relativeTimeShort(ago(40 * DAY))).toBe('1mo'); // covers the `month` suffix the loop can emit
-    expect(relativeTimeShort(ago(400 * DAY))).toBe('1y');
+    expect(relativeTimeShort(ago(2 * MIN), NOW.getTime())).toBe('2m');
+    expect(relativeTimeShort(ago(38 * MIN), NOW.getTime())).toBe('38m');
+    expect(relativeTimeShort(ago(90 * MIN), NOW.getTime())).toBe('1h'); // floors, not rounds
+    expect(relativeTimeShort(ago(2 * HOUR), NOW.getTime())).toBe('2h');
+    expect(relativeTimeShort(ago(3 * DAY), NOW.getTime())).toBe('3d');
+    expect(relativeTimeShort(ago(2 * WEEK), NOW.getTime())).toBe('2w');
+    expect(relativeTimeShort(ago(29 * DAY), NOW.getTime())).toBe('4w'); // weeks cap here — month tier starts at 30d
+    expect(relativeTimeShort(ago(40 * DAY), NOW.getTime())).toBe('1mo'); // covers the `month` suffix the loop can emit
+    expect(relativeTimeShort(ago(400 * DAY), NOW.getTime())).toBe('1y');
   });
 
-  it('returns "" for missing or unparseable input', () => {
-    expect(relativeTimeShort(undefined)).toBe('');
-    expect(relativeTimeShort('not-a-date')).toBe('');
+  it('returns empty for a missing or unparseable timestamp', () => {
+    expect(relativeTimeShort(undefined, NOW.getTime())).toBe('');
+    expect(relativeTimeShort('not-a-date', NOW.getTime())).toBe('');
+  });
+});
+
+describe('relativeTime', () => {
+  it('uses a supplied render time instead of the current clock', () => {
+    const blockedAt = new Date(NOW.getTime() - 29 * MIN - 29 * SEC).toISOString();
+
+    expect(relativeTime(blockedAt, NOW.getTime())).toBe('29 minutes ago');
+    expect(relativeTime(blockedAt, NOW.getTime() + 2 * SEC)).toBe('30 minutes ago');
+  });
+
+  it('returns empty for a missing or unparseable timestamp', () => {
+    expect(relativeTime(undefined, NOW.getTime())).toBe('');
+    expect(relativeTime('not-a-date', NOW.getTime())).toBe('');
+  });
+});
+
+// The reason both helpers require the argument: a page is rendered twice, and a
+// helper measuring against a clock that moved between the two renders produces
+// different text for the same timestamp. These are the boundaries where that
+// shows, driven as two calls that differ ONLY in `now` — which is the whole
+// difference between a server render and the hydration that follows it.
+describe('the boundary a drifting clock crosses', () => {
+  it('changes the long form when the render instant moves by two seconds', () => {
+    // The step is at 60s, not at the 45s cutoff: anything under a minute misses
+    // every tier in UNITS and falls through to the same "just now" the cutoff
+    // returns, so 45-60s is a second path to one answer rather than a boundary.
+    const at = new Date(NOW.getTime() - 59 * SEC - 500).toISOString();
+    expect(relativeTime(at, NOW.getTime())).toBe('just now');
+    expect(relativeTime(at, NOW.getTime() + 2 * SEC)).toBe('1 minute ago');
+  });
+
+  it('changes the short form on a whole-unit boundary, which it floors to', () => {
+    // Two seconds either side of a whole hour: the short form floors, so it
+    // steps at every whole unit rather than at every half one.
+    const at = new Date(NOW.getTime() - HOUR + SEC).toISOString();
+    expect(relativeTimeShort(at, NOW.getTime())).toBe('59m');
+    expect(relativeTimeShort(at, NOW.getTime() + 2 * SEC)).toBe('1h');
   });
 });
 

--- a/packages/dashboard-ui/test/security/RecentlyResolvedCardView.test.tsx
+++ b/packages/dashboard-ui/test/security/RecentlyResolvedCardView.test.tsx
@@ -1,0 +1,67 @@
+import type { ResolvedFeedItem } from '@akasecurity/schema';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { RecentlyResolvedCardView } from '../../src/security/RecentlyResolvedCardView.tsx';
+
+// The resolved feed measures each row's age against the instant the card was
+// handed, and the card reaches that row through a pass-down (`renderedAt` onto
+// `ResolvedRow`) that nothing else covers — the security page composes this
+// view, and the page's own suite asserts the prop reaches the view, not what
+// the view does with it.
+const RENDERED_AT = Date.parse('2026-07-05T12:00:00.000Z');
+
+// Four hours before RENDERED_AT, and far enough from any real clock that a row
+// falling back to `Date.now()` cannot coincidentally read the same label.
+const RESOLVED_AT = '2026-07-05T08:00:00.000Z';
+
+function item(over: Partial<ResolvedFeedItem> = {}): ResolvedFeedItem {
+  return {
+    findingKey: 'fk-1',
+    ruleId: 'aws-key',
+    severity: 'critical',
+    path: 'src/db.ts',
+    resolvedAt: RESOLVED_AT,
+    detectedAt: '2026-07-01T00:00:00.000Z',
+    ...over,
+  };
+}
+
+function render(props: Partial<Parameters<typeof RecentlyResolvedCardView>[0]> = {}) {
+  return renderToStaticMarkup(
+    <RecentlyResolvedCardView
+      renderedAt={RENDERED_AT}
+      items={[item()]}
+      isLoading={false}
+      error={null}
+      {...props}
+    />,
+  );
+}
+
+describe('RecentlyResolvedCardView', () => {
+  it('measures a row against the instant the card was handed', () => {
+    const html = render();
+
+    expect(html).toContain('4 hours ago');
+  });
+
+  it('measures every row against that same instant', () => {
+    const html = render({
+      items: [item(), item({ findingKey: 'fk-2', resolvedAt: '2026-07-03T12:00:00.000Z' })],
+    });
+
+    expect(html).toContain('4 hours ago');
+    expect(html).toContain('2 days ago');
+  });
+
+  it('is a fixture the ambient clock could not produce', () => {
+    // The control: both cases above assert SHORT ages, which is exactly what a
+    // row reading `Date.now()` stops producing once the fixtures age. Pin that
+    // the fixture really is far from now, or a regression to the ambient clock
+    // would pass on any machine whose date sat near it.
+    expect(Math.abs(Date.now() - Date.parse(RESOLVED_AT))).toBeGreaterThan(
+      30 * 24 * 60 * 60 * 1000,
+    );
+  });
+});

--- a/packages/dashboard-ui/test/vault/views.test.tsx
+++ b/packages/dashboard-ui/test/vault/views.test.tsx
@@ -6,6 +6,11 @@ import { DerefAuditTableView } from '../../src/vault/DerefAuditTableView.tsx';
 import { VaultInventoryView } from '../../src/vault/VaultInventoryView.tsx';
 import { VaultReuseView } from '../../src/vault/VaultReuseView.tsx';
 
+// A fixed render instant. These cases assert display contracts rather than
+// ages, so the value only has to be the SAME one every run — but it has to be
+// passed, because the views no longer have a clock of their own to fall back on.
+const RENDERED_AT = Date.parse('2026-07-05T00:00:00.000Z');
+
 // Static-render coverage for the vault views (this package's test environment
 // is node, with no DOM). Everything a view receives is already raw-free —
 // masked previews, locations, counts — so the assertions here pin the display
@@ -108,6 +113,7 @@ describe('VaultInventoryView', () => {
   it('flags only rows covered by an active reveal grant', () => {
     const html = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[
           entry({ pointerId: 'ptr-granted', revealGrantId: 'grant-1' }),
           entry({ pointerId: 'ptr-plain', maskedMatch: 'ghp_****MASK' }),
@@ -118,7 +124,9 @@ describe('VaultInventoryView', () => {
   });
 
   it('renders each sighting with its location and kind chip', () => {
-    const html = renderToStaticMarkup(<VaultInventoryView entries={[entry({})]} />);
+    const html = renderToStaticMarkup(
+      <VaultInventoryView renderedAt={RENDERED_AT} entries={[entry({})]} />,
+    );
     expect(html).toContain('~/.claude/projects/demo/transcript.jsonl');
     expect(html).toContain('Transcript');
     // The consequence of a written pointer is stated, not implied.
@@ -127,17 +135,25 @@ describe('VaultInventoryView', () => {
 
   it('renders row actions only when the callbacks are supplied', () => {
     const rows = [entry({ revealGrantId: 'grant-1' })];
-    const readOnly = renderToStaticMarkup(<VaultInventoryView entries={rows} />);
+    const readOnly = renderToStaticMarkup(
+      <VaultInventoryView renderedAt={RENDERED_AT} entries={rows} />,
+    );
     expect(readOnly).not.toContain('Reveal</button>');
     expect(readOnly).not.toContain('Revoke grant');
     const actionable = renderToStaticMarkup(
-      <VaultInventoryView entries={rows} onReveal={() => undefined} onRevoke={() => undefined} />,
+      <VaultInventoryView
+        renderedAt={RENDERED_AT}
+        entries={rows}
+        onReveal={() => undefined}
+        onRevoke={() => undefined}
+      />,
     );
     expect(actionable).toContain('Reveal</button>');
     expect(actionable).toContain('Revoke grant');
     // No revoke affordance without an active grant to revoke.
     const ungranted = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[entry({})]}
         onReveal={() => undefined}
         onRevoke={() => undefined}
@@ -147,7 +163,7 @@ describe('VaultInventoryView', () => {
   });
 
   it('states the honest empty state', () => {
-    const html = renderToStaticMarkup(<VaultInventoryView entries={[]} />);
+    const html = renderToStaticMarkup(<VaultInventoryView renderedAt={RENDERED_AT} entries={[]} />);
     expect(html).toContain('Nothing vaulted yet');
   });
 
@@ -158,6 +174,7 @@ describe('VaultInventoryView', () => {
   it('keeps the pager on an empty page the reader paged into', () => {
     const stranded = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[]}
         hasPreviousPage={true}
         hasNextPage={false}
@@ -184,6 +201,7 @@ describe('VaultInventoryView', () => {
   it('shows no pager on an empty first page, even when one is wired', () => {
     const fresh = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[]}
         hasPreviousPage={false}
         hasNextPage={false}
@@ -201,13 +219,15 @@ describe('VaultInventoryView', () => {
   it('states the truncation rather than the footer when the caller cannot page', () => {
     const rows = [entry({ pointerId: 'ptr-a' }), entry({ pointerId: 'ptr-b' })];
     // Nothing beyond the page and no way to page: neither branch renders.
-    const complete = renderToStaticMarkup(<VaultInventoryView entries={rows} />);
+    const complete = renderToStaticMarkup(
+      <VaultInventoryView renderedAt={RENDERED_AT} entries={rows} />,
+    );
     expect(complete).not.toContain(FOOTER);
     expect(complete).not.toContain('the rest are in the store');
     // More rows exist and there is no callback to reach them — saying so is
     // the honest render, and silence would hide the missing rows entirely.
     const truncated = renderToStaticMarkup(
-      <VaultInventoryView entries={rows} hasNextPage={true} />,
+      <VaultInventoryView renderedAt={RENDERED_AT} entries={rows} hasNextPage={true} />,
     );
     expect(truncated).not.toContain(FOOTER);
     expect(truncated).toContain('Showing the first 2 values — the rest are in the store.');
@@ -217,6 +237,7 @@ describe('VaultInventoryView', () => {
     const rows = [entry({ pointerId: 'ptr-a' }), entry({ pointerId: 'ptr-b' })];
     const more = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={rows}
         hasNextPage={true}
         onNextPage={() => undefined}
@@ -232,6 +253,7 @@ describe('VaultInventoryView', () => {
     // pager a vanishing Next would also remove the reader's way back.
     const done = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={rows}
         hasNextPage={false}
         onNextPage={() => undefined}
@@ -252,6 +274,7 @@ describe('VaultInventoryView', () => {
     const rows = [entry({ pointerId: 'ptr-a' }), entry({ pointerId: 'ptr-b' })];
     const first = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={rows}
         hasNextPage={true}
         onNextPage={() => undefined}
@@ -264,6 +287,7 @@ describe('VaultInventoryView', () => {
 
     const second = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={rows}
         hasNextPage={true}
         hasPreviousPage={true}
@@ -281,6 +305,7 @@ describe('VaultInventoryView', () => {
   it('disables the footer button while a page is in flight', () => {
     const html = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[entry({})]}
         hasNextPage={true}
         onNextPage={() => undefined}
@@ -295,6 +320,7 @@ describe('VaultInventoryView', () => {
     // hold for a button that is disabled whatever the caller passes.
     const idle = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={[entry({})]}
         hasNextPage={true}
         onNextPage={() => undefined}
@@ -310,6 +336,7 @@ describe('VaultInventoryView', () => {
     const rows = [entry({ pointerId: 'ptr-a' }), entry({ pointerId: 'ptr-b' })];
     const html = renderToStaticMarkup(
       <VaultInventoryView
+        renderedAt={RENDERED_AT}
         entries={rows}
         hasNextPage={true}
         onNextPage={() => undefined}
@@ -320,7 +347,12 @@ describe('VaultInventoryView', () => {
     expect(html).toContain('1–2 of 40 values</p>');
     // With no total the view claims only what it can see.
     const untotalled = renderToStaticMarkup(
-      <VaultInventoryView entries={rows} hasNextPage={true} onNextPage={() => undefined} />,
+      <VaultInventoryView
+        renderedAt={RENDERED_AT}
+        entries={rows}
+        hasNextPage={true}
+        onNextPage={() => undefined}
+      />,
     );
     expect(untotalled).toContain('2 shown</p>');
     expect(untotalled).not.toContain('2 of');
@@ -457,6 +489,7 @@ describe('DerefAuditTableView', () => {
   it('hides batched rows behind a muted count line by default', () => {
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={[deref({})]}
         hiddenBatched={4}
         showBatched={false}
@@ -470,6 +503,7 @@ describe('DerefAuditTableView', () => {
   it('shows batched rows with their pointerCount under the flag', () => {
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={[deref({ reason: 'display', pointerCount: 12 })]}
         hiddenBatched={0}
         showBatched={true}
@@ -482,6 +516,7 @@ describe('DerefAuditTableView', () => {
   it('marks a refused model crossing with the prominence hook', () => {
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={[deref({ target: 'model', reason: 'model-input', outcome: 'refused' })]}
         hiddenBatched={0}
         showBatched={false}
@@ -494,6 +529,7 @@ describe('DerefAuditTableView', () => {
   it('marks a revealed model crossing and its grant prefix', () => {
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={[
           deref({
             target: 'model',
@@ -514,6 +550,7 @@ describe('DerefAuditTableView', () => {
   it('renders a purge as a distinguished event line', () => {
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={[deref({ reason: 'purge', outcome: 'unavailable', pointerCount: 7 })]}
         hiddenBatched={0}
         showBatched={false}
@@ -527,12 +564,23 @@ describe('DerefAuditTableView', () => {
   it('states the truncation rather than the footer when the caller cannot page', () => {
     const rows = [deref({}), deref({ id: 'second-row-id' })];
     const complete = renderToStaticMarkup(
-      <DerefAuditTableView rows={rows} hiddenBatched={0} showBatched={false} />,
+      <DerefAuditTableView
+        renderedAt={RENDERED_AT}
+        rows={rows}
+        hiddenBatched={0}
+        showBatched={false}
+      />,
     );
     expect(complete).not.toContain(FOOTER);
     expect(complete).not.toContain('Showing the most recent');
     const truncated = renderToStaticMarkup(
-      <DerefAuditTableView rows={rows} hiddenBatched={0} showBatched={false} hasNextPage={true} />,
+      <DerefAuditTableView
+        renderedAt={RENDERED_AT}
+        rows={rows}
+        hiddenBatched={0}
+        showBatched={false}
+        hasNextPage={true}
+      />,
     );
     expect(truncated).not.toContain(FOOTER);
     expect(truncated).toContain('Showing the most recent 2 resolutions.');
@@ -542,6 +590,7 @@ describe('DerefAuditTableView', () => {
     const rows = [deref({}), deref({ id: 'second-row-id' })];
     const more = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={0}
         showBatched={false}
@@ -556,6 +605,7 @@ describe('DerefAuditTableView', () => {
     expect(more).not.toContain('Showing the most recent');
     const done = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={0}
         showBatched={false}
@@ -574,6 +624,7 @@ describe('DerefAuditTableView', () => {
     const rows = [deref({}), deref({ id: 'second-row-id' })];
     const html = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={0}
         showBatched={false}
@@ -587,6 +638,7 @@ describe('DerefAuditTableView', () => {
     expect(html).toContain('Loading…');
     const idle = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={0}
         showBatched={false}
@@ -605,6 +657,7 @@ describe('DerefAuditTableView', () => {
     const rows = [deref({}), deref({ id: 'second-row-id' })];
     const hidden = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={4}
         showBatched={false}
@@ -621,6 +674,7 @@ describe('DerefAuditTableView', () => {
     // page footer is untouched by that switch.
     const shown = renderToStaticMarkup(
       <DerefAuditTableView
+        renderedAt={RENDERED_AT}
         rows={rows}
         hiddenBatched={4}
         showBatched={true}
@@ -640,9 +694,13 @@ describe('raw-value hygiene', () => {
   it('never renders a raw-shaped credential from raw-free props', () => {
     const html = renderToStaticMarkup(
       <>
-        <VaultInventoryView entries={[entry({ revealGrantId: 'grant-1' })]} />
+        <VaultInventoryView
+          renderedAt={RENDERED_AT}
+          entries={[entry({ revealGrantId: 'grant-1' })]}
+        />
         <VaultReuseView entries={[entry({ occurrences: 2 })]} />
         <DerefAuditTableView
+          renderedAt={RENDERED_AT}
           rows={[deref({ target: 'model', reason: 'model-input', outcome: 'revealed' })]}
           hiddenBatched={2}
           showBatched={false}
@@ -659,6 +717,7 @@ describe('raw-value hygiene', () => {
     const html = renderToStaticMarkup(
       <>
         <VaultInventoryView
+          renderedAt={RENDERED_AT}
           entries={[entry({ revealGrantId: 'grant-1' })]}
           hasNextPage={true}
           onNextPage={() => undefined}
@@ -672,6 +731,7 @@ describe('raw-value hygiene', () => {
           total={40}
         />
         <DerefAuditTableView
+          renderedAt={RENDERED_AT}
           rows={[deref({ target: 'model', reason: 'model-input', outcome: 'revealed' })]}
           hiddenBatched={2}
           showBatched={false}

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -347,8 +347,52 @@ function tonalInkSelectors() {
   ];
 }
 
-// The tonal-token guard, for the packages that render Tailwind classes: ui-kit,
-// dashboard-ui and web-ui.
+const AMBIENT_CLOCK_MESSAGE =
+  'A component under a `use client` directive is rendered TWICE — once on the server, ' +
+  'once when the browser hydrates it — and reading the clock makes those two renders ' +
+  'disagree whenever a rounding boundary falls between them, which React resolves by ' +
+  'discarding the server HTML for the subtree. Take the instant as a prop (`renderedAt`) ' +
+  'from the server component that captured it, or track it with `useRenderClock`, which ' +
+  'returns that instant for the hydration render and the live clock afterwards. ' +
+  '`new Date(someIso)` and `Date.parse(someIso)` are unaffected — they read no clock.';
+
+/**
+ * The `no-restricted-syntax` entries that reject an ambient clock read inside a
+ * module carrying the `use client` directive.
+ *
+ * The scoping is the whole trick: `Program:has(> ExpressionStatement[directive=…])`
+ * matches only where the directive is a real directive-prologue statement, so a
+ * SERVER component — which is where an instant is legitimately captured, and must
+ * stay legitimate — is untouched, and so is a file that merely mentions the string
+ * `use client` as a value. Only `Date.now()` and a zero-argument `new Date()` are
+ * clock reads; `new Date(iso)` and `Date.parse(iso)` parse a value the caller
+ * already had and are deliberately left alone.
+ *
+ * Known limits, in the shape `tonalInkSelectors` states its own: an alias
+ * (`const n = Date.now; n()`), a clock reached through a helper the client
+ * component calls, and `performance.now()` — which is not a wall clock and cannot
+ * produce a date label — are not matched. This bans the accident, not the evasion.
+ *
+ * @returns {{ selector: string, message: string }[]}
+ */
+function ambientClockSelectors() {
+  const CLIENT = "Program:has(> ExpressionStatement[directive='use client'])";
+  return [
+    {
+      selector: `${CLIENT} CallExpression[callee.object.name='Date'][callee.property.name='now']`,
+      message: AMBIENT_CLOCK_MESSAGE,
+    },
+    {
+      selector: `${CLIENT} NewExpression[callee.name='Date'][arguments.length=0]`,
+      message: AMBIENT_CLOCK_MESSAGE,
+    },
+  ];
+}
+
+// The assembled `no-restricted-syntax` value for the packages that render in a
+// browser: ui-kit, dashboard-ui and web-ui. Named for the tonal guard it was
+// introduced to carry; it is the ONE entry these packages get, so it also carries
+// the ambient-clock ban and, below, the two bans it must not drop.
 //
 // It re-lists the network AND drizzle selectors rather than only its own, because
 // a flat-config `rules` entry REPLACES the rule's options instead of merging them
@@ -356,16 +400,40 @@ function tonalInkSelectors() {
 // exactly these three packages, and this is spread after `noDrizzleImports` in
 // every one of them. `reactUiPackage` below is what keeps that ordering from
 // being re-derived per package.
+/**
+ * The whole `no-restricted-syntax` value one of those packages gets, assembled
+ * from every group rather than composed by spreading — because a later flat-config
+ * entry REPLACES this rule's options, so a config that sets it a second time and
+ * names a subset silently drops the rest.
+ *
+ * That is exactly what a per-file opt-out has to do, which is why the only
+ * supported way to write one is to call this with the group turned off:
+ *
+ *   { files: ['src/lib/useRenderClock.ts'],
+ *     rules: { 'no-restricted-syntax': reactSyntaxBans({ allowAmbientClock: true }) } }
+ *
+ * The other three groups come along by construction, so an opt-out for one ban
+ * cannot become an opt-out for four by omission.
+ *
+ * @param {{ allowAmbientClock?: boolean }} [opts]
+ * @returns {import('eslint').Linter.RuleEntry}
+ */
+export function reactSyntaxBans(opts = {}) {
+  const { allowAmbientClock = false } = opts;
+  return /** @type {import('eslint').Linter.RuleEntry} */ ([
+    'error',
+    ...networkSyntaxSelectors(),
+    ...drizzleSyntaxSelectors(),
+    ...tonalInkSelectors(),
+    ...(allowAmbientClock ? [] : ambientClockSelectors()),
+  ]);
+}
+
 /** @type {import('eslint').Linter.Config[]} */
 export const tonalInkTokens = [
   {
     rules: {
-      'no-restricted-syntax': /** @type {import('eslint').Linter.RuleEntry} */ ([
-        'error',
-        ...networkSyntaxSelectors(),
-        ...drizzleSyntaxSelectors(),
-        ...tonalInkSelectors(),
-      ]),
+      'no-restricted-syntax': reactSyntaxBans(),
     },
   },
 ];

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -358,32 +358,51 @@ const AMBIENT_CLOCK_MESSAGE =
 
 /**
  * The `no-restricted-syntax` entries that reject an ambient clock read inside a
- * module carrying the `use client` directive.
+ * module carrying the `use client` directive — or, with `everyModule: true`,
+ * inside every module in the package, directive or not.
  *
- * The scoping is the whole trick: `Program:has(> ExpressionStatement[directive=…])`
- * matches only where the directive is a real directive-prologue statement, so a
- * SERVER component — which is where an instant is legitimately captured, and must
- * stay legitimate — is untouched, and so is a file that merely mentions the string
- * `use client` as a value. Only `Date.now()` and a zero-argument `new Date()` are
- * clock reads; `new Date(iso)` and `Date.parse(iso)` parse a value the caller
- * already had and are deliberately left alone.
+ * The directive scoping is the whole trick for the default case:
+ * `Program:has(> ExpressionStatement[directive=…])` matches only where the
+ * directive is a real directive-prologue statement, so a SERVER component —
+ * which is where an instant is legitimately captured, and must stay legitimate
+ * — is untouched, and so is a file that merely mentions the string
+ * `use client` as a value. Only `Date.now()` and a zero-argument `new Date()`
+ * are clock reads; `new Date(iso)` and `Date.parse(iso)` parse a value the
+ * caller already had and are deliberately left alone.
+ *
+ * `everyModule` exists because the directive scoping has a gap the default
+ * case cannot close: a PRESENTATIONAL helper module — one that carries no
+ * component and so no directive of its own, `relativeTime.ts` and
+ * `exceptions/meta.ts` are the two this repo ships — is invisible to the
+ * directive-anchored selector no matter how many client components import it.
+ * A caller who reverts `now: number` back to `now: number = Date.now()` there
+ * still typechecks at every existing call site (a default satisfies
+ * "required") and trips no rule, because the selector never runs on a Program
+ * with no directive child. `dashboard-ui` and `ui-kit` close that: neither
+ * package ever legitimately captures an instant — that is `web-ui`'s
+ * `renderInstant()`, which lives outside both — so nothing in either is
+ * exempted by the widening except the one sanctioned reader, which stays
+ * exempted through `allowAmbientClock` (a full opt-out, checked first)
+ * regardless of which mode this produces.
  *
  * Known limits, in the shape `tonalInkSelectors` states its own: an alias
  * (`const n = Date.now; n()`), a clock reached through a helper the client
  * component calls, and `performance.now()` — which is not a wall clock and cannot
  * produce a date label — are not matched. This bans the accident, not the evasion.
  *
+ * @param {{ everyModule?: boolean }} [opts]
  * @returns {{ selector: string, message: string }[]}
  */
-function ambientClockSelectors() {
-  const CLIENT = "Program:has(> ExpressionStatement[directive='use client'])";
+function ambientClockSelectors(opts = {}) {
+  const { everyModule = false } = opts;
+  const scope = everyModule ? '' : "Program:has(> ExpressionStatement[directive='use client']) ";
   return [
     {
-      selector: `${CLIENT} CallExpression[callee.object.name='Date'][callee.property.name='now']`,
+      selector: `${scope}CallExpression[callee.object.name='Date'][callee.property.name='now']`,
       message: AMBIENT_CLOCK_MESSAGE,
     },
     {
-      selector: `${CLIENT} NewExpression[callee.name='Date'][arguments.length=0]`,
+      selector: `${scope}NewExpression[callee.name='Date'][arguments.length=0]`,
       message: AMBIENT_CLOCK_MESSAGE,
     },
   ];
@@ -415,17 +434,24 @@ function ambientClockSelectors() {
  * The other three groups come along by construction, so an opt-out for one ban
  * cannot become an opt-out for four by omission.
  *
- * @param {{ allowAmbientClock?: boolean }} [opts]
+ * `ambientClockEveryModule` is the other direction — WIDENING rather than
+ * lifting the clock ban, to every module in the package regardless of
+ * directive. See `ambientClockSelectors`'s own doc for why that is sound only
+ * for a package with no legitimate ambient-clock reader anywhere in it.
+ * `allowAmbientClock` wins if both are set, since a file that opted all the
+ * way out has nothing left to widen.
+ *
+ * @param {{ allowAmbientClock?: boolean, ambientClockEveryModule?: boolean }} [opts]
  * @returns {import('eslint').Linter.RuleEntry}
  */
 export function reactSyntaxBans(opts = {}) {
-  const { allowAmbientClock = false } = opts;
+  const { allowAmbientClock = false, ambientClockEveryModule = false } = opts;
   return /** @type {import('eslint').Linter.RuleEntry} */ ([
     'error',
     ...networkSyntaxSelectors(),
     ...drizzleSyntaxSelectors(),
     ...tonalInkSelectors(),
-    ...(allowAmbientClock ? [] : ambientClockSelectors()),
+    ...(allowAmbientClock ? [] : ambientClockSelectors({ everyModule: ambientClockEveryModule })),
   ]);
 }
 
@@ -434,6 +460,22 @@ export const tonalInkTokens = [
   {
     rules: {
       'no-restricted-syntax': reactSyntaxBans(),
+    },
+  },
+];
+
+/**
+ * The same assembled value, with the ambient-clock ban widened to every
+ * module in the package rather than only ones carrying `use client`. For
+ * `dashboard-ui` and `ui-kit`: both are pure-presentational packages that
+ * never legitimately capture a render instant (that is `web-ui`'s
+ * `renderInstant()`, outside either), so the directive is not what should
+ * decide whether a clock read there is caught — see `ambientClockSelectors`.
+ */
+export const tonalInkTokensPresentational = [
+  {
+    rules: {
+      'no-restricted-syntax': reactSyntaxBans({ ambientClockEveryModule: true }),
     },
   },
 ];

--- a/packages/eslint-config/src/react.js
+++ b/packages/eslint-config/src/react.js
@@ -2,7 +2,7 @@
 import pluginReact from 'eslint-plugin-react';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 
-import { base, noDrizzleImports, tonalInkTokens } from './index.js';
+import { base, noDrizzleImports, reactSyntaxBans, tonalInkTokens } from './index.js';
 
 // A plain flat-config array, for the reason spelled out over `base` in
 // index.js: the `tseslint.config()` wrapper this used to carry returned the
@@ -43,5 +43,38 @@ export const react = [
 // Spread this, add the package's own `parserOptions`, then `rootConfigFiles`.
 /** @type {import('typescript-eslint').ConfigArray} */
 export const reactUiPackage = [...react, ...noDrizzleImports, ...tonalInkTokens];
+
+// The same preset, LAYERED with a `src/**`-scoped widening of the clock ban,
+// for a package with no legitimate ambient-clock reader anywhere in it:
+// `dashboard-ui` and `ui-kit`, which never capture a render instant themselves
+// (that is `web-ui`'s `renderInstant()`) and only ever take one as a prop.
+// `web-ui` keeps `reactUiPackage` unchanged — its Server Components are
+// exactly where an instant is legitimately captured, so the clock ban there
+// must stay scoped to `use client` modules.
+//
+// Built ON `reactUiPackage` rather than replacing it, because
+// `tonalInkTokensPresentational` sets the WHOLE `no-restricted-syntax` value —
+// network, drizzle and tonal included — so scoping THAT object to `src/**`
+// would silently drop all three from every `test/**` file in the package, the
+// same "a later entry replaces rather than merges" trap this module's other
+// comments warn about. Layering a THIRD, `files`-scoped entry after
+// `reactUiPackage` keeps the base (directive-scoped) ban as the floor
+// everywhere and replaces it with the wider one only inside `src/**` — so
+// `test/**` fixtures keep an unrestricted `Date.now()`, since asserting "this
+// instant is far from now" is not the hydration-mismatch class this ban exists
+// for. See `tonalInkTokensPresentational`'s doc for what the widening itself
+// buys: a presentational helper module (no component, so no directive of its
+// own — `relativeTime.ts` and `exceptions/meta.ts` are the two this repo
+// ships) is invisible to the directive-anchored selector no matter how many
+// client components import it, so reverting its required `now` argument back
+// to a `Date.now()` default trips nothing there today.
+/** @type {import('typescript-eslint').ConfigArray} */
+export const presentationalUiPackage = [
+  ...reactUiPackage,
+  {
+    files: ['src/**'],
+    rules: { 'no-restricted-syntax': reactSyntaxBans({ ambientClockEveryModule: true }) },
+  },
+];
 
 export default react;

--- a/packages/eslint-config/test/ambient-clock.test.js
+++ b/packages/eslint-config/test/ambient-clock.test.js
@@ -1,0 +1,156 @@
+import { Linter } from 'eslint';
+import tseslint from 'typescript-eslint';
+import { describe, expect, it } from 'vitest';
+
+import { noNetworkSyntax, reactSyntaxBans, tonalInkTokens } from '../src/index.js';
+
+// The ambient-clock guard. A component under a `use client` directive is
+// rendered twice — once on the server, once when the browser hydrates it — so a
+// label derived from the clock can differ between the two renders whenever a
+// rounding boundary falls between them, and React resolves that by discarding
+// the server HTML for the subtree. The fix is a required `renderedAt` argument
+// on the time helpers, which the compiler enforces; this ban is what stops the
+// argument being satisfied with a fresh clock read at the call site, which
+// typechecks perfectly and reintroduces the whole defect.
+//
+// Same shape as no-network.test.js and tonal-ink-tokens.test.js: lint snippets
+// with the SHIPPED rule value imported from ../src/index.js, so weakening the
+// ban in the config fails here rather than passing as a config-shape check.
+
+const linter = new Linter();
+
+/** The `no-restricted-syntax` value the three UI packages actually get. */
+const SHIPPED_RULE = tonalInkTokens[0]?.rules?.['no-restricted-syntax'];
+
+// The real parser, on a real .tsx filename. espree would do for the selectors
+// themselves, but the directive-prologue node these are anchored on is produced
+// by the PARSER, and typescript-eslint is the one that parses this repo's
+// components. A selector that works under espree and not under this one would
+// enforce nothing while every config assertion stayed green.
+function lint(code, rule = SHIPPED_RULE) {
+  return linter.verify(
+    code,
+    [
+      {
+        files: ['**/*.tsx'],
+        languageOptions: {
+          parser: tseslint.parser,
+          ecmaVersion: 2024,
+          sourceType: 'module',
+          parserOptions: { ecmaFeatures: { jsx: true } },
+        },
+        rules: { 'no-restricted-syntax': rule },
+      },
+    ],
+    'Component.tsx',
+  );
+}
+
+const firedOn = (code, rule) => lint(code, rule).length;
+const messagesFor = (code, rule) => lint(code, rule).map((m) => m.message);
+
+const CLIENT = "'use client';\n";
+
+describe('a client component may not read the clock', () => {
+  it.each([
+    ['Date.now() in the body', 'export function F() { return <b>{Date.now()}</b>; }'],
+    ['a zero-argument new Date()', 'export function F() { return <b>{String(new Date())}</b>; }'],
+    ['Date.now() in a nested closure', 'export const F = () => () => Date.now();'],
+    ['Date.now() as a default argument', 'export function g(n = Date.now()) { return n; }'],
+    [
+      'Date.now() passed to a helper',
+      'export function F() { return <b>{rel(x, Date.now())}</b>; }',
+    ],
+    [
+      'a clock read inside a hook callback',
+      'export function F() { useEffect(() => { setN(Date.now()); }); return null; }',
+    ],
+  ])('rejects %s', (_label, body) => {
+    expect(firedOn(CLIENT + body)).toBe(1);
+  });
+
+  it('names the prop and the hook, so the fix is in the error', () => {
+    const [message] = messagesFor(CLIENT + 'export function F() { return <b>{Date.now()}</b>; }');
+    expect(message).toContain('renderedAt');
+    expect(message).toContain('useRenderClock');
+  });
+});
+
+// The two halves that make this usable rather than merely strict. Without the
+// first, there would be nowhere left to capture an instant at all; without the
+// second, every date the dashboard formats would be a violation.
+describe('what it must NOT flag', () => {
+  it('leaves a SERVER component alone — that is where an instant is captured', () => {
+    expect(firedOn('export function Page() { const at = Date.now(); return <b>{at}</b>; }')).toBe(
+      0,
+    );
+  });
+
+  it.each([
+    [
+      'new Date(iso) — parses a value, reads no clock',
+      'export function F({ x }) { return <b>{String(new Date(x))}</b>; }',
+    ],
+    ['Date.parse(iso)', 'export function F({ x }) { return <b>{Date.parse(x)}</b>; }'],
+    [
+      'a date built from explicit parts',
+      'export function F() { return <b>{String(new Date(2026, 1, 1))}</b>; }',
+    ],
+    [
+      'a member call that merely ends in now',
+      'export function F({ c }) { return <b>{c.now()}</b>; }',
+    ],
+  ])('accepts %s in a client component', (_label, body) => {
+    expect(firedOn(CLIENT + body)).toBe(0);
+  });
+
+  it('does not fire on a file that merely MENTIONS the directive as a value', () => {
+    // A test or a build script may carry the string without being a client
+    // module. The selector is anchored on the directive-prologue node, not on
+    // the presence of the text.
+    const code = "export const d = 'use client';\nexport function f() { return Date.now(); }\n";
+    expect(firedOn(code)).toBe(0);
+  });
+
+  it('does NOT see a clock reached through a helper — a known, deliberate gap', () => {
+    // Stated rather than fixed: an esquery selector cannot follow a binding.
+    // The required `now` argument on the helpers is what covers this one.
+    const code =
+      CLIENT + 'import { clock } from "./clock";\nexport function F() { return <b>{clock()}</b>; }';
+    expect(firedOn(code)).toBe(0);
+  });
+});
+
+// A flat-config `rules` entry REPLACES this rule's options rather than merging
+// them, so the assembled value has to carry every group at once — and the
+// per-file opt-out has to be built the same way, or lifting one ban lifts four.
+describe('the opt-out cannot become an opt-out for everything', () => {
+  it('drops only the clock selectors, keeping the rest', () => {
+    const withClock = reactSyntaxBans();
+    const withoutClock = reactSyntaxBans({ allowAmbientClock: true });
+    expect(withoutClock.length).toBe(withClock.length - 2);
+
+    const kept = new Set(withoutClock.slice(1).map((e) => e.selector));
+    for (const entry of withClock.slice(1)) {
+      const isClockEntry = entry.selector.includes("directive='use client'");
+      expect(kept.has(entry.selector)).toBe(!isClockEntry);
+    }
+  });
+
+  it('still bans the network in a file that opted out of the clock ban', () => {
+    const rule = reactSyntaxBans({ allowAmbientClock: true });
+    expect(firedOn(CLIENT + "export const p = import('node:https');", rule)).toBe(1);
+    expect(firedOn(CLIENT + 'export function F() { return Date.now(); }', rule)).toBe(0);
+  });
+
+  it('carries every selector noNetworkSyntax ships, not a subset', () => {
+    const shipped = new Set(SHIPPED_RULE.slice(1).map((e) => e.selector));
+    for (const entry of noNetworkSyntax().slice(1)) {
+      expect(shipped.has(entry.selector)).toBe(true);
+    }
+  });
+
+  it('is set to error, so it fails a lint run rather than warning', () => {
+    expect(SHIPPED_RULE[0]).toBe('error');
+  });
+});

--- a/packages/eslint-config/test/ambient-clock.test.js
+++ b/packages/eslint-config/test/ambient-clock.test.js
@@ -2,7 +2,12 @@ import { Linter } from 'eslint';
 import tseslint from 'typescript-eslint';
 import { describe, expect, it } from 'vitest';
 
-import { noNetworkSyntax, reactSyntaxBans, tonalInkTokens } from '../src/index.js';
+import {
+  noNetworkSyntax,
+  reactSyntaxBans,
+  tonalInkTokens,
+  tonalInkTokensPresentational,
+} from '../src/index.js';
 
 // The ambient-clock guard. A component under a `use client` directive is
 // rendered twice — once on the server, once when the browser hydrates it — so a
@@ -19,7 +24,7 @@ import { noNetworkSyntax, reactSyntaxBans, tonalInkTokens } from '../src/index.j
 
 const linter = new Linter();
 
-/** The `no-restricted-syntax` value the three UI packages actually get. */
+/** The `no-restricted-syntax` value `web-ui` gets (`dashboard-ui`/`ui-kit` get the same tonal/network/drizzle selectors via `tonalInkTokensPresentational`, differing only in the ambient-clock scope — see ambient-clock.test.js). */
 const SHIPPED_RULE = tonalInkTokens[0]?.rules?.['no-restricted-syntax'];
 
 // The real parser, on a real .tsx filename. espree would do for the selectors
@@ -152,5 +157,55 @@ describe('the opt-out cannot become an opt-out for everything', () => {
 
   it('is set to error, so it fails a lint run rather than warning', () => {
     expect(SHIPPED_RULE[0]).toBe('error');
+  });
+});
+
+// The gap the directive scoping leaves: a presentational helper module carries
+// no component and so no directive of its own, so it is invisible to the
+// SHIPPED_RULE above no matter how many client components import it —
+// `relativeTime.ts` and `exceptions/meta.ts` are the two this repo ships.
+// `dashboard-ui` and `ui-kit` close it by widening instead: neither package
+// ever legitimately captures an instant, so the directive is not what should
+// decide whether a clock read in it is caught.
+describe('the presentational variant reaches a module with no directive of its own', () => {
+  const PRESENTATIONAL_RULE = tonalInkTokensPresentational[0]?.rules?.['no-restricted-syntax'];
+
+  it('rejects Date.now() in a module carrying NO use client directive at all', () => {
+    // The exact shape of relativeTime.ts before this PR: no component, no
+    // directive, a default parameter reading the clock.
+    const code = 'export function relativeTime(iso, now = Date.now()) { return now; }';
+    expect(firedOn(code, PRESENTATIONAL_RULE)).toBe(1);
+  });
+
+  it('rejects a bare new Date() the same way, directive or not', () => {
+    const code = 'export function dayLabel(iso, now = new Date()) { return now; }';
+    expect(firedOn(code, PRESENTATIONAL_RULE)).toBe(1);
+  });
+
+  it('the DEFAULT (directive-scoped) rule does NOT catch that shape — the regression this closes', () => {
+    const code = 'export function relativeTime(iso, now = Date.now()) { return now; }';
+    expect(firedOn(code, SHIPPED_RULE)).toBe(0);
+  });
+
+  it('still catches the directive-scoped case too — widening does not narrow it', () => {
+    expect(
+      firedOn(CLIENT + 'export function F() { return <b>{Date.now()}</b>; }', PRESENTATIONAL_RULE),
+    ).toBe(1);
+  });
+
+  it('still allows new Date(iso) and Date.parse(iso) — the widening bans no more shapes, only more files', () => {
+    expect(firedOn('export function F(x) { return new Date(x); }', PRESENTATIONAL_RULE)).toBe(0);
+    expect(firedOn('export function F(x) { return Date.parse(x); }', PRESENTATIONAL_RULE)).toBe(0);
+  });
+
+  it('the one sanctioned reader stays exempt: allowAmbientClock wins over everyModule', () => {
+    const rule = reactSyntaxBans({ allowAmbientClock: true, ambientClockEveryModule: true });
+    expect(firedOn('export function useRenderClock() { return Date.now(); }', rule)).toBe(0);
+  });
+
+  it('still bans the network and drizzle in the widened form — the assembly is not a bare override', () => {
+    expect(firedOn("export const p = import('node:https');", PRESENTATIONAL_RULE)).toBe(1);
+    expect(firedOn("import x from 'drizzle-orm';", PRESENTATIONAL_RULE)).toBe(0); // no-restricted-syntax only covers the DYNAMIC form; static is a separate rule
+    expect(firedOn("await import('drizzle-orm');", PRESENTATIONAL_RULE)).toBe(1);
   });
 });

--- a/packages/eslint-config/test/package-walls.test.js
+++ b/packages/eslint-config/test/package-walls.test.js
@@ -230,7 +230,12 @@ describe('the tonal-ink wall reaches every package that renders Tailwind classes
 // fails here. A floor would forbid removals while letting the next unguarded
 // package in, which is the direction this drifts.
 describe('the drizzle wall covers an exact set of packages, not a floor', () => {
-  const WALL_TOKENS = ['noDrizzleImports', 'reactUiPackage', 'drizzleWallRules'];
+  const WALL_TOKENS = [
+    'noDrizzleImports',
+    'reactUiPackage',
+    'presentationalUiPackage',
+    'drizzleWallRules',
+  ];
 
   // Discovered by BASENAME, via the same helper the no-network audit derives
   // from — never a hardcoded `eslint.config.mjs`. ESLint honours `-c
@@ -263,7 +268,8 @@ describe('the drizzle wall covers an exact set of packages, not a floor', () => 
     expect(
       configsReferencingWall(),
       'The set of packages wiring the drizzle wall changed. Every workspace package that ships ' +
-        'product code must spread `noDrizzleImports` (or `reactUiPackage`, which composes it), ' +
+        'product code must spread `noDrizzleImports` (or `reactUiPackage`/`presentationalUiPackage`, ' +
+        'either of which composes it), ' +
         'whether or not it reads the store today: the shipping bundles set ' +
         '`noExternal: [/^@akasecurity\\//]`, so ONE Drizzle import anywhere in that closure is ' +
         'inlined into a published artifact — and into a browser for the extension, web-ui, ' +

--- a/packages/eslint-config/test/package-walls.test.js
+++ b/packages/eslint-config/test/package-walls.test.js
@@ -101,6 +101,32 @@ const RELAXED_FILES = [
   },
 ];
 
+// The ambient-clock ban's WIDENING for `dashboard-ui`/`ui-kit`: `Date.now()`
+// and a bare `new Date()` are banned in every `src/**` module, not only ones
+// carrying `use client`, since neither package ever legitimately captures a
+// render instant. That is a `files: ['src/**']`-scoped entry layered onto
+// `reactUiPackage` inside `presentationalUiPackage` (react.js) — resolved per
+// FILE for the same reason `RELAXED_FILES` above is, since the package-level
+// config says nothing about the split between `src/**` and everywhere else.
+//
+// This is the only place that widening is checked against the REAL resolved
+// config. ambient-clock.test.js's own suite drives `tonalInkTokensPresentational`
+// — a bare rule VALUE that no production config actually consumes once
+// `presentationalUiPackage` stopped spreading it directly (a refactor partway
+// through this file's own history) — so it could not have caught the widening
+// going dead. Verified by deleting the `files`-scoped entry from
+// `presentationalUiPackage` and re-running the whole `eslint-config` suite: it
+// stayed green throughout, `pnpm lint` on `dashboard-ui` stopped catching the
+// exact regression this ban exists for, and only the two cases below noticed.
+const AMBIENT_CLOCK_TEST_FILES = [
+  {
+    name: '@akasecurity/dashboard-ui test',
+    dir: 'packages/dashboard-ui',
+    file: 'test/lib/relativeTime.test.ts',
+  },
+  { name: '@akasecurity/ui-kit test', dir: 'packages/ui-kit', file: 'test/badge.test.ts' },
+];
+
 // The workspace packages that deliberately do NOT carry the drizzle wall, with
 // the reason each is out. Every other workspace package is in WALLED_PACKAGES,
 // and the coverage assertion below holds the two together — so a package added
@@ -140,7 +166,7 @@ const resolved = new Map();
 // surfaced HERE rather than left to surface as ESLint's own bare "Could not find
 // config file", which names neither the package nor the reason.
 beforeAll(async () => {
-  for (const pkg of [...WALLED_PACKAGES, ...RELAXED_FILES]) {
+  for (const pkg of [...WALLED_PACKAGES, ...RELAXED_FILES, ...AMBIENT_CLOCK_TEST_FILES]) {
     const pkgDir = join(REPO_ROOT, pkg.dir);
     const eslint = new ESLint({ cwd: pkgDir });
     let config;
@@ -224,6 +250,42 @@ describe('the tonal-ink wall reaches every package that renders Tailwind classes
   it.each(tonalNames)('%s still enforces the network ban', (name) => {
     expect(firedIn(name, "await import('node:http');", 'no-restricted-syntax')).toBe(1);
   });
+});
+
+// The ambient-clock widening (see AMBIENT_CLOCK_TEST_FILES above), against the
+// REAL resolved config for each package rather than a bare rule value.
+describe('the ambient-clock ban is widened for dashboard-ui/ui-kit src, and only src', () => {
+  // No `use client` directive anywhere in this snippet — the shape of
+  // relativeTime.ts's regression this widening exists to catch. espree (this
+  // suite's plain Linter) parses it fine: the widened selector carries no
+  // directive-prologue requirement to begin with.
+  const NO_DIRECTIVE_CLOCK_READ = 'export function f(n = Date.now()) { return n; }';
+  const DIRECTIVE_SCOPED_CLOCK_READ = "'use client';\nexport function F() { return Date.now(); }";
+
+  it.each(['@akasecurity/dashboard-ui', '@akasecurity/ui-kit'])(
+    '%s catches it in src/**, where directive scoping alone would miss it',
+    (name) => {
+      expect(firedIn(name, NO_DIRECTIVE_CLOCK_READ, 'no-restricted-syntax')).toBe(1);
+    },
+  );
+
+  it.each(['@akasecurity/dashboard-ui test', '@akasecurity/ui-kit test'])(
+    '%s does NOT widen into test/**, where fixtures need an unrestricted clock',
+    (name) => {
+      expect(firedIn(name, NO_DIRECTIVE_CLOCK_READ, 'no-restricted-syntax')).toBe(0);
+    },
+  );
+
+  it('web-ui keeps the directive-scoped ban everywhere — it never widens', () => {
+    expect(firedIn('web-ui', NO_DIRECTIVE_CLOCK_READ, 'no-restricted-syntax')).toBe(0);
+  });
+
+  it.each(['@akasecurity/dashboard-ui', '@akasecurity/ui-kit', 'web-ui'])(
+    '%s still catches the directive-scoped case — widening does not narrow it',
+    (name) => {
+      expect(firedIn(name, DIRECTIVE_SCOPED_CLOCK_READ, 'no-restricted-syntax')).toBe(1);
+    },
+  );
 });
 
 // Derived from the tree rather than listed, so a package added without the wall

--- a/packages/eslint-config/test/tonal-ink-tokens.test.js
+++ b/packages/eslint-config/test/tonal-ink-tokens.test.js
@@ -16,7 +16,7 @@ import { noNetworkSyntax, tonalInkTokens } from '../src/index.js';
 const linter = new Linter();
 const LANG = { ecmaVersion: 'latest', sourceType: 'module' };
 
-/** The `no-restricted-syntax` value the three UI packages actually get. */
+/** The `no-restricted-syntax` value `web-ui` gets (`dashboard-ui`/`ui-kit` get the same tonal/network/drizzle selectors via `tonalInkTokensPresentational`, differing only in the ambient-clock scope — see ambient-clock.test.js). */
 const SHIPPED_RULE = tonalInkTokens[0]?.rules?.['no-restricted-syntax'];
 
 function lintTonal(code, rule = SHIPPED_RULE) {

--- a/packages/ui-kit/eslint.config.mjs
+++ b/packages/ui-kit/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
 import { rootConfigFiles } from '@akasecurity/eslint-config';
-import { reactUiPackage } from '@akasecurity/eslint-config/react';
+import { presentationalUiPackage } from '@akasecurity/eslint-config/react';
 
 export default [
-  ...reactUiPackage,
+  ...presentationalUiPackage,
   {
     languageOptions: {
       parserOptions: {

--- a/web-ui/app/(app)/activity/ActivityClient.tsx
+++ b/web-ui/app/(app)/activity/ActivityClient.tsx
@@ -159,6 +159,7 @@ export function ActivityClient({
     linkHref,
     isLoading: false,
     error: null,
+    renderedAt,
     // Tool chips deep-link to the flat findings view filtered to that
     // tool. `?tool=` is a real filter on the capturing event's recorded
     // tool name, where the previous `?q=via Bash` was a text match

--- a/web-ui/app/(app)/activity/ActivityClient.tsx
+++ b/web-ui/app/(app)/activity/ActivityClient.tsx
@@ -5,6 +5,7 @@ import {
   SessionDetailView,
   SessionListView,
   type TimeRange,
+  useRenderClock,
 } from '@akasecurity/dashboard-ui';
 import type {
   ActivitySession,
@@ -64,12 +65,16 @@ export function ActivityClient({
   /** Whether the full-width session inspector is open (?view=full). */
   expanded: boolean;
   /**
-   * The instant the SERVER rendered against. Passed down rather than read here:
-   * a client that picked its own would render different text than the HTML it
-   * is hydrating.
+   * The instant the SERVER rendered against. Advanced through useRenderClock
+   * below rather than read directly, so hydration matches this exact value
+   * and then the clock resumes moving — a session-list day heading and an
+   * in-progress "· live" duration chip both derive from it, and a client that
+   * never advanced past the server's instant would freeze both for the life
+   * of this component instead of merely matching hydration once.
    */
   renderedAt: number;
 }) {
+  const renderClock = useRenderClock(renderedAt);
   const pathname = usePathname();
   const { isPending, push: pushUrl, replace: replaceUrl } = useNavigationTransition();
 
@@ -159,7 +164,7 @@ export function ActivityClient({
     linkHref,
     isLoading: false,
     error: null,
-    renderedAt,
+    renderedAt: renderClock,
     // Tool chips deep-link to the flat findings view filtered to that
     // tool. `?tool=` is a real filter on the capturing event's recorded
     // tool name, where the previous `?q=via Bash` was a text match
@@ -186,7 +191,7 @@ export function ActivityClient({
     >
       <Card className="flex w-85 shrink-0 flex-col overflow-hidden shadow-sm">
         <SessionListView
-          renderedAt={renderedAt}
+          renderedAt={renderClock}
           sessions={sessions}
           selectedId={selectedId}
           onSelect={(id) => {

--- a/web-ui/app/(app)/activity/ActivityClient.tsx
+++ b/web-ui/app/(app)/activity/ActivityClient.tsx
@@ -41,6 +41,7 @@ export function ActivityClient({
   emptyCount,
   showEmpty,
   expanded,
+  renderedAt,
 }: {
   sessions: ActivitySessionSummary[];
   detail: ActivitySession | null;
@@ -62,6 +63,12 @@ export function ActivityClient({
   showEmpty: boolean;
   /** Whether the full-width session inspector is open (?view=full). */
   expanded: boolean;
+  /**
+   * The instant the SERVER rendered against. Passed down rather than read here:
+   * a client that picked its own would render different text than the HTML it
+   * is hydrating.
+   */
+  renderedAt: number;
 }) {
   const pathname = usePathname();
   const { isPending, push: pushUrl, replace: replaceUrl } = useNavigationTransition();
@@ -178,6 +185,7 @@ export function ActivityClient({
     >
       <Card className="flex w-85 shrink-0 flex-col overflow-hidden shadow-sm">
         <SessionListView
+          renderedAt={renderedAt}
           sessions={sessions}
           selectedId={selectedId}
           onSelect={(id) => {

--- a/web-ui/app/(app)/activity/filters.ts
+++ b/web-ui/app/(app)/activity/filters.ts
@@ -71,15 +71,19 @@ export function parseExpanded(sp: ActivitySearchParams): boolean {
 /**
  * Search + harness + range → the persistence session-list query. The range maps
  * to a `from` lower bound (`now − N days`); `limit: 100` is the schema max (the
- * list shows a truncation notice past it rather than paginating). `nowMs` is
- * injectable so the derived `from` is testable.
+ * list shows a truncation notice past it rather than paginating).
+ *
+ * `nowMs` is required — see `rangeToFromIso`'s own doc for why a default here
+ * is the wrong shape even though this bound is never itself rendered: it must
+ * share the page's `renderedAt` rather than take an independent clock read a
+ * fraction of a second apart from the labels that instant measures.
  */
 export function toListQuery(
   q: string,
   harness: Harness[],
   range: TimeRange,
   showEmpty = false,
-  nowMs: number = Date.now(),
+  nowMs: number,
 ): ListActivitySessionsQuery {
   return {
     ...(q ? { q } : {}),

--- a/web-ui/app/(app)/activity/page.tsx
+++ b/web-ui/app/(app)/activity/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../components/icons';
 import { RangeSelect } from '../../components/RangeSelect';
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import { ActivityClient } from './ActivityClient';
 import {
   type ActivitySearchParams,
@@ -126,6 +127,9 @@ export default async function ActivityPage({
       tone: 'teal',
     },
   ];
+  // One instant for the whole route: every relative label below is measured
+  // against it during the server render and again during hydration.
+  const renderedAt = renderInstant();
   return (
     <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
       {/* Token usage sits in the filter bar beside the range picker rather than
@@ -163,6 +167,7 @@ export default async function ActivityPage({
         emptyCount={list.emptyCount}
         showEmpty={showEmpty}
         expanded={expanded}
+        renderedAt={renderedAt}
       />
     </div>
   );

--- a/web-ui/app/(app)/activity/page.tsx
+++ b/web-ui/app/(app)/activity/page.tsx
@@ -56,14 +56,19 @@ export default async function ActivityPage({
 
   const activity = db().activity;
 
+  // Captured before the range bound below so the query window and every
+  // rendered label this request produces come from the SAME instant, rather
+  // than a range bound computed a clock read apart from the labels it scopes.
+  const renderedAt = renderInstant();
+
   // The time-range lower bound the session list uses, reused to scope the token
   // panel and the harness filter to the window on screen (range maps to `now − N
   // days`; rows/leaves/harnesses before it are excluded).
-  const rangeFromMs = Date.parse(rangeToFromIso(range));
+  const rangeFromMs = Date.parse(rangeToFromIso(range, renderedAt));
 
   const [stats, list, tokenReports, harnessOptions] = await Promise.all([
     activity.stats(),
-    activity.listSessions(toListQuery(q, harness, range, showEmpty)),
+    activity.listSessions(toListQuery(q, harness, range, showEmpty, renderedAt)),
     activity.tokenReports(rangeFromMs),
     // Only the harnesses that actually have sessions in this range populate the
     // filter (not the full enum).
@@ -127,9 +132,6 @@ export default async function ActivityPage({
       tone: 'teal',
     },
   ];
-  // One instant for the whole route: every relative label below is measured
-  // against it during the server render and again during hydration.
-  const renderedAt = renderInstant();
   return (
     <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
       {/* Token usage sits in the filter bar beside the range picker rather than

--- a/web-ui/app/(app)/data-shares/DataSharesClient.tsx
+++ b/web-ui/app/(app)/data-shares/DataSharesClient.tsx
@@ -62,6 +62,7 @@ export function DataSharesClient({
   destination,
   selectedDest,
   selectedEndpoint,
+  renderedAt,
 }: {
   q: string;
   groups: ShareDestinationGroup[];
@@ -69,6 +70,12 @@ export function DataSharesClient({
   destination: ShareDestinationDetail | null;
   selectedDest: string | null;
   selectedEndpoint: string | null;
+  /**
+   * The instant the SERVER rendered against. Passed down rather than read here:
+   * a client that picked its own would render different text than the HTML it
+   * is hydrating.
+   */
+  renderedAt: number;
 }) {
   const pathname = usePathname();
   // Navigation transition (search/selection pushes) — distinct from the write
@@ -186,6 +193,7 @@ export function DataSharesClient({
                 className="min-h-0 flex-1 overflow-y-auto p-3.5"
               >
                 <DataSharesTableView
+                  renderedAt={renderedAt}
                   group={activeGroup}
                   expanded={expanded}
                   forceExpand={!!ql}
@@ -241,6 +249,7 @@ export function DataSharesClient({
                     </div>
                   )}
                   <DataShareDetailView
+                    renderedAt={renderedAt}
                     destination={destination}
                     endpoint={selectedEp}
                     isSettingDecision={isSettingDecision}

--- a/web-ui/app/(app)/data-shares/page.tsx
+++ b/web-ui/app/(app)/data-shares/page.tsx
@@ -1,6 +1,7 @@
 import { PageHead } from '@akasecurity/dashboard-ui';
 
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import { DataSharesClient } from './DataSharesClient';
 import { type DataSharesSearchParams, parseQuery, parseSelection } from './filters';
 
@@ -35,6 +36,9 @@ export default async function DataSharesPage({
     q ? Promise.resolve({ items: [] }) : shares.needsReview(),
   ]);
   const destination = dest ? await shares.getDestination(dest) : null;
+  // One instant for the whole route: every relative label below is measured
+  // against it during the server render and again during hydration.
+  const renderedAt = renderInstant();
 
   return (
     <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
@@ -57,6 +61,7 @@ export default async function DataSharesPage({
         destination={destination}
         selectedDest={dest}
         selectedEndpoint={ep}
+        renderedAt={renderedAt}
       />
     </div>
   );

--- a/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
+++ b/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
@@ -39,6 +39,7 @@ export function ExceptionsClient({
   keyState: FingerprintKeyState;
   activePermanent: ExceptionDescriptor[];
   approvableBlocked: number;
+  /** The instant the server rendered against. */
   renderedAt: number;
 }) {
   // Navigation transition (the blocked-window filter, the audit toggle and row

--- a/web-ui/app/(app)/exceptions/[id]/ExceptionDetailClient.tsx
+++ b/web-ui/app/(app)/exceptions/[id]/ExceptionDetailClient.tsx
@@ -11,6 +11,7 @@ export function ExceptionDetailClient({
   renderedAt,
 }: {
   exception: ExceptionDescriptor;
+  /** The instant the server rendered against. */
   renderedAt: number;
 }) {
   const [error, setError] = useState<string | null>(null);

--- a/web-ui/app/(app)/exceptions/[id]/page.tsx
+++ b/web-ui/app/(app)/exceptions/[id]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import { db } from '../../../lib/db';
+import { renderInstant } from '../../../lib/rendered-at';
 import { ExceptionDetailClient } from './ExceptionDetailClient';
 
 export const runtime = 'nodejs';
@@ -53,8 +54,7 @@ export default async function ExceptionDetailPage({ params }: { params: Promise<
         // revoke form renders at all — must be calculated against the exact
         // same instant during SSR and hydration; otherwise crossing a boundary
         // between the two changes the text, or the form itself.
-        // eslint-disable-next-line react-hooks/purity -- serialized to the client for hydration parity
-        renderedAt={Date.now()}
+        renderedAt={renderInstant()}
       />
     </div>
   );

--- a/web-ui/app/(app)/exceptions/page.tsx
+++ b/web-ui/app/(app)/exceptions/page.tsx
@@ -13,6 +13,7 @@ import type { FingerprintKeyState } from '@akasecurity/schema';
 import { toBlockedDetectionDescriptor, toExceptionDescriptor } from '@akasecurity/schema';
 
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import { ExceptionsClient } from './ExceptionsClient';
 
 // node:sqlite (via @akasecurity/persistence) runs only on the Node.js runtime.
@@ -78,8 +79,8 @@ export default async function ExceptionsPage({
   const approvableBlocked = retained.filter((b) => isBlockedRowApprovable(b, keyState)).length;
   // A relative label must be calculated against the exact same instant during
   // SSR and hydration; otherwise crossing a minute boundary can change its text.
-  // eslint-disable-next-line react-hooks/purity -- serialized to the client for hydration parity
-  const renderedAt = Date.now();
+  // One instant for the whole route, so both child views measure against it.
+  const renderedAt = renderInstant();
 
   return (
     <ExceptionsClient

--- a/web-ui/app/(app)/findings/FindingsClient.tsx
+++ b/web-ui/app/(app)/findings/FindingsClient.tsx
@@ -87,6 +87,12 @@ interface CommonProps {
   tools: string[];
   repo: string;
   file: string;
+  /**
+   * The instant the SERVER rendered against, passed down for the same reason
+   * `from` is: every relative label has to read one instant, and a client that
+   * read its own would render different text than the HTML it is hydrating.
+   */
+  renderedAt: number;
 }
 
 type ViewProps =
@@ -118,6 +124,7 @@ export function FindingsClient(props: CommonProps & ViewProps) {
     tools,
     repo,
     file,
+    renderedAt,
   } = props;
   const pathname = usePathname();
   const { isPending, push } = useNavigationTransition();
@@ -298,6 +305,7 @@ export function FindingsClient(props: CommonProps & ViewProps) {
             columnVisibility={columnVisibility}
             sessionHref={sessionHref}
             emptyState={emptyState}
+            renderedAt={renderedAt}
           />
         )}
         {props.view === 'flat' && (
@@ -311,12 +319,14 @@ export function FindingsClient(props: CommonProps & ViewProps) {
             repo={repo}
             file={file}
             emptyState={emptyState}
+            renderedAt={renderedAt}
           />
         )}
         {props.view === 'files' && (
           <LocationsView
             data={props.locations}
             emptyState={emptyState}
+            renderedAt={renderedAt}
             onSelectFile={(nextRepo, nextFile) => {
               // Drill into one file's findings: the flat view is the one that
               // can filter down to a single location.
@@ -345,6 +355,7 @@ function GroupedView({
   columnVisibility,
   sessionHref,
   emptyState,
+  renderedAt,
 }: {
   data: ListGroupedFindingsResponse;
   filters: FindingsFilters;
@@ -355,6 +366,7 @@ function GroupedView({
   columnVisibility: ColumnVisibility;
   sessionHref: string | null;
   emptyState: React.ReactNode;
+  renderedAt: number;
 }) {
   // Each entry is one fetched page; `cursors[i]` is what fetches the page
   // after `pages[i]`. Stepping forward past the cached frontier fetches and
@@ -442,6 +454,7 @@ function GroupedView({
   return (
     <>
       <FindingsTableView
+        renderedAt={renderedAt}
         groups={groups}
         columns={visibleColumns}
         selection={selected}
@@ -482,6 +495,7 @@ function GroupedView({
         <SheetContent className="p-0" aria-describedby={undefined}>
           {selected && (
             <FindingDetailView
+              renderedAt={renderedAt}
               selection={selected}
               onSelectInstance={(instance) => {
                 setSelected({ finding: selected.finding, instance });
@@ -527,6 +541,7 @@ function FlatView({
   repo,
   file,
   emptyState,
+  renderedAt,
 }: {
   data: ListFindingInstancesResponse;
   filters: FindingsFilters;
@@ -537,6 +552,7 @@ function FlatView({
   repo: string;
   file: string;
   emptyState: React.ReactNode;
+  renderedAt: number;
 }) {
   const [pages, setPages] = useState<FindingInstanceDetail[][]>([data.items]);
   const [cursors, setCursors] = useState<(string | null)[]>([data.nextCursor]);
@@ -590,6 +606,7 @@ function FlatView({
   return (
     <>
       <FindingsFlatTableView
+        renderedAt={renderedAt}
         items={items}
         selectedId={selectedInstanceId}
         onSelect={(instance) => {
@@ -614,6 +631,7 @@ function FlatView({
         <SheetContent className="p-0" aria-describedby={undefined}>
           {selected && (
             <FindingDetailView
+              renderedAt={renderedAt}
               // The flat list has no group to step back to — every row IS a
               // single instance, so the drawer opens narrowed and stays there.
               selection={{ finding: instanceAsGroup(selected), instance: selected }}
@@ -633,10 +651,12 @@ function LocationsView({
   data,
   emptyState,
   onSelectFile,
+  renderedAt,
 }: {
   data: ListFindingLocationsResponse;
   emptyState: React.ReactNode;
   onSelectFile: (repo: string, file: string) => void;
+  renderedAt: number;
 }) {
   const [expandedRepos, setExpandedRepos] = useState<ReadonlySet<string>>(
     // Open the worst-severity repo by default so the view is never a list of
@@ -646,6 +666,7 @@ function LocationsView({
 
   return (
     <FindingsLocationsView
+      renderedAt={renderedAt}
       items={data.items}
       expandedRepos={expandedRepos}
       onToggleRepo={(repo) => {

--- a/web-ui/app/(app)/findings/page.tsx
+++ b/web-ui/app/(app)/findings/page.tsx
@@ -50,12 +50,14 @@ export default async function FindingsPage({
   const repo = parseRepo(sp);
   const file = parseFile(sp);
 
+  // One instant for the whole route: every relative label below is measured
+  // against it during the server render and again during hydration — captured
+  // before `from` below so the query window derives from the same instant
+  // rather than a clock read apart from the labels it scopes.
+  const renderedAt = renderInstant();
   // An absent/unknown range means all time — this list has never had a default
   // window, and applying one silently would hide findings.
-  const from = range ? rangeToFromIso(range) : null;
-  // One instant for the whole route: every relative label below is measured
-  // against it during the server render and again during hydration.
-  const renderedAt = renderInstant();
+  const from = range ? rangeToFromIso(range, renderedAt) : null;
   const scope: FindingsScope = {
     ...(from ? { from } : {}),
     ...(tools.length ? { tools } : {}),

--- a/web-ui/app/(app)/findings/page.tsx
+++ b/web-ui/app/(app)/findings/page.tsx
@@ -1,6 +1,7 @@
 import { rangeToFromIso } from '@akasecurity/dashboard-ui';
 
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import {
   type FindingsScope,
   type FindingsSearchParams,
@@ -52,6 +53,9 @@ export default async function FindingsPage({
   // An absent/unknown range means all time — this list has never had a default
   // window, and applying one silently would hide findings.
   const from = range ? rangeToFromIso(range) : null;
+  // One instant for the whole route: every relative label below is measured
+  // against it during the server render and again during hydration.
+  const renderedAt = renderInstant();
   const scope: FindingsScope = {
     ...(from ? { from } : {}),
     ...(tools.length ? { tools } : {}),
@@ -76,6 +80,7 @@ export default async function FindingsPage({
         tools={tools}
         repo={repo}
         file={file}
+        renderedAt={renderedAt}
       />
     );
   }
@@ -97,6 +102,7 @@ export default async function FindingsPage({
         tools={tools}
         repo={repo}
         file={file}
+        renderedAt={renderedAt}
       />
     );
   }
@@ -120,6 +126,7 @@ export default async function FindingsPage({
       tools={tools}
       repo={repo}
       file={file}
+      renderedAt={renderedAt}
     />
   );
 }

--- a/web-ui/app/(app)/inventory/InventoryClient.tsx
+++ b/web-ui/app/(app)/inventory/InventoryClient.tsx
@@ -8,6 +8,7 @@ import {
   InventoryNav,
   type InventorySelection as Selection,
   ProjectPane,
+  useRenderClock,
 } from '@akasecurity/dashboard-ui';
 import type {
   AccessLevel,
@@ -75,9 +76,18 @@ export function InventoryClient({
   path: string[];
   fq: string;
   drawer: string | null;
-  /** The instant the server rendered against. */
+  /**
+   * The instant the server rendered against. Advanced through useRenderClock
+   * below rather than read directly — see that hook's doc for why: freezing it
+   * for the life of this client component would not just go stale, it would
+   * turn the harness feed's day bucket false. Unlike a relative-time label,
+   * that bucket is a discrete Today/Yesterday/date branch computed once per
+   * event and then held, so a session left open across local midnight would
+   * go on showing "Today" for an event days old were this never advanced.
+   */
   renderedAt: number;
 }) {
+  const renderClock = useRenderClock(renderedAt);
   const pathname = usePathname();
   // Navigation transition (selection/search/path pushes) — distinct from the
   // write transition below, which tracks the access/trust Server Actions.
@@ -215,7 +225,7 @@ export function InventoryClient({
           <Card className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {selHarness ? (
               <HarnessOverview
-                renderedAt={renderedAt}
+                renderedAt={renderClock}
                 harness={selHarness}
                 events={harnessEvents}
                 onSelect={selectAsset}

--- a/web-ui/app/(app)/inventory/InventoryClient.tsx
+++ b/web-ui/app/(app)/inventory/InventoryClient.tsx
@@ -58,6 +58,7 @@ export function InventoryClient({
   path,
   fq,
   drawer,
+  renderedAt,
 }: {
   harnesses: HarnessSummary[];
   assetGroups: AssetGroup[];
@@ -74,6 +75,8 @@ export function InventoryClient({
   path: string[];
   fq: string;
   drawer: string | null;
+  /** The instant the server rendered against. */
+  renderedAt: number;
 }) {
   const pathname = usePathname();
   // Navigation transition (selection/search/path pushes) — distinct from the
@@ -212,6 +215,7 @@ export function InventoryClient({
           <Card className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
             {selHarness ? (
               <HarnessOverview
+                renderedAt={renderedAt}
                 harness={selHarness}
                 events={harnessEvents}
                 onSelect={selectAsset}

--- a/web-ui/app/(app)/inventory/page.tsx
+++ b/web-ui/app/(app)/inventory/page.tsx
@@ -2,6 +2,7 @@ import { PageHead, resolveInventorySelection } from '@akasecurity/dashboard-ui';
 import type { HarnessEventsResponse } from '@akasecurity/schema';
 
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import {
   type InventorySearchParams,
   parseDrawer,
@@ -97,6 +98,7 @@ export default async function InventoryPage({
         path={path}
         fq={fq}
         drawer={drawer}
+        renderedAt={renderInstant()}
       />
     </div>
   );

--- a/web-ui/app/(app)/security/page.tsx
+++ b/web-ui/app/(app)/security/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { RangeSelect } from '../../components/RangeSelect';
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import { RecommendedActionsCard } from './RecommendedActionsCard';
 
 // node:sqlite (via @akasecurity/persistence) runs only on the Node.js runtime.
@@ -76,6 +77,11 @@ export default async function SecurityPage({
     label: bucketLabel.format(new Date(p.timestamp)),
   }));
 
+  // One instant for the whole route. The feed below is a SERVER component, so
+  // there is no hydration render here to disagree with — the instant is required
+  // because the view has no clock of its own to fall back on, which is what keeps
+  // it honest if it ever gains a `use client` directive.
+  const renderedAt = renderInstant();
   return (
     <div className="px-8 pb-10 pt-7">
       <PageHead
@@ -100,7 +106,12 @@ export default async function SecurityPage({
       </div>
 
       <div className="mt-4 xl:mt-5">
-        <RecentlyResolvedCardView items={recentlyResolved.items} isLoading={false} error={null} />
+        <RecentlyResolvedCardView
+          items={recentlyResolved.items}
+          isLoading={false}
+          error={null}
+          renderedAt={renderedAt}
+        />
       </div>
     </div>
   );

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -15,6 +15,7 @@ import { defaultDataDir } from '@akasecurity/persistence';
 import type { UpdateCache } from '@akasecurity/schema';
 
 import { dashboardInstallOrigin } from '../../lib/install-origin';
+import { renderInstant } from '../../lib/rendered-at';
 import type { UpdateAdvisory } from './UpdatesClient';
 import { UpdatesClient } from './UpdatesClient';
 
@@ -115,7 +116,12 @@ export default function UpdatesPage() {
       <UpdatesClient
         statuses={report.statuses}
         availablePlugins={report.availablePlugins}
-        checkedAt={cache ? relativeTime(new Date(cache.checkedAt).toISOString()) : null}
+        // Resolved to a STRING here rather than in the client component: the
+        // label crosses the boundary already formatted, so the browser has
+        // nothing to recompute and nothing to disagree with.
+        checkedAt={
+          cache ? relativeTime(new Date(cache.checkedAt).toISOString(), renderInstant()) : null
+        }
         commands={commands}
         advisories={advisories}
         installCommands={installCommands}

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -107,6 +107,12 @@ export default function UpdatesPage() {
     installCommands[agent.id] = manager.installSpawnPlan(ref, source, marketplace).join('\n');
   }
 
+  // Captured once, per this file's own contract ("call once per request"),
+  // rather than inline in the prop below — harmless with the one label this
+  // page derives today, but an inline call is a landmine for whichever
+  // second time-derived value lands on this page next.
+  const renderedAt = renderInstant();
+
   return (
     <div className="px-8 pb-10 pt-7">
       <PageHead
@@ -119,9 +125,7 @@ export default function UpdatesPage() {
         // Resolved to a STRING here rather than in the client component: the
         // label crosses the boundary already formatted, so the browser has
         // nothing to recompute and nothing to disagree with.
-        checkedAt={
-          cache ? relativeTime(new Date(cache.checkedAt).toISOString(), renderInstant()) : null
-        }
+        checkedAt={cache ? relativeTime(new Date(cache.checkedAt).toISOString(), renderedAt) : null}
         commands={commands}
         advisories={advisories}
         installCommands={installCommands}

--- a/web-ui/app/(app)/vault/VaultDashboardClient.tsx
+++ b/web-ui/app/(app)/vault/VaultDashboardClient.tsx
@@ -34,6 +34,12 @@ interface VaultDashboardClientProps {
   // The audit trail with the batched render reasons hidden (the default). The
   // toggle re-queries rather than filtering a second copy shipped up front.
   derefs: ListVaultDerefsResponse;
+  /**
+   * The instant the SERVER rendered against. Passed down rather than read here:
+   * a client that picked its own would render different text than the HTML it
+   * is hydrating.
+   */
+  renderedAt: number;
 }
 
 // The `{ items, nextCursor }` half the three vault list responses share.
@@ -226,6 +232,7 @@ export function VaultDashboardClient({
   inventory,
   reuse,
   derefs: firstDerefs,
+  renderedAt,
 }: VaultDashboardClientProps) {
   // pointerId → the revealed value (null when the vault could not resolve it)
   // AND the row it was revealed from. The row is CARRIED rather than looked up
@@ -568,6 +575,7 @@ export function VaultDashboardClient({
           </div>
         )}
         <VaultInventoryView
+          renderedAt={renderedAt}
           entries={inventoryRows}
           onReveal={onReveal}
           onRevoke={onRevoke}
@@ -609,6 +617,7 @@ export function VaultDashboardClient({
           sub="Every resolution of a vaulted value — never the value itself. Model crossings render loud."
         />
         <DerefAuditTableView
+          renderedAt={renderedAt}
           rows={derefRows}
           hiddenBatched={deref.hiddenBatched}
           showBatched={showBatched}

--- a/web-ui/app/(app)/vault/page.tsx
+++ b/web-ui/app/(app)/vault/page.tsx
@@ -1,6 +1,7 @@
 import { PageHead } from '@akasecurity/dashboard-ui';
 
 import { db } from '../../lib/db';
+import { renderInstant } from '../../lib/rendered-at';
 import { VaultDashboardClient } from './VaultDashboardClient';
 import { VaultLookupClient } from './VaultLookupClient';
 
@@ -28,6 +29,9 @@ export default function VaultPage() {
   // through an action — fetching both whole trails to save one round-trip was
   // the wrong trade once either of them could be long.
   const derefs = db().secretVault.listDerefs();
+  // One instant for the whole route: every relative label below is measured
+  // against it during the server render and again during hydration.
+  const renderedAt = renderInstant();
 
   return (
     <div className="px-8 pb-10 pt-7">
@@ -37,7 +41,12 @@ export default function VaultPage() {
       />
       <div className="flex flex-col gap-8">
         <VaultLookupClient />
-        <VaultDashboardClient inventory={inventory} reuse={reuse} derefs={derefs} />
+        <VaultDashboardClient
+          inventory={inventory}
+          reuse={reuse}
+          derefs={derefs}
+          renderedAt={renderedAt}
+        />
       </div>
     </div>
   );

--- a/web-ui/app/lib/rendered-at.ts
+++ b/web-ui/app/lib/rendered-at.ts
@@ -1,0 +1,30 @@
+// The one instant a route renders against.
+//
+// Every relative label and every time-derived badge on a page has to be computed
+// against the SAME instant during the server render and during hydration, or the
+// two produce different HTML whenever a rounding boundary falls between them —
+// which React resolves by discarding the server's markup for that subtree. The
+// views make that impossible to forget by requiring the instant as a prop (see
+// @akasecurity/dashboard-ui's lib/relativeTime.ts); this is where a route gets
+// one to hand them.
+//
+// It is a function rather than a module constant on purpose: a constant would be
+// captured once when the module first loaded and then served to every later
+// request, so a long-lived dashboard process would render ages against the
+// instant it booted.
+
+/**
+ * The instant this render is measured against, in epoch milliseconds.
+ *
+ * Call once per request, in a Server Component, and pass the result down. A
+ * client component that wants the label to keep up after hydration feeds this
+ * to `useRenderClock` rather than reading the clock itself.
+ */
+export function renderInstant(): number {
+  // The lone ambient-clock read on the render path, and it is the point of this
+  // module: the value is serialized to the client so both renders agree on it.
+  // No `react-hooks/purity` disable is needed here and one must not be added —
+  // the rule reports a clock read inside a COMPONENT, and this is a plain module
+  // function, so a directive would be an unused one (which this repo fails on).
+  return Date.now();
+}

--- a/web-ui/test/data-shares/data-shares-client-render.test.ts
+++ b/web-ui/test/data-shares/data-shares-client-render.test.ts
@@ -101,6 +101,7 @@ function render(props: Partial<Parameters<typeof DataSharesClient>[0]> = {}) {
         destination: null,
         selectedDest: null,
         selectedEndpoint: null,
+        renderedAt: Date.parse('2026-08-01T00:30:00.000Z'),
         ...props,
       }),
     ),

--- a/web-ui/test/pages/activity-clock-liveness.test.ts
+++ b/web-ui/test/pages/activity-clock-liveness.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+//
+// The LIVENESS half of the activity route's clock, in the same shape
+// exceptions-clock-liveness.test.ts pins for its own routes — see that file's
+// header for why a static (renderToStaticMarkup) suite structurally cannot
+// prove this: under the server renderer `useSyncExternalStore` reads
+// `getServerSnapshot`, which is `() => renderedAt` either way `now` is wired,
+// so `useRenderClock(renderedAt)` and a bare `renderedAt` emit identical
+// markup there.
+//
+// That gap is not theoretical here either: `ActivityClient` shipped a full
+// review round with `renderedAt` threaded straight to `SessionListView` and
+// into `detailProps` with no `useRenderClock` call at all. Every existing
+// suite in this repo stayed green — the hydration mismatch this PR fixes was
+// gone, so nothing caught that the label had gone from "wrong once, then
+// self-correcting" to "correct once, then frozen for the life of the tab".
+// Closing it needs a real client render.
+import { CLOCK_TICK_MS } from '@akasecurity/dashboard-ui';
+import type { ActivitySessionSummary } from '@akasecurity/schema';
+import { act, createElement } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/activity',
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+}));
+
+const { ActivityClient } = await import('../../app/(app)/activity/ActivityClient.tsx');
+const { NavigationTransitionProvider } =
+  await import('../../app/components/NavigationTransition.tsx');
+
+const RENDERED_AT = new Date(2026, 6, 5, 22, 45).getTime();
+const HALF_HOUR = 30 * 60 * 1000;
+
+function session(over: Partial<ActivitySessionSummary> = {}): ActivitySessionSummary {
+  return {
+    id: 'sess-1',
+    harness: 'claudecode',
+    title: 'Refactor auth',
+    project: 'api',
+    repo: 'acme/api',
+    branches: ['main'],
+    startedAt: new Date(RENDERED_AT - HALF_HOUR).toISOString(),
+    endedAt: null,
+    status: 'active',
+    turns: 4,
+    findings: 0,
+    shares: 0,
+    ...over,
+  };
+}
+
+function route(sessions: ActivitySessionSummary[]) {
+  return createElement(
+    NavigationTransitionProvider,
+    null,
+    createElement(ActivityClient, {
+      sessions,
+      detail: null,
+      tokenReport: null,
+      liveFindings: null,
+      q: '',
+      harness: [],
+      harnessOptions: [],
+      range: '30d',
+      selectedId: '',
+      hasMore: false,
+      emptyCount: 0,
+      showEmpty: false,
+      expanded: false,
+      renderedAt: RENDERED_AT,
+    }),
+  );
+}
+
+function mount(element: ReturnType<typeof createElement>): HTMLElement {
+  const container = document.createElement('div');
+  document.body.append(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return container;
+}
+
+describe('the activity clock keeps moving after hydration', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Deliberately ON the server instant, as the exceptions suite does: the
+    // mount-time catch-up is then a no-op, so nothing below can pass because
+    // of it — only the interval firing can move these labels.
+    vi.setSystemTime(RENDERED_AT);
+    (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+      true;
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('advances an active session\'s "· live" duration chip without a navigation', () => {
+    const container = mount(route([session()]));
+
+    expect(container.textContent).toContain('30m · live');
+
+    act(() => {
+      vi.advanceTimersByTime(HALF_HOUR);
+    });
+
+    // Only the interval can have moved this: nothing navigated or re-rendered
+    // the tree from outside, and the session's own endedAt is still null.
+    expect(container.textContent).toContain('1h 0m · live');
+    expect(container.textContent).not.toContain('30m · live');
+  });
+
+  it('relabels the day heading once the clock crosses local midnight, without a navigation', () => {
+    // The session sits just before midnight; the server render is captured at
+    // the same instant, so the heading starts as Today.
+    const container = mount(
+      route([
+        session({
+          startedAt: new Date(RENDERED_AT).toISOString(),
+          endedAt: new Date(RENDERED_AT).toISOString(),
+          status: 'completed',
+        }),
+      ]),
+    );
+
+    expect(container.textContent).toContain('Today');
+    expect(container.textContent).not.toContain('Yesterday');
+
+    act(() => {
+      // 75 minutes: from 22:45 to 00:00 (75m) crosses midnight.
+      vi.advanceTimersByTime(75 * 60 * 1000);
+    });
+
+    expect(container.textContent).toContain('Yesterday');
+  });
+
+  it('drives the duration chip off the shared tick length', () => {
+    // Placed just inside the first tick, the way the exceptions suite's third
+    // case is: a wiring site that hard-coded its own interval, or dropped the
+    // hook back to a bare renderedAt, is caught rather than covered by the
+    // generous half-hour the case above advances.
+    const container = mount(
+      route([session({ startedAt: new Date(RENDERED_AT - 60_000).toISOString() })]),
+    );
+
+    expect(container.textContent).toContain('1m · live');
+
+    act(() => {
+      vi.advanceTimersByTime(CLOCK_TICK_MS);
+    });
+
+    expect(container.textContent).not.toContain('1m · live');
+  });
+});

--- a/web-ui/test/pages/exceptions-client-approvability.test.ts
+++ b/web-ui/test/pages/exceptions-client-approvability.test.ts
@@ -44,6 +44,10 @@ const { NavigationTransitionProvider } =
   await import('../../app/components/NavigationTransition.tsx');
 
 const CURRENT_VERSION = 4;
+// The instant the "server" rendered against. The blocked fixture below is
+// stamped 30 minutes earlier, so a label reading "30 minutes ago" can only have
+// come from THIS value — the suite's real clock is years away from it.
+const RENDERED_AT = Date.parse('2026-08-01T00:30:00.000Z');
 const FRESH = 'blk-fresh';
 const STALE = 'blk-stale';
 const REFERENCES = [FRESH, STALE] as const;
@@ -115,7 +119,7 @@ function render(keyState: FingerprintKeyState): string {
         keyState,
         activePermanent: [],
         approvableBlocked: 1,
-        renderedAt: Date.parse('2026-08-01T00:30:00.000Z'),
+        renderedAt: RENDERED_AT,
       }),
     ),
   );
@@ -179,7 +183,16 @@ describe('the exceptions client asks blockedRowBlockReason per row', () => {
   });
 });
 
-describe('the exceptions client threads renderedAt into the blocked ledger', () => {
+// The host side of the hydration wiring: dashboard-ui pins that each view USES
+// the instant it is given, and only a render from here can see whether this
+// route actually GIVES one — and gives the same one to both of its children.
+//
+// A missing prop is a compile error now that `renderedAt` is required, so what
+// these catch is the failure that still typechecks: a host that passes some
+// OTHER number. The ambient clock is pinned an hour past RENDERED_AT, so a view
+// that fell back to it reads a different label and each case goes red for a
+// reason this file states rather than one it inherits from the calendar.
+describe('the exceptions client hands its render instant to both child views', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(AMBIENT);
@@ -189,30 +202,17 @@ describe('the exceptions client threads renderedAt into the blocked ledger', () 
   });
 
   it('renders the blocked-at label against the SSR instant, not the ambient clock', () => {
-    // Pins the host-side wiring — `renderedAt={renderedAt}` on
-    // BlockedLedgerView in ExceptionsClient.tsx. Delete it and relativeTime
-    // falls back to the pinned ambient clock, which reads "1 hour ago" for a
-    // fixture blocked at 2026-08-01T00:00 and rendered at 2026-08-01T00:30.
+    // Pins `renderedAt` on BlockedLedgerView in ExceptionsClient.tsx. Drop it
+    // and relativeTime falls back to the pinned ambient clock, which reads
+    // "1 hour ago" for a fixture blocked at 2026-08-01T00:00.
     const markup = render({ status: 'present', version: CURRENT_VERSION });
     expect(markup).toContain('30 minutes ago');
   });
-});
-
-describe('the exceptions client threads renderedAt into the exceptions table', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-    vi.setSystemTime(AMBIENT);
-  });
-  afterEach(() => {
-    vi.useRealTimers();
-  });
 
   it('renders the expiry label against the SSR instant, not the ambient clock', () => {
-    // Mirrors the ledger pin above, for the sibling view on the same route:
-    // `renderedAt={renderedAt}` on ExceptionsTableView in ExceptionsClient.tsx.
-    // Delete it and relativeTime falls back to the pinned ambient clock, which
-    // reads "30 minutes ago" — the grant already expired — for one expiring at
-    // 2026-08-01T01:00 when rendered at 2026-08-01T00:30.
+    // Mirrors the ledger pin for ExceptionsTableView on the same route. Drop it
+    // and the ambient clock reads "30 minutes ago" — the grant already expired —
+    // for one expiring at 2026-08-01T01:00.
     const markup = renderToStaticMarkup(
       createElement(
         NavigationTransitionProvider,
@@ -225,11 +225,37 @@ describe('the exceptions client threads renderedAt into the exceptions table', (
           keyState: { status: 'present', version: CURRENT_VERSION },
           activePermanent: [],
           approvableBlocked: 0,
-          renderedAt: Date.parse('2026-08-01T00:30:00.000Z'),
+          renderedAt: RENDERED_AT,
         }),
       ),
     );
 
+    expect(markup).toContain('in 30 minutes');
+  });
+
+  it('gives both views the SAME instant, so two labels cannot disagree', () => {
+    // The blocked row is 30 minutes behind RENDERED_AT and the grant expires 30
+    // minutes ahead of it. Both strings in one markup means one instant reached
+    // both children; a host that captured an instant per child would still
+    // satisfy each case above on its own.
+    const markup = renderToStaticMarkup(
+      createElement(
+        NavigationTransitionProvider,
+        null,
+        createElement(ExceptionsClient, {
+          items: [exceptionRow({ expiresAt: '2026-08-01T01:00:00.000Z' })],
+          blocked: [blockedRow(FRESH, CURRENT_VERSION)],
+          includeTerminal: false,
+          blockedWindow: '30m' as const,
+          keyState: { status: 'present', version: CURRENT_VERSION },
+          activePermanent: [],
+          approvableBlocked: 1,
+          renderedAt: RENDERED_AT,
+        }),
+      ),
+    );
+
+    expect(markup).toContain('30 minutes ago');
     expect(markup).toContain('in 30 minutes');
   });
 });

--- a/web-ui/test/pages/exceptions-page.test.ts
+++ b/web-ui/test/pages/exceptions-page.test.ts
@@ -20,6 +20,8 @@ import type { ComponentProps, ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
+import { ExceptionDetailClient } from '../../app/(app)/exceptions/[id]/ExceptionDetailClient.tsx';
+import ExceptionDetailPage from '../../app/(app)/exceptions/[id]/page.tsx';
 import { ExceptionsClient } from '../../app/(app)/exceptions/ExceptionsClient.tsx';
 import ExceptionsPage from '../../app/(app)/exceptions/page.tsx';
 import { withBundledPacks } from '../helpers/store-templates.ts';
@@ -259,5 +261,132 @@ describe('the exceptions route wires each ledger read to the consumer that needs
     expect(props.approvableBlocked).toBe(0);
     // Still listed: the ledger is a record of what was blocked either way.
     expect(props.blocked).toHaveLength(1);
+  });
+});
+
+// The other thing this route hands down that nothing else can see: the instant
+// every relative label and every lifecycle badge on the page is measured
+// against.
+//
+// A MISSING instant is a compile error — `renderedAt` is required on the client
+// and on each view under it — so what these cover is the failure that still
+// typechecks: an instant captured once and reused. Hoisting `renderInstant()`
+// to module scope, or replacing it with a `const` beside the imports, keeps the
+// whole route green while a long-lived dashboard process renders every age
+// against the instant it booted.
+describe('the exceptions route captures its render instant per request', () => {
+  // Only Date is faked: this suite does real file and store I/O, and faking the
+  // timer APIs as well would stall it.
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hands the client the clock as it stood for THIS render', () => {
+    const at = Date.parse('2026-08-01T00:30:00.000Z');
+    vi.setSystemTime(at);
+    return renderPage().then((props) => {
+      expect(props.renderedAt).toBe(at);
+    });
+  });
+
+  it('captures a new instant on the next request, rather than reusing one', async () => {
+    vi.setSystemTime(Date.parse('2026-08-01T00:30:00.000Z'));
+    const first = await renderPage();
+    vi.setSystemTime(Date.parse('2026-08-01T02:30:00.000Z'));
+    const second = await renderPage();
+
+    expect(second.renderedAt - first.renderedAt).toBe(2 * 60 * 60 * 1000);
+  });
+});
+
+// The same property for the DETAIL route, which no other suite reaches.
+//
+// exception-detail-client.test.ts renders ExceptionDetailClient directly with an
+// instant of its own, so it pins the client-to-view half and structurally cannot
+// see the half above it — the `renderedAt={renderInstant()}` on [id]/page.tsx.
+// Replace that call with a literal and every assertion in that suite stays green
+// while the detail route serves one fixed instant for the life of the process.
+//
+// It matters more here than on the list route: `exceptionState` gates the revoke
+// form, so a stuck instant does not merely age a label, it decides whether a
+// whole subtree renders.
+describe('the exception detail route captures its render instant per request', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function seedGrant(): Promise<string> {
+    const store = openLocalDatabase(dir);
+    try {
+      // A synthetic fingerprint: this route reads the grant by id prefix and
+      // never matches it against a value, so minting a real one would only
+      // couple the test to the key file for nothing.
+      const created = await store.exceptions.create({
+        ruleId: RULE_ID,
+        category: 'secret',
+        valueFingerprint: 'a'.repeat(64),
+        keyVersion: 1,
+        maskedValue: maskMatch(VALUE),
+        scope: 'permanent',
+        expiresAt: null,
+        maxUses: null,
+        justification: 'test fixture',
+        conditions: null,
+        createdBy: 'tester',
+        createdVia: 'web-add',
+      });
+      return created.id;
+    } finally {
+      store.close();
+    }
+  }
+
+  // The page wraps the client in layout markup, so the props are reached by
+  // walking to the client element rather than read off the wrapper — which would
+  // hand back `undefined` for every one of them and fail for the wrong reason.
+  // `toBeDefined` is what separates those two outcomes.
+  async function renderDetail(
+    idPrefix: string,
+  ): Promise<ComponentProps<typeof ExceptionDetailClient>> {
+    const element = (await ExceptionDetailPage({
+      params: Promise.resolve({ id: idPrefix }),
+    })) as ReactElement<{ children?: unknown }>;
+    const found = flatten(element.props.children).find(
+      (child) => child.type === ExceptionDetailClient,
+    );
+    expect(found).toBeDefined();
+    return (found as ReactElement<ComponentProps<typeof ExceptionDetailClient>>).props;
+  }
+
+  function flatten(node: unknown): ReactElement[] {
+    if (Array.isArray(node)) return node.flatMap(flatten);
+    if (node !== null && typeof node === 'object' && 'type' in node) return [node as ReactElement];
+    return [];
+  }
+
+  it('hands the client the clock as it stood for THIS render', async () => {
+    const id = await seedGrant();
+    const at = Date.parse('2026-08-01T00:30:00.000Z');
+    vi.setSystemTime(at);
+
+    const props = await renderDetail(id.slice(0, 8));
+
+    expect(props.renderedAt).toBe(at);
+  });
+
+  it('captures a new instant on the next request, rather than reusing one', async () => {
+    const id = await seedGrant();
+    vi.setSystemTime(Date.parse('2026-08-01T00:30:00.000Z'));
+    const first = await renderDetail(id.slice(0, 8));
+    vi.setSystemTime(Date.parse('2026-08-01T02:30:00.000Z'));
+    const second = await renderDetail(id.slice(0, 8));
+
+    expect(second.renderedAt - first.renderedAt).toBe(2 * 60 * 60 * 1000);
   });
 });

--- a/web-ui/test/pages/render-instant-wiring.test.ts
+++ b/web-ui/test/pages/render-instant-wiring.test.ts
@@ -1,0 +1,139 @@
+import { mkdtempSync } from 'node:fs';
+import type * as NodeOs from 'node:os';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { dataDir, type LocalDatabase } from '@akasecurity/persistence';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { removeTree } from '../../../test/helpers/remove-tree.ts';
+import { withBundledPacks } from '../helpers/store-templates.ts';
+
+// Every route that renders a relative label captures ONE instant per request
+// and hands it to each consumer below it. `exceptions-page.test.ts` pins that
+// for its own two routes; these four had no page test at all, so the line that
+// does it — `const renderedAt = renderInstant()` — was covered by nothing.
+//
+// What makes that worth a test rather than a glance is that it still typechecks
+// when it goes wrong. `renderedAt` is required, so a MISSING one is a compile
+// error; what compiles is an instant captured once and reused — hoisting the
+// call to module scope, or replacing it with a `const` beside the imports —
+// which leaves a long-lived dashboard process rendering every age against the
+// instant it booted.
+//
+// Rather than knowing where each route puts the prop, this walks the element
+// tree the page returns and collects EVERY `renderedAt` it finds. That is the
+// stronger assertion: it says every consumer on the route got this request's
+// instant, not merely that one did.
+const osHome = vi.hoisted(() => ({ dir: '' }));
+vi.mock('node:os', async (importActual) => {
+  const actual = await importActual<typeof NodeOs>();
+  return { ...actual, homedir: () => osHome.dir };
+});
+
+let home: string;
+let dir: string;
+
+function resetSingleton(): void {
+  const store = globalThis as unknown as { __akaDb?: LocalDatabase };
+  store.__akaDb?.close();
+  delete store.__akaDb;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'aka-web-instant-'));
+  osHome.dir = home;
+  dir = dataDir();
+  withBundledPacks.seed(dir);
+  resetSingleton();
+  vi.useFakeTimers({ toFake: ['Date'] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetSingleton();
+  removeTree(home);
+});
+
+/**
+ * Every `renderedAt` prop anywhere in the tree, in document order. Walks props
+ * as well as children, since a route may hand the instant to a component it
+ * passes as a prop rather than nests.
+ */
+function collectRenderedAt(node: unknown, into: number[] = []): number[] {
+  if (Array.isArray(node)) {
+    for (const child of node) collectRenderedAt(child, into);
+    return into;
+  }
+  if (node === null || typeof node !== 'object') return into;
+
+  // Not every object reached here is an element — a props value may be a plain
+  // object, a date, anything — so `props` is read as unknown and narrowed,
+  // rather than cast to an element shape the node may not have.
+  const props: unknown = (node as { props?: unknown }).props;
+  if (props === null || typeof props !== 'object') return into;
+
+  const bag = props as Record<string, unknown>;
+  if (typeof bag.renderedAt === 'number') into.push(bag.renderedAt);
+  for (const value of Object.values(bag)) collectRenderedAt(value, into);
+  return into;
+}
+
+// The four routes, each called the way Next calls it. An empty store is enough:
+// every read returns nothing and the page still renders its tree, which is
+// where the prop lives.
+const ROUTES = [
+  {
+    name: 'activity',
+    load: () => import('../../app/(app)/activity/page.tsx'),
+  },
+  {
+    name: 'data-shares',
+    load: () => import('../../app/(app)/data-shares/page.tsx'),
+  },
+  {
+    name: 'findings',
+    load: () => import('../../app/(app)/findings/page.tsx'),
+  },
+  {
+    name: 'security',
+    load: () => import('../../app/(app)/security/page.tsx'),
+  },
+] as const;
+
+async function render(route: (typeof ROUTES)[number]): Promise<number[]> {
+  const mod = await route.load();
+  const element = await mod.default({ searchParams: Promise.resolve({}) });
+  return collectRenderedAt(element);
+}
+
+describe.each(ROUTES)('the $name route captures its render instant per request', (route) => {
+  it('hands every consumer the clock as it stood for THIS render', async () => {
+    const at = Date.parse('2026-08-01T00:30:00.000Z');
+    vi.setSystemTime(at);
+
+    const found = await render(route);
+
+    // The positive control. A route that stopped passing the prop — or one
+    // whose tree shape moved past this walker — yields an empty list, and
+    // `every` on an empty array is vacuously true.
+    expect(found.length).toBeGreaterThan(0);
+    expect(found.every((v) => v === at)).toBe(true);
+  });
+
+  it('captures a new instant on the next request, rather than reusing one', async () => {
+    vi.setSystemTime(Date.parse('2026-08-01T00:30:00.000Z'));
+    const first = await render(route);
+    vi.setSystemTime(Date.parse('2026-08-01T02:30:00.000Z'));
+    const second = await render(route);
+
+    expect(first.length).toBeGreaterThan(0);
+    expect(second.length).toBeGreaterThan(0);
+    // NaN on an empty list rather than a non-null assertion, so a route that
+    // stopped passing the prop fails the subtraction instead of being asserted
+    // past it.
+    const firstAt = first.at(0) ?? Number.NaN;
+    const secondAt = second.at(0) ?? Number.NaN;
+    expect(secondAt - firstAt).toBe(2 * 60 * 60 * 1000);
+  });
+});

--- a/web-ui/test/pages/render-instant-wiring.test.ts
+++ b/web-ui/test/pages/render-instant-wiring.test.ts
@@ -22,9 +22,13 @@ import { emptyStore } from '../helpers/store-templates.ts';
 // instant it booted.
 //
 // Rather than knowing where each route puts the prop, this walks the element
-// tree the page returns and collects EVERY `renderedAt` it finds. That is the
-// stronger assertion: it says every consumer on the route got this request's
-// instant, not merely that one did.
+// tree the page returns and collects EVERY `renderedAt` it finds, so a route
+// with more than one consumer would be caught if one of them silently got a
+// different value. None of the six routes below is actually that shape today
+// — each has exactly one `renderedAt`-bearing element (`findings` has three,
+// but they are mutually exclusive branches) — so this generalizes correctly
+// without currently exercising the multi-consumer case; do not read the
+// walker's existence as proof that case is covered.
 const osHome = vi.hoisted(() => ({ dir: '' }));
 vi.mock('node:os', async (importActual) => {
   const actual = await importActual<typeof NodeOs>();
@@ -108,11 +112,11 @@ const ROUTES = [
     load: () => import('../../app/(app)/inventory/page.tsx'),
   },
   {
-    // The one route that hoists `renderInstant()` to a local and hands it to
-    // more than one consumer (VaultLookupClient, VaultDashboardClient) — the
-    // shape where a second consumer can quietly be given a different value.
-    // `collectRenderedAt` already walks props as well as children, so nothing
-    // else needed to change to catch that here.
+    // NOT a multi-consumer route, despite this file's earlier claim: the page
+    // also renders `<VaultLookupClient />`, but that component takes zero
+    // props — only `VaultDashboardClient` gets `renderedAt`. Single consumer,
+    // same shape as the other five; added for its zero-argument page function
+    // (below), which none of the others have.
     name: 'vault',
     load: () => import('../../app/(app)/vault/page.tsx'),
   },

--- a/web-ui/test/pages/render-instant-wiring.test.ts
+++ b/web-ui/test/pages/render-instant-wiring.test.ts
@@ -7,11 +7,11 @@ import { dataDir, type LocalDatabase } from '@akasecurity/persistence';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { removeTree } from '../../../test/helpers/remove-tree.ts';
-import { withBundledPacks } from '../helpers/store-templates.ts';
+import { emptyStore } from '../helpers/store-templates.ts';
 
 // Every route that renders a relative label captures ONE instant per request
 // and hands it to each consumer below it. `exceptions-page.test.ts` pins that
-// for its own two routes; these four had no page test at all, so the line that
+// for its own two routes; six others had no page test at all, so the line that
 // does it — `const renderedAt = renderInstant()` — was covered by nothing.
 //
 // What makes that worth a test rather than a glance is that it still typechecks
@@ -44,7 +44,11 @@ beforeEach(() => {
   home = mkdtempSync(join(tmpdir(), 'aka-web-instant-'));
   osHome.dir = home;
   dir = dataDir();
-  withBundledPacks.seed(dir);
+  // None of the six routes below reads `installed_packs` (they read
+  // activity/data-shares/findings/security/inventory/vault store surfaces
+  // only), so the schema alone is enough — no need for the full bundled
+  // ruleset a route that scans against detections would require.
+  emptyStore.seed(dir);
   resetSingleton();
   vi.useFakeTimers({ toFake: ['Date'] });
 });
@@ -79,7 +83,7 @@ function collectRenderedAt(node: unknown, into: number[] = []): number[] {
   return into;
 }
 
-// The four routes, each called the way Next calls it. An empty store is enough:
+// The six routes, each called the way Next calls it. An empty store is enough:
 // every read returns nothing and the page still renders its tree, which is
 // where the prop lives.
 const ROUTES = [
@@ -99,11 +103,33 @@ const ROUTES = [
     name: 'security',
     load: () => import('../../app/(app)/security/page.tsx'),
   },
+  {
+    name: 'inventory',
+    load: () => import('../../app/(app)/inventory/page.tsx'),
+  },
+  {
+    // The one route that hoists `renderInstant()` to a local and hands it to
+    // more than one consumer (VaultLookupClient, VaultDashboardClient) — the
+    // shape where a second consumer can quietly be given a different value.
+    // `collectRenderedAt` already walks props as well as children, so nothing
+    // else needed to change to catch that here.
+    name: 'vault',
+    load: () => import('../../app/(app)/vault/page.tsx'),
+  },
 ] as const;
 
+// `vault/page.tsx`'s component is synchronous and takes no arguments; the
+// other five take `searchParams` as a promise, the way Next hands it.
+// `await`ing a non-promise return still resolves, so only the call shape
+// differs.
 async function render(route: (typeof ROUTES)[number]): Promise<number[]> {
   const mod = await route.load();
-  const element = await mod.default({ searchParams: Promise.resolve({}) });
+  const element =
+    route.name === 'vault'
+      ? await (mod.default as () => unknown)()
+      : await (mod.default as (props: { searchParams: Promise<object> }) => unknown)({
+          searchParams: Promise.resolve({}),
+        });
   return collectRenderedAt(element);
 }
 


### PR DESCRIPTION
A page under `'use client'` is rendered **twice** — once on the server, once when the browser hydrates it. A label derived from the ambient clock is therefore two different strings whenever a rounding boundary falls between those two renders, and React resolves that by discarding the server HTML for the subtree.

#391 fixed that for the exceptions route: a server instant threaded to both list views and the detail view, and `useRenderClock` to keep it live after hydration. Fifteen other views still read the ambient clock. This generalizes that fix and makes the omission unrepresentable.

## Making it unrepresentable

`relativeTime`, `relativeTimeShort` and `exceptionState` take `now` as a **required** argument, and every time-derived view takes a required `renderedAt: number`.

Optional is the shape this replaces, and a **default** argument is the same hole with better manners — both read as safe at every call site that omits them, which is every call site until somebody remembers. Required, the compiler names each place that has to decide which instant it means. That is how the remaining sites were found, and how the next one will be.

`relativeTimeShort` had no `now` parameter at all and could not participate until it gained one.

Server components capture one instant per request through `renderInstant()` — a function rather than a module constant, so a long-lived dashboard process does not render every age against the instant it booted. That also retires the `react-hooks/purity` disables, since the clock read now sits in a plain module function rather than inside a component.

## The hole a required argument leaves

Satisfying it with a fresh clock read at the call site typechecks perfectly. That is closed by `no-restricted-syntax` selectors scoped to modules whose **directive prologue** carries `'use client'`, so:

- a server component may still read the clock, which is what makes capturing an instant possible at all;
- `new Date(iso)` and `Date.parse(iso)` parse a value the caller already had and are left alone;
- a file that merely mentions the string as a value is untouched.

`useRenderClock` is the one sanctioned reader, exempted by name via `reactSyntaxBans({ allowAmbientClock: true })` — which keeps the network, drizzle and tonal bans by construction rather than by re-listing them, since a flat-config `rules` entry replaces options rather than merging them.

**The ban reaches what `react-hooks/purity` cannot.** That rule reports a clock read inside a *component*, so a module-level helper in a client file is invisible to it — which is exactly where the one site this sweep did not find by hand was living: `HarnessOverview`'s `formatEvent`, bucketing rows as Today/Yesterday off the ambient clock. No search for `relativeTime` would have turned it up.

It cannot follow a binding, so a clock reached through an imported helper goes unseen; the required argument covers that direction. The two are complementary, and neither is sufficient alone.

## A gap in #391

`exception-detail-client.test.ts` says it covers "the `renderedAt` [id]/page.tsx captures on the server", but it constructs `ExceptionDetailClient` directly with an instant of its own, so it structurally cannot see that line. Freezing `renderedAt={renderInstant()}` to a literal left all 135 web-ui page tests green.

`exceptions-page.test.ts` now drives the detail route itself. Both mutations — the literal, and `renderInstant()` frozen to a module constant — go red.

This matters more here than on the list route: `exceptionState` gates whether the revoke form renders at all, so a stuck instant does not merely age a label, it takes a whole subtree with it.

## What this does *not* fix

`toLocaleString` and its siblings render in the renderer's own locale and time zone, and the server's need not be the browser's — so passing one instant does not reconcile them. Two sites carry that honestly rather than pretending otherwise: `SessionListView` keeps `suppressHydrationWarning` for the **locale half alone** (its comment previously implied it covered the clock half too, which is now pinned), and `HarnessOverview`'s `formatEvent` says so in its own doc comment. `suppressHydrationWarning` silences a warning without reconciling anything, so it is never a substitute for passing an instant.

## Verification

Every new assertion was mutation-verified — **32 mutations, all red**, across the helpers, the views, the page/client hosts and the lint rule. Including one aimed at #391's own hook (serving the live clock to the server snapshot, which would defeat the freeze it exists to provide).

Full workspace suite 45/45, `typecheck` + `lint` 50/50, `lint:root` clean.

Two full-suite runs at concurrency 4 showed the usual load-sensitive failures in `detections` (ReDoS timing) and `plugin-sdk` (work clock) — both pass in isolation, and neither package is in this diff. At concurrency 2 everything is green.
