### PR TITLE
fix(codex,antigravity): harden the transcript rewrite the way claude-code is

### DIFF
--- a/plugins/antigravity/src/remediation/redact.ts
+++ b/plugins/antigravity/src/remediation/redact.ts
@@ -23,8 +23,17 @@
  * writes are best-effort per file: an unreadable or vanished artifact is skipped so
  * one bad file cannot abort the sweep of the rest.
  */
-import { readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import {
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import type { MaskedFindingLocation } from '@akasecurity/schema';
 
@@ -106,6 +115,65 @@ export interface RedactionDetail {
   readonly struck: readonly RedactionTarget[];
 }
 
+const TMP_SUFFIX = '.aka-redact.tmp';
+
+function tempPathFor(realPath: string): string {
+  return `${realPath}.${String(process.pid)}${TMP_SUFFIX}`;
+}
+
+// True unless the OS says no such process. EPERM means a process that exists and
+// is not ours — a live run, so its temp is not ours to sweep.
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+/**
+ * Delete temp files an earlier, killed run stranded beside this artifact.
+ *
+ * A process killed between the write and the rename leaves a file holding a
+ * whole copy of the artifact — the redacted text, but also every other line of
+ * the transcript around it — and nothing else would ever remove it.
+ *
+ * Deliberately the narrowest sweep that can do that, because it deletes: only
+ * siblings of THIS artifact, only names this module itself mints (the exact
+ * `<basename>.<digits>.aka-redact.tmp` shape — the trailing dot on the prefix
+ * keeps the artifact itself from ever matching), only regular files, and only
+ * when the pid in the name names no living process. A concurrent run's temp is
+ * therefore left alone; our own pid needs no liveness check, since the process
+ * asking is the one that would be using it.
+ */
+function sweepStrandedTemps(realPath: string): void {
+  const dir = dirname(realPath);
+  const prefix = `${basename(realPath)}.`;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return; // best-effort: a directory we cannot list sweeps nothing
+  }
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(TMP_SUFFIX)) continue;
+    const pidPart = name.slice(prefix.length, name.length - TMP_SUFFIX.length);
+    if (!/^\d+$/.test(pidPart)) continue;
+    const pid = Number(pidPart);
+    if (pid !== process.pid && isProcessAlive(pid)) continue;
+    try {
+      const stranded = join(dir, name);
+      // lstat, and regular files only: a symlink or a directory wearing this
+      // name is not something this module wrote, so it is not ours to remove.
+      if (!lstatSync(stranded).isFile()) continue;
+      rmSync(stranded, { force: true });
+    } catch {
+      // best-effort — a sweep that cannot run must not stop the redaction.
+    }
+  }
+}
+
 /**
  * Redact every in-scope leaked-key occurrence in place and report the real count of
  * keys actually redacted (a key counts only when its raw value was present, struck,
@@ -136,11 +204,20 @@ export function redactLeakedKeysDetailed(
   const struck: RedactionTarget[] = [];
   for (const [filePath, fileTargets] of byFile) {
     let content: string;
+    let mode: number;
     try {
+      // The artifact's own permission bits, captured with the read: the rewrite
+      // is published by renaming a fresh file over it, so without them a 0600
+      // transcript would come back at the umask default.
+      mode = statSync(filePath).mode & 0o777;
       content = readFileSync(filePath, 'utf8');
     } catch {
       continue; // unreadable or vanished artifact — skip, don't abort the batch
     }
+    // Before the strike loop, so every artifact this pass opens gets an earlier
+    // run's stranded copy cleared even when nothing here turns out to match. It
+    // never touches the artifact itself, which stays byte-identical.
+    sweepStrandedTemps(filePath);
     const struckHere: RedactionTarget[] = [];
     const struckValues = new Set<string>();
     for (const target of fileTargets) {
@@ -161,9 +238,16 @@ export function redactLeakedKeysDetailed(
     // Write atomically: a full write to a sibling temp file, then rename over the
     // original (rename is atomic on the same filesystem). A crash mid-write leaves
     // the original rollout intact rather than truncated.
-    const tmpPath = `${filePath}.aka-redact.tmp`;
+    const tmpPath = tempPathFor(filePath);
     try {
-      writeFileSync(tmpPath, content);
+      // `wx` (O_EXCL) is what makes the mode binding: it creates the temp or
+      // fails, so the bytes can never land in an inode someone else's mode
+      // already decided, and it refuses to follow a symlink planted at the path
+      // — which would otherwise send this artifact's whole contents wherever the
+      // link pointed and then rename the link itself over the artifact. Anything
+      // already sitting there — a directory, a leftover the sweep would not
+      // touch — is doubt, and doubt leaves the artifact untouched.
+      writeFileSync(tmpPath, content, { mode, flag: 'wx' });
       renameSync(tmpPath, filePath);
     } catch {
       try {

--- a/plugins/antigravity/test/remediation/redact.test.ts
+++ b/plugins/antigravity/test/remediation/redact.test.ts
@@ -1,9 +1,13 @@
 import {
+  chmodSync,
+  existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -277,10 +281,11 @@ describe('redactLeakedKeys', () => {
       writeFileSync(rolloutFile, originalContent);
 
       // Pre-create a DIRECTORY at the exact sibling temp path the atomic write
-      // uses, so `writeFileSync(tmpPath, content)` throws EISDIR instead of
-      // writing — a deterministic, OS-level way to force the write/rename step
-      // to fail without touching the original file at all.
-      const tmpPath = `${rolloutFile}.aka-redact.tmp`;
+      // uses. The sweep leaves it (a directory is not something this module
+      // wrote) and the exclusive create then refuses to publish through it — a
+      // deterministic, OS-level way to force the write/rename step to fail
+      // without touching the original file at all.
+      const tmpPath = `${rolloutFile}.${String(process.pid)}.aka-redact.tmp`;
       mkdirSync(tmpPath);
 
       const count = redactLeakedKeys(
@@ -295,6 +300,119 @@ describe('redactLeakedKeys', () => {
       expect(orphanedTmpEntries(rolloutRoot)).toEqual([]);
       // The atomic-write guarantee: the original artifact is untouched.
       expect(readFileSync(rolloutFile, 'utf8')).toBe(originalContent);
+    });
+
+    // A pid no platform can hand out: Linux caps `pid_max` at 2^22 and macOS at
+    // 99999, so `kill(pid, 0)` answers ESRCH here rather than racing some real
+    // process. That makes "a killed earlier run" a fixture rather than a gamble
+    // on pid reuse.
+    const DEAD_PID = 1_073_741_823;
+
+    // The temp path this module mints for `artifact` when it runs as `pid`.
+    function tempName(artifact: string, pid: number): string {
+      return `${artifact}.${String(pid)}.aka-redact.tmp`;
+    }
+
+    it('sweeps the copy a killed earlier run stranded beside the artifact', () => {
+      const file = join(rolloutRoot, 'stranded.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // A temp a run that died between the write and the rename left behind: a
+      // whole copy of the transcript — every secret it held — that nothing else
+      // would ever remove.
+      const stranded = tempName(file, DEAD_PID);
+      writeFileSync(stranded, `stranded copy ${ROLLOUT_KEY} here`);
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(count).toBe(1);
+      expect(existsSync(stranded)).toBe(false);
+    });
+
+    it('sweeps a stranded copy even when this pass strikes nothing', () => {
+      const file = join(rolloutRoot, 'nostrike.jsonl');
+      const original = 'nothing leaked here';
+      writeFileSync(file, original);
+      const stranded = tempName(file, DEAD_PID);
+      writeFileSync(stranded, `stranded copy ${ROLLOUT_KEY} here`);
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // The artifact stays byte-identical — the sweep runs on every artifact the
+      // pass opens, not only the ones it goes on to rewrite.
+      expect(count).toBe(0);
+      expect(readFileSync(file, 'utf8')).toBe(original);
+      expect(existsSync(stranded)).toBe(false);
+    });
+
+    it("leaves a live run's temp file alone", () => {
+      const file = join(rolloutRoot, 'live.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // The parent of this test process is alive by construction, so its temp is
+      // work in progress rather than a leftover — sweeping it would delete
+      // another run's bytes out from under its own rename.
+      const live = tempName(file, process.ppid);
+      writeFileSync(live, 'in flight');
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(readFileSync(live, 'utf8')).toBe('in flight');
+    });
+
+    it('refuses to publish through a symlink planted at its temp path', (ctx) => {
+      if (process.platform === 'win32') {
+        ctx.skip('unprivileged symlink creation is not available on Windows');
+      }
+      const file = join(rolloutRoot, 'symlink.jsonl');
+      const original = `leaked ${ROLLOUT_KEY} here`;
+      writeFileSync(file, original);
+      // A file outside every artifact root, standing in for whatever a planted
+      // link would aim at. Following the link would copy this artifact's whole
+      // contents over it and then rename the link itself over the artifact.
+      const outside = join(projectRoot, 'notes.txt');
+      writeFileSync(outside, 'untouched');
+      symlinkSync(outside, tempName(file, process.pid));
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // Doubt at the temp path comes out as "did nothing": no write, no count.
+      // The sweep leaves the link (not a regular file, so not ours to remove)
+      // and the exclusive create then refuses to publish through it.
+      expect(count).toBe(0);
+      expect(readFileSync(outside, 'utf8')).toBe('untouched');
+      expect(readFileSync(file, 'utf8')).toBe(original);
+      expect(lstatSync(file).isSymbolicLink()).toBe(false);
+    });
+
+    it('publishes the redacted artifact with the permission bits it had', (ctx) => {
+      if (process.platform === 'win32') ctx.skip('POSIX permission bits');
+      const file = join(rolloutRoot, 'mode.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      chmodSync(file, 0o600);
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // The rewrite is published by renaming a fresh file over the artifact, so
+      // an owner-only transcript must not come back at the umask default. The
+      // remediation that exists BECAUSE the file held a secret must not make it
+      // more readable than it was.
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    });
+
+    it('clears a leftover carrying its own pid rather than writing through it', (ctx) => {
+      if (process.platform === 'win32') ctx.skip('POSIX permission bits');
+      const file = join(rolloutRoot, 'leftover.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`, { mode: 0o600 });
+      // The one temp path this process would pick, left behind by an earlier
+      // process that happened to carry the same pid. Writing through it would
+      // publish the artifact with the leftover's permission bits, since a write
+      // applies its mode only when it CREATES the file.
+      writeFileSync(tempName(file, process.pid), 'stale', { mode: 0o644 });
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(count).toBe(1);
+      expect(readFileSync(file, 'utf8')).toContain('[REDACTED:SECRET]');
+      expect(statSync(file).mode & 0o777).toBe(0o600);
     });
   });
 });

--- a/plugins/codex/src/remediation/redact.ts
+++ b/plugins/codex/src/remediation/redact.ts
@@ -23,8 +23,17 @@
  * writes are best-effort per file: an unreadable or vanished artifact is skipped so
  * one bad file cannot abort the sweep of the rest.
  */
-import { readFileSync, realpathSync, renameSync, rmSync, writeFileSync } from 'node:fs';
-import { isAbsolute, relative, resolve } from 'node:path';
+import {
+  lstatSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import type { MaskedFindingLocation } from '@akasecurity/schema';
 
@@ -106,6 +115,65 @@ export interface RedactionDetail {
   readonly struck: readonly RedactionTarget[];
 }
 
+const TMP_SUFFIX = '.aka-redact.tmp';
+
+function tempPathFor(realPath: string): string {
+  return `${realPath}.${String(process.pid)}${TMP_SUFFIX}`;
+}
+
+// True unless the OS says no such process. EPERM means a process that exists and
+// is not ours — a live run, so its temp is not ours to sweep.
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+/**
+ * Delete temp files an earlier, killed run stranded beside this artifact.
+ *
+ * A process killed between the write and the rename leaves a file holding a
+ * whole copy of the artifact — the redacted text, but also every other line of
+ * the transcript around it — and nothing else would ever remove it.
+ *
+ * Deliberately the narrowest sweep that can do that, because it deletes: only
+ * siblings of THIS artifact, only names this module itself mints (the exact
+ * `<basename>.<digits>.aka-redact.tmp` shape — the trailing dot on the prefix
+ * keeps the artifact itself from ever matching), only regular files, and only
+ * when the pid in the name names no living process. A concurrent run's temp is
+ * therefore left alone; our own pid needs no liveness check, since the process
+ * asking is the one that would be using it.
+ */
+function sweepStrandedTemps(realPath: string): void {
+  const dir = dirname(realPath);
+  const prefix = `${basename(realPath)}.`;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return; // best-effort: a directory we cannot list sweeps nothing
+  }
+  for (const name of names) {
+    if (!name.startsWith(prefix) || !name.endsWith(TMP_SUFFIX)) continue;
+    const pidPart = name.slice(prefix.length, name.length - TMP_SUFFIX.length);
+    if (!/^\d+$/.test(pidPart)) continue;
+    const pid = Number(pidPart);
+    if (pid !== process.pid && isProcessAlive(pid)) continue;
+    try {
+      const stranded = join(dir, name);
+      // lstat, and regular files only: a symlink or a directory wearing this
+      // name is not something this module wrote, so it is not ours to remove.
+      if (!lstatSync(stranded).isFile()) continue;
+      rmSync(stranded, { force: true });
+    } catch {
+      // best-effort — a sweep that cannot run must not stop the redaction.
+    }
+  }
+}
+
 /**
  * Redact every in-scope leaked-key occurrence in place and report the real count of
  * keys actually redacted (a key counts only when its raw value was present, struck,
@@ -136,11 +204,20 @@ export function redactLeakedKeysDetailed(
   const struck: RedactionTarget[] = [];
   for (const [filePath, fileTargets] of byFile) {
     let content: string;
+    let mode: number;
     try {
+      // The artifact's own permission bits, captured with the read: the rewrite
+      // is published by renaming a fresh file over it, so without them a 0600
+      // transcript would come back at the umask default.
+      mode = statSync(filePath).mode & 0o777;
       content = readFileSync(filePath, 'utf8');
     } catch {
       continue; // unreadable or vanished artifact — skip, don't abort the batch
     }
+    // Before the strike loop, so every artifact this pass opens gets an earlier
+    // run's stranded copy cleared even when nothing here turns out to match. It
+    // never touches the artifact itself, which stays byte-identical.
+    sweepStrandedTemps(filePath);
     const struckHere: RedactionTarget[] = [];
     const struckValues = new Set<string>();
     for (const target of fileTargets) {
@@ -161,9 +238,16 @@ export function redactLeakedKeysDetailed(
     // Write atomically: a full write to a sibling temp file, then rename over the
     // original (rename is atomic on the same filesystem). A crash mid-write leaves
     // the original rollout intact rather than truncated.
-    const tmpPath = `${filePath}.aka-redact.tmp`;
+    const tmpPath = tempPathFor(filePath);
     try {
-      writeFileSync(tmpPath, content);
+      // `wx` (O_EXCL) is what makes the mode binding: it creates the temp or
+      // fails, so the bytes can never land in an inode someone else's mode
+      // already decided, and it refuses to follow a symlink planted at the path
+      // — which would otherwise send this artifact's whole contents wherever the
+      // link pointed and then rename the link itself over the artifact. Anything
+      // already sitting there — a directory, a leftover the sweep would not
+      // touch — is doubt, and doubt leaves the artifact untouched.
+      writeFileSync(tmpPath, content, { mode, flag: 'wx' });
       renameSync(tmpPath, filePath);
     } catch {
       try {

--- a/plugins/codex/test/remediation/redact.test.ts
+++ b/plugins/codex/test/remediation/redact.test.ts
@@ -1,9 +1,13 @@
 import {
+  chmodSync,
+  existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from 'node:fs';
@@ -277,10 +281,11 @@ describe('redactLeakedKeys', () => {
       writeFileSync(rolloutFile, originalContent);
 
       // Pre-create a DIRECTORY at the exact sibling temp path the atomic write
-      // uses, so `writeFileSync(tmpPath, content)` throws EISDIR instead of
-      // writing — a deterministic, OS-level way to force the write/rename step
-      // to fail without touching the original file at all.
-      const tmpPath = `${rolloutFile}.aka-redact.tmp`;
+      // uses. The sweep leaves it (a directory is not something this module
+      // wrote) and the exclusive create then refuses to publish through it — a
+      // deterministic, OS-level way to force the write/rename step to fail
+      // without touching the original file at all.
+      const tmpPath = `${rolloutFile}.${String(process.pid)}.aka-redact.tmp`;
       mkdirSync(tmpPath);
 
       const count = redactLeakedKeys(
@@ -295,6 +300,119 @@ describe('redactLeakedKeys', () => {
       expect(orphanedTmpEntries(rolloutRoot)).toEqual([]);
       // The atomic-write guarantee: the original artifact is untouched.
       expect(readFileSync(rolloutFile, 'utf8')).toBe(originalContent);
+    });
+
+    // A pid no platform can hand out: Linux caps `pid_max` at 2^22 and macOS at
+    // 99999, so `kill(pid, 0)` answers ESRCH here rather than racing some real
+    // process. That makes "a killed earlier run" a fixture rather than a gamble
+    // on pid reuse.
+    const DEAD_PID = 1_073_741_823;
+
+    // The temp path this module mints for `artifact` when it runs as `pid`.
+    function tempName(artifact: string, pid: number): string {
+      return `${artifact}.${String(pid)}.aka-redact.tmp`;
+    }
+
+    it('sweeps the copy a killed earlier run stranded beside the artifact', () => {
+      const file = join(rolloutRoot, 'stranded.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // A temp a run that died between the write and the rename left behind: a
+      // whole copy of the transcript — every secret it held — that nothing else
+      // would ever remove.
+      const stranded = tempName(file, DEAD_PID);
+      writeFileSync(stranded, `stranded copy ${ROLLOUT_KEY} here`);
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(count).toBe(1);
+      expect(existsSync(stranded)).toBe(false);
+    });
+
+    it('sweeps a stranded copy even when this pass strikes nothing', () => {
+      const file = join(rolloutRoot, 'nostrike.jsonl');
+      const original = 'nothing leaked here';
+      writeFileSync(file, original);
+      const stranded = tempName(file, DEAD_PID);
+      writeFileSync(stranded, `stranded copy ${ROLLOUT_KEY} here`);
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // The artifact stays byte-identical — the sweep runs on every artifact the
+      // pass opens, not only the ones it goes on to rewrite.
+      expect(count).toBe(0);
+      expect(readFileSync(file, 'utf8')).toBe(original);
+      expect(existsSync(stranded)).toBe(false);
+    });
+
+    it("leaves a live run's temp file alone", () => {
+      const file = join(rolloutRoot, 'live.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // The parent of this test process is alive by construction, so its temp is
+      // work in progress rather than a leftover — sweeping it would delete
+      // another run's bytes out from under its own rename.
+      const live = tempName(file, process.ppid);
+      writeFileSync(live, 'in flight');
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(readFileSync(live, 'utf8')).toBe('in flight');
+    });
+
+    it('refuses to publish through a symlink planted at its temp path', (ctx) => {
+      if (process.platform === 'win32') {
+        ctx.skip('unprivileged symlink creation is not available on Windows');
+      }
+      const file = join(rolloutRoot, 'symlink.jsonl');
+      const original = `leaked ${ROLLOUT_KEY} here`;
+      writeFileSync(file, original);
+      // A file outside every artifact root, standing in for whatever a planted
+      // link would aim at. Following the link would copy this artifact's whole
+      // contents over it and then rename the link itself over the artifact.
+      const outside = join(projectRoot, 'notes.txt');
+      writeFileSync(outside, 'untouched');
+      symlinkSync(outside, tempName(file, process.pid));
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // Doubt at the temp path comes out as "did nothing": no write, no count.
+      // The sweep leaves the link (not a regular file, so not ours to remove)
+      // and the exclusive create then refuses to publish through it.
+      expect(count).toBe(0);
+      expect(readFileSync(outside, 'utf8')).toBe('untouched');
+      expect(readFileSync(file, 'utf8')).toBe(original);
+      expect(lstatSync(file).isSymbolicLink()).toBe(false);
+    });
+
+    it('publishes the redacted artifact with the permission bits it had', (ctx) => {
+      if (process.platform === 'win32') ctx.skip('POSIX permission bits');
+      const file = join(rolloutRoot, 'mode.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      chmodSync(file, 0o600);
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      // The rewrite is published by renaming a fresh file over the artifact, so
+      // an owner-only transcript must not come back at the umask default. The
+      // remediation that exists BECAUSE the file held a secret must not make it
+      // more readable than it was.
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+    });
+
+    it('clears a leftover carrying its own pid rather than writing through it', (ctx) => {
+      if (process.platform === 'win32') ctx.skip('POSIX permission bits');
+      const file = join(rolloutRoot, 'leftover.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`, { mode: 0o600 });
+      // The one temp path this process would pick, left behind by an earlier
+      // process that happened to carry the same pid. Writing through it would
+      // publish the artifact with the leftover's permission bits, since a write
+      // applies its mode only when it CREATES the file.
+      writeFileSync(tempName(file, process.pid), 'stale', { mode: 0o644 });
+
+      const count = redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      expect(count).toBe(1);
+      expect(readFileSync(file, 'utf8')).toContain('[REDACTED:SECRET]');
+      expect(statSync(file).mode & 0o777).toBe(0o600);
     });
   });
 });


### PR DESCRIPTION
Found while triaging #218 ("three near-copies"): the drift between the copies is security-relevant, and two published plugins still ship the shape #176 described.

## Both hosts carry the pre-hardening code, byte-for-byte

```ts
// plugins/{codex,antigravity}/src/remediation/redact.ts
const tmpPath = `${filePath}.aka-redact.tmp`;
writeFileSync(tmpPath, content);
renameSync(tmpPath, filePath);
```

A fixed sibling path, no mode, no exclusive create — in the remediation whose entire reason for running is that the file held a secret. `claude-code` has grown ~162 lines of hardening since; `codex` and `antigravity` are 198 lines and 6 lines apart from each other.

Three consequences, all live on two published plugins:

**Redacting a 0600 transcript leaves it 0644.** The temp lands at the process umask and the rename carries that onto the artifact. The struck value is gone; the rest of the conversation is now world-readable. This is #176 exactly, which was fixed on `claude-code` only.

**A symlink planted at the temp path is followed.** The path is predictable and fixed, so the write copies the artifact's whole contents wherever the link aims and then renames the link over the artifact.

**A killed run strands a whole copy.** A process killed between the write and the rename leaves a file holding every secret the transcript had, at a predictable name beside it, that nothing ever removed.

## Ported, not reinvented

pid-scoped temp names, the liveness-checked sweep, the mode captured with the read, and the exclusive create — taken from `claude-code` so the three do not drift further apart.

The sweep is deliberately the narrowest that works: siblings of this artifact only, the exact name shape this module mints, **regular files only**, and only when the pid in the name names no living process. So a concurrent run's temp is left alone, and so is a planted link.

## What I got wrong on the first pass, and how I caught it

My first port passed both suites while **two of the four properties did nothing**. Mutation testing found it:

| mutation | first pass | now |
| --- | --- | --- |
| drop the mode | reds 2 | reds 2 |
| restore the fixed temp path | reds 1 | reds 1 |
| **drop `wx`** | **passes** | reds the symlink case |
| **let the sweep remove non-regular files** | **passes** | reds the symlink case |

The existing cases plant a *directory* at the temp path, and `writeFileSync` fails on a directory with or without `wx` — so the exclusive create was load-bearing for nothing the suite could see. `claude-code` pins it with a symlink case; I had not ported that one. It is here now, on both hosts.

A separate mistake worth naming: `lstatSync` was missing from the import after prettier reformatted it, so the sweep threw into its own best-effort `catch` and swept nothing — and I had run `tsc` *before* that edit rather than after. Caught by instrumenting the sweep against the real test.

`claude-code` 1230 passed / 4 skipped, `codex` 517 / 1, `antigravity` 535 / 1. Workspace lint, typecheck, prettier clean.

## Scope

Deliberately **not** the extraction #218 asks for — that needs a package-placement decision. This is the drift that should not wait behind it.
