### PR TITLE
fix(schema,persistence,dashboard-ui): report a pinned key this build cannot apply

### DIFF
--- a/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
+++ b/packages/dashboard-ui/src/settings/WorkspaceSettingsFormView.tsx
@@ -435,20 +435,36 @@ function SettingGroup({ title, children }: { title: string; children: ReactNode 
   );
 }
 
+/** `1 setting` / `3 settings`, so the sentence below reads in either case. */
+const settings = (count: number): string =>
+  count === 1 ? '1 setting' : `${String(count)} settings`;
+
 /**
- * The line rendered when an administrator's file locks keys this build does
- * not know. Such a lock is dropped from the locked set rather than failing the
- * whole file (which would run the machine unmanaged), and this is the one
- * place that says a lock exists which is not being applied. A count rather
- * than the names: the names are the administrator's to fix, in the file.
+ * The line rendered when an administrator's file names settings this build does
+ * not know — pinned, locked, or both. Such a name is dropped rather than
+ * failing the whole file (which would run the machine unmanaged), and this is
+ * the one place that says an administrative decision exists which is not being
+ * applied. Counts rather than the names: the names are the administrator's to
+ * fix, in the file.
+ *
+ * PINS AND LOCKS ARE COUNTED SEPARATELY inside one sentence. Two sentences read
+ * worse and a single merged count reads wrong: an unapplied lock leaves a
+ * control the administrator meant to freeze still editable, while an unapplied
+ * pin leaves a default they meant to set unset. Those send an administrator to
+ * different lines of their own file, so the sentence has to keep them apart
+ * even though the remedy — update AKA — is the same one.
  */
-export function managedUnknownLocksNotice(context: ManagedContext): string | undefined {
-  const count = context.unknownLockedFields?.length ?? 0;
-  if (!context.present || count === 0) return undefined;
+export function managedUnrecognizedNotice(context: ManagedContext): string | undefined {
+  const locks = context.unknownLockedFields?.length ?? 0;
+  const pins = context.unknownValueFields?.length ?? 0;
+  if (!context.present || locks + pins === 0) return undefined;
   const who = context.organization ?? 'Your organization';
-  return count === 1
-    ? `${who} locks 1 setting this version of AKA does not recognize. Update AKA to apply it.`
-    : `${who} locks ${String(count)} settings this version of AKA does not recognize. Update AKA to apply them.`;
+  const clauses = [
+    ...(pins > 0 ? [`pins ${settings(pins)}`] : []),
+    ...(locks > 0 ? [`locks ${settings(locks)}`] : []),
+  ];
+  const what = locks + pins === 1 ? 'it' : 'them';
+  return `${who} ${clauses.join(' and ')} this version of AKA does not recognize. Update AKA to apply ${what}.`;
 }
 
 export interface WorkspaceSettingsFormViewProps {
@@ -582,7 +598,7 @@ export function WorkspaceSettingsFormView({
   // ends up editable.
   const lockOn = (key: ManagedSettingKey): string | undefined =>
     isFieldManaged(managed, key) ? managedByLabel(managed) : undefined;
-  const unknownLocks = managedUnknownLocksNotice(managed);
+  const unrecognized = managedUnrecognizedNotice(managed);
 
   const dirty =
     historicalAccess !== settings.historicalAccess ||
@@ -606,9 +622,9 @@ export function WorkspaceSettingsFormView({
 
   return (
     <div className="flex max-w-4xl flex-col gap-7">
-      {unknownLocks !== undefined && (
+      {unrecognized !== undefined && (
         <p className="text-xs text-text-3" data-slot="managed-unknown-locks">
-          {unknownLocks}
+          {unrecognized}
         </p>
       )}
       <SettingGroup title="Connection">

--- a/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
+++ b/packages/dashboard-ui/test/settings/WorkspaceSettingsFormView.test.ts
@@ -36,7 +36,7 @@ import {
   HISTORY_SYNC_STALE_NOTICE,
   INLINE_REVEAL_CHOICES,
   INLINE_REVEAL_SECTION_DESCRIPTION,
-  managedUnknownLocksNotice,
+  managedUnrecognizedNotice,
   MODEL_JUDGE_CHOICES,
   MODEL_JUDGE_SECTION_DESCRIPTION,
   MODEL_JUDGE_SECTION_LABEL,
@@ -878,14 +878,14 @@ describe('administratively locked rows', () => {
   });
 
   it('words the unknown-lock notice for one and for several, and never on an unmanaged machine', () => {
-    const one = managedUnknownLocksNotice({
+    const one = managedUnrecognizedNotice({
       present: true,
       lockedFields: [],
       unknownLockedFields: ['a'],
     });
     expect(one).toContain('Your organization locks 1 setting');
     expect(one).toContain('apply it.');
-    const several = managedUnknownLocksNotice({
+    const several = managedUnrecognizedNotice({
       present: true,
       organization: 'Acme',
       lockedFields: [],
@@ -896,9 +896,67 @@ describe('administratively locked rows', () => {
     // Gated on `present` like isFieldManaged: a stale context must not
     // announce locks from an administrator who is not there.
     expect(
-      managedUnknownLocksNotice({ present: false, lockedFields: [], unknownLockedFields: ['a'] }),
+      managedUnrecognizedNotice({ present: false, lockedFields: [], unknownLockedFields: ['a'] }),
     ).toBeUndefined();
-    expect(managedUnknownLocksNotice({ present: true, lockedFields: [] })).toBeUndefined();
+    expect(managedUnrecognizedNotice({ present: true, lockedFields: [] })).toBeUndefined();
+  });
+
+  it('words the same notice for an unrecognised PIN, which is the silent half', () => {
+    // A pin with no lock is a supported shape — the schema's own comment calls
+    // it a default the user may still change — so an administrator writing one
+    // against a newer key got nothing applied and nothing said. The lock half
+    // had a notice; this is the same sentence covering the other half.
+    const one = managedUnrecognizedNotice({
+      present: true,
+      lockedFields: [],
+      unknownValueFields: ['a'],
+    });
+    expect(one).toContain('Your organization pins 1 setting');
+    expect(one).toContain('apply it.');
+    const several = managedUnrecognizedNotice({
+      present: true,
+      organization: 'Acme',
+      lockedFields: [],
+      unknownValueFields: ['a', 'b'],
+    });
+    expect(several).toContain('Acme pins 2 settings');
+    expect(several).toContain('apply them.');
+    expect(
+      managedUnrecognizedNotice({ present: false, lockedFields: [], unknownValueFields: ['a'] }),
+    ).toBeUndefined();
+  });
+
+  it('counts pins and locks separately inside one sentence', () => {
+    // Not one merged count, and not two sentences. The two send an
+    // administrator to different lines of their own file: an unapplied lock
+    // leaves a control they meant to freeze editable, an unapplied pin leaves a
+    // default they meant to set unset.
+    const both = managedUnrecognizedNotice({
+      present: true,
+      organization: 'Acme',
+      lockedFields: [],
+      unknownLockedFields: ['a'],
+      unknownValueFields: ['b', 'c'],
+    });
+
+    expect(both).toBe(
+      'Acme pins 2 settings and locks 1 setting this version of AKA does not recognize. ' +
+        'Update AKA to apply them.',
+    );
+  });
+
+  it('says "them" once the two halves total more than one', () => {
+    // The pluralisation reads the TOTAL, not either half. One pin and one lock
+    // is two unapplied decisions, and a sentence ending "apply it" would name
+    // one of them.
+    expect(
+      managedUnrecognizedNotice({
+        present: true,
+        lockedFields: [],
+        unknownLockedFields: ['a'],
+        unknownValueFields: ['b'],
+      }),
+    ).toContain('apply them.');
   });
 });
 

--- a/packages/persistence/src/managed-settings.ts
+++ b/packages/persistence/src/managed-settings.ts
@@ -119,12 +119,17 @@ export function UNSAFE_TEST_ONLY_setManagedSettingsPaths(paths: readonly string[
  * on every managed machine breaking at once, which is a far worse outcome than
  * a lock that has to be noticed and repaired.
  *
- * One shape is deliberately NOT read as damage: a `lockedFields` entry naming a
- * key this build does not know. That is what an older build sees when an
- * administrator locks a key a newer build added, and refusing the whole file
- * there ran it unmanaged, every pin and lock gone. The schema drops such a name
- * from the locked set and reports it as `unknownLockedFields`, so every lock
- * this build understands still holds and the surface can say one does not.
+ * Two shapes are deliberately NOT read as damage, and they are the same shape
+ * on either half of the file: a `lockedFields` entry, or a `values` key, naming
+ * a setting this build does not know. That is what an older build sees when an
+ * administrator locks or pins a key a newer build added, and refusing the whole
+ * file there ran it unmanaged, every pin and lock gone. The schema drops such a
+ * name and reports it — `unknownLockedFields` for the lock half,
+ * `unknownValueFields` for the pin half — so everything this build understands
+ * still holds and the surface can say what does not.
+ *
+ * A bad value under a key this build DOES know is still damage, and still fails
+ * the file. That is what keeps the tolerance above from covering a typo.
  */
 export function readManagedSettings(
   paths: readonly string[] = testOnlyManagedPaths ?? managedSettingsPaths(),
@@ -157,6 +162,9 @@ export function managedContextOf(managed: ManagedSettings | null): ManagedContex
     ...(managed.unknownLockedFields === undefined
       ? {}
       : { unknownLockedFields: managed.unknownLockedFields }),
+    ...(managed.unknownValueFields === undefined
+      ? {}
+      : { unknownValueFields: managed.unknownValueFields }),
   };
 }
 

--- a/packages/persistence/test/managed-settings.test.ts
+++ b/packages/persistence/test/managed-settings.test.ts
@@ -119,6 +119,45 @@ describe('readManagedSettings — fail-open on a damaged administrative file', (
     expect(context.unknownLockedFields).toEqual(['lockFromANewerBuild']);
   });
 
+  it('keeps every pin it knows beside one it does not, and reports the stranger', () => {
+    // The mirror of the lock case, and the half that was silent: a pin with no
+    // lock is a supported shape — a default the user may still change — so an
+    // administrator writing one against a newer key had it dropped with
+    // nothing anywhere saying so.
+    writeManaged({
+      organization: 'Acme',
+      values: { runMode: 'attached', pinFromANewerBuild: true },
+    });
+
+    const managed = readManagedSettings([managedFile()]);
+
+    expect(managed?.values).toEqual({ runMode: 'attached' });
+    expect(managed?.unknownValueFields).toEqual(['pinFromANewerBuild']);
+    const context = managedContextOf(managed);
+    expect(context.present).toBe(true);
+    expect(context.unknownValueFields).toEqual(['pinFromANewerBuild']);
+  });
+
+  it('carries no unknown-pin key when every pin is known', () => {
+    // The control on the case above: a context that always carried the key
+    // would satisfy it whether or not anything was dropped.
+    writeManaged({ organization: 'Acme', values: { runMode: 'attached' } });
+
+    expect(managedContextOf(readManagedSettings([managedFile()]))).not.toHaveProperty(
+      'unknownValueFields',
+    );
+  });
+
+  it('runs unmanaged on a BAD value under a key it does know', () => {
+    // The line between tolerance and damage. The pin half is forgiving about a
+    // NAME from a newer build and must stay strict about a value it can read
+    // and reject — otherwise a typo'd enum reads as healthy while the
+    // administrator's decision is not applied.
+    writeManaged({ organization: 'Acme', values: { runMode: 'attachd' } });
+
+    expect(readManagedSettings([managedFile()])).toBeNull();
+  });
+
   it('runs UNMANAGED rather than refusing when the file is malformed', () => {
     // The posture cuts one way and it is deliberate: a typo in an MDM payload
     // must not break every hook on every managed machine at once. Stated as

--- a/packages/schema/src/zod/managed.ts
+++ b/packages/schema/src/zod/managed.ts
@@ -78,7 +78,21 @@ export const ManagedSettings = z
     // decision from a bug. Absent renders as a generic "your organization".
     organization: z.string().min(1).optional(),
     // What the administrator pinned.
-    values: ManagedSettingsValues.default({}),
+    //
+    // Parsed as a RECORD rather than as the nested schema, and split below for
+    // the same reason `lockedFields` is parsed as names: a plain `z.object`
+    // drops an unrecognised key and succeeds, so a pin this build does not know
+    // vanished and nothing anywhere said so. A pin with no lock is a supported
+    // shape — it is a DEFAULT the user may still change — so that silence hit
+    // exactly the file an administrator is most likely to write while a fleet
+    // is mid-upgrade.
+    //
+    // Splitting here rather than calling `.strict()`: strict would REFUSE the
+    // file, which is the outcome the lock half already rejected — an older
+    // build then runs entirely unmanaged, every pin and lock gone. A bad KNOWN
+    // value still fails, because the nested schema is re-run over the known
+    // subset and its issues are re-raised on this parse.
+    values: z.record(z.string(), z.unknown()).default({}),
     // Which of those the user may not change. A key here with no matching value
     // freezes whatever the user last chose; a value with no lock is a DEFAULT
     // the user may still override. The two are separable on purpose.
@@ -92,19 +106,39 @@ export const ManagedSettings = z
     // is still never HONOURED: the lockable set stays explicit above.
     lockedFields: z.array(z.string()).default([]),
   })
-  .transform(({ lockedFields, ...rest }) => {
+  .transform(({ lockedFields, values, ...rest }, ctx) => {
     const known: ManagedSettingKey[] = [];
     const unknown: string[] = [];
     for (const name of lockedFields) {
       if (isManagedSettingKey(name)) known.push(name);
       else unknown.push(name);
     }
-    // The unknown list is present only when non-empty, so the ordinary file
+
+    const knownValues: Record<string, unknown> = {};
+    const unknownValues: string[] = [];
+    for (const [name, value] of Object.entries(values)) {
+      if (name in ManagedSettingsValues.shape) knownValues[name] = value;
+      else unknownValues.push(name);
+    }
+    const pinned = ManagedSettingsValues.safeParse(knownValues);
+    if (!pinned.success) {
+      // Re-raised on THIS parse, under the `values` path, so a typo in a key
+      // this build does know is still a damaged file rather than a silently
+      // dropped pin. Losing that refusal is what makes the tolerance above
+      // dangerous instead of merely forgiving.
+      for (const issue of pinned.error.issues)
+        ctx.addIssue({ ...issue, path: ['values', ...issue.path] });
+      return z.NEVER;
+    }
+
+    // Each unknown list is present only when non-empty, so the ordinary file
     // carries no key for it and a consumer spreading the result carries none.
     return {
       ...rest,
+      values: pinned.data,
       lockedFields: known,
       ...(unknown.length > 0 ? { unknownLockedFields: unknown } : {}),
+      ...(unknownValues.length > 0 ? { unknownValueFields: unknownValues } : {}),
     };
   })
   .meta({ id: 'ManagedSettings' });
@@ -123,6 +157,12 @@ export interface ManagedContext {
   // surface can say a lock exists that it is not applying. Absent when there
   // are none.
   unknownLockedFields?: readonly string[];
+  // The same for PINNED VALUES, and kept separate rather than folded in
+  // because the two have different consequences: an unapplied lock leaves a
+  // control the administrator meant to freeze still editable, while an
+  // unapplied pin leaves a default they meant to set unset. A surface may say
+  // both in one sentence; it may not infer one from the other.
+  unknownValueFields?: readonly string[];
 }
 
 export const NO_MANAGED_CONTEXT: ManagedContext = { present: false, lockedFields: [] };

--- a/packages/schema/src/zod/managed.ts
+++ b/packages/schema/src/zod/managed.ts
@@ -114,10 +114,27 @@ export const ManagedSettings = z
       else unknown.push(name);
     }
 
-    const knownValues: Record<string, unknown> = {};
+    // `Object.hasOwn`, never `name in shape`: `in` consults the PROTOTYPE CHAIN,
+    // so every `Object.prototype` name — `toString`, `constructor`, `valueOf`,
+    // `__proto__` and the rest — classifies as known, is handed to the nested
+    // schema, and is dropped there with nothing reported. That is exactly the
+    // silence this split exists to end, reached from the one direction the
+    // split itself created.
+    //
+    // `__proto__` specifically never reaches here: the `z.record` above strips
+    // it, so a pin by that name is neither applied nor reported. That is Zod's
+    // behaviour rather than this function's, and it is the safe direction — but
+    // it IS one more silently dropped pin, so do not read the split below as
+    // covering it.
+    //
+    // The accumulator is null-prototype anyway. Nothing can reach it through
+    // `__proto__` today, and that is a property of the parser above rather than
+    // of this loop; a plain `{}` here would make the loop's correctness depend
+    // on it.
+    const knownValues = Object.create(null) as Record<string, unknown>;
     const unknownValues: string[] = [];
     for (const [name, value] of Object.entries(values)) {
-      if (name in ManagedSettingsValues.shape) knownValues[name] = value;
+      if (Object.hasOwn(ManagedSettingsValues.shape, name)) knownValues[name] = value;
       else unknownValues.push(name);
     }
     const pinned = ManagedSettingsValues.safeParse(knownValues);

--- a/packages/schema/test/zod/managed.test.ts
+++ b/packages/schema/test/zod/managed.test.ts
@@ -89,4 +89,58 @@ describe('ManagedSettings parsing', () => {
       false,
     );
   });
+
+  it('keeps a pin it knows and reports one it does not', () => {
+    // The mirror of the lock case above, and the half that used to be silent:
+    // a plain `z.object` drops an unrecognised key and succeeds, so this pin
+    // vanished with nothing anywhere saying so.
+    const parsed = ManagedSettings.parse({
+      values: { runMode: 'attached', notASetting: true, alsoNew: 'x' },
+    });
+
+    expect(parsed.values).toEqual({ runMode: 'attached' });
+    expect(parsed.unknownValueFields).toEqual(['notASetting', 'alsoNew']);
+  });
+
+  it('reports no unknown pins at all when every pin is known', () => {
+    const parsed = ManagedSettings.parse({ values: { runMode: 'attached' } });
+
+    expect(parsed.values).toEqual({ runMode: 'attached' });
+    expect(parsed).not.toHaveProperty('unknownValueFields');
+  });
+
+  it('still refuses a BAD value under a key it does know', () => {
+    // The line between tolerance and damage, and the reason the split re-runs
+    // the nested schema rather than calling `.strict()` or trusting the record.
+    // Without this a typo'd enum would be kept as an unparsed value or dropped
+    // as unknown, and either way the administrator's decision is not applied
+    // and the file still reads as healthy.
+    const bad = ManagedSettings.safeParse({ values: { runMode: 'attachd' } });
+
+    expect(bad.success).toBe(false);
+    expect(bad.error?.issues[0]?.path).toEqual(['values', 'runMode']);
+  });
+
+  it('refuses a values that is not an object at all', () => {
+    // Same boundary the lockedFields shape case draws: tolerance is for a NAME
+    // this build does not know, never for a shape it cannot read.
+    expect(ManagedSettings.safeParse({ values: 'runMode' }).success).toBe(false);
+    expect(ManagedSettings.safeParse({ values: [1] }).success).toBe(false);
+  });
+
+  it('tolerates an unknown pin and an unknown lock in one file, separately', () => {
+    // The shape a mid-upgrade fleet really produces: the newer build's key
+    // both pinned and locked. Both halves are reported, and neither is folded
+    // into the other — an unapplied lock and an unapplied pin have different
+    // consequences for the administrator reading the notice.
+    const parsed = ManagedSettings.parse({
+      values: { runMode: 'attached', newerKey: 1 },
+      lockedFields: ['runMode', 'newerKey'],
+    });
+
+    expect(parsed.values).toEqual({ runMode: 'attached' });
+    expect(parsed.lockedFields).toEqual(['runMode']);
+    expect(parsed.unknownValueFields).toEqual(['newerKey']);
+    expect(parsed.unknownLockedFields).toEqual(['newerKey']);
+  });
 });

--- a/packages/schema/test/zod/managed.test.ts
+++ b/packages/schema/test/zod/managed.test.ts
@@ -128,6 +128,40 @@ describe('ManagedSettings parsing', () => {
     expect(ManagedSettings.safeParse({ values: [1] }).success).toBe(false);
   });
 
+  it.each(['toString', 'constructor', 'valueOf', 'hasOwnProperty', 'isPrototypeOf'])(
+    'reports a pin named %s rather than swallowing it',
+    (name) => {
+      // Every one of these is an `Object.prototype` member, so a `name in shape`
+      // test calls it KNOWN, hands it to the nested schema and loses it there
+      // with nothing reported — the exact silence this split exists to end,
+      // reached from the one direction the split itself created.
+      const parsed = ManagedSettings.parse({ values: { runMode: 'attached', [name]: 'x' } });
+
+      expect(parsed.values).toEqual({ runMode: 'attached' });
+      expect(parsed.unknownValueFields).toEqual([name]);
+    },
+  );
+
+  it('drops a `__proto__` pin in the parser, before the split can report it', () => {
+    // Pinned as the LIMIT it is rather than as a fix. The managed file arrives
+    // through JSON.parse, which makes `__proto__` an own enumerable key rather
+    // than invoking the setter, so an administrator's file can really carry
+    // one — and `z.record` strips it before the known/unknown split runs. The
+    // pin is therefore neither applied nor reported: safe, and still silent.
+    //
+    // Built through JSON.parse for that reason; an object literal would invoke
+    // the setter and test a shape this code never sees. If Zod's record ever
+    // stops stripping it, this case goes red and the split has to report it.
+    const values: unknown = JSON.parse('{"runMode":"attached","__proto__":{"polluted":true}}');
+
+    const parsed = ManagedSettings.parse({ values });
+
+    expect(parsed.values).toEqual({ runMode: 'attached' });
+    expect(parsed).not.toHaveProperty('unknownValueFields');
+    // And nothing downstream carries an administrator-supplied prototype.
+    expect(Object.getPrototypeOf(parsed.values)).not.toHaveProperty('polluted');
+  });
+
   it('tolerates an unknown pin and an unknown lock in one file, separately', () => {
     // The shape a mid-upgrade fleet really produces: the newer build's key
     // both pinned and locked. Both halves are reported, and neither is folded


### PR DESCRIPTION
Closes #437.

## The half that said nothing

The lock half of the administrative overlay already tolerates a key an older build does not know and says so on the Settings page. The value half was tolerant and **completely silent**: `ManagedSettingsValues` is a plain `z.object`, so Zod dropped an unrecognised key and the parse succeeded. Nothing carried it, nothing rendered it, no log line mentioned it.

That silence lands on exactly the shape an administrator legitimately writes. The schema's own comment makes a pin with no lock first class — *"a value with no lock is a DEFAULT the user may still override"* — so a pinned default against a newer key did nothing on an older build and told nobody, on the fleets most likely to be mid-upgrade.

## The split, and why not `.strict()`

`values` is parsed as a record and split against the nested schema's own shape, which is the same move `lockedFields` already makes against the enum.

`.strict()` would **refuse the file** — the outcome the lock half already rejected, because refusing runs the machine entirely unmanaged, every pin and lock gone.

**A bad value under a key this build does know still fails the file.** The known subset is re-run through `ManagedSettingsValues` and its issues are re-raised under the `values` path, so a typo'd `runMode: 'attachd'` is damage rather than a silently dropped pin. That is what keeps the tolerance above from also covering a mistake, and it is the case I would look at first in review.

## One notice, two counts

Counted separately inside one sentence:

> Acme pins 2 settings and locks 1 setting this version of AKA does not recognize. Update AKA to apply them.

Two sentences read worse, and a merged count reads *wrong*: an unapplied lock leaves a control the administrator meant to freeze still editable, while an unapplied pin leaves a default they meant to set unset. Those send them to different lines of their own file. The pluralisation reads the **total**, since one pin and one lock is two unapplied decisions.

The locks-only wording is byte-identical to what shipped, so nothing that reads that sentence changes.

## One place I diverged from the issue, deliberately

#437 says `ManagedContext` carries `unknownLockedCount` and that the value half should match. It carries `unknownLockedFields?: readonly string[]` — the **names** — and the view counts them. So I mirrored what the code does rather than what the issue describes: the two halves must not diverge on this, and changing the lock half's shape is a separate decision from adding the pin half.

If the names should not cross to the client, that is one change covering both halves and I am happy to make it — but it should be made deliberately rather than as a side effect of this.

## Verification

| mutation | red |
| --- | --- |
| restore the nested object (the silent drop) | 2 schema + 1 persistence |
| drop the re-raise, tolerating a bad known value | 2 schema + 1 persistence |
| drop the pin half from the context | 1 persistence |
| fold pins into the lock count | 2 view |
| pluralise on either half instead of the total | 3 view |

`schema` 919 passed, `persistence` 1613 passed / 2 skipped, `dashboard-ui` 566 passed. Downstream consumers green: `plugin-runtime` 556, `cli` 488 / 5 skipped, `web-ui` 818. Workspace lint, typecheck, prettier and the portability gate clean.
