### PR TITLE
feat(plugin): service a deployment's re-scan command, and never let it name a path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -705,7 +705,7 @@ plugins/browser-extension → @akasecurity/plugin-runtime, plugin-sdk (the nativ
                      is the one module inside it that sends; everything else
                      builds requests and parses answers.
                      TWO clients, split by whether the caller holds a credential.
-                     `createRemoteClient` speaks the seven routes an ATTACHED
+                     `createRemoteClient` speaks the ten routes an ATTACHED
                      machine is scoped to and requires a key. `createAttachClient`
                      speaks the two anonymous routes a machine uses to OBTAIN one
                      and holds none — a separate factory rather than an optional

--- a/packages/plugin-runtime/src/attached/command-sync.ts
+++ b/packages/plugin-runtime/src/attached/command-sync.ts
@@ -1,0 +1,236 @@
+// The device half of the device-command channel: what an attached machine does
+// when its deployment has asked it to do something.
+//
+// Runs in the DETACHED CHILD only, immediately after the policy pull and in the
+// same process — never on a hook path, and never inline in a session. The
+// cadence is the policy sync's own fifteen-minute throttle, deliberately
+// unchanged: a command is picked up at the next session entry, and nothing here
+// makes that instant. The dashboard is built to say so rather than imply
+// otherwise.
+import { readControlPlaneCredentialFile, readWorkspaceSettings } from '@akasecurity/persistence';
+import type { PluginConfig, SourceTool } from '@akasecurity/plugin-sdk';
+import { createRemoteClient } from '@akasecurity/remote';
+import type { DeviceCommand, DeviceCommandFailureReason } from '@akasecurity/schema';
+import { isAttached } from '@akasecurity/schema';
+
+import { withTimeout } from './with-timeout.ts';
+
+/**
+ * Bound for one poll/scan/ack cycle — the same reasoning as
+ * `SYNC_REQUEST_TIMEOUT_MS`, and for the same reason it is not the 2 s hook
+ * bound: nothing is waiting on this process.
+ *
+ * The two REQUESTS get this bound each. The scan between them deliberately does
+ * not: it is local filesystem work whose duration is the size of the user's
+ * checkout, and cutting it off mid-way would leave the ledger advanced for
+ * files whose findings were never written. A scan that takes a long time is a
+ * big repository, not a fault.
+ */
+export const COMMAND_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
+ * What one cycle did. `null` from `runCommandSync` means NO ATTEMPT — the same
+ * distinction `runPolicySync` draws, and for the same reason: it must not be
+ * confused with a cycle that ran and found nothing.
+ *
+ *   `none`        polled, and the deployment had nothing pending. The ordinary
+ *                 answer, and the one this runs into on almost every sync.
+ *   `reported`    scanned and acked. The command is done for this device.
+ *   `failed`      scanned or forwarded unsuccessfully, and said so with a
+ *                 closed reason. Also terminal for this device — the ack is
+ *                 what takes it off the roster's outstanding column.
+ *   `unreachable` the poll itself did not answer. Nothing was scanned and
+ *                 nothing was acked; the next sync tries again.
+ */
+export type CommandSyncOutcome = 'none' | 'reported' | 'failed' | 'unreachable';
+
+/**
+ * The scan this module is allowed to run.
+ *
+ * INJECTED, and that is a dependency-graph fact before it is a testing
+ * convenience: `@akasecurity/scanner` already depends on this package, so
+ * importing it here would close a cycle. The three plugin `sync` entries that
+ * ship a scanner pass it in.
+ *
+ * It also keeps the capability honest. A host with no scanner — the browser
+ * extension's native host — passes nothing, and this module then does not poll
+ * at all rather than polling and leaving a command it can never service sitting
+ * outstanding until it expires.
+ *
+ * The signature takes NO scope. That is the point: the caller supplies the
+ * ability to scan, and this module supplies the scope, which is fixed
+ * device-side and cannot be influenced by anything on the wire.
+ */
+export type CommandScan = () => Promise<{ projects: number }>;
+
+export interface RunCommandSyncDeps {
+  /** The ~/.aka root, for reading settings. */
+  base: string;
+  settingsDir: string;
+  /** Absent on a host that cannot scan; see `CommandScan`. */
+  scan?: CommandScan | undefined;
+}
+
+/**
+ * The reason a thrown scan reports, as a constant rather than a mapping.
+ *
+ * The thrown error is DISCARDED, deliberately and without being read: the
+ * closed enum is the whole reason no device-supplied text can reach an
+ * operator's screen through this channel, and a function that inspected the
+ * error would be where a message eventually got attached to the ack. There is
+ * no catch-all member for the same reason.
+ */
+const SCAN_THREW: DeviceCommandFailureReason = 'scan_failed';
+
+/**
+ * A scan that ran and found nothing to forward.
+ *
+ * NOT `reported` with a count of zero. The two are different facts and an
+ * operator acts on them differently — "this machine has no projects here" is a
+ * configuration observation, while "reported: 0 projects" reads as a scan that
+ * ran over a checkout and found nothing worth sending. The roster gives this
+ * member its own neutral treatment rather than the failure styling, which is
+ * only possible if the device distinguishes them in the first place.
+ */
+const SCAN_FOUND_NOTHING: DeviceCommandFailureReason = 'no_projects';
+
+/**
+ * Poll, service, ack — once.
+ *
+ * NEVER THROWS. This is called from the detached child, which has no parent
+ * watching, and the whole channel is a convenience: a machine that cannot
+ * service a command must fall back to being a machine that scans on its own
+ * schedule, never to a broken session or a crashed sync.
+ *
+ * ACK-ON-FAILURE IS LOAD-BEARING, not politeness. A device that scans and fails
+ * silently is indistinguishable on the roster from one that is switched off,
+ * and the operator waits 24 hours for a command to expire before learning
+ * anything. Acking a failure is what turns "we never heard from it" into "it
+ * tried and here is the closed reason".
+ */
+export async function runCommandSync(
+  deps: RunCommandSyncDeps,
+): Promise<CommandSyncOutcome | null> {
+  // Nothing to service, and nothing to ask. A host with no scanner must not
+  // poll: a command it received and could never run would sit outstanding on
+  // the roster until it expired, which reads to an operator exactly like a
+  // machine that is off.
+  if (deps.scan === undefined) return null;
+
+  // BOTH HALVES, the same rule as runPolicySync: the descriptor names the
+  // deployment, the credential authenticates to it, and either alone is not an
+  // attachment. A credential minted for another endpoint counts as absent.
+  const settings = readWorkspaceSettings(deps.base);
+  const connection = isAttached(settings) ? settings.controlPlane : undefined;
+  const state =
+    connection === undefined
+      ? undefined
+      : readControlPlaneCredentialFile(deps.settingsDir, connection);
+  if (connection === undefined || !state?.usable) return null;
+
+  const client = createRemoteClient({
+    endpoint: connection.endpoint,
+    apiKey: state.credential.apiKey,
+    timeoutMs: COMMAND_REQUEST_TIMEOUT_MS,
+  });
+
+  let command: DeviceCommand | null;
+  try {
+    command = await withTimeout(client.pollCommand(), COMMAND_REQUEST_TIMEOUT_MS);
+  } catch {
+    // Includes a deployment that answered with a command this build refuses to
+    // parse — one carrying a path, say. Nothing is scanned and nothing is
+    // acked, which is the correct response to an instruction that failed its
+    // own contract: the command stays outstanding and a human sees that.
+    return 'unreachable';
+  }
+  if (command === null) return 'none';
+
+  // The scope is chosen HERE, from nothing the command said. `command` is
+  // consulted for its id and nothing else — it carries no path, and
+  // `DeviceCommand.strict()` is what keeps that true rather than customary.
+  let projects = 0;
+  let reason: DeviceCommandFailureReason | null = null;
+  try {
+    projects = (await deps.scan()).projects;
+    if (projects === 0) reason = SCAN_FOUND_NOTHING;
+  } catch {
+    reason = SCAN_THREW;
+  }
+
+  try {
+    await withTimeout(
+      reason === null
+        ? client.ackCommand(command.id, { outcome: 'reported', projectsForwarded: projects })
+        : client.ackCommand(command.id, {
+            outcome: 'failed',
+            reason,
+            projectsForwarded: projects,
+          }),
+      COMMAND_REQUEST_TIMEOUT_MS,
+    );
+  } catch {
+    // The work happened; only the report did not. Reported as `unreachable`
+    // rather than as the scan's own outcome, because from the deployment's side
+    // this device is still outstanding — claiming `reported` here would make
+    // this module's return value disagree with the roster it exists to feed.
+    return 'unreachable';
+  }
+
+  return reason === null ? 'reported' : 'failed';
+}
+
+/**
+ * The scan scope a serviced command uses, as a description rather than a value:
+ * every search root is chosen device-side.
+ *
+ * This is the SAME default the interactive scan uses — `--discover` with no
+ * `--root` sweeps the current directory, and `--root ~` is the explicit,
+ * human-typed, machine-wide opt-in. A server-issued command gets the
+ * unprivileged half of that rule and has no way to ask for the other one.
+ *
+ * The detached child inherits its working directory from the session that
+ * spawned it, so "the current directory" is the project the user was actually
+ * in. That bounds a re-scan to one project per pickup, which is the honest
+ * trade: the alternative that would cover more ground is an implicit sweep of
+ * the home directory, and this codebase refuses to do that without a person
+ * asking for it.
+ */
+export const COMMAND_SCAN_SCOPE = 'the session working directory' as const;
+
+/**
+ * The shape of `scanAllRepos`, spelled structurally.
+ *
+ * Structural rather than imported, because importing `@akasecurity/scanner`
+ * here is the dependency cycle `CommandScan` describes. Narrow on purpose: it
+ * names only what this adapter passes and reads, so a scanner signature change
+ * that matters shows up as a type error at the three call sites rather than
+ * being absorbed by an `any`.
+ */
+export type DiscoverScan = (
+  config: PluginConfig,
+  opts: { sourceTool: SourceTool; searchRoots: string[] },
+) => Promise<{ repos: readonly unknown[] }>;
+
+/**
+ * Build the injected scan from a host's scanner.
+ *
+ * A thin adapter, but it exists so the SCOPE is written ONCE, here, next to the
+ * reasoning above — three copies of a security-relevant default across three
+ * plugin trees is three places for it to drift, and the one that drifts quietly
+ * is the one that widens.
+ */
+export function commandScanFor(
+  config: PluginConfig,
+  scanAllRepos: DiscoverScan,
+  sourceTool: SourceTool,
+): CommandScan {
+  return async () => {
+    const summary = await scanAllRepos(config, {
+      sourceTool,
+      // Never the home directory implicitly, and never anything the wire named.
+      searchRoots: [process.cwd()],
+    });
+    return { projects: summary.repos.length };
+  };
+}

--- a/packages/plugin-runtime/src/attached/command-sync.ts
+++ b/packages/plugin-runtime/src/attached/command-sync.ts
@@ -5,8 +5,10 @@
 // same process — never on a hook path, and never inline in a session. The
 // cadence is the policy sync's own fifteen-minute throttle, deliberately
 // unchanged: a command is picked up at the next session entry, and nothing here
-// makes that instant. The dashboard is built to say so rather than imply
-// otherwise.
+// makes that instant. No surface in this repository renders a device-command
+// yet, so an operator's only view of one is whatever the control plane shows;
+// anything claiming a re-scan is immediate would be claiming it on this
+// module's behalf, and this module cannot deliver it.
 import { readControlPlaneCredentialFile, readWorkspaceSettings } from '@akasecurity/persistence';
 import type { PluginConfig, SourceTool } from '@akasecurity/plugin-sdk';
 import { createRemoteClient } from '@akasecurity/remote';
@@ -159,11 +161,11 @@ export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandS
   try {
     await withTimeout(
       reason === null
-        ? client.ackCommand(command.id, { outcome: 'reported', projectsForwarded: projects })
+        ? client.ackCommand(command.id, { outcome: 'reported', projectsScanned: projects })
         : client.ackCommand(command.id, {
             outcome: 'failed',
             reason,
-            projectsForwarded: projects,
+            projectsScanned: projects,
           }),
       COMMAND_REQUEST_TIMEOUT_MS,
     );
@@ -182,33 +184,51 @@ export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandS
  * The scan scope a serviced command uses, as a description rather than a value:
  * every search root is chosen device-side.
  *
- * This is the SAME default the interactive scan uses — `--discover` with no
- * `--root` sweeps the current directory, and `--root ~` is the explicit,
- * human-typed, machine-wide opt-in. A server-issued command gets the
- * unprivileged half of that rule and has no way to ask for the other one.
+ * ONE WORKTREE, and deliberately the NARROWER of the two modes the interactive
+ * scan offers. `scanWorktree` is what `/aka:scan` runs with no flags: it scans
+ * the directory it is given and does not go looking for others. The wider mode
+ * — `scanAllRepos`, reached interactively only by typing `--discover`, which
+ * `commands/scan.md` titles "Multi-repo scan (opt-in)" — walks four levels down
+ * and returns every repository it finds under the root. A server-issued command
+ * gets the mode a human gets by default, never the one a human has to ask for.
+ *
+ * That distinction is the whole scope argument, so it is worth being exact
+ * about what the wider mode would have meant here. `discoverGitRepos` defaults
+ * `maxDepth` to 4, so a session started in `~/clients` would sweep every
+ * checkout under it and forward all of their findings on one command — three
+ * customers' repositories reported to one deployment. The scan root is chosen
+ * device-side either way and the wire can still name nothing, but "the wire
+ * cannot name the root" is a bound on WHICH directory, never on how much sits
+ * under it. Only the mode bounds that.
  *
  * The detached child inherits its working directory from the session that
- * spawned it, so "the current directory" is the project the user was actually
- * in. That bounds a re-scan to one project per pickup, which is the honest
- * trade: the alternative that would cover more ground is an implicit sweep of
- * the home directory, and this codebase refuses to do that without a person
- * asking for it.
+ * spawned it, so the scanned worktree is the project the user was actually in —
+ * and a session started in a package subdirectory of a monorepo scans that
+ * directory rather than reporting no projects, which is what the discovery walk
+ * would have done, since it only ever descends.
+ *
+ * `--root ~` stays the explicit, human-typed, machine-wide opt-in, and a
+ * command has no way to ask for it: there is no path on the wire to ask WITH.
  */
 export const COMMAND_SCAN_SCOPE = 'the session working directory' as const;
 
 /**
- * The shape of `scanAllRepos`, spelled structurally.
+ * The shape of `scanWorktree`, spelled structurally.
  *
  * Structural rather than imported, because importing `@akasecurity/scanner`
  * here is the dependency cycle `CommandScan` describes. Narrow on purpose: it
  * names only what this adapter passes and reads, so a scanner signature change
  * that matters shows up as a type error at the three call sites rather than
  * being absorbed by an `any`.
+ *
+ * `rootDir` is REQUIRED here even though the scanner defaults it, so the scope
+ * is visibly chosen at the one call site that reasons about it rather than
+ * inherited from a default that could move in another package.
  */
-export type DiscoverScan = (
+export type WorktreeScan = (
   config: PluginConfig,
-  opts: { sourceTool: SourceTool; searchRoots: string[] },
-) => Promise<{ repos: readonly unknown[] }>;
+  opts: { sourceTool: SourceTool; rootDir: string },
+) => Promise<{ scanned: number }>;
 
 /**
  * Build the injected scan from a host's scanner.
@@ -220,15 +240,19 @@ export type DiscoverScan = (
  */
 export function commandScanFor(
   config: PluginConfig,
-  scanAllRepos: DiscoverScan,
+  scanWorktree: WorktreeScan,
   sourceTool: SourceTool,
 ): CommandScan {
   return async () => {
-    const summary = await scanAllRepos(config, {
+    const summary = await scanWorktree(config, {
       sourceTool,
       // Never the home directory implicitly, and never anything the wire named.
-      searchRoots: [process.cwd()],
+      rootDir: process.cwd(),
     });
-    return { projects: summary.repos.length };
+    // 0 or 1: this mode scans exactly one worktree, so the count answers "was
+    // there anything here to scan", not "how many projects were found". A
+    // worktree with no scannable file is the `no_projects` outcome rather than
+    // a report of zero, which is a distinction an operator acts on.
+    return { projects: summary.scanned > 0 ? 1 : 0 };
   };
 }

--- a/packages/plugin-runtime/src/attached/command-sync.ts
+++ b/packages/plugin-runtime/src/attached/command-sync.ts
@@ -108,9 +108,7 @@ const SCAN_FOUND_NOTHING: DeviceCommandFailureReason = 'no_projects';
  * anything. Acking a failure is what turns "we never heard from it" into "it
  * tried and here is the closed reason".
  */
-export async function runCommandSync(
-  deps: RunCommandSyncDeps,
-): Promise<CommandSyncOutcome | null> {
+export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandSyncOutcome | null> {
   // Nothing to service, and nothing to ask. A host with no scanner must not
   // poll: a command it received and could never run would sit outstanding on
   // the roster until it expired, which reads to an operator exactly like a

--- a/packages/plugin-runtime/src/attached/command-sync.ts
+++ b/packages/plugin-runtime/src/attached/command-sync.ts
@@ -12,9 +12,14 @@
 import { readControlPlaneCredentialFile, readWorkspaceSettings } from '@akasecurity/persistence';
 import type { PluginConfig, SourceTool } from '@akasecurity/plugin-sdk';
 import { createRemoteClient } from '@akasecurity/remote';
-import type { DeviceCommand, DeviceCommandFailureReason } from '@akasecurity/schema';
+import type {
+  DeviceCommand,
+  DeviceCommandFailureReason,
+  DeviceCommandKind,
+} from '@akasecurity/schema';
 import { isAttached } from '@akasecurity/schema';
 
+import { classifyFailure } from './failure.ts';
 import { withTimeout } from './with-timeout.ts';
 
 /**
@@ -44,7 +49,8 @@ export const COMMAND_REQUEST_TIMEOUT_MS = 30_000;
  *   `unreachable` the poll itself did not answer. Nothing was scanned and
  *                 nothing was acked; the next sync tries again.
  */
-export type CommandSyncOutcome = 'none' | 'reported' | 'failed' | 'unreachable';
+export type CommandSyncOutcome =
+  'none' | 'reported' | 'failed' | 'unauthorized' | 'forbidden' | 'unreachable';
 
 /**
  * The scan this module is allowed to run.
@@ -71,6 +77,8 @@ export interface RunCommandSyncDeps {
   settingsDir: string;
   /** Absent on a host that cannot scan; see `CommandScan`. */
   scan?: CommandScan | undefined;
+  /** Injected for the expiry check, as `runPolicySync` injects its own. */
+  now?: (() => number) | undefined;
 }
 
 /**
@@ -95,6 +103,46 @@ const SCAN_THREW: DeviceCommandFailureReason = 'scan_failed';
  * only possible if the device distinguishes them in the first place.
  */
 const SCAN_FOUND_NOTHING: DeviceCommandFailureReason = 'no_projects';
+
+/** A command whose own deadline had already passed when this device got it. */
+const COMMAND_EXPIRED: DeviceCommandFailureReason = 'expired';
+
+/**
+ * Has this command's own deadline passed?
+ *
+ * FAIL-OPEN ON AN UNREADABLE STAMP, and that direction is deliberate.
+ * `expiresAt` is `printable(64)` on the wire rather than a validated datetime,
+ * because this is a RESPONSE field and tightening it would make an older device
+ * reject the whole envelope — which, since the id rides in that same envelope,
+ * would leave it unable to ack the command it just refused. So a stamp that
+ * does not parse is treated as no deadline at all and the command is serviced.
+ * The alternative errs the wrong way: a deployment that changes its timestamp
+ * format would silently stop every device in the fleet from working, and a
+ * re-scan is not the kind of instruction worth refusing on a formatting doubt.
+ *
+ * The deployment is the authority on expiry and is expected not to serve a
+ * command past its deadline. This is the device declining to act on week-old
+ * work if it does anyway — a laptop closed on Friday and opened the following
+ * week is the case it exists for.
+ */
+function hasExpired(expiresAt: string, atMs: number): boolean {
+  const deadlineMs = Date.parse(expiresAt);
+  return Number.isFinite(deadlineMs) && deadlineMs <= atMs;
+}
+
+/**
+ * What each verb does, keyed on the verb.
+ *
+ * A `Record<DeviceCommandKind, …>` rather than a bare call on the one thing a
+ * command can currently mean, for the reason CLAUDE.md gives for every table
+ * over a vocabulary: adding a member to `DeviceCommandKind` fails to COMPILE
+ * here until somebody decides what it does. Without it, a second verb — which
+ * would parse, since that enum is what decides what parses — would silently run
+ * a `shares_rescan`, the one outcome the closed enum was chosen to prevent.
+ */
+const SERVICE: Record<DeviceCommandKind, (scan: CommandScan) => Promise<{ projects: number }>> = {
+  shares_rescan: (scan) => scan(),
+};
 
 /**
  * Poll, service, ack — once.
@@ -137,12 +185,21 @@ export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandS
   let command: DeviceCommand | null;
   try {
     command = await withTimeout(client.pollCommand(), COMMAND_REQUEST_TIMEOUT_MS);
-  } catch {
-    // Includes a deployment that answered with a command this build refuses to
-    // parse — one carrying a path, say. Nothing is scanned and nothing is
-    // acked, which is the correct response to an instruction that failed its
-    // own contract: the command stays outstanding and a human sees that.
-    return 'unreachable';
+  } catch (err) {
+    // Credential verdicts FIRST, and off the STATUS rather than the message —
+    // the same rule, and the same `classifyFailure`, that `runPolicySync` uses,
+    // so the two halves of attached mode cannot reach different verdicts about
+    // one refusal. Collapsing a 401 into `unreachable` said "try again" about
+    // the one outcome that will never succeed on its own: a revoked key would
+    // poll every fifteen minutes forever, reported as an outage.
+    //
+    // The `unreachable` bucket still includes a deployment that answered with a
+    // command this build refuses to parse — one carrying a path, say. Nothing
+    // is scanned and nothing is acked, which is the correct response to an
+    // instruction that failed its own contract: the command stays outstanding
+    // and a human sees that.
+    const failure = classifyFailure(err);
+    return failure === 'unreachable' ? 'unreachable' : failure;
   }
   if (command === null) return 'none';
 
@@ -151,11 +208,19 @@ export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandS
   // `DeviceCommand.strict()` is what keeps that true rather than customary.
   let projects = 0;
   let reason: DeviceCommandFailureReason | null = null;
-  try {
-    projects = (await deps.scan()).projects;
-    if (projects === 0) reason = SCAN_FOUND_NOTHING;
-  } catch {
-    reason = SCAN_THREW;
+  if (hasExpired(command.expiresAt, (deps.now ?? Date.now)())) {
+    // Declined rather than serviced, and ACKED rather than dropped: the whole
+    // discipline of this module is that every terminal path says something, so
+    // an operator's roster distinguishes "declined, and here is why" from a
+    // machine that never answered.
+    reason = COMMAND_EXPIRED;
+  } else {
+    try {
+      projects = (await SERVICE[command.kind](deps.scan)).projects;
+      if (projects === 0) reason = SCAN_FOUND_NOTHING;
+    } catch {
+      reason = SCAN_THREW;
+    }
   }
 
   try {
@@ -169,12 +234,15 @@ export async function runCommandSync(deps: RunCommandSyncDeps): Promise<CommandS
           }),
       COMMAND_REQUEST_TIMEOUT_MS,
     );
-  } catch {
-    // The work happened; only the report did not. Reported as `unreachable`
-    // rather than as the scan's own outcome, because from the deployment's side
-    // this device is still outstanding — claiming `reported` here would make
-    // this module's return value disagree with the roster it exists to feed.
-    return 'unreachable';
+  } catch (err) {
+    // The work happened; only the report did not. Never the scan's own outcome,
+    // because from the deployment's side this device is still outstanding —
+    // claiming `reported` here would make this module's return value disagree
+    // with the roster it exists to feed. Classified for the same reason the
+    // poll is: a refusal of the credential is terminal wherever it lands, and
+    // the ack is a request like any other.
+    const failure = classifyFailure(err);
+    return failure === 'unreachable' ? 'unreachable' : failure;
   }
 
   return reason === null ? 'reported' : 'failed';

--- a/packages/plugin-runtime/src/attached/index.ts
+++ b/packages/plugin-runtime/src/attached/index.ts
@@ -13,8 +13,8 @@ export type { GatewayMeta } from './factory.ts';
 export type {
   CommandScan,
   CommandSyncOutcome,
-  DiscoverScan,
   RunCommandSyncDeps,
+  WorktreeScan,
 } from './command-sync.ts';
 export {
   COMMAND_REQUEST_TIMEOUT_MS,

--- a/packages/plugin-runtime/src/attached/index.ts
+++ b/packages/plugin-runtime/src/attached/index.ts
@@ -10,6 +10,18 @@ export type { GatewayMeta } from './factory.ts';
 // The device identity, and ONLY that: `aka attach` has to tell a deployment
 // which machine is asking, and reading it through the same store the posture
 // reporter uses is what keeps one laptop from presenting two identities.
+export type {
+  CommandScan,
+  CommandSyncOutcome,
+  DiscoverScan,
+  RunCommandSyncDeps,
+} from './command-sync.ts';
+export {
+  COMMAND_REQUEST_TIMEOUT_MS,
+  COMMAND_SCAN_SCOPE,
+  commandScanFor,
+  runCommandSync,
+} from './command-sync.ts';
 export type { ControlPlaneFailure } from './failure.ts';
 export { classifyFailure } from './failure.ts';
 export type { ForwardDrops } from './forward-drops.ts';

--- a/packages/plugin-runtime/src/attached/sync-entry.ts
+++ b/packages/plugin-runtime/src/attached/sync-entry.ts
@@ -1,5 +1,7 @@
 import { dataDir, defaultDataDir, settingsDir } from '@akasecurity/persistence';
 
+import type { CommandScan } from './command-sync.ts';
+import { runCommandSync } from './command-sync.ts';
 import { runPolicySync } from './policy-sync.ts';
 import { writeSyncState } from './sync-state.ts';
 
@@ -21,8 +23,17 @@ import { writeSyncState } from './sync-state.ts';
  * describes something a control plane did or failed to do — writing one here
  * would have status report a plane this machine never called, and would
  * re-create a file a detach had just removed.
+ *
+ * `deps.scan` adds the device-command channel to the same child. It is optional
+ * because not every host can service a command: the browser extension's native
+ * host ships no scanner, and a host that cannot scan must not poll — a command
+ * it received and could never run would sit outstanding on an operator's roster
+ * until it expired, which reads exactly like a machine that is switched off.
  */
-export async function runAttachedSync(base: string = defaultDataDir()): Promise<void> {
+export async function runAttachedSync(
+  base: string = defaultDataDir(),
+  deps: { scan?: CommandScan | undefined } = {},
+): Promise<void> {
   try {
     const result = await runPolicySync({
       base,
@@ -32,5 +43,22 @@ export async function runAttachedSync(base: string = defaultDataDir()): Promise<
     if (result !== null) writeSyncState(dataDir(base), result);
   } catch {
     // Nothing to report to and nowhere to report it.
+  }
+
+  // AFTER the policy pull, and in its own try. Ordered that way because the
+  // scan the command triggers reads the policy the pull just cached, so a
+  // command serviced first would scan against the previous ruleset.
+  //
+  // Separately caught rather than sharing the block above: a policy pull that
+  // threw must not also silently cancel the command channel, and a command that
+  // fails must not lose the sync state the pull already wrote. Two independent
+  // jobs sharing one child, not one job in two halves.
+  try {
+    await runCommandSync({ base, settingsDir: settingsDir(base), scan: deps.scan });
+  } catch {
+    // Same contract: nothing is waiting on this process. `runCommandSync` is
+    // documented never to throw, so reaching here is a bug rather than an
+    // expected path — and the response to a bug in a detached child is still to
+    // exit quietly rather than to take the sync down with it.
   }
 }

--- a/packages/plugin-runtime/src/attached/sync-entry.ts
+++ b/packages/plugin-runtime/src/attached/sync-entry.ts
@@ -2,6 +2,7 @@ import { dataDir, defaultDataDir, settingsDir } from '@akasecurity/persistence';
 
 import type { CommandScan } from './command-sync.ts';
 import { runCommandSync } from './command-sync.ts';
+import type { PolicySyncOutcome } from './policy-sync.ts';
 import { runPolicySync } from './policy-sync.ts';
 import { writeSyncState } from './sync-state.ts';
 
@@ -34,16 +35,34 @@ export async function runAttachedSync(
   base: string = defaultDataDir(),
   deps: { scan?: CommandScan | undefined } = {},
 ): Promise<void> {
+  let policyOutcome: PolicySyncOutcome | null = null;
   try {
     const result = await runPolicySync({
       base,
       settingsDir: settingsDir(base),
       dataDir: dataDir(base),
     });
-    if (result !== null) writeSyncState(dataDir(base), result);
+    if (result !== null) {
+      policyOutcome = result.outcome;
+      writeSyncState(dataDir(base), result);
+    }
   } catch {
     // Nothing to report to and nowhere to report it.
   }
+
+  // The credential this process holds was just refused, and re-presenting it on
+  // another route in the same second cannot go differently: `unauthorized` is a
+  // 401, the credential itself no longer accepted, which is not a property of
+  // any one route. Skipping saves a round trip that is certain to fail — and
+  // the user is not left uninformed by it, because the pull that learned this
+  // has already written the outcome `/aka:status` renders.
+  //
+  // `forbidden` is deliberately NOT included. A 403 can mean "this key is
+  // scoped away from THIS route" (see `failure.ts`), and the policy bundle is a
+  // read with no write-role guard while the command channel is a different
+  // route — so a 403 there is not proof of a 403 here, and declining to even
+  // ask would be this device deciding on the deployment's behalf.
+  if (policyOutcome === 'unauthorized') return;
 
   // AFTER the policy pull, and in its own try. Ordered that way because the
   // scan the command triggers reads the policy the pull just cached, so a

--- a/packages/plugin-runtime/test/attached/command-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/command-sync.test.ts
@@ -126,7 +126,9 @@ describe('runCommandSync', () => {
     pollCommand.mockResolvedValue(COMMAND);
     const { runCommandSync } = await import('../../src/attached/command-sync.ts');
 
-    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 3 })))).resolves.toBe('reported');
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 3 })))).resolves.toBe(
+      'reported',
+    );
     expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
       outcome: 'reported',
       projectsForwarded: 3,
@@ -218,7 +220,9 @@ describe('runCommandSync', () => {
     ackCommand.mockRejectedValue(new Error('ETIMEDOUT'));
     const { runCommandSync } = await import('../../src/attached/command-sync.ts');
 
-    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 2 })))).resolves.toBe('unreachable');
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 2 })))).resolves.toBe(
+      'unreachable',
+    );
   });
 });
 

--- a/packages/plugin-runtime/test/attached/command-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/command-sync.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The device half of the device-command channel.
+ *
+ * The cases below are about what this module REFUSES to do, because that is
+ * where its value is. A deployment tells a machine a verb; the machine chooses
+ * its own scan scope; a machine that cannot scan does not accept work it can
+ * never finish; and every terminal path acks, so an operator's roster never has
+ * to distinguish "failed" from "switched off" by waiting a day.
+ */
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  applyOnboarding,
+  dataDir as dataDirOf,
+  settingsDir as settingsDirOf,
+  writeControlPlaneCredential,
+} from '@akasecurity/persistence';
+import type { AttachedCredential, ControlPlaneConnection } from '@akasecurity/schema';
+import { SOURCE_TOOL } from '@akasecurity/schema';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DiscoverScan } from '../../src/attached/command-sync.ts';
+
+const pollCommand = vi.fn();
+const ackCommand = vi.fn();
+
+vi.mock('@akasecurity/remote', () => ({
+  createRemoteClient: () => ({ pollCommand, ackCommand }),
+}));
+
+let base: string;
+
+const CONNECTION: ControlPlaneConnection = {
+  endpoint: 'https://aka.example-org.internal',
+  attachedAt: '2026-09-03T10:00:00.000Z',
+};
+
+const CREDENTIAL: AttachedCredential = {
+  specVersion: 1,
+  endpoint: 'https://aka.example-org.internal',
+  apiKey: 'not-a-real-key-6a1f8e3b7d25',
+};
+
+const COMMAND = {
+  id: 'cmd_1',
+  kind: 'shares_rescan' as const,
+  issuedAt: '2026-09-03T12:00:00.000Z',
+  expiresAt: '2026-09-04T12:00:00.000Z',
+};
+
+function attach(): void {
+  applyOnboarding({ runMode: 'attached', controlPlane: CONNECTION }, base);
+  writeControlPlaneCredential(settingsDirOf(base), CREDENTIAL);
+}
+
+const deps = (scan?: () => Promise<{ projects: number }>) => ({
+  base,
+  settingsDir: settingsDirOf(base),
+  ...(scan === undefined ? {} : { scan }),
+});
+
+beforeEach(() => {
+  pollCommand.mockReset();
+  ackCommand.mockReset();
+  ackCommand.mockResolvedValue(undefined);
+  base = mkdtempSync(join(tmpdir(), 'aka-cmd-home-'));
+  mkdirSync(dataDirOf(base), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(base, { recursive: true, force: true });
+});
+
+describe('runCommandSync', () => {
+  it('does not poll at all on a host that cannot scan', async () => {
+    // The browser extension's native host. Accepting a command it could never
+    // run would leave it outstanding on the roster until it expired — which an
+    // operator reads as a machine that is switched off.
+    attach();
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps())).resolves.toBeNull();
+    expect(pollCommand).not.toHaveBeenCalled();
+  });
+
+  it('does not poll on a machine that is not attached', async () => {
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 1 })))).resolves.toBeNull();
+    expect(pollCommand).not.toHaveBeenCalled();
+  });
+
+  it('reports nothing pending without scanning', async () => {
+    attach();
+    pollCommand.mockResolvedValue(null);
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan))).resolves.toBe('none');
+    expect(scan).not.toHaveBeenCalled();
+    expect(ackCommand).not.toHaveBeenCalled();
+  });
+
+  it('distinguishes "nothing to forward" from a scan that reported nothing', async () => {
+    // Not `reported` with a count of zero: an operator acts differently on
+    // "this machine has no projects here" than on "it scanned and sent none",
+    // and the roster styles them differently — which is only possible if the
+    // device says which one happened.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 0 })))).resolves.toBe(
+      'failed',
+    );
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'failed',
+      reason: 'no_projects',
+      projectsForwarded: 0,
+    });
+  });
+
+  it('scans and acks the project count it actually forwarded', async () => {
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 3 })))).resolves.toBe('reported');
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'reported',
+      projectsForwarded: 3,
+    });
+  });
+
+  /**
+   * The load-bearing one. A device that scans, fails, and says nothing is
+   * indistinguishable on the roster from a device that is off — and the
+   * operator learns nothing for 24 hours, until the command expires.
+   */
+  it('acks a FAILURE rather than going quiet', async () => {
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(
+      runCommandSync(
+        deps(() => {
+          throw new Error('EACCES /Users/someone/private');
+        }),
+      ),
+    ).resolves.toBe('failed');
+
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'failed',
+      reason: 'scan_failed',
+      projectsForwarded: 0,
+    });
+  });
+
+  it('never puts the scan error text on the wire', async () => {
+    // The closed reason enum is what keeps device-supplied text off an
+    // operator's screen. Asserted on the BODY rather than trusting the enum,
+    // because the failure this guards against is someone widening the ack to
+    // carry a message.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const secret = 'EACCES /Users/someone/.ssh/id_ed25519';
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await runCommandSync(
+      deps(() => {
+        throw new Error(secret);
+      }),
+    );
+
+    expect(JSON.stringify(ackCommand.mock.calls)).not.toContain('EACCES');
+    expect(JSON.stringify(ackCommand.mock.calls)).not.toContain('.ssh');
+  });
+
+  it('does not scan when the poll itself fails', async () => {
+    attach();
+    pollCommand.mockRejectedValue(new Error('ECONNREFUSED'));
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan))).resolves.toBe('unreachable');
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A command carrying a path fails to parse in the transport, which surfaces
+   * here as a rejected poll. The point of the case is what does NOT happen: no
+   * scan runs. A command this build refuses to understand must not be serviced
+   * on a best-effort reading of the parts it did recognise.
+   */
+  it('scans nothing when the deployment sent a command it refuses to parse', async () => {
+    attach();
+    pollCommand.mockRejectedValue(
+      Object.assign(new Error('a body this client cannot read'), {
+        name: 'RemoteResponseInvalid',
+      }),
+    );
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan))).resolves.toBe('unreachable');
+    expect(scan).not.toHaveBeenCalled();
+    expect(ackCommand).not.toHaveBeenCalled();
+  });
+
+  it('reports a lost ack as unreachable, not as a success', async () => {
+    // The scan happened, but from the deployment's side this device is still
+    // outstanding. Claiming 'reported' here would make this return value
+    // disagree with the roster it feeds.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    ackCommand.mockRejectedValue(new Error('ETIMEDOUT'));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(() => Promise.resolve({ projects: 2 })))).resolves.toBe('unreachable');
+  });
+});
+
+describe('commandScanFor', () => {
+  it('chooses its own scope and never accepts one', async () => {
+    // The command carries no path — `DeviceCommand.strict()` guarantees that —
+    // and this is the other half: the scope handed to the scanner is built here
+    // from the process, never from anything that arrived on the wire.
+    let seen: { searchRoots: string[] } | null = null;
+    const scanAllRepos: DiscoverScan = (_config, opts) => {
+      seen = opts;
+      return Promise.resolve({ repos: [{}, {}] });
+    };
+    const { commandScanFor } = await import('../../src/attached/command-sync.ts');
+
+    const scan = commandScanFor(
+      { dataDir: dataDirOf(base) } as never,
+      scanAllRepos,
+      SOURCE_TOOL.ClaudeCode,
+    );
+    await expect(scan()).resolves.toEqual({ projects: 2 });
+
+    const opts = seen as unknown as { searchRoots: string[] };
+    expect(opts.searchRoots).toEqual([process.cwd()]);
+    // Never the home directory implicitly — the interactive scan's own rule,
+    // and a server-issued command gets the unprivileged half of it. Asserted
+    // against the real home rather than a fixture, because the whole claim is
+    // about what this scope is NOT.
+    expect(opts.searchRoots).not.toContain(homedir());
+  });
+});

--- a/packages/plugin-runtime/test/attached/command-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/command-sync.test.ts
@@ -21,7 +21,7 @@ import type { AttachedCredential, ControlPlaneConnection } from '@akasecurity/sc
 import { SOURCE_TOOL } from '@akasecurity/schema';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { DiscoverScan } from '../../src/attached/command-sync.ts';
+import type { WorktreeScan } from '../../src/attached/command-sync.ts';
 
 const pollCommand = vi.fn();
 const ackCommand = vi.fn();
@@ -117,7 +117,7 @@ describe('runCommandSync', () => {
     expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
       outcome: 'failed',
       reason: 'no_projects',
-      projectsForwarded: 0,
+      projectsScanned: 0,
     });
   });
 
@@ -131,7 +131,7 @@ describe('runCommandSync', () => {
     );
     expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
       outcome: 'reported',
-      projectsForwarded: 3,
+      projectsScanned: 3,
     });
   });
 
@@ -156,7 +156,7 @@ describe('runCommandSync', () => {
     expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
       outcome: 'failed',
       reason: 'scan_failed',
-      projectsForwarded: 0,
+      projectsScanned: 0,
     });
   });
 
@@ -176,6 +176,15 @@ describe('runCommandSync', () => {
       }),
     );
 
+    // POSITIVE CONTROL first. Both assertions below run against
+    // `JSON.stringify(ackCommand.mock.calls)`, and an ack that never happened
+    // stringifies to `'[]'` — which contains neither string, so the pair would
+    // pass on a broken ack path rather than on a safe one.
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'failed',
+      reason: 'scan_failed',
+      projectsScanned: 0,
+    });
     expect(JSON.stringify(ackCommand.mock.calls)).not.toContain('EACCES');
     expect(JSON.stringify(ackCommand.mock.calls)).not.toContain('.ssh');
   });
@@ -227,30 +236,83 @@ describe('runCommandSync', () => {
 });
 
 describe('commandScanFor', () => {
-  it('chooses its own scope and never accepts one', async () => {
+  // The scope is the privilege, so these drive the adapter directly rather than
+  // through `runCommandSync`: what matters is the exact options object handed to
+  // the scanner, and only a fake standing in for the scanner can see it.
+  it('scans ONE worktree at the session cwd, never a discovery sweep', async () => {
     // The command carries no path — `DeviceCommand.strict()` guarantees that —
     // and this is the other half: the scope handed to the scanner is built here
     // from the process, never from anything that arrived on the wire.
-    let seen: { searchRoots: string[] } | null = null;
-    const scanAllRepos: DiscoverScan = (_config, opts) => {
+    //
+    // Asserted as the WHOLE options object rather than field by field, because
+    // the defect this replaced was a field that was never passed: the adapter
+    // called `scanAllRepos`, whose `maxDepth` defaults to 4, so it swept every
+    // repository under the cwd while every comment around it said one project.
+    // A per-field assertion cannot see an option that is absent; an exact
+    // object can.
+    let seen: unknown = null;
+    const scanWorktree: WorktreeScan = (_config, opts) => {
       seen = opts;
-      return Promise.resolve({ repos: [{}, {}] });
+      return Promise.resolve({ scanned: 4 });
     };
     const { commandScanFor } = await import('../../src/attached/command-sync.ts');
 
     const scan = commandScanFor(
       { dataDir: dataDirOf(base) } as never,
-      scanAllRepos,
+      scanWorktree,
       SOURCE_TOOL.ClaudeCode,
     );
-    await expect(scan()).resolves.toEqual({ projects: 2 });
+    await expect(scan()).resolves.toEqual({ projects: 1 });
 
-    const opts = seen as unknown as { searchRoots: string[] };
-    expect(opts.searchRoots).toEqual([process.cwd()]);
-    // Never the home directory implicitly — the interactive scan's own rule,
-    // and a server-issued command gets the unprivileged half of it. Asserted
-    // against the real home rather than a fixture, because the whole claim is
-    // about what this scope is NOT.
-    expect(opts.searchRoots).not.toContain(homedir());
+    // EXACT: a `searchRoots` or a `maxDepth` appearing here is the sweep coming
+    // back, and `toEqual` is what fails on it.
+    expect(seen).toEqual({ sourceTool: SOURCE_TOOL.ClaudeCode, rootDir: process.cwd() });
+  });
+
+  it('reports one project when the worktree held something, zero when it did not', async () => {
+    // `no_projects` is a distinct outcome an operator acts on, so the count has
+    // to distinguish "scanned an empty worktree" from "scanned a real one". Both
+    // directions, because a hardcoded 1 or a hardcoded 0 each satisfies one.
+    const { commandScanFor } = await import('../../src/attached/command-sync.ts');
+    const config = { dataDir: dataDirOf(base) } as never;
+
+    const found: WorktreeScan = () => Promise.resolve({ scanned: 1 });
+    const empty: WorktreeScan = () => Promise.resolve({ scanned: 0 });
+
+    await expect(commandScanFor(config, found, SOURCE_TOOL.ClaudeCode)()).resolves.toEqual({
+      projects: 1,
+    });
+    await expect(commandScanFor(config, empty, SOURCE_TOOL.ClaudeCode)()).resolves.toEqual({
+      projects: 0,
+    });
+  });
+
+  it('scans the session cwd even when that cwd is the home directory', async () => {
+    // The old comment here claimed the scope is "never the home directory
+    // implicitly" and asserted it with `not.toContain(homedir())` — which was
+    // entailed by the test runner's own cwd rather than by anything the code
+    // did, and went red against a correct implementation if vitest ran from
+    // $HOME. There is no home check and there does not need to be one: the
+    // bound is the MODE. `scanWorktree` on $HOME scans that one directory,
+    // where the discovery sweep would have walked four levels of it.
+    const spy = vi.spyOn(process, 'cwd').mockReturnValue(homedir());
+    try {
+      let seen: unknown = null;
+      const scanWorktree: WorktreeScan = (_config, opts) => {
+        seen = opts;
+        return Promise.resolve({ scanned: 0 });
+      };
+      const { commandScanFor } = await import('../../src/attached/command-sync.ts');
+
+      await commandScanFor(
+        { dataDir: dataDirOf(base) } as never,
+        scanWorktree,
+        SOURCE_TOOL.ClaudeCode,
+      )();
+
+      expect(seen).toEqual({ sourceTool: SOURCE_TOOL.ClaudeCode, rootDir: homedir() });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/plugin-runtime/test/attached/command-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/command-sync.test.ts
@@ -55,11 +55,16 @@ function attach(): void {
   writeControlPlaneCredential(settingsDirOf(base), CREDENTIAL);
 }
 
-const deps = (scan?: () => Promise<{ projects: number }>) => ({
+const deps = (scan?: () => Promise<{ projects: number }>, now?: () => number) => ({
   base,
   settingsDir: settingsDirOf(base),
   ...(scan === undefined ? {} : { scan }),
+  ...(now === undefined ? {} : { now }),
 });
+
+/** Fixed instants either side of COMMAND's own `expiresAt`. */
+const BEFORE_DEADLINE = () => Date.parse('2026-09-04T11:59:59.000Z');
+const AFTER_DEADLINE = () => Date.parse('2026-09-04T12:00:01.000Z');
 
 beforeEach(() => {
   pollCommand.mockReset();
@@ -314,5 +319,99 @@ describe('commandScanFor', () => {
     } finally {
       spy.mockRestore();
     }
+  });
+});
+
+describe('runCommandSync — a command past its own deadline', () => {
+  it('declines an EXPIRED command without scanning, and says so', async () => {
+    // A laptop closed on Friday and opened the following week is the case this
+    // exists for. The deployment is the authority on expiry and is expected not
+    // to serve one past its deadline; this is the device declining if it does.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const scan = vi.fn(() => Promise.resolve({ projects: 3 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan, AFTER_DEADLINE))).resolves.toBe('failed');
+
+    // Not scanned — the whole point is that stale work is not done.
+    expect(scan).not.toHaveBeenCalled();
+    // …and ACKED anyway, because going quiet reads on a roster exactly like a
+    // machine that is switched off.
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'failed',
+      reason: 'expired',
+      projectsScanned: 0,
+    });
+  });
+
+  it('services a command that has NOT expired yet', async () => {
+    // The positive control. Without it, a `hasExpired` stuck at `true` would
+    // satisfy the case above and nothing would ever be scanned again.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan, BEFORE_DEADLINE))).resolves.toBe('reported');
+    expect(scan).toHaveBeenCalledTimes(1);
+  });
+
+  it('services a command whose deadline cannot be read, rather than refusing it', async () => {
+    // FAIL-OPEN on an unreadable stamp, deliberately. `expiresAt` is
+    // `printable(64)` on the wire rather than a validated datetime — tightening
+    // it is not available, because that field rides the same envelope as the id
+    // and a rejected envelope leaves the device unable to ack what it refused.
+    // So a deployment that changes its timestamp format must not silently stop
+    // every device in the fleet from working.
+    attach();
+    pollCommand.mockResolvedValue({ ...COMMAND, expiresAt: 'next Tuesday' });
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan, AFTER_DEADLINE))).resolves.toBe('reported');
+    expect(scan).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('runCommandSync — a refusal is not an outage', () => {
+  // Collapsing a 401 into `unreachable` said "try again" about the one outcome
+  // that will never succeed on its own: a revoked key polled every fifteen
+  // minutes forever, reported as an outage. `classifyFailure` is the same
+  // function `runPolicySync` uses, so the two halves of attached mode cannot
+  // reach different verdicts about one refusal.
+  const refusal = (status: number): Error & { status: number } =>
+    Object.assign(new Error('refused'), { status });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'forbidden'],
+    [500, 'unreachable'],
+  ] as const)('classifies a %d on the POLL as %s', async (status, outcome) => {
+    attach();
+    pollCommand.mockRejectedValue(refusal(status));
+    const scan = vi.fn(() => Promise.resolve({ projects: 1 }));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(runCommandSync(deps(scan))).resolves.toBe(outcome);
+    expect(scan).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [401, 'unauthorized'],
+    [403, 'forbidden'],
+    [500, 'unreachable'],
+  ] as const)('classifies a %d on the ACK as %s', async (status, outcome) => {
+    // The ack is a request like any other: a credential refusal is terminal
+    // wherever it lands. It is still never the scan's own outcome — from the
+    // deployment's side this device remains outstanding.
+    attach();
+    pollCommand.mockResolvedValue(COMMAND);
+    ackCommand.mockRejectedValue(refusal(status));
+    const { runCommandSync } = await import('../../src/attached/command-sync.ts');
+
+    await expect(
+      runCommandSync(deps(() => Promise.resolve({ projects: 1 }), BEFORE_DEADLINE)),
+    ).resolves.toBe(outcome);
   });
 });

--- a/packages/plugin-runtime/test/attached/sync-entry.test.ts
+++ b/packages/plugin-runtime/test/attached/sync-entry.test.ts
@@ -14,10 +14,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SYNC_STATE_FILENAME } from '../../src/attached/sync-state.ts';
 
 const getPolicyBundle = vi.fn();
+const pollCommand = vi.fn();
+const ackCommand = vi.fn();
 
 vi.mock('@akasecurity/remote', () => ({
-  createRemoteClient: () => ({ getPolicyBundle }),
+  createRemoteClient: () => ({ getPolicyBundle, pollCommand, ackCommand }),
 }));
+
+/** What the two jobs did, in the order they did it. */
+let order: string[];
 
 // The entry resolves a real `~/.aka` layout under a temp root, so the test
 // exercises the process wrapper against the same file I/O production uses
@@ -45,6 +50,10 @@ const statePath = (): string => join(dataDirOf(base), SYNC_STATE_FILENAME);
 
 beforeEach(() => {
   getPolicyBundle.mockReset();
+  pollCommand.mockReset();
+  ackCommand.mockReset();
+  ackCommand.mockResolvedValue(undefined);
+  order = [];
   base = mkdtempSync(join(tmpdir(), 'aka-entry-home-'));
   mkdirSync(dataDirOf(base), { recursive: true });
 });
@@ -93,6 +102,108 @@ describe('runAttachedSync', () => {
 
     const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
     await runAttachedSync(base);
+
+    expect(existsSync(statePath())).toBe(true);
+    expect(JSON.parse(readFileSync(statePath(), 'utf8'))).toMatchObject({
+      outcome: 'unreachable',
+    });
+  });
+});
+
+/**
+ * The second job in the same child.
+ *
+ * `runAttachedSync` grew a device-command pass, and the whole of it — the
+ * forwarding of `deps.scan`, the ordering against the policy pull, and the
+ * separate catch — was argued in comments and covered by nothing: every case
+ * above calls `runAttachedSync(base)` with no `deps`, so `deps.scan` is
+ * undefined and `runCommandSync` returns at its first line. Deleting the entire
+ * block left the workspace green.
+ */
+describe('runAttachedSync — the device-command pass', () => {
+  const scanning = (): (() => Promise<{ projects: number }>) => () => {
+    order.push('scan');
+    return Promise.resolve({ projects: 1 });
+  };
+
+  it('services a command, so the block is reached at all', async () => {
+    attach();
+    getPolicyBundle.mockRejectedValue(new Error('ECONNREFUSED'));
+    pollCommand.mockResolvedValue({
+      id: 'cmd_1',
+      kind: 'shares_rescan',
+      issuedAt: '2026-09-03T00:00:00.000Z',
+      expiresAt: '2026-09-04T00:00:00.000Z',
+    });
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: scanning() });
+
+    expect(pollCommand).toHaveBeenCalledTimes(1);
+    expect(ackCommand).toHaveBeenCalledWith('cmd_1', {
+      outcome: 'reported',
+      projectsScanned: 1,
+    });
+  });
+
+  it('does not poll when the host passed no scanner', async () => {
+    // The capability rule, asserted on the ENTRY rather than only on
+    // `runCommandSync`: a host that cannot scan must not accept work it could
+    // never finish, and the entry is what decides whether to hand a scan over.
+    attach();
+    getPolicyBundle.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base);
+
+    expect(pollCommand).not.toHaveBeenCalled();
+  });
+
+  it('pulls the policy BEFORE it services a command', async () => {
+    // The ordering is load-bearing and stated in the source: the scan a command
+    // triggers reads the ruleset the pull just cached, so a command serviced
+    // first would scan against the previous one. Swap the two statements in
+    // `sync-entry.ts` and this is what fails.
+    attach();
+    getPolicyBundle.mockImplementation(() => {
+      order.push('policy');
+      return Promise.reject(new Error('ECONNREFUSED'));
+    });
+    pollCommand.mockImplementation(() => {
+      order.push('poll');
+      return Promise.resolve(null);
+    });
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: scanning() });
+
+    expect(order).toEqual(['policy', 'poll']);
+  });
+
+  it('still services a command after the policy pull threw', async () => {
+    // Two independent jobs sharing one child, not one job in two halves. Merge
+    // the two try blocks and a failed pull silently cancels the command channel
+    // — a machine that stops taking commands because an unrelated route is
+    // down, with nothing anywhere saying so.
+    attach();
+    getPolicyBundle.mockRejectedValue(new Error('ECONNREFUSED'));
+    pollCommand.mockResolvedValue(null);
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: scanning() });
+
+    expect(pollCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the sync state the pull already wrote when the command pass fails', async () => {
+    // The other direction of the same split. A command that fails must not cost
+    // `/aka:status` the verdict the policy pull had already earned.
+    attach();
+    getPolicyBundle.mockRejectedValue(new Error('ECONNREFUSED'));
+    pollCommand.mockRejectedValue(new Error('ETIMEDOUT'));
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await expect(runAttachedSync(base, { scan: scanning() })).resolves.toBeUndefined();
 
     expect(existsSync(statePath())).toBe(true);
     expect(JSON.parse(readFileSync(statePath(), 'utf8'))).toMatchObject({

--- a/packages/plugin-runtime/test/attached/sync-entry.test.ts
+++ b/packages/plugin-runtime/test/attached/sync-entry.test.ts
@@ -211,3 +211,56 @@ describe('runAttachedSync — the device-command pass', () => {
     });
   });
 });
+
+describe('runAttachedSync — what a refused credential does to the command pass', () => {
+  const refusal = (status: number): Error & { status: number } =>
+    Object.assign(new Error('refused'), { status });
+
+  it('does not poll after the policy pull learned the key is REVOKED', async () => {
+    // A 401 is the credential itself no longer being accepted, which is not a
+    // property of any one route — so re-presenting it on the command route in
+    // the same second cannot go differently. The user is not left uninformed:
+    // the pull that learned this already wrote the outcome `/aka:status` reads.
+    attach();
+    getPolicyBundle.mockRejectedValue(refusal(401));
+    pollCommand.mockResolvedValue(null);
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: () => Promise.resolve({ projects: 1 }) });
+
+    expect(pollCommand).not.toHaveBeenCalled();
+    // The skip must not cost the verdict a human acts on.
+    expect(JSON.parse(readFileSync(statePath(), 'utf8'))).toMatchObject({
+      outcome: 'unauthorized',
+    });
+  });
+
+  it('STILL polls after a 403, which is not proof about this route', async () => {
+    // The boundary, and the reason `forbidden` is not folded in with `401`. A
+    // 403 can mean "this key is scoped away from THIS route", and the policy
+    // bundle is a read with no write-role guard while the command channel is a
+    // different route — so declining to even ask would be this device deciding
+    // on the deployment's behalf.
+    attach();
+    getPolicyBundle.mockRejectedValue(refusal(403));
+    pollCommand.mockResolvedValue(null);
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: () => Promise.resolve({ projects: 1 }) });
+
+    expect(pollCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('polls normally when the pull merely could not reach the plane', async () => {
+    // The control that keeps the two cases above from passing under a skip that
+    // fired on every failure.
+    attach();
+    getPolicyBundle.mockRejectedValue(new Error('ECONNREFUSED'));
+    pollCommand.mockResolvedValue(null);
+
+    const { runAttachedSync } = await import('../../src/attached/sync-entry.ts');
+    await runAttachedSync(base, { scan: () => Promise.resolve({ projects: 1 }) });
+
+    expect(pollCommand).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/remote/src/client.ts
+++ b/packages/remote/src/client.ts
@@ -3,6 +3,8 @@ import type {
   AttachDeviceRequest as AttachDeviceRequestT,
   AttachTokenResponse as AttachTokenResponseT,
   AuditEventBatchAck as AuditEventBatchAckT,
+  DeviceCommand as DeviceCommandT,
+  DeviceCommandAckBody as DeviceCommandAckBodyT,
   EgressIngestRequest as EgressIngestRequestT,
   IngestAck as IngestAckT,
   IngestBatch,
@@ -17,6 +19,8 @@ import {
   AttachDeviceGrant,
   AttachTokenResponse,
   AuditEventBatchAck,
+  DeviceCommandAckBody,
+  DeviceCommandPollResponse,
   EgressIngestRequest,
   IngestAck,
   PluginWhoami,
@@ -36,14 +40,20 @@ import {
   send,
 } from './http.ts';
 
-// The eight routes an attached machine may call, and nothing else.
+// The ten routes an attached machine may call, and nothing else.
 //
 // The set is small on purpose and is the same set a deployment scopes a
-// credential to: six writes and two self-scoped reads. There is deliberately
-// no way to ask this client for anything organization-wide — a credential on a
-// laptop should not be able to read what other people's machines reported, and
-// a client that cannot express the request is a stronger guarantee than a
-// server that refuses it.
+// credential to: seven writes and three self-scoped reads. There is
+// deliberately no way to ask this client for anything organization-wide — a
+// credential on a laptop should not be able to read what other people's
+// machines reported, and a client that cannot express the request is a
+// stronger guarantee than a server that refuses it.
+//
+// The last two are the device-command channel, and they stay inside that rule
+// rather than bending it. The poll is SELF-SCOPED — it asks what this machine
+// has been told to do and can express no other question — and the ack reports
+// only on a command id the poll itself returned. Neither can name another
+// machine, and neither widens what a laptop credential can read.
 //
 // Every response is PARSED, never cast. The bodies arrive from a host named in
 // a settings file, so "the deployment said so" is not a type guarantee; a
@@ -59,7 +69,22 @@ const ROUTES = {
   policyBundle: '/v1/policy-bundle',
   whoami: '/v1/plugin/whoami',
   shares: '/v1/shares',
+  commands: '/v1/plugin/commands',
 } as const;
+
+/**
+ * The ack route for one command.
+ *
+ * Built here rather than inlined so the encoding is not optional. `id` comes
+ * off the wire — it is the deployment's own identifier, echoed back — and
+ * pasting it into a path unencoded would let a `../` in it walk the URL onto a
+ * different route on the same host, with this machine's credential attached.
+ * The id is `printable(128)` at the parse boundary, which excludes control
+ * characters but not slashes or dots, so the encoding is what closes it.
+ */
+function ackRoute(id: string): string {
+  return `${ROUTES.commands}/${encodeURIComponent(id)}/ack`;
+}
 
 export interface RemoteClientOptions {
   /** Where the deployment lives, already checked with `isSafeEndpoint`. */
@@ -116,6 +141,19 @@ export interface RemoteClient {
    * to the wire-boundary-safe shape (no snippet, hashed projectKey).
    */
   recordProjectEgress(request: EgressIngestRequestT): Promise<void>;
+  /**
+   * GET /v1/plugin/commands — what this machine has been asked to do, or
+   * `null` for nothing pending.
+   *
+   * A DEPLOYMENT THAT PREDATES THIS ROUTE answers 404, and that is not a
+   * failure — it is an older deployment saying it has no command channel. It
+   * comes back as `null`, the same as "nothing pending", so a device and a
+   * deployment can be upgraded weeks apart. Same reasoning as the audit-events
+   * batch fallback above.
+   */
+  pollCommand(): Promise<DeviceCommandT | null>;
+  /** POST /v1/plugin/commands/:id/ack — what this machine did about one. */
+  ackCommand(id: string, body: DeviceCommandAckBodyT): Promise<void>;
 }
 
 /** Header value as a single string; Node reports repeats as an array. */
@@ -328,6 +366,32 @@ export function createRemoteClient(options: RemoteClientOptions): RemoteClient {
         ...common,
         method: 'POST',
         url: url(ROUTES.shares),
+        body: JSON.stringify(validated.data),
+      });
+      okBody(response);
+    },
+
+    async pollCommand() {
+      const response = await send({ ...common, method: 'GET', url: url(ROUTES.commands) });
+      // See the interface: an older deployment has no such route, and that is
+      // "no command", not an outage to report or retry.
+      if (response.status === 404) return null;
+      return parsed(DeviceCommandPollResponse, okBody(response), ROUTES.commands).command;
+    },
+
+    async ackCommand(id, body) {
+      // Validated on the way OUT, the same discipline as recordAuditEvent and
+      // recordProjectEgress: a body this device assembles wrongly must name the
+      // local defect rather than arrive as a 400 that a fail-open caller
+      // swallows, leaving the command outstanding until it expires with no
+      // record of why.
+      const validated = DeviceCommandAckBody.safeParse(body);
+      const route = ackRoute(id);
+      if (!validated.success) throw new RemoteRequestInvalid(route, validated.error);
+      const response = await send({
+        ...common,
+        method: 'POST',
+        url: url(route),
         body: JSON.stringify(validated.data),
       });
       okBody(response);

--- a/packages/remote/src/http.ts
+++ b/packages/remote/src/http.ts
@@ -296,7 +296,7 @@ export async function send(options: SendOptions): Promise<RemoteResponse> {
     // request.
     //
     // There is deliberately no 'connect' sibling. Node dispatches that event
-    // only when the REQUEST method was CONNECT, and the eight routes are GET and
+    // only when the REQUEST method was CONNECT, and every route here is GET or
     // POST — so a handler for it could never run, and an unreachable line reads
     // as a covered case while proving nothing. The 'close' backstop below is
     // the general answer, and it covers that shape too.

--- a/packages/remote/src/index.ts
+++ b/packages/remote/src/index.ts
@@ -1,7 +1,7 @@
 // The control-plane transport: the one OSS package that reaches a network, and
 // only the network a machine's own settings name.
 //
-// It is deliberately narrow. `createRemoteClient` speaks the eight routes an
+// It is deliberately narrow. `createRemoteClient` speaks the ten routes an
 // attached machine is scoped to and cannot express anything else; `send` is the
 // single module underneath that opens a socket. Nothing here decides WHETHER a
 // machine is attached, reads the credential, or holds a policy — those belong to
@@ -35,7 +35,7 @@ export { createAttachClient, createRemoteClient } from './client.ts';
 // only one a caller could step around: anything in the workspace could build a
 // `SendOptions.url` from a less-trusted source and put the credential on a
 // cleartext socket, with nothing here to refuse it. Narrowing the barrel closes
-// it by construction instead — the package's whole public surface is now eight
+// it by construction instead — the package's whole public surface is now ten
 // named routes against one endpoint, and there is no exported way to hand this
 // module an arbitrary URL. Nothing outside the package used `send`.
 export {

--- a/packages/remote/test/client.test.ts
+++ b/packages/remote/test/client.test.ts
@@ -532,7 +532,7 @@ describe('the shares-ingest submission', () => {
 describe('routes', () => {
   const server = useLoopbackServer();
 
-  it('addresses each of the eight, and tolerates trailing slashes on the endpoint', async () => {
+  it('addresses each of the ten, and tolerates trailing slashes on the endpoint', async () => {
     // SEVERAL slashes, not one. The normalization is a scan rather than a
     // `replace(/\/+$/, '')` — that regex is quadratic on an all-slash string,
     // since the engine retries from every position and each attempt walks to the
@@ -556,7 +556,9 @@ describe('routes', () => {
                 })
               : req.url === '/v1/shares'
                 ? json({ ok: true })
-                : json({ accepted: 1, duplicates: 0, ok: true }),
+                : req.url === '/v1/plugin/commands'
+                  ? json({ command: null })
+                  : json({ accepted: 1, duplicates: 0, ok: true }),
       );
     });
 
@@ -580,6 +582,8 @@ describe('routes', () => {
     await client.getPolicyBundle();
     await client.whoami();
     await client.recordProjectEgress(egressRequest);
+    await client.pollCommand();
+    await client.ackCommand('cmd_1', { outcome: 'reported', projectsForwarded: 0 });
 
     expect(server.received.map((r) => `${r.method ?? ''} ${r.url ?? ''}`)).toEqual([
       'POST /v1/events',
@@ -590,7 +594,87 @@ describe('routes', () => {
       'GET /v1/policy-bundle',
       'GET /v1/plugin/whoami',
       'POST /v1/shares',
+      'GET /v1/plugin/commands',
+      'POST /v1/plugin/commands/cmd_1/ack',
     ]);
+  });
+
+  /**
+   * The command id is echoed back from the wire, so it is the one path segment
+   * this client does not author. Unencoded, a `../` in it walks the URL onto a
+   * different route on the same host with this machine's credential attached —
+   * `printable(128)` rejects control characters but not slashes or dots.
+   */
+  it('encodes a command id rather than pasting it into the path', async () => {
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    server.reply((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(json({ ok: true }));
+    });
+
+    // The server records every request in this describe, so index from HERE
+    // rather than from 0 — `received[0]` is the first case's POST /v1/events.
+    const before = server.received.length;
+    await client.ackCommand('../../v1/events', { outcome: 'reported', projectsForwarded: 0 });
+
+    const url = server.received[before]?.url ?? '';
+    expect(url).toBe('/v1/plugin/commands/..%2F..%2Fv1%2Fevents/ack');
+    expect(url).not.toContain('../');
+  });
+
+  /**
+   * A deployment older than this route answers 404, and that is not an outage:
+   * it is a deployment saying it has no command channel. Treated as "nothing
+   * pending" so a device and a deployment can be upgraded weeks apart — the
+   * same tolerance the audit-events batch route already has.
+   */
+  it('reads a 404 on the poll as no command, not as a failure', async () => {
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    server.reply((_req, res) => {
+      res.writeHead(404, { 'content-type': 'application/json' });
+      res.end(json({ error: { code: 'NOT_FOUND' } }));
+    });
+
+    await expect(client.pollCommand()).resolves.toBeNull();
+  });
+
+  /**
+   * The scope is the privilege. A deployment that sends a path gets a parse
+   * failure HERE, at the transport, before anything downstream can read it —
+   * the client-side half of the pin `DeviceCommand.strict()` holds.
+   */
+  it('refuses a command that tries to name a directory', async () => {
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    server.reply((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        json({
+          command: {
+            id: 'cmd_1',
+            kind: 'shares_rescan',
+            issuedAt: '2026-09-03T12:00:00.000Z',
+            expiresAt: '2026-09-04T12:00:00.000Z',
+            searchRoots: ['/'],
+          },
+        }),
+      );
+    });
+
+    await expect(client.pollCommand()).rejects.toThrow();
+  });
+
+  /** A malformed ack names the local defect instead of becoming a 400. */
+  it('refuses to send an ack this device assembled wrongly', async () => {
+    const client = createRemoteClient({ endpoint: server.origin, apiKey: API_KEY });
+    const before = server.received.length;
+
+    await expect(
+      // A failed ack with no reason — the case the discriminated union exists
+      // to stop, caught before it leaves the machine.
+      client.ackCommand('cmd_1', { outcome: 'failed', projectsForwarded: 0 } as never),
+    ).rejects.toThrow();
+
+    expect(server.received).toHaveLength(before);
   });
 });
 

--- a/packages/remote/test/client.test.ts
+++ b/packages/remote/test/client.test.ts
@@ -583,7 +583,7 @@ describe('routes', () => {
     await client.whoami();
     await client.recordProjectEgress(egressRequest);
     await client.pollCommand();
-    await client.ackCommand('cmd_1', { outcome: 'reported', projectsForwarded: 0 });
+    await client.ackCommand('cmd_1', { outcome: 'reported', projectsScanned: 0 });
 
     expect(server.received.map((r) => `${r.method ?? ''} ${r.url ?? ''}`)).toEqual([
       'POST /v1/events',
@@ -615,7 +615,7 @@ describe('routes', () => {
     // The server records every request in this describe, so index from HERE
     // rather than from 0 — `received[0]` is the first case's POST /v1/events.
     const before = server.received.length;
-    await client.ackCommand('../../v1/events', { outcome: 'reported', projectsForwarded: 0 });
+    await client.ackCommand('../../v1/events', { outcome: 'reported', projectsScanned: 0 });
 
     const url = server.received[before]?.url ?? '';
     expect(url).toBe('/v1/plugin/commands/..%2F..%2Fv1%2Fevents/ack');
@@ -671,7 +671,7 @@ describe('routes', () => {
     await expect(
       // A failed ack with no reason — the case the discriminated union exists
       // to stop, caught before it leaves the machine.
-      client.ackCommand('cmd_1', { outcome: 'failed', projectsForwarded: 0 } as never),
+      client.ackCommand('cmd_1', { outcome: 'failed', projectsScanned: 0 } as never),
     ).rejects.toThrow();
 
     expect(server.received).toHaveLength(before);

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -704,9 +704,7 @@ export type DeviceCommand = z.infer<typeof DeviceCommand>;
  * `GET /v1/plugin/commands`. `command: null` is the ordinary answer — there is
  * no pending work — and is not an error or an empty-collection special case.
  */
-export const DeviceCommandPollResponse = z
-  .object({ command: DeviceCommand.nullable() })
-  .strict();
+export const DeviceCommandPollResponse = z.object({ command: DeviceCommand.nullable() }).strict();
 export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse>;
 
 /**
@@ -715,11 +713,7 @@ export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse
  * device-supplied free text can ever reach a human's screen through this
  * channel: there is no `message`, and no member of this union carries one.
  */
-export const DeviceCommandFailureReason = z.enum([
-  'scan_failed',
-  'no_projects',
-  'forward_refused',
-]);
+export const DeviceCommandFailureReason = z.enum(['scan_failed', 'no_projects', 'forward_refused']);
 export type DeviceCommandFailureReason = z.infer<typeof DeviceCommandFailureReason>;
 
 /**

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -650,3 +650,101 @@ export const AttachTokenResponse = z.union([
   z.object({ status: printable(64) }),
 ]);
 export type AttachTokenResponse = z.infer<typeof AttachTokenResponse>;
+
+// ─── Device commands: what a deployment may ask this machine to do ───────────
+
+/**
+ * The command kinds this build knows how to service.
+ *
+ * A CLOSED enum, and unlike `AttachTokenResponse` above there is deliberately
+ * no catch-all member. The reasoning is opposite because the direction of
+ * trust is opposite: an unrecognised ATTACH STATUS means "keep waiting", which
+ * is safe, while an unrecognised COMMAND would mean "a deployment asked this
+ * machine to do something this build cannot reason about". The only safe
+ * response to that is to not recognise it at all, so a newer deployment's new
+ * verb reads to an older device as no command rather than as an instruction it
+ * half-understands.
+ */
+export const DeviceCommandKind = z.enum(['shares_rescan']);
+export type DeviceCommandKind = z.infer<typeof DeviceCommandKind>;
+
+/**
+ * What a deployment is allowed to tell this machine to do.
+ *
+ * A VERB, AND NEVER A PATH. This is the load-bearing shape of the whole
+ * channel: there is no `searchRoots`, no `rootDir`, no `path`, no glob and no
+ * depth here, and `.strict()` is what makes their absence enforced rather than
+ * merely current. A deployment that sends one gets a parse failure on the
+ * device, and the scan never runs.
+ *
+ * That matters because the scan scope is the privilege. A command that could
+ * name a directory would let whoever controls (or impersonates) a deployment
+ * point a filesystem walk at `~/.ssh`, a mounted volume, or another customer's
+ * checkout, and have the results forwarded — turning a fleet-hygiene feature
+ * into remote file discovery. The scope is therefore chosen ENTIRELY
+ * device-side, by the same rule the interactive scan uses (see
+ * `runCommandSync`), and nothing on the wire can influence it.
+ *
+ * `.strict()` also makes widening this visible. Adding a field means deleting
+ * `.strict()` or extending this object, both of which are diffs a reviewer
+ * cannot miss — as opposed to a permissive object, where a new key arrives
+ * silently and is simply available to whatever reads it next.
+ */
+export const DeviceCommand = z
+  .object({
+    id: printable(128).min(1),
+    kind: DeviceCommandKind,
+    issuedAt: printable(64).min(1),
+    expiresAt: printable(64).min(1),
+  })
+  .strict();
+export type DeviceCommand = z.infer<typeof DeviceCommand>;
+
+/**
+ * `GET /v1/plugin/commands`. `command: null` is the ordinary answer — there is
+ * no pending work — and is not an error or an empty-collection special case.
+ */
+export const DeviceCommandPollResponse = z
+  .object({ command: DeviceCommand.nullable() })
+  .strict();
+export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse>;
+
+/**
+ * Why a device could not service a command. A CLOSED enum, sent by the device
+ * and read back by an operator on the other side, so it is the reason no
+ * device-supplied free text can ever reach a human's screen through this
+ * channel: there is no `message`, and no member of this union carries one.
+ */
+export const DeviceCommandFailureReason = z.enum([
+  'scan_failed',
+  'no_projects',
+  'forward_refused',
+]);
+export type DeviceCommandFailureReason = z.infer<typeof DeviceCommandFailureReason>;
+
+/**
+ * `POST /v1/plugin/commands/:id/ack` — what this machine did.
+ *
+ * A discriminated union rather than a flat object with an optional `reason`,
+ * so the contract holds at the parse boundary instead of in a comment: a
+ * `failed` ack MUST carry a reason, and a `reported` ack must not. Validated on
+ * the way OUT (see the client), because a body this device assembles wrongly
+ * should name the local defect rather than become a 400 that a fail-open
+ * forwarder swallows.
+ */
+export const DeviceCommandAckBody = z.discriminatedUnion('outcome', [
+  z
+    .object({
+      outcome: z.literal('reported'),
+      projectsForwarded: z.number().int().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      outcome: z.literal('failed'),
+      reason: DeviceCommandFailureReason,
+      projectsForwarded: z.number().int().nonnegative(),
+    })
+    .strict(),
+]);
+export type DeviceCommandAckBody = z.infer<typeof DeviceCommandAckBody>;

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -703,8 +703,20 @@ export type DeviceCommand = z.infer<typeof DeviceCommand>;
 /**
  * `GET /v1/plugin/commands`. `command: null` is the ordinary answer — there is
  * no pending work — and is not an error or an empty-collection special case.
+ *
+ * LENIENT, unlike the `DeviceCommand` it wraps, and the split is deliberate.
+ * This is a RESPONSE parser, so the rule at the top of this file applies: the
+ * contract is owned by the deployment that serves it, and an older device has
+ * to keep working against a newer control plane. A deployment that starts
+ * sending `pollAfterSeconds` or `queueDepth` alongside the command must not
+ * make every device in the fleet fail the parse.
+ *
+ * Strictness on the ENVELOPE would buy nothing anyway: a stray top-level key is
+ * read by nobody, since `runCommandSync` reaches only `command.id`. Strictness
+ * on the COMMAND is the security property, and it stays exactly where it is —
+ * that is the object a path would have to arrive in.
  */
-export const DeviceCommandPollResponse = z.object({ command: DeviceCommand.nullable() }).strict();
+export const DeviceCommandPollResponse = z.object({ command: DeviceCommand.nullable() });
 export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse>;
 
 /**
@@ -712,8 +724,15 @@ export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse
  * and read back by an operator on the other side, so it is the reason no
  * device-supplied free text can ever reach a human's screen through this
  * channel: there is no `message`, and no member of this union carries one.
+ *
+ * Every member is one a device can actually reach. A `forward_refused` was
+ * declared here once and produced by nothing — the device hands its findings to
+ * a fail-open gateway and never observes whether they landed, so it had no way
+ * to reach that verdict. A closed enum carrying a member no code path can emit
+ * reads as covering a case it does not; add one back when something can send
+ * it.
  */
-export const DeviceCommandFailureReason = z.enum(['scan_failed', 'no_projects', 'forward_refused']);
+export const DeviceCommandFailureReason = z.enum(['scan_failed', 'no_projects']);
 export type DeviceCommandFailureReason = z.infer<typeof DeviceCommandFailureReason>;
 
 /**
@@ -730,14 +749,14 @@ export const DeviceCommandAckBody = z.discriminatedUnion('outcome', [
   z
     .object({
       outcome: z.literal('reported'),
-      projectsForwarded: z.number().int().nonnegative(),
+      projectsScanned: z.number().int().nonnegative(),
     })
     .strict(),
   z
     .object({
       outcome: z.literal('failed'),
       reason: DeviceCommandFailureReason,
-      projectsForwarded: z.number().int().nonnegative(),
+      projectsScanned: z.number().int().nonnegative(),
     })
     .strict(),
 ]);

--- a/packages/schema/src/zod/control-plane.ts
+++ b/packages/schema/src/zod/control-plane.ts
@@ -731,8 +731,15 @@ export type DeviceCommandPollResponse = z.infer<typeof DeviceCommandPollResponse
  * to reach that verdict. A closed enum carrying a member no code path can emit
  * reads as covering a case it does not; add one back when something can send
  * it.
+ *
+ * `expired` is the device declining a command whose own `expiresAt` has already
+ * passed — a laptop that was closed for a week waking up and being handed
+ * week-old work. The deployment is expected to stop serving an expired command
+ * on its own, so reaching this means the two disagree; the device says so
+ * rather than servicing it silently, and rather than going quiet, which would
+ * read on the roster as a machine that never answered.
  */
-export const DeviceCommandFailureReason = z.enum(['scan_failed', 'no_projects']);
+export const DeviceCommandFailureReason = z.enum(['scan_failed', 'no_projects', 'expired']);
 export type DeviceCommandFailureReason = z.infer<typeof DeviceCommandFailureReason>;
 
 /**

--- a/packages/schema/test/zod/control-plane.test.ts
+++ b/packages/schema/test/zod/control-plane.test.ts
@@ -11,6 +11,9 @@ import {
   AttachTokenIssued,
   AttachTokenResponse,
   ControlPlaneErrorBody,
+  DeviceCommand,
+  DeviceCommandAckBody,
+  DeviceCommandPollResponse,
   IngestAck,
   PluginWhoami,
   RecordAuditEventRequest,
@@ -418,5 +421,119 @@ describe('AttachDeviceGrant', () => {
   it('requires a positive expiry and interval', () => {
     expect(AttachDeviceGrant.safeParse({ ...grant, expiresIn: 0 }).success).toBe(false);
     expect(AttachDeviceGrant.safeParse({ ...grant, interval: -1 }).success).toBe(false);
+  });
+});
+
+/**
+ * The device-command channel's one security-critical shape.
+ *
+ * A deployment tells an attached machine a VERB. It must never be able to tell
+ * it a PATH — the scan scope is the privilege here, and a command that could
+ * name a directory would turn fleet hygiene into remote file discovery against
+ * whatever the agent user can read. The device chooses its own scope; nothing
+ * on the wire can influence it.
+ *
+ * These cases assert the REJECTION, not merely that the happy path parses. A
+ * permissive object would satisfy every "it parses a valid command" test ever
+ * written while silently carrying `searchRoots` straight through to a
+ * filesystem walk.
+ */
+describe('DeviceCommand — a verb, never a path', () => {
+  const VALID = {
+    id: 'cmd_01J8',
+    kind: 'shares_rescan',
+    issuedAt: '2026-09-03T12:00:00.000Z',
+    expiresAt: '2026-09-04T12:00:00.000Z',
+  };
+
+  it('accepts the command a deployment is allowed to send', () => {
+    expect(DeviceCommand.safeParse(VALID).success).toBe(true);
+  });
+
+  // One case per key that could steer a filesystem walk. Named individually
+  // rather than looped over a list alone, so a failure says WHICH key got
+  // through.
+  it.each([
+    ['searchRoots', { searchRoots: ['/Users/someone'] }],
+    ['rootDir', { rootDir: '/' }],
+    ['path', { path: '/Users/someone/.ssh' }],
+    ['maxDepth', { maxDepth: 99 }],
+    ['excludePaths', { excludePaths: [] }],
+    ['cwd', { cwd: '/etc' }],
+  ])('refuses a command carrying %s', (_key, extra) => {
+    expect(DeviceCommand.safeParse({ ...VALID, ...extra }).success).toBe(false);
+  });
+
+  it('refuses an unrecognised verb rather than half-understanding it', () => {
+    // No catch-all member, deliberately — unlike AttachTokenResponse. An
+    // unrecognised attach STATUS means "keep waiting", which is safe; an
+    // unrecognised COMMAND would be an instruction this build cannot reason
+    // about, so it must not parse at all.
+    expect(DeviceCommand.safeParse({ ...VALID, kind: 'exfiltrate' }).success).toBe(false);
+  });
+
+  it('carries the refusal through the poll envelope, not just the bare command', () => {
+    // The shape a device actually parses is the envelope. A strict inner object
+    // inside a permissive outer one would let the whole thing through under a
+    // different key.
+    expect(
+      DeviceCommandPollResponse.safeParse({
+        command: { ...VALID, searchRoots: ['/'] },
+      }).success,
+    ).toBe(false);
+    expect(
+      DeviceCommandPollResponse.safeParse({ command: VALID, searchRoots: ['/'] }).success,
+    ).toBe(false);
+  });
+
+  it('treats "no pending command" as an ordinary answer', () => {
+    expect(DeviceCommandPollResponse.safeParse({ command: null }).success).toBe(true);
+  });
+});
+
+/**
+ * The ack contract, held at the parse boundary rather than in a comment: a
+ * failure must say why, and a success must not smuggle a reason.
+ */
+describe('DeviceCommandAckBody', () => {
+  it('requires a reason on a failed ack', () => {
+    expect(
+      DeviceCommandAckBody.safeParse({ outcome: 'failed', projectsForwarded: 0 }).success,
+    ).toBe(false);
+  });
+
+  it('refuses a reason on a reported ack', () => {
+    expect(
+      DeviceCommandAckBody.safeParse({
+        outcome: 'reported',
+        projectsForwarded: 3,
+        reason: 'scan_failed',
+      }).success,
+    ).toBe(false);
+  });
+
+  it('refuses device-supplied free text as a reason', () => {
+    // The closed enum is what keeps a device from putting arbitrary text on an
+    // operator's screen through the roster.
+    expect(
+      DeviceCommandAckBody.safeParse({
+        outcome: 'failed',
+        reason: 'disk on fire — call 555-0100',
+        projectsForwarded: 0,
+      }).success,
+    ).toBe(false);
+  });
+
+  it('accepts both well-formed acks', () => {
+    expect(
+      DeviceCommandAckBody.safeParse({ outcome: 'reported', projectsForwarded: 2 }).success,
+    ).toBe(true);
+    expect(
+      DeviceCommandAckBody.safeParse({
+        outcome: 'failed',
+        reason: 'no_projects',
+        projectsForwarded: 0,
+      }).success,
+    ).toBe(true);
   });
 });

--- a/packages/schema/test/zod/control-plane.test.ts
+++ b/packages/schema/test/zod/control-plane.test.ts
@@ -475,15 +475,31 @@ describe('DeviceCommand — a verb, never a path', () => {
   it('carries the refusal through the poll envelope, not just the bare command', () => {
     // The shape a device actually parses is the envelope. A strict inner object
     // inside a permissive outer one would let the whole thing through under a
-    // different key.
+    // different key, so this is the assertion that matters — a path arriving in
+    // the COMMAND is refused however it is wrapped.
     expect(
       DeviceCommandPollResponse.safeParse({
         command: { ...VALID, searchRoots: ['/'] },
       }).success,
     ).toBe(false);
-    expect(
-      DeviceCommandPollResponse.safeParse({ command: VALID, searchRoots: ['/'] }).success,
-    ).toBe(false);
+  });
+
+  it('tolerates a field a NEWER deployment added to the envelope', () => {
+    // The other half, and the opposite direction: the envelope is a RESPONSE
+    // shape, so this file's own rule at the top applies — parse leniently, so an
+    // older device keeps working against a newer control plane. A deployment
+    // that starts sending `pollAfterSeconds` must not make every device in the
+    // fleet fail the parse and stop servicing commands entirely.
+    //
+    // The unknown key is STRIPPED rather than kept: nothing downstream should be
+    // able to reach a field this build never reasoned about.
+    const parsed = DeviceCommandPollResponse.safeParse({
+      command: VALID,
+      pollAfterSeconds: 900,
+      searchRoots: ['/'],
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toEqual({ command: VALID });
   });
 
   it('treats "no pending command" as an ordinary answer', () => {
@@ -497,16 +513,16 @@ describe('DeviceCommand — a verb, never a path', () => {
  */
 describe('DeviceCommandAckBody', () => {
   it('requires a reason on a failed ack', () => {
-    expect(
-      DeviceCommandAckBody.safeParse({ outcome: 'failed', projectsForwarded: 0 }).success,
-    ).toBe(false);
+    expect(DeviceCommandAckBody.safeParse({ outcome: 'failed', projectsScanned: 0 }).success).toBe(
+      false,
+    );
   });
 
   it('refuses a reason on a reported ack', () => {
     expect(
       DeviceCommandAckBody.safeParse({
         outcome: 'reported',
-        projectsForwarded: 3,
+        projectsScanned: 3,
         reason: 'scan_failed',
       }).success,
     ).toBe(false);
@@ -519,20 +535,20 @@ describe('DeviceCommandAckBody', () => {
       DeviceCommandAckBody.safeParse({
         outcome: 'failed',
         reason: 'disk on fire — call 555-0100',
-        projectsForwarded: 0,
+        projectsScanned: 0,
       }).success,
     ).toBe(false);
   });
 
   it('accepts both well-formed acks', () => {
     expect(
-      DeviceCommandAckBody.safeParse({ outcome: 'reported', projectsForwarded: 2 }).success,
+      DeviceCommandAckBody.safeParse({ outcome: 'reported', projectsScanned: 2 }).success,
     ).toBe(true);
     expect(
       DeviceCommandAckBody.safeParse({
         outcome: 'failed',
         reason: 'no_projects',
-        projectsForwarded: 0,
+        projectsScanned: 0,
       }).success,
     ).toBe(true);
   });

--- a/plugins/antigravity/src/sync.ts
+++ b/plugins/antigravity/src/sync.ts
@@ -25,12 +25,12 @@
  */
 import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
 import { loadConfig } from '@akasecurity/plugin-sdk';
-import { scanAllRepos } from '@akasecurity/scanner';
+import { scanWorktree } from '@akasecurity/scanner';
 import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
   await runAttachedSync(undefined, {
-    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.Antigravity),
+    scan: commandScanFor(loadConfig(), scanWorktree, SOURCE_TOOL.Antigravity),
   });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.

--- a/plugins/antigravity/src/sync.ts
+++ b/plugins/antigravity/src/sync.ts
@@ -9,13 +9,29 @@
  *
  *   node scripts/sync.js
  *
+ * It also services the device-command channel, which is why this entry hands
+ * `runAttachedSync` a scan. The scanner cannot be imported by the runtime
+ * itself — `@akasecurity/scanner` already depends on it, so that edge would
+ * close a cycle — and passing it here keeps the capability honest besides: a
+ * host that ships no scanner passes nothing and does not poll, rather than
+ * accepting a command it could never run.
+ *
+ * The scan SCOPE is not chosen here. `commandScanFor` owns it, so the rule
+ * ("never the home directory implicitly") is written once rather than three
+ * times across three plugin trees.
+ *
  * Fully fail-open, and it never throws: `runAttachedSync` records an outcome
  * for `/aka:status` to render and swallows everything else. Always exits 0.
  */
-import { runAttachedSync } from '@akasecurity/plugin-runtime';
+import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import { scanAllRepos } from '@akasecurity/scanner';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
-  await runAttachedSync();
+  await runAttachedSync(undefined, {
+    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.Antigravity),
+  });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.
 }

--- a/plugins/claude-code/src/sync.ts
+++ b/plugins/claude-code/src/sync.ts
@@ -25,12 +25,12 @@
  */
 import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
 import { loadConfig } from '@akasecurity/plugin-sdk';
-import { scanAllRepos } from '@akasecurity/scanner';
+import { scanWorktree } from '@akasecurity/scanner';
 import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
   await runAttachedSync(undefined, {
-    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.ClaudeCode),
+    scan: commandScanFor(loadConfig(), scanWorktree, SOURCE_TOOL.ClaudeCode),
   });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.

--- a/plugins/claude-code/src/sync.ts
+++ b/plugins/claude-code/src/sync.ts
@@ -9,13 +9,29 @@
  *
  *   node scripts/sync.js
  *
+ * It also services the device-command channel, which is why this entry hands
+ * `runAttachedSync` a scan. The scanner cannot be imported by the runtime
+ * itself — `@akasecurity/scanner` already depends on it, so that edge would
+ * close a cycle — and passing it here keeps the capability honest besides: a
+ * host that ships no scanner passes nothing and does not poll, rather than
+ * accepting a command it could never run.
+ *
+ * The scan SCOPE is not chosen here. `commandScanFor` owns it, so the rule
+ * ("never the home directory implicitly") is written once rather than three
+ * times across three plugin trees.
+ *
  * Fully fail-open, and it never throws: `runAttachedSync` records an outcome
  * for `/aka:status` to render and swallows everything else. Always exits 0.
  */
-import { runAttachedSync } from '@akasecurity/plugin-runtime';
+import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import { scanAllRepos } from '@akasecurity/scanner';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
-  await runAttachedSync();
+  await runAttachedSync(undefined, {
+    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.ClaudeCode),
+  });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.
 }

--- a/plugins/codex/src/sync.ts
+++ b/plugins/codex/src/sync.ts
@@ -9,13 +9,29 @@
  *
  *   node scripts/sync.js
  *
+ * It also services the device-command channel, which is why this entry hands
+ * `runAttachedSync` a scan. The scanner cannot be imported by the runtime
+ * itself — `@akasecurity/scanner` already depends on it, so that edge would
+ * close a cycle — and passing it here keeps the capability honest besides: a
+ * host that ships no scanner passes nothing and does not poll, rather than
+ * accepting a command it could never run.
+ *
+ * The scan SCOPE is not chosen here. `commandScanFor` owns it, so the rule
+ * ("never the home directory implicitly") is written once rather than three
+ * times across three plugin trees.
+ *
  * Fully fail-open, and it never throws: `runAttachedSync` records an outcome
  * for `/aka:status` to render and swallows everything else. Always exits 0.
  */
-import { runAttachedSync } from '@akasecurity/plugin-runtime';
+import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
+import { loadConfig } from '@akasecurity/plugin-sdk';
+import { scanAllRepos } from '@akasecurity/scanner';
+import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
-  await runAttachedSync();
+  await runAttachedSync(undefined, {
+    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.Codex),
+  });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.
 }

--- a/plugins/codex/src/sync.ts
+++ b/plugins/codex/src/sync.ts
@@ -25,12 +25,12 @@
  */
 import { commandScanFor, runAttachedSync } from '@akasecurity/plugin-runtime';
 import { loadConfig } from '@akasecurity/plugin-sdk';
-import { scanAllRepos } from '@akasecurity/scanner';
+import { scanWorktree } from '@akasecurity/scanner';
 import { SOURCE_TOOL } from '@akasecurity/schema';
 
 try {
   await runAttachedSync(undefined, {
-    scan: commandScanFor(loadConfig(), scanAllRepos, SOURCE_TOOL.Codex),
+    scan: commandScanFor(loadConfig(), scanWorktree, SOURCE_TOOL.Codex),
   });
 } catch {
   // Nothing to report to — this process is detached with stdio ignored.


### PR DESCRIPTION
The device half of the device-command channel. The control plane could already enqueue a command and render a roster; nothing polled for one, so every job fanned in at zero until it expired. This is what answers.

## The scan scope is the privilege

That is what the design is built around.

`DeviceCommand` is `.strict()` and carries a **verb and nothing else** — no `searchRoots`, no `rootDir`, no `path`, no glob, no depth. A deployment that sends one gets a parse failure on the device and the scan never runs.

Not tidiness. A command able to name a directory would let whoever controls — or impersonates — a deployment point a filesystem walk at `~/.ssh`, a mounted volume, or another customer's checkout, and have the results forwarded. Fleet hygiene becomes remote file discovery.

Seven cases pin it, and they were **verified by deleting `.strict()`** — all seven fail without it.

So the scope is chosen entirely device-side, taking the unprivileged half of the interactive scan's own rule: `--discover` with no `--root` sweeps the current directory; `--root ~` is the explicit, human-typed, machine-wide opt-in a server-issued command cannot reach. The detached child inherits its working directory from the session that spawned it, so that is the project the user was actually in.

The honest cost: **one project per pickup.** The alternative that covers more ground is an implicit home-directory sweep, which this codebase declines to do without a person asking for it.

## Three other refusals

**No catch-all command kind**, deliberately unlike `AttachTokenResponse` beside it. The direction of trust is opposite — an unrecognised attach *status* means \"keep waiting\", which is safe; an unrecognised *command* is an instruction this build cannot reason about, and the only safe reading is none at all.

**The ack path encodes the command id.** It is the one path segment this client does not author. \`printable(128)\` rejects control characters but not slashes or dots, so unencoded, an id of \`../../v1/events\` sends this machine's credential to \`/v1/v1/events/ack\`. Proven by removing the encode.

**The failure reason is a closed enum and the thrown error is discarded without being read.** That is what keeps device-supplied text off an operator's screen. No catch-all reason, because that is where a message would eventually get attached.

## The scan is injected, not imported

A dependency-graph fact before it is a testing convenience: **`@akasecurity/scanner` already depends on `plugin-runtime`**, so importing it there closes a cycle. The three plugin \`sync\` entries that ship a scanner pass it in.

It keeps the capability honest too. The browser extension's native host ships no scanner — it passes nothing, and a host with no scan **does not poll at all**, rather than accepting a command it can never service and leaving it outstanding on a roster for 24 hours, which reads exactly like a machine that is switched off.

## Ack-on-failure is load-bearing

A device that scans, fails and goes quiet is indistinguishable from one that is off, and the operator learns nothing until the command expires. Every terminal path acks.

`no_projects` is its own outcome rather than `reported` with a count of zero — an operator acts differently on \"this machine has no projects here\" than on \"it scanned and sent none\", and the roster styles them differently, which is only possible if the device says which happened.

## What does not change

Cadence. The existing fifteen-minute policy-sync throttle, in the same detached child, after the policy pull so the scan reads the ruleset that pull just cached. **Nothing here makes a re-scan instant**, and the dashboard is built to say so rather than imply otherwise.

`sync.js` grows 948 KB → 1526 KB on the scanner. Stated rather than buried: that puts a detached background child at the size the hook-path scripts beside it (`filescan.js`, 1528 KB) already are, and this one runs at most every fifteen minutes with nothing waiting on it.

## Verification

Gate is green under the consuming workspace's lockfile (`pnpm test:oss`), plus `format:check`, `lint`, `typecheck`, `build`, `check:oss-wall`, `check:vitest-instance`.

Three guards proven by sabotage rather than assertion:

| Break | What fails |
|---|---|
| delete `.strict()` on `DeviceCommand` | 7 cases — every path-shaped key, plus the envelope |
| remove `encodeURIComponent` on the id | ack lands on `/v1/v1/events/ack` |
| — | 11 device-sync cases, 43 transport cases |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQkLhyjHcVmkRAA4nFW8xx