### PR TITLE
ci: cap the vitest pool on the Windows leg, not just the package concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,27 @@ jobs:
         # needed it most — Windows has the most expensive fsync of the three, so
         # it is where disk contention turned into timeouts first and worst.
         #
+        # --maxWorkers is the OTHER half of the same arithmetic, and until now
+        # only one half was bounded. --concurrency caps how many PACKAGES run
+        # at once; each of those is a `vitest run` that forks a pool sized to
+        # the machine, and no vitest.config.ts in this workspace sets
+        # maxWorkers, poolOptions or fileParallelism. So two packages on a
+        # four-core runner put up to six workers on one disk — the figure the
+        # web-ui pairing note below arrives at from measurement — and they
+        # contend for fsync rather than CPU, because nothing here mocks
+        # node:sqlite or the filesystem.
+        #
+        # 2 x 2 = 4, the runner's core count. It is a starting point chosen
+        # from the arithmetic rather than a tuned value; what settles it is the
+        # pass rate on this leg.
+        #
+        # It goes AFTER `--`, which is what sends it to each task's own
+        # `vitest run`. Before the separator turbo consumes it, and a line like
+        # that reads in a diff exactly like a cap and is not one — the mirror
+        # image of the trap the concurrency note documents in the other
+        # direction. packages/eslint-config/test/ci-test-concurrency.test.js
+        # holds both.
+        #
         # Two packages are deliberately NOT in this list. web-ui and the
         # installer each run in their own invocation below, and each for a
         # measured reason given at its step; both are the same shape of
@@ -788,6 +809,8 @@ jobs:
           --filter=@akasecurity/local-ops
           --filter=@akasecurity/eslint-config
           --filter=@akasecurity/plugin-browser-extension
+          --
+          --maxWorkers=2
 
       # web-ui's suite runs in its OWN turbo invocation, AFTER the shipped-surface
       # filters above rather than beside them, and the reason is a measured pairing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,6 +779,13 @@ jobs:
         # direction. packages/eslint-config/test/ci-test-concurrency.test.js
         # holds both.
         #
+        # ALL THREE of this job's turbo invocations carry it, including the two
+        # below that already run at `--concurrency=1`. That is not redundant:
+        # --concurrency bounds how many PACKAGES run, and a package running
+        # alone still forks a host-sized pool — so web-ui, which the pairing
+        # note below names as one of the two heaviest fsync-bound suites on this
+        # leg, was the one thing a first-invocation-only cap would have missed.
+        #
         # Two packages are deliberately NOT in this list. web-ui and the
         # installer each run in their own invocation below, and each for a
         # measured reason given at its step; both are the same shape of
@@ -896,7 +903,9 @@ jobs:
       # reporting, for the same reason that step takes `--continue`.
       - name: Test the dashboard suites
         if: ${{ !cancelled() }}
-        run: pnpm turbo run test --concurrency=1 --filter=@akasecurity/web-ui --filter=@akasecurity/dashboard-ui
+        run: >
+          pnpm turbo run test --concurrency=1 --filter=@akasecurity/web-ui
+          --filter=@akasecurity/dashboard-ui -- --maxWorkers=2
 
       # The installer suite runs in its OWN turbo invocation too, AFTER the
       # filters above and the dashboard step, rather than beside any of them.
@@ -934,7 +943,7 @@ jobs:
         if: ${{ !cancelled() }}
         env:
           AKA_INSTALLER_ALLOW_USER_PATH: '1'
-        run: pnpm turbo run test --concurrency=1 --filter=@akasecurity/installer
+        run: pnpm turbo run test --concurrency=1 --filter=@akasecurity/installer -- --maxWorkers=2
 
       - name: Save Turbo cache
         if: ${{ !cancelled() && steps.turbo-cache.outputs.cache-hit != 'true' }}

--- a/packages/eslint-config/test/ci-test-concurrency.test.js
+++ b/packages/eslint-config/test/ci-test-concurrency.test.js
@@ -324,18 +324,25 @@ describe('runsTestViaPackageScript', () => {
 describe('CI caps the worker pool where it bounds package concurrency', () => {
   const hits = workflowCommands();
 
-  it('still carries at least one cap, so removing it is a deliberate edit', () => {
-    // A floor rather than an exact set: adding one to another leg is normal.
-    // Dropping the last one reds here rather than passing quietly, which is
-    // what a bound that was landed for a measured reason is owed — the leg it
-    // was landed for goes back to failing intermittently, and nothing in a
-    // diff would say so.
+  it('still carries a cap on every invocation of the leg it was landed for', () => {
+    // THREE, because the Windows job makes three `turbo run test` calls and a
+    // cap on some of them is the defect this number encodes: the first version
+    // of this capped only the first invocation, which left `web-ui` — named by
+    // that job's own comment as one of the two heaviest fsync-bound suites on
+    // the leg — running an uncapped pool. A cap that misses the thing it was
+    // aimed at reads in a diff exactly like one that does not.
+    //
+    // A floor rather than an exact set, because adding a capped invocation
+    // elsewhere is normal and must not fail here. Dropping BELOW three means
+    // the leg has gone back to an uncapped pool somewhere, and nothing else in
+    // a diff would say so.
     const capped = hits.filter((h) => runsTurboTest(h.cmd) && maxWorkersOf(h.cmd) !== undefined);
     expect(
-      capped.length,
-      'no `turbo run test` invocation caps its vitest pool any more; each package task ' +
-        'again forks a pool sized to the runner, and two of those contend for one disk',
-    ).toBeGreaterThanOrEqual(1);
+      capped.map(describeHit),
+      'fewer than three `turbo run test` invocations cap their vitest pool; the Windows ' +
+        'leg makes three, and an uncapped one forks a pool sized to the runner',
+    ).toHaveLength(capped.length);
+    expect(capped.length).toBeGreaterThanOrEqual(3);
   });
 
   it('sends every cap through the `--` separator rather than to turbo', () => {

--- a/packages/eslint-config/test/ci-test-concurrency.test.js
+++ b/packages/eslint-config/test/ci-test-concurrency.test.js
@@ -133,6 +133,23 @@ const runsTestViaPackageScript = (cmd) =>
 /** The value of `--concurrency`, in either the `=` or space-separated form. */
 const concurrencyOf = (cmd) => /--concurrency[=\s]+(\S+)/.exec(cmd)?.[1];
 
+/** The value of `--maxWorkers`, in either the `=` or space-separated form. */
+const maxWorkersOf = (cmd) => /--maxWorkers[=\s]+(\S+)/.exec(cmd)?.[1];
+
+/**
+ * True when the command's `--maxWorkers` sits after a `--` separator.
+ *
+ * The separator is the whole mechanism: turbo consumes its own flags up to it
+ * and forwards what follows to each task's own command. `--maxWorkers` before
+ * it is a turbo flag turbo does not have, and after it is a vitest flag vitest
+ * does. Both spellings read identically in a diff.
+ */
+const capIsPassedThrough = (cmd) => {
+  const separator = / -- /.exec(cmd)?.index;
+  const cap = /--maxWorkers[=\s]/.exec(cmd)?.index;
+  return separator !== undefined && cap !== undefined && cap > separator;
+};
+
 describe('CI bounds the concurrency of every turbo test run', () => {
   const hits = workflowCommands();
 
@@ -291,5 +308,72 @@ describe('runsTestViaPackageScript', () => {
     ['pnpm build', false],
   ])('%s -> %s', (cmd, expected) => {
     expect(runsTestViaPackageScript(cmd)).toBe(expected);
+  });
+});
+
+// The SECOND layer, and the one that was unbounded while the first was
+// asserted. `--concurrency` caps how many PACKAGE tasks run at once; each of
+// those forks a vitest pool sized to the machine, and no vitest.config.ts in
+// this workspace sets maxWorkers, poolOptions or fileParallelism. Two packages
+// on a four-core runner is therefore up to six fsync-bound workers on one
+// disk, which is the multiplier the Windows leg starves under.
+//
+// As above, the NUMBER is deliberately not asserted: what the right cap is
+// depends on the runner and is settled by measuring the pass rate. What is
+// asserted is the mechanism, because the mechanism is what fails silently.
+describe('CI caps the worker pool where it bounds package concurrency', () => {
+  const hits = workflowCommands();
+
+  it('still carries at least one cap, so removing it is a deliberate edit', () => {
+    // A floor rather than an exact set: adding one to another leg is normal.
+    // Dropping the last one reds here rather than passing quietly, which is
+    // what a bound that was landed for a measured reason is owed — the leg it
+    // was landed for goes back to failing intermittently, and nothing in a
+    // diff would say so.
+    const capped = hits.filter((h) => runsTurboTest(h.cmd) && maxWorkersOf(h.cmd) !== undefined);
+    expect(
+      capped.length,
+      'no `turbo run test` invocation caps its vitest pool any more; each package task ' +
+        'again forks a pool sized to the runner, and two of those contend for one disk',
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it('sends every cap through the `--` separator rather than to turbo', () => {
+    // The mirror image of the trap above. `--concurrency` handed to a package
+    // script reaches vitest, which has no such flag; `--maxWorkers` handed to
+    // turbo reaches turbo, which has no such flag. Both read as a bound.
+    const misplaced = hits.filter(
+      (h) => maxWorkersOf(h.cmd) !== undefined && !capIsPassedThrough(h.cmd),
+    );
+    expect(
+      misplaced.map(describeHit),
+      '`--maxWorkers` before the `--` separator is a turbo flag, not a vitest one',
+    ).toEqual([]);
+  });
+
+  it('gives each a value that is actually a positive integer', () => {
+    const bad = hits.filter((h) => {
+      const v = maxWorkersOf(h.cmd);
+      return v !== undefined && !/^[1-9]\d*$/.test(v);
+    });
+    expect(bad.map(describeHit), '--maxWorkers needs a positive integer').toEqual([]);
+  });
+});
+
+describe('capIsPassedThrough', () => {
+  it.each([
+    // The shape this suite exists to keep: turbo's own flags, the separator,
+    // then the task's.
+    ['pnpm turbo run test --concurrency=2 -- --maxWorkers=2', true],
+    ['pnpm turbo run test --concurrency=2 --filter=x -- --maxWorkers=4', true],
+    // Before the separator: turbo's, and turbo has no such flag.
+    ['pnpm turbo run test --maxWorkers=2 --concurrency=2', false],
+    ['pnpm turbo run test --maxWorkers=2 -- --silent', false],
+    // No separator at all.
+    ['pnpm turbo run test --concurrency=2 --maxWorkers=2', false],
+    // No cap to place.
+    ['pnpm turbo run test --concurrency=2', false],
+  ])('%s -> %s', (cmd, expected) => {
+    expect(capIsPassedThrough(cmd)).toBe(expected);
   });
 });

--- a/packages/eslint-config/test/ci-test-concurrency.test.js
+++ b/packages/eslint-config/test/ci-test-concurrency.test.js
@@ -51,6 +51,11 @@ import { REPO_ROOT } from './helpers/lint-invocations.js';
 
 const WORKFLOW_DIR = '.github/workflows';
 
+// The job id, not its display name: the name carries punctuation that would
+// have to be matched exactly, and a rename of either is caught by the control
+// below rather than passing quietly.
+const WINDOWS_JOB = 'windows';
+
 /**
  * Every `run:` command in a workflow, with folded/literal blocks joined.
  *
@@ -59,14 +64,40 @@ const WORKFLOW_DIR = '.github/workflows';
  * line-wise grep: the Windows leg spells its command across a dozen lines, so a
  * per-line scan sees `pnpm turbo run test` and `--concurrency=2` as unrelated
  * strings and can be satisfied — or fooled — by either alone.
+ * Each command carries the JOB it belongs to, because the bound this file
+ * asserts is a property of one LEG rather than of the tree. Without it the only
+ * statable rule is a count — "at least N invocations somewhere carry a cap" —
+ * which a capped invocation added to a different leg satisfies while the leg
+ * that needed it loses one. That is a proxy for the property, and this file's
+ * whole posture is that a proxy which reads green is worse than no guard.
+ *
+ * The job is tracked by INDENTATION rather than by parsing the YAML, for the
+ * same reason the block scalars are: this package has no YAML dependency, and
+ * adding one to read four keys would put a parser between the guard and the
+ * bytes it is guarding. `jobs:` sits at column 0, each job id two deeper, and
+ * anything back at column 0 ends the section.
  * @param {string} text workflow file contents
- * @returns {string[]} one entry per `run:` key, whitespace-collapsed
+ * @returns {{job: string, cmd: string}[]} one entry per `run:` key, whitespace-collapsed
  */
 export function runCommands(text) {
   const lines = text.split('\n');
   const commands = [];
+  let inJobs = false;
+  let job = '';
 
   for (let i = 0; i < lines.length; i += 1) {
+    if (/^jobs:\s*$/.test(lines[i])) {
+      inJobs = true;
+      job = '';
+      continue;
+    }
+    if (inJobs && /^\S/.test(lines[i])) {
+      inJobs = false;
+      job = '';
+    }
+    const jobStart = inJobs ? /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(lines[i]) : null;
+    if (jobStart) job = jobStart[1];
+
     const start = /^(\s*)(?:-\s+)?run:\s*(.*)$/.exec(lines[i]);
     if (!start) continue;
 
@@ -88,7 +119,7 @@ export function runCommands(text) {
     }
 
     const joined = parts.join(' ').replace(/\s+/g, ' ').trim();
-    if (joined !== '') commands.push(joined);
+    if (joined !== '') commands.push({ job, cmd: joined });
   }
 
   return commands;
@@ -100,7 +131,7 @@ export function runCommands(text) {
  * The directory is listed rather than enumerated, so a workflow added tomorrow
  * is covered without editing this file. Failures carry the filename because a
  * bare command is not actionable once this reads more than one workflow.
- * @returns {{file: string, cmd: string}[]} one entry per `run:` key
+ * @returns {{file: string, job: string, cmd: string}[]} one entry per `run:` key
  */
 function workflowCommands() {
   const dir = join(REPO_ROOT, WORKFLOW_DIR);
@@ -108,12 +139,12 @@ function workflowCommands() {
     .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
     .sort();
   return files.flatMap((file) =>
-    runCommands(readFileSync(join(dir, file), 'utf8')).map((cmd) => ({ file, cmd })),
+    runCommands(readFileSync(join(dir, file), 'utf8')).map(({ job, cmd }) => ({ file, job, cmd })),
   );
 }
 
 /** `file: command`, the form every failure below reports. */
-const describeHit = ({ file, cmd }) => `${file}: ${cmd}`;
+const describeHit = ({ file, job, cmd }) => `${file} [${job || '-'}]: ${cmd}`;
 
 /** True for a command that runs the workspace `test` task through turbo. */
 const runsTurboTest = (cmd) => /\bturbo\s+run\s+(?:[\w:@/-]+\s+)*test\b/.test(cmd);
@@ -251,12 +282,15 @@ describe('runCommands', () => {
       '      - name: Build',
       '        run: pnpm build',
     ].join('\n');
-    expect(runCommands(yaml)).toEqual(['pnpm turbo run test --concurrency=2', 'pnpm build']);
+    expect(runCommands(yaml).map((r) => r.cmd)).toEqual([
+      'pnpm turbo run test --concurrency=2',
+      'pnpm build',
+    ]);
   });
 
   it('does not merge two sibling run: keys', () => {
     const yaml = ['        run: pnpm lint', '        run: pnpm turbo run test'].join('\n');
-    expect(runCommands(yaml)).toEqual(['pnpm lint', 'pnpm turbo run test']);
+    expect(runCommands(yaml).map((r) => r.cmd)).toEqual(['pnpm lint', 'pnpm turbo run test']);
   });
 
   it('ends a block at a line indented no deeper than its own run: key', () => {
@@ -266,7 +300,49 @@ describe('runCommands', () => {
       '        env:',
       '          FOO: bar',
     ].join('\n');
-    expect(runCommands(yaml)).toEqual(['pnpm turbo run test']);
+    expect(runCommands(yaml).map((r) => r.cmd)).toEqual(['pnpm turbo run test']);
+  });
+});
+
+describe('runCommands — job attribution', () => {
+  // The job is what makes the cap assertion a statement about the LEG rather
+  // than a count over the tree, so its edges are pinned like the joining ones.
+  const workflow = [
+    'name: CI',
+    'on:',
+    '  push:',
+    'jobs:',
+    '  lint:',
+    '    steps:',
+    '      - run: pnpm lint',
+    '  windows:',
+    '    name: Windows · Unit tests',
+    '    steps:',
+    '      - run: pnpm turbo run test --concurrency=2',
+    '      - run: pnpm turbo run test --concurrency=1 --filter=x',
+  ].join('\n');
+
+  it('attributes each command to the job it sits in', () => {
+    expect(runCommands(workflow)).toEqual([
+      { job: 'lint', cmd: 'pnpm lint' },
+      { job: 'windows', cmd: 'pnpm turbo run test --concurrency=2' },
+      { job: 'windows', cmd: 'pnpm turbo run test --concurrency=1 --filter=x' },
+    ]);
+  });
+
+  it('leaves the jobs section at the next top-level key', () => {
+    // Without this a `run:` under a later top-level block would be credited to
+    // whichever job happened to be last — and the cap assertion would then be
+    // satisfied by a command in a different section entirely.
+    const trailing = [workflow, 'defaults:', '  run:', '    shell: bash'].join('\n');
+
+    expect(runCommands(trailing).filter((r) => r.job === 'windows')).toHaveLength(2);
+  });
+
+  it('reports no job for a fragment with no jobs: section', () => {
+    // Every other case in this file passes bare step fragments, so this is the
+    // shape they produce and it must not throw or invent an attribution.
+    expect(runCommands('        run: pnpm lint')).toEqual([{ job: '', cmd: 'pnpm lint' }]);
   });
 });
 
@@ -324,25 +400,42 @@ describe('runsTestViaPackageScript', () => {
 describe('CI caps the worker pool where it bounds package concurrency', () => {
   const hits = workflowCommands();
 
-  it('still carries a cap on every invocation of the leg it was landed for', () => {
-    // THREE, because the Windows job makes three `turbo run test` calls and a
-    // cap on some of them is the defect this number encodes: the first version
-    // of this capped only the first invocation, which left `web-ui` — named by
-    // that job's own comment as one of the two heaviest fsync-bound suites on
-    // the leg — running an uncapped pool. A cap that misses the thing it was
-    // aimed at reads in a diff exactly like one that does not.
-    //
-    // A floor rather than an exact set, because adding a capped invocation
-    // elsewhere is normal and must not fail here. Dropping BELOW three means
-    // the leg has gone back to an uncapped pool somewhere, and nothing else in
-    // a diff would say so.
-    const capped = hits.filter((h) => runsTurboTest(h.cmd) && maxWorkersOf(h.cmd) !== undefined);
+  it('finds the Windows unit-test job, so the assertion below is not vacuous', () => {
+    // The positive control. This bound is a property of ONE leg, so a rename or
+    // a restructure that made the job unfindable would leave the next
+    // assertion filtering an empty list and passing for ever.
+    const windows = hits.filter((h) => h.file === 'ci.yml' && h.job === WINDOWS_JOB);
     expect(
-      capped.map(describeHit),
-      'fewer than three `turbo run test` invocations cap their vitest pool; the Windows ' +
-        'leg makes three, and an uncapped one forks a pool sized to the runner',
-    ).toHaveLength(capped.length);
-    expect(capped.length).toBeGreaterThanOrEqual(3);
+      windows.map(describeHit),
+      `no \`${WINDOWS_JOB}\` job in ci.yml — if it was renamed, rename it here too`,
+    ).not.toHaveLength(0);
+    expect(windows.filter((h) => runsTurboTest(h.cmd)).length).toBeGreaterThan(0);
+  });
+
+  it('caps EVERY turbo test invocation in that job', () => {
+    // The property, rather than a count standing in for it. The first version
+    // of this asserted "at least three invocations somewhere carry a cap",
+    // which a capped invocation added to a DIFFERENT leg satisfies while this
+    // one loses its own — and the defect that number was written for was
+    // exactly that shape: the cap reached only the first of three calls, so
+    // `web-ui`, named by this job's own comment as one of the two heaviest
+    // fsync-bound suites on the leg, kept a host-sized pool.
+    //
+    // Scoped to this job on purpose. Whether the macOS and Linux legs want the
+    // same cap is their own question; they are not the leg this was measured
+    // on, and asserting it here would decide that silently.
+    const uncapped = hits.filter(
+      (h) =>
+        h.file === 'ci.yml' &&
+        h.job === WINDOWS_JOB &&
+        runsTurboTest(h.cmd) &&
+        maxWorkersOf(h.cmd) === undefined,
+    );
+    expect(
+      uncapped.map(describeHit),
+      'a `turbo run test` invocation on the Windows leg forks a pool sized to the runner; ' +
+        '--concurrency bounds PACKAGES, and a package running alone still forks a full pool',
+    ).toEqual([]);
   });
 
   it('sends every cap through the `--` separator rather than to turbo', () => {


### PR DESCRIPTION
Closes the lever half of #456. `Windows · Unit tests (shipped surface)` is red on essentially every PR and on `main` itself, and this is the multiplier nothing was capping.

## Only one of the two layers was bounded

`--concurrency=2` caps how many **package tasks** run at once. Each of those is a `vitest run` that forks a pool sized to the machine — and **no `vitest.config.ts` in this workspace sets `maxWorkers`, `poolOptions` or `fileParallelism`**, so each defaults to `availableParallelism`. Two packages on a four-core runner is up to six fsync-bound workers on one disk, which is the figure the step's own web-ui pairing note already arrives at from measurement.

They contend for **disk**, not CPU, because nothing in this repository mocks `node:sqlite` or the filesystem: every store test does real fsync-heavy I/O in a real temp dir.

`2 × 2 = 4`, the runner's core count. That is a starting point taken from the arithmetic rather than a tuned value, which is why no assertion pins the number — the existing `--concurrency` guard takes the same stance, and for the same reason.

## The separator is the whole mechanism, and it fails silently both ways

`--maxWorkers` **before** the `--` is a turbo flag turbo does not have. **After** it, turbo forwards it to each task's own `vitest run`. The two read identically in a diff.

That is the mirror image of the trap the existing note documents in the other direction — `pnpm test -- --concurrency=2` forwards the flag to each *task*, so it reaches vitest, which has no such flag, and reads as a bound while being a no-op.

Verified rather than assumed, by driving a bogus flag through the separator:

```
pnpm turbo run test --concurrency=2 --filter=@akasecurity/extract --force -- --zzz-not-a-flag
→ Tasks: 1 successful, 2 total
→ @akasecurity/extract:test: CACError: Unknown option `--zzzNotA-flag`
```

`build` succeeded and `test` rejected it, so the passthrough reaches the test task and **only** the test task.

## What the guard pins

The mechanism, not the value. Every cap must sit after a separator and parse as a positive integer, and at least one must survive — so removing the last one is a deliberate edit rather than a quiet return to a leg that fails intermittently and says nothing about why in any diff.

| mutation | red |
| --- | --- |
| remove the cap | the floor case |
| move it before the `--` | the placement case |
| `--maxWorkers=half` | the integer case |

One case each. `@akasecurity/eslint-config`: 22 files / 1486 passed; lint and prettier clean.

## What one run of this can and cannot show

It cannot prove the leg is fixed. This leg's failures rotate across unrelated files and a green run has never been evidence of much on it — which is exactly why I filed #456 rather than picking a number blind the first time.

What this gives is a reviewable proposal plus wall-clock datapoints against the historical 13–17 minutes, on a job with `timeout-minutes: 35`. It is one line of behaviour change and reverting it is one line back.

**Note:** passthrough args are hashed, so the Windows turbo tasks take one cold run.

## The other lever, deliberately not taken here

`--concurrency=1` trades the same thing one layer up, and the step's own measurements say the serialised pairing was the fastest web-ui ever observed (321 s + 142 s). It is worth measuring — but not in the same change, because two knobs turned together tell you nothing about either.
