### PR TITLE
chore(deps): raise the js-yaml floor past a new high advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
       "browserslist": "^4.28.7",
       "esbuild": "^0.28.2",
       "fast-uri": "^3.1.6",
-      "js-yaml": "^4.3.1",
+      "js-yaml": "^4.3.2",
       "nanoid": "^3.3.17",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   browserslist: ^4.28.7
   esbuild: ^0.28.2
   fast-uri: ^3.1.6
-  js-yaml: ^4.3.1
+  js-yaml: ^4.3.2
   nanoid: ^3.3.17
   postcss: ^8.5.18
   sharp: ^0.35.0
@@ -3764,8 +3764,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+  js-yaml@4.3.2:
+    resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -5358,7 +5358,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6730,7 +6730,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -7515,7 +7515,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
`GHSA-2883-xcg3-v3hh` (high, `js-yaml`: *maxTotalMergeKeys does not limit CPU use for empty merge sources*) was published at **2026-09-08T21:24Z**. Main's last green Dependency audit ran at 18:45, so nothing has seen it yet — it now fails that gate on every open PR and will fail main's next run.

## The fix

A floor for `js-yaml` already existed in the root `pnpm.overrides` at `^4.3.1`. The advisory patches at **4.3.2**, so this raises the floor by one patch and the lockfile resolves to it. That is CLAUDE.md's documented workspace remedy ("fix a workspace hit by upgrading, or by raising a floor in the root `pnpm.overrides` — the existing entries there are exactly such floors").

**Not a waiver**, deliberately: CONTRIBUTING.md's expiring-waiver route is for an advisory with no fixed release reachable from the tree, and this one has one a patch away.

`js-yaml` is transitive here — no workspace package depends on it directly, and only one version is resolved — so the override is the whole of the change.

## Verification

- `tools/audit-gate`: was `[workspace] high advisory GHSA-2883-xcg3-v3hh in js-yaml`, now `Dependency audit (workspace) passed: 0 waived, 1 below the gate`.
- Lockfile resolves `js-yaml@4.3.2`, and the diff is that plus the override line.
- Full workspace green: `turbo run test` 46/46, `typecheck lint` 52/52, `format:check` clean.

Unblocks #438 and #439, which are otherwise red on this check alone.
