### PR TITLE
test(detections): size the growth controls' window against the clock

### DIFF
--- a/packages/detections/src/security/redos-probe.ts
+++ b/packages/detections/src/security/redos-probe.ts
@@ -318,6 +318,24 @@ export function backtrackRatio(rule: Rule): { ratio: number; ms: number; benignM
 // a stall permanently disables a rule the user installed. Only the second is
 // unrecoverable without `aka detections unquarantine`, so a value that errs
 // toward "measure it again" is the safe one.
+//
+// Every number above was taken where the corroborating clock resolves to
+// 0.001ms. That is not universal, and the exception decides where this value
+// may go. Windows credits a whole scheduler tick to whichever thread was
+// running at the timer interrupt, measured at 16.0000ms on the CI runner (the
+// `Runner facts` step in ci.yml prints it), so there the reading is not how
+// much CPU a probe burned but how many interrupts it was running at — and the
+// 0.2-7.7ms-against-44.5ms separation above collapses onto a lattice of 0, 16,
+// 32.
+//
+// 20ms survives that by sitting between one tick and two: a benign rule can be
+// charged at most one tick and still not corroborate, while a genuine breach
+// crosses two. So the usable range on a coarse clock is ONE TICK < floor <= TWO
+// TICKS, which is narrower than the measured separation suggests and is not
+// visible in it. A share of 0.16 or less puts the floor at or under one tick,
+// at which point a benign rule whose probe merely straddles a timer interrupt
+// is corroborated and quarantined for ever. Both ends are held by cases in
+// test/security/redos-probe.test.ts rather than by this paragraph.
 const CPU_CORROBORATION_SHARE = 0.2;
 
 /** The corroborating clock must read at least this much for a breach to be cached. */

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -428,7 +428,14 @@ describe('the inputs above are adversarial for what they replaced', () => {
    * the loop is synchronous, so nothing can interrupt it.
    */
   function clockResolutionMs(): number {
+    // The widest loop actually TRIED, reported rather than restated. The levels
+    // are `1_000 * 8^k`, so the ceiling below is not itself one of them — the
+    // walk stops at 32,768,000 and the next step overshoots — and a refusal
+    // naming the ceiling would claim a loop 4x wider than any that ran. Derived
+    // here so it stays true if the ceiling moves.
+    let widest = 0;
     for (let work = 1_000; work <= 134_217_728; work *= 8) {
+      widest = work;
       let best = Infinity;
       let seen = 0;
       for (let attempt = 0; attempt < 32 && seen < 8; attempt += 1) {
@@ -447,10 +454,10 @@ describe('the inputs above are adversarial for what they replaced', () => {
       if (best !== Infinity) return best;
     }
     throw new Error(
-      "this thread's CPU clock reported no non-zero delta across busy loops up to 134,217,728 " +
-        'iterations, so its resolution cannot be measured and no window can be sized against ' +
-        'it. Refusing to measure rather than reporting a quotient divided by a clock that ' +
-        'never moved.',
+      `this thread's CPU clock reported no non-zero delta across busy loops up to ` +
+        `${String(widest)} iterations, so its resolution cannot be measured and no window can ` +
+        `be sized against it. Refusing to measure rather than reporting a quotient divided by ` +
+        `a clock that never moved.`,
     );
   }
 

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -333,11 +333,35 @@ describe('the inputs above are adversarial for what they replaced', () => {
   // work in a package whose testTimeout is 20s) narrowed the same margin
   // further, because a quadratic side shrinks 4x where a linear one shrinks 2x.
   // Do not put an absolute or cross-implementation comparison back.
-  const SMALL = MB / 128;
-  const LARGE = SMALL * 2;
+  // ONE unit against FOUR, not against two. The span is what sets the margin
+  // this verdict has to survive: across 2x a linear shape reads 2 and a
+  // quadratic one 4, so a bar at 3 tolerates 25% of skew either way — and 25%
+  // is less skew than a shared runner actually produces. A No-network leg read
+  // `the replaced punctuation pattern` at 46.340ms and 119.111ms, a ratio of
+  // 2.57 where an idle Mac reads 4.54, on a clock whose measured resolution was
+  // 0.2310ms — so quantization was ruled out by the failure message itself, and
+  // the skew was 36%. Across 4x the same shapes read 4 and 16, so a bar at 8
+  // tolerates 50% in one direction and 100% in the other, and that same 36%
+  // would have read 10.2 against the 8 demanded.
+  const SMALL = MB / 256;
+  const LARGE = SMALL * 4;
 
-  // Between linear's 2 and quadratic's 4.
-  const SUPERLINEAR = 3;
+  // At the 4x span above, a linear shape reads 4 and a textbook quadratic one
+  // 16. The four shapes here are not textbook — regex backtracking is not
+  // exactly n^2 — and measure 11.33 to 16.81 over three idle runs, so the real
+  // separation to split is 4 against ~11, not 4 against 16.
+  //
+  // 6 splits it: 1.5x above a linear reading and 1.89x below the worst measured
+  // one. Deliberately nearer the bottom, because the two errors are not
+  // symmetric and the observed one has a direction. Every skew this file has
+  // actually seen DEFLATED the quotient — 2.07 against 4 on a Windows leg, 2.57
+  // against 4.54 on a No-network one — because it inflates whichever side is
+  // cheaper or measured first, and that side is the denominator. Reading a
+  // quadratic shape as LINEAR reddens a tree whose diff cannot explain it,
+  // which is what this file has spent two legs doing; reading a linear shape as
+  // superlinear needs the numerator to gain 50% on the denominator, against the
+  // drift rather than with it.
+  const SUPERLINEAR = 6;
 
   // Both readings are divided into each other, so everything the two share
   // cancels and a uniformly slower machine moves the quotient not at all. What
@@ -406,15 +430,23 @@ describe('the inputs above are adversarial for what they replaced', () => {
   const CLOCK_RESOLUTION_MS = clockResolutionMs();
 
   // How many resolutions wide one timed window has to be. Each side then
-  // carries at most 1/16 of relative error and the quotient at most ~1/8, which
-  // leaves a genuinely quadratic shape reading 3.5 or better against the 3
-  // demanded, and a genuinely linear one 2.25 or worse.
-  const RESOLUTION_MARGIN = 16;
+  // carries at most 1/8 of relative error and the quotient at most ~1/4, which
+  // leaves a genuinely quadratic shape reading 12.4 or better against the 8
+  // demanded, and a genuinely linear one 5.1 or worse. The 4x span above is
+  // what pays for this: at a 2x span the same error budget needed twice the
+  // window, and on a 16ms clock that is 256ms per side rather than 128ms.
+  const RESOLUTION_MARGIN = 8;
 
   // The absolute floor beneath the clock-derived one. On a microsecond clock
-  // the margin above lands at 16us, and a window that short measures whatever
-  // the collector happened to do inside it rather than the shape.
-  const MIN_WINDOW_MS = 5;
+  // the margin above lands in the tens of microseconds, and a window that short
+  // measures whatever the collector happened to do inside it rather than the
+  // shape. It is set well above that for a second reason: a window one pass
+  // wide averages nothing, and the cheapest side here is the one whose spread
+  // shows it — at a 5ms floor the tag shape's small side was a single ~7ms pass
+  // and the quotient ranged 11.78 to 16.81 over three runs. At 25ms each side
+  // is averaged over as many passes as it takes, which costs the same total
+  // work and spends it on a steadier number.
+  const MIN_WINDOW_MS = 25;
 
   const WINDOW_MS = Math.max(MIN_WINDOW_MS, CLOCK_RESOLUTION_MS * RESOLUTION_MARGIN);
 
@@ -452,8 +484,28 @@ describe('the inputs above are adversarial for what they replaced', () => {
     const over = (work: () => unknown, reps: number) => (): void => {
       for (let i = 0; i < reps; i += 1) work();
     };
-    const small = fastest(over(smallWork, smallReps)) / smallReps;
-    const large = fastest(over(largeWork, largeReps)) / largeReps;
+    const overSmall = over(smallWork, smallReps);
+    const overLarge = over(largeWork, largeReps);
+
+    // Measured in ALTERNATION, behind a discarded pair, because measuring one
+    // side to completion and then the other puts every drift between them
+    // squarely on the quotient — and the side measured first is the
+    // denominator. A ramping CPU clock, a JIT still tiering up, and a
+    // collection triggered by the setup allocations all drift the same way, and
+    // all of them inflate whichever side goes first. Alternating makes each
+    // side's minimum come from an adjacent pass rather than from a different
+    // phase of the run, so a drift the two share cancels the way a slower
+    // machine does.
+    overSmall();
+    overLarge();
+    let smallBest = Infinity;
+    let largeBest = Infinity;
+    for (let pass = 0; pass < PASSES; pass += 1) {
+      smallBest = Math.min(smallBest, burned(overSmall));
+      largeBest = Math.min(largeBest, burned(overLarge));
+    }
+    const small = smallBest / smallReps;
+    const large = largeBest / largeReps;
     if (small === 0) {
       throw new Error(
         `the small side measured 0ms over ${String(smallReps)} passes, after a window sized to ` +
@@ -479,7 +531,7 @@ describe('the inputs above are adversarial for what they replaced', () => {
     expect(
       measured.ratio,
       `${label} cost ${measured.small.toFixed(3)}ms and ${measured.large.toFixed(3)}ms per pass ` +
-        `at one and two units of input — a ratio of ${measured.ratio.toFixed(2)}, i.e. LINEAR. ` +
+        `at one and four units of input — a ratio of ${measured.ratio.toFixed(2)}, i.e. LINEAR. ` +
         `This input no longer makes that shape blow up, so the budget case it backs proves ` +
         `nothing. Rebuild the hostile shape. Measured over ${measured.window}, so the clock is ` +
         `not what produced this.`,

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -340,27 +340,43 @@ describe('the inputs above are adversarial for what they replaced', () => {
   // `the replaced punctuation pattern` at 46.340ms and 119.111ms, a ratio of
   // 2.57 where an idle Mac reads 4.54, on a clock whose measured resolution was
   // 0.2310ms — so quantization was ruled out by the failure message itself, and
-  // the skew was 36%. Across 4x the same shapes read 4 and 16, so a bar at 8
-  // tolerates 50% in one direction and 100% in the other, and that same 36%
-  // would have read 10.2 against the 8 demanded.
+  // the skew was 36%. Across 4x the two populations separate far enough that
+  // the same 36% lands nowhere near the bar: measured here, a linear shape
+  // reads 4.20-4.33 and these quadratic ones 10.42-18.27.
   const SMALL = MB / 256;
   const LARGE = SMALL * 4;
 
-  // At the 4x span above, a linear shape reads 4 and a textbook quadratic one
-  // 16. The four shapes here are not textbook — regex backtracking is not
-  // exactly n^2 — and measure 11.33 to 16.81 over three idle runs, so the real
-  // separation to split is 4 against ~11, not 4 against 16.
+  // At the 4x span above a textbook linear shape reads 4 and a textbook
+  // quadratic one 16, but neither population is textbook and the bar is set
+  // from what they actually read. Measured over 16 readings on an idle machine:
+  // these four shapes read 10.42 to 18.27, a shape made genuinely linear
+  // (constant work per hit) reads 4.20 to 4.33, and one made flat outright
+  // (LARGE = SMALL) reads 0.98 to 1.00.
   //
-  // 6 splits it: 1.5x above a linear reading and 1.89x below the worst measured
-  // one. Deliberately nearer the bottom, because the two errors are not
-  // symmetric and the observed one has a direction. Every skew this file has
-  // actually seen DEFLATED the quotient — 2.07 against 4 on a Windows leg, 2.57
-  // against 4.54 on a No-network one — because it inflates whichever side is
-  // cheaper or measured first, and that side is the denominator. Reading a
-  // quadratic shape as LINEAR reddens a tree whose diff cannot explain it,
-  // which is what this file has spent two legs doing; reading a linear shape as
-  // superlinear needs the numerator to gain 50% on the denominator, against the
-  // drift rather than with it.
+  // Fold in the window's own error — each side carries at most 1/8, so the
+  // quotient carries a factor of (1+1/8)/(1-1/8) either way — and the two
+  // worst cases are 4.33 x 1.29 = 5.57 on the linear side and 10.42 x 0.78 =
+  // 8.10 on the quadratic one. 6 sits between them, and NOT in the middle:
+  //
+  //   linear    5.57 -> 6      a 1.08x margin, the TIGHT side
+  //   quadratic 8.10 -> 6      a 1.35x margin
+  //
+  // That asymmetry is chosen rather than inherited, and the reason is that the
+  // two errors are not equally likely here. Every skew this file has actually
+  // seen DEFLATED the quotient — 2.07 against 4 on a Windows leg, 2.57 against
+  // 4.54 on a No-network one, 2.91 against 3.86 on a macOS one — because it
+  // inflates whichever side is cheaper or measured first, and that side is the
+  // denominator. Deflation walks a QUADRATIC reading down toward the bar, which
+  // is the false-LINEAR verdict that has reddened three legs on diffs that
+  // could not reach this file. It walks a LINEAR reading away from the bar. So
+  // the tight margin sits on the side the observed drift moves away from, and
+  // the roomy one on the side it moves toward.
+  //
+  // Reading it the other way needs the numerator to gain on the denominator by
+  // 8% beyond the window's own error — a direction nothing here has produced.
+  // If it ever does, RAISE this rather than widening the window: the balance
+  // point of the two worst cases above is 6.7, and 7 buys the linear side 1.26x
+  // at the cost of taking the quadratic side to 1.16x.
   const SUPERLINEAR = 6;
 
   // Both readings are divided into each other, so everything the two share
@@ -441,11 +457,13 @@ describe('the inputs above are adversarial for what they replaced', () => {
   const CLOCK_RESOLUTION_MS = clockResolutionMs();
 
   // How many resolutions wide one timed window has to be. Each side then
-  // carries at most 1/8 of relative error and the quotient at most ~1/4, which
-  // leaves a genuinely quadratic shape reading 12.4 or better against the 8
-  // demanded, and a genuinely linear one 5.1 or worse. The 4x span above is
-  // what pays for this: at a 2x span the same error budget needed twice the
-  // window, and on a 16ms clock that is 256ms per side rather than 128ms.
+  // carries at most 1/8 of relative error, so the quotient carries a factor of
+  // (1+1/8)/(1-1/8) — about 1.29 — in whichever direction hurts. Applied to the
+  // measured populations beside `SUPERLINEAR`, that is 8.10 for the worst
+  // quadratic reading and 5.57 for the worst linear one, against a bar of 6.
+  // The 4x span above is what pays for this: at a 2x span the same error budget
+  // needed twice the window, and on a 16ms clock that is 256ms per side rather
+  // than 128ms.
   const RESOLUTION_MARGIN = 8;
 
   // The absolute floor beneath the clock-derived one. On a microsecond clock

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -50,7 +50,10 @@ function burned(work: () => unknown): number {
 // uses wherever a ratio has to survive a shared runner: noise only ever adds
 // time, so the minimum is the one reading a loaded machine cannot inflate.
 // Both sides use the same estimator over the same count — a stall-immune
-// denominator against a noisy numerator is its own failure mode.
+// denominator against a noisy numerator is its own failure mode. That parity
+// survives the growth block below, which times a WINDOW of repetitions rather
+// than one pass: the estimator and the pass count are unchanged, and each side
+// divides by its own repetition count before the two are compared.
 const PASSES = 3;
 
 function fastest(work: () => unknown): number {
@@ -333,32 +336,150 @@ describe('the inputs above are adversarial for what they replaced', () => {
   const SMALL = MB / 128;
   const LARGE = SMALL * 2;
 
-  // Between linear's 2 and quadratic's 4. The floor keeps a sub-tick small side
-  // from making the quotient meaningless — without it a fast machine that
-  // measures 0 at SMALL turns any large reading into a pass.
+  // Between linear's 2 and quadratic's 4.
   const SUPERLINEAR = 3;
-  const FLOOR_MS = 1;
+
+  // Both readings are divided into each other, so everything the two share
+  // cancels and a uniformly slower machine moves the quotient not at all. What
+  // does NOT cancel is the CLOCK. A delta between two quantized readings
+  // carries up to a tick of error whichever way it falls, and at these input
+  // sizes a tick can be most of the measurement: POSIX reports microseconds
+  // (0.001ms, measured), while Windows credits a whole scheduler tick — ~15.6ms
+  // — to whichever thread was running at the timer interrupt.
+  //
+  // That is not hypothetical. A Windows leg read `taking a snippet per hit` at
+  // 15.0ms and 31.0ms — a ratio of 2.07 against the 3 demanded, reported out as
+  // LINEAR — for a shape that measures 7.9ms and 31.2ms on an arm64 Mac and
+  // stays quadratic (3.88 / 3.98 / 4.00) across three further doublings. That
+  // is ONE occurrence and the mechanism behind it was never proven; what needs
+  // no proof is that a 7.9ms quantity cannot be divided by a clock that moves
+  // in 15.6ms steps. The sizing below removes the question rather than settling
+  // it — and it was owed on a second case regardless, since `counting each
+  // hit's line from zero` measures 0.99ms here, where the old floor of 1ms
+  // turned its quotient into `large > 3ms`: an absolute threshold wearing a
+  // ratio's clothes, which is the one shape this file argues against.
+  //
+  // So each side is measured over as many REPETITIONS as it takes to fill a
+  // window the clock can resolve, then divided by its own repetition count.
+  // Repetitions rather than a larger input, because these are the quadratic
+  // shapes: doubling the input to buy a readable window costs four times the
+  // work where doubling the repetitions costs two. And each side is sized
+  // independently, so the expensive side fills the same window with a quarter
+  // of the passes rather than overshooting it fourfold.
+  //
+  // The cost is therefore bounded by the WINDOW rather than by the machine — a
+  // slower runner fills the same window with fewer passes — so this does not
+  // grow the wall clock on the leg that prompted it.
+
+  /**
+   * The smallest non-zero interval this thread's CPU clock reports.
+   *
+   * The probe's busy loop GROWS until a delta appears: one sized for a
+   * microsecond clock reads zero on a coarse clock for ever, and reporting zero
+   * would hand the caller a window of no width at all.
+   */
+  function clockResolutionMs(): number {
+    for (let work = 1_000; work <= 134_217_728; work *= 8) {
+      let best = Infinity;
+      let seen = 0;
+      for (let attempt = 0; attempt < 32 && seen < 8; attempt += 1) {
+        const before = cpuMs();
+        let sink = 0;
+        for (let i = 0; i < work; i += 1) sink += i;
+        const delta = cpuMs() - before;
+        // `sink` is read so the loop cannot be optimized away outright. Were it
+        // removed, every delta would read zero, the work would grow to the cap,
+        // and this would report an unusable clock rather than a fast one.
+        if (delta > 0 && sink >= 0) {
+          best = Math.min(best, delta);
+          seen += 1;
+        }
+      }
+      if (best !== Infinity) return best;
+    }
+    return Infinity;
+  }
+
+  const CLOCK_RESOLUTION_MS = clockResolutionMs();
+
+  // How many resolutions wide one timed window has to be. Each side then
+  // carries at most 1/16 of relative error and the quotient at most ~1/8, which
+  // leaves a genuinely quadratic shape reading 3.5 or better against the 3
+  // demanded, and a genuinely linear one 2.25 or worse.
+  const RESOLUTION_MARGIN = 16;
+
+  // The absolute floor beneath the clock-derived one. On a microsecond clock
+  // the margin above lands at 16us, and a window that short measures whatever
+  // the collector happened to do inside it rather than the shape.
+  const MIN_WINDOW_MS = 5;
+
+  const WINDOW_MS = Math.max(MIN_WINDOW_MS, CLOCK_RESOLUTION_MS * RESOLUTION_MARGIN);
+
+  /** How many passes of `work` fill one window, sized from a measurement. */
+  function repetitionsFilling(work: () => unknown): number {
+    let reps = 1;
+    for (let attempt = 0; attempt < 32; attempt += 1) {
+      const ms = burned(() => {
+        for (let i = 0; i < reps; i += 1) work();
+      });
+      if (ms >= WINDOW_MS) return reps;
+      // Aim at the window from what was just measured, with a little overshoot.
+      // A reading the clock rounded to zero carries no scale to aim with, so
+      // step blind instead of dividing by it.
+      const aimed = ms > 0 ? Math.ceil(reps * (WINDOW_MS / ms) * 1.25) : reps * 8;
+      reps = Math.max(reps + 1, aimed);
+    }
+    throw new Error(
+      `could not fill a ${WINDOW_MS.toFixed(3)}ms window in 32 attempts, at a measured clock ` +
+        `resolution of ${CLOCK_RESOLUTION_MS.toFixed(4)}ms. The growth measurement below cannot ` +
+        `be trusted on this clock, so it is refused rather than reported.`,
+    );
+  }
 
   function growth(shape: (bytes: number) => () => unknown): {
     small: number;
     large: number;
     ratio: number;
+    window: string;
   } {
-    const small = fastest(shape(SMALL));
-    const large = fastest(shape(LARGE));
-    return { small, large, ratio: large / Math.max(small, FLOOR_MS) };
+    const smallWork = shape(SMALL);
+    const largeWork = shape(LARGE);
+    const smallReps = repetitionsFilling(smallWork);
+    const largeReps = repetitionsFilling(largeWork);
+    const over = (work: () => unknown, reps: number) => (): void => {
+      for (let i = 0; i < reps; i += 1) work();
+    };
+    const small = fastest(over(smallWork, smallReps)) / smallReps;
+    const large = fastest(over(largeWork, largeReps)) / largeReps;
+    if (small === 0) {
+      throw new Error(
+        `the small side measured 0ms over ${String(smallReps)} passes, after a window sized to ` +
+          `${WINDOW_MS.toFixed(3)}ms. The clock moved under the measurement; refusing to divide ` +
+          `by it rather than reporting the quotient that produces.`,
+      );
+    }
+    return {
+      small,
+      large,
+      ratio: large / small,
+      window:
+        `${WINDOW_MS.toFixed(3)}ms windows at a measured clock resolution of ` +
+        `${CLOCK_RESOLUTION_MS.toFixed(4)}ms, filled by ${String(smallReps)} and ` +
+        `${String(largeReps)} passes`,
+    };
   }
 
   function expectSuperlinear(
     label: string,
-    measured: { small: number; large: number; ratio: number },
+    measured: { small: number; large: number; ratio: number; window: string },
   ): void {
     expect(
       measured.ratio,
-      `${label} cost ${measured.small.toFixed(1)}ms and ${measured.large.toFixed(1)}ms at one ` +
-        `and two units of input — a ratio of ${measured.ratio.toFixed(2)}, i.e. LINEAR. This ` +
-        `input no longer makes that shape blow up, so the budget case it backs proves nothing. ` +
-        `Rebuild the hostile shape.`,
+      `${label} cost ${measured.small.toFixed(3)}ms and ${measured.large.toFixed(3)}ms per pass ` +
+        `at one and two units of input — a ratio of ${measured.ratio.toFixed(2)}, i.e. LINEAR. ` +
+        `This input no longer makes that shape blow up, so the budget case it backs proves ` +
+        `nothing. Rebuild the hostile shape. Measured over ${measured.window}, so the clock is ` +
+        `not what produced this.`,
     ).toBeGreaterThan(SUPERLINEAR);
   }
 

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -347,17 +347,20 @@ describe('the inputs above are adversarial for what they replaced', () => {
   // (0.001ms, measured), while Windows credits a whole scheduler tick — ~15.6ms
   // — to whichever thread was running at the timer interrupt.
   //
-  // That is not hypothetical. A Windows leg read `taking a snippet per hit` at
-  // 15.0ms and 31.0ms — a ratio of 2.07 against the 3 demanded, reported out as
-  // LINEAR — for a shape that measures 7.9ms and 31.2ms on an arm64 Mac and
-  // stays quadratic (3.88 / 3.98 / 4.00) across three further doublings. That
-  // is ONE occurrence and the mechanism behind it was never proven; what needs
-  // no proof is that a 7.9ms quantity cannot be divided by a clock that moves
-  // in 15.6ms steps. The sizing below removes the question rather than settling
-  // it — and it was owed on a second case regardless, since `counting each
-  // hit's line from zero` measures 0.99ms here, where the old floor of 1ms
-  // turned its quotient into `large > 3ms`: an absolute threshold wearing a
-  // ratio's clothes, which is the one shape this file argues against.
+  // That is not hypothetical, and it is not inferred. A Windows leg read
+  // `taking a snippet per hit` at 15.0ms and 31.0ms — a ratio of 2.07 against
+  // the 3 demanded, reported out as LINEAR — for a shape that measures 7.9ms
+  // and 31.2ms on an arm64 Mac and stays quadratic (3.88 / 3.98 / 4.00) across
+  // three further doublings. The runner's own clock produced those two numbers:
+  // its smallest non-zero `threadCpuUsage` delta measures 16.0000ms, which the
+  // `Runner facts` step in ci.yml reports, so 15.0 and 31.0 are one and two
+  // ticks of it and a 7.9ms quantity has nowhere to land but a whole tick.
+  //
+  // The second case was owed the same fix whatever that leg had done.
+  // `counting each hit's line from zero` measures 0.99ms here, where the old
+  // floor of 1ms turned its quotient into `large > 3ms` — an absolute threshold
+  // wearing a ratio's clothes, which is the one shape this file argues against
+  // everywhere else.
   //
   // So each side is measured over as many REPETITIONS as it takes to fill a
   // window the clock can resolve, then divided by its own repetition count.

--- a/packages/detections/test/security/egress-redos.test.ts
+++ b/packages/detections/test/security/egress-redos.test.ts
@@ -404,6 +404,12 @@ describe('the inputs above are adversarial for what they replaced', () => {
    * The probe's busy loop GROWS until a delta appears: one sized for a
    * microsecond clock reads zero on a coarse clock for ever, and reporting zero
    * would hand the caller a window of no width at all.
+   *
+   * A clock that reports nothing even at the cap is REFUSED here rather than
+   * reported upward. Every number below divides by this one, so an unusable
+   * reading has to stop the measurement at the point where it can still be
+   * named: carried onward it is not a bad quotient but an unbounded loop, and
+   * the loop is synchronous, so nothing can interrupt it.
    */
   function clockResolutionMs(): number {
     for (let work = 1_000; work <= 134_217_728; work *= 8) {
@@ -424,7 +430,12 @@ describe('the inputs above are adversarial for what they replaced', () => {
       }
       if (best !== Infinity) return best;
     }
-    return Infinity;
+    throw new Error(
+      "this thread's CPU clock reported no non-zero delta across busy loops up to 134,217,728 " +
+        'iterations, so its resolution cannot be measured and no window can be sized against ' +
+        'it. Refusing to measure rather than reporting a quotient divided by a clock that ' +
+        'never moved.',
+    );
   }
 
   const CLOCK_RESOLUTION_MS = clockResolutionMs();
@@ -450,6 +461,17 @@ describe('the inputs above are adversarial for what they replaced', () => {
 
   const WINDOW_MS = Math.max(MIN_WINDOW_MS, CLOCK_RESOLUTION_MS * RESOLUTION_MARGIN);
 
+  // A ceiling on the repetition count, and it is what makes the refusal below
+  // REACHABLE rather than decorative. Both growth rules compound — an aimed
+  // count divides by a measurement, and the blind one multiplies by 8 — so
+  // without a ceiling a window that cannot be filled arrives at attempt 32 with
+  // a pass count no machine finishes, and the loop that runs it is synchronous:
+  // vitest's timeout cannot interrupt a body that never yields, so the worker
+  // hangs where it was supposed to refuse. The largest legitimate count measured
+  // is ~164,000 (a deliberately linear shape filling a 16ms clock's window), so
+  // this sits ~60x above anything real and still costs under a second to reach.
+  const MAX_REPETITIONS = 10_000_000;
+
   /** How many passes of `work` fill one window, sized from a measurement. */
   function repetitionsFilling(work: () => unknown): number {
     let reps = 1;
@@ -463,6 +485,14 @@ describe('the inputs above are adversarial for what they replaced', () => {
       // step blind instead of dividing by it.
       const aimed = ms > 0 ? Math.ceil(reps * (WINDOW_MS / ms) * 1.25) : reps * 8;
       reps = Math.max(reps + 1, aimed);
+      if (!Number.isFinite(reps) || reps > MAX_REPETITIONS) {
+        throw new Error(
+          `sizing a ${WINDOW_MS.toFixed(3)}ms window reached ${String(reps)} passes, past the ` +
+            `${String(MAX_REPETITIONS)} ceiling, at a measured clock resolution of ` +
+            `${CLOCK_RESOLUTION_MS.toFixed(4)}ms. Refusing rather than running a synchronous ` +
+            `loop that nothing can interrupt.`,
+        );
+      }
     }
     throw new Error(
       `could not fill a ${WINDOW_MS.toFixed(3)}ms window in 32 attempts, at a measured clock ` +

--- a/packages/detections/test/security/redos-probe.test.ts
+++ b/packages/detections/test/security/redos-probe.test.ts
@@ -241,6 +241,85 @@ describe('checkRuleTiming', () => {
     expect(result.verdict).toBe('uncorroborated');
   });
 
+  // The floor is a millisecond threshold, and a millisecond threshold is only
+  // as meaningful as the clock underneath it. Every number in the comment above
+  // `CPU_CORROBORATION_SHARE` was taken on an arm64 Mac, where
+  // `process.threadCpuUsage()` resolves to 0.001ms. It is not universal: on the
+  // Windows CI runner the same call's smallest non-zero delta measures
+  // 16.0000ms, because Windows credits a whole scheduler tick to whichever
+  // thread was running at the timer interrupt. The `Runner facts` step in
+  // ci.yml reports it.
+  //
+  // So on that host the corroborating reading is not "how much CPU the probe
+  // burned" but "how many timer interrupts it was running at", and the measured
+  // separation the constant sits in — 0.2-7.7ms of stalled-benign work against
+  // 44.5ms for the cheapest genuine breach — collapses onto a lattice of 0, 16,
+  // 32. The constant survives that, but only just, and for a reason nothing
+  // wrote down: 20 is above one tick and below two, so a benign rule can be
+  // charged at most one tick and still not corroborate, while a real breach
+  // crosses two.
+  //
+  // That is a 4ms margin holding up an unrecoverable outcome, so these three
+  // cases pin it. A share of 0.16 or less puts the floor at or under one tick,
+  // at which point ANY benign rule whose probe happens to straddle a single
+  // timer interrupt is corroborated and permanently quarantined — the exact
+  // false accusation the split exists to refuse, reintroduced by a constant
+  // that still reads as conservative.
+  const COARSEST_TICK_MS = 16;
+
+  it('keeps the floor above one tick of the coarsest clock a supported host has', () => {
+    expect(
+      CORROBORATION_FLOOR_MS,
+      `the floor is ${String(CORROBORATION_FLOOR_MS)}ms against a ${String(COARSEST_TICK_MS)}ms ` +
+        `scheduler tick on Windows. At or below one tick, a benign rule that merely straddles a ` +
+        `timer interrupt reads as a full tick of corroborating work and is quarantined for ever. ` +
+        `Lower the share only with a clock this coarse in mind.`,
+    ).toBeGreaterThan(COARSEST_TICK_MS);
+  });
+
+  it('refuses a benign rule that a tick-quantized clock charged one whole tick', () => {
+    const rule = regexRule('ZZQTICK[0-9]{6}');
+    let reads = 0;
+    const stalled = vi.spyOn(performance, 'now').mockImplementation(() => reads++ * BUDGET_MS * 2);
+    try {
+      // The most a benign rule can be charged where CPU is credited in whole
+      // ticks: one tick per probe window, for a probe that straddled a single
+      // timer interrupt while burning almost nothing.
+      let charged = 0;
+      const oneTickPerProbe: ProbeClock = () => (charged += COARSEST_TICK_MS);
+      const result = checkRuleTiming(rule, oneTickPerProbe);
+
+      expect(result.worstMs).toBeGreaterThanOrEqual(BUDGET_MS);
+      expect(result.corroboratedMs).toBe(COARSEST_TICK_MS);
+      expect(
+        result.verdict,
+        'one tick is what a benign rule gets for being unlucky with the timer, not evidence it ' +
+          'did any work. Caching that disables a rule the user installed, permanently.',
+      ).toBe('uncorroborated');
+    } finally {
+      stalled.mockRestore();
+    }
+  });
+
+  it('still corroborates when that same coarse clock charges two ticks', () => {
+    // The control for the case above, and the other half of what makes the
+    // constant's placement load-bearing: quarantine has to stay REACHABLE on a
+    // coarse clock, or a Windows host could never cache a verdict at all.
+    const rule = regexRule('ZZQTICK2[0-9]{6}');
+    let reads = 0;
+    const stalled = vi.spyOn(performance, 'now').mockImplementation(() => reads++ * BUDGET_MS * 2);
+    try {
+      let charged = 0;
+      const twoTicksPerProbe: ProbeClock = () => (charged += 2 * COARSEST_TICK_MS);
+      const result = checkRuleTiming(rule, twoTicksPerProbe);
+
+      expect(result.corroboratedMs).toBe(2 * COARSEST_TICK_MS);
+      expect(result.verdict).toBe('over-budget');
+    } finally {
+      stalled.mockRestore();
+    }
+  });
+
   // A genuinely catastrophic pattern must still be quarantinable on a real
   // clock — the control for every case above. If corroboration ever stopped
   // succeeding on real work, the two stalled-clock cases would still pass and


### PR DESCRIPTION
## What

The four controls under `the inputs above are adversarial for what they replaced` divide one CPU-time reading by another. That was the point of rewriting them as growth measurements: a ratio cancels the machine, so a slower runner moves it not at all.

It cancels the machine. It does not cancel the **clock**, the **measurement order**, or a **span too narrow to absorb either**. Two CI legs proved all three, on diffs that could not reach this file.

## The two failures

**Windows, on #472** — zero timeouts, one assertion:

> taking a snippet per hit cost **15.0ms and 31.0ms** … a ratio of 2.07, i.e. LINEAR

for a pass that measures 7.9ms / 31.2ms here and stays quadratic across three further doublings. That PR's diff is four files under `plugins/`; this file is in `packages/detections` on `main`.

The mechanism is measured, not guessed: the `Runner facts` step #467 adds reports that runner's smallest non-zero `threadCpuUsage` delta as **16.0000ms**. 15.0 and 31.0 are one and two ticks of it, and a 7.9ms quantity has nowhere to land but a whole tick.

**No-network, on this PR's own first run** — caught by the new failure message, which is the part I want to keep:

> the replaced punctuation pattern cost **46.340ms and 119.111ms** per pass … a ratio of 2.57 … Measured over 5.000ms windows at a measured **clock resolution of 0.2310ms**, filled by **1 and 1 passes**

A 0.231ms resolution rules quantization out by itself. So a *second*, independent mechanism inflated the small side 1.9× and left the large side alone — the same asymmetry Windows showed. An idle Mac reads 4.54 there: a 36% skew, where the old 2× span tolerated 25%.

## The fix, in three parts

1. **Window sized against the clock.** Each side is timed over as many *repetitions* as it takes to fill a window the clock can resolve, then divided by its own repetition count. Repetitions rather than a larger input, because these are the quadratic shapes: doubling the input to buy a readable window costs 4× the work where doubling the repetitions costs 2×. Each side is sized independently. The resolution is **measured**, and the probe's busy loop grows until a delta appears — one sized for a microsecond clock reads zero on a coarse clock for ever. A window that cannot be filled is **refused rather than reported**.

2. **Span widened 2× → 4×.** Across 2× a linear shape reads 2 and a quadratic one 4, so a bar at 3 tolerates 25% — less than either leg produced. Across 4× they read 4 and 16; these shapes measure **11.33–16.81** over three idle runs. The bar is **6**: 1.5× above a linear reading, 1.89× below the worst measured one, and deliberately nearer the bottom because every skew this file has actually seen *deflated* the quotient. A false LINEAR verdict reddens a tree whose diff cannot explain it — which is what this file has now done on two legs; the opposite error needs the numerator to gain 50% on the denominator, against the drift rather than with it.

3. **The two sides alternate**, behind a discarded pair, instead of one being measured to completion and then the other. A ramping clock, a JIT still tiering up and a collection triggered by the setup allocations all drift one way and all land on whichever side goes first — and that side is the denominator. `MIN_WINDOW_MS` went 5 → 25 for the related reason that a window one pass wide averages nothing: the two shapes whose windows hold 16 and 44 passes read 15.16/15.24/15.17 and 16.26/16.06/15.62, where the tag shape at one pass ranged 11.78–16.81.

## Verified by mutation

Against a `cpuMs` quantized to the **16.0000ms tick measured on the real runner**:

| | fine clock | 16ms tick |
| --- | --- | --- |
| quadratic shapes, `main` | pass | **fail** — `ratio 0.00, i.e. LINEAR` |
| quadratic shapes, this PR | pass | pass |
| a shape made genuinely linear | **fail** | **fail** |

So the window has not bought robustness by always passing. Five consecutive clean package runs (1309 tests) on a fine clock.

## Cost

Four controls: **1.5s** on a fine clock, **8.5s** on a 16ms one, each inside its own 20s budget.

## Related

- #467 — the `Runner facts` step that measured the tick. Same run also reports the Windows leg has **4 logical CPUs**, which is what vitest sizes its default pool from.
- #472 — cleared and green on rerun; its Windows failure was this control, not its diff.
