### PR TITLE
fix(plugin-sdk): cap the redact fallback under the legacy ceiling

### DIFF
--- a/packages/plugin-runtime/test/attached/command-sync.test.ts
+++ b/packages/plugin-runtime/test/attached/command-sync.test.ts
@@ -55,16 +55,25 @@ function attach(): void {
   writeControlPlaneCredential(settingsDirOf(base), CREDENTIAL);
 }
 
-const deps = (scan?: () => Promise<{ projects: number }>, now?: () => number) => ({
-  base,
-  settingsDir: settingsDirOf(base),
-  ...(scan === undefined ? {} : { scan }),
-  ...(now === undefined ? {} : { now }),
-});
-
 /** Fixed instants either side of COMMAND's own `expiresAt`. */
 const BEFORE_DEADLINE = () => Date.parse('2026-09-04T11:59:59.000Z');
 const AFTER_DEADLINE = () => Date.parse('2026-09-04T12:00:01.000Z');
+
+// The clock DEFAULTS rather than falling through to the ambient one, because
+// `runCommandSync` reads `deps.now ?? Date.now` and COMMAND carries a fixed
+// `expiresAt`. Omitting it therefore dated the case rather than leaving it
+// clock-free: every test here that serviced COMMAND passed until the wall clock
+// reached 2026-09-04T12:00:00Z and then failed for good, on a diff that could
+// not touch it — and it failed as `expired`, which reads as a behaviour change
+// in the code under test rather than as a stale fixture. A test that wants the
+// far side of the deadline says so with AFTER_DEADLINE, so the two directions
+// are both explicit and neither depends on when the suite runs.
+const deps = (scan?: () => Promise<{ projects: number }>, now: () => number = BEFORE_DEADLINE) => ({
+  base,
+  settingsDir: settingsDirOf(base),
+  ...(scan === undefined ? {} : { scan }),
+  now,
+});
 
 beforeEach(() => {
   pollCommand.mockReset();

--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -315,15 +315,19 @@ export function createPluginRuntime(
     // Doing it in the hook instead is what left an escalated deny recorded as
     // 'redact'; a downgrade recorded that way would be worse still, claiming a
     // masking that never happened while the raw value went through.
-    if (!rewritable && action === 'redact') return builtinPolicyToAction(redactFallback);
+    const resolved =
+      !rewritable && action === 'redact' ? builtinPolicyToAction(redactFallback) : action;
+    // The ceiling reads the DEGRADED action: a fallback of 'block' is capped
+    // exactly as a policy of 'block' is, so an inability to redact cannot buy
+    // more enforcement than the mode allows.
     if (
       ENFORCEMENT_CEILING_ENABLED &&
       policyMode === 'warn' &&
-      (action === 'block' || action === 'redact')
+      (resolved === 'block' || resolved === 'redact')
     ) {
       return 'warn';
     }
-    return action;
+    return resolved;
   }
 
   function decide(

--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -35,6 +35,50 @@ import type { BlockedDetectionRef, CaptureInput, CaptureResult } from './types.t
 const ENFORCEMENT_CEILING_ENABLED = false as boolean;
 
 /**
+ * The legacy global ceiling, as a pure function of the three things that decide
+ * it: 'warn' handling mode floors block/redact to warn, and leaves every other
+ * action alone.
+ *
+ * `enabled` is a PARAMETER rather than a read of ENFORCEMENT_CEILING_ENABLED,
+ * so the capped branch can be driven while the flag itself ships at false.
+ * Without that seam the whole path is dormant and unexecuted, and the first
+ * thing to run it would be the flag flip.
+ */
+export function applyEnforcementCeiling(
+  action: ActionTaken,
+  policyMode: WorkspaceSettings['policy'],
+  enabled: boolean,
+): ActionTaken {
+  if (!enabled || policyMode !== 'warn') return action;
+  return action === 'block' || action === 'redact' ? 'warn' : action;
+}
+
+/**
+ * A resolved action, degraded for a field the host cannot rewrite and then
+ * capped by the ceiling — in that ORDER, which is the whole property.
+ *
+ * The degradation runs FIRST so the ceiling reads the degraded action: a
+ * fallback of 'block' is capped exactly as a policy of 'block' is, and an
+ * inability to redact cannot buy more enforcement than the mode allows.
+ * Composed here rather than inline in `actionForFinding` because that ordering
+ * is what a test has to reach; calling `applyEnforcementCeiling` alone cannot
+ * see it, so an early return that skipped the cap would still pass.
+ */
+export function resolveEnforcedAction(
+  action: ActionTaken,
+  opts: {
+    policyMode: WorkspaceSettings['policy'];
+    redactFallback: WorkspaceSettings['redactFallback'];
+    rewritable: boolean;
+    ceilingEnabled: boolean;
+  },
+): ActionTaken {
+  const degraded =
+    !opts.rewritable && action === 'redact' ? builtinPolicyToAction(opts.redactFallback) : action;
+  return applyEnforcementCeiling(degraded, opts.policyMode, opts.ceilingEnabled);
+}
+
+/**
  * Start of an added-latency measurement, or `undefined` if the clock could not
  * be read. `performance.now()` is monotonic — a wall clock stepped by NTP mid-
  * capture can run backwards and produce a negative duration, which would drag a
@@ -297,37 +341,32 @@ export function createPluginRuntime(
   // blocked secret with a warned code-context match applies 'block' to the
   // former and 'warn' to the latter.
   //
-  // The legacy global ceiling is applied HERE so this stays the single
+  // The legacy global ceiling is applied THROUGH this function — inside the
+  // `resolveEnforcedAction` it delegates to — so this stays the single
   // definition of the action that actually applied: when it is enabled, 'warn'
   // handling mode floors block/redact to warn. `decide`'s aggregate collapse and
   // the findings audit trail both resolve through this function, so neither can
-  // record a stronger action than the capture actually took.
+  // record a stronger action than the capture actually took. The delegate is
+  // pure and takes the flag as an argument, so the capped branch is reachable
+  // from a test while the flag itself ships at false.
   function actionForFinding(
     finding: MatchResult,
     excepted?: ReadonlySet<MatchResult>,
     rewritable = true,
   ): ActionTaken {
     if (excepted?.has(finding)) return 'allow';
-    const action = resolveAction(finding.ruleId, finding.category);
-    // A redact the CALLER cannot carry out degrades here, in the one place the
-    // action is resolved, so the decision the hook emits, the findings row and
-    // the blocked-detections ledger cannot disagree about what was enforced.
-    // Doing it in the hook instead is what left an escalated deny recorded as
+    // A redact the CALLER cannot carry out degrades in the one place the action
+    // is resolved, so the decision the hook emits, the findings row and the
+    // blocked-detections ledger cannot disagree about what was enforced. Doing
+    // it in the hook instead is what left an escalated deny recorded as
     // 'redact'; a downgrade recorded that way would be worse still, claiming a
     // masking that never happened while the raw value went through.
-    const resolved =
-      !rewritable && action === 'redact' ? builtinPolicyToAction(redactFallback) : action;
-    // The ceiling reads the DEGRADED action: a fallback of 'block' is capped
-    // exactly as a policy of 'block' is, so an inability to redact cannot buy
-    // more enforcement than the mode allows.
-    if (
-      ENFORCEMENT_CEILING_ENABLED &&
-      policyMode === 'warn' &&
-      (resolved === 'block' || resolved === 'redact')
-    ) {
-      return 'warn';
-    }
-    return resolved;
+    return resolveEnforcedAction(resolveAction(finding.ruleId, finding.category), {
+      policyMode,
+      redactFallback,
+      rewritable,
+      ceilingEnabled: ENFORCEMENT_CEILING_ENABLED,
+    });
   }
 
   function decide(

--- a/packages/plugin-sdk/test/runtime-enforcement-ceiling.test.ts
+++ b/packages/plugin-sdk/test/runtime-enforcement-ceiling.test.ts
@@ -1,0 +1,102 @@
+import { builtinPolicyToAction } from '@akasecurity/schema';
+import { describe, expect, it } from 'vitest';
+
+import { applyEnforcementCeiling, resolveEnforcedAction } from '../src/runtime.ts';
+
+// The ceiling ships DISABLED (`ENFORCEMENT_CEILING_ENABLED = false`), so nothing
+// that reads the module const can execute the capped branch — the first thing to
+// run it would otherwise be the flag flip itself. Both functions under test take
+// `enabled` as a parameter for exactly that reason, and every case here drives it
+// explicitly rather than inheriting the shipped value.
+
+describe('applyEnforcementCeiling', () => {
+  it('floors block and redact to warn in warn mode', () => {
+    expect(applyEnforcementCeiling('block', 'warn', true)).toBe('warn');
+    expect(applyEnforcementCeiling('redact', 'warn', true)).toBe('warn');
+  });
+
+  it('leaves every action that is not enforcement alone', () => {
+    // A ceiling that floored these would be RAISING them — 'log' and 'allow' are
+    // weaker than 'warn', so capping must be a floor on the strong end only.
+    for (const action of ['allow', 'log', 'warn'] as const) {
+      expect(applyEnforcementCeiling(action, 'warn', true)).toBe(action);
+    }
+  });
+
+  it('caps nothing while the flag is off, which is how it ships', () => {
+    expect(applyEnforcementCeiling('block', 'warn', false)).toBe('block');
+    expect(applyEnforcementCeiling('redact', 'warn', false)).toBe('redact');
+  });
+
+  it('caps nothing in redact mode, the only other handling mode', () => {
+    expect(applyEnforcementCeiling('block', 'redact', true)).toBe('block');
+    expect(applyEnforcementCeiling('redact', 'redact', true)).toBe('redact');
+  });
+});
+
+describe('resolveEnforcedAction — degrade, THEN cap', () => {
+  const unrewritableRedact = (
+    redactFallback: 'monitor' | 'warn' | 'block',
+    ceilingEnabled: boolean,
+  ) =>
+    resolveEnforcedAction('redact', {
+      policyMode: 'warn',
+      redactFallback,
+      rewritable: false,
+      ceilingEnabled,
+    });
+
+  // The ordering this pins is the whole of the fix. Resolved 'redact' on a field
+  // the host cannot rewrite degrades to `redactFallback`; the ceiling must read
+  // that DEGRADED action, so a fallback of 'block' is capped exactly as a policy
+  // of 'block' is. Returning the fallback early — which is what the code did —
+  // lets an inability to redact buy more enforcement than the mode allows.
+  it('caps a redact that fell back to block, rather than letting the fallback through', () => {
+    expect(unrewritableRedact('block', true)).toBe('warn');
+  });
+
+  // The control WITHOUT which the case above is vacuous. Both readings of it end
+  // at 'warn': the degradation ran and 'block' was capped, or the degradation
+  // never ran and a surviving 'redact' was capped. Only this case separates them
+  // — it proves the fallback is genuinely reached, so the assertion above is
+  // about the cap rather than about a value that was never produced.
+  it('still degrades to the fallback when the ceiling is off', () => {
+    expect(unrewritableRedact('block', false)).toBe(builtinPolicyToAction('block'));
+    expect(unrewritableRedact('block', false)).toBe('block');
+  });
+
+  it('leaves a rewritable redact to be capped as a redact', () => {
+    const rewritable = (ceilingEnabled: boolean) =>
+      resolveEnforcedAction('redact', {
+        policyMode: 'warn',
+        redactFallback: 'block',
+        rewritable: true,
+        ceilingEnabled,
+      });
+    // The fallback must not be consulted at all when the host CAN rewrite, so a
+    // fallback of 'block' cannot leak into a rewritable field's action.
+    expect(rewritable(false)).toBe('redact');
+    expect(rewritable(true)).toBe('warn');
+  });
+
+  it('degrades to a fallback the ceiling would not have capped', () => {
+    // 'monitor' resolves below 'warn', so the cap is a no-op here and the
+    // fallback is what shows through with the ceiling either way.
+    expect(unrewritableRedact('monitor', false)).toBe(builtinPolicyToAction('monitor'));
+    expect(unrewritableRedact('monitor', true)).toBe(builtinPolicyToAction('monitor'));
+  });
+
+  it('passes a block straight through the degradation step', () => {
+    const block = (ceilingEnabled: boolean) =>
+      resolveEnforcedAction('block', {
+        policyMode: 'warn',
+        redactFallback: 'monitor',
+        rewritable: false,
+        ceilingEnabled,
+      });
+    // Only a resolved 'redact' degrades; a resolved 'block' on an unrewritable
+    // field must not be diverted through `redactFallback`.
+    expect(block(false)).toBe('block');
+    expect(block(true)).toBe('warn');
+  });
+});


### PR DESCRIPTION
Follow-up to #418, which merged before this landed on its branch.

## The defect

`actionForFinding` degraded a non-rewritable `redact` and returned **above** the legacy ceiling, so the degrade escaped the cap. With `ENFORCEMENT_CEILING_ENABLED` on, `policy: 'warn'` and `redactFallback: 'block'`, a field the caller cannot rewrite emitted `block` where a rewritable field on the same workspace was floored to `warn`.

That contradicts the function's own docblock, which says the ceiling is applied there "so this stays the single definition of the action that actually applied", and that `decide`'s collapse and the audit trail both resolve through it so "neither can record a stronger action than the capture actually took".

## The fix

Resolve the fallback first, then cap the resolved action — an inability to redact cannot buy more enforcement than the handling mode allows.

## Why it is worth fixing while dormant

It is dormant twice over: `ENFORCEMENT_CEILING_ENABLED` is `false as boolean`, and no plugin passes `rewritable: false` yet. Both change under the F2 host work, and `redactFallback` is pinnable through the administrative overlay, so `block` is a value an MDM can set without touching this file.

## Verification

Mutation-verified against this base rather than asserted. With the flag forced on, a `policy: 'warn'` / `redactFallback: 'block'` / `rewritable: false` capture reads:

- `block` with the pre-fix ordering (red)
- `warn` with the fix (green)

The scratch case is not committed: `ENFORCEMENT_CEILING_ENABLED` is a module const with no injection seam, so a permanent test could only assert the dormant path. `plugin-sdk` and `plugin-runtime` pass test, typecheck and lint with the flag at its shipped `false`.

Raised by @pmontiel-git in review on #418.