### PR TITLE
feat(claude-code): record which surface of Claude Code a session runs on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,7 @@ and adding one anywhere schema can reach is what would break it.
 
 ### 3. `process.env` is off by default
 
-ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Nine places in shipped source genuinely need the host environment and opt out. Three kinds of file are out of this table's scope and carry inline disables of their own: test harnesses that spawn the real hooks, the real installer scripts, and `tools/` — repo tooling that is never shipped, where a CI gate reads the runner's own output channels. All three are inventoried by `packages/eslint-config/test/inline-disables.test.js` instead, which reads the whole tracked tree rather than only what this table calls shipped:
+ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace — a violation is a CI failure, not a warning. Ten places in shipped source genuinely need the host environment and opt out. Three kinds of file are out of this table's scope and carry inline disables of their own: test harnesses that spawn the real hooks, the real installer scripts, and `tools/` — repo tooling that is never shipped, where a CI gate reads the runner's own output channels. All three are inventoried by `packages/eslint-config/test/inline-disables.test.js` instead, which reads the whole tracked tree rather than only what this table calls shipped:
 
 | Site                                              | Mechanism                         | Why                                                         |
 | ------------------------------------------------- | --------------------------------- | ----------------------------------------------------------- |
@@ -184,8 +184,9 @@ ESLint (`n/no-process-env`) forbids reading `process.env` across the workspace �
 | `plugins/antigravity/src/triage/judge.ts`         | file-scoped ESLint config         | the judge subprocess must inherit PATH + `~/.gemini` auth   |
 | `packages/plugin-sdk/src/provider-antigravity.ts` | file-scoped ESLint config         | LLM-provider resolution at Antigravity's first invocation   |
 | `packages/plugin-sdk/src/bare-command.ts`         | file-scoped ESLint config         | the env an env-less Windows spawn inherits, for `where.exe` |
+| `plugins/claude-code/src/hooks/session-start.ts`  | file-scoped ESLint config         | the interface the host stamps on its own subprocess env     |
 
-Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding a tenth site means updating this table.
+Prefer a file-scoped config opt-out over an inline disable — an inline disable is invisible to anyone auditing the ESLint configs. Adding an eleventh site means updating this table.
 
 That last sentence is enforced, not merely asked: `packages/eslint-config/test/effective-config.test.js` parses this table and drives each column against the thing it describes — the site against the tracked tree, the mechanism against the resolved config and the file's own text, the count word against the row count, and the row set against every opt-out shipped source actually carries. So a fifth site that never reaches the table fails CI, and so does a row that outlives the exception it describes. The `Why` column is prose about intent and is guarded by nothing.
 

--- a/packages/eslint-config/test/helpers/claude-md.js
+++ b/packages/eslint-config/test/helpers/claude-md.js
@@ -139,6 +139,7 @@ const CARDINALS = [
   'eight',
   'nine',
   'ten',
+  'eleven',
 ];
 const ORDINALS = [
   'zeroth',
@@ -152,6 +153,7 @@ const ORDINALS = [
   'eighth',
   'ninth',
   'tenth',
+  'eleventh',
 ];
 
 /** The English word for `n`. Throws past the list rather than returning undefined. */

--- a/plugins/claude-code/eslint.config.mjs
+++ b/plugins/claude-code/eslint.config.mjs
@@ -12,5 +12,16 @@ export default [
       },
     },
   },
+  {
+    // SessionStart reads the interface the HOST stamps on its own subprocess
+    // environment (terminal, the VS Code panel, the desktop app). Nothing else
+    // in a hook's payload distinguishes them, and the transcript cannot: the
+    // record carrying `entrypoint` does not exist yet when a fresh session
+    // starts.
+    files: ['src/hooks/session-start.ts'],
+    rules: {
+      'n/no-process-env': 'off',
+    },
+  },
   ...rootConfigFiles,
 ];

--- a/plugins/claude-code/src/hooks/session-start.ts
+++ b/plugins/claude-code/src/hooks/session-start.ts
@@ -27,6 +27,27 @@ import { standingBrief } from '../protocol/notes.ts';
 import { emit, getString, parseJson, readStdin } from './shared.ts';
 import { warnIfStoreRedirected } from './store-health.ts';
 
+// Which SURFACE of Claude Code is running this session — the value the host
+// stamps on its own subprocess environment. `claude-vscode` for the VS Code
+// panel, `claude-desktop` for the desktop app, `cli` for a terminal, plus the
+// SDK's own spellings; treated as an opaque string either way, never mapped to
+// a harness id here.
+//
+// Read from the environment rather than peeked out of the transcript, and the
+// difference is not a preference. `entrypoint` appears on the first
+// user/assistant record — measured as record 3 or 4 across sixty transcripts —
+// so a session that has just STARTED has no record carrying it, which is every
+// `source: startup` session at the moment this hook runs. The transcript stays
+// the backfill's source (history/usage.ts reads it there, where the records
+// exist).
+//
+// Best-effort: an absent or empty value omits the fact, which is exactly the
+// behaviour before this existed. Nothing downstream requires it.
+function harnessInterface(): string | undefined {
+  const value = process.env.CLAUDE_CODE_ENTRYPOINT;
+  return value === undefined || value === '' ? undefined : value;
+}
+
 // The plugin's own version, read from the manifest the hook command passes as
 // argv[2] (same source as the intro card). Best-effort: an unreadable/old
 // manifest just omits the version — the harness dimension still resolves on tool.
@@ -68,10 +89,11 @@ async function main(): Promise<void> {
     tool: SOURCE_TOOL.ClaudeCode,
     harnessVersion: version,
     pluginBuild: version === undefined ? undefined : { package: PLUGIN_PACKAGE, version },
-    // harnessInterface is intentionally omitted: Claude Code's SessionStart hook
-    // exposes no meaningful interface discriminator (terminal vs IDE vs web) yet.
-    // The resolver already folds it into the harness bag, so pass it here once
-    // the harness surfaces one — no schema change needed.
+    // The surface this session is running on, when the host says. Folded into
+    // the harness bag by the resolver and snapshotted as `harness_interface`;
+    // absent when the host stamps nothing, which reads as unknown rather than
+    // as a terminal session.
+    harnessInterface: harnessInterface(),
   });
   // Stale-session notice (once per session — it rides the SessionStart claim):
   // a newer binary recorded the mirror, so this session's plugin generation is

--- a/plugins/claude-code/test/e2e/session-start-interface.e2e.test.ts
+++ b/plugins/claude-code/test/e2e/session-start-interface.e2e.test.ts
@@ -1,0 +1,103 @@
+// SessionStart records WHICH SURFACE of Claude Code is running — the terminal,
+// the VS Code panel, the desktop app — from the value the host stamps on its
+// own subprocess environment. Drives the REAL built script, because the read is
+// of `process.env` inside that process and nothing an in-process test does can
+// stand in for it.
+//
+// Why not the transcript, which also carries an `entrypoint`: that field sits on
+// the first user/assistant record (measured as record 3 or 4 across sixty
+// transcripts on a reference machine), so a session that has just STARTED has no
+// record carrying it — which is every `source: startup` session at the moment
+// this hook runs. The transcript stays the backfill's source, where the records
+// do exist by the time it reads them.
+import { mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+import { describe, expect, it } from 'vitest';
+
+import { runHook, tempHomeEnv, withTempHome } from '../helpers/run-hook.ts';
+
+const SESSION_ID = 'session-start-interface-e2e';
+
+function payload(home: string): string {
+  const cwd = join(home, 'project');
+  mkdirSync(cwd, { recursive: true });
+  return JSON.stringify({
+    session_id: SESSION_ID,
+    cwd,
+    hook_event_name: 'SessionStart',
+    source: 'startup',
+  });
+}
+
+/**
+ * The session root's attribute bag, read back out of the store the hook wrote.
+ *
+ * Read with `node:sqlite` directly (the pattern the history suites already use)
+ * because nothing in `@akasecurity/persistence` surfaces `harness_interface`
+ * yet: it is written by the capture path and rendered by no read surface. That
+ * gap is not this file's to close, but it does mean the value has to be
+ * asserted where it lands rather than through an API.
+ */
+function sessionRootAttributes(home: string): Record<string, unknown> {
+  const db = new DatabaseSync(join(home, '.aka', 'data', 'aka.db'), { readOnly: true });
+  try {
+    const row = db
+      .prepare("SELECT attributes FROM audit_events WHERE id = ? AND event_type = 'session'")
+      .get(SESSION_ID) as { attributes: string } | undefined;
+    expect(row, 'the hook wrote no session root').toBeDefined();
+    return JSON.parse(row?.attributes ?? '{}') as Record<string, unknown>;
+  } finally {
+    db.close();
+  }
+}
+
+describe('session-start records the harness interface the host stamps', () => {
+  it('records the VS Code panel as its own interface', () => {
+    withTempHome((home) => {
+      const result = runHook('session-start', payload(home), {
+        env: { ...tempHomeEnv(home), CLAUDE_CODE_ENTRYPOINT: 'claude-vscode' },
+      });
+      expect(result.status).toBe(0);
+
+      const attributes = sessionRootAttributes(home);
+      expect(attributes.harness_interface).toBe('claude-vscode');
+      // Opaque, and NOT folded into the harness id: the surface is recorded
+      // beside the tool, never in place of it.
+      expect(attributes.harness).toBe('claudecode');
+    });
+  });
+
+  it('carries the value through verbatim, whatever the host says', () => {
+    // The set of spellings is the host's, not this plugin's — `sdk-ts`,
+    // `claude-desktop`, `remote*` and others exist — so nothing here may
+    // validate against a list this plugin would have to keep in step.
+    withTempHome((home) => {
+      runHook('session-start', payload(home), {
+        env: { ...tempHomeEnv(home), CLAUDE_CODE_ENTRYPOINT: 'sdk-ts' },
+      });
+      expect(sessionRootAttributes(home).harness_interface).toBe('sdk-ts');
+    });
+  });
+
+  it('omits the fact when the host stamps nothing, rather than guessing a terminal', () => {
+    // Empty rather than deleted: `runHook` layers its env over the host's, and
+    // this process is itself a Claude Code session carrying the variable — so a
+    // test that merely left it unset would inherit whatever ran the suite. The
+    // hook treats empty and absent alike, which is what makes that substitution
+    // sound; a reader who needs the truly-unset case has the same code path.
+    withTempHome((home) => {
+      const result = runHook('session-start', payload(home), {
+        env: { ...tempHomeEnv(home), CLAUDE_CODE_ENTRYPOINT: '' },
+      });
+      expect(result.status).toBe(0);
+
+      const attributes = sessionRootAttributes(home);
+      expect(attributes).not.toHaveProperty('harness_interface');
+      // The positive control: the root was written and IS populated, so the
+      // absence above is a missing key rather than a missing row.
+      expect(attributes.harness).toBe('claudecode');
+    });
+  });
+});


### PR DESCRIPTION
#412 Phase B. SessionStart records **which surface of Claude Code** a session is running on — the terminal, the VS Code panel, the desktop app — into the session root's existing `harness_interface` attribute.

Every Claude Code session root written so far carries none: **1,894 of 1,894** on a reference machine. The attribute itself is not new; Codex populates it from its transcript's originator, and the browser extension records `claude.ai` / `chatgpt.com`. Claude Code was the gap.

## The issue's design does not work, and this is what replaced it

#412 Phase B says to peek the transcript's first record for `entrypoint`, the Codex `peekSessionOriginator` precedent. Measured before building on it:

- `entrypoint` first appears on record **3 or 4** of a transcript, never the first — the first is `queue-operation`, `bridge-session` or `mode` — so a 4KB first-line peek finds nothing.
- A session that has just **started** has no such record at all, which is every `source: startup` session at the moment this hook runs.
- The reconcile cannot repair it later either: the session-root upsert only ever fills an attribute-less stub, and SessionStart has already populated one. That is why `history/usage.ts` forwarding `anchor.entrypoint` has never landed on a live session.

Reading the value the host stamps on its own subprocess environment answers for a fresh session, which is the case the transcript cannot reach. The transcript keeps its existing job as the **backfill's** source, where by then the records exist.

## What it costs, and what it does not do

It costs a §3 `process.env` opt-out — file-scoped, with the table, its count word and the "adding a site" sentence moved, and the guard's ordinal list extended by the word it now needs.

Deliberately **not** here:

- **No new `HARNESS` member for the panel.** Under D2 (resolved on #410) that surface gets its own display id — but a new member needs a `SCAN_COVERAGE` row, and that number is an argument the panel spike has to supply rather than one to invent. `harness` stays `claudecode`; the surface is recorded beside the tool, never in place of it.
- **No rendering.** The attribute is written by the capture path and read by no surface. That gap is pre-existing (Codex and the extension sit in it too) and is a separate #412 bullet.

## Caveat, stated rather than buried

The stamp was confirmed present in a **subprocess** of the host binary, not observed in a hook process specifically. `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` exists and its list could not be read out of the binary; a subprocess carrying the variable is evidence the scrub does not strip it, and installing a probe hook to watch one directly was outside what this session could do. If a panel session turns out to omit it, the fact is simply absent and nothing else changes — which is exactly today's behaviour.

## Tests

Three cases driving the **real built script**, because the read is of `process.env` inside that process and no in-process test can stand in for it: the panel value recorded, an arbitrary host spelling carried through verbatim (the set of spellings is the host's, so nothing validates against a list this plugin would have to keep in step), and an absent stamp omitting the fact with a positive control that the root was still written and populated.

Mutation-verified: dropping the read reds two of the three, and the third is the control that must survive it.

## Verification

- Full workspace: `turbo run test` 46/46, `typecheck lint` 52/52, `format:check` clean.
- `@akasecurity/eslint-config` guards 1466/1466 — including the §3 table audit, which fails on the count word alone.
