### PR TITLE
chore(turbo): exclude codex and antigravity script outDirs from the guard hash

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -338,7 +338,15 @@
         "!$TURBO_ROOT$/web-ui/out/**",
         "!$TURBO_ROOT$/web-ui/next-env.d.ts",
         "!$TURBO_ROOT$/cli/web-ui/**",
+        // All three CLI plugins' tsup outDirs. None is named `dist`, so the
+        // blanket dist exclusion above does not reach them — and being listed in
+        // .gitignore does not reach them either, exactly as the `.turbo` note
+        // above records: a `$TURBO_ROOT$` glob hashes an untracked file anyway.
+        // Without all three, every plugin build perturbs this task's hash and
+        // costs a full re-run of the guard suite.
         "!$TURBO_ROOT$/plugins/claude-code/scripts/**",
+        "!$TURBO_ROOT$/plugins/codex/scripts/**",
+        "!$TURBO_ROOT$/plugins/antigravity/scripts/**",
         // plugins/browser-extension's tsup outDir, and the copies of it that
         // cli/scripts/bundle-extension.mjs stages into the CLI package. All
         // three are generated and gitignored, and none is named `dist`, so the


### PR DESCRIPTION
`@akasecurity/eslint-config#test` hashes the tree through `**/*.json` and the extension globs above it, then excludes the generated directories that would otherwise perturb it. `plugins/claude-code/scripts/**` was excluded; `plugins/codex/scripts/**` and `plugins/antigravity/scripts/**` were not — though all three are the same thing, that plugin's tsup `outDir`.

So every build of the Codex or Antigravity plugin cost a full re-run of the ~1,400-test guard suite instead of a cache hit.

## Measurement

A positive control was taken **before** the change, because three identical hashes afterwards mean nothing unless the probe is known to be able to detect the pollution.

| | `plugins/codex/scripts` | `plugins/antigravity/scripts` |
|---|---|---|
| **Before** | `8cc0133f…` → `51562efb…` → `3dd40e0a…` | `8cc0133f…` → `8a590824…` → `abc11ee3…` |
| **After** | `7b81b58c…` ×3 | `7b81b58c…` ×3 |

Each row is: directory absent → probe file created → probe file edited. Before the change both paths moved the hash, and each *edit* moved it again, so the probe was live. After, both hold still.

The clean hash moved once, `8cc0133f…` → `7b81b58c…`. That is this diff editing `turbo.json`, which is itself an input to the task — the legitimate one-time move. The property under test is that *build output* no longer moves it.

Re-verified after an unrelated `pnpm install` bumped turbo 2.10.10 → 2.10.12, this time non-destructively against real build output and with a liveness control: a probe at `packages/schema/zz-probe-tmp.json` (a hashed path) moved the hash to `d96e7ccf…`, while probes under both excluded paths held `7b81b58c…` across create and edit.

## Why `.gitignore` does not already cover this

A `$TURBO_ROOT$` glob hashes an untracked file anyway — which is what the `.turbo` note further up the same block already records. Verified separately: a `.gitignore` entry left the hash at the polluted value, and only the turbo `inputs` exclusion held it still.

## No coverage is lost

The guards that read this task's inputs all walk `git ls-files`, and `git ls-files` over both paths returns nothing, so a file there could only ever cost cache hits — never buy coverage. This matches the reasoning already written into the block.

A generated path that slips through these exclusions costs a cache miss and never a false pass, so this is a CI-cost fix rather than a correctness one.

## Verification

- `pnpm --filter @akasecurity/eslint-config test` — 1,408 tests across 20 files pass, 100% coverage.
- `pnpm lint` (turbo lint + `lint:root` + `check:portability`) passes.
- Change is confined to `turbo.json`.
