### PR TITLE
fix(eslint-config): merge a caller's restrictions into the drizzle wall

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -270,17 +270,33 @@ const DRIZZLE_IMPORT_MESSAGE =
  * `allow` drops a network module from base's bans, exactly as `noNetworkImports`
  * takes it. The Drizzle half deliberately takes NO allow list: `@akasecurity/schema`
  * is the one package that may import Drizzle, and it carries no wall to relax.
- * @param {{ allow?: string[] }} [opts]
+ *
+ * `paths` and `patterns` are MERGED with the Drizzle entries rather than
+ * replacing them, which is what `noNetworkImports` already does with its own.
+ * The two have to agree: this function's whole job is to carry a ban forward
+ * that flat config would otherwise replace, so a caller adding one restriction
+ * to the wall and silently losing every other is this module's own failure
+ * mode reached from the inside. A caller's entries go LAST, matching
+ * `noNetworkImports`, so the wall's own message is the one a reader sees for a
+ * specifier both halves name.
+ * @param {{ allow?: string[], paths?: object[], patterns?: object[] }} [opts]
  */
 export function drizzleWallRules(opts = {}) {
+  const { paths = [], patterns = [], ...rest } = opts;
   return {
     'no-restricted-imports': noNetworkImports({
-      ...opts,
-      paths: DRIZZLE_MODULES.map((name) => ({ name, message: DRIZZLE_IMPORT_MESSAGE })),
-      patterns: DRIZZLE_MODULES.map((name) => ({
-        group: [`${name}/*`],
-        message: DRIZZLE_IMPORT_MESSAGE,
-      })),
+      ...rest,
+      paths: [
+        ...DRIZZLE_MODULES.map((name) => ({ name, message: DRIZZLE_IMPORT_MESSAGE })),
+        ...paths,
+      ],
+      patterns: [
+        ...DRIZZLE_MODULES.map((name) => ({
+          group: [`${name}/*`],
+          message: DRIZZLE_IMPORT_MESSAGE,
+        })),
+        ...patterns,
+      ],
     }),
     // The dynamic half. `no-restricted-imports` sees only a written specifier,
     // so without this a code-split `await import('drizzle-orm/pg-core')` reaches

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -279,7 +279,11 @@ const DRIZZLE_IMPORT_MESSAGE =
  * mode reached from the inside. A caller's entries go LAST, matching
  * `noNetworkImports`, so the wall's own message is the one a reader sees for a
  * specifier both halves name.
- * @param {{ allow?: string[], paths?: object[], patterns?: object[] }} [opts]
+ * @param {{
+ *   allow?: string[],
+ *   paths?: { name: string, message: string }[],
+ *   patterns?: { group: string[], message: string }[],
+ * }} [opts]
  */
 export function drizzleWallRules(opts = {}) {
   const { paths = [], patterns = [], ...rest } = opts;

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -277,8 +277,11 @@ const DRIZZLE_IMPORT_MESSAGE =
  * that flat config would otherwise replace, so a caller adding one restriction
  * to the wall and silently losing every other is this module's own failure
  * mode reached from the inside. A caller's entries go LAST, matching
- * `noNetworkImports`, so the wall's own message is the one a reader sees for a
- * specifier both halves name.
+ * `noNetworkImports`, so for a specifier both halves name the wall's message is
+ * REPORTED FIRST — not the only one reported. `no-restricted-imports` emits
+ * every matching entry rather than stopping at the first, verified against the
+ * workspace's own ESLint: two `paths` entries naming one specifier produce two
+ * messages, ordered as the array is.
  * @param {{
  *   allow?: string[],
  *   paths?: { name: string, message: string }[],

--- a/packages/eslint-config/test/drizzle-wall-merge.test.js
+++ b/packages/eslint-config/test/drizzle-wall-merge.test.js
@@ -1,0 +1,84 @@
+import { Linter } from 'eslint';
+import { describe, expect, it } from 'vitest';
+
+import { drizzleWallRules } from '../src/index.js';
+
+// `drizzleWallRules` exists BECAUSE flat config replaces a rule rather than
+// merging it: a package that wants the Drizzle ban and the network bans has to
+// receive both in one value, or the later entry silently drops the other. The
+// function then did the same thing to its own caller — `paths` and `patterns`
+// handed in were overwritten by the Drizzle-derived arrays before they reached
+// `noNetworkImports`, so a caller adding one restriction to the wall got that
+// restriction and nothing else.
+//
+// It is the module's own failure mode reached from the inside, and it fails the
+// way every one of them does: lint still exits 0.
+//
+// Driven through a real `Linter` rather than asserted against the rule's
+// structure. A shape assertion passes on a value nothing enforces — and what a
+// caller needs to know is which imports are refused, which is a question only
+// the linter answers.
+const linter = new Linter();
+
+/** How many messages `code` produces under a wall built with `opts`. */
+const firedUnder = (opts, code) =>
+  linter.verify(code, {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    rules: { 'no-restricted-imports': drizzleWallRules(opts)['no-restricted-imports'] },
+  }).length;
+
+const CALLER_PATH = { name: 'left-pad', message: "the caller's own ban" };
+const CALLER_PATTERN = { group: ['lodash/*'], message: "the caller's own pattern" };
+
+describe('drizzleWallRules merges a caller’s restrictions rather than replacing its own', () => {
+  const wall = { paths: [CALLER_PATH], patterns: [CALLER_PATTERN] };
+
+  it("refuses the caller's own path", () => {
+    expect(firedUnder(wall, "import lp from 'left-pad';")).toBe(1);
+  });
+
+  it("refuses the caller's own pattern", () => {
+    expect(firedUnder(wall, "import get from 'lodash/get';")).toBe(1);
+  });
+
+  it('still refuses drizzle, which is the half a replace would have kept', () => {
+    // The overwrite kept the Drizzle entries and dropped the caller's, so this
+    // case passed throughout and is here as the control: it is what tells a
+    // reader the merge did not trade one ban for the other.
+    expect(firedUnder(wall, "import { eq } from 'drizzle-orm';")).toBe(1);
+    expect(firedUnder(wall, "import { p } from 'drizzle-orm/pg-core';")).toBe(1);
+  });
+
+  it('still refuses the network modules it carries forward from base', () => {
+    // The other half this function exists to carry. A merge written as a
+    // wholesale replace one level down would drop these instead, which is the
+    // same defect moved rather than fixed.
+    expect(firedUnder(wall, "import https from 'node:https';")).toBe(1);
+    expect(firedUnder(wall, "import a from 'axios/lib/adapters/http.js';")).toBe(1);
+  });
+
+  it('leaves an unrestricted import alone', () => {
+    // Without this every count above is satisfied by a wall that refuses
+    // everything.
+    expect(firedUnder(wall, "import { join } from 'node:path';")).toBe(0);
+  });
+
+  it('still honours allow alongside the merged entries', () => {
+    // `allow` rides in `...rest` now that `paths`/`patterns` are destructured
+    // out. A destructure that swallowed it would leave the network ban intact
+    // and the opt-out silently inert — green lint on a file that needs the
+    // exception, which is the shape of every other failure in this module.
+    expect(firedUnder({ ...wall, allow: ['node:https'] }, "import https from 'node:https';")).toBe(
+      0,
+    );
+    expect(firedUnder({ ...wall, allow: ['node:https'] }, "import net from 'node:net';")).toBe(1);
+  });
+
+  it('takes no paths or patterns at all, exactly as every call site does today', () => {
+    // The backward-compatibility case. Every existing caller passes neither, so
+    // the defaults must leave the wall byte-for-byte what it was.
+    expect(firedUnder({}, "import { eq } from 'drizzle-orm';")).toBe(1);
+    expect(firedUnder(undefined, "import { eq } from 'drizzle-orm';")).toBe(1);
+    expect(firedUnder({}, "import lp from 'left-pad';")).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #316.

## The function did to its caller what it exists to prevent

`drizzleWallRules` exists **because** flat config replaces a rule rather than merging it: a package that wants the Drizzle ban and the network bans has to receive both in one value, or the later entry silently drops the other.

It then did exactly that to its own caller. `paths` and `patterns` handed in were overwritten by the Drizzle-derived arrays before reaching `noNetworkImports`, so a caller adding one restriction alongside the wall got that restriction and **nothing else**. Its sibling `noNetworkImports` already concatenates a caller's entries after its own — the two now agree, which they have to, since disagreeing is what made this invisible.

It fails the way every failure in this module does: lint still exits 0.

## Two details

A caller's entries go **last**, matching `noNetworkImports`, so for a specifier both halves name it is the wall's own message a reader sees rather than the caller's.

`allow` now rides in `...rest` rather than in the spread. That is worth its own case: a destructure that swallowed it would leave the network ban intact and the **opt-out** inert — green lint on the one file that needs the exception, which is the same shape as everything else here.

Backward compatible by construction: every call site today passes neither, so the `[]` defaults leave the rule value unchanged. Pinned as its own case rather than argued.

## Driven through a real linter

A structure assertion passes on a rule value nothing enforces, and what a caller needs to know is which imports are actually refused — a question only the linter answers. So each case lints a snippet under a wall built with the caller's entries and counts the messages.

The suite carries its own controls: Drizzle and the network modules must still be refused (a merge written as a wholesale replace one level down would be the same defect moved rather than fixed), and an unrestricted `node:path` import must still produce nothing, without which every count is satisfied by a wall that refuses everything.

| mutation | red |
| --- | --- |
| restore the overwrite | the two caller cases |
| drop the Drizzle entries from the merge | the Drizzle control + the no-options case |
| swallow `...rest` so `allow` never arrives | the opt-out case |

`@akasecurity/eslint-config` 23 files / 1484 passed. Workspace `pnpm lint` and the portability gate clean — the wall is live in every walled package, so a regression here would have shown up there.
