### PR TITLE
style(web-ui): tighten page padding to p-6

### DIFF
--- a/web-ui/app/(app)/activity/loading.tsx
+++ b/web-ui/app/(app)/activity/loading.tsx
@@ -6,7 +6,7 @@ import {
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div aria-busy className="flex h-full min-h-0 flex-col p-6">
       <PageHeadSkeleton actions />
       {/* Token usage is a chip inside the PageHead actions, not a card of its
           own — so the strip is the only band above the session master/detail. */}

--- a/web-ui/app/(app)/activity/page.tsx
+++ b/web-ui/app/(app)/activity/page.tsx
@@ -133,7 +133,7 @@ export default async function ActivityPage({
     },
   ];
   return (
-    <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div className="flex h-full min-h-0 flex-col p-6">
       {/* Token usage sits in the filter bar beside the range picker rather than
           in a card of its own: it is a per-range summary like the range itself,
           and the vertical band it used to occupy is the session list's. */}

--- a/web-ui/app/(app)/data-shares/loading.tsx
+++ b/web-ui/app/(app)/data-shares/loading.tsx
@@ -2,7 +2,7 @@ import { PageHeadSkeleton, TableSkeleton, ToolbarSkeleton } from '../../componen
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div aria-busy className="flex h-full min-h-0 flex-col p-6">
       <PageHeadSkeleton actions />
       <ToolbarSkeleton />
       <TableSkeleton />

--- a/web-ui/app/(app)/data-shares/page.tsx
+++ b/web-ui/app/(app)/data-shares/page.tsx
@@ -41,7 +41,7 @@ export default async function DataSharesPage({
   const renderedAt = renderInstant();
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div className="flex h-full min-h-0 flex-col p-6">
       <PageHead
         title="Data Shares"
         sub="Outbound data egress detected in your software — grouped by destination"

--- a/web-ui/app/(app)/detections/loading.tsx
+++ b/web-ui/app/(app)/detections/loading.tsx
@@ -6,7 +6,7 @@ import {
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div aria-busy className="flex h-full min-h-0 flex-col p-6">
       <PageHeadSkeleton />
       <CompactStatStripSkeleton />
       <MasterDetailSkeleton listWidth="w-88" />

--- a/web-ui/app/(app)/detections/page.tsx
+++ b/web-ui/app/(app)/detections/page.tsx
@@ -108,7 +108,7 @@ export default async function DetectionsPage({
     },
   ];
   return (
-    <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div className="flex h-full min-h-0 flex-col p-6">
       <PageHead title="Detections" sub="Rules that generate findings from code, prompts & pastes" />
 
       {showsVaultDrift(vaultDrift) && (

--- a/web-ui/app/(app)/error.tsx
+++ b/web-ui/app/(app)/error.tsx
@@ -22,7 +22,7 @@ export default function AppError({
   reset: () => void;
 }) {
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <Card className="mx-auto max-w-lg">
         <CardContent className="flex flex-col items-center gap-4 py-10 text-center">
           <span className="flex size-11 items-center justify-center rounded-full bg-sev-critical-fill">

--- a/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
+++ b/web-ui/app/(app)/exceptions/ExceptionsClient.tsx
@@ -110,7 +110,7 @@ export function ExceptionsClient({
   };
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead
         title="Exceptions"
         sub="Explicit, audited bypasses — one exact value each, never a rule-wide suppression"

--- a/web-ui/app/(app)/exceptions/[id]/loading.tsx
+++ b/web-ui/app/(app)/exceptions/[id]/loading.tsx
@@ -2,7 +2,7 @@ import { CardSkeleton, PageHeadSkeleton } from '../../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="px-8 pb-10 pt-7">
+    <div aria-busy className="p-6">
       <PageHeadSkeleton />
       <CardSkeleton />
     </div>

--- a/web-ui/app/(app)/exceptions/[id]/page.tsx
+++ b/web-ui/app/(app)/exceptions/[id]/page.tsx
@@ -26,7 +26,7 @@ export default async function ExceptionDetailPage({ params }: { params: Promise<
   } catch (err) {
     if (err instanceof AmbiguousExceptionIdError) {
       return (
-        <div className="px-8 pb-10 pt-7 text-sm text-text-2">
+        <div className="p-6 text-sm text-text-2">
           The id prefix “{id}” matches more than one exception — use a longer prefix from the{' '}
           <Link href="/exceptions" className="text-primary underline">
             list
@@ -40,7 +40,7 @@ export default async function ExceptionDetailPage({ params }: { params: Promise<
   if (!exception) notFound();
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <div className="pb-4 text-xs">
         <Link href="/exceptions" className="text-text-3 hover:text-text-2">
           ← All exceptions

--- a/web-ui/app/(app)/exceptions/loading.tsx
+++ b/web-ui/app/(app)/exceptions/loading.tsx
@@ -2,7 +2,7 @@ import { CardSkeleton, PageHeadSkeleton, TableSkeleton } from '../../components/
 
 export default function Loading() {
   return (
-    <div aria-busy className="px-8 pb-10 pt-7">
+    <div aria-busy className="p-6">
       <PageHeadSkeleton />
       <CardSkeleton className="h-24" />
       <TableSkeleton />

--- a/web-ui/app/(app)/exceptions/new/loading.tsx
+++ b/web-ui/app/(app)/exceptions/new/loading.tsx
@@ -2,7 +2,7 @@ import { CardSkeleton, PageHeadSkeleton } from '../../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="px-8 pb-10 pt-7">
+    <div aria-busy className="p-6">
       <PageHeadSkeleton />
       <CardSkeleton />
     </div>

--- a/web-ui/app/(app)/exceptions/new/page.tsx
+++ b/web-ui/app/(app)/exceptions/new/page.tsx
@@ -15,7 +15,7 @@ export default function NewExceptionPage() {
   const options = rules.map((r) => ({ id: r.id, name: r.name }));
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <div className="pb-4 text-xs">
         <Link href="/exceptions" className="text-text-3 hover:text-text-2">
           ← All exceptions

--- a/web-ui/app/(app)/findings/FindingsClient.tsx
+++ b/web-ui/app/(app)/findings/FindingsClient.tsx
@@ -206,7 +206,7 @@ export function FindingsClient(props: CommonProps & ViewProps) {
   const sessionHref = session ? `/activity?id=${encodeURIComponent(session)}` : null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-8 pb-10 pt-7">
+    <div className="flex h-full min-h-0 flex-col p-6">
       <PageHead
         title="Findings"
         sub="Every sensitive-data finding across providers"

--- a/web-ui/app/(app)/findings/loading.tsx
+++ b/web-ui/app/(app)/findings/loading.tsx
@@ -2,7 +2,7 @@ import { PageHeadSkeleton, TableSkeleton, ToolbarSkeleton } from '../../componen
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex h-full min-h-0 flex-col px-8 pb-10 pt-7">
+    <div aria-busy className="flex h-full min-h-0 flex-col p-6">
       <PageHeadSkeleton actions />
       <ToolbarSkeleton />
       <TableSkeleton />

--- a/web-ui/app/(app)/inventory/loading.tsx
+++ b/web-ui/app/(app)/inventory/loading.tsx
@@ -2,7 +2,7 @@ import { MasterDetailSkeleton, PageHeadSkeleton } from '../../components/skeleto
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div aria-busy className="flex h-full min-h-0 flex-col p-6">
       <PageHeadSkeleton />
       <MasterDetailSkeleton />
     </div>

--- a/web-ui/app/(app)/inventory/page.tsx
+++ b/web-ui/app/(app)/inventory/page.tsx
@@ -77,7 +77,7 @@ export default async function InventoryPage({
   const harnessEvents = selHarness ? EMPTY_HARNESS_EVENTS : null;
 
   return (
-    <div className="flex h-full min-h-0 flex-col px-8 pb-8 pt-7">
+    <div className="flex h-full min-h-0 flex-col p-6">
       <PageHead
         title="Inventory"
         sub="Projects, skills, MCP servers, hooks & configuration — with attention flags & per-file LLM access"

--- a/web-ui/app/(app)/policies/loading.tsx
+++ b/web-ui/app/(app)/policies/loading.tsx
@@ -7,7 +7,7 @@ import {
 export default function Loading() {
   return (
     // Mirrors page.tsx's wrapper, including the lg-gated height cap.
-    <div aria-busy className="flex min-h-full flex-col px-8 pb-8 pt-7 lg:h-full lg:min-h-0">
+    <div aria-busy className="flex min-h-full flex-col p-6 lg:h-full lg:min-h-0">
       <PageHeadSkeleton />
       <CompactStatStripSkeleton />
       <MasterDetailSkeleton stacksBelowLg listWidth="w-80" />

--- a/web-ui/app/(app)/policies/page.tsx
+++ b/web-ui/app/(app)/policies/page.tsx
@@ -38,7 +38,7 @@ export default async function PoliciesPage({
     // way Detections/Activity/Inventory behave. Below `lg` the grid stacks into
     // one column, and capping there would split the viewport between two
     // letterboxed panes — so the floor (and the page scroll it implies) stays.
-    <div className="flex min-h-full flex-col px-8 pb-8 pt-7 lg:h-full lg:min-h-0">
+    <div className="flex min-h-full flex-col p-6 lg:h-full lg:min-h-0">
       <PageHead title="Policies" sub="Enforcement actions detections take when they match" />
 
       <PolicyStatsView stats={stats} />

--- a/web-ui/app/(app)/scan/loading.tsx
+++ b/web-ui/app/(app)/scan/loading.tsx
@@ -2,7 +2,7 @@ import { CardSkeleton, PageHeadSkeleton } from '../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex max-w-3xl flex-col gap-6 px-8 pb-10 pt-7">
+    <div aria-busy className="flex max-w-3xl flex-col gap-6 p-6">
       <PageHeadSkeleton />
       <CardSkeleton className="h-50 rounded-xl" />
     </div>

--- a/web-ui/app/(app)/scan/page.tsx
+++ b/web-ui/app/(app)/scan/page.tsx
@@ -12,7 +12,7 @@ export default function ScanPage() {
   const ruleset = db().installedPacks.installedRuleset();
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead
         title="Scan"
         sub="Run the installed detection rules over a local file or directory — the web twin of `aka scan`"

--- a/web-ui/app/(app)/security/loading.tsx
+++ b/web-ui/app/(app)/security/loading.tsx
@@ -2,7 +2,7 @@ import { CardGridSkeleton, PageHeadSkeleton } from '../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="px-8 pb-10 pt-7">
+    <div aria-busy className="p-6">
       <PageHeadSkeleton actions />
       <CardGridSkeleton cards={3} />
       <CardGridSkeleton cards={2} className="mt-4 lg:grid-cols-2 xl:mt-5" />

--- a/web-ui/app/(app)/security/page.tsx
+++ b/web-ui/app/(app)/security/page.tsx
@@ -83,7 +83,7 @@ export default async function SecurityPage({
   // it honest if it ever gains a `use client` directive.
   const renderedAt = renderInstant();
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead
         title="Security"
         sub="Data-exposure posture across all AI traffic"

--- a/web-ui/app/(app)/settings/loading.tsx
+++ b/web-ui/app/(app)/settings/loading.tsx
@@ -5,7 +5,7 @@ import { CardSkeleton, PageHeadSkeleton } from '../../components/skeletons';
 // skeleton followed by a compact page is a layout jump, not a loading state.
 export default function Loading() {
   return (
-    <div aria-busy className="flex max-w-4xl flex-col gap-7 px-8 pb-10 pt-7">
+    <div aria-busy className="flex max-w-4xl flex-col gap-7 p-6">
       <PageHeadSkeleton />
       <CardSkeleton className="h-28 rounded-xl" />
       <CardSkeleton className="h-16 rounded-xl" />

--- a/web-ui/app/(app)/settings/page.tsx
+++ b/web-ui/app/(app)/settings/page.tsx
@@ -44,7 +44,7 @@ export default function SettingsPage() {
   const credentialState = readControlPlaneCredentialState(settingsDir(), settings.controlPlane);
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead title="Settings" sub="Workspace configuration for this machine." />
       <SettingsClient settings={settings} managed={managed} credentialState={credentialState} />
     </div>

--- a/web-ui/app/(app)/updates/loading.tsx
+++ b/web-ui/app/(app)/updates/loading.tsx
@@ -2,7 +2,7 @@ import { CardSkeleton, PageHeadSkeleton } from '../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="flex max-w-3xl flex-col gap-6 px-8 pb-10 pt-7">
+    <div aria-busy className="flex max-w-3xl flex-col gap-6 p-6">
       <PageHeadSkeleton />
       <CardSkeleton className="h-50 rounded-xl" />
       <CardSkeleton className="h-50 rounded-xl" />

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -114,7 +114,7 @@ export default function UpdatesPage() {
   const renderedAt = renderInstant();
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead
         title="Updates"
         sub="Installed vs latest for the CLI and agent plugins — the web twin of `aka update`"

--- a/web-ui/app/(app)/vault/loading.tsx
+++ b/web-ui/app/(app)/vault/loading.tsx
@@ -2,7 +2,7 @@ import { PageHeadSkeleton, TableSkeleton } from '../../components/skeletons';
 
 export default function Loading() {
   return (
-    <div aria-busy className="px-8 pb-10 pt-7">
+    <div aria-busy className="p-6">
       <PageHeadSkeleton />
       <TableSkeleton />
     </div>

--- a/web-ui/app/(app)/vault/page.tsx
+++ b/web-ui/app/(app)/vault/page.tsx
@@ -34,7 +34,7 @@ export default function VaultPage() {
   const renderedAt = renderInstant();
 
   return (
-    <div className="px-8 pb-10 pt-7">
+    <div className="p-6">
       <PageHead
         title="Vault"
         sub="Every value this machine holds, where its pointers have been written, and every de-reference. Reveals are audited."


### PR DESCRIPTION
Every page under `(app)` set its own frame — `px-8 pb-10 pt-7` (32px sides, 28
top, 40 bottom) — which was more room than the content needed and cost a row of
it on the denser lists. This makes it `p-6`, 24 all round.

## What moved

The value was written out **30 times across 29 files**, and had already
drifted: `pb-10` on most pages, `pb-8` on the six that fill their height.
Both collapse to `p-6`, so the pages agree again.

Each page's `loading.tsx` carries the same frame and moves with it. That part
is not optional: the skeleton and the content it stands in for are the same
box, so a frame that changed between them would shift the whole page as the
data lands.

## Why not move it to the shell

`AppShell`'s `<main>` wraps every page and could own this once instead of 29
times. Not done here, deliberately — the pages carry their own height chains
(`flex h-full min-h-0 flex-col`, and `min-h-full … lg:h-full lg:min-h-0` on
policies), and moving the frame onto the scroll container changes what those
resolve against. That is worth doing, but as its own change with its own
pass over all 29 pages rather than folded into a value swap.

## Checks

Padding measured at 24px on all four sides, and the bottom padding still
survives inside `<main>`'s scroll container. Spot-checked Security (scrolling),
Inventory (master/detail height chain) and Settings (`max-w-4xl`).

No test pins these classes, so nothing needed updating. The 12 failures in
`connection.test.ts` and `settings-page.test.ts` are pre-existing on `main` and
unrelated to this diff.