### PR TITLE
feat(copilot): register the plugins/copilot workspace package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -477,8 +477,10 @@ jobs:
   # THE FOUR PUBLISHED ARTIFACTS ARE THE FIRST FOUR FILTERS, and that is the one
   # part of this list with a rule behind it rather than a judgement. `cli`,
   # `ai-tc-claude-code`, `ai-tc-codex` and `ai-tc-antigravity` are every package
-  # in the workspace npm actually publishes — everything else here is
-  # `private: true` and reaches a user only inlined into one of those four. They
+  # in the workspace npm actually publishes — everything else here is either
+  # `private: true` and reaches a user only inlined into one of those four
+  # (`plugin-browser-extension`), or `private: true` and reaches no user at all
+  # yet (`ai-tc-copilot`, a scaffold with nothing built or published). They
   # are also the packages carrying the most platform-specific code (`open-url.ts`'s
   # `cmd /c start`, `prompter.ts`'s setRawMode, `dashboard.ts`'s spawn +
   # require.resolve, `external-dispatch.ts`'s POSIX-only guard, the plugins'
@@ -490,11 +492,14 @@ jobs:
   # matching no package, so a typo here fails the job rather than quietly
   # narrowing it.
   #
-  # `plugin-browser-extension` is the one filter entry that is `private: true`
-  # AND here on purpose, so the derived rule above cannot require it and a bare
-  # entry would be removable with nothing going red. It is pinned by name in
-  # required-checks.test.js the way `@akasecurity/eslint-config` below is, and
-  # for a reason of the same shape: its `test/native-host/scan-worker-bundle
+  # `plugin-browser-extension` and `ai-tc-copilot` are `private: true` AND here
+  # on purpose, so the derived rule above cannot require either and a bare
+  # entry would be removable with nothing going red. Both are pinned by name in
+  # required-checks.test.js the way `@akasecurity/eslint-config` below is, but
+  # for different reasons and on different timelines: `plugin-browser-extension`
+  # stays private permanently (it ships through the CLI, never npm) and its pin
+  # is a reason of the same shape as `@akasecurity/eslint-config`'s below —
+  # its `test/native-host/scan-worker-bundle
   # .e2e.test.ts` is the ONLY place `resolveWorkerUrl()` is exercised from the
   # built NATIVE HOST, and that resolver is `fileURLToPath` over a bundled
   # script's own URL — drive letters, UNC paths, the `file:///C:/…` round trip,
@@ -508,6 +513,11 @@ jobs:
   # `cli`'s extension suite covers the Windows INSTALL path already, and that is
   # a different property: installing the native host is not the same as the host
   # resolving its worker at runtime.
+  #
+  # `ai-tc-copilot`'s pin is TEMPORARY rather than permanent — see
+  # required-checks.test.js's own comment on that entry for why, so the
+  # rationale is not kept in two places. It drops out of this paragraph and
+  # into the derived set the moment Phase B unsets `private`.
   #
   # Whose `test` is deliberately NOT here: `ui-kit` (presentational, no I/O, and
   # no `test` script at all) and `audit-gate` (repo tooling, never shipped).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -458,9 +458,9 @@ jobs:
             turbo-${{ runner.os }}-
 
       - name: Test
-        # --concurrency: see the Test step in the lint job. This leg runs all 20
-        # packages on a hosted macOS runner and was one of the two that failed
-        # on rotating unrelated files.
+        # --concurrency: see the Test step in the lint job. This leg runs the
+        # whole workspace fan-out on a hosted macOS runner and was one of the two
+        # that failed on rotating unrelated files.
         run: pnpm turbo run test --continue --concurrency=2
 
       - name: Save Turbo cache
@@ -765,6 +765,7 @@ jobs:
           --filter=@akasecurity/ai-tc-claude-code
           --filter=@akasecurity/ai-tc-codex
           --filter=@akasecurity/ai-tc-antigravity
+          --filter=@akasecurity/ai-tc-copilot
           --filter=@akasecurity/schema
           --filter=@akasecurity/extract
           --filter=@akasecurity/detections
@@ -778,8 +779,8 @@ jobs:
           --filter=@akasecurity/eslint-config
           --filter=@akasecurity/plugin-browser-extension
 
-      # web-ui's suite runs in its OWN turbo invocation, AFTER the fourteen
-      # above rather than beside them, and the reason is a measured pairing
+      # web-ui's suite runs in its OWN turbo invocation, AFTER the shipped-surface
+      # filters above rather than beside them, and the reason is a measured pairing
       # rather than a hunch about load: `@akasecurity/persistence#test` and
       # `@akasecurity/web-ui#test` are the two heaviest fsync-bound suites in
       # the workspace, and under `--concurrency=2` they overlapped in nearly
@@ -865,7 +866,7 @@ jobs:
         run: pnpm turbo run test --concurrency=1 --filter=@akasecurity/web-ui --filter=@akasecurity/dashboard-ui
 
       # The installer suite runs in its OWN turbo invocation too, AFTER the
-      # fourteen above and the dashboard step, rather than beside any of them.
+      # filters above and the dashboard step, rather than beside any of them.
       # It is by far the most disk-expensive suite in the workspace on this
       # platform — it copies, zips and expands a real ~115 MB PE — and under
       # `--concurrency=2` it was therefore always running alongside one of the
@@ -892,7 +893,7 @@ jobs:
       # told about, so undeclared it would hash-match a cached run without it
       # and replay a green in which the case skipped. It sits on this step
       # alone rather than the whole job because this is the only package that
-      # reads it — the other fifteen were being hashed against a variable none
+      # reads it — the others were being hashed against a variable none
       # of them consults. That is also why web-ui is not folded into this
       # invocation, though both are single-package serial steps: it would put
       # this variable into web-ui#test's hash for no reason.
@@ -909,10 +910,9 @@ jobs:
           path: .turbo/cache
           key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
 
-  # Windows lint leg: every `lint` script in this workspace carries a GLOB — all
-  # twenty-two packages target `*.config.*`, and so does the repo-root
-  # `lint:root`, which is the twenty-third invocation rather than a
-  # twenty-third package —
+  # Windows lint leg: every `lint` script in this workspace carries a GLOB —
+  # they all target `*.config.*`, and so does the repo-root `lint:root`, which
+  # is one more invocation rather than one more package —
   # and WHO EXPANDS IT is decided by the platform, not by the script. On POSIX
   # the shell expands the pattern and hands eslint concrete filenames; `cmd.exe`
   # does not glob at all, so eslint receives the literal pattern and runs its
@@ -959,8 +959,8 @@ jobs:
   # affordable where a cold `test` would not be. Measured on THIS runner rather
   # than extrapolated (`gh run view 31536100993 --repo akasecurity/ai-tc`): the
   # Lint step 1m49s, the whole job 2m41s. The same `pnpm lint` at `Cached: 0` on
-  # an M-series Mac is 72s for all twenty packages plus 6.5s for lint:root and
-  # 0.6s for check:portability.
+  # an M-series Mac is 72s for the workspace fan-out (measured when it was twenty
+  # packages) plus 6.5s for lint:root and 0.6s for check:portability.
   #
   # So the ~10x factor the test leg above documents does NOT transfer to lint —
   # here it is about 1.5x. Size a lint budget off a lint measurement; the factor

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage
 plugins/claude-code/scripts/
 plugins/codex/scripts/
 plugins/antigravity/scripts/
+plugins/copilot/scripts/
 plugins/browser-extension/native-host/
 
 # written by tools/audit-gate on every run, always at the repo root

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -283,6 +283,7 @@ const EXPECTED_WORKSPACE_PACKAGE_NAMES = [
   '@akasecurity/ai-tc-claude-code',
   '@akasecurity/ai-tc-codex',
   '@akasecurity/ai-tc-antigravity',
+  '@akasecurity/ai-tc-copilot',
   '@akasecurity/audit-gate',
   '@akasecurity/cli',
   '@akasecurity/codeql-alerts-gate',

--- a/packages/eslint-config/test/no-network-runtime.test.js
+++ b/packages/eslint-config/test/no-network-runtime.test.js
@@ -185,6 +185,7 @@ const EXPECTED_VITEST_PACKAGES = [
   '@akasecurity/ai-tc-claude-code',
   '@akasecurity/ai-tc-codex',
   '@akasecurity/ai-tc-antigravity',
+  '@akasecurity/ai-tc-copilot',
   '@akasecurity/audit-gate',
   '@akasecurity/cli',
   '@akasecurity/codeql-alerts-gate',

--- a/packages/eslint-config/test/package-walls.test.js
+++ b/packages/eslint-config/test/package-walls.test.js
@@ -26,12 +26,16 @@ import {
 // failures landing on whichever file lost the race rather than on the change.
 // Anything new that needs a resolved per-package config belongs in this file.
 //
-// The budget is charged per RESOLUTION, and the wall now reaches every package
-// that ships product code rather than five of them, so this hook resolves 17
-// configs where it once resolved 5. The ceiling is sized against that count on a
-// contended runner, not against the few seconds it takes on an idle machine — a
-// hook that overruns is reported as a timeout, which reads as a budget failure
-// and is not one.
+// The budget is charged per RESOLUTION: the hook resolves one config for every
+// entry in `RESOLVE_TARGETS`, the three tables below spread together. That count
+// is deliberately NOT written here. It was five when the wall covered five
+// packages and is far higher now that the wall reaches every package shipping
+// product code, and a figure in this comment goes stale silently while still
+// reading as the number the ceiling was sized against — which is the one thing
+// a reader checking that sizing would rely on. The ceiling is sized for the
+// whole of that set on a contended runner, not for the few seconds it takes on
+// an idle machine — a hook that overruns is reported as a timeout, which reads
+// as a budget failure and is not one.
 const RESOLVE_TIMEOUT_MS = 120_000;
 
 /**
@@ -63,6 +67,7 @@ const WALLED_PACKAGES = [
   },
   { name: '@akasecurity/ai-tc-codex', dir: 'plugins/codex', file: 'src/backfill.ts' },
   { name: '@akasecurity/ai-tc-antigravity', dir: 'plugins/antigravity', file: 'src/backfill.ts' },
+  { name: '@akasecurity/ai-tc-copilot', dir: 'plugins/copilot', file: 'src/identity.ts' },
   { name: '@akasecurity/detections', dir: 'packages/detections', file: 'src/engine.ts' },
   { name: '@akasecurity/extract', dir: 'packages/extract', file: 'src/csv.ts' },
   { name: '@akasecurity/setup-wizard', dir: 'packages/setup-wizard', file: 'src/index.ts' },
@@ -165,8 +170,12 @@ const resolved = new Map();
 // for a package whose only config is oddly named, and that disagreement is
 // surfaced HERE rather than left to surface as ESLint's own bare "Could not find
 // config file", which names neither the package nor the reason.
+// Every per-package resolution this suite performs, in one place: what
+// RESOLVE_TIMEOUT_MS is sized against, and what grows when any table above does.
+const RESOLVE_TARGETS = [...WALLED_PACKAGES, ...RELAXED_FILES, ...AMBIENT_CLOCK_TEST_FILES];
+
 beforeAll(async () => {
-  for (const pkg of [...WALLED_PACKAGES, ...RELAXED_FILES, ...AMBIENT_CLOCK_TEST_FILES]) {
+  for (const pkg of RESOLVE_TARGETS) {
     const pkgDir = join(REPO_ROOT, pkg.dir);
     const eslint = new ESLint({ cwd: pkgDir });
     let config;

--- a/packages/eslint-config/test/required-checks.test.js
+++ b/packages/eslint-config/test/required-checks.test.js
@@ -128,7 +128,7 @@ function matrixValues(source, key) {
 // boundary is `(?![\w:])` rather than `\b` because `:` is a NON-word character,
 // so `pnpm lint\b` also matches `pnpm lint:root` — and that is not a hypothetical
 // spelling, it is a script this repo really has. Swapping the step to it drops
-// `turbo run lint` (all twenty packages) and `check:portability`, leaving only
+// `turbo run lint` (every workspace package) and `check:portability`, leaving only
 // the repo-root pass, while every assertion below goes on passing. The negative
 // class deliberately excludes a SPACE, so an argument appended after the script
 // name still matches: that is what lets this double as the positive control for
@@ -792,6 +792,28 @@ describe('the Windows legs', () => {
     expect(suite).toMatch(/spawnSync\(process\.execPath, \[join\(HOST_DIR, HOST_SCRIPT\)\]/);
   });
 
+  // The third entry the derived check cannot reach, and the one whose exclusion
+  // is TEMPORARY. `plugins/copilot` is `private: true` only while it is a
+  // scaffold with no build and nothing to publish, so `private !== true` drops
+  // it from the derived set exactly as it drops the two above — and the filter
+  // line is then removable with nothing going red. Phase B unsets `private` and
+  // the derived check resumes covering this entry; until then this pin is the
+  // only thing carrying the Windows leg across that gap.
+  //
+  // Losing it silently is what makes it worth pinning rather than re-adding
+  // later: the plugin hosts differ most on Windows — PATHEXT resolution, the
+  // working directory searched ahead of PATH, and the shell re-parse the
+  // bare-command planner exists for — so a copilot hook landing without a
+  // Windows run is a gap nothing else here reports.
+  it('tests the copilot plugin, which is private only while it is a scaffold', () => {
+    const block = jobBlock(ci, 'windows');
+    expect(block).toMatch(/turbo run test/);
+    // `(?![\w-])` for the same reason as the two pins above: `\b` would also
+    // accept a rename to `--filter=@akasecurity/ai-tc-copilot-ide`, taking this
+    // package's Windows coverage away while this test stayed green.
+    expect(block).toMatch(/--filter=@akasecurity\/ai-tc-copilot(?![\w-])/);
+  });
+
   // A filter is only a filter while there is something to filter. `turbo run
   // test` with no --filter at all would satisfy the containment check above by
   // running everything, which is a different job with a different cost — and it
@@ -941,25 +963,27 @@ describe('the Windows legs', () => {
   // about the tree, so derive it rather than asserting it in a comment: a package
   // whose lint script drops `*.config.*` takes its root config files out of every
   // lint pass on every platform, and this job would stay green throughout —
-  // twenty-one other scripts still expand, so nothing here reddens.
+  // every other script still expands, so nothing here reddens.
   //
   // The count is pinned first for the usual reason: an empty list satisfies a
   // `for` loop over it without checking anything. It is a floor AND a ceiling, so
   // a package added without a lint script is caught by the same assertion.
   //
   // It is also the one number here that two branches can both raise to the SAME
-  // value for different reasons and merge clean: one adding a package and one
-  // adding another both write 21, git sees identical text, and the merged truth
-  // is 22. Re-derive it after a merge rather than trusting that it merged.
+  // value for different reasons and merge clean: from a base of N, one adding a
+  // package and one adding another both write N+1, git sees identical text, and
+  // the merged truth is N+2. Re-derive it after a merge rather than trusting
+  // that it merged. The shape is spelled here rather than the number, because a
+  // second copy of the count is the thing that goes stale.
   it('every lint script carries the glob this job exists to observe', () => {
     const scripts = workspaceLintScripts();
-    expect(scripts).toHaveLength(25);
+    expect(scripts).toHaveLength(26);
     for (const { dir, lintScript } of scripts) {
       expect(lintScript, `${dir} declares no lint script`).not.toBe('');
       expect(lintScript, `${dir}'s lint script targets no *.config.* glob`).toContain('*.config.*');
     }
-    // And the repo-root pass, which is the twenty-third invocation rather than a
-    // twenty-third package — it is the only one covering files no package owns.
+    // And the repo-root pass, which is one more invocation rather than one more
+    // package — it is the only one covering files no package owns.
     expect(rootScripts()['lint:root']).toContain('*.config.*');
   });
 });

--- a/plugins/copilot/eslint.config.mjs
+++ b/plugins/copilot/eslint.config.mjs
@@ -1,0 +1,16 @@
+// @ts-check
+import { base, noDrizzleImports, rootConfigFiles } from '@akasecurity/eslint-config';
+
+export default [
+  ...base,
+  ...noDrizzleImports,
+  {
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+  },
+  ...rootConfigFiles,
+];

--- a/plugins/copilot/package.json
+++ b/plugins/copilot/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@akasecurity/ai-tc-copilot",
+  "version": "0.9.9",
+  "description": "AI Traffic Control — inspect and govern AI prompts in GitHub Copilot",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/akasecurity/ai-tc.git",
+    "directory": "plugins/copilot"
+  },
+  "homepage": "https://github.com/akasecurity/ai-tc/tree/main/plugins/copilot",
+  "scripts": {
+    "lint": "eslint src test *.config.*",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@akasecurity/eslint-config": "workspace:*",
+    "@akasecurity/plugin-runtime": "workspace:*",
+    "@akasecurity/plugin-sdk": "workspace:*",
+    "@akasecurity/schema": "workspace:*",
+    "@types/node": "^24.13.3",
+    "@vitest/coverage-v8": "^4.1.11",
+    "eslint": "^9.39.5",
+    "typescript": "^5.8.0",
+    "vitest": "^4.1.11"
+  }
+}

--- a/plugins/copilot/src/identity.ts
+++ b/plugins/copilot/src/identity.ts
@@ -1,0 +1,2 @@
+/** The plugin's own package name. A placeholder: this package ships no product behaviour yet. */
+export const PLUGIN_PACKAGE = '@akasecurity/ai-tc-copilot';

--- a/plugins/copilot/test/identity.test.ts
+++ b/plugins/copilot/test/identity.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { PLUGIN_PACKAGE } from '../src/identity.ts';
+
+describe('skeleton', () => {
+  it('names its own package', () => {
+    expect(PLUGIN_PACKAGE).toBe('@akasecurity/ai-tc-copilot');
+  });
+});

--- a/plugins/copilot/test/identity.test.ts
+++ b/plugins/copilot/test/identity.test.ts
@@ -1,9 +1,16 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import { PLUGIN_PACKAGE } from '../src/identity.ts';
 
+// Pinned against the file that actually defines it, so a rename of the npm
+// package fails here rather than shipping under a stale identity.
 describe('skeleton', () => {
-  it('names its own package', () => {
-    expect(PLUGIN_PACKAGE).toBe('@akasecurity/ai-tc-copilot');
+  it('names the npm package this plugin publishes as', () => {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as {
+      name: string;
+    };
+    expect(PLUGIN_PACKAGE).toBe(pkg.name);
   });
 });

--- a/plugins/copilot/tsconfig.json
+++ b/plugins/copilot/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src", "test"]
+}

--- a/plugins/copilot/vitest.config.ts
+++ b/plugins/copilot/vitest.config.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+
+import { defineConfig } from 'vitest/config';
+
+import { coverageOptions } from '../../test/vitest/coverage.ts';
+
+// Every test file runs behind the no-network guard: it refuses any outbound
+// connection that is not loopback and names the call site that made it.
+const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+
+export default defineConfig({
+  test: {
+    setupFiles: [noNetworkGuard],
+    coverage: coverageOptions(import.meta.url),
+    // No timeout overrides: this suite is synchronous assertions with no child
+    // process, no store and no migration template, so it runs on vitest's own
+    // defaults — which is why the package is absent from the ratchet's TIMEOUTS.
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,36 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  plugins/copilot:
+    devDependencies:
+      '@akasecurity/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@akasecurity/plugin-runtime':
+        specifier: workspace:*
+        version: link:../../packages/plugin-runtime
+      '@akasecurity/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+      '@akasecurity/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
+      eslint:
+        specifier: ^9.39.5
+        version: 9.39.5(jiti@2.7.0)
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1)(vite@8.0.16(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
   tools/audit-gate:
     devDependencies:
       '@akasecurity/eslint-config':

--- a/test/vitest/coverage.ts
+++ b/test/vitest/coverage.ts
@@ -105,6 +105,7 @@ export const COVERAGE_FLOORS: Readonly<Record<string, number>> = Object.freeze({
   '@akasecurity/local-ops': 65, //                  66.75
   '@akasecurity/audit-gate': 61, //                 62.88
   '@akasecurity/ai-tc-antigravity': 59, //          60.96
+  '@akasecurity/ai-tc-copilot': 99, //              100 (placeholder only — RE-MEASURE when real source lands)
   '@akasecurity/ai-tc-codex': 58, //                59.78
   '@akasecurity/plugin-browser-extension': 57, //   58.02
   '@akasecurity/cli': 51, //                        52.66

--- a/turbo.json
+++ b/turbo.json
@@ -338,15 +338,18 @@
         "!$TURBO_ROOT$/web-ui/out/**",
         "!$TURBO_ROOT$/web-ui/next-env.d.ts",
         "!$TURBO_ROOT$/cli/web-ui/**",
-        // All three CLI plugins' tsup outDirs. None is named `dist`, so the
+        // The CLI plugins' build outDirs. None is named `dist`, so the
         // blanket dist exclusion above does not reach them — and being listed in
         // .gitignore does not reach them either, exactly as the `.turbo` note
         // above records: a `$TURBO_ROOT$` glob hashes an untracked file anyway.
-        // Without all three, every plugin build perturbs this task's hash and
-        // costs a full re-run of the guard suite.
+        // Without them, every plugin build perturbs this task's hash and costs a
+        // full re-run of the guard suite. plugins/copilot builds nothing yet —
+        // that entry reserves the path, so the exclusion is already in place on
+        // the commit that first writes to it.
         "!$TURBO_ROOT$/plugins/claude-code/scripts/**",
         "!$TURBO_ROOT$/plugins/codex/scripts/**",
         "!$TURBO_ROOT$/plugins/antigravity/scripts/**",
+        "!$TURBO_ROOT$/plugins/copilot/scripts/**",
         // plugins/browser-extension's tsup outDir, and the copies of it that
         // cli/scripts/bundle-extension.mjs stages into the CLI package. All
         // three are generated and gitignored, and none is named `dist`, so the


### PR DESCRIPTION
## Summary

Registers `@akasecurity/ai-tc-copilot` as a real workspace member. Part of #410 (host coverage epic) / #411 (GitHub Copilot).

This is F0's findings (#417) landed for real rather than the rehearsal itself — #417 stays open as the historical record of which of the twelve package-set guards a new plugin trips and what each says to do. This branch takes that already-CI-proven diff and applies it off current `main` (which carries #421's redact-fallback fix), so it's a clean, mergeable PR rather than a draft.

**What's here:** `package.json`, eslint config, `tsconfig.json`, vitest config (wired to the shared no-network guard and coverage floor), and a placeholder identity module with one test — the same shape as the other three plugin packages minus any product code. Also updates the eslint-config guard suites, `ci.yml`'s turbo-hash exclusion, and the coverage floor table to know about the new package.

**What's deliberately not here.** No `hooks/`, no build wiring, no manifest, no event handling. #411's own Phase A is a spike that needs a live, authenticated session against each real surface (Copilot CLI, VS Code 1.135+ agent mode, the cloud coding agent) to produce recorded fixtures under `plugins/copilot/test/fixtures/`. Phase B's hook files, field tables and event handling are explicitly built *from* those fixtures, not from vendor docs — #411 itself catalogs specific vendor-doc claims already found wrong or contradicted between GitHub's and Microsoft's own pages. Writing hook logic ahead of the spike would repeat exactly the mistake the phased process exists to avoid.

## Verification

- `@akasecurity/eslint-config` test: 1466/1466 (with the package `git add`-ed — the derivations walk `git ls-files`, so an unstaged package under-counts by one everywhere; caught this via two guard failures before staging)
- Full workspace (`pnpm turbo run test`): 46/46 tasks, 0 cached
- `pnpm turbo run lint typecheck`: 52/52
- `pnpm lint:root` / `pnpm typecheck:root`: clean
- `pnpm format:check`: clean

## Next

Phase A spike, which needs a human at the keyboard for VS Code/Copilot CLI live capture — tracked on #411, not started here.
