### PR TITLE
ci: measure the Windows runner instead of inferring it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,6 +750,39 @@ jobs:
             turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
             turbo-${{ runner.os }}-
 
+      # Two facts the cap's arithmetic currently INFERS and should not:
+      # the runner's logical CPU count, and the worker count vitest sizes from
+      # it — derived today by dividing a package's aggregate `tests` time by its
+      # reported `Duration` and noticing the quotient tops out near 3.
+      #
+      # Nothing depends on what these print. They are here so the NEXT decision
+      # about this leg can be measured rather than argued.
+      - name: Runner facts
+        continue-on-error: true
+        run: |
+          $cs = Get-CimInstance Win32_ComputerSystem
+          $os = Get-CimInstance Win32_OperatingSystem
+          "logical CPUs: $($cs.NumberOfLogicalProcessors)"
+          "availableParallelism (what vitest sizes its pool from): $(node -e "process.stdout.write(String(require('node:os').availableParallelism()))")"
+          "total RAM MB: $([math]::Round($os.TotalVisibleMemorySize / 1KB))"
+          "free RAM MB:  $([math]::Round($os.FreePhysicalMemory / 1KB))"
+          Get-PSDrive -PSProvider FileSystem |
+            Where-Object { $null -ne $_.Used } |
+            ForEach-Object { "drive $($_.Name): used $([math]::Round($_.Used / 1GB))GB free $([math]::Round($_.Free / 1GB))GB" }
+
+      # DETACHED, not Start-Job. Each `run:` step is its own PowerShell, and a
+      # background job dies with the session that created it — so a job started
+      # here would be gone before the first test ran, having written an empty
+      # file that reads exactly like a quiet runner.
+      - name: Start runner sampler
+        continue-on-error: true
+        run: |
+          $proc = Start-Process pwsh -PassThru -WindowStyle Hidden -ArgumentList @(
+            '-NoProfile', '-File', 'tools/ci/windows-runner-sampler.ps1'
+          )
+          "sampler pid: $($proc.Id)"
+          "$($proc.Id)" | Set-Content (Join-Path $env:RUNNER_TEMP 'sampler-pid')
+
       - name: Test the shipped surface and its enforcement
         # --continue: report every package's failures in one run instead of
         # hiding later packages behind the first red one.
@@ -944,6 +977,33 @@ jobs:
         env:
           AKA_INSTALLER_ALLOW_USER_PATH: '1'
         run: pnpm turbo run test --concurrency=1 --filter=@akasecurity/installer -- --maxWorkers=2
+
+      # `always()`, because the run this most needs to explain is the one that
+      # FAILED — a summary that prints only on success describes the case nobody
+      # is investigating.
+      - name: Runner samples
+        if: always()
+        continue-on-error: true
+        run: |
+          $pidFile = Join-Path $env:RUNNER_TEMP 'sampler-pid'
+          if (Test-Path $pidFile) {
+            Stop-Process -Id (Get-Content $pidFile) -Force -ErrorAction SilentlyContinue
+          }
+          $path = Join-Path $env:RUNNER_TEMP 'runner-samples.csv'
+          if (-not (Test-Path $path)) { "no samples were written"; exit 0 }
+          $rows = @(Import-Csv $path)
+          "samples: $($rows.Count) over $([math]::Round($rows.Count * 10 / 60, 1)) minutes"
+          foreach ($col in 'cpu_pct', 'disk_queue', 'avail_mb') {
+            $vals = @($rows | ForEach-Object { [double]$_.$col } | Sort-Object)
+            if ($vals.Count -eq 0) { continue }
+            $p95 = $vals[[math]::Min($vals.Count - 1, [int][math]::Floor(0.95 * $vals.Count))]
+            $p50 = $vals[[int][math]::Floor(0.5 * $vals.Count)]
+            "$col  min $($vals[0])  p50 $p50  p95 $p95  max $($vals[-1])"
+          }
+          # The whole series too: a p95 cannot show a stall that lasted one
+          # sample, and the stalls this exists to explain are 20-55 seconds.
+          "--- full series ---"
+          Get-Content $path
 
       - name: Save Turbo cache
         if: ${{ !cancelled() && steps.turbo-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -992,6 +992,17 @@ jobs:
           $path = Join-Path $env:RUNNER_TEMP 'runner-samples.csv'
           if (-not (Test-Path $path)) { "no samples were written"; exit 0 }
           $rows = @(Import-Csv $path)
+          # Said BEFORE the per-column loop, because otherwise a sampler that
+          # never ticked prints "(not available on this image)" three times and
+          # reads as three renamed counters. Those are opposite conclusions —
+          # one is "this image lacks the counter", the other is "the sampler did
+          # not run" — and the second is the one the next reader has to know,
+          # since it invalidates the whole measurement rather than one column.
+          if ($rows.Count -eq 0) {
+            "no samples collected — the file exists but carries only its header, so the " +
+              "sampler was killed before its first tick or never started"
+            exit 0
+          }
           "samples: $($rows.Count) over $([math]::Round($rows.Count * 10 / 60, 1)) minutes"
           foreach ($col in 'cpu_pct', 'disk_queue', 'avail_mb') {
             # Empty fields are skipped rather than read as zero: the sampler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -764,6 +764,11 @@ jobs:
           $os = Get-CimInstance Win32_OperatingSystem
           "logical CPUs: $($cs.NumberOfLogicalProcessors)"
           "availableParallelism (what vitest sizes its pool from): $(node -e "process.stdout.write(String(require('node:os').availableParallelism()))")"
+          # The granularity of the clock every CPU-time guard in this repo reads.
+          # POSIX reports microseconds; Windows charges whole scheduler ticks to
+          # whichever thread was running at the interrupt, so a guard measuring a
+          # few milliseconds of work here is reading the clock rather than the work.
+          "smallest non-zero threadCpuUsage deltas, ms: $(node -e "const seen = new Set(); for (let i = 0; i < 2000; i += 1) { const a = process.threadCpuUsage(); let x = 0; for (let j = 0; j < 5000; j += 1) x += j; const b = process.threadCpuUsage(); const d = (b.user + b.system - a.user - a.system) / 1000; if (d > 0) seen.add(d); } const v = [...seen].sort((p, q) => p - q); process.stdout.write(v.length === 0 ? 'no non-zero delta in 2000 tries' : v.slice(0, 4).map((m) => m.toFixed(4)).join(', '))")"
           "total RAM MB: $([math]::Round($os.TotalVisibleMemorySize / 1KB))"
           "free RAM MB:  $([math]::Round($os.FreePhysicalMemory / 1KB))"
           Get-PSDrive -PSProvider FileSystem |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -994,8 +994,12 @@ jobs:
           $rows = @(Import-Csv $path)
           "samples: $($rows.Count) over $([math]::Round($rows.Count * 10 / 60, 1)) minutes"
           foreach ($col in 'cpu_pct', 'disk_queue', 'avail_mb') {
-            $vals = @($rows | ForEach-Object { [double]$_.$col } | Sort-Object)
-            if ($vals.Count -eq 0) { continue }
+            # Empty fields are skipped rather than read as zero: the sampler
+            # leaves a column blank for a counter this image does not carry, and
+            # a blank coerced to 0 would report a perfectly idle disk.
+            $vals = @($rows | Where-Object { $_.$col -ne '' } |
+              ForEach-Object { [double]$_.$col } | Sort-Object)
+            if ($vals.Count -eq 0) { "$col  (not available on this image)"; continue }
             $p95 = $vals[[math]::Min($vals.Count - 1, [int][math]::Floor(0.95 * $vals.Count))]
             $p50 = $vals[[int][math]::Floor(0.5 * $vals.Count)]
             "$col  min $($vals[0])  p50 $p50  p95 $p95  max $($vals[-1])"

--- a/tools/ci/windows-runner-sampler.ps1
+++ b/tools/ci/windows-runner-sampler.ps1
@@ -18,18 +18,29 @@
 $ErrorActionPreference = 'Continue'
 $out = Join-Path $env:RUNNER_TEMP 'runner-samples.csv'
 'time,cpu_pct,disk_queue,avail_mb' | Set-Content $out
-while ($true) {
+
+# PER COUNTER, not one call for the three. Under `-ErrorAction Stop` a single
+# call promotes any per-counter error to a terminating one, so a name this image
+# does not carry loses the whole tick — and since a renamed counter is not a
+# transient condition, it loses EVERY tick and the file ends as its header line
+# alone. That is the empty series this sampler exists to never produce, and it
+# would read exactly like a quiet runner.
+#
+# Read separately, a missing counter costs its own column and nothing else.
+function Read-Counter {
+  param([string] $Path)
   try {
-    $counters = Get-Counter -Counter @(
-      '\Processor(_Total)\% Processor Time',
-      '\PhysicalDisk(_Total)\Current Disk Queue Length',
-      '\Memory\Available MBytes'
-    ) -ErrorAction Stop
-    $values = $counters.CounterSamples | ForEach-Object { [math]::Round($_.CookedValue, 1) }
-    "$(Get-Date -Format o),$($values -join ',')" | Add-Content $out
+    $sample = (Get-Counter -Counter $Path -ErrorAction Stop).CounterSamples[0]
+    return [math]::Round($sample.CookedValue, 1)
   } catch {
-    # A counter this image does not carry: keep sampling the ones it does on the
-    # next tick rather than ending the series.
+    return ''
   }
+}
+
+while ($true) {
+  $cpu = Read-Counter '\Processor(_Total)\% Processor Time'
+  $disk = Read-Counter '\PhysicalDisk(_Total)\Current Disk Queue Length'
+  $mem = Read-Counter '\Memory\Available MBytes'
+  "$(Get-Date -Format o),$cpu,$disk,$mem" | Add-Content $out
   Start-Sleep -Seconds 10
 }

--- a/tools/ci/windows-runner-sampler.ps1
+++ b/tools/ci/windows-runner-sampler.ps1
@@ -1,0 +1,35 @@
+# Samples the Windows runner while the test legs run.
+#
+# Everything anyone has proposed for the `Windows · Unit tests` leg — capping the
+# vitest pool, serialising the step, raising the ceiling, cutting per-test store
+# setup — is a guess about a resource NO LOG IN THIS REPOSITORY MEASURES. No job
+# records the runner's CPU steal, its disk queue or its memory pressure, so every
+# causal claim about that leg is inferred from the shape of timing data.
+#
+# It matters that this SAMPLES rather than snapshots. The failures are stalls in
+# the tail: individual tests that take 0.6-1.8s on a green run intermittently take
+# 20-55s, with nothing in between. A before/after reading cannot see that; a
+# periodic one can say whether the disk queue or the CPU was saturated while it
+# happened.
+#
+# It must never fail the job it is measuring. The counter names are locale-bound,
+# so a runner image that renames one has to cost a missing measurement rather than
+# a red leg — hence the empty catch, which is deliberate and not an oversight.
+$ErrorActionPreference = 'Continue'
+$out = Join-Path $env:RUNNER_TEMP 'runner-samples.csv'
+'time,cpu_pct,disk_queue,avail_mb' | Set-Content $out
+while ($true) {
+  try {
+    $counters = Get-Counter -Counter @(
+      '\Processor(_Total)\% Processor Time',
+      '\PhysicalDisk(_Total)\Current Disk Queue Length',
+      '\Memory\Available MBytes'
+    ) -ErrorAction Stop
+    $values = $counters.CounterSamples | ForEach-Object { [math]::Round($_.CookedValue, 1) }
+    "$(Get-Date -Format o),$($values -join ',')" | Add-Content $out
+  } catch {
+    # A counter this image does not carry: keep sampling the ones it does on the
+    # next tick rather than ending the series.
+  }
+  Start-Sleep -Seconds 10
+}


### PR DESCRIPTION
Stacked on #460 — same job, and a reviewer weighing that cap needs this to evaluate it later.

## Nothing in this repository measures the runner

Every lever proposed for the `Windows · Unit tests` leg — capping the vitest pool (#460), serialising the step, raising the ceiling, cutting per-test store setup (#452) — is a **guess about a resource no log records**. No job prints the runner's CPU count, its steal, its disk queue or its memory pressure, so every causal claim about that leg, including the ones written in its own comments, is inferred from the shape of timing data.

Two of those inferences are load-bearing and cheap to replace with a reading:

- **the logical CPU count**, which #460's `2 × 2 = 4` arithmetic assumes;
- **vitest's worker count**, derived today by dividing a package's aggregate `tests` time by its reported `Duration` and noticing the quotient tops out near 2.90.

Neither has ever been read from a log line.

## It samples, because the failures are stalls in the tail

Measured on one commit with `persistence` executing in both attempts of run 34576095089:

| test | red | green | ratio |
| --- | --- | --- | --- |
| `keeps a backlog grant made while attaching TO the new deployment` | 54,010 ms | 1,829 ms | 29.5× |
| `rotates from the key file when it is ahead of the store` | 31,495 ms | 606 ms | 52× |
| `upserts one host/harness/account/project row…` | 31,280 ms | 1,086 ms | 28.8× |
| `records no persistent exclusion that matches nothing…` | 32,086 ms | 1,414 ms | 22.7× |

The package aggregate moved only 1022 s → 494 s. **A ~2× aggregate move cannot produce 22–52× per-test moves.** The distribution is bimodal with an empty gap — green maxima 1.5–5.7 s, failure minima 20.6–46.2 s, nothing at 15–19 s.

A before/after snapshot cannot see that shape. A 10-second sampler can say whether the disk queue or the CPU was saturated while it happened.

## Three implementation notes that are not incidental

**The sampler is a tracked `.ps1`, not an inline block.** A PowerShell here-string cannot live inside a YAML block scalar — its terminator must sit at column 0, which ends the scalar. I hit exactly that before moving it out.

**It is detached, not `Start-Job`.** Each `run:` step is its own PowerShell, and a background job dies with the session that created it — so a job started in one step would be gone before the first test ran, having written an empty file that reads *exactly like a quiet runner*. That failure would be silent and would have misled the next reader worse than no data.

**The summary is `always()`.** The run this most needs to explain is the one that failed; a summary printing only on success describes the case nobody is investigating. It prints percentiles **and the full series**, because a p95 cannot show a stall that lasted one sample and the stalls here are 20–55 s.

## It cannot cost what it observes

Every step is `continue-on-error`. The counter reads swallow a name the image does not carry — they are locale-bound, and a renamed counter must cost a missing measurement rather than a red leg. Nothing in the job depends on what any of it prints, and no test command changes.

## What it deliberately does not do

It does not add `--reporter=json` to the test invocations. That would give machine-readable per-test durations, which is genuinely wanted — but changing the test command in the same change that caps its worker pool makes two variables move at once, and #460 is already an unvalidated bet.

## Why this before another lever

There is an alternative hypothesis nobody has tested and this data cannot exclude: a **lock-ordering or `busy_timeout`-expiry bug in the store harness**. It would look identical — diff-independent, concentrated in the lock/fsync suites, resolving after multiples of a timeout — and would be untouched by *any* concurrency lever, #460 included. CLAUDE.md §1 notes `PRAGMA busy_timeout = 2000` is charged per contended **statement**, so the product itself supplies that mechanism.

Distinguishing "the runner stalled" from "the store deadlocked and waited" needs a reading of the runner. That is this.
