### PR TITLE
fix(local-ops,schema,web-ui): resolve "latest" the way the host will install it

### DIFF
--- a/cli/test/privacy-claims.test.ts
+++ b/cli/test/privacy-claims.test.ts
@@ -43,6 +43,7 @@ gatherReport({
     return null;
   },
   cliInstalled: null,
+  marketplacePin: () => null,
   installed: new Map(),
 });
 

--- a/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
+++ b/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
@@ -104,6 +104,9 @@ export function UpdateStatusCardView({
         <div className="flex flex-col">
           {statuses.map((s, i) => {
             const outcome = outcomes[s.id];
+            // Bound once: the presence check and the render must not be free to
+            // disagree if this grows a branch.
+            const note = pinNote(s);
             return (
               <div key={s.id} className={cn('py-3', i > 0 && 'border-t border-hairline')}>
                 <div className="flex items-center gap-3">
@@ -113,9 +116,9 @@ export function UpdateStatusCardView({
                       {s.installed ?? '—'}
                       {s.latest && s.updateAvailable && ` → ${s.latest}`}
                     </div>
-                    {pinNote(s) !== undefined && (
+                    {note !== undefined && (
                       <div className="mt-1 text-xs text-text-3" data-slot="marketplace-pin-note">
-                        {pinNote(s)}
+                        {note}
                       </div>
                     )}
                   </div>

--- a/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
+++ b/packages/dashboard-ui/src/updates/UpdateStatusCardView.tsx
@@ -39,6 +39,28 @@ export interface UpdateStatusCardViewProps {
   busy?: boolean;
 }
 
+/**
+ * The line explaining a row that reads "up to date" at a version the reader can
+ * see is not the newest published.
+ *
+ * `latest` is the version the HOST will install, which for a plugin resolved
+ * through a marketplace manifest is that manifest's pin rather than npm's
+ * latest. Without this the page shows the installed version, a green badge and
+ * nothing else — indistinguishable from a report that is simply stale, which is
+ * the ambiguity the pin was carried here to remove. The CLI prints the same
+ * fact; a surface that has the data and does not say it is the worse half of
+ * the pair.
+ *
+ * Only when the pin is strictly BEHIND npm. A pin that equals it explains
+ * nothing, and on the happy path the two agree — so a note on every pinned row
+ * would be noise everywhere and signal nowhere.
+ */
+function pinNote(s: ComponentStatus): string | undefined {
+  const pin = s.marketplacePin;
+  if (!pin || !pin.npmAhead || s.latest === null || pin.npmLatest === null) return undefined;
+  return `${pin.marketplace} pins v${s.latest} — npm has v${pin.npmLatest}, which this machine cannot install until that marketplace moves.`;
+}
+
 function statusBadge(s: ComponentStatus) {
   if (s.installed === null || s.latest === null) return <Badge variant="default">unknown</Badge>;
   if (s.updateAvailable) return <Badge variant="high">update available</Badge>;
@@ -91,6 +113,11 @@ export function UpdateStatusCardView({
                       {s.installed ?? '—'}
                       {s.latest && s.updateAvailable && ` → ${s.latest}`}
                     </div>
+                    {pinNote(s) !== undefined && (
+                      <div className="mt-1 text-xs text-text-3" data-slot="marketplace-pin-note">
+                        {pinNote(s)}
+                      </div>
+                    )}
                   </div>
                   {statusBadge(s)}
                   {s.updateAvailable && (

--- a/packages/dashboard-ui/test/updates/UpdateStatusCardView.test.ts
+++ b/packages/dashboard-ui/test/updates/UpdateStatusCardView.test.ts
@@ -1,0 +1,85 @@
+// The web half of the marketplace-pin explanation.
+//
+// `latest` is the version the HOST will install, which for a plugin resolved
+// through a marketplace manifest is that manifest's pin rather than npm's
+// latest. The CLI prints why; without this the page shows the installed
+// version, a green badge and nothing else — indistinguishable from a report
+// that is simply stale, which is the ambiguity carrying the pin here removes.
+import type { ComponentStatus } from '@akasecurity/schema';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { UpdateStatusCardView } from '../../src/updates/UpdateStatusCardView.tsx';
+
+const status = (over: Partial<ComponentStatus> = {}): ComponentStatus => ({
+  id: 'claude-code',
+  name: 'Claude Code plugin',
+  kind: 'plugin',
+  installed: '0.9.9',
+  latest: '0.9.9',
+  updateAvailable: false,
+  ...over,
+});
+
+const render = (s: ComponentStatus): string =>
+  renderToStaticMarkup(
+    createElement(UpdateStatusCardView, {
+      statuses: [s],
+      checkedAt: null,
+      onCheckNow: () => undefined,
+      onApply: () => undefined,
+      applyingId: null,
+      outcomes: {},
+      restartRequired: false,
+    }),
+  );
+
+const NOTE = 'data-slot="marketplace-pin-note"';
+
+describe('UpdateStatusCardView — the marketplace-pin note', () => {
+  it('renders the row at all, so the absences below are not vacuous', () => {
+    const html = render(status());
+
+    expect(html).toContain('Claude Code plugin');
+    expect(html).toContain('0.9.9');
+  });
+
+  it('explains a pin that is behind npm, naming the marketplace that has to move', () => {
+    const html = render(
+      status({
+        marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10', npmAhead: true },
+      }),
+    );
+
+    expect(html).toContain(NOTE);
+    expect(html).toContain('akasecurity');
+    expect(html).toContain('0.9.10');
+  });
+
+  it.each([
+    [
+      'a pin npm has not moved past',
+      { marketplace: 'akasecurity', npmLatest: '0.9.9', npmAhead: false },
+    ],
+    ['a pin with no npm answer', { marketplace: 'akasecurity', npmLatest: null, npmAhead: false }],
+  ])('says nothing about %s, which explains nothing', (_label, marketplacePin) => {
+    expect(render(status({ marketplacePin }))).not.toContain(NOTE);
+  });
+
+  it('says nothing when there is no pin', () => {
+    expect(render(status())).not.toContain(NOTE);
+  });
+
+  it('says nothing when the pinned latest is unknown', () => {
+    // Comparing against an unknown would be inventing a gap.
+    expect(
+      render(
+        status({
+          latest: null,
+          marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10', npmAhead: true },
+        }),
+      ),
+    ).not.toContain(NOTE);
+  });
+});

--- a/packages/local-ops/src/cli-plugin-manager.ts
+++ b/packages/local-ops/src/cli-plugin-manager.ts
@@ -152,14 +152,28 @@ const HOST_VERBS: Record<CliPluginBin, HostVerbs> = {
   },
   codex: {
     install: (ref) => [['plugin', 'add', ref]],
-    // No `update` verb — `add` is the whole operation, and it takes no scope:
-    // Codex keeps one plugin cache per home, so there is nothing to target.
-    // The parameter is ignored here rather than absent, so the two hosts share
-    // one signature and a caller cannot pass a scope to only one of them. It resolves the plugin
-    // from the marketplace manifest, which for this repo's entries names an npm
-    // package with no version pin, so `add` picks up a published bump on its
-    // own. Refreshing the git snapshot is about the MANIFEST (a renamed package,
-    // a newly listed plugin), which is why it is a separate, optional step.
+    // No `update` verb — `add` is the whole operation. It resolves the plugin
+    // from the marketplace manifest, and refreshing the git snapshot is about
+    // the MANIFEST (a renamed package, a newly listed plugin), which is why it
+    // is a separate, optional step.
+    //
+    // It takes no scope either: Codex keeps one plugin cache per home, so there
+    // is nothing to target. The parameter is ignored here rather than absent,
+    // so the two hosts share one signature and a caller cannot pass a scope to
+    // only one of them.
+    //
+    // This used to add "which for this repo's entries names an npm package with
+    // NO VERSION PIN, so `add` picks up a published bump on its own", and that
+    // premise is false for Claude Code's marketplace: the resolved manifest's
+    // `ai-tc` entry reads `{ source: 'npm', package: …, version: '0.9.10' }` on
+    // a real install, on the default branch. An entry with no pin does exist —
+    // a `github` or `git-subdir` source — so the shape varies per entry rather
+    // than per repository.
+    //
+    // Whether it holds for the CODEX marketplace is UNVERIFIED: Codex keeps no
+    // marketplaces directory to read a resolved manifest from, so nothing here
+    // has seen one. It is stated as unknown rather than corrected to a second
+    // guess, because what rests on it is this host's whole update path.
     update: (ref) => [['plugin', 'add', ref]],
     register: (source) => [['plugin', 'marketplace', 'add', source]],
     refresh: (marketplace) => [['plugin', 'marketplace', 'upgrade', marketplace]],

--- a/packages/local-ops/src/index.ts
+++ b/packages/local-ops/src/index.ts
@@ -48,6 +48,7 @@ export {
   detectInstallChannel,
   planCliUpdate,
 } from './install-channel.ts';
+export { marketplacePinnedVersion } from './marketplace-manifest.ts';
 export type { ProjectInventoryResult } from './project-inventory.ts';
 export { recordProjectInventory } from './project-inventory.ts';
 export type { AgentPlugin } from './registry.ts';

--- a/packages/local-ops/src/marketplace-manifest.ts
+++ b/packages/local-ops/src/marketplace-manifest.ts
@@ -1,0 +1,90 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// What the HOST will actually install, read from the marketplace manifest it
+// resolved — as distinct from what npm has published.
+//
+// `aka update` decided whether an update existed by asking npm, while
+// `claude plugin install` / `plugin update` resolve through the marketplace
+// manifest, whose entries name an exact version. Nothing reconciled the two, so
+// the report could offer an update the host structurally cannot deliver: a
+// consent prompt promising a state change that cannot happen, and — where a
+// marketplace is registered at a pinned ref — one that reappears on every run
+// and no-ops every time.
+//
+// The two agree on the happy path, which is why this was latent. They come
+// apart in the publish → manifest-bump window (two repositories, two commits),
+// and indefinitely when a marketplace is registered against a branch or tag
+// whose manifest holds an older pin.
+
+// Its own guard rather than `updates.ts`'s `isRecord`, which is what keeps this
+// module a LEAF: `updates.ts` has to import this one, so importing back would
+// make a cycle out of a two-line type guard.
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** Where the host records the marketplaces it knows and where each is unpacked. */
+function knownMarketplacesPath(claudeHome: string): string {
+  return join(claudeHome, 'plugins', 'known_marketplaces.json');
+}
+
+function readJson(path: string): unknown {
+  if (!existsSync(path)) return undefined;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined; // garbage on disk reads as "no pin", never as a throw
+  }
+}
+
+/**
+ * The directory a registered marketplace was unpacked into.
+ *
+ * Read from the host's own record rather than assembled from a convention. The
+ * conventional layout — `<claudeHome>/plugins/marketplaces/<name>` — is what
+ * this machine happens to use today, and a reader that assumed it would answer
+ * confidently for a host that moved it. `installLocation` is the host stating
+ * where it put the thing, so an unrecognised layout produces no answer instead
+ * of a wrong one.
+ */
+function marketplaceRoot(claudeHome: string, marketplace: string): string | null {
+  const known = readJson(knownMarketplacesPath(claudeHome));
+  if (!isRecord(known)) return null;
+  const entry = known[marketplace];
+  if (!isRecord(entry)) return null;
+  return typeof entry.installLocation === 'string' ? entry.installLocation : null;
+}
+
+/**
+ * The version a marketplace manifest pins a plugin to, or null.
+ *
+ * Null covers every way this can fail to produce an ANSWER — the marketplace is
+ * not registered, the manifest is absent or damaged, the plugin is not listed,
+ * or its entry carries no version. That is deliberate rather than lazy: an
+ * entry with no pin is the shape a `github` or `git-subdir` source really has,
+ * and for those the host does follow the published head, so npm's latest is the
+ * right answer and the caller falls back to it.
+ *
+ * Claude Code's layout only. A Codex-hosted plugin is simply absent from this
+ * file, so it falls back to npm — which is what it did before. Do not read this
+ * as covering that host.
+ */
+export function marketplacePinnedVersion(
+  marketplace: string,
+  pluginName: string,
+  claudeHome: string = join(homedir(), '.claude'),
+): string | null {
+  const root = marketplaceRoot(claudeHome, marketplace);
+  if (root === null) return null;
+  const manifest = readJson(join(root, '.claude-plugin', 'marketplace.json'));
+  if (!isRecord(manifest) || !Array.isArray(manifest.plugins)) return null;
+  const entry = manifest.plugins.find(
+    (candidate): candidate is Record<string, unknown> =>
+      isRecord(candidate) && candidate.name === pluginName,
+  );
+  if (entry === undefined || !isRecord(entry.source)) return null;
+  const version = entry.source.version;
+  return typeof version === 'string' && version !== '' ? version : null;
+}

--- a/packages/local-ops/src/marketplace-manifest.ts
+++ b/packages/local-ops/src/marketplace-manifest.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import type { AgentPlugin } from './registry.ts';
+
 // What the HOST will actually install, read from the marketplace manifest it
 // resolved — as distinct from what npm has published.
 //
@@ -58,24 +60,32 @@ function marketplaceRoot(claudeHome: string, marketplace: string): string | null
 }
 
 /**
- * The version a marketplace manifest pins a plugin to, or null.
+ * The version a marketplace manifest pins an agent's plugin to, or null.
  *
- * Null covers every way this can fail to produce an ANSWER — the marketplace is
- * not registered, the manifest is absent or damaged, the plugin is not listed,
- * or its entry carries no version. That is deliberate rather than lazy: an
- * entry with no pin is the shape a `github` or `git-subdir` source really has,
- * and for those the host does follow the published head, so npm's latest is the
- * right answer and the caller falls back to it.
+ * Null covers every way this can fail to produce an ANSWER — the agent is not
+ * hosted by Claude Code, it carries no marketplace coordinates, the marketplace
+ * is not registered, the manifest is absent or damaged, the plugin is not
+ * listed, or its entry carries no version. That is deliberate rather than lazy:
+ * an entry with no pin is the shape a `github` or `git-subdir` source really
+ * has, and for those the host does follow the published head, so npm's latest is
+ * the right answer and the caller falls back to it.
  *
- * Claude Code's layout only. A Codex-hosted plugin is simply absent from this
- * file, so it falls back to npm — which is what it did before. Do not read this
- * as covering that host.
+ * THE HOST CHECK IS HERE rather than at the call sites, and that is the whole
+ * reason this takes an agent instead of two strings. Everything below reads
+ * CLAUDE CODE's layout, and every registered agent carries a marketplace and a
+ * plugin name — the Codex entry's are `ai-tc` / `aka-codex`. A caller gating on
+ * "are the coordinates present" therefore admits Codex into this reader, which
+ * would answer it out of `~/.claude`'s ledger. That is inert today only because
+ * no marketplace named `ai-tc` happens to be registered there, and dogfooding
+ * both hosts against this repo is the obvious way to make it not inert.
  */
 export function marketplacePinnedVersion(
-  marketplace: string,
-  pluginName: string,
+  agent: AgentPlugin,
   claudeHome: string = join(homedir(), '.claude'),
 ): string | null {
+  if (agent.cliBin !== 'claude') return null;
+  const { marketplace, pluginName } = agent;
+  if (marketplace === undefined || pluginName === undefined) return null;
   const root = marketplaceRoot(claudeHome, marketplace);
   if (root === null) return null;
   const manifest = readJson(join(root, '.claude-plugin', 'marketplace.json'));

--- a/packages/local-ops/src/update-render.ts
+++ b/packages/local-ops/src/update-render.ts
@@ -1,5 +1,35 @@
 import type { ComponentStatus, UpdateReport } from '@akasecurity/schema';
 
+import { isNewer } from './semver.ts';
+
+/**
+ * The lines explaining a `latest` that came from a marketplace pin.
+ *
+ * Only where the pin is BEHIND npm, because that is the only case a reader
+ * cannot account for on their own: the row says "up to date" at a version they
+ * can see is not the newest published, and without this the output is
+ * indistinguishable from a stale report or a failed update. A pin that equals
+ * npm's latest explains nothing and is left unsaid.
+ *
+ * It names the marketplace rather than only the version, because the marketplace
+ * is the thing that has to move — and under a marketplace registered at a pinned
+ * ref, nothing else ever will.
+ */
+function pinNotes(report: UpdateReport): string[] {
+  const notes: string[] = [];
+  for (const s of report.statuses) {
+    const pin = s.marketplacePin;
+    if (!pin || s.latest === null || pin.npmLatest === null) continue;
+    if (!isNewer(pin.npmLatest, s.latest)) continue;
+    notes.push(
+      `    ${s.name}: the ${pin.marketplace} marketplace pins v${s.latest}. ` +
+        `npm has v${pin.npmLatest}, which this machine cannot install until that ` +
+        `marketplace moves.`,
+    );
+  }
+  return notes;
+}
+
 function statusLabel(s: ComponentStatus): string {
   // Not-installed plugins are reported under availablePlugins, never here — so a null
   // installed in a status row means "couldn't determine version" (the CLI's own
@@ -31,6 +61,13 @@ export function renderReport(report: UpdateReport): string {
     lines.push(
       `  ${r.name.padEnd(nameW)}  ${r.installed.padEnd(instW)}  ${r.latest.padEnd(latW)}  ${r.status}`,
     );
+  }
+
+  const notes = pinNotes(report);
+  if (notes.length > 0) {
+    lines.push('');
+    lines.push('  Pinned by a marketplace:');
+    lines.push(...notes);
   }
 
   if (report.availablePlugins.length > 0) {

--- a/packages/local-ops/src/update-render.ts
+++ b/packages/local-ops/src/update-render.ts
@@ -1,7 +1,5 @@
 import type { ComponentStatus, UpdateReport } from '@akasecurity/schema';
 
-import { isNewer } from './semver.ts';
-
 /**
  * The lines explaining a `latest` that came from a marketplace pin.
  *
@@ -19,8 +17,7 @@ function pinNotes(report: UpdateReport): string[] {
   const notes: string[] = [];
   for (const s of report.statuses) {
     const pin = s.marketplacePin;
-    if (!pin || s.latest === null || pin.npmLatest === null) continue;
-    if (!isNewer(pin.npmLatest, s.latest)) continue;
+    if (!pin || !pin.npmAhead || s.latest === null || pin.npmLatest === null) continue;
     notes.push(
       `    ${s.name}: the ${pin.marketplace} marketplace pins v${s.latest}. ` +
         `npm has v${pin.npmLatest}, which this machine cannot install until that ` +

--- a/packages/local-ops/src/updates.ts
+++ b/packages/local-ops/src/updates.ts
@@ -6,7 +6,8 @@ import { fileURLToPath } from 'node:url';
 import type { AvailablePlugin, ComponentStatus, UpdateReport } from '@akasecurity/schema';
 
 import { runCapture } from './exec.ts';
-import { AGENT_PLUGINS, pluginRef } from './registry.ts';
+import { marketplacePinnedVersion } from './marketplace-manifest.ts';
+import { AGENT_PLUGINS, type AgentPlugin, pluginRef } from './registry.ts';
 import { compareSemver, isNewer, isSemver } from './semver.ts';
 
 // Pure update-report gathering: version discovery over npm + the local Claude Code
@@ -26,6 +27,16 @@ export interface ReportDeps {
   viewVersion: (pkg: string) => string | null;
   installed: Map<string, string>;
   cliInstalled: string | null;
+  // What the HOST would install for this agent, from the marketplace manifest
+  // it resolved — null when no pin applies and npm's latest is the right
+  // answer. See marketplace-manifest.ts for why the two can differ.
+  //
+  // REQUIRED, not optional. An optional seam reads as safe at every call site
+  // that omits it, which is every call site until somebody remembers — and the
+  // one that omitted it would go back to reporting an update the host cannot
+  // deliver, silently. Required, the compiler names each caller that has to
+  // decide; a caller with no marketplace to read says so with `() => null`.
+  marketplacePin: (agent: AgentPlugin) => string | null;
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
@@ -235,7 +246,17 @@ export function gatherReport(deps: ReportDeps): UpdateReport {
   for (const agent of AGENT_PLUGINS) {
     const ref = pluginRef(agent);
     if (!ref || !agent.npmPackage) continue;
-    const latest = deps.viewVersion(agent.npmPackage);
+    const npmLatest = deps.viewVersion(agent.npmPackage);
+    // The pin WINS where there is one, because it is what the host resolves an
+    // install through. npm's answer is kept beside it rather than discarded:
+    // it is the only thing that can explain a machine reading "up to date" at a
+    // version the user can see is behind.
+    const pin = deps.marketplacePin(agent);
+    const latest = pin ?? npmLatest;
+    const pinned =
+      pin !== null && agent.marketplace !== undefined
+        ? { marketplacePin: { marketplace: agent.marketplace, npmLatest } }
+        : {};
     const installed = deps.installed.get(ref) ?? null;
     if (installed === null) {
       availablePlugins.push({ id: agent.id, name: agent.name, latest });
@@ -248,6 +269,7 @@ export function gatherReport(deps: ReportDeps): UpdateReport {
       installed,
       latest,
       updateAvailable: latest !== null && isNewer(latest, installed),
+      ...pinned,
     });
   }
   return { statuses, availablePlugins };
@@ -260,5 +282,9 @@ export function gatherReportLive(): UpdateReport {
     viewVersion: npmViewVersion,
     installed: installedAgentPluginVersions(),
     cliInstalled: cliVersion(),
+    marketplacePin: (agent) =>
+      agent.marketplace !== undefined && agent.pluginName !== undefined
+        ? marketplacePinnedVersion(agent.marketplace, agent.pluginName)
+        : null,
   });
 }

--- a/packages/local-ops/src/updates.ts
+++ b/packages/local-ops/src/updates.ts
@@ -255,7 +255,13 @@ export function gatherReport(deps: ReportDeps): UpdateReport {
     const latest = pin ?? npmLatest;
     const pinned =
       pin !== null && agent.marketplace !== undefined
-        ? { marketplacePin: { marketplace: agent.marketplace, npmLatest } }
+        ? {
+            marketplacePin: {
+              marketplace: agent.marketplace,
+              npmLatest,
+              npmAhead: npmLatest !== null && isNewer(npmLatest, pin),
+            },
+          }
         : {};
     const installed = deps.installed.get(ref) ?? null;
     if (installed === null) {
@@ -282,9 +288,10 @@ export function gatherReportLive(): UpdateReport {
     viewVersion: npmViewVersion,
     installed: installedAgentPluginVersions(),
     cliInstalled: cliVersion(),
-    marketplacePin: (agent) =>
-      agent.marketplace !== undefined && agent.pluginName !== undefined
-        ? marketplacePinnedVersion(agent.marketplace, agent.pluginName)
-        : null,
+    // No coordinate guard here: `marketplacePinnedVersion` owns both that and
+    // the HOST check, because a guard written at the call site admits Codex —
+    // its registry entry carries a marketplace and a plugin name like any
+    // other — into a reader that only understands Claude Code's layout.
+    marketplacePin: (agent) => marketplacePinnedVersion(agent),
   });
 }

--- a/packages/local-ops/test/marketplace-manifest.test.ts
+++ b/packages/local-ops/test/marketplace-manifest.test.ts
@@ -18,6 +18,20 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { marketplacePinnedVersion } from '../src/marketplace-manifest.ts';
+import type { AgentPlugin } from '../src/registry.ts';
+
+/** A Claude-Code-hosted agent with the coordinates a lookup needs. */
+const agent = (over: Partial<AgentPlugin> = {}): AgentPlugin => ({
+  id: 'claude-code',
+  name: 'Claude Code plugin',
+  sourceTool: 'claude-code',
+  description: '',
+  npmPackage: '@akasecurity/ai-tc-claude-code',
+  pluginName: 'ai-tc',
+  marketplace: 'akasecurity',
+  cliBin: 'claude',
+  ...over,
+});
 
 let claudeHome: string;
 
@@ -58,7 +72,12 @@ describe('marketplacePinnedVersion', () => {
   it('reads the version the host would install', () => {
     registerMarketplace('akasecurity', [npmEntry('ai-tc', '0.9.9')]);
 
-    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('0.9.9');
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'ai-tc' }),
+        claudeHome,
+      ),
+    ).toBe('0.9.9');
   });
 
   it('picks the named plugin out of a manifest listing several', () => {
@@ -70,8 +89,18 @@ describe('marketplacePinnedVersion', () => {
       npmEntry('other', '1.2.3'),
     ]);
 
-    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('0.9.9');
-    expect(marketplacePinnedVersion('akasecurity', 'other', claudeHome)).toBe('1.2.3');
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'ai-tc' }),
+        claudeHome,
+      ),
+    ).toBe('0.9.9');
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'other' }),
+        claudeHome,
+      ),
+    ).toBe('1.2.3');
   });
 
   it('says nothing for an entry that carries no pin', () => {
@@ -83,7 +112,12 @@ describe('marketplacePinnedVersion', () => {
       { name: 'preflight', source: { source: 'github', repo: 'akasecurity/preflight-skills' } },
     ]);
 
-    expect(marketplacePinnedVersion('akasecurity', 'preflight', claudeHome)).toBeNull();
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'preflight' }),
+        claudeHome,
+      ),
+    ).toBeNull();
   });
 
   it('follows installLocation rather than assuming the conventional layout', () => {
@@ -104,7 +138,12 @@ describe('marketplacePinnedVersion', () => {
       'utf8',
     );
 
-    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('1.1.1');
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'ai-tc' }),
+        claudeHome,
+      ),
+    ).toBe('1.1.1');
   });
 
   it.each([
@@ -170,14 +209,67 @@ describe('marketplacePinnedVersion', () => {
     // a throw would take down `aka update` and the passive notice with it.
     seed();
 
-    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBeNull();
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'akasecurity', pluginName: 'ai-tc' }),
+        claudeHome,
+      ),
+    ).toBeNull();
   });
+
+  it('answers nothing for a Codex-hosted agent, whatever its coordinates say', () => {
+    // The registry's Codex entry carries `marketplace: 'ai-tc'` and
+    // `pluginName: 'aka-codex'` like any other, so a caller gating on "are the
+    // coordinates present" admits it into a reader that only understands Claude
+    // Code's layout — answering it out of `~/.claude`'s ledger. Inert today only
+    // because no marketplace named `ai-tc` is registered there, which is one
+    // `plugin marketplace add` away from being false.
+    registerMarketplace('ai-tc', [npmEntry('aka-codex', '9.9.9')]);
+
+    expect(
+      marketplacePinnedVersion(
+        agent({ cliBin: 'codex', marketplace: 'ai-tc', pluginName: 'aka-codex' }),
+        claudeHome,
+      ),
+    ).toBeNull();
+    // The control on the line above: that manifest IS readable, so the null is
+    // the host check rather than a lookup that failed for its own reasons.
+    expect(
+      marketplacePinnedVersion(
+        agent({ cliBin: 'claude', marketplace: 'ai-tc', pluginName: 'aka-codex' }),
+        claudeHome,
+      ),
+    ).toBe('9.9.9');
+  });
+
+  it.each<'marketplace' | 'pluginName'>(['marketplace', 'pluginName'])(
+    'answers nothing for an agent carrying no %s',
+    (field) => {
+      // `exactOptionalPropertyTypes` makes an explicit `undefined` a different
+      // thing from an absent key, and the registry's own entries omit these
+      // rather than setting them undefined — so the fixture deletes the key.
+      registerMarketplace('akasecurity', [npmEntry('ai-tc', '0.9.9')]);
+      // Rebuilt WITHOUT the key rather than deleted from a complete one:
+      // `exactOptionalPropertyTypes` makes an explicit `undefined` a different
+      // thing from an absent key, and the registry's entries omit these.
+      const incomplete = Object.fromEntries(
+        Object.entries(agent()).filter(([key]) => key !== field),
+      ) as AgentPlugin;
+
+      expect(marketplacePinnedVersion(incomplete, claudeHome)).toBeNull();
+    },
+  );
 
   it('does not confuse two marketplaces that list the same plugin name', () => {
     // The control on the lookup: registering one marketplace must not make its
     // pin answer for another's, which a reader keyed only on plugin name would.
     registerMarketplace('akasecurity', [npmEntry('ai-tc', '0.9.9')]);
 
-    expect(marketplacePinnedVersion('some-other-marketplace', 'ai-tc', claudeHome)).toBeNull();
+    expect(
+      marketplacePinnedVersion(
+        agent({ marketplace: 'some-other-marketplace', pluginName: 'ai-tc' }),
+        claudeHome,
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/local-ops/test/marketplace-manifest.test.ts
+++ b/packages/local-ops/test/marketplace-manifest.test.ts
@@ -1,0 +1,183 @@
+// What the HOST will install, as opposed to what npm has published.
+//
+// `aka update` asked npm; `claude plugin install` / `plugin update` resolve
+// through the marketplace manifest, whose entries name an exact version.
+// Nothing reconciled the two, so the report could offer an update the host
+// structurally cannot deliver — and under a marketplace registered at a pinned
+// ref, offer the same one on every run and no-op every time.
+//
+// Driven against a real on-disk layout rather than a stub, because the shape is
+// the host's and not ours: these fixtures are the shapes read off a working
+// install (`known_marketplaces.json` carrying `installLocation`, and a
+// `marketplace.json` whose npm entries carry `source.version` while its github
+// and git-subdir entries carry none).
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { marketplacePinnedVersion } from '../src/marketplace-manifest.ts';
+
+let claudeHome: string;
+
+beforeEach(() => {
+  claudeHome = mkdtempSync(join(tmpdir(), 'aka-marketplace-'));
+});
+
+afterEach(() => {
+  rmSync(claudeHome, { recursive: true, force: true });
+});
+
+/** Register a marketplace the way the host does, and write its manifest. */
+function registerMarketplace(name: string, plugins: unknown[]): string {
+  const root = join(claudeHome, 'plugins', 'marketplaces', name);
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    join(root, '.claude-plugin', 'marketplace.json'),
+    JSON.stringify({ name, owner: {}, metadata: {}, plugins }),
+    'utf8',
+  );
+  const knownPath = join(claudeHome, 'plugins', 'known_marketplaces.json');
+  writeFileSync(
+    knownPath,
+    JSON.stringify({
+      [name]: { source: { source: 'github', repo: `x/${name}` }, installLocation: root },
+    }),
+    'utf8',
+  );
+  return root;
+}
+
+const npmEntry = (name: string, version: string): unknown => ({
+  name,
+  source: { source: 'npm', package: `@akasecurity/${name}`, version },
+});
+
+describe('marketplacePinnedVersion', () => {
+  it('reads the version the host would install', () => {
+    registerMarketplace('akasecurity', [npmEntry('ai-tc', '0.9.9')]);
+
+    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('0.9.9');
+  });
+
+  it('picks the named plugin out of a manifest listing several', () => {
+    // The real manifest lists every plugin the marketplace offers, so matching
+    // by name rather than taking the first entry is the whole read.
+    registerMarketplace('akasecurity', [
+      { name: 'preflight', source: { source: 'github', repo: 'x/preflight' } },
+      npmEntry('ai-tc', '0.9.9'),
+      npmEntry('other', '1.2.3'),
+    ]);
+
+    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('0.9.9');
+    expect(marketplacePinnedVersion('akasecurity', 'other', claudeHome)).toBe('1.2.3');
+  });
+
+  it('says nothing for an entry that carries no pin', () => {
+    // A `github` / `git-subdir` source has no version, and for those the host
+    // really does follow the published head — so npm's latest is the right
+    // answer and the caller must fall back to it rather than reporting "no
+    // update available".
+    registerMarketplace('akasecurity', [
+      { name: 'preflight', source: { source: 'github', repo: 'akasecurity/preflight-skills' } },
+    ]);
+
+    expect(marketplacePinnedVersion('akasecurity', 'preflight', claudeHome)).toBeNull();
+  });
+
+  it('follows installLocation rather than assuming the conventional layout', () => {
+    // The host states where it put the marketplace. A reader that assembled
+    // `<home>/plugins/marketplaces/<name>` would answer confidently for a host
+    // that moved it — and be wrong, which is worse than saying nothing.
+    const elsewhere = join(claudeHome, 'somewhere-else');
+    mkdirSync(join(elsewhere, '.claude-plugin'), { recursive: true });
+    writeFileSync(
+      join(elsewhere, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify({ plugins: [npmEntry('ai-tc', '1.1.1')] }),
+      'utf8',
+    );
+    mkdirSync(join(claudeHome, 'plugins'), { recursive: true });
+    writeFileSync(
+      join(claudeHome, 'plugins', 'known_marketplaces.json'),
+      JSON.stringify({ akasecurity: { installLocation: elsewhere } }),
+      'utf8',
+    );
+
+    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBe('1.1.1');
+  });
+
+  it.each([
+    [
+      'nothing registered',
+      (): void => {
+        /* the temp home is created empty */
+      },
+    ],
+    [
+      'a marketplace registered with no installLocation',
+      (): void => {
+        mkdirSync(join(claudeHome, 'plugins'), { recursive: true });
+        writeFileSync(
+          join(claudeHome, 'plugins', 'known_marketplaces.json'),
+          JSON.stringify({ akasecurity: { source: {} } }),
+          'utf8',
+        );
+      },
+    ],
+    [
+      'a registered marketplace whose manifest is missing',
+      (): void => {
+        mkdirSync(join(claudeHome, 'plugins'), { recursive: true });
+        writeFileSync(
+          join(claudeHome, 'plugins', 'known_marketplaces.json'),
+          JSON.stringify({ akasecurity: { installLocation: join(claudeHome, 'gone') } }),
+          'utf8',
+        );
+      },
+    ],
+    [
+      'a damaged known_marketplaces.json',
+      (): void => {
+        mkdirSync(join(claudeHome, 'plugins'), { recursive: true });
+        writeFileSync(join(claudeHome, 'plugins', 'known_marketplaces.json'), '{ not json', 'utf8');
+      },
+    ],
+    [
+      'a damaged manifest',
+      (): void => {
+        const root = registerMarketplace('akasecurity', []);
+        writeFileSync(join(root, '.claude-plugin', 'marketplace.json'), '{ not json', 'utf8');
+      },
+    ],
+    [
+      'a plugin the manifest does not list',
+      (): void => {
+        registerMarketplace('akasecurity', [npmEntry('something-else', '2.0.0')]);
+      },
+    ],
+    [
+      'an entry whose version is empty',
+      (): void => {
+        registerMarketplace('akasecurity', [
+          { name: 'ai-tc', source: { source: 'npm', package: 'x', version: '' } },
+        ]);
+      },
+    ],
+  ])('says nothing on %s, rather than throwing', (_label, seed) => {
+    // Every one of these is "no ANSWER", and the caller falls back to npm — the
+    // behaviour that shipped. Failing open matters more here than being clever:
+    // a throw would take down `aka update` and the passive notice with it.
+    seed();
+
+    expect(marketplacePinnedVersion('akasecurity', 'ai-tc', claudeHome)).toBeNull();
+  });
+
+  it('does not confuse two marketplaces that list the same plugin name', () => {
+    // The control on the lookup: registering one marketplace must not make its
+    // pin answer for another's, which a reader keyed only on plugin name would.
+    registerMarketplace('akasecurity', [npmEntry('ai-tc', '0.9.9')]);
+
+    expect(marketplacePinnedVersion('some-other-marketplace', 'ai-tc', claudeHome)).toBeNull();
+  });
+});

--- a/packages/local-ops/test/update-render.test.ts
+++ b/packages/local-ops/test/update-render.test.ts
@@ -37,7 +37,9 @@ describe('renderReport — the marketplace-pin note', () => {
 
   it('explains a pin that is BEHIND npm, naming the marketplace that has to move', () => {
     const out = renderReport(
-      report({ marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10' } }),
+      report({
+        marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10', npmAhead: true },
+      }),
     );
 
     expect(out).toContain('Pinned by a marketplace');
@@ -49,9 +51,12 @@ describe('renderReport — the marketplace-pin note', () => {
   });
 
   it.each([
-    ['a pin that equals npm', { marketplace: 'akasecurity', npmLatest: '0.9.9' }],
-    ['a pin AHEAD of npm', { marketplace: 'akasecurity', npmLatest: '0.9.8' }],
-    ['a pin with no npm answer to compare', { marketplace: 'akasecurity', npmLatest: null }],
+    ['a pin that equals npm', { marketplace: 'akasecurity', npmLatest: '0.9.9', npmAhead: false }],
+    ['a pin AHEAD of npm', { marketplace: 'akasecurity', npmLatest: '0.9.8', npmAhead: false }],
+    [
+      'a pin with no npm answer to compare',
+      { marketplace: 'akasecurity', npmLatest: null, npmAhead: false },
+    ],
   ])('says nothing about %s, which explains nothing', (_label, marketplacePin) => {
     // A note on every pinned row would be noise on the happy path, where the
     // pin and npm agree — which is most of the time, and is why this defect

--- a/packages/local-ops/test/update-render.test.ts
+++ b/packages/local-ops/test/update-render.test.ts
@@ -1,0 +1,78 @@
+// The note that explains a row reading "up to date" at a version the user can
+// see is not the newest published.
+//
+// `latest` is the version the HOST will install, which for a plugin resolved
+// through a marketplace manifest is the manifest's pin rather than npm's
+// latest. Without the note that renders as a report that is simply wrong, or as
+// a failed update — the issue this closes reported it as indistinguishable from
+// both.
+import { describe, expect, it } from 'vitest';
+
+import { renderReport } from '../src/update-render.ts';
+
+const status = (over: Record<string, unknown> = {}): never =>
+  ({
+    id: 'claude-code',
+    name: 'Claude Code plugin',
+    kind: 'plugin',
+    installed: '0.9.9',
+    latest: '0.9.9',
+    updateAvailable: false,
+    ...over,
+  }) as never;
+
+const report = (over: Record<string, unknown> = {}): never =>
+  ({ statuses: [status(over)], availablePlugins: [] }) as never;
+
+describe('renderReport — the marketplace-pin note', () => {
+  it('renders the table itself, whatever the note does', () => {
+    // The positive control for every absence assertion below: an empty render
+    // satisfies all of them.
+    const out = renderReport(report());
+
+    expect(out).toContain('Claude Code plugin');
+    expect(out).toContain('0.9.9');
+    expect(out).toContain('up to date');
+  });
+
+  it('explains a pin that is BEHIND npm, naming the marketplace that has to move', () => {
+    const out = renderReport(
+      report({ marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10' } }),
+    );
+
+    expect(out).toContain('Pinned by a marketplace');
+    // Both versions, because the gap is the whole point, and the marketplace,
+    // because under a pinned ref it is the only thing that can ever close it.
+    expect(out).toContain('akasecurity');
+    expect(out).toContain('v0.9.9');
+    expect(out).toContain('v0.9.10');
+  });
+
+  it.each([
+    ['a pin that equals npm', { marketplace: 'akasecurity', npmLatest: '0.9.9' }],
+    ['a pin AHEAD of npm', { marketplace: 'akasecurity', npmLatest: '0.9.8' }],
+    ['a pin with no npm answer to compare', { marketplace: 'akasecurity', npmLatest: null }],
+  ])('says nothing about %s, which explains nothing', (_label, marketplacePin) => {
+    // A note on every pinned row would be noise on the happy path, where the
+    // pin and npm agree — which is most of the time, and is why this defect
+    // stayed latent. Only the gap is worth a line.
+    expect(renderReport(report({ marketplacePin }))).not.toContain('Pinned by a marketplace');
+  });
+
+  it('says nothing when there is no pin at all', () => {
+    expect(renderReport(report())).not.toContain('Pinned by a marketplace');
+  });
+
+  it('says nothing when the pinned latest could not be resolved', () => {
+    // `latest: null` is "unknown", and a note comparing against an unknown
+    // would be inventing a gap.
+    expect(
+      renderReport(
+        report({
+          latest: null,
+          marketplacePin: { marketplace: 'akasecurity', npmLatest: '0.9.10' },
+        }),
+      ),
+    ).not.toContain('Pinned by a marketplace');
+  });
+});

--- a/packages/local-ops/test/updates.test.ts
+++ b/packages/local-ops/test/updates.test.ts
@@ -18,6 +18,7 @@ describe('gatherReport', () => {
       viewVersion: views({ [CLI]: '0.0.3', [PLUGIN]: '0.0.2-alpha.0' }),
       installed: new Map([[REF, '0.0.2-alpha.0']]),
       cliInstalled: '0.0.2-alpha.0',
+      marketplacePin: () => null,
     });
     const cli = report.statuses.find((s) => s.id === 'cli');
     expect(cli?.updateAvailable).toBe(true);
@@ -29,6 +30,7 @@ describe('gatherReport', () => {
       viewVersion: views({ [CLI]: '0.0.2', [PLUGIN]: '0.0.3' }),
       installed: new Map([[REF, '0.0.2']]),
       cliInstalled: '0.0.2',
+      marketplacePin: () => null,
     });
     // Codex CLI is a separate, uninstalled registry entry (a distinct ref —
     // see registry.ts's pluginName comment) so it still surfaces as available;
@@ -44,6 +46,7 @@ describe('gatherReport', () => {
       viewVersion: views({ [CLI]: '0.0.2', [PLUGIN]: '0.0.3', [CODEX_PLUGIN]: '0.1.0' }),
       installed: new Map(), // nothing installed
       cliInstalled: '0.0.2',
+      marketplacePin: () => null,
     });
     expect(report.statuses.map((s) => s.id)).toEqual(['cli']);
     // Every registered agent with no installed version surfaces here — both
@@ -59,6 +62,7 @@ describe('gatherReport', () => {
       viewVersion: views({ [CLI]: '9.9.9', [PLUGIN]: '0.0.1' }),
       installed: new Map([[REF, '0.0.1']]),
       cliInstalled: null, // package.json walk-up missed
+      marketplacePin: () => null,
     });
     const cli = report.statuses.find((s) => s.id === 'cli');
     expect(cli?.installed).toBeNull();
@@ -70,10 +74,128 @@ describe('gatherReport', () => {
       viewVersion: views({}), // every lookup returns null
       installed: new Map([[REF, '0.0.1']]),
       cliInstalled: '0.0.1',
+      marketplacePin: () => null,
     });
     for (const s of report.statuses) {
       expect(s.latest).toBeNull();
       expect(s.updateAvailable).toBe(false);
     }
+  });
+});
+
+// The pin WINS over npm, because it is what the host resolves an install
+// through. Reading "latest" off npm let the report offer an update
+// `claude plugin update` structurally could not deliver: a consent prompt
+// promising a state change that cannot happen, and — under a marketplace
+// registered at a pinned ref — the same one on every run, no-opping each time.
+//
+// The two agree on the happy path, which is why this was latent rather than
+// obvious. Every case below is a state where they come apart.
+describe('gatherReport — the marketplace pin decides what "latest" means', () => {
+  const pinned = (version: string | null) => (): string | null => version;
+
+  it('reports the PIN as latest, not npm', () => {
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: '0.9.10' }),
+      installed: new Map([[REF, '0.9.8']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    const plugin = report.statuses.find((s) => s.id === 'claude-code');
+    expect(plugin?.latest).toBe('0.9.9');
+    expect(plugin?.marketplacePin).toEqual({ marketplace: 'akasecurity', npmLatest: '0.9.10' });
+  });
+
+  it('does NOT offer an update the host cannot install', () => {
+    // The defect, stated as the case it produced: npm is ahead, the manifest is
+    // not, and the installed version already equals the pin. Before this, the
+    // row said "update available" and the apply resolved back to what was
+    // already there.
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: '0.9.10' }),
+      installed: new Map([[REF, '0.9.9']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    expect(report.statuses.find((s) => s.id === 'claude-code')?.updateAvailable).toBe(false);
+  });
+
+  it('still offers an update the host CAN install', () => {
+    // The positive control for the case above: pinning must not be a way to
+    // stop reporting updates. A pin ahead of the installed version is a real
+    // update and the host will deliver it.
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: '0.9.10' }),
+      installed: new Map([[REF, '0.9.8']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    expect(report.statuses.find((s) => s.id === 'claude-code')?.updateAvailable).toBe(true);
+  });
+
+  it('falls back to npm when no pin applies, which is what shipped', () => {
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: '0.9.10' }),
+      installed: new Map([[REF, '0.9.8']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned(null),
+    });
+
+    const plugin = report.statuses.find((s) => s.id === 'claude-code');
+    expect(plugin?.latest).toBe('0.9.10');
+    expect(plugin?.updateAvailable).toBe(true);
+    // Absent rather than null: a surface spreading the status carries no key,
+    // and "npm answered" is not a pin worth rendering.
+    expect(plugin).not.toHaveProperty('marketplacePin');
+  });
+
+  it('carries the pin onto a plugin that is not installed yet', () => {
+    // `availablePlugins` is what `aka plugins install` would deliver, so it has
+    // to name the same version the install will actually reach.
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: '0.9.10' }),
+      installed: new Map(),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    expect(report.availablePlugins.find((p) => p.id === 'claude-code')?.latest).toBe('0.9.9');
+  });
+
+  it('leaves the CLI alone, which npm really is the install path for', () => {
+    // The CLI is not a marketplace plugin. A pin reaching its row would be this
+    // defect inverted — reporting a ceiling that does not apply to it.
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '9.9.9', [PLUGIN]: '0.9.10' }),
+      installed: new Map([[REF, '0.9.9']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    const cli = report.statuses.find((s) => s.id === 'cli');
+    expect(cli?.latest).toBe('9.9.9');
+    expect(cli?.updateAvailable).toBe(true);
+    expect(cli).not.toHaveProperty('marketplacePin');
+  });
+
+  it('keeps npm unread-from but still ASKED, so the note can explain itself', () => {
+    // The npm answer is kept beside the pin rather than dropped: it is the only
+    // thing that can explain a row reading "up to date" at a version the user
+    // can see is behind. A report that silently used the pin and forgot npm
+    // would be correct and unreadable.
+    const report = gatherReport({
+      viewVersion: views({ [CLI]: '0.0.1', [PLUGIN]: null }),
+      installed: new Map([[REF, '0.9.9']]),
+      cliInstalled: '0.0.1',
+      marketplacePin: pinned('0.9.9'),
+    });
+
+    expect(report.statuses.find((s) => s.id === 'claude-code')?.marketplacePin).toEqual({
+      marketplace: 'akasecurity',
+      npmLatest: null,
+    });
   });
 });

--- a/packages/local-ops/test/updates.test.ts
+++ b/packages/local-ops/test/updates.test.ts
@@ -104,7 +104,12 @@ describe('gatherReport — the marketplace pin decides what "latest" means', () 
 
     const plugin = report.statuses.find((s) => s.id === 'claude-code');
     expect(plugin?.latest).toBe('0.9.9');
-    expect(plugin?.marketplacePin).toEqual({ marketplace: 'akasecurity', npmLatest: '0.9.10' });
+    expect(plugin?.marketplacePin).toEqual({
+      marketplace: 'akasecurity',
+      npmLatest: '0.9.10',
+      // npm is ahead of the pin, which is the only case worth explaining.
+      npmAhead: true,
+    });
   });
 
   it('does NOT offer an update the host cannot install', () => {
@@ -196,6 +201,8 @@ describe('gatherReport — the marketplace pin decides what "latest" means', () 
     expect(report.statuses.find((s) => s.id === 'claude-code')?.marketplacePin).toEqual({
       marketplace: 'akasecurity',
       npmLatest: null,
+      // Nothing to compare against, so nothing to explain.
+      npmAhead: false,
     });
   });
 });

--- a/packages/schema/src/zod/updates.ts
+++ b/packages/schema/src/zod/updates.ts
@@ -13,8 +13,29 @@ export interface ComponentStatus {
   name: string;
   kind: ComponentKind;
   installed: string | null;
+  // The version the host would actually INSTALL, which is not always npm's
+  // latest: a plugin resolved through a marketplace manifest that names an
+  // exact version can only reach that version. Null when it could not be
+  // resolved at all (offline / no registry auth).
   latest: string | null;
   updateAvailable: boolean;
+  // Present only when `latest` came from a marketplace pin rather than from
+  // npm, which is what lets a surface explain a machine that is current
+  // against its own marketplace while npm has moved on. Without it the two
+  // cases render identically — "up to date" beside a version the user can see
+  // is behind — and the difference is exactly what a reader needs.
+  marketplacePin?: MarketplacePin;
+}
+
+// Where a pinned `latest` came from, and what npm said instead.
+export interface MarketplacePin {
+  // The marketplace whose manifest carries the pin, so the message can name
+  // the thing the user would have to move.
+  marketplace: string;
+  // npm's own latest for the same package, or null when it could not be read.
+  // Carried rather than recomputed because a surface that re-derived it would
+  // ask the registry a second time to explain one line of output.
+  npmLatest: string | null;
 }
 
 // An available agent plugin the user has NOT installed yet — surfaced so they

--- a/packages/schema/src/zod/updates.ts
+++ b/packages/schema/src/zod/updates.ts
@@ -36,6 +36,13 @@ export interface MarketplacePin {
   // Carried rather than recomputed because a surface that re-derived it would
   // ask the registry a second time to explain one line of output.
   npmLatest: string | null;
+  // Whether npm is strictly AHEAD of the pin — the only case worth explaining,
+  // since a pin that equals npm explains nothing and the two agree on the happy
+  // path. Computed where semver comparison already lives rather than in each
+  // renderer: `@akasecurity/dashboard-ui` may not import `local-ops` at all, so
+  // a view deriving this would either cross a package wall or carry a second
+  // comparator that could disagree with the first.
+  npmAhead: boolean;
 }
 
 // An available agent plugin the user has NOT installed yet — surfaced so they

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -8,6 +8,7 @@ import {
   gatherReport,
   installedAgentPluginVersions,
   installedPluginScope,
+  marketplacePinnedVersion,
   planCliUpdate,
   pluginRef,
   readCache,
@@ -49,6 +50,14 @@ export default function UpdatesPage() {
     },
     installed: installedAgentPluginVersions(),
     cliInstalled: cliVersion(process.cwd()),
+    // Read live rather than from the cache, unlike `latest` above: the pin is a
+    // local file the host itself wrote, so there is no request to amortise, and
+    // a stale pin would put this page back to offering an update the host
+    // cannot deliver — the defect the pin exists to close.
+    marketplacePin: (agent) =>
+      agent.marketplace !== undefined && agent.pluginName !== undefined
+        ? marketplacePinnedVersion(agent.marketplace, agent.pluginName)
+        : null,
   });
 
   // The CLI's command depends on how THIS copy was installed (npm global under

--- a/web-ui/app/(app)/updates/page.tsx
+++ b/web-ui/app/(app)/updates/page.tsx
@@ -54,10 +54,7 @@ export default function UpdatesPage() {
     // local file the host itself wrote, so there is no request to amortise, and
     // a stale pin would put this page back to offering an update the host
     // cannot deliver — the defect the pin exists to close.
-    marketplacePin: (agent) =>
-      agent.marketplace !== undefined && agent.pluginName !== undefined
-        ? marketplacePinnedVersion(agent.marketplace, agent.pluginName)
-        : null,
+    marketplacePin: (agent) => marketplacePinnedVersion(agent),
   });
 
   // The CLI's command depends on how THIS copy was installed (npm global under


### PR DESCRIPTION
Closes #393. Stacked on #463 — review that first; they share `cli-plugin-manager.ts`.

## The two halves asked different sources

`aka update` decided whether an update existed by asking **npm**. `claude plugin install` / `plugin update` resolve through the **marketplace manifest**, whose entries name an exact version. Nothing reconciled them, so the report could offer an update the host structurally cannot deliver — a consent prompt promising a state change that cannot happen, and, in the output, indistinguishable from a genuine failure.

The pin wins where there is one, because it is what the host resolves an install through.

## Confirmed against a real install, not inferred

```
~/.claude/plugins/known_marketplaces.json
  akasecurity -> installLocation: ~/.claude/plugins/marketplaces/akasecurity

<installLocation>/.claude-plugin/marketplace.json
  { "name": "ai-tc",     "source": { "source": "npm", "package": "@akasecurity/ai-tc-claude-code", "version": "0.9.10" } }
  { "name": "preflight", "source": { "source": "github", "repo": "akasecurity/preflight-skills" } }
  { "name": "claude-tools", "source": { "source": "git-subdir", "url": "…", "path": "…" } }
```

So the shape varies **per entry**, not per repository: npm sources carry a pin, github and git-subdir sources do not. An entry with no pin falls back to npm, which is correct rather than lenient — for those sources the host really does follow the published head.

**The reader follows `installLocation` rather than assembling `<home>/plugins/marketplaces/<name>`.** The conventional path is what this machine happens to use; the host stating where it put the thing is what makes an unrecognised layout produce *no* answer instead of a wrong one. Pinned by its own case.

Every other way the read can fail — not registered, manifest absent or damaged, plugin unlisted, empty version — falls back the same way. A throw here would take down `aka update` **and** the passive notice with it.

## npm is still asked, and that is the point

The npm answer is kept beside the pin rather than discarded, because it is the only thing that can explain a row reading `up to date` at a version the user can see is behind:

```
  Pinned by a marketplace:
    Claude Code plugin: the akasecurity marketplace pins v0.9.9. npm has v0.9.10,
    which this machine cannot install until that marketplace moves.
```

It names the **marketplace**, since under one registered at a pinned ref that is the only thing that can ever close the gap. A pin equal to npm explains nothing and is left unsaid — otherwise the happy path, where the two agree, is all note and no signal.

## A required seam, and the seven callers it named

`ReportDeps.marketplacePin` is **required**. An optional one reads as safe at every call site that omits it, and the site that omitted it would go back to offering an update the host cannot deliver, silently. Required, the compiler named all seven; the existing tests pass `() => null`, which preserves exactly what they asserted before.

## The false premise it corrects

`cli-plugin-manager.ts` stated that manifest entries name an npm package **with no version pin**, "so `add` picks up a published bump on its own" — and Codex's `update` verb is `plugin add`, chosen on that premise. Claude Code's entries do carry a pin, as above.

Whether it holds for the **Codex** marketplace is **unverified**: that host keeps no marketplaces directory to read a resolved manifest from, so nothing here has seen one. I recorded it as unknown rather than correcting it to a second guess, because that host's whole update path rests on it. Worth a maintainer's eye.

## Verification

| mutation | red |
| --- | --- |
| let npm win over the pin (the shipped bug) | 3 |
| assume the conventional layout instead of reading `installLocation` | 1 |
| take the first manifest entry rather than matching the name | 2 |
| fire the note on every pin, not only one behind npm | 2 |

`local-ops` 336 passed / 1 skipped, `schema` 914, `cli` 488 / 5 skipped, `web-ui` 818. Workspace lint, typecheck, prettier and the portability gate clean.
