### PR TITLE
fix(persistence): detach stops reporting undelivered rows as delivered

### DIFF
--- a/packages/persistence/src/repositories/history-sync.ts
+++ b/packages/persistence/src/repositories/history-sync.ts
@@ -165,6 +165,12 @@ export interface HistorySyncPartition {
   failed: number;
   /** Rows this deployment refused. Freed by a change of deployment. */
   refused: number;
+  /**
+   * Rows the attached window closed over — never offered to anyone, because the
+   * machine detached while they were still outstanding. Not a failure of the
+   * row or of a deployment, which is why it is neither of the two above.
+   */
+  detached: number;
   total: number;
 }
 
@@ -398,7 +404,12 @@ export class SqliteHistorySyncRepository {
          SUM(CASE WHEN synced_at IS NOT NULL AND synced_at <= 0
                        AND sync_failure = 'deployment_refused' THEN 1 ELSE 0 END) AS refused,
          SUM(CASE WHEN synced_at IS NOT NULL AND synced_at <= 0
-                       AND (sync_failure IS NULL OR sync_failure <> 'deployment_refused')
+                       AND sync_failure = 'detached_undelivered' THEN 1 ELSE 0 END) AS detached,
+         -- Spelled as what it INCLUDES rather than what it excludes, so a reason
+         -- added later lands in no bucket and fails the sum assertion, instead
+         -- of silently joining this one.
+         SUM(CASE WHEN synced_at IS NOT NULL AND synced_at <= 0
+                       AND (sync_failure IS NULL OR sync_failure = 'payload_invalid')
                   THEN 1 ELSE 0 END) AS failed,
          COUNT(*) AS total
        FROM audit_events
@@ -410,7 +421,7 @@ export class SqliteHistorySyncRepository {
          SUM(CASE WHEN synced_at IS NULL AND started_at < :before THEN 1 ELSE 0 END) AS pending,
          SUM(CASE WHEN synced_at > 0 THEN 1 ELSE 0 END) AS sent,
          SUM(CASE WHEN synced_at = ${String(SKIPPED)}
-                       AND (sync_failure IS NULL OR sync_failure <> 'deployment_refused')
+                       AND (sync_failure IS NULL OR sync_failure = 'payload_invalid')
                   THEN 1 ELSE 0 END) AS skipped,
          SUM(CASE WHEN synced_at = ${String(SKIPPED)}
                        AND sync_failure = 'deployment_refused' THEN 1 ELSE 0 END) AS refused
@@ -440,8 +451,18 @@ export class SqliteHistorySyncRepository {
           SET endpoint_fingerprint = :fingerprint, backlog_before = :backlogBefore
         WHERE id = 1`,
     );
-    // Permanent skips are NOT re-armed: a row that failed to rebuild locally
-    // fails the same way against any deployment.
+    // WHICH terminal rows are re-armed, and why it is not all of them. A row
+    // this machine could not express fails the same way against any deployment,
+    // so `payload_invalid` stays put. The other two are terminal only against
+    // the deployment that produced them — a refusal is one deployment's verdict
+    // on one body, and a row the attached window closed over was simply never
+    // offered to anyone — so both are freed here, exactly as a delivered row is.
+    //
+    // Freeing `detached_undelivered` is what keeps this change from LOSING data.
+    // Before these columns existed, detach stamped that window with a delivery
+    // time, so the clause below re-armed it like any other stamp and the rows
+    // reached the next deployment. Marking them terminal without naming them
+    // here would quietly stop that.
     // STRUCTURAL ONLY, and the capture half is handled by disownCapturesStmt
     // below rather than here — the two lanes discard different things.
     //
@@ -486,7 +507,8 @@ export class SqliteHistorySyncRepository {
     this.rearmStmt = db.prepare(
       `UPDATE audit_events
           SET synced_at = NULL, sync_failed_at = NULL, sync_failure = NULL
-        WHERE (synced_at > 0 OR sync_failure = 'deployment_refused')
+        WHERE (synced_at > 0
+               OR sync_failure IN ('deployment_refused', 'detached_undelivered'))
           AND event_type IN (${TYPE_LIST})`,
     );
 
@@ -515,7 +537,10 @@ export class SqliteHistorySyncRepository {
     // drain has never covered it — stamping it is what lets the boundary move
     // forward afterwards without re-sending any of it.
     this.closeWindowStmt = db.prepare(
-      `UPDATE audit_events SET synced_at = :at
+      `UPDATE audit_events
+          SET synced_at = ${String(SKIPPED)},
+              sync_failed_at = :at,
+              sync_failure = 'detached_undelivered'
         WHERE synced_at IS NULL
           AND event_type IN (${TYPE_LIST})
           AND started_at >= :attachedAt`,
@@ -756,6 +781,7 @@ export class SqliteHistorySyncRepository {
       synced: row?.synced ?? 0,
       failed: row?.failed ?? 0,
       refused: row?.refused ?? 0,
+      detached: row?.detached ?? 0,
       total: row?.total ?? 0,
     };
   }
@@ -879,11 +905,18 @@ export class SqliteHistorySyncRepository {
    * recorded in that window sit after the boundary and before the re-attach, so
    * neither path takes them, and the pending count reports none outstanding.
    *
-   * Stamping the attached window is not a claim that every one of those rows
-   * reached the deployment — the live path drops on failure and says so
-   * elsewhere. It records that they were ITS to deliver, which is exactly the
-   * status quo: they sit outside the frozen boundary today and are equally never
-   * re-sent. Making it explicit is what lets the boundary move.
+   * WHAT IT RECORDS, and what it deliberately does not. These rows were the
+   * closing attachment's to deliver and are no longer outstanding — that is what
+   * lets the boundary move. It is NOT a claim that any of them arrived, and the
+   * distinction is not academic: this used to write a delivery TIME, which every
+   * read treats as delivery, so one detach turned a window of undelivered rows
+   * into a window of delivered ones and no surface could tell. It writes the
+   * skip sentinel and a reason of its own instead, so "no longer owed" and
+   * "received" stop being the same fact.
+   *
+   * A change of deployment still frees them (see the re-arm), because the next
+   * deployment has seen none of this machine's history — so the rows reach it
+   * exactly as they did when this wrote a delivery time.
    *
    * ONE TRANSACTION, so a crash cannot release the boundary while leaving the
    * window unstamped — that half-state would re-send the whole attached period

--- a/packages/persistence/src/sync-failure.ts
+++ b/packages/persistence/src/sync-failure.ts
@@ -27,11 +27,10 @@
  *   to send. It fails identically against every deployment, so it is terminal
  *   everywhere and the re-arm leaves it alone.
  * - `detached_undelivered` — the attached window closed with the row still
- *   undelivered. Declared here so the CHECK admits it; nothing writes it yet,
- *   and that is deliberate rather than an oversight. A CHECK cannot be widened
- *   in place on SQLite — admitting one more member means rewriting the table —
- *   so a member the detach path is going to need is cheaper to admit now than
- *   to add later.
+ *   undelivered, so it was never offered to anyone. Not a fault of the row or
+ *   of a deployment. Terminal for the attachment that closed over it, and freed
+ *   by a change of deployment like a refusal, since the next deployment has seen
+ *   none of this machine's history.
  *
  * A row carrying one of these keeps `synced_at` at the skip sentinel. The
  * column answers "why", never "whether" — nothing reads `sync_failure` to

--- a/packages/persistence/test/repositories/history-sync.test.ts
+++ b/packages/persistence/test/repositories/history-sync.test.ts
@@ -636,6 +636,57 @@ describe('SqliteHistorySyncRepository — closing the attached period', () => {
 
     expect(db.historySync.pendingSessions(10, ALL)).toEqual(['s-before']);
   });
+
+  // THE POINT of recording a reason here. Closing the window makes those rows
+  // no longer outstanding, which is what lets the boundary move — but it says
+  // nothing about whether any of them arrived, and writing a delivery time said
+  // the opposite. Every case above asserts only that they stop being pending,
+  // which is why one detach could turn a window of undelivered rows into a
+  // window of delivered ones without reddening anything.
+  it('does not report the closed window as delivered', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.rearmFor('fp', T0);
+
+    db.historySync.closeAttachedWindow(T0, T0 + MINUTE);
+
+    const p = db.historySync.partition();
+    expect(p.synced).toBe(0);
+    expect(p.detached).toBe(3);
+    // Still not outstanding — the boundary can move, which is what this is for.
+    expect(p.queued).toBe(0);
+    expect(db.historySync.counts(ALL).sent).toBe(0);
+  });
+
+  // A row that genuinely reached the deployment before the detach keeps saying
+  // so: the window covers what is still NULL, never what is already settled.
+  it('leaves a row delivered before the detach alone', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.rearmFor('fp', T0);
+    db.historySync.markSynced(['s-1'], T0);
+
+    db.historySync.closeAttachedWindow(T0, T0 + MINUTE);
+
+    expect(db.historySync.partition()).toMatchObject({ synced: 1, detached: 2 });
+  });
+
+  // And the half that would have been a silent LOSS. Before a reason could be
+  // recorded, this wrote a delivery time, so the re-arm freed the window like
+  // any other stamp and the rows reached the next deployment. A terminal marker
+  // that the re-arm did not name would have quietly stopped that.
+  it('offers the closed window to a NEW deployment, as a delivery time used to', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.historySync.rearmFor('fp-a', T0);
+    db.historySync.closeAttachedWindow(T0, T0 + MINUTE);
+    expect(db.historySync.pendingSessions(10, ALL)).toEqual([]);
+
+    db.historySync.rearmFor('fp-b', ALL);
+
+    expect(db.historySync.pendingSessions(10, ALL)).toEqual(['s-1']);
+    expect(db.historySync.partition().detached).toBe(0);
+  });
 });
 
 // The delivery-state partition backs a surface that reports what has been sent,
@@ -737,6 +788,7 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
       synced: 0,
       failed: 0,
       refused: 0,
+      detached: 0,
       total: 0,
     });
   });


### PR DESCRIPTION
Stacked on #469 (its enum member and columns are what this writes). Review that one first; this diff is against it.

## The defect

Closing the attached window makes its rows no longer outstanding — that is what lets the boundary move to the next attachment, and it has never been a claim that any of them arrived. The docblock said exactly that.

But it expressed "no longer owed" by writing a **delivery time**, and every read treats a delivery time as delivery. So one detach turned a window of undelivered rows into a window of delivered ones, and no surface could tell:

```sql
UPDATE audit_events SET synced_at = :at WHERE synced_at IS NULL AND … AND started_at >= :attachedAt
```

It writes the skip sentinel and a reason of its own now, so "no longer owed" and "received" stop being the same fact. `partition()` gains a `detached` bucket rather than folding these into `failed`: a row nobody was ever offered is neither a defect of the row nor a deployment's verdict on it.

## The half that would have been a silent loss

Re-arming exists because a stamp records that ONE deployment received a row and the next has not — so for the structural lane it clears `synced_at` and those rows are offered to the new deployment again.

Because detach wrote a **positive** timestamp, the re-arm was already freeing this window, and the rows reached the next deployment. **A terminal marker the re-arm did not name would have quietly stopped that.** So the re-arm names it, and a case fails when the reason is dropped from the clause.

That gives the rule the enum now documents: `payload_invalid` is terminal everywhere and stays put; `deployment_refused` and `detached_undelivered` are terminal only against the attachment that produced them and are both freed by a change of deployment.

## Why a green suite did not catch the original bug

Every existing case over this path asserted only that the rows **stop being pending** — true whether they are marked delivered, skipped or anything else. That is an assertion that passes regardless of the thing under test.

The three added assert what state the rows land in, and each fails without this change:

- a closed window is not reported as delivered (and is still not outstanding, so the boundary can still move);
- a row genuinely delivered before the detach keeps saying so;
- a closed window still reaches a NEW deployment, as a delivery time used to.

## Also

The two surviving buckets are spelled as what they INCLUDE rather than what they exclude, so a fourth reason added later lands in no bucket and fails the partition's sum assertion instead of silently joining one.

## Verification

`@akasecurity/persistence` 1,620 passing, `@akasecurity/plugin-runtime` 559 (it drives this path too), and a forced fully-uncached `turbo run test` across all 42 OSS tasks green with zero failures. Lint, typecheck and formatting clean.

Both halves are **mutation-checked**: restoring the old stamp reds two cases, and dropping the new reason from the re-arm reds the third.
