### PR TITLE
test: make suites hermetic against the machine's managed-settings overlay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1816,7 +1816,7 @@ twenty-eight cases across `persistence`, `plugin-sdk` and the CLI on a clean
 checkout of main. CI has no such file, so CI stayed green and the failure landed
 only on the machines with no gate on them.
 
-Four things about it are load-bearing:
+Five things about it are load-bearing:
 
 - **A per-call override cannot replace it.** `readEffectiveSettings` and
   `applyOnboarding` both take a `managedOverride`, and neither reaches the reads
@@ -1844,6 +1844,27 @@ Four things about it are load-bearing:
   unmocked instance back — nineteen cases failing on a branch they could no longer
   enter. Their own "the interception fired" guards are what caught it. That import
   is pinned by its own case in the guard suite.
+- **A CHILD PROCESS is invisible to it**, exactly as one is to the no-network
+  guard, and for the same reason: the pin lives in ONE process's instance of
+  `managed-settings.ts`, and a spawned child loads its own copy with the shipped
+  `null`. A redirected `HOME` does not move an absolute system path — which is
+  the premise this whole section rests on — so the child reads the real
+  administrator's file. Measured rather than reasoned: with the pin installed,
+  the parent reads `null` while a child spawned with `HOME` redirected reads the
+  machine's own managed values. Every suite that drives a BUILT script is on the
+  far side of that boundary. `plugins/*/test/e2e/fail-open.e2e.test.ts` runs the
+  built hooks under a redirected home and `loadConfig` applies the overlay inside
+  the child, so an administrator pinning `redactFallback` — a key that is both
+  pinnable and lockable — flips rows asserting an exact wire shape. Read that as
+  REACHABLE rather than currently failing: those suites pass on the enrolled
+  machine that motivated this section, whose file pins `runMode` and not
+  `redactFallback`. A worker thread sits on the same boundary and is out of reach
+  today only because `scan-worker.ts` takes no persistence dependency. It is
+  documented rather than closed, because the no-network guard's own mechanism
+  does not transfer: it reaches a worker by appending `--import <itself>` to its
+  `execArgv`, and a child spawned with a deliberately minimal env cannot be
+  reached that way. Nothing covers this the way the `No-network` CI job covers
+  shell-outs.
 
 ### The PATH shim, and why it fails OPEN
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1128,6 +1128,16 @@ tools/                repo tooling, never shipped: the installer one-liners and
    test: { setupFiles: [noNetworkGuard], … }
    ```
 
+   A package whose dependency closure can load `@akasecurity/persistence` wires a
+   SECOND setup file beside it, `test/setup/no-managed-settings.ts` — the
+   administrative overlay is read from absolute system paths a temp home cannot
+   redirect, so without it the package's suite reads whichever administrator the
+   developer's own machine is enrolled with. That set is DERIVED rather than
+   listed, by `packages/eslint-config/test/no-managed-settings-guard.test.js`, so a
+   new package that takes such a dependency is told to wire it rather than
+   discovering it as twenty-eight unrelated-looking failures later. See "The
+   no-managed-settings guard" under Testing.
+
    A package that also declares `testTimeout`/`hookTimeout` in that config must add
    itself to `TIMEOUTS` in `packages/eslint-config/test/hook-timeout-ratchet.test.js`,
    which pins every package's ceilings as an EXACT map. The ratchet holds in BOTH
@@ -1789,6 +1799,51 @@ front door only, which is why phase 3 asserts the drop-back landed as well — a
 evaluate false without checking. The full reasoning is in the script's own header and
 phase-3 comment; it is not restated here, because a rationale kept in two places is one
 that goes out of step.
+
+### The no-managed-settings guard
+
+`test/setup/no-managed-settings.ts` is the second shared setup file, wired beside
+the no-network guard by every package whose dependency closure can load
+`@akasecurity/persistence`. It declares, once per test file, that the machine has
+**no administrator**.
+
+The administrative overlay (§6) is read from absolute system paths — outside
+`~/.aka` on purpose, so a lock is not removable by the party being locked — and
+`base` redirects only the home. So a suite that builds a whole fake machine in a
+temp dir still reads the REAL managed file, and its result depends on who ran it:
+a laptop enrolled for dogfooding pins `runMode: attached`, which failed
+twenty-eight cases across `persistence`, `plugin-sdk` and the CLI on a clean
+checkout of main. CI has no such file, so CI stayed green and the failure landed
+only on the machines with no gate on them.
+
+Four things about it are load-bearing:
+
+- **A per-call override cannot replace it.** `readEffectiveSettings` and
+  `applyOnboarding` both take a `managedOverride`, and neither reaches the reads
+  that actually fail: `db.installedPacks.setPolicy()` reaches
+  `readWorkspaceSettings` through `openControlPlaneFloors`, and `aka sync-history`
+  reaches it again inside the attached-mode pass. Threading a parameter there
+  means a test-only argument on `openLocalDatabase` and on the history-sync deps,
+  and the next deep caller reopens the hole. The property is process-scoped
+  because the thing it describes — which administrator owns this machine — is.
+- **It moves the DEFAULT only.** `readManagedSettings` still honours paths it is
+  given, which is what keeps the managed layer's own suite testing the managed
+  layer rather than asserting an unmanaged machine. Verified by mutation: making
+  `overlayManagedSettings` a no-op still reds 39 of that file's 75 cases.
+- **The seam it installs is test-only, and audited.**
+  `UNSAFE_TEST_ONLY_setManagedSettingsPaths` is named by exactly one shipped file
+  and is NOT re-exported from the package entry point — the same two properties
+  the raw handle carries, held by
+  `packages/eslint-config/test/test-only-seam.test.js`. The setup file reaches it
+  by relative path, which is why no `exports` entry is needed.
+- **It imports ONE MODULE, never the package barrel.** A setup file loads before
+  every test file in every package that wires it, so whatever it imports is cached
+  before any of them registers a mock. Importing the barrel pre-cached `paths.ts`,
+  `fingerprint.ts` and the vault against the real `node:fs`, and the three suites
+  that `vi.mock('node:fs')` and then `await import('../src/paths.ts')` got the
+  unmocked instance back — nineteen cases failing on a branch they could no longer
+  enter. Their own "the interception fired" guards are what caught it. That import
+  is pinned by its own case in the guard suite.
 
 ### The PATH shim, and why it fails OPEN
 

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -10,13 +10,20 @@ import { coverageOptions } from '../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // The CLI suite exercises real node:sqlite file I/O, which runs slowly under
 // Turbo's parallel task load, so raise the per-test AND per-hook timeouts above
 // vitest's 5s/10s defaults (mirrors packages/persistence/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20_000,

--- a/packages/eslint-config/test/effective-config.test.js
+++ b/packages/eslint-config/test/effective-config.test.js
@@ -660,6 +660,7 @@ const EXPECTED_NON_PACKAGE_FILES = [
   'test/helpers/perf.ts',
   'test/helpers/remove-tree.ts',
   'test/helpers/store-template.ts',
+  'test/setup/no-managed-settings.ts',
   'test/setup/no-network.ts',
   'test/vitest/coverage.ts',
   'tools/ci/egress-probe.mjs',

--- a/packages/eslint-config/test/no-managed-settings-guard.test.js
+++ b/packages/eslint-config/test/no-managed-settings-guard.test.js
@@ -1,0 +1,205 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  readPackageManifest,
+  REPO_ROOT,
+  toPosix,
+  workspacePackageDirs,
+} from './helpers/lint-invocations.js';
+
+// The administrative overlay is read from ABSOLUTE SYSTEM paths — outside
+// `~/.aka` on purpose, so that a lock is not removable by the party being
+// locked (packages/persistence/src/managed-settings.ts). A suite that builds a
+// whole fake machine in a temp dir therefore still reads the REAL one: `base`
+// redirects the home and reaches none of it.
+//
+// That made twenty-eight cases across three packages depend on who ran them. A
+// developer laptop enrolled for dogfooding pins `runMode: attached`, so those
+// cases assert `standalone` and receive `attached` on a clean checkout of main,
+// while CI — which has no such file — stays green and reports nothing. An
+// undeclared input that only fails off-CI is the worst shape a test dependency
+// takes: the machines that can see it are the ones with no gate on them.
+//
+// `test/setup/no-managed-settings.ts` declares the answer once per test file,
+// process-wide, exactly as the no-network guard does and for the same reason —
+// the reads that fail sit several frames below the test, so no per-call
+// override reaches them.
+//
+// What this file guards is the WIRING, and it derives which packages owe it
+// rather than listing them. A package can only be affected if its dependency
+// closure can load @akasecurity/persistence at all, so that closure IS the
+// rule; a list would leave the next package to gain that edge silently
+// unguarded, which is the drift this whole class of bug comes from.
+
+const GUARD_REL = 'test/setup/no-managed-settings.ts';
+const GUARD_ABS = join(REPO_ROOT, ...GUARD_REL.split('/'));
+const SEAM = 'UNSAFE_TEST_ONLY_setManagedSettingsPaths';
+const PERSISTENCE = '@akasecurity/persistence';
+
+/**
+ * Strip comments, so prose naming the guard is never mistaken for live wiring.
+ * Every config edited here carries a comment that names it.
+ * @param {string} source
+ */
+const stripComments = (source) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+// Both halves matter: the entry proves the guard is wired into the run, and the
+// URL is where a wrong `../..` depth would hide — a binding that resolves
+// nowhere still reads as wiring.
+const SETUP_ENTRY = /setupFiles\s*:\s*\[[^\]]*\bnoManagedSettingsGuard\b[^\]]*\]/;
+const GUARD_URL = new RegExp(
+  String.raw`new URL\(\s*'([^']*test/setup/no-managed-settings\.ts)'\s*,\s*import\.meta\.url\s*\)`,
+);
+
+/**
+ * Every workspace package, by name, with its declared edges and test script.
+ *
+ * `workspacePackageDirs()` yields repo-RELATIVE dirs and `readPackageManifest`
+ * joins the root itself, so each manifest is read once here and passed around
+ * as data — re-deriving a path from it downstream is how this double-joined
+ * the root on its first run.
+ */
+function workspaceByName() {
+  /** @type {Map<string, {dir: string, deps: string[], testScript: string}>} */
+  const byName = new Map();
+  for (const dir of workspacePackageDirs()) {
+    const pkg = readPackageManifest(dir);
+    if (!pkg?.name) continue;
+    byName.set(pkg.name, {
+      dir: toPosix(dir),
+      // devDependencies count. A test may import a package the product never
+      // does — web-ui takes @akasecurity/plugin-sdk dev-only for fixture
+      // seeding — and a test is exactly what this guard is about.
+      deps: [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})],
+      testScript: pkg.scripts?.test ?? '',
+    });
+  }
+  return byName;
+}
+
+/**
+ * Can this package's test process load @akasecurity/persistence at all?
+ * @param {string} name
+ * @param {Map<string, {dir: string, deps: string[]}>} byName
+ */
+function reachesPersistence(name, byName, seen = new Set()) {
+  if (name === PERSISTENCE) return true;
+  const entry = byName.get(name);
+  if (!entry) return false; // outside the workspace: cannot re-enter it
+  for (const dep of entry.deps) {
+    if (dep === PERSISTENCE) return true;
+    if (seen.has(dep)) continue;
+    seen.add(dep);
+    if (reachesPersistence(dep, byName, seen)) return true;
+  }
+  return false;
+}
+
+/** Every vitest package, tagged with whether it owes the guard and wires it. */
+function auditPackages() {
+  const byName = workspaceByName();
+  return [...byName.entries()]
+    .map(([name, { dir, testScript }]) => {
+      const configAbs = join(REPO_ROOT, ...dir.split('/'), 'vitest.config.ts');
+      const runsVitest = /(^|[\s/])vitest([\s/]|$)/.test(testScript);
+      const owes = runsVitest && reachesPersistence(name, byName);
+      if (!owes || !existsSync(configAbs)) {
+        return { name, dir, owes, wired: false, resolved: null, hasConfig: false };
+      }
+      const source = stripComments(readFileSync(configAbs, 'utf8'));
+      const url = GUARD_URL.exec(source);
+      return {
+        name,
+        dir,
+        owes,
+        hasConfig: true,
+        wired: SETUP_ENTRY.test(source),
+        resolved: url ? resolve(REPO_ROOT, dir, url[1]) : null,
+      };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+const PACKAGES = auditPackages();
+const OWING = PACKAGES.filter((p) => p.owes);
+
+describe('the no-managed-settings guard', () => {
+  it('exists, and installs the seam rather than merely importing it', () => {
+    // A guard file that imports the seam and never calls it wires perfectly,
+    // resolves perfectly, and neutralises nothing — every assertion below would
+    // still pass while all twenty-eight cases went back to reading the
+    // developer's own machine.
+    expect(existsSync(GUARD_ABS)).toBe(true);
+    const source = readFileSync(GUARD_ABS, 'utf8');
+    expect(source).toMatch(new RegExp(String.raw`${SEAM}\(\s*\[\s*\]\s*\)`));
+  });
+
+  it('reaches the seam by module path, never through the package barrel', () => {
+    // A setup file is loaded before EVERY test file in every package that wires
+    // it, so whatever it imports sits in the module cache before any of them
+    // registers a mock. Importing the BARREL pre-cached `paths.ts`,
+    // `fingerprint.ts` and the vault bound to the real `node:fs`, so the three
+    // suites that `vi.mock('node:fs')` and then `await import('../src/…')` got
+    // the unmocked instance back and nineteen cases failed on a branch they
+    // could no longer enter.
+    //
+    // Naming the one module keeps that graph to `managed-settings.ts`. Nothing
+    // in the assertions elsewhere in this file would notice the barrel coming
+    // back — the wiring, the depth and the install all stay correct — and the
+    // damage lands in a different package's suite, on a mock, which reads as
+    // anything but a setup-file import. Hence a case of its own.
+    const source = readFileSync(GUARD_ABS, 'utf8');
+    const specifiers = [...source.matchAll(/^\s*import\s[^;]*?from\s+'([^']+)'/gm)].map(
+      (m) => m[1],
+    );
+
+    expect(specifiers).toEqual(['../../packages/persistence/src/managed-settings.ts']);
+  });
+
+  it('is owed by the packages that can actually load the overlay', () => {
+    // The positive control on the derivation itself. An empty or near-empty
+    // closure — a manifest reader returning nothing, a workspace glob that
+    // matched no directory — makes every per-package assertion below hold
+    // vacuously, and this suite would report green over an unwired workspace.
+    const owed = OWING.map((p) => p.name);
+    expect(owed).toContain(PERSISTENCE);
+    expect(owed).toContain('@akasecurity/cli');
+    expect(owed).toContain('@akasecurity/plugin-sdk');
+    expect(owed).toContain('@akasecurity/web-ui');
+    expect(owed.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('is not owed by a package that cannot reach the overlay', () => {
+    // The other direction, and it is what keeps the rule a RULE rather than
+    // "everything". A closure that answered true for every package would make
+    // the case above pass just as well, while quietly demanding the guard in
+    // tools/ and packages/schema — where the import would not even resolve.
+    const exempt = PACKAGES.filter((p) => !p.owes).map((p) => p.name);
+    expect(exempt).toContain('@akasecurity/schema');
+    expect(exempt).toContain('@akasecurity/detections');
+    expect(exempt).toContain('@akasecurity/portability-gate');
+  });
+
+  it('every owing package ships a vitest.config.ts', () => {
+    expect(OWING.filter((p) => !p.hasConfig).map((p) => p.dir)).toEqual([]);
+  });
+
+  it('every owing package wires it into setupFiles', () => {
+    expect(OWING.filter((p) => !p.wired).map((p) => p.dir)).toEqual([]);
+  });
+
+  it('every owing package points at a path that resolves to the guard', () => {
+    // A relative depth is the half that fails silently: `../` from a package
+    // two levels down resolves to a file that does not exist, and vitest is
+    // what reports it — after the wiring has already read as correct here.
+    const wrong = OWING.filter((p) => p.resolved !== GUARD_ABS).map((p) => ({
+      dir: p.dir,
+      resolved: p.resolved,
+    }));
+    expect(wrong).toEqual([]);
+  });
+});

--- a/packages/eslint-config/test/test-only-seam.test.js
+++ b/packages/eslint-config/test/test-only-seam.test.js
@@ -65,8 +65,11 @@ function isTestFile(file) {
   );
 }
 
-/** Every tracked lintable file whose text names the seam. */
-function filesNamingSeam() {
+/**
+ * Every tracked lintable file whose text names the given seam.
+ * @param {string} seam defaults to the raw handle, this file's original subject
+ */
+function filesNamingSeam(seam = SEAM) {
   return lintableTrackedFiles().filter((file) => {
     // A tracked path can still be unreadable — a submodule gitlink, a symlink
     // to nowhere. Skipping one silently would drop a file out of the audit
@@ -75,9 +78,9 @@ function filesNamingSeam() {
     try {
       text = readFileSync(join(REPO_ROOT, file), 'utf8');
     } catch (cause) {
-      throw new Error(`Could not read tracked file ${file} while auditing ${SEAM}.`, { cause });
+      throw new Error(`Could not read tracked file ${file} while auditing ${seam}.`, { cause });
     }
-    return text.includes(SEAM);
+    return text.includes(seam);
   });
 }
 
@@ -145,6 +148,69 @@ describe(`the ${SEAM} test-only seam`, () => {
       // and a hardcoded list does not.
       expect(trackedFiles()).toContain(DEFINITION);
       expect(lintableTrackedFiles()).toContain(DEFINITION);
+    },
+    TREE_WALK_TIMEOUT_MS,
+  );
+});
+
+// The workspace's SECOND test-only seam, and it is held to the SAME two
+// properties as the raw handle above: one shipped definition site, and no
+// re-export from the package entry point.
+//
+// UNSAFE_TEST_ONLY_setManagedSettingsPaths points the DEFAULT managed read at
+// other locations, or at none, so that a suite's view of which administrator
+// owns this machine stops depending on whose machine is running it. Its one
+// caller outside this package is the shared vitest setup file, which reaches it
+// by RELATIVE path — `test/setup/no-managed-settings.ts` sits at the repo root
+// and is not a package, so it needs no `exports` entry to import a module. That
+// is what lets the seam keep the stronger property while still being installed
+// process-wide in every package that can load the overlay.
+const MANAGED_SEAM = 'UNSAFE_TEST_ONLY_setManagedSettingsPaths';
+
+/** The only shipped-source file allowed to name it: where it is defined. */
+const MANAGED_DEFINITION = 'packages/persistence/src/managed-settings.ts';
+
+/** The shared vitest setup file that installs it for every owing package. */
+const MANAGED_GUARD = 'test/setup/no-managed-settings.ts';
+
+describe(`the ${MANAGED_SEAM} test-only seam`, () => {
+  it(
+    'is named by exactly one shipped source file — the one that defines it',
+    () => {
+      const shipped = filesNamingSeam(MANAGED_SEAM)
+        .filter((file) => !isTestFile(file))
+        .sort();
+
+      // An exact set of one, not a floor. A floor keeps the definition honest
+      // and lets the next product caller in beside it — and a product caller is
+      // the entire failure mode, since a seam something in `src/` calls is not a
+      // test seam at all, it is a way for shipped code to decide which
+      // administrator this machine has.
+      expect(shipped).toEqual([MANAGED_DEFINITION]);
+    },
+    TREE_WALK_TIMEOUT_MS,
+  );
+
+  it('is not re-exported from the package entry point', () => {
+    // The same structural property the raw handle has, and available here for
+    // the same reason: the manifest exposes `.` alone, so `src/*.ts` is
+    // unreachable from another PACKAGE. Re-export it here and every consumer of
+    // @akasecurity/persistence could name it, leaving the walk above as the
+    // whole guarantee rather than a second line of defence.
+    expect(readFileSync(join(REPO_ROOT, ENTRY), 'utf8')).not.toContain(MANAGED_SEAM);
+  });
+
+  it(
+    'is installed by the shared guard, so this suite is not guarding an absence',
+    () => {
+      // The positive control. Delete the seam, its guard and its callers and
+      // every assertion above holds perfectly, describing a workspace where the
+      // thing being guarded does not exist. `isTestFile` classifies the guard
+      // as test code on its `test/` segment, which is what keeps it out of the
+      // shipped set above rather than an exemption written by hand.
+      const tests = filesNamingSeam(MANAGED_SEAM).filter(isTestFile);
+      expect(tests).toContain(MANAGED_GUARD);
+      expect(tests).toContain('packages/persistence/test/managed-settings.test.ts');
     },
     TREE_WALK_TIMEOUT_MS,
   );

--- a/packages/local-ops/vitest.config.ts
+++ b/packages/local-ops/vitest.config.ts
@@ -10,13 +10,20 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // One suite exercises real node:sqlite file I/O, which runs slowly on the Windows
 // CI runner under parallel load, so raise the per-test AND per-hook timeouts above
 // vitest's 5s/10s defaults (mirrors packages/persistence/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20000,

--- a/packages/persistence/src/managed-settings.ts
+++ b/packages/persistence/src/managed-settings.ts
@@ -64,6 +64,50 @@ export function managedSettingsPaths(platform: NodeJS.Platform = process.platfor
 }
 
 /**
+ * The managed locations this PROCESS reads when a caller names none.
+ *
+ * Null — the shipped value, never assigned outside a test — means "ask the
+ * platform", which is what every product path does.
+ */
+let testOnlyManagedPaths: readonly string[] | null = null;
+
+/**
+ * TEST-ONLY: point the default managed read at other locations, or at NONE.
+ *
+ * The managed file sits at absolute system paths on purpose (see
+ * managedSettingsPaths), so a suite that builds a whole fake machine in a temp
+ * dir still reads the REAL one. That is not a stale-fixture nuisance, it is a
+ * suite whose result depends on who ran it: on a developer laptop enrolled with
+ * `runMode: attached` pinned, twenty-eight cases across three packages assert
+ * `standalone` and get `attached`, while CI — where no administrator has placed
+ * a file — stays green. The machine is the input nobody declared.
+ *
+ * A per-call `managedOverride` parameter, which readEffectiveSettings and
+ * applyOnboarding both take, cannot close that. The reads at issue are several
+ * frames below the test: `db.installedPacks.setPolicy()` reaches
+ * readWorkspaceSettings through openControlPlaneFloors, and `aka sync-history`
+ * reaches it again inside the attached-mode pass. Threading a parameter to
+ * those means putting a test-only argument on openLocalDatabase and on the
+ * history-sync deps, and the NEXT deep caller reopens the hole. The property is
+ * process-scoped because the thing being described — which administrator owns
+ * this machine — is process-scoped.
+ *
+ * So this is deliberately a process-wide declaration, installed once per test
+ * file by `test/setup/no-managed-settings.ts` exactly as the no-network guard
+ * is installed, and reaching every frame for the same reason. Passing `[]`
+ * states "no administrator"; passing paths states which file to read instead,
+ * so a suite can simulate a managed machine end to end rather than only through
+ * the two override parameters.
+ *
+ * It changes the DEFAULT only. Every explicit caller — readManagedSettings's
+ * own suite passes paths on every call — is untouched, which is what keeps the
+ * managed layer's own tests testing the managed layer.
+ */
+export function UNSAFE_TEST_ONLY_setManagedSettingsPaths(paths: readonly string[] | null): void {
+  testOnlyManagedPaths = paths;
+}
+
+/**
  * Read the managed file, or null when no administrator has placed one.
  *
  * Fully fail-open, like readWorkspaceSettings: a missing, unreadable or
@@ -83,7 +127,7 @@ export function managedSettingsPaths(platform: NodeJS.Platform = process.platfor
  * this build understands still holds and the surface can say one does not.
  */
 export function readManagedSettings(
-  paths: string[] = managedSettingsPaths(),
+  paths: readonly string[] = testOnlyManagedPaths ?? managedSettingsPaths(),
 ): ManagedSettings | null {
   for (const path of paths) {
     let text: string;

--- a/packages/persistence/test/managed-settings.test.ts
+++ b/packages/persistence/test/managed-settings.test.ts
@@ -20,6 +20,7 @@ import {
   managedSettingsPaths,
   overlayManagedSettings,
   readManagedSettings,
+  UNSAFE_TEST_ONLY_setManagedSettingsPaths,
 } from '../src/managed-settings.ts';
 import {
   applyOnboarding,
@@ -934,4 +935,67 @@ describe('every lockable key is handled by all four per-key lists', () => {
       expect(sample.read(readWorkspaceSettings(base))).toEqual(sample.underUser);
     },
   );
+});
+
+// The seam that makes every suite in this workspace independent of whoever's
+// machine is running it — see its doc comment in src/managed-settings.ts, and
+// test/setup/no-managed-settings.ts, which is what installs it.
+//
+// Every OTHER case in this file hands `readManagedSettings` its paths, so none
+// of them touches the default at all and none of them would notice the seam
+// being deleted. These drive the default itself, which is the only thing the
+// product ever calls.
+describe('UNSAFE_TEST_ONLY_setManagedSettingsPaths', () => {
+  // Restore what test/setup/no-managed-settings.ts installed. Leaving a pin
+  // behind would hand the next case in this file an administrator it never
+  // asked for — the very failure this seam exists to remove.
+  afterEach(() => {
+    UNSAFE_TEST_ONLY_setManagedSettingsPaths([]);
+  });
+
+  it('redirects the read a caller makes with NO paths', () => {
+    writeManaged({
+      specVersion: 1,
+      organization: 'Example Org',
+      values: { runMode: 'attached' },
+    });
+    // The positive control, and it is doing real work: the assertion below is
+    // `toBeNull`, which is also what an unmanaged machine returns and what a
+    // seam that silently ignored its argument would return. Without a pin that
+    // demonstrably lands first, the case passes on a workspace where this seam
+    // does nothing whatsoever.
+    UNSAFE_TEST_ONLY_setManagedSettingsPaths([managedFile()]);
+    expect(readManagedSettings()?.organization).toBe('Example Org');
+
+    UNSAFE_TEST_ONLY_setManagedSettingsPaths([]);
+    expect(readManagedSettings()).toBeNull();
+  });
+
+  it('reaches readWorkspaceSettings, which takes no override at all', () => {
+    // The property the seam exists for, and the reason a per-call parameter was
+    // not enough. `readWorkspaceSettings` has no override argument, and neither
+    // do the frames that reach it in the product — openControlPlaneFloors from
+    // `db.installedPacks.setPolicy()`, the attached-mode pass from `aka
+    // sync-history`. A process-scoped pin is the only thing that reaches them.
+    writeManaged({ specVersion: 1, values: { runMode: 'attached' } });
+
+    expect(readWorkspaceSettings(base).runMode).toBe('standalone');
+    UNSAFE_TEST_ONLY_setManagedSettingsPaths([managedFile()]);
+    expect(readWorkspaceSettings(base).runMode).toBe('attached');
+  });
+
+  it('leaves an explicit caller alone', () => {
+    // What keeps this file's other ninety-odd cases meaningful: they pass their
+    // own paths, so the process-wide pin must not override an argument. If it
+    // did, the setup guard's `[]` would blank every managed case in the
+    // workspace and they would assert an unmanaged machine while reading as
+    // tests of the managed layer.
+    const file = writeManaged({
+      specVersion: 1,
+      organization: 'Example Org',
+      values: { runMode: 'attached' },
+    });
+    UNSAFE_TEST_ONLY_setManagedSettingsPaths([]);
+    expect(readManagedSettings([file])?.organization).toBe('Example Org');
+  });
 });

--- a/packages/persistence/vitest.config.ts
+++ b/packages/persistence/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // The suite exercises real node:sqlite file I/O; the fixture-heavy tests run
 // well over a second each on the Windows CI runner, so raise the per-test AND
@@ -22,7 +29,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // compile-time signal.
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20000,

--- a/packages/plugin-runtime/vitest.config.ts
+++ b/packages/plugin-runtime/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // The session-start and gateway suites exercise real node:sqlite file I/O; those
 // DB-backed tests run well over a second each on the Windows CI runner, so raise
@@ -18,7 +25,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // setup hooks open the DB and are just as slow under Windows-runner contention).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20000,

--- a/packages/plugin-sdk/vitest.config.ts
+++ b/packages/plugin-sdk/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // The rule timing tests exercise real ReDoS backtracking behavior via checkRuleTiming
 // and filterUnsafeRules; catastrophic patterns can take well over a second to evaluate
@@ -18,7 +25,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // and packages/plugin-runtime for the same reason under heavy workspace contention).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20_000,

--- a/packages/scanner/vitest.config.ts
+++ b/packages/scanner/vitest.config.ts
@@ -10,13 +10,20 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // Real FS + gateway work runs slowly on the Windows CI runner under parallel
 // load, so raise the per-test AND per-hook timeouts above vitest's 5s/10s
 // defaults (mirrors packages/persistence/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20_000,

--- a/packages/setup-wizard/vitest.config.ts
+++ b/packages/setup-wizard/vitest.config.ts
@@ -10,10 +10,17 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
   },

--- a/plugins/antigravity/vitest.config.ts
+++ b/plugins/antigravity/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // globalSetup builds scripts/*.js once, in the main process, before any worker
 // runs — the onboard and start-light suites drive those built scripts.
@@ -20,7 +27,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // plugins/claude-code/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     globalSetup: ['./test/global-setup.ts'],

--- a/plugins/browser-extension/vitest.config.ts
+++ b/plugins/browser-extension/vitest.config.ts
@@ -10,10 +10,17 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     // Builds dist/ and native-host/ once, in the main process, before any
     // worker starts — the scan-worker bundle suite drives the built artifacts.

--- a/plugins/claude-code/vitest.config.ts
+++ b/plugins/claude-code/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // globalSetup builds scripts/*.js once, in the main process, before any worker
 // runs — the journey harness (test/journey) drives those built scripts.
@@ -20,7 +27,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // packages/persistence/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     globalSetup: ['./test/journey/global-setup.ts'],

--- a/plugins/codex/vitest.config.ts
+++ b/plugins/codex/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // globalSetup builds scripts/*.js once, in the main process, before any worker
 // runs — the onboard and start-light suites drive those built scripts.
@@ -20,7 +27,7 @@ const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', i
 // plugins/claude-code/vitest.config.ts).
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     globalSetup: ['./test/global-setup.ts'],

--- a/plugins/copilot/vitest.config.ts
+++ b/plugins/copilot/vitest.config.ts
@@ -7,10 +7,17 @@ import { coverageOptions } from '../../test/vitest/coverage.ts';
 // Every test file runs behind the no-network guard: it refuses any outbound
 // connection that is not loopback and names the call site that made it.
 const noNetworkGuard = fileURLToPath(new URL('../../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 export default defineConfig({
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     // No timeout overrides: this suite is synchronous assertions with no child
     // process, no store and no migration template, so it runs on vitest's own

--- a/test/setup/no-managed-settings.ts
+++ b/test/setup/no-managed-settings.ts
@@ -27,6 +27,21 @@
 // a guarantee that has to hold in every frame belongs in setup, not at a call
 // site somebody has to remember.
 //
+// It reaches as far as THIS PROCESS and no further, which is the same boundary
+// the no-network guard has and is worth stating in the same breath as the frames
+// it does reach. The pin lives in this process's instance of
+// `managed-settings.ts`; a child loads its own copy with the shipped `null`, and
+// a redirected `HOME` does not move an absolute system path — so a spawned child
+// reads the real administrator's file. Every suite driving a BUILT script is on
+// the far side of it: `plugins/*/test/e2e/fail-open.e2e.test.ts` runs the built
+// hooks under a redirected home and `loadConfig` applies the overlay inside the
+// child, so a pinned `redactFallback` flips rows asserting an exact wire shape.
+// Reachable rather than currently failing — those suites pass on the machine
+// that motivated this file, which pins `runMode` and not `redactFallback`.
+// Documented rather than closed: the no-network guard reaches a worker by
+// appending `--import <itself>` to its `execArgv`, and a child spawned with a
+// deliberately minimal env cannot be reached that way.
+//
 // It moves the DEFAULT only. A suite that wants an administrator still says so
 // — by passing paths to `readManagedSettings`, a `managedOverride` to the two
 // writers, or its own paths back through the seam below — which is what keeps

--- a/test/setup/no-managed-settings.ts
+++ b/test/setup/no-managed-settings.ts
@@ -1,0 +1,57 @@
+// Every test file runs on a machine with NO administrator, stated rather than
+// inherited.
+//
+// The administrative overlay (packages/persistence/src/managed-settings.ts) is
+// read from absolute system paths — `/Library/Application Support/AKASecurity`
+// on macOS, `%ProgramData%\AKASecurity` on Windows, `/etc/aka` on Linux —
+// deliberately outside `~/.aka`, so that a lock is not removable by the party
+// being locked. The consequence for the suite is that a test which builds a
+// whole fake machine in a temp dir still reads the REAL administrator's file:
+// `base` redirects `~/.aka` and reaches none of this.
+//
+// That is not a stale fixture, it is an undeclared input. It arrived as
+// twenty-eight failures across @akasecurity/persistence,
+// @akasecurity/plugin-sdk and the CLI, on a clean checkout of main and caused
+// by no change in the tree: a laptop enrolled for dogfooding pins `runMode:
+// attached`, so every case asserting the `standalone` default received
+// `attached`. CI has no such file, so CI stayed green throughout and the
+// failure landed only on the people who had installed one.
+//
+// A per-call override cannot close it. `readEffectiveSettings` and
+// `applyOnboarding` both take a `managedOverride`, and both are useless for the
+// reads that actually fail, which sit several frames below the test:
+// `db.installedPacks.setPolicy()` reaches `readWorkspaceSettings` through
+// `openControlPlaneFloors`, and `aka sync-history` reaches it again inside the
+// attached-mode pass. So the declaration is process-scoped, like the property
+// it describes, and installed here for the same reason the no-network guard is:
+// a guarantee that has to hold in every frame belongs in setup, not at a call
+// site somebody has to remember.
+//
+// It moves the DEFAULT only. A suite that wants an administrator still says so
+// — by passing paths to `readManagedSettings`, a `managedOverride` to the two
+// writers, or its own paths back through the seam below — which is what keeps
+// the managed layer's own suite testing the managed layer.
+//
+// Which packages wire it is derived rather than counted — every one whose
+// dependency closure can load @akasecurity/persistence, asserted by
+// packages/eslint-config/test/no-managed-settings-guard.test.js. pnpm symlinks
+// each of those to this same directory and vitest resolves symlinks, so the
+// module instance this mutates is the one the code under test reads.
+//
+// The import names ONE MODULE by relative path, and both halves of that are
+// load-bearing. A setup file is loaded before EVERY test file in every package
+// that wires it, so whatever it imports is in the module cache before any of
+// them registers a mock — and three suites in this package `vi.mock('node:fs')`
+// and then `await import('../src/paths.ts')` to reach a branch only a mocked
+// syscall can. Importing the package BARREL here pre-cached `paths.ts`,
+// `fingerprint.ts` and the vault against the real `fs`, so those dynamic
+// imports handed back the unmocked instance and nineteen cases failed on a
+// branch they could no longer enter. (They caught it: each asserts its
+// interception actually fired, which is the guard that turned a silent
+// green-for-the-wrong-reason into a visible failure.) Reaching for the one
+// module keeps that graph to `managed-settings.ts` itself, which nothing mocks;
+// the relative path is what makes that possible, since the package exports its
+// barrel alone — and it is why this seam need not be re-exported from there.
+import { UNSAFE_TEST_ONLY_setManagedSettingsPaths } from '../../packages/persistence/src/managed-settings.ts';
+
+UNSAFE_TEST_ONLY_setManagedSettingsPaths([]);

--- a/web-ui/vitest.config.ts
+++ b/web-ui/vitest.config.ts
@@ -10,6 +10,13 @@ import { coverageOptions } from '../test/vitest/coverage.ts';
 // packages/eslint-config/test/no-network-runtime.test.js fails the workspace
 // if a package drops the entry or points it at the wrong path.
 const noNetworkGuard = fileURLToPath(new URL('../test/setup/no-network.ts', import.meta.url));
+// And on a machine with no ADMINISTRATOR, declared for the same reason: the
+// managed overlay is read from absolute system paths that a temp home cannot
+// redirect, so without this a suite reads whatever the developer's own laptop
+// is enrolled in. See the guard for why a per-call override cannot cover it.
+const noManagedSettingsGuard = fileURLToPath(
+  new URL('../test/setup/no-managed-settings.ts', import.meta.url),
+);
 
 // web-ui's test runner, covering two suites with different needs.
 //
@@ -38,7 +45,7 @@ const noNetworkGuard = fileURLToPath(new URL('../test/setup/no-network.ts', impo
 export default defineConfig({
   oxc: { jsx: { runtime: 'automatic' } },
   test: {
-    setupFiles: [noNetworkGuard],
+    setupFiles: [noNetworkGuard, noManagedSettingsGuard],
     coverage: coverageOptions(import.meta.url),
     environment: 'node',
     testTimeout: 20_000,


### PR DESCRIPTION
## The problem

`readManagedSettings()` reads absolute system paths by design — the administrative
overlay sits outside `~/.aka` so that a lock is not removable by the party being
locked. Tests redirect `~/.aka` through `base`, which reaches none of that, so every
suite silently read the real machine's enrolment.

On a machine with an administrator installed, 28 cases fail on a clean checkout of
`main`, caused by no change in the tree. CI has no such file, so CI stays green — the
failure lands only where nothing gates it.

<details><summary>Baseline, before the fix (commands + raw output)</summary>

```
$ pnpm --filter @akasecurity/persistence exec vitest run \
    test/settings.test.ts test/policy-floor.test.ts test/managed-settings.test.ts
      Tests  9 failed | 115 passed (124)

$ pnpm --filter @akasecurity/plugin-sdk exec vitest run test/config.test.ts
      Tests  5 failed | 8 passed (13)

$ pnpm --filter @akasecurity/cli exec vitest run \
    test/commands/attach.test.ts test/commands/sync-history.test.ts \
    test/commands/sync-history-report.test.ts
      Tests  14 failed | 54 passed (68)
```

</details>

## Why not a per-call override

`readEffectiveSettings` and `applyOnboarding` already take a `managedOverride`, and
it covers 17 of the 28. It cannot reach the other 11: `policy-floor` reaches the read
through `db.installedPacks.setPolicy()` → `openControlPlaneFloors`, and
`aka sync-history` reaches it again inside the attached-mode pass. Threading a
parameter there means a test-only argument on `openLocalDatabase` and on the
history-sync deps — and the next deep caller reopens the hole.

The property is process-scoped because the thing it describes — which administrator
owns this machine — is process-scoped.

## The change

- `UNSAFE_TEST_ONLY_setManagedSettingsPaths` moves the **default** managed read only.
  Shipped behaviour is unchanged: the backing variable is `null` in production, and
  no product signature changed.
- `test/setup/no-managed-settings.ts` installs `[]` once per test file, wired beside
  the no-network guard into every package whose dependency closure can load
  `@akasecurity/persistence`. That set is **derived**, not listed.
- Guards: a tree-wide audit that no shipped file calls the seam and that it is not
  re-exported from the package entry point (the same two properties the raw handle
  carries); the derived owing-package set; the wiring depth; and the import specifier.

## Verification

Every claim below was measured on this branch.

**Mutation testing** — each mutation applied, proven landed by grep, then restored:

| Mutation | Raw output |
|---|---|
| Seam no longer feeds the default read | persistence `11 failed \| 116 passed (127)`, plugin-sdk `5 failed \| 8 passed (13)`, cli `14 failed \| 54 passed (68)` |
| Guard installs `null` instead of `[]` | plugin-sdk `5 failed \| 8 passed (13)`; guard's install case red |
| Unwire one package from `setupFiles` | guard `1 failed \| 6 passed (7)`; plugin-sdk `5 failed \| 8 passed (13)` |
| Wrong relative depth | guard `1 failed \| 6 passed (7)` (resolution case) |
| A product caller of the seam in shipped source | seam audit `1 failed \| 14 passed (15)` |
| Setter ignores its argument | persistence `2 failed \| 73 passed (75)` |
| **`overlayManagedSettings` made a no-op** | **`39 failed \| 36 passed (75)`** |

That last row is the one that matters for correctness of the approach: the
process-wide `[]` does **not** make the managed-overlay suite vacuous. Those cases
pass their own paths, so the seam — which moves only the default — leaves them
testing the managed layer.

**A regression found and fixed mid-review.** The first version imported the
`persistence` **barrel** in the setup file. A setup file loads before every test file
in every package that wires it, so that pre-cached `paths.ts`, `fingerprint.ts` and
the vault against the real `node:fs`; the three suites that `vi.mock('node:fs')` and
then `await import('../src/paths.ts')` got the unmocked instance back. Control run:

```
# guard wired, barrel import
      Tests  19 failed | 48 passed (67)
# guard wired, single-module import
      Tests  67 passed (67)
```

Fixed by importing the one module by relative path, which also lets the seam keep the
stronger "not re-exported from the entry point" property. That specifier now has its
own guard case, since every other assertion stays green when the barrel returns.

**Full workspace**, from the same run:

```
$ pnpm lint         -> exit 0
$ pnpm typecheck    -> exit 0
$ pnpm turbo run test --force --continue
 Tasks:    46 successful, 46 total
 -> exit 0

$ grep -E "^[^ ]+:test: +Tests +" final.txt | grep -cE "failed"
0
$ grep -E "^[^ ]+:test: +Tests +" final.txt | grep -oE "[0-9]+ passed" | awk '{s+=$1} END {print s}'
11498
```
