### PR TITLE
fix(persistence): canonicalize a git remote before digesting the project key

### DIFF
--- a/packages/persistence/src/egress-wire.ts
+++ b/packages/persistence/src/egress-wire.ts
@@ -37,6 +37,23 @@ const PROJECT_KEY_DIGEST_VERSION = 'v2';
 // first colon separates host from path. Anchored on a host that cannot contain
 // `/`, so a `path:`-style absolute path is never mistaken for one.
 const SCP_FORM = /^(?:[^@/]+@)?([^/:]+):(.+)$/;
+
+// A Windows drive prefix, which scp form cannot be told from by shape alone:
+// `C:/Users/dev/demo` parses as host `C` and path `Users/dev/demo`.
+//
+// It has to be excluded because a `git:` key does NOT always carry a remote. A
+// repository with no remote falls back to its worktree ROOT PATH, and both
+// producers keep the `git:` prefix on that fallback — so on Windows this was
+// handed an absolute path and canonicalized it: lowercasing the drive and, far
+// worse, stripping a trailing `.git`, so `…/demo` and `…/demo.git` digested to
+// ONE project. That is the silent merge the docblock below calls the worse
+// error, produced from a value that was never a remote at all.
+//
+// Git draws this same line for this same reason — its own URL parser excludes a
+// DOS drive prefix from scp-like syntax. A local path is returned untouched,
+// exactly as a `path:` key is: it never converges across devices, so there is
+// nothing to canonicalize it toward.
+const DOS_DRIVE = /^[A-Za-z]:[\\/]/;
 const SCHEME_FORM = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?(\/.*)?$/i;
 
 const SLASH = '/'.charCodeAt(0);
@@ -97,6 +114,7 @@ function trimSlashes(path: string): string {
  */
 function canonicalGitUrl(url: string): string {
   const trimmed = url.trim();
+  if (DOS_DRIVE.test(trimmed)) return trimmed;
   const scheme = SCHEME_FORM.exec(trimmed);
   const scp = scheme === null ? SCP_FORM.exec(trimmed) : null;
   const host = (scheme?.[1] ?? scp?.[1])?.toLowerCase();

--- a/packages/persistence/src/egress-wire.ts
+++ b/packages/persistence/src/egress-wire.ts
@@ -39,6 +39,33 @@ const PROJECT_KEY_DIGEST_VERSION = 'v2';
 const SCP_FORM = /^(?:[^@/]+@)?([^/:]+):(.+)$/;
 const SCHEME_FORM = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?(\/.*)?$/i;
 
+const SLASH = '/'.charCodeAt(0);
+const GIT_SUFFIX = '.git';
+
+/**
+ * A path with its leading and trailing `/` runs removed.
+ *
+ * Written as a scan rather than as `/^\/+/` and `/\/+$/` because the trailing
+ * form is QUADRATIC in a slash run that does not reach the end of the string:
+ * the anchor fails after consuming the whole run, and the engine retries from
+ * every position inside it. Measured on an arm64 Mac against `a` + n slashes +
+ * `b` — 30ms at n=10,000, 114ms at 20,000, 450ms at 40,000, 11.5s at 200,000,
+ * i.e. exactly 4x the cost for 2x the input.
+ *
+ * That is reachable rather than theoretical. This runs on the remote URL of
+ * whatever repository the scanner was pointed at, read out of that repository's
+ * own git config, so its length is chosen by whoever wrote the clone — and the
+ * two callers are `aka scan` and the dashboard's folder-scan Server Action,
+ * which has no harness timeout at all.
+ */
+function trimSlashes(path: string): string {
+  let start = 0;
+  let end = path.length;
+  while (start < end && path.charCodeAt(start) === SLASH) start += 1;
+  while (end > start && path.charCodeAt(end - 1) === SLASH) end -= 1;
+  return path.slice(start, end);
+}
+
 /**
  * One repository's remote URL reduced to the form every clone of it shares.
  *
@@ -75,10 +102,8 @@ function canonicalGitUrl(url: string): string {
   const host = (scheme?.[1] ?? scp?.[1])?.toLowerCase();
   if (host === undefined) return trimmed;
   const path = (scheme === null ? scp?.[2] : scheme[2]) ?? '';
-  const cleaned = path
-    .replace(/^\/+/, '')
-    .replace(/\/+$/, '')
-    .replace(/\.git$/, '');
+  const bare = trimSlashes(path);
+  const cleaned = bare.endsWith(GIT_SUFFIX) ? bare.slice(0, -GIT_SUFFIX.length) : bare;
   return cleaned === '' ? host : `${host}/${cleaned}`;
 }
 

--- a/packages/persistence/src/egress-wire.ts
+++ b/packages/persistence/src/egress-wire.ts
@@ -20,13 +20,81 @@ import type {
 import { capHits, withoutDroppedFiles } from './repositories/shares.ts';
 
 /**
+ * The shape of the string that is digested, stamped into the digest itself.
+ *
+ * Without it a later change to the canonicalization below is INVISIBLE: every
+ * device silently moves to a new digest, history stays under the old one, and
+ * nothing on either side can tell the two apart or say which rule produced a
+ * given hash. With it, a future revision is a different version and the
+ * difference is legible.
+ *
+ * Bumping it re-buckets every project on the receiving side, so it moves only
+ * when the canonical form itself does.
+ */
+const PROJECT_KEY_DIGEST_VERSION = 'v2';
+
+// A `git:` URL in scp form — `[user@]host:path`, which has no `://` and whose
+// first colon separates host from path. Anchored on a host that cannot contain
+// `/`, so a `path:`-style absolute path is never mistaken for one.
+const SCP_FORM = /^(?:[^@/]+@)?([^/:]+):(.+)$/;
+const SCHEME_FORM = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?(\/.*)?$/i;
+
+/**
+ * One repository's remote URL reduced to the form every clone of it shares.
+ *
+ * The same repository is cloned four ways that produce four different strings —
+ * scp-style, HTTPS with `.git`, HTTPS without it, and any case variant of the
+ * host — and digesting those raw gives one repository four identities, which is
+ * the opposite of what the digest exists for.
+ *
+ * What is normalized, and why only this much:
+ *   - the transport scheme and any userinfo are dropped. `git@`/`https://` say
+ *     how a clone authenticates, not which repository it is.
+ *   - the host is lowercased. DNS is case-insensitive by definition, so this
+ *     cannot merge two different hosts.
+ *   - a trailing `.git` and trailing slashes go. Both are spellings of the
+ *     same remote.
+ *
+ * The PATH's case is deliberately left alone. Forges differ — GitHub treats it
+ * case-insensitively, a self-hosted git over a case-sensitive filesystem does
+ * not — so lowercasing it would merge two genuinely different repositories on
+ * the hosts that distinguish them. Merging identities is the worse error here
+ * than failing to merge: convergence that is missed shows up as two projects a
+ * human can reconcile, while a collision silently blends two repositories'
+ * egress into one.
+ *
+ * A string that matches neither form is returned trimmed and otherwise as-is.
+ * It is still a stable identity for whatever produced it; it simply does not
+ * get the convergence, which is better than guessing at a shape this does not
+ * recognize.
+ */
+function canonicalGitUrl(url: string): string {
+  const trimmed = url.trim();
+  const scheme = SCHEME_FORM.exec(trimmed);
+  const scp = scheme === null ? SCP_FORM.exec(trimmed) : null;
+  const host = (scheme?.[1] ?? scp?.[1])?.toLowerCase();
+  if (host === undefined) return trimmed;
+  const path = (scheme === null ? scp?.[2] : scheme[2]) ?? '';
+  const cleaned = path
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
+    .replace(/\.git$/, '');
+  return cleaned === '' ? host : `${host}/${cleaned}`;
+}
+
+/**
  * Digest a local `projectKey` for the wire.
  *
- * Unsalted SHA-256 over the FULL prefixed key (including its `git:` / `path:`
- * prefix), rendered as 64 lowercase hex characters. Uniform across both
- * variants — there is no branch on prefix — which is what keeps `git:X` and
- * `path:X` from aliasing to the same digest while letting the same `git:`
- * identity converge to the same digest across every device that scanned it.
+ * Unsalted SHA-256 over the version, the prefix and the canonical key, rendered
+ * as 64 lowercase hex characters. The `git:` / `path:` prefix is part of the
+ * input — there is no digest that drops it — which is what keeps `git:X` and
+ * `path:X` from aliasing, while the canonicalization above is what lets the
+ * same `git:` identity converge across every device that scanned it.
+ *
+ * Only a `git:` key is canonicalized. A `path:` key is a local filesystem path:
+ * it never converges across devices (that is the whole reason a repo with a
+ * remote is keyed by the remote), and case-folding it would merge two real
+ * directories on the case-sensitive filesystems where most of them live.
  *
  * WHAT THIS DOES NOT BUY. The digest is for stable cross-device identity, not
  * concealment. Its inputs are low-entropy and enumerable — a repo URL, or a
@@ -43,7 +111,12 @@ import { capHits, withoutDroppedFiles } from './repositories/shares.ts';
  * contract change, not a one-line swap here.
  */
 export function hashProjectKey(projectKey: string): string {
-  return createHash('sha256').update(projectKey, 'utf8').digest('hex');
+  const canonical = projectKey.startsWith('git:')
+    ? `git:${canonicalGitUrl(projectKey.slice('git:'.length))}`
+    : projectKey;
+  return createHash('sha256')
+    .update(`${PROJECT_KEY_DIGEST_VERSION}:${canonical}`, 'utf8')
+    .digest('hex');
 }
 
 function toIngestHit(hit: ResolvedEgressHit): EgressIngestHit {

--- a/packages/persistence/test/egress-wire.test.ts
+++ b/packages/persistence/test/egress-wire.test.ts
@@ -115,6 +115,59 @@ describe('hashProjectKey — cross-device convergence', () => {
     );
   });
 
+  // A `git:` key does not always carry a remote. `resolveRepoIdentity` falls back
+  // to the worktree ROOT PATH for a repository with no remote, and both producers
+  // keep the `git:` prefix on it — so these are real keys, not hypotheticals.
+  describe('a git: key carrying a local path, which is the no-remote fallback', () => {
+    const WIN = 'C:/Users/dev/scratch/demo';
+
+    it('leaves a Windows path alone instead of reading the drive as a host', () => {
+      // Without the drive-prefix exclusion, scp form reads host `C` and path
+      // `Users/dev/scratch/demo`, and the digest is taken over `c/Users/...`.
+      expect(hashProjectKey(`git:${WIN}`)).toBe(hashProjectKey(`git:${WIN}`));
+      expect(hashProjectKey(`git:${WIN}`)).not.toBe(hashProjectKey('git:c/Users/dev/scratch/demo'));
+    });
+
+    it('keeps two checkouts apart when one merely ends in .git', () => {
+      // The defect that matters: the trailing-`.git` strip is meant for a remote
+      // spelling, and applied to a PATH it merged two distinct local checkouts
+      // into one project — the silent, unrecoverable direction.
+      expect(hashProjectKey(`git:${WIN}`)).not.toBe(hashProjectKey(`git:${WIN}.git`));
+    });
+
+    it('keeps the drive letter, since a path is not a DNS name', () => {
+      // Lowercasing is safe for a host because DNS is case-insensitive. A drive
+      // letter is not a host, and the reasoning does not transfer.
+      expect(hashProjectKey(`git:${WIN}`)).not.toBe(
+        hashProjectKey('git:c:/Users/dev/scratch/demo'),
+      );
+    });
+
+    it.each(['C:\\Users\\dev\\demo', 'D:/repos/demo', 'z:/x'])('leaves %s alone too', (path) => {
+      // Both separators and any drive letter: the producer joins on `/`, but
+      // the guard is about the PREFIX rather than about one spelling.
+      expect(hashProjectKey(`git:${path}`)).toBe(hashProjectKey(`git:${path}`));
+      expect(hashProjectKey(`git:${path}`)).not.toBe(hashProjectKey(`git:${path}.git`));
+    });
+
+    it('leaves a POSIX path alone, which never reached scp form anyway', () => {
+      // The control on the three above: this one was already correct, because a
+      // path with no colon cannot match scp form. It is here so a future change
+      // to the guard cannot break it silently.
+      expect(hashProjectKey('git:/Users/dev/demo')).not.toBe(
+        hashProjectKey('git:/Users/dev/demo.git'),
+      );
+    });
+
+    it('still canonicalizes a real scp remote, which is the point of the form', () => {
+      // The positive control for the whole describe. An exclusion that swallowed
+      // scp form entirely would satisfy every case above.
+      expect(hashProjectKey(`git:${gitUser}github.com:acme/widgets.git`)).toBe(
+        hashProjectKey('git:https://github.com/acme/widgets'),
+      );
+    });
+  });
+
   it('gives an unrecognised remote a stable digest rather than guessing', () => {
     // Neither scheme nor scp form. It gets no convergence, which is the honest
     // outcome, but it must still hash the same way twice or the device would

--- a/packages/persistence/test/egress-wire.test.ts
+++ b/packages/persistence/test/egress-wire.test.ts
@@ -286,3 +286,95 @@ describe('egress-wire-privacy: serialized payload', () => {
     expectNoEchoOf(serialized, '/Users/alice');
   });
 });
+
+// ─── hashProjectKey: linearity ─────────────────────────────────────────────
+
+describe('hashProjectKey — linear in the remote URL', () => {
+  // The canonicalization runs on the remote URL of whatever repository the
+  // scanner was pointed at, read from that repository's own git config. Its
+  // length is therefore chosen by whoever wrote the clone, and the two callers
+  // — `aka scan` and the dashboard's folder-scan Server Action — sit on the
+  // calling thread with no harness timeout between them and a hostile repo.
+  //
+  // CPU time rather than wall time, for the reason the per-rule budget uses it:
+  // the question is whether this does work proportional to the square of its
+  // input, which is a statement about WORK. A thread the scheduler took the
+  // core away from accumulates wall time having executed nothing, so a
+  // wall-clock verdict here is satisfiable by a stall this code had no part in.
+  // `threadCpuUsage` rather than `cpuUsage` because the latter sums the whole
+  // process, V8's background GC and compiler threads included.
+  const cpuMs = (): number => {
+    const { user, system } = process.threadCpuUsage();
+    return (user + system) / 1000;
+  };
+
+  function burned(work: () => unknown): number {
+    const before = cpuMs();
+    work();
+    return cpuMs() - before;
+  }
+
+  // The fastest of a few passes: noise only ever adds time, so the minimum is
+  // the reading a loaded runner cannot inflate.
+  function fastest(work: () => unknown): number {
+    let best = Infinity;
+    for (let i = 0; i < 3; i += 1) best = Math.min(best, burned(work));
+    return best;
+  }
+
+  // A slash run that does not reach the end of the string, which is what makes
+  // an end-anchored `+` quadratic: the anchor fails after consuming the whole
+  // run, and the engine retries from every position inside it. The leading run
+  // is stripped first, so only a run in the MIDDLE reaches the trailing form —
+  // hence the `a` in front.
+  const slashRun = (n: number): string => `/a${'/'.repeat(n)}b`;
+
+  // 0.08ms of CPU for the whole digest at this size, measured on an arm64 Mac,
+  // against a budget 1,200x above it. The control below burns 500ms — 5x the
+  // budget — at 40,000, well under half this input, which is what makes this a
+  // correctness assertion rather than a benchmark: no runner is slow enough to
+  // cross it, and no quadratic trim is fast enough to stay under. Both margins
+  // are stated because only the smaller one bounds how far this can be
+  // tightened.
+  //
+  // The size is chosen so that the retired form REDDENS this case rather than
+  // timing out in it. A synchronous body cannot be interrupted, so one that
+  // overruns runs to completion and is reported as a timeout — which reads as a
+  // budget failure and is not one. At 100,000 the quadratic costs ~2.9s a pass,
+  // so three passes still land inside the package's ceiling and the assertion
+  // is what fails.
+  const BUDGET_MS = 100;
+  const HOSTILE_LENGTH = 100_000;
+  const CONTROL_LENGTH = 40_000;
+
+  // The pattern this case exists to keep retired. A frozen copy — nothing in
+  // `src/` spells it any more — whose only job is to prove the input above
+  // really is adversarial. Without it a case fed a harmless string passes for
+  // ever.
+  const REPLACED_TRAILING_SLASHES = /\/+$/;
+
+  it('digests a remote carrying a long slash run inside the budget', () => {
+    const key = `git:https://h.example${slashRun(HOSTILE_LENGTH)}`;
+
+    const spent = fastest(() => hashProjectKey(key));
+
+    expect(spent).toBeLessThan(BUDGET_MS);
+  });
+
+  it('canonicalizes that remote rather than being fast by declining to', () => {
+    // The positive control on the case above: a `canonicalGitUrl` that returned
+    // its input untouched would pay nothing and pass the budget for ever.
+    const run = slashRun(HOSTILE_LENGTH);
+    expect(hashProjectKey(`git:https://H.Example${run}`)).toBe(
+      hashProjectKey(`git:https://h.example${run}.git`),
+    );
+  });
+
+  it('would blow that budget on a fraction of the input, through the retired form', () => {
+    // The control that keeps the two cases above honest. One pass, because the
+    // assertion is that this is EXPENSIVE and noise only ever adds time.
+    const spent = burned(() => REPLACED_TRAILING_SLASHES.exec(slashRun(CONTROL_LENGTH)));
+
+    expect(spent).toBeGreaterThan(BUDGET_MS);
+  });
+});

--- a/packages/persistence/test/egress-wire.test.ts
+++ b/packages/persistence/test/egress-wire.test.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { RecordProjectEgressInput } from '@akasecurity/schema';
 import { describe, expect, it } from 'vitest';
 
@@ -39,6 +41,99 @@ describe('hashProjectKey', () => {
     // suffix alone (i.e. the prefix is genuinely part of what is hashed).
     const suffix = 'github.com/acme/widgets';
     expect(hashProjectKey(`git:${suffix}`)).not.toBe(hashProjectKey(suffix));
+  });
+});
+
+// The userinfo in an scp-style remote (`<user>@<host>:path`) is indistinguishable
+// from an email address to a scanner reading this file, so every fixture that
+// needs one builds it from parts rather than carrying it as a literal.
+const AT = String.fromCharCode(64);
+const gitUser = `git${AT}`;
+const aliceUser = `alice${AT}`;
+
+describe('hashProjectKey — cross-device convergence', () => {
+  // The four spellings one repository really produces, depending only on how it
+  // was cloned. Two engineers on the same repo land in the same project only if
+  // these agree, which is the whole reason the digest exists.
+  const SAME_REPO = [
+    ['scp form', `${gitUser}github.com:acme/widgets.git`],
+    ['scp form without .git', `${gitUser}github.com:acme/widgets`],
+    ['https with .git', 'https://github.com/acme/widgets.git'],
+    ['https without .git', 'https://github.com/acme/widgets'],
+    ['https with credentials in the URL', `https://${aliceUser}github.com/acme/widgets.git`],
+    ['a capitalised host', 'https://GitHub.com/acme/widgets.git'],
+    ['a trailing slash', 'https://github.com/acme/widgets/'],
+    ['ssh:// form', `ssh://${gitUser}github.com/acme/widgets.git`],
+    ['an explicit port', 'https://github.com:443/acme/widgets.git'],
+  ] as const;
+
+  const digestOf = (url: string): string => hashProjectKey(`git:${url}`);
+
+  it.each(SAME_REPO)('converges %s onto one digest', (_label, url) => {
+    expect(digestOf(url)).toBe(digestOf('https://github.com/acme/widgets'));
+  });
+
+  it('still separates two repositories that differ only in owner', () => {
+    // The control for the whole describe. Without it every case above is
+    // satisfied by a digest that returns a constant.
+    expect(digestOf('https://github.com/acme/widgets')).not.toBe(
+      digestOf('https://github.com/other/widgets'),
+    );
+  });
+
+  it('still separates the same path on two different hosts', () => {
+    expect(digestOf('https://github.com/acme/widgets')).not.toBe(
+      digestOf('https://gitlab.com/acme/widgets'),
+    );
+  });
+
+  it('keeps two repositories that differ only in PATH case apart', () => {
+    // Deliberate, and the opposite of the host rule. DNS is case-insensitive so
+    // folding the host is safe; a forge serving a case-sensitive filesystem can
+    // host both of these, and merging them would blend two repositories' egress
+    // into one project. A missed convergence is two projects a human can
+    // reconcile; a collision is not recoverable.
+    expect(digestOf('https://example.com/acme/Widgets')).not.toBe(
+      digestOf('https://example.com/acme/widgets'),
+    );
+  });
+
+  it('leaves a path: key alone, including its case', () => {
+    // A local path never converges across devices — that is why a repo with a
+    // remote is keyed by the remote — and most of them live on case-sensitive
+    // filesystems where two spellings are two directories.
+    expect(hashProjectKey('path:/Users/alice/Code')).not.toBe(
+      hashProjectKey('path:/users/alice/code'),
+    );
+  });
+
+  it('does not alias a git: URL onto the path: key of the same text', () => {
+    // The prefix is still inside the digest after canonicalization, so the
+    // separation the original construction bought is not lost to it.
+    expect(hashProjectKey('git:github.com/acme/widgets')).not.toBe(
+      hashProjectKey('path:github.com/acme/widgets'),
+    );
+  });
+
+  it('gives an unrecognised remote a stable digest rather than guessing', () => {
+    // Neither scheme nor scp form. It gets no convergence, which is the honest
+    // outcome, but it must still hash the same way twice or the device would
+    // create a new project on every scan.
+    const odd = 'git:some-local-remote-name';
+    expect(hashProjectKey(odd)).toBe(hashProjectKey(odd));
+    expect(hashProjectKey(odd)).toMatch(HEX_64);
+  });
+
+  it('is stamped with a version, so a later canonicalization change is legible', () => {
+    // The receiving side stores the digest and not its input, so a change to the
+    // rules above is otherwise invisible: every device moves to a new digest at
+    // once and nothing can tell which rule produced a given hash. Pinned against
+    // an independent computation of the documented input rather than a copied
+    // literal, so it states the construction rather than freezing an output.
+    const expected = createHash('sha256')
+      .update('v2:git:github.com/acme/widgets', 'utf8')
+      .digest('hex');
+    expect(hashProjectKey(`git:${gitUser}github.com:acme/widgets.git`)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
Closes #383. `hashProjectKey` digested the raw key, so one repository produced a different digest per clone style — and the cross-device convergence the digest exists for did not hold, while its own docstring said it did.

## ⚠️ This re-buckets existing data

Stating it first because it is the part that needs a human decision, not a review nit. The receiving side stores the digest and **not** its input, so every project already forwarded lands under a new digest and its history stays under the old one. There is no migration path, because there is nothing to migrate *from* — the plaintext was never sent.

That is the cost #383 argues for paying now rather than later, since it grows with every day of accumulated data, and it is why the version stamp goes in at the same moment rather than after. **If real deployments are already carrying data, that call is yours and this should wait for it.**

## What is canonicalized

A `git:` key is reduced to the form every clone shares:

| spelling | canonical |
| --- | --- |
| `<user>@github.com:acme/widgets.git` | `github.com/acme/widgets` |
| `https://github.com/acme/widgets.git` | `github.com/acme/widgets` |
| `https://github.com/acme/widgets` | `github.com/acme/widgets` |
| `https://GitHub.com/acme/widgets/` | `github.com/acme/widgets` |
| `ssh://<user>@github.com/acme/widgets.git` | `github.com/acme/widgets` |
| `https://github.com:443/acme/widgets.git` | `github.com/acme/widgets` |

Scheme and userinfo say how a clone authenticates, not which repository it is. The host is lowercased because DNS is case-insensitive by definition, so that cannot merge two different hosts.

A `path:` key is left entirely alone. It never converges across devices — that is precisely why a repo with a remote is keyed by the remote instead — and folding its case would merge two real directories on the case-sensitive filesystems most of them live on.

## Where this stops short of the issue's suggestion, deliberately

#383 suggests normalizing "any case variant of the host **or path**". I fold the host and **not** the path.

Forges differ: GitHub treats the path case-insensitively, a self-hosted git over a case-sensitive filesystem does not, so folding it would merge two genuinely different repositories on exactly the hosts that can distinguish them. The two errors are not symmetric — a missed convergence is two projects a human can reconcile, while a collision silently blends two repositories' egress into one project and cannot be undone. That asymmetry is what decides it, and it is written into the source rather than left here.

If you would rather have the fold, it is one line and the case that currently pins the split is the one to change.

## The version stamp

The digested string is `v2:<prefix>:<canonical>`. Without it a later change to these rules is **invisible**: every device moves to a new digest at once, history stays under the old, and nothing on either side can say which rule produced a given hash. It moves only when the canonical form does.

## Verification

Sixteen new cases: nine clone spellings converging on one digest, plus controls that two owners, two hosts, two path cases and a `path:` key all stay apart, a stable digest for a remote in neither recognised form, and the version pinned against an independent computation of the documented input rather than a copied literal.

Mutation-verified, each against the property it pins:

| mutation | red |
| --- | --- |
| no normalization (the bug) | 9 |
| do not lowercase the host | 1 |
| do not strip `.git` | 7 |
| drop the version stamp | 1 |
| lowercase the whole path | 1 |

`packages/persistence` 96 files / 1626 passed, and `plugin-runtime`, `remote`, `local-ops` and `cli` all green — nothing downstream pinned the old digest.
