### PR TITLE
fix(activity): search the tool target the timeline already shows

### DIFF
--- a/packages/persistence/src/repositories/activity.ts
+++ b/packages/persistence/src/repositories/activity.ts
@@ -547,6 +547,15 @@ export class SqliteActivityRepository implements ActivityReadPort {
 
     if (query.q) {
       const pattern = containsPattern(query.q);
+      // The descendant arm searches the SAME expression the timeline renders as
+      // a row's detail — `TIMELINE_COLUMNS` above coalesces `$.detail` onto
+      // `$.target`, and so does this. Searching a narrower set than the view
+      // displays is how a session goes missing for a term the user can see on
+      // it: `$.detail` alone matches no `tool_call` at all (that bag carries
+      // `target`, the masked WebFetch url / Bash command, and no `content`), so
+      // a search for a command or a url found nothing while the timeline showed
+      // it. The two expressions have to move together — if one grows a field,
+      // so does the other.
       conditions.push(
         `(content LIKE ? ESCAPE '\\'
           OR json_extract(attributes, '$.project') LIKE ? ESCAPE '\\'
@@ -556,7 +565,8 @@ export class SqliteActivityRepository implements ActivityReadPort {
             SELECT 1 FROM audit_events d
             WHERE d.root_session_id = audit_events.id
               AND (d.content LIKE ? ESCAPE '\\'
-                   OR json_extract(d.attributes, '$.detail') LIKE ? ESCAPE '\\')))`,
+                   OR coalesce(json_extract(d.attributes, '$.detail'),
+                               json_extract(d.attributes, '$.target')) LIKE ? ESCAPE '\\')))`,
       );
       params.push(pattern, pattern, pattern, pattern, pattern, pattern);
     }

--- a/packages/persistence/test/repositories/activity.test.ts
+++ b/packages/persistence/test/repositories/activity.test.ts
@@ -415,6 +415,32 @@ describe('listSessions', () => {
     expect(res.items.map((s) => s.id)).toEqual(['A']);
   });
 
+  // REGRESSION. The descendant arm searched `$.detail` alone, and a `tool_call`
+  // carries none — its searchable text is `$.target`, and it has no `content`
+  // either — so a search for a Bash command or a fetched url matched nothing,
+  // on rows the timeline was rendering that very text for (TIMELINE_COLUMNS
+  // coalesces the same two fields). The case above cannot see this: it searches
+  // a `detection` row, which DOES carry `$.detail`.
+  it('matches q against a tool_call target, which the timeline shows as its detail', async () => {
+    // A REALISTIC tool_call: no `content`, no `$.detail`, its searchable text in
+    // `$.target` — the masked Bash command / WebFetch url the reconciler writes.
+    insertEvent({
+      id: 'B9',
+      sessionId: 'B',
+      type: 'tool_call',
+      startedAt: NOW - HOUR_MS + 3000,
+      attributes: { tool_name: 'Bash', target: 'rg --files-with-matches needle-token' },
+    });
+
+    const res = await activity().listSessions({ limit: 50, q: 'needle-token' });
+    expect(res.items.map((s) => s.id)).toEqual(['B']);
+
+    // The same row through the read that RENDERS it, so the search and the view
+    // are pinned to each other rather than each to a literal of its own.
+    const session = await activity().getSession('B');
+    expect(session?.events.find((e) => e.id === 'B9')?.detail).toContain('needle-token');
+  });
+
   it('filters by from lower bound', async () => {
     const res = await activity().listSessions({
       limit: 50,


### PR DESCRIPTION
Searching the session list for a Bash command or a fetched URL matched nothing — on rows the timeline was displaying that very text for.

## The bug

The descendant arm of the `q` predicate looked at `content` and `$.detail`:

```sql
EXISTS (SELECT 1 FROM audit_events d
        WHERE d.root_session_id = audit_events.id
          AND (d.content LIKE ? OR json_extract(d.attributes,'$.detail') LIKE ?))
```

A `tool_call` carries **neither**. Its searchable text lives in `$.target` — the masked WebFetch url / Bash command — and it has no `content` at all. So every tool call in the store was unmatchable, which is most of what anyone would search their own activity for.

Meanwhile the timeline read has always rendered `coalesce($.detail, $.target)` as a row's detail. The view and the search disagreed about what a row's detail *is*.

## The fix

The search now spells the same expression the display does. Searching a narrower set than the view shows is exactly how a session goes missing for a term the user can see printed on it — so the two are now one expression, with a comment on each saying they move together.

`$.detail` is kept rather than replaced: a `detection` row does carry it, and the coalesce can only ever *add* matches.

## Measured

20k-capture store — 500 session roots, 60,382 descendants — 30-day window:

| search | before | after |
| --- | --- | --- |
| term held in `$.target` | **0 matches**, 27.4 ms | **262 matches**, 1.2 ms |
| term matching nothing | 27.9 ms | 36.2 ms |

The hit case gets ~23× faster because the `EXISTS` can now stop at its first matching descendant instead of walking all of them to conclude nothing matched.

The all-miss case costs ~8 ms more: the coalesce evaluates a second extraction on rows whose `$.detail` is null. That is the honest price of the arm finding anything at all, and it is the path a debounced search box hits while you are still typing.

A follow-up could recover it and more — the same window measured 23.7 ms when the walk skips `llm_call` rows, which carry no content, no target and no detail. It is left out here because the attribute bag has a catchall and `content` is a column, so "an llm_call can never match" is measured rather than proven, and this change is about correctness.

## Test

The regression case drives a `tool_call` whose only searchable text is its target, and asserts **both** that the search finds its session **and** that the timeline renders the same text — so the two reads are pinned to each other rather than each to a literal of its own. Reverting the coalesce fails it with `expected [] to deeply equal [ 'B' ]`.

The existing search case cannot catch this: it searches a `detection` row, which does carry `$.detail`.

## Verification

`activity.test.ts` 39/39. Package suite: 1,541 pass. Nine failures in `settings.test.ts` / `managed-settings.test.ts` / `policy-floor.test.ts` are **pre-existing** — reproduced on a clean tree with this change stashed (1,540 pass, same 9 failures), and unrelated to activity. Lint and format clean.