### PR TITLE
fix(installer): retry a pwsh run that died in the CLR before the script began

### DIFF
--- a/tools/installer/test/helpers/run-installer.test.ts
+++ b/tools/installer/test/helpers/run-installer.test.ts
@@ -1,113 +1,98 @@
-// Guards the env handed to a PowerShell child.
-//
-// This exists because the defect it covers is invisible everywhere except the
-// one platform that runs it. `Get-FileHash` lives in Microsoft.PowerShell
-// .Utility, autoloaded off `PSModulePath` — and pwsh 7 and Windows PowerShell
-// 5.1 need DIFFERENT values for it. GitHub Actions runs Windows `run:` steps
-// under pwsh by default, so a spawn that inherits the step's environment hands
-// 5.1 a pwsh-7 module path, 5.1 cannot autoload its own standard library, and
-// install.ps1 dies at the hashing step with CommandNotFoundException — a failure
-// that names a cmdlet and mentions neither the module path nor the edition.
-//
-// The stripping runs on every host, so its regression is catchable on every
-// host; only its CONSEQUENCE is Windows-only. Hence a unit test rather than
-// trusting the Windows leg to notice.
 import { describe, expect, it } from 'vitest';
 
-import { assertHostArchitecture, powershellEnv } from './run-installer.ts';
+import { type InstallerRun, runScript, type ScriptRunner } from './run-installer.ts';
 
-describe('powershellEnv', () => {
-  // `extra` is merged before the strip runs, so a key supplied here goes through
-  // exactly the loop a host-supplied one does — which is what makes this a real
-  // test of the stripping rather than of the merge. Injecting via `extra` also
-  // keeps the case off `process.env`, which it must not mutate for its
-  // neighbours.
-  it.each(['PSModulePath', 'PSMODULEPATH', 'psmodulepath', 'PsModulePath'])(
-    'strips %s, whatever its casing',
-    (spelling) => {
-      const env = powershellEnv({ [spelling]: 'C:\\Program Files\\PowerShell\\7\\Modules' });
+/**
+ * The retry inside `runScript`, driven through its injected spawner.
+ *
+ * It exists for a crash that cannot be provoked on demand — pwsh dying inside
+ * .NET's own assembly-name parser before the script it was handed begins — so
+ * against a real PowerShell the retry branch is dead code on every leg that
+ * runs this suite. The failure is injected instead.
+ *
+ * `compressArchive` already retries the same corruption where it BUILDS the
+ * fixture archive, and this is the other call site it reaches. The two see it
+ * differently, which is why one check does not cover both: the archive build
+ * gets a child killed outright (`status: null, signal: 'SIGABRT'`), while pwsh
+ * running a `-File` script gets far enough to print an unhandled-exception
+ * trace and exit non-zero. So this one discriminates on the TEXT.
+ */
 
-      const survivors = Object.keys(env).filter((k) => k.toLowerCase() === 'psmodulepath');
-      expect(survivors).toEqual([]);
-    },
-  );
+// The shape the corrupted run really produces. Only the two markers matter, so
+// the assembly-name tail is left out rather than transcribed: a real one is a
+// version and a public-key token, and a literal of that shape in a public
+// repository reads as a credential to this product's own scanner.
+const CLR_ABORT_STDERR =
+  'Unhandled exception. System.IO.FileLoadException: The given assembly name was invalid.\n' +
+  "File name: 'System.Private.Uri, <truncated mid-token by the crash>'";
 
-  it('keeps everything else, so the child still resolves its own tools', () => {
-    const env = powershellEnv({
-      AKA_DOWNLOAD_BASE: 'http://127.0.0.1:1/',
-      PSModulePath: 'drop me',
-    });
-
-    // Positive control on the same object the absence check reads: an env that
-    // came back empty would satisfy the strip assertion above vacuously.
-    expect(env.AKA_DOWNLOAD_BASE).toBe('http://127.0.0.1:1/');
-    expect(Object.keys(env).length).toBeGreaterThan(1);
-  });
-
-  it('lets a caller override a host value', () => {
-    // The overrides are how a fixture base reaches the script at all; a strip
-    // that rebuilt the object from HOST_ENV alone would silently drop them.
-    expect(powershellEnv({ AKA_VERSION: '9.9.9' }).AKA_VERSION).toBe('9.9.9');
-  });
-});
-
-// Both branches are driven with an injected platform rather than gated on the
-// real one, so the win32 half is covered from every runner. A platform guard
-// here would leave the case that matters unexercised on the two legs that run
-// most of the suite.
-describe('assertHostArchitecture', () => {
-  const ARCH = 'PROCESSOR_ARCHITECTURE';
-
-  it.each([
-    ['unset', {}, 'unset'],
-    ['empty', { [ARCH]: '' }, 'empty'],
-  ])('refuses a win32 host whose architecture is %s', (_label, env, word) => {
-    const error = errorFrom(() => {
-      assertHostArchitecture(env, 'win32');
-    });
-
-    // What it SAYS before what it omits: a never-thrown error arrives as
-    // undefined, and every `toContain` below would then read as vacuous.
-    expect(error).toBeDefined();
-    expect(error?.message).toContain(ARCH);
-    expect(error?.message).toContain(word);
-    // The refusal has to point at the cause, or it is one more message that
-    // names the script and leaves the reader where they started.
-    expect(error?.message).toContain('passThroughEnv');
-    expect(error?.message).toContain('setup failure');
-  });
-
-  it('accepts a win32 host that reports an architecture', () => {
-    expect(() => {
-      assertHostArchitecture({ [ARCH]: 'AMD64' }, 'win32');
-    }).not.toThrow();
-  });
-
-  // Asserted non-empty rather than equal to AMD64 on purpose: an arm64 runner
-  // must reach install.ps1's own unsupported-architecture refusal, which is a
-  // property of the script this harness is not entitled to pre-empt.
-  it('accepts an unsupported architecture, leaving the refusal to the script', () => {
-    expect(() => {
-      assertHostArchitecture({ [ARCH]: 'ARM64' }, 'win32');
-    }).not.toThrow();
-  });
-
-  it.each<NodeJS.Platform>(['darwin', 'linux'])(
-    'says nothing on %s, where the variable does not exist',
-    (platform) => {
-      expect(() => {
-        assertHostArchitecture({}, platform);
-      }).not.toThrow();
-    },
-  );
-});
-
-/** The error a thunk threw, captured OUTSIDE its own catch. */
-function errorFrom(fn: () => void): Error | undefined {
-  try {
-    fn();
-    return undefined;
-  } catch (err) {
-    return err as Error;
-  }
+function aborts(times: number, then: InstallerRun): { run: ScriptRunner; calls: () => number } {
+  let calls = 0;
+  const run: ScriptRunner = () => {
+    calls += 1;
+    if (calls <= times) {
+      return Promise.resolve({ status: 134, stdout: '', stderr: CLR_ABORT_STDERR });
+    }
+    return Promise.resolve(then);
+  };
+  return { run, calls: () => calls };
 }
+
+const REFUSAL: InstallerRun = { status: 1, stdout: '', stderr: 'checksum mismatch' };
+const SUCCESS: InstallerRun = { status: 0, stdout: 'ok', stderr: '' };
+
+describe('runScript retries a CLR startup abort', () => {
+  it('re-runs past an abort and returns the run that happened', async () => {
+    const { run, calls } = aborts(1, REFUSAL);
+    const result = await runScript('pwsh', [], {}, run);
+    // The script's own refusal, not the crash — which is the whole point: the
+    // assertion the caller makes is about what install.ps1 said.
+    expect(result).toEqual(REFUSAL);
+    expect(calls()).toBe(2);
+  });
+
+  it('gives up rather than looping, and hands back the last abort', async () => {
+    const { run, calls } = aborts(Infinity, SUCCESS);
+    const result = await runScript('pwsh', [], {}, run);
+    // Bounded: a host where this fails three times running is not flaking, and
+    // the caller sees the crash rather than a hang.
+    expect(calls()).toBe(3);
+    expect(result.stderr).toBe(CLR_ABORT_STDERR);
+  });
+
+  it('does NOT retry a script that ran and failed', async () => {
+    // The refusals this suite exists to assert all exit non-zero. Retrying one
+    // would re-run it for no reason, and a budget spent here is a budget not
+    // available for the crash.
+    const { run, calls } = aborts(0, REFUSAL);
+    const result = await runScript('pwsh', [], {}, run);
+    expect(result).toEqual(REFUSAL);
+    expect(calls()).toBe(1);
+  });
+
+  it('does NOT retry a crash the script itself caused', async () => {
+    // An unhandled .NET exception from a `Compress-Archive` the SCRIPT ran is a
+    // real failure. Only the assembly-name parser marks the startup corruption,
+    // so both markers are required and this one carries the first alone.
+    const selfInflicted: InstallerRun = {
+      status: 1,
+      stdout: '',
+      stderr: 'Unhandled exception. System.IO.IOException: There is not enough space on the disk.',
+    };
+    const { run, calls } = aborts(0, selfInflicted);
+    const result = await runScript('pwsh', [], {}, run);
+    expect(result).toEqual(selfInflicted);
+    expect(calls()).toBe(1);
+  });
+
+  it('does NOT retry a zero exit, whatever it wrote', async () => {
+    // A run that happened is a run that happened. Without this a script that
+    // printed the marker and succeeded would be re-run, and the second run's
+    // side effects would land on top of the first's.
+    const noisySuccess: InstallerRun = { status: 0, stdout: '', stderr: CLR_ABORT_STDERR };
+    const { run, calls } = aborts(0, noisySuccess);
+    const result = await runScript('pwsh', [], {}, run);
+    expect(result).toEqual(noisySuccess);
+    expect(calls()).toBe(1);
+  });
+});

--- a/tools/installer/test/helpers/run-installer.test.ts
+++ b/tools/installer/test/helpers/run-installer.test.ts
@@ -1,6 +1,112 @@
+// Guards the env handed to a PowerShell child.
+//
+// This exists because the defect it covers is invisible everywhere except the
+// one platform that runs it. `Get-FileHash` lives in Microsoft.PowerShell
+// .Utility, autoloaded off `PSModulePath` — and pwsh 7 and Windows PowerShell
+// 5.1 need DIFFERENT values for it. GitHub Actions runs Windows `run:` steps
+// under pwsh by default, so a spawn that inherits the step's environment hands
+// 5.1 a pwsh-7 module path, 5.1 cannot autoload its own standard library, and
+// install.ps1 dies at the hashing step with CommandNotFoundException — a failure
+// that names a cmdlet and mentions neither the module path nor the edition.
+//
+// The stripping runs on every host, so its regression is catchable on every
+// host; only its CONSEQUENCE is Windows-only. Hence a unit test rather than
+// trusting the Windows leg to notice.
 import { describe, expect, it } from 'vitest';
 
-import { type InstallerRun, runScript, type ScriptRunner } from './run-installer.ts';
+import {
+  assertHostArchitecture,
+  type InstallerRun,
+  powershellEnv,
+  runScript,
+  type ScriptRunner,
+} from './run-installer.ts';
+
+describe('powershellEnv', () => {
+  // `extra` is merged before the strip runs, so a key supplied here goes through
+  // exactly the loop a host-supplied one does — which is what makes this a real
+  // test of the stripping rather than of the merge. Injecting via `extra` also
+  // keeps the case off `process.env`, which it must not mutate for its
+  // neighbours.
+  it.each(['PSModulePath', 'PSMODULEPATH', 'psmodulepath', 'PsModulePath'])(
+    'strips %s, whatever its casing',
+    (spelling) => {
+      const env = powershellEnv({ [spelling]: 'C:\\Program Files\\PowerShell\\7\\Modules' });
+
+      const survivors = Object.keys(env).filter((k) => k.toLowerCase() === 'psmodulepath');
+      expect(survivors).toEqual([]);
+    },
+  );
+
+  it('keeps everything else, so the child still resolves its own tools', () => {
+    const env = powershellEnv({
+      AKA_DOWNLOAD_BASE: 'http://127.0.0.1:1/',
+      PSModulePath: 'drop me',
+    });
+
+    // Positive control on the same object the absence check reads: an env that
+    // came back empty would satisfy the strip assertion above vacuously.
+    expect(env.AKA_DOWNLOAD_BASE).toBe('http://127.0.0.1:1/');
+    expect(Object.keys(env).length).toBeGreaterThan(1);
+  });
+
+  it('lets a caller override a host value', () => {
+    // The overrides are how a fixture base reaches the script at all; a strip
+    // that rebuilt the object from HOST_ENV alone would silently drop them.
+    expect(powershellEnv({ AKA_VERSION: '9.9.9' }).AKA_VERSION).toBe('9.9.9');
+  });
+});
+
+// Both branches are driven with an injected platform rather than gated on the
+// real one, so the win32 half is covered from every runner. A platform guard
+// here would leave the case that matters unexercised on the two legs that run
+// most of the suite.
+describe('assertHostArchitecture', () => {
+  const ARCH = 'PROCESSOR_ARCHITECTURE';
+
+  it.each([
+    ['unset', {}, 'unset'],
+    ['empty', { [ARCH]: '' }, 'empty'],
+  ])('refuses a win32 host whose architecture is %s', (_label, env, word) => {
+    const error = errorFrom(() => {
+      assertHostArchitecture(env, 'win32');
+    });
+
+    // What it SAYS before what it omits: a never-thrown error arrives as
+    // undefined, and every `toContain` below would then read as vacuous.
+    expect(error).toBeDefined();
+    expect(error?.message).toContain(ARCH);
+    expect(error?.message).toContain(word);
+    // The refusal has to point at the cause, or it is one more message that
+    // names the script and leaves the reader where they started.
+    expect(error?.message).toContain('passThroughEnv');
+    expect(error?.message).toContain('setup failure');
+  });
+
+  it('accepts a win32 host that reports an architecture', () => {
+    expect(() => {
+      assertHostArchitecture({ [ARCH]: 'AMD64' }, 'win32');
+    }).not.toThrow();
+  });
+
+  // Asserted non-empty rather than equal to AMD64 on purpose: an arm64 runner
+  // must reach install.ps1's own unsupported-architecture refusal, which is a
+  // property of the script this harness is not entitled to pre-empt.
+  it('accepts an unsupported architecture, leaving the refusal to the script', () => {
+    expect(() => {
+      assertHostArchitecture({ [ARCH]: 'ARM64' }, 'win32');
+    }).not.toThrow();
+  });
+
+  it.each<NodeJS.Platform>(['darwin', 'linux'])(
+    'says nothing on %s, where the variable does not exist',
+    (platform) => {
+      expect(() => {
+        assertHostArchitecture({}, platform);
+      }).not.toThrow();
+    },
+  );
+});
 
 /**
  * The retry inside `runScript`, driven through its injected spawner.
@@ -96,3 +202,13 @@ describe('runScript retries a CLR startup abort', () => {
     expect(calls()).toBe(1);
   });
 });
+
+/** The error a thunk threw, captured OUTSIDE its own catch. */
+function errorFrom(fn: () => void): Error | undefined {
+  try {
+    fn();
+    return undefined;
+  } catch (err) {
+    return err as Error;
+  }
+}

--- a/tools/installer/test/helpers/run-installer.ts
+++ b/tools/installer/test/helpers/run-installer.ts
@@ -156,6 +156,20 @@ const SCRIPT_TIMEOUT_MS = 60_000;
  */
 const CLR_ABORT_MARKERS = ['Unhandled exception.', 'assembly name was invalid'] as const;
 
+// Three attempts against a 60s per-attempt kill ceiling is 180s of budget, and
+// this package's testTimeout/hookTimeout is 120s — so three attempts that each
+// ran to their SIGKILL would surface as a bare vitest timeout rather than as
+// anything this file says.
+//
+// That cannot arise from what this retries. A CLR startup abort is near-instant:
+// the process dies before the script it was handed begins, which is exactly what
+// `diedInClrStartup` keys on. An attempt that is RETRIED therefore costs no
+// meaningful budget, and an attempt that spends real time is by construction one
+// that ran and is returned rather than retried.
+//
+// Written down because the two constants sit twenty lines apart and nothing
+// structural ties either to the ceiling: a future marker matching something slow
+// would spend the budget three times over and report it as a timeout.
 const SCRIPT_ATTEMPTS = 3;
 
 /** What `runScript` spawns with, injectable so the abort can be driven. */

--- a/tools/installer/test/helpers/run-installer.ts
+++ b/tools/installer/test/helpers/run-installer.ts
@@ -136,7 +136,64 @@ function toRun(command: string, result: SpawnSyncReturns<string>): InstallerRun 
  */
 const SCRIPT_TIMEOUT_MS = 60_000;
 
-async function runScript(
+/**
+ * A run that died inside .NET's own startup rather than inside the script.
+ *
+ * `compressArchive` already retries this crash where it builds the fixture
+ * archive; the same corruption reaches the run that executes the installer, and
+ * that call site had nothing. It arrives differently here, which is why the
+ * signal check there does not cover it: the archive build sees the child killed
+ * (`signal: 'SIGABRT'`), while pwsh running a `-File` script gets far enough to
+ * write an unhandled-exception trace to stderr and exit non-zero. So the
+ * discriminator is the TEXT, and it has to be one the installer can never
+ * produce itself — install.ps1 writes its own refusals (`checksum mismatch` and
+ * the rest) and never a .NET exception trace.
+ *
+ * Both markers are required. `Unhandled exception.` alone would also match a
+ * genuine crash inside a `Compress-Archive` the script itself ran, which is a
+ * real failure this must not swallow; pairing it with the assembly-name parser
+ * narrows it to the startup corruption, where the script has not begun.
+ */
+const CLR_ABORT_MARKERS = ['Unhandled exception.', 'assembly name was invalid'] as const;
+
+const SCRIPT_ATTEMPTS = 3;
+
+/** What `runScript` spawns with, injectable so the abort can be driven. */
+export type ScriptRunner = (
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+) => Promise<InstallerRun>;
+
+function diedInClrStartup({ status, stderr }: InstallerRun): boolean {
+  // A zero exit is a run that happened, whatever it wrote.
+  if (status === 0) return false;
+  return CLR_ABORT_MARKERS.every((marker) => stderr.includes(marker));
+}
+
+/**
+ * Run a script, retrying only a CLR startup abort.
+ *
+ * Bounded and narrow on purpose: a retry that widened to any non-zero exit
+ * would re-run the refusals this suite exists to assert, and a flake budget
+ * spent on a real failure reports green for a script that never worked.
+ */
+export async function runScript(
+  command: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  // Injectable for the same reason `compressArchive`'s runner is: driven
+  // against a real pwsh this branch is dead code on every leg that runs the
+  // suite, because the abort cannot be provoked on demand.
+  spawnOne: ScriptRunner = spawnScript,
+): Promise<InstallerRun> {
+  for (let attempt = 1; ; attempt += 1) {
+    const result = await spawnOne(command, args, env);
+    if (attempt >= SCRIPT_ATTEMPTS || !diedInClrStartup(result)) return result;
+  }
+}
+
+async function spawnScript(
   command: string,
   args: readonly string[],
   env: NodeJS.ProcessEnv,


### PR DESCRIPTION
Bounds a second symptom of #299. Does **not** close it — the corruption itself is still unexplained and still a property of the runner.

## Two call sites, one protected

#299's crash — pwsh dying inside .NET's own assembly-name parser — reaches `tools/installer` twice. `compressArchive` retries it where the fixture archive is **built**. The run that **executes the installer** had nothing, so every occurrence there fails a PR that could not have caused it.

Three times today, across three branches, none of which touches `tools/`:

| PR | leg | diff scope |
| --- | --- | --- |
| #447 | `darwin-arm64`, `linux-arm64` | `packages/detections`, `packages/local-ops/test` |
| #444 | `No-network · Full suite` | `packages/dashboard-ui`, `packages/schema`, `web-ui` |
| #443 (earlier) | `win32-x64` | `packages/local-ops`, `cli`, `web-ui` |

## Why the existing check does not cover it

The two sites see the same crash differently, and that is the whole reason one guard missed:

- **Building the archive** — the child is killed outright: `status: null, signal: 'SIGABRT'`. That is what `compressArchive` keys on.
- **Running a `-File` script** — pwsh gets far enough to write an unhandled-exception trace and exit non-zero. There is no signal.

So the assertion that fails is not the exit code. `expect(result.status).not.toBe(0)` **passes**; the next line is the one that breaks, because stderr holds the .NET trace where the test expected `checksum mismatch`:

```
AssertionError: expected 'Unhandled exception. System.IO.FileLo…' to contain 'checksum mismatch'
```

## What it keys on, and what it refuses to key on

The discriminator is the **text**, and text `install.ps1` cannot produce — it writes its own refusals and never a .NET exception trace.

**Both markers are required.** `Unhandled exception.` alone would also match a genuine crash inside a `Compress-Archive` the script itself ran, which is a real failure this must not swallow. Pairing it with the assembly-name parser narrows it to the startup corruption, where the script has not begun.

**A zero exit is never retried, whatever it wrote.** A run that happened is a run that happened, and the second one's side effects would land on top of the first's.

**Bounded at three**, matching `compressArchive`: a host where this fails three times running is not flaking, and turning that into a longer stall would replace a clear error with a slow one.

## Verification

The spawner is injectable for the reason `compressArchive`'s runner is — driven against a real pwsh this branch is dead code on every leg, because the abort cannot be provoked on demand. So the failure is injected, and each of the five cases is mutation-verified against the property it pins:

| mutation | red |
| --- | --- |
| retry any non-zero exit | 3 cases |
| accept either marker alone | 1 |
| drop the zero-exit guard | 1 |
| raise the attempt budget to 99 | 1 |

Installer suite 46 passed / 6 skipped, plus lint, typecheck, prettier, the portability gate, and `@akasecurity/eslint-config`'s tree-wide audits (the package is already in `EXPECTED_VITEST_PACKAGES`, and the new file is a `test/helpers/*.test.ts` beside the one `compressArchive` already has).

## What this is not

It is a **bound on a symptom**, not a diagnosis. #299 stays open: nobody has explained why a runner's .NET returns a truncated assembly name, and this makes the suite survive it rather than making it stop happening. If it recurs at a *third* site, the retry is the wrong layer and the runner image is the thing to look at.

It also does not touch `cli/scripts/archive-sea.mjs`, which #354 tracks separately for the same corruption on the shipped release path.

