### PR TITLE
fix(plugin-runtime): follow-ups from #404's review, found after it merged

### DIFF
--- a/packages/plugin-runtime/src/attached/failure.ts
+++ b/packages/plugin-runtime/src/attached/failure.ts
@@ -45,8 +45,13 @@ export type ControlPlaneFailure = 'unauthorized' | 'forbidden' | 'unreachable';
  * Range-checked rather than merely typed as a number: the value can come from a
  * thrown response BODY the control plane did not author (a proxy, a captive portal),
  * and a `status` field that is not an HTTP status is not evidence of anything.
+ *
+ * EXPORTED, unlike `classifyFailure` here it feeds: `forward-policy.ts`'s
+ * `isServerRejection` reads the same status for a DIFFERENT question — not
+ * "what should a human do", but "did the deployment answer at all" — and must
+ * agree with this module on what counts as a status rather than re-deriving it.
  */
-function statusOf(err: unknown): number | null {
+export function statusOf(err: unknown): number | null {
   if (typeof err !== 'object' || err === null || !('status' in err)) return null;
   const { status } = err;
   if (typeof status !== 'number' || !Number.isInteger(status)) return null;

--- a/packages/plugin-runtime/src/attached/forward-drops.ts
+++ b/packages/plugin-runtime/src/attached/forward-drops.ts
@@ -8,18 +8,29 @@ import {
 } from '@akasecurity/persistence';
 
 /**
- * Where events discarded by the BATCH BUDGET are counted, for `status` to render.
+ * Where events the live forward gives up on are counted, for `status` to render.
  *
- * This file exists because a drop on that path was the one kind this package
- * could not see. Every other forward failure ends in `ForwardPolicy.run`'s catch
- * and moves the breaker's own file, which is what lets `aka status` say the
- * forward is unhealthy. A batch-deadline drop returns BEFORE `run` is called, so
- * nothing was written anywhere — and the machine it happens on is precisely the
- * one that looks healthiest: a slow-but-answering plane produces no failures at
- * all, so the breaker stays closed, the policy line says "synced", and the tail
- * of every batch past the budget is discarded indefinitely with nothing to show
- * for it. That is the shape §5 forbids for a dropped rule ("the scan says what
- * it dropped"), reached on the forwarding path.
+ * Two causes, and this file exists for the first: the BATCH BUDGET, which was
+ * the one kind of drop this package could not see at all. Every other forward
+ * failure ends in `ForwardPolicy.run`'s catch and moves the breaker's own file,
+ * which is what lets `aka status` say the forward is unhealthy. A batch-deadline
+ * drop returns BEFORE `run` is called, so nothing was written anywhere — and the
+ * machine it happens on is precisely the one that looks healthiest: a
+ * slow-but-answering plane produces no failures at all, so the breaker stays
+ * closed, the policy line says "synced", and the tail of every batch past the
+ * budget is discarded indefinitely with nothing to show for it. That is the
+ * shape §5 forbids for a dropped rule ("the scan says what it dropped"),
+ * reached on the forwarding path.
+ *
+ * The second is a chunk this file's own `forwardBatch` gives up on ONCE the
+ * breaker opens mid-retry — that call DOES move the breaker's file, but the
+ * events themselves still land nowhere else: they are neither delivered nor
+ * (past that one call) reached by anything that would count them again. The
+ * two are worth telling apart in a rewrite of the surface that renders this,
+ * but not worth a second file for: both describe rows this pass will not
+ * re-offer, both are equally "at least" (see the `lastDropAtMs` comment on
+ * concurrency), and this counter has never claimed to explain WHY, only how
+ * many.
  *
  * NOT `attached-state.json`, and not for tidiness: `forward-policy.ts` rewrites
  * that file WHOLESALE on every breaker transition, so a counter parked there is
@@ -43,7 +54,11 @@ export const FORWARD_DROPS_FILENAME = ATTACHED_FORWARD_DROPS_FILENAME;
  * for keeping `lastFailure` an enum applies to every field of this file too.
  */
 export interface ForwardDrops {
-  /** Events the batch budget discarded, since the last attach. */
+  /**
+   * Events this pass gave up on and will not re-offer, since the last attach
+   * — past the batch budget, or because the breaker opened mid-retry with
+   * nothing left to isolate.
+   */
   droppedForwards: number;
   /** When the most recent drop happened, epoch millis on the local clock. */
   lastDropAtMs: number;

--- a/packages/plugin-runtime/src/attached/forward-policy.ts
+++ b/packages/plugin-runtime/src/attached/forward-policy.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 import { ATTACHED_FORWARD_STATE_FILENAME } from '@akasecurity/persistence';
 import { DATA_FILE_MODE, ensureDataDir } from '@akasecurity/plugin-sdk';
 
-import { classifyFailure, type ControlPlaneFailure } from './failure.ts';
+import { classifyFailure, type ControlPlaneFailure, statusOf } from './failure.ts';
 import { withTimeout } from './with-timeout.ts';
 
 /**
@@ -39,6 +39,44 @@ function isRouteAbsent(err: unknown): boolean {
     typeof err === 'object' &&
     err !== null &&
     (err as { name?: unknown }).name === 'RemoteRouteAbsent'
+  );
+}
+
+/**
+ * A 4xx from the DEPLOYMENT that says "you answered, and refused this BODY" —
+ * never "you are down" (a 5xx, a timeout, a 429) or "this credential is no
+ * good" (401/403).
+ *
+ * A 400/413/422 is what a schema mismatch between a device build and a
+ * deployment build produces from the SERVER side, the same way a stale build
+ * produces `invalid-request` on the client's own side — reachable for the same
+ * reason `route-absent` is. 404 is excluded because that status already has
+ * its own, more specific meaning on this route.
+ *
+ * 429 is excluded DELIBERATELY, and gets it wrong in both directions if it is
+ * not: `run()` never counts a `rejected` verdict toward the breaker (see
+ * `restoreOpenedAtMs`), so a sustained 429 could never trip it — and
+ * `forwardBatch` retries every `rejected` chunk one event at a time, up to 50
+ * more requests at the SAME already-rate-limited endpoint with no pacing
+ * between them. That is precisely the burst `forwardBatch`'s own docblock
+ * says stays serial to avoid: "the plane's per-key rate limiting answers with
+ * the refusals the breaker THEN COUNTS." A 429 is retriable, not malformed —
+ * it belongs with `unreachable`, which both counts it and never retries a
+ * whole chunk item by item.
+ *
+ * Read the same way `statusOf` reads every other status: structurally, off
+ * whatever the transport raised, never by class identity.
+ */
+function isServerRejection(err: unknown): boolean {
+  const status = statusOf(err);
+  return (
+    status !== null &&
+    status >= 400 &&
+    status <= 499 &&
+    status !== 401 &&
+    status !== 403 &&
+    status !== 404 &&
+    status !== 429
   );
 }
 
@@ -240,10 +278,11 @@ export interface ForwardPolicyDeps {
 /**
  * Why a forward produced no value.
  *
- * THREE of these are not verdicts of the control plane, and all three are kept
- * apart from the rest deliberately — none may be counted toward the breaker or
- * written down as its last verdict. That is the same distinction `runPolicySync`
- * draws by returning `null` for a sync it never performed.
+ * FOUR of these are not verdicts of the control plane, and all four are kept
+ * apart from the rest deliberately — none may be counted toward the breaker's
+ * FAILURE count or written down as its `lastFailure`. That is the same
+ * distinction `runPolicySync` draws by returning `null` for a sync it never
+ * performed.
  *
  * Two of them are cases where NO ATTEMPT WAS MADE:
  *
@@ -255,22 +294,31 @@ export interface ForwardPolicyDeps {
  *                     unrelated forward while status reported an outage that
  *                     never happened.
  *
- * The third is NOT one of those, and the difference decides what the breaker
- * does with it:
+ * The other two are NOT that — the request was made and ANSWERED — and the
+ * difference decides what the breaker does with them:
  *
- *   `route-absent`    the request was made and ANSWERED — with a 404, because
- *                     this deployment predates the route. That is a statement
- *                     about which version it speaks, not about this device, so
- *                     it is still not a verdict. But unlike the two above it is
- *                     positive evidence of REACHABILITY, which is the only thing
- *                     the breaker measures — so it CLOSES the breaker rather
- *                     than merely declining to open it. That matters in the
- *                     half-open state, where the probe is the batch call and
- *                     404s by definition: leaving it open would suppress the
- *                     single-event retry that is the whole remedy.
+ *   `route-absent`    a 404, because this deployment predates the batch route.
+ *   `rejected`        a 4xx (other than 401/403/404) — the deployment answered
+ *                     and refused the BODY, the server-side twin of
+ *                     `invalid-request`: a schema mismatch between a device
+ *                     build and a deployment build, from the other side.
+ *
+ * Neither is a statement about this device's credential or the plane's health,
+ * so neither is a verdict — but unlike the two above, both are positive
+ * evidence of REACHABILITY, which is the only thing the breaker measures. A
+ * half-open probe that lands on either one therefore restores `openedAtMs` to
+ * null (see `run()`'s catch) rather than merely declining to advance it. That
+ * matters because the probe re-stamps `openedAtMs` BEFORE the op runs: leaving
+ * it re-stamped would suppress the single-event retry `forwardBatch` uses these
+ * two reasons to trigger, answering it with a freshly-cooled `breaker-open`.
+ *
+ * The restore touches ONLY `openedAtMs`, never `consecutiveFailures` or
+ * `lastFailure` — this breaker is shared by every route a gateway forwards
+ * through, so an answer on ONE route is not permission to erase a failure count
+ * or a cause a DIFFERENT route just earned.
  */
 export type ForwardFailureReason =
-  ControlPlaneFailure | 'breaker-open' | 'invalid-request' | 'route-absent';
+  ControlPlaneFailure | 'breaker-open' | 'invalid-request' | 'route-absent' | 'rejected';
 
 /**
  * What one forward did. A DISCRIMINATED UNION rather than `T | null`, because
@@ -383,6 +431,21 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
         current = { ...CLOSED };
       }
 
+      // Shared by the three catch arms that answer a half-open probe without
+      // treating it as a verdict: `invalid-request` restores the EXACT
+      // pre-probe `openedAtMs` (nothing reached the network, so nothing may
+      // move), `route-absent`/`rejected` restore it to `null` (the deployment
+      // ANSWERED, which is reachability evidence). All three preserve
+      // `consecutiveFailures` and `lastFailure` unconditionally: this breaker
+      // is shared by every route a gateway forwards through, so none of these
+      // three calls may erase a count or a cause a DIFFERENT route earned.
+      const restoreOpenedAtMs = (openedAtMs: number | null): Promise<void> =>
+        persist({
+          consecutiveFailures: current.consecutiveFailures,
+          openedAtMs,
+          lastFailure: current.lastFailure,
+        });
+
       const at = now();
       if (current.openedAtMs !== null) {
         if (at - current.openedAtMs < BREAKER_COOLDOWN_MS) {
@@ -447,14 +510,13 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
         // there. Recording it would move the breaker on evidence the control
         // plane never supplied; see ForwardFailureReason.
         if (isInvalidRequest(err)) {
-          // Undo the half-open re-stamp above, rather than leaving it or
-          // clearing it. Nothing reached the network on this path — the body
-          // was refused before a socket opened — so unlike the SUCCESS arm this
-          // is no evidence of reachability, and unlike `route-absent` it is no
+          // Nothing reached the network on this path — the body was refused
+          // before a socket opened — so unlike the two arms below this is no
+          // evidence of reachability, and unlike a real failure it is no
           // evidence of anything about the deployment at all. The only correct
-          // outcome is for this call to have changed NOTHING: `current` still
-          // holds whatever `load()` returned before `run()` touched the file,
-          // so writing it back exactly undoes the re-stamp.
+          // outcome is for this call to have changed NOTHING, which is why the
+          // restore target is `current.openedAtMs` — exactly what `load()`
+          // returned before `run()` touched the file — rather than `null`.
           //
           // Left un-restored, the re-stamp is a real bug and not merely
           // untidy: `openedAtMs` moves forward to THIS probe's own timestamp,
@@ -462,39 +524,34 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
           // is measured from a moment nothing was learned at — a caller
           // retrying a single malformed event during the half-open window pays
           // a second full cooldown for a chance the first one already earned.
-          if (current.openedAtMs !== null) {
-            await persist({
-              consecutiveFailures: current.consecutiveFailures,
-              openedAtMs: current.openedAtMs,
-              lastFailure: current.lastFailure,
-            });
-          }
+          if (current.openedAtMs !== null) await restoreOpenedAtMs(current.openedAtMs);
           return { ok: false, reason: 'invalid-request' };
         }
-        // Beside `invalid-request`, and returned before the breaker write for
-        // the same reason: a 404 on a route is this deployment saying which
-        // version it speaks, not a refusal and not an outage. Counting it would
-        // open the breaker against a deployment answering every request it
-        // understands, and then suppress every unrelated forward for the
-        // cooldown. The caller's remedy is the older route, not to stop trying.
-        if (isRouteAbsent(err)) {
-          // Mirrors the SUCCESS arm above, not the failure arm below, and the
-          // half-open state is why. A probe re-stamps `openedAtMs` before the op
-          // runs, and against a deployment that predates the batch route the
-          // probe IS the batch call — 404 by definition. Returning without
-          // clearing would leave the breaker open on a fresh cooldown and answer
-          // the single-event retry, the remedy this reason exists to trigger,
-          // with `breaker-open`: nothing delivered, and nothing counted either,
-          // since the drop tally sits past the reason check in `forwardBatch`.
+        // `route-absent` and `rejected` share one arm below: both are the
+        // deployment ANSWERING (a 404, or a 4xx body refusal), never a refusal
+        // of this credential and never an outage — so counting either toward
+        // the breaker would open it against a deployment responding to every
+        // request it understands, and suppress every unrelated forward for the
+        // cooldown. The caller's remedy is the older route or an isolated
+        // per-item resend, not to stop trying.
+        const routeAbsent = isRouteAbsent(err);
+        if (routeAbsent || isServerRejection(err)) {
+          // Restores ONLY `openedAtMs`, to `null` rather than back to
+          // `current.openedAtMs` as `invalid-request` above does — the
+          // difference is that THIS call reached the deployment and got an
+          // answer, which is reachability evidence the invalid-request arm
+          // never has. `consecutiveFailures`/`lastFailure` ride through
+          // untouched regardless: this breaker is shared by every route a
+          // gateway forwards through, so an answer on ONE of them is not
+          // permission to erase a count or a cause a DIFFERENT route earned.
           //
-          // Clearing is not a courtesy to that caller, it is what the evidence
-          // says. A 404 is an ANSWER: the deployment is reachable and talking,
-          // and reachability is the only thing this breaker measures. If the
-          // plane is in fact still sick, the retries that follow re-open it.
-          if (current.openedAtMs !== null || current.consecutiveFailures > 0) {
-            await persist({ ...CLOSED });
-          }
-          return { ok: false, reason: 'route-absent' };
+          // The re-stamp still has to be undone, and for the same reason as
+          // above: a probe re-stamps `openedAtMs` before the op runs, and
+          // leaving it re-stamped would answer the per-item retry these two
+          // reasons exist to trigger with a freshly-cooled `breaker-open` —
+          // nothing delivered and nothing counted.
+          if (current.openedAtMs !== null) await restoreOpenedAtMs(null);
+          return { ok: false, reason: routeAbsent ? 'route-absent' : 'rejected' };
         }
 
         const reason = classifyFailure(err);

--- a/packages/plugin-runtime/src/attached/forward-policy.ts
+++ b/packages/plugin-runtime/src/attached/forward-policy.ts
@@ -53,16 +53,18 @@ function isRouteAbsent(err: unknown): boolean {
  * reason `route-absent` is. 404 is excluded because that status already has
  * its own, more specific meaning on this route.
  *
- * 429 is excluded DELIBERATELY, and gets it wrong in both directions if it is
- * not: `run()` never counts a `rejected` verdict toward the breaker (see
- * `restoreOpenedAtMs`), so a sustained 429 could never trip it — and
- * `forwardBatch` retries every `rejected` chunk one event at a time, up to 50
- * more requests at the SAME already-rate-limited endpoint with no pacing
- * between them. That is precisely the burst `forwardBatch`'s own docblock
- * says stays serial to avoid: "the plane's per-key rate limiting answers with
- * the refusals the breaker THEN COUNTS." A 429 is retriable, not malformed —
- * it belongs with `unreachable`, which both counts it and never retries a
- * whole chunk item by item.
+ * 429 is excluded DELIBERATELY, and for a narrower reason than it looks: a
+ * `rejected` verdict DOES count toward the breaker now (see `recordFailure`),
+ * so the risk is not that a sustained 429 goes uncounted — it is
+ * `forwardBatch`'s per-item pass, which every `rejected` chunk still enters.
+ * Isolating one row makes sense against a genuine body-shape defect; against a
+ * rate limit it is the opposite of the remedy, firing up to 50 more requests
+ * at the SAME already-throttled endpoint with no pacing between them before
+ * the third chunk finally opens the breaker. That is precisely the burst
+ * `forwardBatch`'s own docblock says stays serial to avoid: "the plane's
+ * per-key rate limiting answers with the refusals the breaker THEN COUNTS." A
+ * 429 is retriable, not malformed — it belongs with `unreachable`, which
+ * counts it without ever retrying a whole chunk item by item.
  *
  * Read the same way `statusOf` reads every other status: structurally, off
  * whatever the transport raised, never by class identity.
@@ -278,8 +280,8 @@ export interface ForwardPolicyDeps {
 /**
  * Why a forward produced no value.
  *
- * FOUR of these are not verdicts of the control plane, and all four are kept
- * apart from the rest deliberately — none may be counted toward the breaker's
+ * THREE of these are not verdicts of the control plane, and are kept apart
+ * from the rest deliberately — none may be counted toward the breaker's
  * FAILURE count or written down as its `lastFailure`. That is the same
  * distinction `runPolicySync` draws by returning `null` for a sync it never
  * performed.
@@ -294,28 +296,37 @@ export interface ForwardPolicyDeps {
  *                     unrelated forward while status reported an outage that
  *                     never happened.
  *
- * The other two are NOT that — the request was made and ANSWERED — and the
- * difference decides what the breaker does with them:
+ * `route-absent` is NOT that — the request was made and ANSWERED, a 404
+ * because this deployment predates the batch route. That is not a statement
+ * about this device's credential or the plane's health, so it is not a
+ * verdict either — but unlike the two above it IS positive evidence of
+ * REACHABILITY, which is the only thing the breaker measures. A half-open
+ * probe that lands on it therefore restores `openedAtMs` to null (see
+ * `run()`'s catch) rather than merely declining to advance it — the probe
+ * re-stamps `openedAtMs` BEFORE the op runs, and leaving it re-stamped would
+ * suppress the single-event retry `forwardBatch` uses this reason to trigger,
+ * answering it with a freshly-cooled `breaker-open`. The restore touches
+ * ONLY `openedAtMs`, never `consecutiveFailures` or `lastFailure` — this
+ * breaker is shared by every route a gateway forwards through, so an answer
+ * on ONE route is not permission to erase a failure count or a cause a
+ * DIFFERENT route just earned.
  *
- *   `route-absent`    a 404, because this deployment predates the batch route.
- *   `rejected`        a 4xx (other than 401/403/404) — the deployment answered
- *                     and refused the BODY, the server-side twin of
- *                     `invalid-request`: a schema mismatch between a device
- *                     build and a deployment build, from the other side.
- *
- * Neither is a statement about this device's credential or the plane's health,
- * so neither is a verdict — but unlike the two above, both are positive
- * evidence of REACHABILITY, which is the only thing the breaker measures. A
- * half-open probe that lands on either one therefore restores `openedAtMs` to
- * null (see `run()`'s catch) rather than merely declining to advance it. That
- * matters because the probe re-stamps `openedAtMs` BEFORE the op runs: leaving
- * it re-stamped would suppress the single-event retry `forwardBatch` uses these
- * two reasons to trigger, answering it with a freshly-cooled `breaker-open`.
- *
- * The restore touches ONLY `openedAtMs`, never `consecutiveFailures` or
- * `lastFailure` — this breaker is shared by every route a gateway forwards
- * through, so an answer on ONE route is not permission to erase a failure count
- * or a cause a DIFFERENT route just earned.
+ * `rejected` is answered too — a 4xx other than 401/403/404, the deployment
+ * refusing the BODY, the server-side twin of `invalid-request` — but it DOES
+ * count toward the breaker, unlike every reason above. The difference from
+ * `route-absent` is what a 404 versus a 4xx body refusal is EVIDENCE OF: a
+ * 404 states which version the deployment runs, true of the whole deployment
+ * regardless of which row asked. A body refusal is schema drift, and schema
+ * drift is a property of the BUILD, not of one row — a deployment that
+ * refuses one event's shape refuses all fifty sharing that shape. Exempting
+ * it the way `route-absent` is exempt would isolate a single "bad" event
+ * forever at no cost to the breaker: every chunk 4xx's, every single retry
+ * 4xx's identically, and nothing ever opens the circuit — the exact storm the
+ * 429 exclusion above exists to prevent, for every other status this range
+ * still admits. So it is recorded through the SAME path an ordinary failure
+ * takes, just with its own `reason` returned to the caller: three rejected
+ * chunks open the breaker exactly as three timeouts would, while
+ * `forwardBatch` still isolates the row that genuinely is alone.
  */
 export type ForwardFailureReason =
   ControlPlaneFailure | 'breaker-open' | 'invalid-request' | 'route-absent' | 'rejected';
@@ -431,20 +442,39 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
         current = { ...CLOSED };
       }
 
-      // Shared by the three catch arms that answer a half-open probe without
+      // Shared by the two catch arms that answer a half-open probe without
       // treating it as a verdict: `invalid-request` restores the EXACT
       // pre-probe `openedAtMs` (nothing reached the network, so nothing may
-      // move), `route-absent`/`rejected` restore it to `null` (the deployment
-      // ANSWERED, which is reachability evidence). All three preserve
-      // `consecutiveFailures` and `lastFailure` unconditionally: this breaker
-      // is shared by every route a gateway forwards through, so none of these
-      // three calls may erase a count or a cause a DIFFERENT route earned.
+      // move); `route-absent` restores it to `null` (the deployment ANSWERED,
+      // which is reachability evidence). Both preserve `consecutiveFailures`
+      // and `lastFailure` unconditionally: this breaker is shared by every
+      // route a gateway forwards through, so neither call may erase a count
+      // or a cause a DIFFERENT route earned. `rejected` does NOT use this —
+      // see its own arm below for why it needs the opposite treatment.
       const restoreOpenedAtMs = (openedAtMs: number | null): Promise<void> =>
         persist({
           consecutiveFailures: current.consecutiveFailures,
           openedAtMs,
           lastFailure: current.lastFailure,
         });
+
+      // Shared by `rejected` and the generic failure path below: both are
+      // real evidence the breaker must count, differing only in what they
+      // record as `lastFailure`. Recording `'unreachable'` for `rejected`
+      // rather than widening `ControlPlaneFailure` is deliberate — that type
+      // is deliberately coarse for the reason its own docblock gives, and a
+      // 4xx body refusal has no more of a human remediation than a timeout
+      // does; it belongs in the same "no verdict we are willing to name"
+      // bucket.
+      const recordFailure = (cause: ControlPlaneFailure): Promise<void> => {
+        const failures = current.consecutiveFailures + 1;
+        const shouldOpen = current.openedAtMs !== null || failures >= BREAKER_FAILURE_THRESHOLD;
+        return persist({
+          consecutiveFailures: failures,
+          openedAtMs: shouldOpen ? now() : null,
+          lastFailure: cause,
+        });
+      };
 
       const at = now();
       if (current.openedAtMs !== null) {
@@ -527,15 +557,13 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
           if (current.openedAtMs !== null) await restoreOpenedAtMs(current.openedAtMs);
           return { ok: false, reason: 'invalid-request' };
         }
-        // `route-absent` and `rejected` share one arm below: both are the
-        // deployment ANSWERING (a 404, or a 4xx body refusal), never a refusal
-        // of this credential and never an outage — so counting either toward
-        // the breaker would open it against a deployment responding to every
-        // request it understands, and suppress every unrelated forward for the
-        // cooldown. The caller's remedy is the older route or an isolated
-        // per-item resend, not to stop trying.
-        const routeAbsent = isRouteAbsent(err);
-        if (routeAbsent || isServerRejection(err)) {
+        // `route-absent` is the deployment ANSWERING — a 404, because this
+        // deployment predates the batch route — never a refusal of this
+        // credential and never an outage. Counting it toward the breaker
+        // would open it against a deployment responding to every request it
+        // understands, and suppress every unrelated forward for the cooldown.
+        // The caller's remedy is the older route, not to stop trying.
+        if (isRouteAbsent(err)) {
           // Restores ONLY `openedAtMs`, to `null` rather than back to
           // `current.openedAtMs` as `invalid-request` above does — the
           // difference is that THIS call reached the deployment and got an
@@ -547,21 +575,34 @@ export function createForwardPolicy(deps: ForwardPolicyDeps): ForwardPolicy {
           //
           // The re-stamp still has to be undone, and for the same reason as
           // above: a probe re-stamps `openedAtMs` before the op runs, and
-          // leaving it re-stamped would answer the per-item retry these two
-          // reasons exist to trigger with a freshly-cooled `breaker-open` —
-          // nothing delivered and nothing counted.
+          // leaving it re-stamped would answer the per-item retry this reason
+          // exists to trigger with a freshly-cooled `breaker-open` — nothing
+          // delivered and nothing counted.
           if (current.openedAtMs !== null) await restoreOpenedAtMs(null);
-          return { ok: false, reason: routeAbsent ? 'route-absent' : 'rejected' };
+          return { ok: false, reason: 'route-absent' };
+        }
+        // `rejected` is ALSO the deployment answering — a 4xx body refusal —
+        // but unlike `route-absent` it DOES count toward the breaker, exactly
+        // like a genuine outage. The reason is what makes `route-absent` safe
+        // to exempt: a 404 is a fact about which VERSION the deployment runs,
+        // true of the whole deployment regardless of which row triggered it.
+        // A 4xx body refusal is not that — "schema drift on the other side of
+        // the wire" is a property of the BUILD, not of one row, so a
+        // deployment that refuses one event's shape refuses all fifty. Left
+        // exempt the way `route-absent` is, a sustained 422 would isolate a
+        // single event costlessly forever — 51 requests a pass, breaker
+        // permanently closed, nothing ever delivered, exactly the storm the
+        // 429 exclusion above exists to prevent, for every status this range
+        // still admits. Counting it is what bounds that: three rejected
+        // chunks open the breaker exactly as three timeouts would, and the
+        // isolation stays available for the row that genuinely is alone.
+        if (isServerRejection(err)) {
+          await recordFailure('unreachable');
+          return { ok: false, reason: 'rejected' };
         }
 
         const reason = classifyFailure(err);
-        const failures = current.consecutiveFailures + 1;
-        const shouldOpen = current.openedAtMs !== null || failures >= BREAKER_FAILURE_THRESHOLD;
-        await persist({
-          consecutiveFailures: failures,
-          openedAtMs: shouldOpen ? now() : null,
-          lastFailure: reason,
-        });
+        await recordFailure(reason);
         // Dropped, never spooled (G8). The local write already succeeded, so
         // the caller has a correct result to return.
         return { ok: false, reason };

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -679,11 +679,24 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
    * fifty events is well-formed. Trusting `ok` alone would stamp all fifty as
    * delivered and never re-offer the twenty the plane did not take. So success
    * is checked against `chunk.length`; anything short of it falls into the same
-   * per-item pass as a refused chunk, which is SAFE to do blindly, because the
-   * receiver's own upsert settles a duplicate silently (`AuditEventBatchAck`'s
-   * own docblock) — re-sending a row that already landed is a no-op there, and
-   * it is the only way to recover the rows that did not, since the ack carries
-   * no per-row verdict to resend by.
+   * per-item pass as a refused chunk, which is the only way to recover the
+   * rows that did not land, since the ack carries no per-row verdict to
+   * resend by.
+   *
+   * That fallback ASSUMES a re-send of an already-landed row is a harmless
+   * no-op rather than a second cost — an assumption this file cannot verify.
+   * `AuditEventBatchAck` carries only `accepted`, unlike its sibling
+   * `IngestAck` (`accepted` + `duplicates`, with `accepted + duplicates ==`
+   * the batch size as the invariant `recordCapture` reads), so whether a
+   * duplicate counts toward THIS route's `accepted` is not expressed
+   * anywhere in this repo. If it follows its sibling's convention and does
+   * NOT, a chunk containing even one already-delivered row — the ordinary
+   * consequence of a lost stamp, which this file already treats as cheap —
+   * answers short forever and enters the per-item pass on every pass it is
+   * offered again. The cost of that is bounded rather than silent: the
+   * pass converges (every row lands and stamps), so it is one wasted round
+   * of singles rather than a stall, and it errs toward an extra resend
+   * rather than toward the lost row the alternative risks.
    *
    * BATCH-ATOMIC SETTLEMENT is otherwise the rule: the receiver wraps a chunk in
    * one transaction, so a full 2xx settles every event in it and a non-2xx
@@ -755,9 +768,10 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
           // A well-formed ack claiming fewer accepted than sent. `ok` is not
           // delivery here any more than it is for a single capture — fall
           // through to the per-item pass below, which is the only way to find
-          // out which of the fifty actually landed. Blind re-sending the whole
-          // chunk is safe rather than wasteful, per the docblock above: the
-          // upsert on the far side settles a duplicate silently.
+          // out which of the fifty actually landed. Bounded rather than
+          // free, per the docblock above: this assumes a re-send of a
+          // row that already landed costs an extra round trip, not a
+          // second write.
         } else if (
           // THREE reasons are worth a second pass, one at a time, and they are
           // the three settled BEFORE the control plane refused anything, or
@@ -810,14 +824,20 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
             continue;
           }
           if (single.reason === 'breaker-open') {
-            // Three failures inside THIS retry just opened the breaker, so
-            // every remaining `run()` call in this chunk would short-circuit
-            // identically at zero network cost — nothing left to isolate.
-            // Counted ONCE for the whole remainder rather than once per event,
-            // which is what continuing the loop would otherwise cost in
-            // redundant file I/O for an outcome already decided.
-            recordForwardDrops(this.deps.dataDir, chunk.length - j, at);
-            break;
+            // The breaker is now open for every route this gateway forwards
+            // through, not just the rest of THIS chunk — so the next chunk's
+            // own batch attempt would ALSO come back breaker-open, and that
+            // reason is not one of the three the outer gate retries per item
+            // (`:788-790`), so it falls straight into the `continue` beside
+            // them. That `continue` records nothing. Left as a `break`, every
+            // chunk after this one — not merely the rest of this one —
+            // vanishes with no tally anywhere: the exact failure mode the
+            // deadline exit fourteen lines up already solves, for the
+            // identical reason. So this counts the FULL remainder, from here
+            // to the end of the whole batch, and returns from the whole pass
+            // rather than merely breaking this loop.
+            recordForwardDrops(this.deps.dataDir, inputs.length - i - j, at);
+            return;
           }
           // Any other single-level failure — this one event's own
           // invalid-request or rejected, a refusal, a timeout that has not yet

--- a/packages/plugin-runtime/src/attached/gateway.ts
+++ b/packages/plugin-runtime/src/attached/gateway.ts
@@ -662,15 +662,35 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
    *
    * When the deadline passes the remainder is dropped rather than sent: the
    * local write has already succeeded, so every caller has a correct result to
-   * return. What is dropped is COUNTED — this path returns BEFORE
-   * `ForwardPolicy.run` is reached, so without the tally in `forward-drops.ts` a
-   * slow-but-answering plane produces no failures, keeps the breaker closed,
-   * renders a healthy block, and discards the tail of every batch indefinitely.
+   * return. What is dropped is COUNTED, everywhere it can happen — this path
+   * returns BEFORE `ForwardPolicy.run` is reached, so without the tally in
+   * `forward-drops.ts` a slow-but-answering plane produces no failures, keeps
+   * the breaker closed, renders a healthy block, and discards the tail of every
+   * batch indefinitely. The SAME tally also covers a single that fails inside
+   * the per-item retry below — the breaker opening mid-retry is a failure the
+   * breaker's own state DOES capture, but the events still in this chunk once
+   * that happens are neither delivered nor otherwise counted anywhere, which is
+   * the same invisibility with a different cause.
    *
-   * BATCH-ATOMIC SETTLEMENT. The receiver wraps a chunk in one transaction, so a
-   * 2xx settles every event in it and a non-2xx settles none — which is why the
-   * whole chunk is stamped on `ok` and none of it otherwise. TWO cases do not
-   * deserve that treatment, and both are re-sent one event at a time:
+   * `ok` ALONE IS NOT DELIVERY, the same rule `recordCapture` states for the
+   * single-event ack and at fifty times the blast radius here:
+   * `AuditEventBatchAck.accepted` is an aggregate count the wire contract does
+   * not tie to the chunk's own length, so a 2xx answering `{accepted: 30}` for
+   * fifty events is well-formed. Trusting `ok` alone would stamp all fifty as
+   * delivered and never re-offer the twenty the plane did not take. So success
+   * is checked against `chunk.length`; anything short of it falls into the same
+   * per-item pass as a refused chunk, which is SAFE to do blindly, because the
+   * receiver's own upsert settles a duplicate silently (`AuditEventBatchAck`'s
+   * own docblock) — re-sending a row that already landed is a no-op there, and
+   * it is the only way to recover the rows that did not, since the ack carries
+   * no per-row verdict to resend by.
+   *
+   * BATCH-ATOMIC SETTLEMENT is otherwise the rule: the receiver wraps a chunk in
+   * one transaction, so a full 2xx settles every event in it and a non-2xx
+   * settles none — which is why the whole chunk is stamped together on a FULL
+   * accept and none of it otherwise. THREE reasons do not deserve whole-chunk
+   * treatment, alongside a short accept, and all are re-sent one event at a
+   * time:
    *
    *   `invalid-request` a chunk the client refused to send at all. One malformed
    *                     event would otherwise cost the 49 good ones beside it —
@@ -680,8 +700,17 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
    *                     single-event route is the one it serves, and re-sending
    *                     here rather than inside the client is what gives each
    *                     request its own budget instead of 50 inside one.
+   *   `rejected`        the deployment's SERVER-side twin of `invalid-request` —
+   *                     a 4xx body refusal from schema drift on the other side
+   *                     of the wire. Settlement is batch-atomic on this reason
+   *                     exactly as on the others, so leaving it out would cost
+   *                     the whole chunk for one event the DEPLOYMENT considers
+   *                     malformed, where the per-item form cost only that one.
    *
-   * Either way the blast radius stays exactly what it was before batching.
+   * Every other reason (breaker-open, a refusal, a timeout) applies to the whole
+   * chunk, and re-sending it item by item would just spend the budget failing 50
+   * more times — for those, the blast radius stays exactly what it was before
+   * batching.
    */
   private async forwardBatch<T>(
     inputs: readonly T[],
@@ -719,29 +748,47 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
           ),
         );
         if (forwarded.ok) {
-          delivered.push(...chunk);
-          continue;
-        }
-        // TWO reasons are worth a second pass, one at a time, and they are the
-        // two settled BEFORE the control plane refused anything.
-        //
-        // `invalid-request` — the CLIENT refused the body before any request
-        // went out: a defect in one event, not an outage. Re-sending singly
-        // isolates the bad one instead of charging its 49 neighbours for it.
-        //
-        // `route-absent` — the deployment predates the batch route and serves
-        // only the single-event one. The retry IS the compatibility path, and it
-        // has to live HERE rather than inside the client: each single gets its
-        // own FORWARD_BUDGET_MS through `run`, whereas the client's own fallback
-        // would spend 50 sequential round trips inside the ONE budget wrapping
-        // this call — turning a working older deployment into a timeout, three
-        // of those into an open breaker, and every row into a silent drop while
-        // the status surface called an answering deployment down.
-        //
-        // Every other reason (breaker-open, a refusal, a timeout) applies to the
-        // whole chunk; re-sending it item by item would just spend the budget
-        // failing 50 more times.
-        if (forwarded.reason !== 'invalid-request' && forwarded.reason !== 'route-absent') {
+          if (forwarded.value.accepted === chunk.length) {
+            delivered.push(...chunk);
+            continue;
+          }
+          // A well-formed ack claiming fewer accepted than sent. `ok` is not
+          // delivery here any more than it is for a single capture — fall
+          // through to the per-item pass below, which is the only way to find
+          // out which of the fifty actually landed. Blind re-sending the whole
+          // chunk is safe rather than wasteful, per the docblock above: the
+          // upsert on the far side settles a duplicate silently.
+        } else if (
+          // THREE reasons are worth a second pass, one at a time, and they are
+          // the three settled BEFORE the control plane refused anything, or
+          // (for `rejected`) refused the BODY rather than the connection.
+          //
+          // `invalid-request` — the CLIENT refused the body before any request
+          // went out: a defect in one event, not an outage. Re-sending singly
+          // isolates the bad one instead of charging its 49 neighbours for it.
+          //
+          // `route-absent` — the deployment predates the batch route and serves
+          // only the single-event one. The retry IS the compatibility path, and
+          // it has to live HERE rather than inside the client: each single gets
+          // its own FORWARD_BUDGET_MS through `run`, whereas the client's own
+          // fallback would spend 50 sequential round trips inside the ONE
+          // budget wrapping this call — turning a working older deployment into
+          // a timeout, three of those into an open breaker, and every row into
+          // a silent drop while the status surface called an answering
+          // deployment down.
+          //
+          // `rejected` — the deployment's own 4xx refusal of the body, the
+          // server-side twin of `invalid-request`: isolating it the same way
+          // costs one event instead of the whole chunk for a defect the
+          // deployment considers local to one row.
+          //
+          // Every other reason (breaker-open, a refusal, a timeout) applies to
+          // the whole chunk; re-sending it item by item would just spend the
+          // budget failing 50 more times.
+          forwarded.reason !== 'invalid-request' &&
+          forwarded.reason !== 'route-absent' &&
+          forwarded.reason !== 'rejected'
+        ) {
           continue;
         }
         for (const [j, event] of chunk.entries()) {
@@ -758,7 +805,28 @@ export class AttachedDataGateway implements DataGateway, LocalStoreMaintenance {
           const single = await this.deps.forward.run(() =>
             this.deps.client.recordAuditEvent(reKeyForForward(event, this.remoteInventory)),
           );
-          if (single.ok) delivered.push(event);
+          if (single.ok) {
+            delivered.push(event);
+            continue;
+          }
+          if (single.reason === 'breaker-open') {
+            // Three failures inside THIS retry just opened the breaker, so
+            // every remaining `run()` call in this chunk would short-circuit
+            // identically at zero network cost — nothing left to isolate.
+            // Counted ONCE for the whole remainder rather than once per event,
+            // which is what continuing the loop would otherwise cost in
+            // redundant file I/O for an outcome already decided.
+            recordForwardDrops(this.deps.dataDir, chunk.length - j, at);
+            break;
+          }
+          // Any other single-level failure — this one event's own
+          // invalid-request or rejected, a refusal, a timeout that has not yet
+          // opened the breaker — is isolated to THIS row. The rest of the
+          // chunk still deserves its own attempt, which is the whole point of
+          // retrying one at a time, so the loop continues rather than
+          // aborting. Counted individually: each is its own verdict, not part
+          // of a remainder abandoned together.
+          recordForwardDrops(this.deps.dataDir, 1, at);
         }
       }
     } finally {

--- a/packages/plugin-runtime/src/attached/status.ts
+++ b/packages/plugin-runtime/src/attached/status.ts
@@ -216,14 +216,19 @@ function policyLines(dataDir: string, nowMs: number): string[] {
  * overstatement as the clean block this whole surface replaced.
  */
 /**
- * What the batch budget threw away, if anything.
+ * What the live forward gave up on, if anything.
  *
  * Rendered INDEPENDENTLY of breaker state, and that is the whole reason it
- * exists: the machine this happens on is the one whose breaker is closed. A
- * plane that answers every request successfully but slowly produces no
- * failures, so every other line in this block reads healthy while the tail of
- * each batch is discarded. Appended to all three of `forwardLines`' outcomes
- * rather than to one.
+ * exists for its original cause: the machine a batch-budget drop happens on
+ * is the one whose breaker is closed. A plane that answers every request
+ * successfully but slowly produces no failures, so every other line in this
+ * block reads healthy while the tail of each batch is discarded. Appended to
+ * all three of `forwardLines`' outcomes rather than to one — the second cause
+ * `forward-drops.ts` now also counts (the breaker opening mid-retry with
+ * nothing left to isolate) DOES move the breaker's own file, but that alone
+ * says nothing was delivered, never how much; this line is still the only
+ * place that number is rendered, so it stays independent of which of the two
+ * caused it.
  *
  * "at least" is accuracy, not hedging. Concurrent detached workers increment the
  * tally with an unlocked read-modify-write, so a simultaneous pair can lose one
@@ -234,8 +239,8 @@ function dropLines(dataDir: string, nowMs: number): string[] {
   const drops = readForwardDrops(dataDir);
   if (!drops) return [];
   return [
-    `             at least ${String(drops.droppedForwards)} events dropped past the ` +
-      `batch budget, last ${ageLine(drops.lastDropAtMs, nowMs)}`,
+    `             at least ${String(drops.droppedForwards)} events dropped by the ` +
+      `live forward, last ${ageLine(drops.lastDropAtMs, nowMs)}`,
   ];
 }
 

--- a/packages/plugin-runtime/test/attached/forward-policy.test.ts
+++ b/packages/plugin-runtime/test/attached/forward-policy.test.ts
@@ -484,31 +484,59 @@ describe('createForwardPolicy', () => {
     });
 
     it.each([400, 413, 422])(
-      'a %d body refusal classifies as rejected, and never moves the breaker',
+      'a %d body refusal classifies as rejected, and DOES open the breaker after three',
       async (status) => {
+        // Schema drift is a property of the BUILD, not of one row: a
+        // deployment that refuses one event's shape refuses all fifty
+        // sharing it. Left exempt from the failure count the way
+        // `route-absent` is, a sustained 422 would isolate a single "bad"
+        // event forever at no cost to the breaker — the exact storm the 429
+        // exclusion exists to prevent, reachable here through every OTHER
+        // status this classifier admits. So three of them opens the breaker
+        // exactly as three timeouts would; the reason returned is still
+        // `rejected`, so `forwardBatch` keeps isolating the row that
+        // genuinely is alone, but the circuit itself stops the fan-out once
+        // it is not.
         const policy = createForwardPolicy({ dir });
-        for (let i = 0; i < BREAKER_FAILURE_THRESHOLD + 2; i++) {
+        for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
           await expect(policy.run(() => Promise.reject(serverRejection(status)))).resolves.toEqual(
             failed('rejected'),
           );
         }
-        const op = vi.fn(() => Promise.resolve('ran'));
-        await expect(policy.run(op)).resolves.toEqual(ok('ran'));
-        expect(op).toHaveBeenCalledTimes(1);
+        const op = vi.fn(() => Promise.resolve('should not run'));
+        await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
+        expect(op).not.toHaveBeenCalled();
       },
     );
 
-    it.each([401, 403, 404, 429, 500])(
-      'a %d is NOT classified as rejected — it keeps its own existing meaning',
-      async (status) => {
-        // The boundary the range check draws. 401/403 already have their own
-        // members; 404 on this route is `route-absent`, handled earlier and
-        // never reaching `classifyFailure` at all; 429 and 500 are both
-        // retriable rather than a body-shape refusal and must still count
-        // toward the breaker like any other `unreachable`.
+    it('rejected records its cause for /aka:status, the same as any other failure', async () => {
+      // `rejected` is not in ForwardFailureReason's "no verdict we are
+      // willing to name" split at the type level, but it persists through
+      // that exact bucket (`lastFailure: 'unreachable'`) rather than
+      // widening `ControlPlaneFailure` — a 4xx body refusal has no more of a
+      // human remediation than a timeout does.
+      const policy = createForwardPolicy({ dir, now: () => 7 });
+      await expect(policy.run(() => Promise.reject(serverRejection(422)))).resolves.toEqual(
+        failed('rejected'),
+      );
+      expect(readForwardHealth(dir, 7)?.lastFailure).toBe('unreachable');
+    });
+
+    it.each([
+      [401, 'unauthorized'],
+      [403, 'forbidden'],
+      // 404 is excluded from `isServerRejection`'s range because it has its
+      // own, sharper meaning — but only `isRouteAbsent` (name-based, matching
+      // `RemoteRouteAbsent`) reaches it there. This fixture is a plain
+      // status-bearing `Error`, so it is NOT `route-absent` here.
+      [404, 'unreachable'],
+      [500, 'unreachable'],
+    ] as const)(
+      'a %d is NOT classified as rejected — it keeps its own existing meaning of %s',
+      async (status, reason) => {
         const policy = createForwardPolicy({ dir });
         const result = await policy.run(() => Promise.reject(serverRejection(status)));
-        expect(result).not.toEqual(failed('rejected'));
+        expect(result).toEqual(failed(reason));
       },
     );
 
@@ -531,10 +559,14 @@ describe('createForwardPolicy', () => {
       expect(op).not.toHaveBeenCalled();
     });
 
-    it('rejected does not erase a failure count a DIFFERENT route earned', async () => {
-      // Mirrors the equivalent route-absent test: the breaker is shared across
-      // every route a gateway forwards through, so a 422 on THIS one must not
-      // zero a count `ingestEvents` (say) already earned.
+    it('a rejected failure ACCUMULATES onto a count a different route earned', async () => {
+      // Unlike route-absent, rejected is a real failure — so two unrelated
+      // failures on one route plus a 422 on another must together reach the
+      // SAME shared threshold, exactly as three failures on one route would.
+      // Mirrors what the original design got wrong: exempting this reason
+      // meant a permanently-rejecting deployment could never contribute to
+      // opening the breaker no matter how many other routes were also
+      // failing alongside it.
       const policy = createForwardPolicy({ dir });
       await policy.run(() => Promise.reject(new Error('ingestEvents down')));
       await policy.run(() => Promise.reject(new Error('ingestEvents down')));
@@ -543,17 +575,19 @@ describe('createForwardPolicy', () => {
       await expect(policy.run(() => Promise.reject(serverRejection(422)))).resolves.toEqual(
         failed('rejected'),
       );
-      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(2);
+      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(3);
 
-      await expect(
-        policy.run(() => Promise.reject(new Error('ingestEvents still down'))),
-      ).resolves.toEqual(failed('unreachable'));
       const op = vi.fn(() => Promise.resolve('should not run'));
       await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
       expect(op).not.toHaveBeenCalled();
     });
 
-    it('a rejected PROBE closes the breaker instead of spending the cooldown', async () => {
+    it('a rejected PROBE re-opens the breaker instead of closing it', async () => {
+      // The opposite of route-absent's half-open behaviour, and deliberately
+      // so: a 404 is reachability evidence with nothing further to explain,
+      // while a 422 is itself the ongoing failure — so where route-absent's
+      // probe clears the cooldown, a rejected probe must extend it exactly as
+      // a probe that timed out would.
       let clock = 1_000;
       const policy = createForwardPolicy({ dir, now: () => clock });
       await tripOpen(policy);
@@ -563,9 +597,12 @@ describe('createForwardPolicy', () => {
         failed('rejected'),
       );
 
-      const op = vi.fn(() => Promise.resolve('ran'));
-      await expect(policy.run(op)).resolves.toEqual(ok('ran'));
-      expect(op).toHaveBeenCalledTimes(1);
+      // Nowhere near a second full cooldown — if the probe had cleared
+      // `openedAtMs` the way route-absent's does, this would already run.
+      clock += 1;
+      const op = vi.fn(() => Promise.resolve('should not run'));
+      await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
+      expect(op).not.toHaveBeenCalled();
     });
 
     it('reads the STATUS, not the message — a 403 in the text is not a 403', async () => {

--- a/packages/plugin-runtime/test/attached/forward-policy.test.ts
+++ b/packages/plugin-runtime/test/attached/forward-policy.test.ts
@@ -58,6 +58,16 @@ function routeAbsent(): Error {
 }
 
 /**
+ * An error shaped the way the transport raises one for an ANSWERED non-2xx —
+ * a status field, structurally, exactly as `refusal` above does for 401/403.
+ */
+function serverRejection(status: number): Error & { status: number } {
+  return Object.assign(new Error(`control-plane request failed with status ${String(status)}`), {
+    status,
+  });
+}
+
+/**
  * An error shaped the way the client raises one for a body it refused to
  * send. Matched by NAME, exactly as `isInvalidRequest` matches it.
  */
@@ -401,6 +411,60 @@ describe('createForwardPolicy', () => {
       expect(after?.consecutiveFailures).toBe(before?.consecutiveFailures);
     });
 
+    it('route-absent does not erase a failure count a DIFFERENT route earned', async () => {
+      // The property the shared breaker demands. `AttachedDataGateway` holds
+      // ONE `ForwardPolicy` for every route it forwards through, so a 404 on
+      // the batch route is evidence about THAT route only — it did not
+      // disprove a failure `ingestEvents` (say) just recorded moments earlier.
+      // Zeroing it here would let a permanently-dead batch route mask a
+      // genuine, unrelated outage on every other route from the breaker
+      // forever, since 404-then-fail-then-404-then-fail never reaches
+      // BREAKER_FAILURE_THRESHOLD.
+      const policy = createForwardPolicy({ dir });
+      // Two failures on some OTHER route — short of the threshold, breaker
+      // still closed.
+      await policy.run(() => Promise.reject(new Error('ingestEvents down')));
+      await policy.run(() => Promise.reject(new Error('ingestEvents down')));
+      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(2);
+
+      // The batch route 404s. The breaker was closed, so no half-open re-stamp
+      // exists to undo — nothing about the OTHER route's count may move.
+      await expect(policy.run(() => Promise.reject(routeAbsent()))).resolves.toEqual(
+        failed('route-absent'),
+      );
+      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(2);
+
+      // The THIRD real failure — on the original route again — must still be
+      // the one that opens the breaker, exactly as it would have without the
+      // 404 in between.
+      await expect(
+        policy.run(() => Promise.reject(new Error('ingestEvents still down'))),
+      ).resolves.toEqual(failed('unreachable'));
+      const op = vi.fn(() => Promise.resolve('should not run'));
+      await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
+      expect(op).not.toHaveBeenCalled();
+    });
+
+    it('route-absent from a half-open probe restores the ORIGINAL cause, not a wiped one', async () => {
+      // The other half: when there IS a re-stamp to undo (a probe fired because
+      // the cooldown elapsed), the restore must bring back what caused the
+      // breaker to open in the first place — not silence it. `lastFailure`
+      // exists specifically for `/aka:status` to render a cause; a `{...CLOSED}`
+      // write here would have it report a healthy device seconds after a 403.
+      let clock = 1_000;
+      const policy = createForwardPolicy({ dir, now: () => clock });
+      await tripOpen(policy, () => Object.assign(new Error('forbidden'), { status: 403 }));
+      clock += BREAKER_COOLDOWN_MS + 1;
+
+      await expect(policy.run(() => Promise.reject(routeAbsent()))).resolves.toEqual(
+        failed('route-absent'),
+      );
+
+      const health = readForwardHealth(dir, clock);
+      expect(health?.consecutiveFailures).toBe(BREAKER_FAILURE_THRESHOLD);
+      expect(health?.lastFailure).toBe('forbidden');
+    });
+
     it('a route the deployment does not serve never moves the breaker', async () => {
       // The property the reason exists for. An older deployment answers 404 on
       // EVERY chunk, so if this counted as a failure the third chunk would open
@@ -414,6 +478,91 @@ describe('createForwardPolicy', () => {
           failed('route-absent'),
         );
       }
+      const op = vi.fn(() => Promise.resolve('ran'));
+      await expect(policy.run(op)).resolves.toEqual(ok('ran'));
+      expect(op).toHaveBeenCalledTimes(1);
+    });
+
+    it.each([400, 413, 422])(
+      'a %d body refusal classifies as rejected, and never moves the breaker',
+      async (status) => {
+        const policy = createForwardPolicy({ dir });
+        for (let i = 0; i < BREAKER_FAILURE_THRESHOLD + 2; i++) {
+          await expect(policy.run(() => Promise.reject(serverRejection(status)))).resolves.toEqual(
+            failed('rejected'),
+          );
+        }
+        const op = vi.fn(() => Promise.resolve('ran'));
+        await expect(policy.run(op)).resolves.toEqual(ok('ran'));
+        expect(op).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it.each([401, 403, 404, 429, 500])(
+      'a %d is NOT classified as rejected — it keeps its own existing meaning',
+      async (status) => {
+        // The boundary the range check draws. 401/403 already have their own
+        // members; 404 on this route is `route-absent`, handled earlier and
+        // never reaching `classifyFailure` at all; 429 and 500 are both
+        // retriable rather than a body-shape refusal and must still count
+        // toward the breaker like any other `unreachable`.
+        const policy = createForwardPolicy({ dir });
+        const result = await policy.run(() => Promise.reject(serverRejection(status)));
+        expect(result).not.toEqual(failed('rejected'));
+      },
+    );
+
+    it('a 429 counts toward the breaker — it is retriable, not a body-shape refusal', async () => {
+      // The property `rejected`'s exclusion exists for. Left classified as
+      // `rejected`, a sustained 429 could never trip the breaker (that reason
+      // never touches consecutiveFailures) AND would trigger an unpaced
+      // per-item retry storm at the deployment's own rate limiter through
+      // `forwardBatch` — the exact burst its docblock says staying serial is
+      // meant to avoid. Excluded, three 429s behave like three 500s: they
+      // open the breaker and stop the storm.
+      const policy = createForwardPolicy({ dir });
+      for (let i = 0; i < BREAKER_FAILURE_THRESHOLD; i++) {
+        await expect(policy.run(() => Promise.reject(serverRejection(429)))).resolves.toEqual(
+          failed('unreachable'),
+        );
+      }
+      const op = vi.fn(() => Promise.resolve('should not run'));
+      await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
+      expect(op).not.toHaveBeenCalled();
+    });
+
+    it('rejected does not erase a failure count a DIFFERENT route earned', async () => {
+      // Mirrors the equivalent route-absent test: the breaker is shared across
+      // every route a gateway forwards through, so a 422 on THIS one must not
+      // zero a count `ingestEvents` (say) already earned.
+      const policy = createForwardPolicy({ dir });
+      await policy.run(() => Promise.reject(new Error('ingestEvents down')));
+      await policy.run(() => Promise.reject(new Error('ingestEvents down')));
+      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(2);
+
+      await expect(policy.run(() => Promise.reject(serverRejection(422)))).resolves.toEqual(
+        failed('rejected'),
+      );
+      expect(readForwardHealth(dir)?.consecutiveFailures).toBe(2);
+
+      await expect(
+        policy.run(() => Promise.reject(new Error('ingestEvents still down'))),
+      ).resolves.toEqual(failed('unreachable'));
+      const op = vi.fn(() => Promise.resolve('should not run'));
+      await expect(policy.run(op)).resolves.toEqual(failed('breaker-open'));
+      expect(op).not.toHaveBeenCalled();
+    });
+
+    it('a rejected PROBE closes the breaker instead of spending the cooldown', async () => {
+      let clock = 1_000;
+      const policy = createForwardPolicy({ dir, now: () => clock });
+      await tripOpen(policy);
+      clock += BREAKER_COOLDOWN_MS + 1;
+
+      await expect(policy.run(() => Promise.reject(serverRejection(422)))).resolves.toEqual(
+        failed('rejected'),
+      );
+
       const op = vi.fn(() => Promise.resolve('ran'));
       await expect(policy.run(op)).resolves.toEqual(ok('ran'));
       expect(op).toHaveBeenCalledTimes(1);

--- a/packages/plugin-runtime/test/attached/gateway.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway.test.ts
@@ -712,8 +712,7 @@ describe('the batch budget records what it discards', () => {
         // Every call SUCCEEDS, and each one costs 600ms of the budget. That is
         // the case the breaker cannot see: it only counts failures.
         clock += 600;
-        await op();
-        return { ok: true } as ForwardResult<unknown>;
+        return { ok: true, value: await op() } as ForwardResult<unknown>;
       },
     } as unknown as ForwardPolicy;
 
@@ -757,8 +756,7 @@ describe('the batch budget records what it discards', () => {
     const forward: ForwardPolicy = {
       run: async (op: () => Promise<unknown>) => {
         clock += 600;
-        await op();
-        return { ok: true } as ForwardResult<unknown>;
+        return { ok: true, value: await op() } as ForwardResult<unknown>;
       },
     } as unknown as ForwardPolicy;
 
@@ -809,8 +807,7 @@ describe('the live forward stamps what it delivered', () => {
       run: async (op: () => Promise<unknown>) => {
         call += 1;
         if (call % 2 === 1) {
-          await op();
-          return { ok: true } as ForwardResult<unknown>;
+          return { ok: true, value: await op() } as ForwardResult<unknown>;
         }
         return { ok: false, reason: 'unreachable' } as ForwardResult<unknown>;
       },
@@ -918,6 +915,224 @@ describe('the live forward stamps what it delivered', () => {
     // of them is stamped — not left reading as owed.
     expect(singles).toHaveLength(10);
     expect(calls.delivered).toHaveLength(10);
+  });
+
+  it('recovers a chunk the deployment ACCEPTED FEWER of than it was sent', async () => {
+    // The batch ack is an aggregate count, not delivery: `ok: true` with
+    // `accepted` short of `chunk.length` is a well-formed answer the wire
+    // contract permits. Trusting `ok` alone would stamp all ten as delivered
+    // and never re-offer the ones the plane silently dropped.
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) =>
+        ({ ok: true, value: await op() }) as ForwardResult<unknown>,
+    } as unknown as ForwardPolicy;
+
+    const singles: string[] = [];
+    const calls: Calls = { order: [], delivered: [], batchSizes: [] };
+    const client = {
+      ...makeClient(calls),
+      // Claims only 7 of the 10 sent — which seven is not knowable from the
+      // ack, so recovery has to re-send all ten.
+      recordAuditEvents: vi.fn((events: readonly unknown[]) =>
+        Promise.resolve({ accepted: 7 }).then((ack) => {
+          calls.batchSizes.push(events.length);
+          return ack;
+        }),
+      ),
+      recordAuditEvent: vi.fn((e: { id: string }) => {
+        singles.push(e.id);
+        return Promise.resolve();
+      }),
+    } as unknown as AttachedClient;
+
+    const { gateway } = build({ forward, client, local: makeLocal(calls) });
+    await gateway.recordToolCalls(
+      Array.from({ length: 10 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+    );
+
+    // The batch attempt happened once, then every row was recovered singly —
+    // safe because a re-send of a row that DID land is a no-op on the receiver.
+    expect(calls.batchSizes).toEqual([10]);
+    expect(singles).toHaveLength(10);
+    expect(calls.delivered).toHaveLength(10);
+  });
+
+  it('re-sends singly against a deployment that REJECTS the batch body', async () => {
+    // The server-side twin of the CLIENT-refused case above: the deployment
+    // answered with a 4xx it considers a body-shape problem, not an outage.
+    // Isolating it the same way costs one event instead of the whole chunk.
+    const bad = toolCallId('s', 'call-3');
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        try {
+          return { ok: true, value: await op() } as ForwardResult<unknown>;
+        } catch {
+          return { ok: false, reason: 'rejected' } as ForwardResult<unknown>;
+        }
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [], batchSizes: [] };
+    const client = {
+      ...makeClient(calls),
+      recordAuditEvents: vi.fn((events: readonly { id: string }[]) =>
+        events.some((e) => e.id === bad)
+          ? Promise.reject(Object.assign(new Error('unprocessable'), { status: 422 }))
+          : Promise.resolve({ accepted: events.length }),
+      ),
+      recordAuditEvent: vi.fn((e: { id: string }) =>
+        e.id === bad
+          ? Promise.reject(Object.assign(new Error('unprocessable'), { status: 422 }))
+          : Promise.resolve(),
+      ),
+    } as unknown as AttachedClient;
+
+    const { gateway } = build({ forward, client, local: makeLocal(calls) });
+    await gateway.recordToolCalls(
+      Array.from({ length: 10 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+    );
+
+    expect(calls.delivered).toHaveLength(9);
+    expect(calls.delivered).not.toContain(bad);
+  });
+
+  it('does NOT retry a 429 singly — a rate limit is not a body rejection', async () => {
+    // The regression this fix could have introduced in the other direction.
+    // 429 does not classify as `rejected` (forward-policy.ts's own boundary),
+    // so this fake mirrors that: a chunk refused with a 429 status comes back
+    // `unreachable`, which is NOT one of the three reasons this loop retries
+    // per item. Retrying it here would fire up to 50 more requests at the
+    // same already-rate-limited endpoint with no pacing between them — the
+    // exact burst `forwardBatch`'s own docblock says staying serial exists to
+    // avoid.
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        try {
+          return { ok: true, value: await op() } as ForwardResult<unknown>;
+        } catch {
+          // What the real policy now returns for a 429 — never `rejected`.
+          return { ok: false, reason: 'unreachable' } as ForwardResult<unknown>;
+        }
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [], batchSizes: [] };
+    const recordAuditEvent = vi.fn(() => Promise.resolve());
+    const client = {
+      ...makeClient(calls),
+      recordAuditEvents: vi.fn(() =>
+        Promise.reject(Object.assign(new Error('too many requests'), { status: 429 })),
+      ),
+      recordAuditEvent,
+    } as unknown as AttachedClient;
+
+    const { gateway } = build({ forward, client, local: makeLocal(calls) });
+    await gateway.recordToolCalls(
+      Array.from({ length: 50 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+    );
+
+    // The whole chunk stays pending — no per-item burst, nothing delivered.
+    expect(recordAuditEvent).not.toHaveBeenCalled();
+    expect(calls.delivered).toHaveLength(0);
+  });
+
+  it('counts a single that fails INSIDE the retry, not just the ones never attempted', async () => {
+    // The gap beside the deadline tally: a single that fails within the
+    // per-item pass is neither in `delivered` nor caught by the deadline
+    // check, so without its own accounting it is simply invisible — the same
+    // failure mode the deadline tally exists to prevent, with a different
+    // cause. This one is NOT breaker-open, so the loop must keep going: the
+    // rest of the chunk still deserves its own attempt.
+    const bad = toolCallId('s', 'call-4');
+    // The batch attempt's rejection must classify as `invalid-request` (to
+    // enter the retry) while the one failed SINGLE classifies as `unreachable`
+    // (to prove it does NOT stop the loop) — distinguished by the error's name,
+    // exactly as the real policy distinguishes them.
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        try {
+          return { ok: true, value: await op() } as ForwardResult<unknown>;
+        } catch (err) {
+          const reason =
+            (err as { name?: string }).name === 'RemoteRequestInvalid'
+              ? 'invalid-request'
+              : 'unreachable';
+          return { ok: false, reason } as ForwardResult<unknown>;
+        }
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [], batchSizes: [] };
+    const client = {
+      ...makeClient(calls),
+      recordAuditEvents: vi.fn(() =>
+        Promise.reject(Object.assign(new Error('invalid'), { name: 'RemoteRequestInvalid' })),
+      ),
+      recordAuditEvent: vi.fn((e: { id: string }) =>
+        e.id === bad ? Promise.reject(new Error('down')) : Promise.resolve(),
+      ),
+    } as unknown as AttachedClient;
+
+    const { gateway, dataDir: dir } = build({ forward, client, local: makeLocal(calls) });
+    await gateway.recordToolCalls(
+      Array.from({ length: 10 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+    );
+
+    // Nine delivered — the loop did not stop at the failed one.
+    expect(calls.delivered).toHaveLength(9);
+    expect(calls.delivered).not.toContain(bad);
+    const drops = readForwardDrops(dir);
+    expect(drops?.droppedForwards).toBe(1);
+  });
+
+  it('stops the retry — and counts the WHOLE remainder once — the moment the breaker opens mid-pass', async () => {
+    // Once a single comes back breaker-open, every remaining `run()` call in
+    // this chunk would short-circuit identically at zero network cost: nothing
+    // left to isolate. The loop must stop rather than iterate through a
+    // decided outcome, and the remainder is counted as ONE write, not one per
+    // event, since `recordForwardDrops` is a real file read-modify-write.
+    let calls_ = 0;
+    const forward: ForwardPolicy = {
+      run: async (op: () => Promise<unknown>) => {
+        calls_ += 1;
+        if (calls_ === 1) {
+          // The batch attempt: refused, triggering the retry.
+          return { ok: false, reason: 'invalid-request' } as ForwardResult<unknown>;
+        }
+        if (calls_ <= 4) {
+          // Singles 1-3 succeed, THEN the breaker opens on the 4th call.
+          return { ok: true, value: await op() } as ForwardResult<unknown>;
+        }
+        return { ok: false, reason: 'breaker-open' } as ForwardResult<unknown>;
+      },
+    } as unknown as ForwardPolicy;
+
+    const calls: Calls = { order: [], delivered: [], batchSizes: [] };
+    const singles: string[] = [];
+    const client = {
+      ...makeClient(calls),
+      recordAuditEvents: vi.fn(() =>
+        Promise.reject(Object.assign(new Error('invalid'), { name: 'RemoteRequestInvalid' })),
+      ),
+      recordAuditEvent: vi.fn((e: { id: string }) => {
+        singles.push(e.id);
+        return Promise.resolve();
+      }),
+    } as unknown as AttachedClient;
+
+    const { gateway, dataDir: dir } = build({ forward, client, local: makeLocal(calls) });
+    // 10 events: 1 batch attempt (refused) + 3 successful singles, then the
+    // breaker opens on the 4th and the remaining 6 are never attempted.
+    await gateway.recordToolCalls(
+      Array.from({ length: 10 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+    );
+
+    // The breaker-open call itself DID reach the client (that is how the fake
+    // decides to answer breaker-open), but nothing past it did.
+    expect(singles.length).toBeLessThanOrEqual(4);
+    expect(calls.delivered).toHaveLength(3);
+    const drops = readForwardDrops(dir);
+    expect(calls.delivered.length + (drops?.droppedForwards ?? 0)).toBe(10);
   });
 
   it('counts the events a chunk never reached when the deadline lands mid-retry', async () => {
@@ -1083,8 +1298,7 @@ describe('the live forward stamps what it delivered', () => {
     const forward: ForwardPolicy = {
       run: async (op: () => Promise<unknown>) => {
         clock += 600;
-        await op();
-        return { ok: true } as ForwardResult<unknown>;
+        return { ok: true, value: await op() } as ForwardResult<unknown>;
       },
     } as unknown as ForwardPolicy;
 
@@ -1113,8 +1327,13 @@ describe('the live forward stamps what it delivered', () => {
     // opposite bug.
     expect(seen.length).toBeGreaterThan(0);
     expect(seen.length).toBeLessThan(600);
-    // Exactly what landed, and nothing the deadline discarded.
-    expect(calls.delivered).toHaveLength(seen.length);
+    // IDENTITY, not count. `toHaveLength(seen.length)` would pass if the
+    // accumulator had stamped the wrong ids — the first N inputs rather than
+    // the N that came back `ok`. Those coincide here, which is exactly why a
+    // length assertion cannot tell them apart; this pins the join the whole PR
+    // rests on. `reKeyForForward` rewrites inventory ids, not `event.id`, so
+    // `seen`'s own ids are still comparable to what got stamped.
+    expect(calls.delivered).toEqual(seen.map((e) => (e as AuditEventInput).id));
   });
 });
 

--- a/packages/plugin-runtime/test/attached/gateway.test.ts
+++ b/packages/plugin-runtime/test/attached/gateway.test.ts
@@ -1085,24 +1085,31 @@ describe('the live forward stamps what it delivered', () => {
     expect(drops?.droppedForwards).toBe(1);
   });
 
-  it('stops the retry — and counts the WHOLE remainder once — the moment the breaker opens mid-pass', async () => {
-    // Once a single comes back breaker-open, every remaining `run()` call in
-    // this chunk would short-circuit identically at zero network cost: nothing
-    // left to isolate. The loop must stop rather than iterate through a
-    // decided outcome, and the remainder is counted as ONE write, not one per
-    // event, since `recordForwardDrops` is a real file read-modify-write.
-    let calls_ = 0;
+  it('stops the WHOLE PASS — not just this chunk — and counts every chunk still owed, the moment the breaker opens mid-retry', async () => {
+    // TWO chunks, deliberately: with only one, `break` and `return` behave
+    // identically, because there is no next chunk for the bug to hide in.
+    // Once a single comes back breaker-open here, every remaining `run()`
+    // call — this chunk's own remainder AND every later chunk's batch
+    // attempt — would answer breaker-open identically at zero network cost.
+    // `breaker-open` is not one of the three reasons the outer gate retries
+    // per item, so a chunk that reaches it via `continue` records NOTHING —
+    // which is what a `break` here used to leave the SECOND chunk to. The
+    // fix counts the full remainder, across every chunk still owed, and
+    // returns from the whole pass rather than merely breaking this loop.
+    let callCount = 0;
     const forward: ForwardPolicy = {
       run: async (op: () => Promise<unknown>) => {
-        calls_ += 1;
-        if (calls_ === 1) {
-          // The batch attempt: refused, triggering the retry.
+        callCount += 1;
+        if (callCount === 1) {
+          // Chunk 1's own batch attempt: refused, triggering the retry.
           return { ok: false, reason: 'invalid-request' } as ForwardResult<unknown>;
         }
-        if (calls_ <= 4) {
-          // Singles 1-3 succeed, THEN the breaker opens on the 4th call.
+        if (callCount <= 4) {
+          // Three singles succeed, THEN the breaker opens on the fourth.
           return { ok: true, value: await op() } as ForwardResult<unknown>;
         }
+        // Everything from here on, including chunk 2's own batch attempt if
+        // it were ever reached, answers breaker-open at zero network cost.
         return { ok: false, reason: 'breaker-open' } as ForwardResult<unknown>;
       },
     } as unknown as ForwardPolicy;
@@ -1121,18 +1128,27 @@ describe('the live forward stamps what it delivered', () => {
     } as unknown as AttachedClient;
 
     const { gateway, dataDir: dir } = build({ forward, client, local: makeLocal(calls) });
-    // 10 events: 1 batch attempt (refused) + 3 successful singles, then the
-    // breaker opens on the 4th and the remaining 6 are never attempted.
+    // 100 events is two chunks of 50. Chunk 1's batch is refused; three
+    // singles land, the fourth opens the breaker. Chunk 2 must never even be
+    // ATTEMPTED — the whole pass stops here.
     await gateway.recordToolCalls(
-      Array.from({ length: 10 }, (_, i) => toolCallInput(`call-${String(i)}`)),
+      Array.from({ length: 100 }, (_, i) => toolCallInput(`call-${String(i)}`)),
     );
 
-    // The breaker-open call itself DID reach the client (that is how the fake
-    // decides to answer breaker-open), but nothing past it did.
-    expect(singles.length).toBeLessThanOrEqual(4);
+    // Exactly three singles reached the client and succeeded — the fourth
+    // call answers breaker-open without calling `op()` at all, so this is
+    // the value, not merely a bound on it.
+    expect(singles).toHaveLength(3);
     expect(calls.delivered).toHaveLength(3);
+    // The client was never asked for chunk 2's batch: only the five calls
+    // chunk 1 itself made (one batch + four singles) ever happened.
+    expect(callCount).toBe(5);
     const drops = readForwardDrops(dir);
-    expect(calls.delivered.length + (drops?.droppedForwards ?? 0)).toBe(10);
+    // 97, not 47: the remainder covers BOTH chunk 1's own un-retried tail
+    // and the whole of chunk 2, which a `break` would have abandoned to the
+    // outer loop's silent `continue`.
+    expect(drops?.droppedForwards).toBe(97);
+    expect(calls.delivered.length + (drops?.droppedForwards ?? 0)).toBe(100);
   });
 
   it('counts the events a chunk never reached when the deadline lands mid-retry', async () => {

--- a/packages/plugin-runtime/test/attached/status.test.ts
+++ b/packages/plugin-runtime/test/attached/status.test.ts
@@ -245,7 +245,7 @@ describe('renderAttachedStatus — the forward half', () => {
     writeBreaker(0, null);
     const out = renderAttachedStatus({ base: root, settingsDir, dataDir, now: () => 1_000_000 });
     expect(out).toContain('reporting normally');
-    expect(out).not.toContain('dropped past the batch budget');
+    expect(out).not.toContain('events dropped');
   });
 
   it('reports health only when a success actually cleared the failures', () => {


### PR DESCRIPTION
## Summary

Follow-up to #404, which merged before this landed. `@Vaishnav-OM` posted five findings on the merged PR after `bf52f92d`; this branch addresses all five plus one an adversarial review pass caught in the fix for #3.

- **Shared breaker.** `route-absent`'s catch arm cleared the ENTIRE breaker state (`{...CLOSED}`) whenever it undid a half-open re-stamp — wiping `consecutiveFailures`/`lastFailure` earned by a completely different route, since `AttachedDataGateway` holds one `ForwardPolicy` shared across every route it forwards through. A permanently-dead batch route could mask a genuine outage on every other route forever. Fixed with a `restoreOpenedAtMs` helper that touches only `openedAtMs`.
- **Batch ack's `accepted` count discarded.** `AuditEventBatchAck.accepted` is an aggregate the wire contract never ties to the chunk length, so `ok: true` with a short count is well-formed. The whole chunk was stamped delivered regardless. Now checked against `chunk.length`; a short count falls into the existing per-item retry (safe — the receiving upsert settles a duplicate resend silently).
- **A server-side 4xx dropped 50 events for 1.** `classifyFailure` deliberately collapses everything but 401/403 into `unreachable`, so a genuine 400/413/422 body refusal from the deployment was indistinguishable from an outage and dropped the whole chunk. Added a `rejected` reason, classified by status range before any breaker write, added to the per-item retry gate.
- **A single failing inside the retry was uncounted.** Three failures opening the breaker mid-retry silently dropped the remainder with no accounting. `breaker-open` now counts the whole remainder once and stops; any other single-level failure counts itself and the loop continues.
- **A weakened test.** An identity assertion (`toEqual`) had been quietly replaced with a count-only one (`toHaveLength`) that can't tell a correctly-stamped batch from one stamped under the wrong ids. Reverted.

**The one this round found on its own:** the `rejected` status range as first written included 429. That's wrong in both directions — `rejected` never touches the breaker, so a sustained 429 could never trip it, and it's in the per-item retry gate, so a 429'd chunk would fire up to 50 more unpaced requests at the same already-throttled endpoint, exactly the burst `forwardBatch`'s own docblock says staying serial exists to avoid. 429 is now excluded and classifies as `unreachable`.

## Test plan

- [x] `packages/plugin-runtime` + `packages/remote` full suites: 539 + 42 passing
- [x] Typecheck, eslint, prettier clean
- [x] 14 mutations across all five findings plus the 429 boundary — reverting any fix, or reintroducing any original bug shape, fails the suite
- [x] Diff coverage: 100% of 20 changed lines
- [x] An independent adversarial review pass (6 lenses, verify-by-refutation) confirmed only the 429 finding above; three other candidate findings it raised were refuted on inspection
