### PR TITLE
fix(plugins): name commands and skills in their invokable form

### DIFF
--- a/plugins/antigravity/skills/setup/SKILL.md
+++ b/plugins/antigravity/skills/setup/SKILL.md
@@ -811,10 +811,11 @@ what happened, show the one-liner so they can retry later, and continue the
 wizard normally. The plugin is already fully set up and works on its own; a
 failed CLI install changes nothing about that.
 
-**Close the wizard.** The first-run summary already confirmed the saved posture
-and pointed at the aka-health skill. Whichever way the CLI offer went —
-installed, declined, or a failed install you already reported — end with one
-warm close: "That's it — I'm watching out for Antigravity going forward."
+**Close the wizard.** The first-run summary already confirmed the saved posture,
+reported the health score, and pointed at the aka-dashboard and aka-scan
+skills. Whichever way the CLI offer went — installed, declined, or a failed
+install you already reported — end with one warm close: "That's it — I'm
+watching out for Antigravity going forward."
 
 Before you finish, confirm every AKA_SHOW region on the path you took was
 relayed to the user. If you summarized one instead of pasting it, paste it now.

--- a/plugins/antigravity/test/render.test.ts
+++ b/plugins/antigravity/test/render.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import type { FindingView } from '@akasecurity/plugin-sdk';
+import type { FindingView, HealthSummary } from '@akasecurity/plugin-sdk';
 import {
   buildRecommendations as sdkBuildRecommendations,
   severityFloorPosture,
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildHandoffOffer,
+  buildHealthReport,
   buildRecommendations,
   RE_TUNE_HINT,
   renderAdjustConfirm,
@@ -25,8 +26,10 @@ import {
   renderCategoriesTuned,
   renderDetections,
   renderFirstRun,
+  renderHealth,
   renderPosture,
   renderPostureGrid,
+  renderRecommend,
   renderRecommendedPosture,
   renderStartLight,
   topFindings,
@@ -744,5 +747,61 @@ describe('renderDetections — the policy column', () => {
     const out = renderDetections([item({ policyId: 'my-custom-policy' })]);
     expect(out).toContain('my-custom-policy');
     expect(out).not.toContain(BUILTIN_POLICIES[DEFAULT_PACK_POLICY_ID].name);
+  });
+});
+
+describe('read-surface footers name skills this host can actually invoke', () => {
+  // This host invokes a skill by its frontmatter `name:` (`aka-health`), not as a
+  // slash command — `/aka:health` is the Claude Code plugin's namespace and
+  // resolves to nothing here. Neither footer was pinned by anything, which is
+  // exactly how the sibling plugin's two footers drifted to a bare `/recommend`.
+  const REGISTRY = readRegisteredSkills();
+
+  const summary: HealthSummary = {
+    findings: 2,
+    byAction: { block: 1, redact: 1, warn: 0, allow: 0, log: 0 },
+    bySeverity: { critical: 1, high: 0, medium: 0, low: 1 },
+    coverage: 1,
+  };
+  const status = {
+    score: 72,
+    unreviewed: { critical: 1, high: 0, medium: 0, low: 1 },
+    openFindings: 2,
+  };
+
+  it('the health footer names the recommend skill', () => {
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const out = renderHealth(buildHealthReport(summary, findings, []));
+    expect(out).toContain('Use the aka-recommend skill to review');
+    // No slash-command form of any kind reaches this host's transcript.
+    expect(out).not.toContain('/aka:');
+    expect(out).not.toContain('/recommend');
+  });
+
+  it('the recommend footer names the recommend and health skills', () => {
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const recs = buildRecommendations(findings);
+    // The footer renders only on the populated path, so an empty build would
+    // leave every assertion below holding vacuously.
+    expect(recs.length).toBeGreaterThan(0);
+    const out = renderRecommend(recs, status);
+    expect(out).toContain('Use aka-recommend <n> to act on one, or aka-health for the summary.');
+    expect(out).not.toContain('/aka:');
+    expect(out).not.toContain('/health');
+  });
+
+  it('every skill either footer names is one the plugin ships', () => {
+    // The names are read OUT OF the rendered footers rather than listed here, so
+    // a footer that grows a third skill is checked too. Listing them instead
+    // would pass while that third skill was renamed out of existence.
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const health = renderHealth(buildHealthReport(summary, findings, []));
+    const recommend = renderRecommend(buildRecommendations(findings), status);
+    const named = [
+      ...health.matchAll(/\baka-[a-z-]+/g),
+      ...recommend.matchAll(/\baka-[a-z-]+/g),
+    ].map((m) => m[0]);
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of named) expect(REGISTRY).toContain(skill);
   });
 });

--- a/plugins/claude-code/commands/scan.md
+++ b/plugins/claude-code/commands/scan.md
@@ -23,7 +23,7 @@ cryptography, hardcoded credentials, dev-mode configuration leaks, and other
 OWASP Top 10 issues.
 
 Results are recorded to the local store (`~/.aka/data/aka.db`) and are visible
-via `/findings`. Re-running `/aka:scan` is safe — files whose content has already
+via `/aka:findings`. Re-running `/aka:scan` is safe — files whose content has already
 been recorded are skipped.
 
 Files excluded by the repo's `.gitignore` are **still scanned** — local scratch

--- a/plugins/claude-code/commands/setup.md
+++ b/plugins/claude-code/commands/setup.md
@@ -885,9 +885,10 @@ what happened, show the one-liner so they can retry later, and continue the
 wizard normally. The plugin is already fully set up and works on its own; a
 failed CLI install changes nothing about that.
 
-**Close the wizard.** The first-run summary already confirmed the saved posture
-and pointed at `/health`. Whichever way the CLI offer went — installed,
-declined, or a failed install you already reported — end with one warm close:
+**Close the wizard.** The first-run summary already confirmed the saved posture,
+reported the health score, and pointed at `/aka:dashboard` · `/aka:scan`.
+Whichever way the CLI offer went — installed, declined, or a failed install you
+already reported — end with one warm close:
 "That's it — I'm watching out for Claude going forward."
 
 Before you finish, confirm every AKA_SHOW region on the path you took was

--- a/plugins/claude-code/src/backfill.ts
+++ b/plugins/claude-code/src/backfill.ts
@@ -221,7 +221,7 @@ export async function runBackfill(deps: BackfillDeps): Promise<void> {
       const scope = `Scanned ${String(summary.scanned)} messages from the last ${String(summary.windowDays)} days of Claude Code history.`;
       const result =
         summary.findings > 0
-          ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with /findings.`
+          ? `Found ${String(summary.findings)} pre-install finding${summary.findings === 1 ? '' : 's'} — review them with /aka:findings.`
           : 'No new pre-install secrets found in your history.';
       const lines = [heading, '', indent(scope), '', indent(result)];
       if (scrubbedFiles > 0) {

--- a/plugins/claude-code/src/filescan.ts
+++ b/plugins/claude-code/src/filescan.ts
@@ -59,7 +59,7 @@ function parseFlags(argv: string[]): Flags {
 
 // The follow-up hint is host-specific (a Claude Code slash command), so it is
 // injected here rather than baked into the shared renderer.
-const FOLLOW_UP = 'Run /findings to review details.';
+const FOLLOW_UP = 'Run /aka:findings to review details.';
 
 try {
   const { dir, discover, root, depth } = parseFlags(process.argv.slice(2));

--- a/plugins/claude-code/src/render.ts
+++ b/plugins/claude-code/src/render.ts
@@ -682,7 +682,9 @@ export function renderHealth(r: HealthReport): string {
   lines.push(indent(`${String(r.weekFindings)} findings in the last 7 days`));
 
   lines.push('');
-  lines.push(indent(`Run /recommend to review ${String(r.recommendCount)} prioritized actions.`));
+  lines.push(
+    indent(`Run /aka:recommend to review ${String(r.recommendCount)} prioritized actions.`),
+  );
 
   lines.push('');
   lines.push(
@@ -798,7 +800,7 @@ export function renderRecommend(recs: Recommendation[], status: FindingStatus): 
   });
 
   lines.push(
-    indent('Run /recommend <n> to act on one, or /health for the summary.'),
+    indent('Run /aka:recommend <n> to act on one, or /aka:health for the summary.'),
     '',
     indent(renderStatusBar(status)),
   );

--- a/plugins/claude-code/test/command-registry.test.ts
+++ b/plugins/claude-code/test/command-registry.test.ts
@@ -155,15 +155,30 @@ describe('chaining-line secret-scan continuation selection', () => {
   });
 });
 
+const PLUGIN_DIR = fileURLToPath(new URL('..', import.meta.url));
+const COMMANDS_DIR = join(PLUGIN_DIR, 'commands');
+const NAMES = readRegisteredCommands().map((c) => c.replace('/aka:', ''));
+
+// `/aka:foo` contains no `/foo` substring — its only slash is followed by `a` —
+// so a bare occurrence is exactly what this matches. The leading class rejects a
+// path segment or URL tail (`scripts/scan-worker.js`, `~/.aka/data`), which is
+// the only shape that would otherwise read as a bare command. Shared by both
+// scans below: two matchers for one rule could disagree about what a bare form is.
+const bareForm = (): RegExp => new RegExp(`(^|[^A-Za-z0-9_:/.\\-])/(${NAMES.join('|')})\\b`, 'g');
+
+const scan = (text: string): string[] =>
+  text
+    .split('\n')
+    .flatMap((line, i) =>
+      [...line.matchAll(bareForm())].map((m) => `${String(i + 1)}: ${m[0].trim()}`),
+    );
+
 describe('shipped command prose names commands in their invokable form', () => {
   // These files reach the user either way — scan.md's description is shown, and
   // setup.md is the wizard script the model follows and quotes from. A command
   // file `foo.md` registers as `/aka:foo`, so a bare `/foo` in that prose is a
   // call-to-action nobody can invoke. Two had drifted with nothing looking at
   // them, which is what this scan is for.
-  const PLUGIN_DIR = fileURLToPath(new URL('..', import.meta.url));
-  const COMMANDS_DIR = join(PLUGIN_DIR, 'commands');
-  const NAMES = readRegisteredCommands().map((c) => c.replace('/aka:', ''));
 
   // Every markdown file the tarball carries, not just commands/. npm ships the
   // `files` entries plus README.md whether or not it is listed — confirmed
@@ -196,19 +211,6 @@ describe('shipped command prose names commands in their invokable form', () => {
     return found;
   };
 
-  // `/aka:foo` contains no `/foo` substring — its only slash is followed by `a` —
-  // so a bare occurrence is exactly what this matches. The leading class rejects a
-  // path segment or URL tail (`scripts/scan-worker.js`, `~/.aka/data`), which is
-  // the only shape that would otherwise read as a bare command.
-  const bareForm = (): RegExp => new RegExp(`(^|[^A-Za-z0-9_:/.\\-])/(${NAMES.join('|')})\\b`, 'g');
-
-  const scan = (text: string): string[] =>
-    text
-      .split('\n')
-      .flatMap((line, i) =>
-        [...line.matchAll(bareForm())].map((m) => `${String(i + 1)}: ${m[0].trim()}`),
-      );
-
   it('no shipped markdown names a bare /<command>', () => {
     const offenders = shippedMarkdown().flatMap((rel) =>
       scan(readFileSync(join(PLUGIN_DIR, rel), 'utf8')).map((hit) => `${rel}:${hit}`),
@@ -240,5 +242,71 @@ describe('shipped command prose names commands in their invokable form', () => {
     // Paths and URLs carry these words after a slash and are not commands.
     expect(scan('scripts/scan-worker.js and ~/.aka/data/aka.db')).toEqual([]);
     expect(scan('see https://example.com/health for more')).toEqual([]);
+  });
+});
+
+describe('shipped source strings name commands in their invokable form', () => {
+  // The markdown scan above cannot see a command named from TypeScript, and two
+  // shipped strings had drifted there — filescan.ts's scan follow-up and
+  // backfill.ts's historical-scan result both said `/findings`, which resolves to
+  // nothing. Both reach the user on ordinary paths and neither was pinned.
+  //
+  // Only QUOTED SPANS are scanned. Comments are the noise to exclude: this
+  // package names commands bare in doc headers on purpose (query.ts, firstrun.ts,
+  // present.ts), and those are fine because nobody types a comment. Two limits are
+  // real and stated rather than papered over — a bare form inside a template
+  // literal spanning several lines is missed, as is one in a trailing comment that
+  // happens to contain a matched pair of quotes.
+  const SRC_DIR = join(PLUGIN_DIR, 'src');
+
+  // A full-line comment cannot hold a string, so dropping those first keeps an
+  // apostrophe in prose from opening a bogus span.
+  const isCommentLine = (line: string): boolean => /^\s*(\/\/|\*|\/\*)/.test(line);
+  const QUOTED = /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`/g;
+
+  const scanSource = (text: string): string[] =>
+    text
+      .split('\n')
+      .flatMap((line, i) =>
+        isCommentLine(line)
+          ? []
+          : (line.match(QUOTED) ?? []).flatMap((span) =>
+              scan(span).map(() => `${String(i + 1)}: ${span.trim()}`),
+            ),
+      );
+
+  const sourceFiles = (): string[] =>
+    readdirSync(SRC_DIR, { recursive: true, withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith('.ts'))
+      .map((e) => relative(PLUGIN_DIR, join(e.parentPath, e.name)));
+
+  it('no shipped source string names a bare /<command>', () => {
+    const offenders = sourceFiles().flatMap((rel) =>
+      scanSource(readFileSync(join(PLUGIN_DIR, rel), 'utf8')).map((hit) => `${rel}:${hit}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('the source scan sees a string, ignores a comment, and reaches every file', () => {
+    // Without this control a broken span extractor reports an empty offender list
+    // for ever, which reads exactly like a clean tree.
+    expect(scanSource(`const FOLLOW_UP = 'Run /findings to review details.';`)).toHaveLength(1);
+    expect(scanSource('const x = `… — review them with /findings.`;')).toHaveLength(1);
+    expect(scanSource(`const x = "Run /health";`)).toHaveLength(1);
+
+    // The namespaced form is what both corrected sites now use.
+    expect(scanSource(`const FOLLOW_UP = 'Run /aka:findings to review details.';`)).toEqual([]);
+
+    // Comments name commands bare on purpose here and must not be flagged.
+    expect(scanSource(' * Invoked by the /health, /findings, /recommend commands')).toEqual([]);
+    expect(scanSource('// (the /findings look); without it the header gets…')).toEqual([]);
+
+    // A path in a string is not a command.
+    expect(scanSource(`const p = 'scripts/scan-worker.js';`)).toEqual([]);
+
+    // And the walk must actually reach the two files this guard was added for.
+    const walked = new Set(sourceFiles());
+    expect(walked).toContain(join('src', 'filescan.ts'));
+    expect(walked).toContain(join('src', 'backfill.ts'));
   });
 });

--- a/plugins/claude-code/test/command-registry.test.ts
+++ b/plugins/claude-code/test/command-registry.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -151,5 +152,93 @@ describe('chaining-line secret-scan continuation selection', () => {
       (c) => c !== '/aka:scan' && c !== '/aka:secretscan',
     );
     expect(() => selectSecretScanContinuation(withoutSecretScan)).toThrow();
+  });
+});
+
+describe('shipped command prose names commands in their invokable form', () => {
+  // These files reach the user either way — scan.md's description is shown, and
+  // setup.md is the wizard script the model follows and quotes from. A command
+  // file `foo.md` registers as `/aka:foo`, so a bare `/foo` in that prose is a
+  // call-to-action nobody can invoke. Two had drifted with nothing looking at
+  // them, which is what this scan is for.
+  const PLUGIN_DIR = fileURLToPath(new URL('..', import.meta.url));
+  const COMMANDS_DIR = join(PLUGIN_DIR, 'commands');
+  const NAMES = readRegisteredCommands().map((c) => c.replace('/aka:', ''));
+
+  // Every markdown file the tarball carries, not just commands/. npm ships the
+  // `files` entries plus README.md whether or not it is listed — confirmed
+  // against `npm pack --dry-run`, where README.md appears despite its absence
+  // from `files`. Scanning commands/ alone left the README, which names four
+  // commands and is the most-read page here, guarded by nothing.
+  const pkg = JSON.parse(readFileSync(join(PLUGIN_DIR, 'package.json'), 'utf8')) as {
+    files?: string[];
+  };
+  const SHIPPED_ROOTS = [...(pkg.files ?? []), 'README.md'];
+
+  // `scripts/` is build output and may be absent before a build, so a missing
+  // root is skipped rather than fatal — the coverage assertion below is what
+  // catches a walk that silently found nothing.
+  const shippedMarkdown = (): string[] => {
+    const found: string[] = [];
+    for (const root of SHIPPED_ROOTS) {
+      const abs = join(PLUGIN_DIR, root);
+      if (!existsSync(abs)) continue;
+      if (statSync(abs).isFile()) {
+        if (abs.endsWith('.md')) found.push(root);
+        continue;
+      }
+      for (const entry of readdirSync(abs, { recursive: true, withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          found.push(relative(PLUGIN_DIR, join(entry.parentPath, entry.name)));
+        }
+      }
+    }
+    return found;
+  };
+
+  // `/aka:foo` contains no `/foo` substring — its only slash is followed by `a` —
+  // so a bare occurrence is exactly what this matches. The leading class rejects a
+  // path segment or URL tail (`scripts/scan-worker.js`, `~/.aka/data`), which is
+  // the only shape that would otherwise read as a bare command.
+  const bareForm = (): RegExp => new RegExp(`(^|[^A-Za-z0-9_:/.\\-])/(${NAMES.join('|')})\\b`, 'g');
+
+  const scan = (text: string): string[] =>
+    text
+      .split('\n')
+      .flatMap((line, i) =>
+        [...line.matchAll(bareForm())].map((m) => `${String(i + 1)}: ${m[0].trim()}`),
+      );
+
+  it('no shipped markdown names a bare /<command>', () => {
+    const offenders = shippedMarkdown().flatMap((rel) =>
+      scan(readFileSync(join(PLUGIN_DIR, rel), 'utf8')).map((hit) => `${rel}:${hit}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it('the walk reaches the README and every command file', () => {
+    // A walk that found nothing reports an empty offender list, which reads
+    // exactly like a clean tree — so pin what it must have covered.
+    const walked = new Set(shippedMarkdown());
+    expect(walked).toContain('README.md');
+    for (const f of readdirSync(COMMANDS_DIR).filter((n) => n.endsWith('.md'))) {
+      expect(walked).toContain(join('commands', f));
+    }
+  });
+
+  it('the matcher catches a bare form and passes the namespaced one', () => {
+    // Without this control a broken pattern reports an empty offender list for
+    // ever, which reads exactly like a clean tree.
+    expect(scan('visible via `/findings`.')).toHaveLength(1);
+    expect(scan('and pointed at `/health`.')).toHaveLength(1);
+    expect(scan('Run /recommend to review 5 prioritized actions.')).toHaveLength(1);
+
+    // The namespaced form is what every corrected site uses.
+    expect(scan('visible via `/aka:findings`.')).toEqual([]);
+    expect(scan('Run /aka:recommend <n> to act on one, or /aka:health.')).toEqual([]);
+
+    // Paths and URLs carry these words after a slash and are not commands.
+    expect(scan('scripts/scan-worker.js and ~/.aka/data/aka.db')).toEqual([]);
+    expect(scan('see https://example.com/health for more')).toEqual([]);
   });
 });

--- a/plugins/claude-code/test/render.test.ts
+++ b/plugins/claude-code/test/render.test.ts
@@ -243,6 +243,55 @@ describe('pure renderers', () => {
     expect(one).toContain('1 recommendation for your setup');
   });
 
+  it('health/recommend footers name commands in the invokable /aka: namespace', () => {
+    // Both footers named a bare `/recommend` / `/health` once. Neither resolves
+    // when typed: a command file `foo.md` registers as `/aka:foo`, so the bare
+    // form is a call-to-action the user cannot invoke. Nothing pinned these two
+    // lines while they were literals, which is how they drifted — this is that
+    // pin. The namespaced form does not contain the bare one (`/aka:recommend`
+    // has no `/recommend` substring: its only `/` is followed by `a`), so a
+    // plain not.toContain is an exact check for the defect.
+    const summary: HealthSummary = {
+      findings: 2,
+      byAction: { block: 1, redact: 1, warn: 0, allow: 0, log: 0 },
+      bySeverity: { critical: 1, high: 0, medium: 0, low: 1 },
+      coverage: 1,
+    };
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const status = {
+      score: 72,
+      unreviewed: { critical: 1, high: 0, medium: 0, low: 1 },
+      openFindings: 2,
+    };
+
+    const health = strip(renderHealth(buildHealthReport(summary, findings, [])));
+    expect(health).toContain('Run /aka:recommend to review');
+    expect(health).not.toContain('/recommend');
+
+    const recs = buildRecommendations(findings);
+    // The footer only renders on the populated path, so an empty build would
+    // make every assertion below hold vacuously.
+    expect(recs.length).toBeGreaterThan(0);
+    const recommend = strip(renderRecommend(recs, status));
+    expect(recommend).toContain(
+      'Run /aka:recommend <n> to act on one, or /aka:health for the summary.',
+    );
+    expect(recommend).not.toContain('/recommend');
+    expect(recommend).not.toContain('/health');
+
+    // Every command the footers name must be one the plugin registers — and the
+    // names are read OUT OF the rendered footers rather than listed here, so a
+    // footer that grows a third command is checked too. Listing them instead
+    // would pass while that third command was renamed out of existence.
+    const named = [
+      ...health.matchAll(/\/aka:[a-z-]+/g),
+      ...recommend.matchAll(/\/aka:[a-z-]+/g),
+    ].map((m) => m[0]);
+    expect(named.length).toBeGreaterThan(0);
+    const registry = readRegisteredCommands();
+    for (const cmd of named) expect(registry).toContain(cmd);
+  });
+
   it('audit: decision log with action and source', () => {
     const out = strip(renderAudit([finding({ actionTaken: 'redact' })]));
     expect(out).toContain('Recent decisions (1)');

--- a/plugins/codex/skills/setup/SKILL.md
+++ b/plugins/codex/skills/setup/SKILL.md
@@ -797,10 +797,11 @@ what happened, show the one-liner so they can retry later, and continue the
 wizard normally. The plugin is already fully set up and works on its own; a
 failed CLI install changes nothing about that.
 
-**Close the wizard.** The first-run summary already confirmed the saved posture
-and pointed at the aka-health skill. Whichever way the CLI offer went —
-installed, declined, or a failed install you already reported — end with one
-warm close: "That's it — I'm watching out for Codex going forward."
+**Close the wizard.** The first-run summary already confirmed the saved posture,
+reported the health score, and pointed at the aka-dashboard and aka-scan
+skills. Whichever way the CLI offer went — installed, declined, or a failed
+install you already reported — end with one warm close: "That's it — I'm
+watching out for Codex going forward."
 
 Before you finish, confirm every AKA_SHOW region on the path you took was
 relayed to the user. If you summarized one instead of pasting it, paste it now.

--- a/plugins/codex/test/render.test.ts
+++ b/plugins/codex/test/render.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 
-import type { FindingView } from '@akasecurity/plugin-sdk';
+import type { FindingView, HealthSummary } from '@akasecurity/plugin-sdk';
 import {
   buildRecommendations as sdkBuildRecommendations,
   severityFloorPosture,
@@ -18,6 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildHandoffOffer,
+  buildHealthReport,
   buildRecommendations,
   RE_TUNE_HINT,
   renderAdjustConfirm,
@@ -25,8 +26,10 @@ import {
   renderCategoriesTuned,
   renderDetections,
   renderFirstRun,
+  renderHealth,
   renderPosture,
   renderPostureGrid,
+  renderRecommend,
   renderRecommendedPosture,
   renderStartLight,
   topFindings,
@@ -744,5 +747,61 @@ describe('renderDetections — the policy column', () => {
     const out = renderDetections([item({ policyId: 'my-custom-policy' })]);
     expect(out).toContain('my-custom-policy');
     expect(out).not.toContain(BUILTIN_POLICIES[DEFAULT_PACK_POLICY_ID].name);
+  });
+});
+
+describe('read-surface footers name skills this host can actually invoke', () => {
+  // This host invokes a skill by its frontmatter `name:` (`aka-health`), not as a
+  // slash command — `/aka:health` is the Claude Code plugin's namespace and
+  // resolves to nothing here. Neither footer was pinned by anything, which is
+  // exactly how the sibling plugin's two footers drifted to a bare `/recommend`.
+  const REGISTRY = readRegisteredSkills();
+
+  const summary: HealthSummary = {
+    findings: 2,
+    byAction: { block: 1, redact: 1, warn: 0, allow: 0, log: 0 },
+    bySeverity: { critical: 1, high: 0, medium: 0, low: 1 },
+    coverage: 1,
+  };
+  const status = {
+    score: 72,
+    unreviewed: { critical: 1, high: 0, medium: 0, low: 1 },
+    openFindings: 2,
+  };
+
+  it('the health footer names the recommend skill', () => {
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const out = renderHealth(buildHealthReport(summary, findings, []));
+    expect(out).toContain('Use the aka-recommend skill to review');
+    // No slash-command form of any kind reaches this host's transcript.
+    expect(out).not.toContain('/aka:');
+    expect(out).not.toContain('/recommend');
+  });
+
+  it('the recommend footer names the recommend and health skills', () => {
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const recs = buildRecommendations(findings);
+    // The footer renders only on the populated path, so an empty build would
+    // leave every assertion below holding vacuously.
+    expect(recs.length).toBeGreaterThan(0);
+    const out = renderRecommend(recs, status);
+    expect(out).toContain('Use aka-recommend <n> to act on one, or aka-health for the summary.');
+    expect(out).not.toContain('/aka:');
+    expect(out).not.toContain('/health');
+  });
+
+  it('every skill either footer names is one the plugin ships', () => {
+    // The names are read OUT OF the rendered footers rather than listed here, so
+    // a footer that grows a third skill is checked too. Listing them instead
+    // would pass while that third skill was renamed out of existence.
+    const findings = [finding(), finding({ category: 'pii', severity: 'low' })];
+    const health = renderHealth(buildHealthReport(summary, findings, []));
+    const recommend = renderRecommend(buildRecommendations(findings), status);
+    const named = [
+      ...health.matchAll(/\baka-[a-z-]+/g),
+      ...recommend.matchAll(/\baka-[a-z-]+/g),
+    ].map((m) => m[0]);
+    expect(named.length).toBeGreaterThan(0);
+    for (const skill of named) expect(REGISTRY).toContain(skill);
   });
 });


### PR DESCRIPTION
The Claude Code read surfaces closed on a call-to-action nobody could invoke.
`/aka:health` printed **`Run /recommend to review N prioritized actions.`** and
`/aka:recommend` printed **`Run /recommend <n> to act on one, or /health for the
summary.`** A command file `foo.md` registers as `/aka:foo`, so neither bare form
resolves when typed.

Both literals were unpinned, which is how they drifted — every other surface
(`READY_COMMANDS`, `TRY_COMMANDS`, the remediation chaining line) already
validates its names against the installed registry.

## What changed

**The bug** — two string literals in `plugins/claude-code/src/render.ts`, now
`/aka:recommend` and `/aka:health`.

**Shipped prose naming a dead command**

- `commands/scan.md` pointed at `/findings`, one sentence before a correctly
  namespaced `/aka:scan`.
- `commands/setup.md` said the first-run summary "pointed at `/health`". Wrong
  twice: the bare form does not resolve, and that summary never names a health
  command — it reports a health score and its Try line names `/aka:dashboard` and
  `/aka:scan`. Both sibling `skills/setup/SKILL.md` files carried the same false
  claim with correct namespacing, so a grep for bad command forms never saw them.

**Guards, since nothing pinned any of this**

- Each plugin pins both footers and derives the names they may use *out of the
  rendered footer*, checked against the installed command/skill registry — so a
  footer that grows a third name is covered without editing the test.
- A scan over every shipped markdown file for a bare `/<command>`. Scoped to the
  packed set (`package.json` `files` plus `README.md`, which npm ships whether or
  not it is listed), because the README names four commands and sat outside a
  commands-only scan.

## Verification

Each guard was mutation-tested: the fix reverted, the test confirmed red for its
own assertion, the tree restored. Two carry control runs showing the *previous*
form was blind — a footer naming a non-shipped `/aka:usage` passes the old
hardcoded check, and a footer rendering `Run /recommend.` passes the old
trailing-space assertion.

`pnpm vitest run` per plugin, after merging `origin/main`:

```
claude-code     Tests  1234 passed | 4 skipped (1238)
codex           Tests   514 passed | 1 skipped  (515)
antigravity     Tests   531 passed | 2 skipped  (533)
```

`pnpm typecheck` and `pnpm lint` report 0 errors in all three. Confirmed against
a real store through a built `scripts/query.js`:

```
  Run /aka:recommend to review 5 prioritized actions.
  Run /aka:recommend <n> to act on one, or /aka:health for the summary.
```

No behaviour change beyond the two strings; the renderer signatures are untouched.