### PR TITLE
test(installer): make an installer refusal say what the script actually did

### DIFF
--- a/tools/installer/test/helpers/run-installer.test.ts
+++ b/tools/installer/test/helpers/run-installer.test.ts
@@ -317,10 +317,20 @@ describe('describeRun', () => {
   });
 
   it('keeps a stream that fits, whole', () => {
-    // The control on the case above: an excerpt that truncated everything
-    // would satisfy the length bound for ever.
+    // The control on the case above, and it has to say BOTH things. An excerpt
+    // that truncated everything would satisfy the length bound for ever — and
+    // so would one that took the truncation branch on EVERY stream, because
+    // `slice(0, EXCERPT_CHARS)` of a 75-character string still contains the
+    // whole string. It just arrives annotated as an excerpt of itself, and a
+    // `toContain` alone cannot tell the two apart: forcing that branch left all
+    // of this file's cases green.
+    //
+    // One bound call, so the presence check and the absence check describe the
+    // same bytes rather than two independent reads.
     const whole = 'aka: checksum mismatch for aka-1.2.3-win32-x64.zip -- refusing to install.';
+    const line = describeRun(runOf({ stderr: whole }));
 
-    expect(describeRun(runOf({ stderr: whole }))).toContain(whole);
+    expect(line).toContain(whole);
+    expect(line).not.toContain('chars)');
   });
 });

--- a/tools/installer/test/helpers/run-installer.test.ts
+++ b/tools/installer/test/helpers/run-installer.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assertHostArchitecture,
+  describeRun,
   type InstallerRun,
   powershellEnv,
   runScript,
@@ -132,20 +133,32 @@ const CLR_ABORT_STDERR =
   'Unhandled exception. System.IO.FileLoadException: The given assembly name was invalid.\n' +
   "File name: 'System.Private.Uri, <truncated mid-token by the crash>'";
 
+/**
+ * An `InstallerRun` for a case that cares about two of its fields.
+ *
+ * A builder rather than five object literals: `signal` and `elapsedMs` say
+ * nothing about the retry, and spelling them at every site makes the field the
+ * case IS about harder to see — while a sixth field added later would be five
+ * more edits, each of which reads as a decision and is not one.
+ */
+function runOf(over: Partial<InstallerRun>): InstallerRun {
+  return { status: 0, signal: null, elapsedMs: 1, stdout: '', stderr: '', ...over };
+}
+
 function aborts(times: number, then: InstallerRun): { run: ScriptRunner; calls: () => number } {
   let calls = 0;
   const run: ScriptRunner = () => {
     calls += 1;
     if (calls <= times) {
-      return Promise.resolve({ status: 134, stdout: '', stderr: CLR_ABORT_STDERR });
+      return Promise.resolve(runOf({ status: 134, stderr: CLR_ABORT_STDERR }));
     }
     return Promise.resolve(then);
   };
   return { run, calls: () => calls };
 }
 
-const REFUSAL: InstallerRun = { status: 1, stdout: '', stderr: 'checksum mismatch' };
-const SUCCESS: InstallerRun = { status: 0, stdout: 'ok', stderr: '' };
+const REFUSAL: InstallerRun = runOf({ status: 1, stderr: 'checksum mismatch' });
+const SUCCESS: InstallerRun = runOf({ stdout: 'ok' });
 
 describe('runScript retries a CLR startup abort', () => {
   it('re-runs past an abort and returns the run that happened', async () => {
@@ -180,11 +193,10 @@ describe('runScript retries a CLR startup abort', () => {
     // An unhandled .NET exception from a `Compress-Archive` the SCRIPT ran is a
     // real failure. Only the assembly-name parser marks the startup corruption,
     // so both markers are required and this one carries the first alone.
-    const selfInflicted: InstallerRun = {
+    const selfInflicted: InstallerRun = runOf({
       status: 1,
-      stdout: '',
       stderr: 'Unhandled exception. System.IO.IOException: There is not enough space on the disk.',
-    };
+    });
     const { run, calls } = aborts(0, selfInflicted);
     const result = await runScript('pwsh', [], {}, run);
     expect(result).toEqual(selfInflicted);
@@ -195,7 +207,7 @@ describe('runScript retries a CLR startup abort', () => {
     // A run that happened is a run that happened. Without this a script that
     // printed the marker and succeeded would be re-run, and the second run's
     // side effects would land on top of the first's.
-    const noisySuccess: InstallerRun = { status: 0, stdout: '', stderr: CLR_ABORT_STDERR };
+    const noisySuccess: InstallerRun = runOf({ stderr: CLR_ABORT_STDERR });
     const { run, calls } = aborts(0, noisySuccess);
     const result = await runScript('pwsh', [], {}, run);
     expect(result).toEqual(noisySuccess);
@@ -212,3 +224,103 @@ function errorFrom(fn: () => void): Error | undefined {
     return err as Error;
   }
 }
+
+/**
+ * What a failing assertion about a run is allowed to say about it.
+ *
+ * These read like formatting tests and are not. The assertions that fail
+ * intermittently on CI are `expect(status).not.toBe(0)`, which vitest renders
+ * as `expected +0 not to be +0` — a message that names neither the script nor
+ * anything it did. Three occurrences of one signature produced no evidence
+ * between them and two investigations dead-ended for the lack of it, so what
+ * this carries is the difference between the next occurrence being an answer
+ * and being another investigation.
+ */
+describe('a real spawn fills the record', () => {
+  // Every case above injects a runner, so all of them would pass with
+  // `elapsedMs` hardcoded to zero and the signal never read — and the reading
+  // this whole record exists for is the one taken from a real child. Driven
+  // through the default runner for that reason, against this very Node rather
+  // than a PowerShell: the fields are filled by `spawnScript`, which does not
+  // care what it started, and requiring an interpreter here would leave the
+  // measurement unpinned on exactly the hosts that have none.
+  it('reports the status, the streams and a non-zero elapsed', async () => {
+    const result = await runScript(
+      process.execPath,
+      ['-e', 'process.stdout.write("ran"); process.stderr.write("noted")'],
+      {},
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.signal).toBeNull();
+    expect(result.stdout).toBe('ran');
+    expect(result.stderr).toBe('noted');
+    // Not a timing assertion — no budget, no ceiling. Starting a process and
+    // reading its output cannot take zero, so a zero here means the clock is
+    // not wired rather than that the machine is fast.
+    expect(result.elapsedMs).toBeGreaterThan(0);
+  });
+});
+
+describe('describeRun', () => {
+  it('names the three readings that separate a run from a non-run', () => {
+    const line = describeRun(runOf({ status: 0, signal: null, elapsedMs: 107 }));
+
+    expect(line).toContain('status=0');
+    expect(line).toContain('signal=null');
+    expect(line).toContain('elapsed=107ms');
+  });
+
+  it('carries both streams', () => {
+    const line = describeRun(runOf({ stdout: 'downloading', stderr: 'checksum mismatch' }));
+
+    expect(line).toContain('downloading');
+    expect(line).toContain('checksum mismatch');
+  });
+
+  it('says an empty stream is empty rather than rendering nothing', () => {
+    // "the script printed nothing" and "the message was lost on the way here"
+    // look identical when an empty stream renders as an empty string, and they
+    // point at opposite causes.
+    const line = describeRun(runOf({ stdout: '', stderr: '' }));
+
+    expect(line).toContain('stdout: (empty)');
+    expect(line).toContain('stderr: (empty)');
+  });
+
+  it('excerpts a long stream and says how long it really was', () => {
+    // A 46 MB archive download can print a great deal, and a message that
+    // scrolls the failure off the top of a CI log is one nobody reads.
+    const long = 'z'.repeat(5_000);
+
+    const line = describeRun(runOf({ stderr: long }));
+
+    expect(line.length).toBeLessThan(2_000);
+    expect(line).toContain('(5000 chars)');
+  });
+
+  it('reaches the failure message vitest actually renders', () => {
+    // The assumption the whole change rests on, and it is not self-evident:
+    // `expect(actual, message)` is vitest's second parameter, so a runner
+    // upgrade that stopped honouring it would leave every call site above
+    // compiling, passing, and carrying nothing. Driven through the real
+    // assertion rather than asserted about it.
+    const run = runOf({ status: 0, elapsedMs: 107, stderr: 'nothing was downloaded' });
+
+    const error = errorFrom(() => {
+      expect(run.status, describeRun(run)).not.toBe(0);
+    });
+
+    expect(error).toBeDefined();
+    expect(error?.message).toContain('elapsed=107ms');
+    expect(error?.message).toContain('nothing was downloaded');
+  });
+
+  it('keeps a stream that fits, whole', () => {
+    // The control on the case above: an excerpt that truncated everything
+    // would satisfy the length bound for ever.
+    const whole = 'aka: checksum mismatch for aka-1.2.3-win32-x64.zip -- refusing to install.';
+
+    expect(describeRun(runOf({ stderr: whole }))).toContain(whole);
+  });
+});

--- a/tools/installer/test/helpers/run-installer.ts
+++ b/tools/installer/test/helpers/run-installer.ts
@@ -96,8 +96,54 @@ export function userPathOptIn(): boolean {
 export interface InstallerRun {
   /** The script's exit status; null if it was killed by a signal. */
   status: number | null;
+  /** The signal that killed it, or null for an ordinary exit. */
+  signal: NodeJS.Signals | null;
+  /**
+   * Wall time from spawn to close, in ms.
+   *
+   * Carried because it is the one reading that separates a script that ran and
+   * reached a decision from one that barely started, and nothing else here can
+   * tell them apart: both arrive as an exit status. The refusal cases below
+   * take ~3.6s on a Linux runner, so a refusal that reports 107ms did not
+   * refuse — whatever its status says.
+   */
+  elapsedMs: number;
   stdout: string;
   stderr: string;
+}
+
+/** How much of a stream to carry into a failure message. */
+const EXCERPT_CHARS = 600;
+
+function excerpt(stream: string): string {
+  const trimmed = stream.trim();
+  if (trimmed === '') return '(empty)';
+  return trimmed.length <= EXCERPT_CHARS
+    ? trimmed
+    : `${trimmed.slice(0, EXCERPT_CHARS)}… (${String(trimmed.length)} chars)`;
+}
+
+/**
+ * What a run actually did, for the message on an assertion about it.
+ *
+ * Vitest renders `expect(status).not.toBe(0)` as `expected +0 not to be +0`,
+ * which says nothing about the script — and these assertions are exactly the
+ * ones that fail intermittently on CI, where the process is gone by the time
+ * anyone reads the log. Three occurrences of one signature have now produced no
+ * evidence at all between them, and two investigations dead-ended for the lack
+ * of it. Passed as vitest's message argument, this turns the next occurrence
+ * into an answer rather than another investigation.
+ *
+ * Both streams are carried, and an empty one says so rather than rendering as
+ * nothing: "the script printed nothing" and "the message was lost" look
+ * identical otherwise, and they point at opposite causes.
+ */
+export function describeRun(run: InstallerRun): string {
+  return [
+    `status=${String(run.status)} signal=${String(run.signal)} elapsed=${run.elapsedMs.toFixed(0)}ms`,
+    `stdout: ${excerpt(run.stdout)}`,
+    `stderr: ${excerpt(run.stderr)}`,
+  ].join('\n');
 }
 
 export interface InstallerOverrides {
@@ -112,11 +158,17 @@ export interface InstallerOverrides {
 }
 
 /** Fail loudly on a spawn that never started; a silent null status reads as a refusal. */
-function toRun(command: string, result: SpawnSyncReturns<string>): InstallerRun {
+function toRun(command: string, result: SpawnSyncReturns<string>, startedAt: number): InstallerRun {
   if (result.error !== undefined) {
     throw new Error(`could not spawn ${command}: ${result.error.message}`);
   }
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+  return {
+    status: result.status,
+    signal: result.signal,
+    elapsedMs: performance.now() - startedAt,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
 }
 
 /**
@@ -213,6 +265,7 @@ async function spawnScript(
   env: NodeJS.ProcessEnv,
 ): Promise<InstallerRun> {
   return await new Promise<InstallerRun>((resolve, reject) => {
+    const startedAt = performance.now();
     const child = spawn(command, args, {
       env,
       timeout: SCRIPT_TIMEOUT_MS,
@@ -227,8 +280,12 @@ async function spawnScript(
     child.on('error', (err) => {
       reject(new Error(`could not spawn ${command}: ${err.message}`));
     });
-    child.on('close', (status) => {
-      resolve({ status, stdout, stderr });
+    // The SIGNAL is the second argument, and dropping it is how a killed run
+    // and a clean one become the same record: `status` is null for both a
+    // SIGKILL from the timeout above and anything else that killed the child,
+    // and only the signal says which.
+    child.on('close', (status, signal) => {
+      resolve({ status, signal, elapsedMs: performance.now() - startedAt, stdout, stderr });
     });
   });
 }
@@ -351,6 +408,7 @@ export async function runInstallPs1(
  * caveat in install-ps1.test.ts.
  */
 export function readUserPath(exe: string): string | null {
+  const startedAt = performance.now();
   const result = spawnSync(
     exe,
     [
@@ -361,7 +419,7 @@ export function readUserPath(exe: string): string | null {
     ],
     { encoding: 'utf8', env: powershellEnv() },
   );
-  const run = toRun(`${exe} (read user Path)`, result);
+  const run = toRun(`${exe} (read user Path)`, result, startedAt);
   if (run.status !== 0) throw new Error(`could not read the user Path: ${run.stderr}`);
   const value = run.stdout.replace(/\r?\n$/u, '');
   return value === 'ABSENT' ? null : value.slice('PRESENT'.length);
@@ -372,6 +430,7 @@ export function writeUserPath(exe: string, value: string | null): void {
   // The value travels in the child's environment rather than inside the command
   // string: a user Path is full of backslashes, semicolons and spaces, and
   // quoting it into `-Command` is a way to corrupt the thing being restored.
+  const startedAt = performance.now();
   const result = spawnSync(
     exe,
     [
@@ -388,6 +447,6 @@ export function writeUserPath(exe: string, value: string | null): void {
       }),
     },
   );
-  const run = toRun(`${exe} (restore user Path)`, result);
+  const run = toRun(`${exe} (restore user Path)`, result, startedAt);
   if (run.status !== 0) throw new Error(`could not restore the user Path: ${run.stderr}`);
 }

--- a/tools/installer/test/install-ps1.test.ts
+++ b/tools/installer/test/install-ps1.test.ts
@@ -54,6 +54,7 @@ import {
   writeSums,
 } from './helpers/release-fixture.ts';
 import {
+  describeRun,
   powershellExe,
   readUserPath,
   realDistDir,
@@ -143,7 +144,7 @@ describe.skipIf(PS === undefined)('install.ps1', () => {
       const result = await run();
 
       expect(result.stderr).toBe('');
-      expect(result.status).toBe(0);
+      expect(result.status, describeRun(result)).toBe(0);
       // The script runs `aka.exe --version` itself and prints what it got, so
       // this asserts the extracted binary was reached and ran.
       expect(result.stdout).toContain(expectedVersionOutput(FIXTURE_VERSION));
@@ -175,7 +176,7 @@ describe.skipIf(PS === undefined)('install.ps1', () => {
 
     const result = await run();
 
-    expect(result.status).not.toBe(0);
+    expect(result.status, describeRun(result)).not.toBe(0);
     expect(flat(result.stderr)).toContain('checksum mismatch');
     // Nothing extracted, nothing linked. The happy path above is the positive
     // control for these reads — without it, a script that always refused would
@@ -197,7 +198,7 @@ describe.skipIf(PS === undefined)('install.ps1', () => {
 
     const result = await run();
 
-    expect(result.status).not.toBe(0);
+    expect(result.status, describeRun(result)).not.toBe(0);
     expect(flat(result.stderr)).toContain('not listed in SHA256SUMS');
     // The DISTINCT path, not the mismatch one. Without the `if (-not $line)`
     // guard the unlisted archive is compared against an empty expectation and
@@ -229,7 +230,7 @@ describe.skipIf(PS === undefined)('install.ps1', () => {
       const result = await run(real.version);
 
       expect(result.stderr).toBe('');
-      expect(result.status).toBe(0);
+      expect(result.status, describeRun(result)).toBe(0);
       // `aka --version` prints a bare X.Y.Z, and it has to be the version the
       // asset name claimed — the installer resolved the asset from that string.
       expect(result.stdout).toContain(real.version);

--- a/tools/installer/test/install-sh.test.ts
+++ b/tools/installer/test/install-sh.test.ts
@@ -27,7 +27,7 @@ import {
   writeRelease,
   writeSums,
 } from './helpers/release-fixture.ts';
-import { realDistDir, runInstallSh } from './helpers/run-installer.ts';
+import { describeRun, realDistDir, runInstallSh } from './helpers/run-installer.ts';
 import { type ReleaseServer, serveRelease } from './helpers/serve-release.ts';
 
 const REAL_DIST = realDistDir();
@@ -90,7 +90,7 @@ describe.skipIf(process.platform === 'win32' || hostIsUnsupportedByInstallSh())(
       const result = await run();
 
       expect(result.stderr).toBe('');
-      expect(result.status).toBe(0);
+      expect(result.status, describeRun(result)).toBe(0);
       // The script runs `aka --version` itself and prints what it got, so this
       // asserts the extracted binary was reached and ran.
       expect(result.stdout).toContain(expectedVersionOutput(FIXTURE_VERSION));
@@ -121,7 +121,7 @@ describe.skipIf(process.platform === 'win32' || hostIsUnsupportedByInstallSh())(
 
       const result = await run();
 
-      expect(result.status).not.toBe(0);
+      expect(result.status, describeRun(result)).not.toBe(0);
       expect(result.stderr).toContain('checksum mismatch');
       // Nothing extracted, nothing linked. The happy path above is the positive
       // control for these two reads — without it, a script that always refused
@@ -144,7 +144,7 @@ describe.skipIf(process.platform === 'win32' || hostIsUnsupportedByInstallSh())(
 
       const result = await run();
 
-      expect(result.status).not.toBe(0);
+      expect(result.status, describeRun(result)).not.toBe(0);
       expect(result.stderr).toContain('not listed in SHA256SUMS');
       // The DISTINCT path, not the mismatch one. Without the `[ -n "$want" ]`
       // guard an unlisted archive compares against an empty expectation and is
@@ -171,7 +171,7 @@ describe.skipIf(process.platform === 'win32' || hostIsUnsupportedByInstallSh())(
       const result = await run(real.version);
 
       expect(result.stderr).toBe('');
-      expect(result.status).toBe(0);
+      expect(result.status, describeRun(result)).toBe(0);
       // `aka --version` prints a bare X.Y.Z, and it has to be the version the
       // asset name claimed — the installer resolved the asset from that string.
       expect(result.stdout).toContain(real.version);


### PR DESCRIPTION
Stacked on #455 — review that first; this touches the same file.

## The problem is that a real failure tells us nothing

`expect(result.status).not.toBe(0)` renders as:

```
AssertionError: expected +0 not to be +0 // Object.is equality
```

It names neither the script nor anything it did. That is the assertion behind the installer suite's most persistent CI flake — `refuses a tampered archive, and installs nothing` — which has now fired three times (linux-x64 on #401, linux-arm64 on #417, linux-arm64 on #457) and produced **no evidence on any of them**. Two investigations have gone looking and both were recorded as "cause unknown". On its face the signature reads as a security control not firing, which is precisely why it must not be normalized — and equally why guessing at it is the wrong response.

## What the record carries now

`describeRun` renders the run and is passed as vitest's message argument at every status assertion in both installer suites.

```
status=0 signal=null elapsed=107ms
stdout: (empty)
stderr: aka: downloading aka-1.2.3-win32-x64.zip...
```

**`elapsedMs` would have settled the last occurrence on its own.** That run reported exit 0 from a refusal case in **107 ms**, while the sibling refusal on the same leg took **3,610 ms**. So the script did not reach a decision and accept a tampered archive — it barely started. Nothing in the old record could separate those two readings, because both arrive as an exit status and nothing else.

**`signal` was being dropped on the floor.** `child.on('close', (status) => …)` ignores the second argument, so a child SIGKILLed by the 60 s timeout and one that exited cleanly both recorded `status: null` with nothing to tell them apart. That is the shape of a fourth signature already seen on win32.

**An empty stream renders as `(empty)`** rather than as nothing. "The script printed nothing" and "the message was lost getting here" point at opposite causes and otherwise look identical. A long stream is excerpted with its real length stated, so a 46 MB download's output cannot scroll the failure off the top of a CI log.

## Required, not optional

Both new fields are required. An optional one reads as safe at every site that omits it — which is every site until somebody remembers — so the compiler named all five fixture sites in #455's own suite instead. They go through a small builder, so a sixth field is one edit rather than five that each read as a decision and are not one.

## Verification

Mutation-verified, each against the case that pins it:

| mutation | red |
| --- | --- |
| drop the elapsed from the render | 2 |
| drop the signal | 1 |
| render an empty stream as nothing | 1 |
| always truncate | 3, including the control that keeps the length bound from passing vacuously |
| hardcode a zero elapsed in the real spawn | 1 |

That last one is the case worth keeping. Every other case here **injects** a runner, so all of them would pass with the clock unwired — only a case driving the default runner against a real child can show the measurement is live.

One case drives the real assertion and reads the error vitest actually raised, because `expect(actual, message)` honouring its second parameter is the assumption the whole change rests on and is not self-evident from the signature.

`tools/installer`: 5 files passed / 1 skipped, 53 passed / 6 skipped. Lint, typecheck and prettier clean.

## What this does not do

It does not fix the flake. The cause is still unknown, and I would rather say so than land a plausible-looking guess — the two previous attempts at one are why this exists. What it changes is that the next occurrence answers the question instead of starting a fourth investigation.
