### PR TITLE
feat(schema,persistence,dashboard-ui): keep known managed locks beside an unknown one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -487,6 +487,11 @@ properties are load-bearing:
   about, which is this section's whole failure mode. And a damaged managed file leaves the machine
   UNMANAGED rather than refusing to run, because a typo in an MDM payload must not break every
   hook on every managed machine at once; that direction is deliberate and stated in the module.
+  One shape is deliberately NOT damage: a lock naming a key this build does not know is dropped
+  from the locked set and reported (`unknownLockedFields`), never a reason to run unmanaged.
+  That is what an older build sees when an administrator locks a key a newer build added, and
+  refusing the whole file there cost it every pin and lock it understood, on exactly the fleets
+  most likely to carry a version skew. A name outside the enum is still never honoured.
 - **Anything derived from the current file is derived INSIDE it.** `applyOnboarding` takes an
   updater function for exactly this: a caller that reads first and passes a plain object has put
   its read outside the lock and kept the lost update, one frame further out. The dashboard's

--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -435,6 +435,22 @@ function SettingGroup({ title, children }: { title: string; children: ReactNode 
   );
 }
 
+/**
+ * The line rendered when an administrator's file locks keys this build does
+ * not know. Such a lock is dropped from the locked set rather than failing the
+ * whole file (which would run the machine unmanaged), and this is the one
+ * place that says a lock exists which is not being applied. A count rather
+ * than the names: the names are the administrator's to fix, in the file.
+ */
+export function managedUnknownLocksNotice(context: ManagedContext): string | undefined {
+  const count = context.unknownLockedFields?.length ?? 0;
+  if (!context.present || count === 0) return undefined;
+  const who = context.organization ?? 'Your organization';
+  return count === 1
+    ? `${who} locks 1 setting this version of AKA does not recognize. Update AKA to apply it.`
+    : `${who} locks ${String(count)} settings this version of AKA does not recognize. Update AKA to apply them.`;
+}
+
 export interface WorkspaceSettingsFormViewProps {
   settings: WorkspaceSettings;
   // What an administrator has pinned, and which of those the user may not
@@ -566,6 +582,7 @@ export function WorkspaceSettingsFormView({
   // ends up editable.
   const lockOn = (key: ManagedSettingKey): string | undefined =>
     isFieldManaged(managed, key) ? managedByLabel(managed) : undefined;
+  const unknownLocks = managedUnknownLocksNotice(managed);
 
   const dirty =
     historicalAccess !== settings.historicalAccess ||
@@ -589,6 +606,11 @@ export function WorkspaceSettingsFormView({
 
   return (
     <div className="flex max-w-4xl flex-col gap-7">
+      {unknownLocks !== undefined && (
+        <p className="text-xs text-text-3" data-slot="managed-unknown-locks">
+          {unknownLocks}
+        </p>
+      )}
       <SettingGroup title="Connection">
         <ConnectionRow
           settings={settings}

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -36,6 +36,7 @@ import {
   HISTORY_SYNC_STALE_NOTICE,
   INLINE_REVEAL_CHOICES,
   INLINE_REVEAL_SECTION_DESCRIPTION,
+  managedUnknownLocksNotice,
   MODEL_JUDGE_CHOICES,
   MODEL_JUDGE_SECTION_DESCRIPTION,
   MODEL_JUDGE_SECTION_LABEL,
@@ -835,6 +836,55 @@ describe('administratively locked rows', () => {
     );
     expect(inputFor(html, 'historicalAccess')).not.toContain('disabled');
     expect(html).not.toContain('data-slot="managed-notice"');
+  });
+
+  it('says when the administrator locked a key this build does not know', () => {
+    // The lock is dropped rather than failing the file, so this line is the
+    // only thing that tells the user a lock exists which is not being applied.
+    // The known lock beside it must still hold.
+    const html = renderToStaticMarkup(
+      createElement(WorkspaceSettingsFormView, {
+        settings,
+        onSave: () => undefined,
+        managed: {
+          present: true,
+          organization: 'Acme',
+          lockedFields: ['historicalAccess'],
+          unknownLockedFields: ['lockFromANewerBuild'],
+        },
+      }),
+    );
+    expect(html).toContain('data-slot="managed-unknown-locks"');
+    expect(html).toContain('Acme locks 1 setting');
+    expect(inputFor(html, 'historicalAccess')).toContain('disabled');
+  });
+
+  it('says nothing about unknown locks when every lock is known', () => {
+    expect(lockedHtml()).not.toContain('data-slot="managed-unknown-locks"');
+  });
+
+  it('words the unknown-lock notice for one and for several, and never on an unmanaged machine', () => {
+    const one = managedUnknownLocksNotice({
+      present: true,
+      lockedFields: [],
+      unknownLockedFields: ['a'],
+    });
+    expect(one).toContain('Your organization locks 1 setting');
+    expect(one).toContain('apply it.');
+    const several = managedUnknownLocksNotice({
+      present: true,
+      organization: 'Acme',
+      lockedFields: [],
+      unknownLockedFields: ['a', 'b'],
+    });
+    expect(several).toContain('Acme locks 2 settings');
+    expect(several).toContain('apply them.');
+    // Gated on `present` like isFieldManaged: a stale context must not
+    // announce locks from an administrator who is not there.
+    expect(
+      managedUnknownLocksNotice({ present: false, lockedFields: [], unknownLockedFields: ['a'] }),
+    ).toBeUndefined();
+    expect(managedUnknownLocksNotice({ present: true, lockedFields: [] })).toBeUndefined();
   });
 });
 

--- a/packages/persistence/src/managed-settings.ts
+++ b/packages/persistence/src/managed-settings.ts
@@ -74,6 +74,13 @@ export function managedSettingsPaths(platform: NodeJS.Platform = process.platfor
  * damaged administrative file) turns a typo in an MDM payload into every hook
  * on every managed machine breaking at once, which is a far worse outcome than
  * a lock that has to be noticed and repaired.
+ *
+ * One shape is deliberately NOT read as damage: a `lockedFields` entry naming a
+ * key this build does not know. That is what an older build sees when an
+ * administrator locks a key a newer build added, and refusing the whole file
+ * there ran it unmanaged, every pin and lock gone. The schema drops such a name
+ * from the locked set and reports it as `unknownLockedFields`, so every lock
+ * this build understands still holds and the surface can say one does not.
  */
 export function readManagedSettings(
   paths: string[] = managedSettingsPaths(),
@@ -103,6 +110,9 @@ export function managedContextOf(managed: ManagedSettings | null): ManagedContex
     present: true,
     ...(managed.organization === undefined ? {} : { organization: managed.organization }),
     lockedFields: managed.lockedFields,
+    ...(managed.unknownLockedFields === undefined
+      ? {}
+      : { unknownLockedFields: managed.unknownLockedFields }),
   };
 }
 

--- a/packages/persistence/test/managed-settings.test.ts
+++ b/packages/persistence/test/managed-settings.test.ts
@@ -99,6 +99,23 @@ describe('readManagedSettings — fail-open on a damaged administrative file', (
     const managed = readManagedSettings([join(managedDir, MANAGED_SETTINGS_FILENAME)]);
     expect(managed?.organization).toBe('Acme');
     expect(managed?.lockedFields).toEqual(['runMode']);
+    // Every lock was known, so the context carries no key saying otherwise.
+    expect(managedContextOf(managed)).not.toHaveProperty('unknownLockedFields');
+  });
+
+  it('keeps every lock it knows beside one it does not, and reports the stranger', () => {
+    // An administrator locking a key a NEWER build added must not cost an
+    // older build the locks it understands. Refusing the file here ran the
+    // machine unmanaged — every pin and lock gone — on exactly the fleets most
+    // likely to carry a version skew.
+    writeManaged({ organization: 'Acme', lockedFields: ['runMode', 'lockFromANewerBuild'] });
+    const managed = readManagedSettings([managedFile()]);
+    expect(managed?.lockedFields).toEqual(['runMode']);
+    expect(managed?.unknownLockedFields).toEqual(['lockFromANewerBuild']);
+    const context = managedContextOf(managed);
+    expect(context.present).toBe(true);
+    expect(isFieldManaged(context, 'runMode')).toBe(true);
+    expect(context.unknownLockedFields).toEqual(['lockFromANewerBuild']);
   });
 
   it('runs UNMANAGED rather than refusing when the file is malformed', () => {
@@ -110,7 +127,9 @@ describe('readManagedSettings — fail-open on a damaged administrative file', (
   });
 
   it('skips a file whose shape fails the schema', () => {
-    writeManaged({ lockedFields: ['notASetting'] });
+    // A shape the reader cannot read, not a name it does not know: the
+    // unknown-name case is tolerated on purpose, above.
+    writeManaged({ lockedFields: 'runMode' });
     expect(readManagedSettings([join(managedDir, MANAGED_SETTINGS_FILENAME)])).toBeNull();
   });
 
@@ -132,7 +151,7 @@ describe('readManagedSettings — fail-open on a damaged administrative file', (
   it('falls through a malformed first location to a valid second', () => {
     const second = mkdtempSync(join(tmpdir(), 'aka-managed-2-'));
     try {
-      writeManaged({ lockedFields: ['bogus'] });
+      writeManaged({ lockedFields: 'bogus' });
       writeManaged({ organization: 'Second' }, second);
       const managed = readManagedSettings([
         join(managedDir, MANAGED_SETTINGS_FILENAME),

--- a/packages/schema/src/zod/managed.ts
+++ b/packages/schema/src/zod/managed.ts
@@ -37,6 +37,11 @@ export const ManagedSettingKey = z
   .meta({ id: 'ManagedSettingKey' });
 export type ManagedSettingKey = z.infer<typeof ManagedSettingKey>;
 
+/** Whether a name in an administrator's file is a key this build can lock. */
+export function isManagedSettingKey(value: string): value is ManagedSettingKey {
+  return ManagedSettingKey.safeParse(value).success;
+}
+
 // The values an administrator may pin, as a partial overlay. Each is the same
 // shape WorkspaceSettings carries for that key, so an overlay cannot introduce
 // a value the settings schema would reject.
@@ -77,7 +82,30 @@ export const ManagedSettings = z
     // Which of those the user may not change. A key here with no matching value
     // freezes whatever the user last chose; a value with no lock is a DEFAULT
     // the user may still override. The two are separable on purpose.
-    lockedFields: z.array(ManagedSettingKey).default([]),
+    //
+    // Parsed as NAMES rather than as the enum, and split below: a name this
+    // build does not know is dropped from the locked set and reported, never a
+    // reason to refuse the file. The same shape reaches an older build whenever
+    // an administrator locks a key a newer build added, and refusing it there
+    // ran that build entirely unmanaged — every pin and lock gone — on exactly
+    // the fleets most likely to carry a version skew. A name outside the enum
+    // is still never HONOURED: the lockable set stays explicit above.
+    lockedFields: z.array(z.string()).default([]),
+  })
+  .transform(({ lockedFields, ...rest }) => {
+    const known: ManagedSettingKey[] = [];
+    const unknown: string[] = [];
+    for (const name of lockedFields) {
+      if (isManagedSettingKey(name)) known.push(name);
+      else unknown.push(name);
+    }
+    // The unknown list is present only when non-empty, so the ordinary file
+    // carries no key for it and a consumer spreading the result carries none.
+    return {
+      ...rest,
+      lockedFields: known,
+      ...(unknown.length > 0 ? { unknownLockedFields: unknown } : {}),
+    };
   })
   .meta({ id: 'ManagedSettings' });
 export type ManagedSettings = z.infer<typeof ManagedSettings>;
@@ -91,6 +119,10 @@ export interface ManagedContext {
   present: boolean;
   organization?: string;
   lockedFields: readonly ManagedSettingKey[];
+  // Names the administrator locked that this build does not know, so a
+  // surface can say a lock exists that it is not applying. Absent when there
+  // are none.
+  unknownLockedFields?: readonly string[];
 }
 
 export const NO_MANAGED_CONTEXT: ManagedContext = { present: false, lockedFields: [] };

--- a/packages/schema/test/zod/managed.test.ts
+++ b/packages/schema/test/zod/managed.test.ts
@@ -55,12 +55,33 @@ describe('ManagedSettings parsing', () => {
     expect(parsed.specVersion).toBeGreaterThan(0);
   });
 
-  it('refuses a lock on a key that is not lockable', () => {
+  it('keeps the locks it knows and reports the ones it does not', () => {
     // The lockable set is an explicit enum rather than keyof WorkspaceSettings,
-    // so a field added tomorrow is not remotely lockable until someone decides
-    // it should be.
-    expect(ManagedSettings.safeParse({ lockedFields: ['onboardedAt'] }).success).toBe(false);
-    expect(ManagedSettings.safeParse({ lockedFields: ['notASetting'] }).success).toBe(false);
+    // so a name outside it is never honoured — `onboardedAt` is bookkeeping and
+    // `notASetting` is a typo. But neither may cost the file its OTHER locks:
+    // this is the shape an older build sees when an administrator locks a key
+    // a newer build added, and refusing the file there ran that build
+    // unmanaged with every pin and lock gone.
+    const parsed = ManagedSettings.parse({
+      lockedFields: ['runMode', 'onboardedAt', 'notASetting'],
+    });
+    expect(parsed.lockedFields).toEqual(['runMode']);
+    expect(parsed.unknownLockedFields).toEqual(['onboardedAt', 'notASetting']);
+  });
+
+  it('reports no unknown locks at all when every lock is known', () => {
+    // Absent rather than empty: the ordinary file carries no key for it, so a
+    // consumer spreading the result carries none either.
+    const parsed = ManagedSettings.parse({ lockedFields: ['runMode'] });
+    expect(parsed.lockedFields).toEqual(['runMode']);
+    expect(parsed).not.toHaveProperty('unknownLockedFields');
+  });
+
+  it('still refuses a lockedFields that is not a list of names', () => {
+    // Tolerance is for a NAME this build does not know, not for a shape it
+    // cannot read. A string or a number here is a damaged file.
+    expect(ManagedSettings.safeParse({ lockedFields: 'runMode' }).success).toBe(false);
+    expect(ManagedSettings.safeParse({ lockedFields: [1] }).success).toBe(false);
   });
 
   it('refuses an empty endpoint on a pinned connection', () => {


### PR DESCRIPTION
F1 of the host-coverage epic (#410), the prerequisite item #418 wrote down: make `lockedFields` tolerant of a key this build does not know, so an older build keeps every lock it understands when an administrator locks a key a newer build added.

## The defect

`lockedFields` was `z.array(ManagedSettingKey)`, so a managed file naming any key outside the enum failed the parse, `readManagedSettings` returned `null`, and the machine ran **entirely unmanaged** — every existing pin and lock gone. That is exactly the shape an older build sees the moment a policy locks `redactFallback` (or the next key), and it lands on the fleets most likely to carry a version skew. #418 recorded it as an ordering hazard no version bump fixes; this is the fix.

## What changes

- **Schema** (`managed.ts`): `lockedFields` is parsed as a list of names and split by a transform — the names this build knows stay in `lockedFields`, the rest are reported as `unknownLockedFields`, present only when non-empty. `isManagedSettingKey` is the guard. The lockable set stays an explicit enum, and a name outside it is still never honoured: it is dropped, not applied.
- **Persistence** (`managed-settings.ts`): `managedContextOf` carries `unknownLockedCount` onto `ManagedContext` — the COUNT, not the names, because the context is handed to a client component and serialized to the browser on every settings render, while the names are unbounded where `lockedFields` is bounded by the enum. The names stay on the parsed `ManagedSettings` for a reader that wants them.
- **Dashboard** (`WorkspaceSettingsFormView.tsx`): one line at the top of the Settings page — "Acme locks 1 setting this version of AKA does not recognize. Update AKA to apply it." — so the drop is visible rather than silent. A count, not the names: the names are the administrator's to fix, in the file. Gated on `present` like `isFieldManaged`.
- **CLAUDE.md §6**: the managed-overlay bullet states the one shape that is deliberately not damage.

## What does not change

Tolerance is for a **name** this build does not know, not a **shape** it cannot read. A `lockedFields` that is a string, or that holds a number, still fails the parse and still leaves the machine unmanaged — the fail-open-on-damage posture is untouched, and both directions are pinned.

**And it closes only the lock half.** `ManagedSettingsValues` is a plain `z.object`, so an unrecognised *value* key was never refused — but it is dropped **silently**, with no `unknownValueFields`, no notice and nothing on this page. That half is untouched here and is filed as #437, because this PR adds the one place on the Settings page that talks about version skew, and it answers only the lock half.

## Tests

- Schema: keeps known locks beside unknown ones and reports them; reports no `unknownLockedFields` key at all when every lock is known; still refuses a non-list.
- Persistence: a file locking `runMode` and a key from a newer build reads as managed with `runMode` locked and the stranger reported; the two malformed-file cases now use a genuinely malformed shape, since the name they used is tolerated on purpose.
- Dashboard: the notice renders with the count and the known lock still disables its row; absent when every lock is known; wording for one and several; nothing on an unmanaged context.
- **Mutation-verified**: restoring `z.array(ManagedSettingKey)` reddens the new schema case and the new persistence case, and nothing else.

## Verification

- Typecheck: schema, persistence, dashboard-ui, web-ui — clean.
- Tests: schema 905/905, dashboard-ui 542/542, web-ui 740/740, persistence 1579 passed (2 platform skips).
- `@akasecurity/eslint-config` guards: 1466/1466.
- Lint on the three touched packages clean; `pnpm format:check` clean.

