### PR TITLE
chore(release): merge release/0.9.11 back to main

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/cli",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control — local-first CLI to inspect and govern AI agent traffic on your machine",
   "license": "Apache-2.0",
   "repository": {

--- a/plugins/antigravity/package.json
+++ b/plugins/antigravity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-antigravity",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Antigravity CLI",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/antigravity/plugin.json
+++ b/plugins/antigravity/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://antigravity.google/schemas/v1/plugin.json",
   "name": "aka-antigravity",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control — inspect and govern AI prompts in Antigravity. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks.json",
   "skills": "./skills",

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "homepage": "https://github.com/akasecurity/ai-tc",
   "author": { "name": "AKA Security" }

--- a/plugins/claude-code/package.json
+++ b/plugins/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-claude-code",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control — inspect and govern AI prompts in Claude Code",
   "license": "Apache-2.0",
   "type": "module",

--- a/plugins/codex/.codex-plugin/plugin.json
+++ b/plugins/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "aka-codex",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI. Detection runs locally; events are recorded to a local SQLite store on your machine.",
   "hooks": "./hooks/hooks.json",
   "skills": "./skills",

--- a/plugins/codex/package.json
+++ b/plugins/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akasecurity/ai-tc-codex",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "AI Traffic Control \u2014 inspect and govern AI prompts in Codex CLI",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Release 0.9.11 — 133 commits since `cli-v0.9.10` (2026-09-04).

## Headline: manual scans forward their Data Shares register

On an attached machine, `aka scan` and the dashboard's Scan page now forward the register they record
to the deployment the machine is attached to, and say what happened. Until this release only the
plugin's own scanner forwarded, so a fleet's Data Shares page stayed empty unless somebody ran
`/aka:scan` — the two surfaces people actually reach wrote to the local store and stopped.

- `aka scan` prints `Data shares: forwarded to <deployment> · N call site(s)`, or a refusal naming
  what to do about it; `--format json` gains a `forward` key.
- `aka scan --no-forward` records locally and skips the forward for one invocation.
- The Scan page says before the click that an attached machine forwards, and offers a per-scan
  checkbox to keep one tree local without detaching the machine.
- What crosses is the projection the plugin already sent: destination hosts, endpoints and file/line
  call sites, with no source text and the project key replaced by a digest.
- An unattached machine behaves exactly as before, and a failed forward never changes a scan's exit
  code, findings or counts.

Disclosure moved with it: `cli/README.md` now counts four network paths, `SECURITY.md` and the root
README name the machine (not just the plugin) as what forwards, and `aka attach`'s consent names the
register.

## Also in this release

- Security widgets link into filtered findings views; recommendations cover `code_flaw` and `config`,
  and are scoped by status rather than by a window.
- `aka scan` never walks the host's own live credential files.
- The AKA home stays protected when `--home` moves the one in use.
- A host-version floor warns when the harness is too old for AKA's protections.
- The zsh completion script parses — a command summary containing an apostrophe used to break it, so
  `source <(aka completion zsh)` registered nothing.

## Mechanics

Seven manifests bumped, matching `chore(release): 0.9.10` exactly: the CLI, and the three plugins with
their manifests. Tags `cli-v0.9.11`, `plugin-claude-v0.9.11`, `plugin-codex-v0.9.11`,
`plugin-antigravity-v0.9.11` and `bin-v0.9.11` go on the release commit once this merges.
