### PR TITLE
test(detections): pin the corroboration floor against a coarse clock

### DIFF
--- a/packages/detections/src/security/redos-probe.ts
+++ b/packages/detections/src/security/redos-probe.ts
@@ -318,6 +318,24 @@ export function backtrackRatio(rule: Rule): { ratio: number; ms: number; benignM
 // a stall permanently disables a rule the user installed. Only the second is
 // unrecoverable without `aka detections unquarantine`, so a value that errs
 // toward "measure it again" is the safe one.
+//
+// Every number above was taken where the corroborating clock resolves to
+// 0.001ms. That is not universal, and the exception decides where this value
+// may go. Windows credits a whole scheduler tick to whichever thread was
+// running at the timer interrupt, measured at 16.0000ms on the CI runner (the
+// `Runner facts` step in ci.yml prints it), so there the reading is not how
+// much CPU a probe burned but how many interrupts it was running at — and the
+// 0.2-7.7ms-against-44.5ms separation above collapses onto a lattice of 0, 16,
+// 32.
+//
+// 20ms survives that by sitting between one tick and two: a benign rule can be
+// charged at most one tick and still not corroborate, while a genuine breach
+// crosses two. So the usable range on a coarse clock is ONE TICK < floor <= TWO
+// TICKS, which is narrower than the measured separation suggests and is not
+// visible in it. A share of 0.16 or less puts the floor at or under one tick,
+// at which point a benign rule whose probe merely straddles a timer interrupt
+// is corroborated and quarantined for ever. Both ends are held by cases in
+// test/security/redos-probe.test.ts rather than by this paragraph.
 const CPU_CORROBORATION_SHARE = 0.2;
 
 /** The corroborating clock must read at least this much for a breach to be cached. */

--- a/packages/detections/test/security/redos-probe.test.ts
+++ b/packages/detections/test/security/redos-probe.test.ts
@@ -241,6 +241,85 @@ describe('checkRuleTiming', () => {
     expect(result.verdict).toBe('uncorroborated');
   });
 
+  // The floor is a millisecond threshold, and a millisecond threshold is only
+  // as meaningful as the clock underneath it. Every number in the comment above
+  // `CPU_CORROBORATION_SHARE` was taken on an arm64 Mac, where
+  // `process.threadCpuUsage()` resolves to 0.001ms. It is not universal: on the
+  // Windows CI runner the same call's smallest non-zero delta measures
+  // 16.0000ms, because Windows credits a whole scheduler tick to whichever
+  // thread was running at the timer interrupt. The `Runner facts` step in
+  // ci.yml reports it.
+  //
+  // So on that host the corroborating reading is not "how much CPU the probe
+  // burned" but "how many timer interrupts it was running at", and the measured
+  // separation the constant sits in — 0.2-7.7ms of stalled-benign work against
+  // 44.5ms for the cheapest genuine breach — collapses onto a lattice of 0, 16,
+  // 32. The constant survives that, but only just, and for a reason nothing
+  // wrote down: 20 is above one tick and below two, so a benign rule can be
+  // charged at most one tick and still not corroborate, while a real breach
+  // crosses two.
+  //
+  // That is a 4ms margin holding up an unrecoverable outcome, so these three
+  // cases pin it. A share of 0.16 or less puts the floor at or under one tick,
+  // at which point ANY benign rule whose probe happens to straddle a single
+  // timer interrupt is corroborated and permanently quarantined — the exact
+  // false accusation the split exists to refuse, reintroduced by a constant
+  // that still reads as conservative.
+  const COARSEST_TICK_MS = 16;
+
+  it('keeps the floor above one tick of the coarsest clock a supported host has', () => {
+    expect(
+      CORROBORATION_FLOOR_MS,
+      `the floor is ${String(CORROBORATION_FLOOR_MS)}ms against a ${String(COARSEST_TICK_MS)}ms ` +
+        `scheduler tick on Windows. At or below one tick, a benign rule that merely straddles a ` +
+        `timer interrupt reads as a full tick of corroborating work and is quarantined for ever. ` +
+        `Lower the share only with a clock this coarse in mind.`,
+    ).toBeGreaterThan(COARSEST_TICK_MS);
+  });
+
+  it('refuses a benign rule that a tick-quantized clock charged one whole tick', () => {
+    const rule = regexRule('ZZQTICK[0-9]{6}');
+    let reads = 0;
+    const stalled = vi.spyOn(performance, 'now').mockImplementation(() => reads++ * BUDGET_MS * 2);
+    try {
+      // The most a benign rule can be charged where CPU is credited in whole
+      // ticks: one tick per probe window, for a probe that straddled a single
+      // timer interrupt while burning almost nothing.
+      let charged = 0;
+      const oneTickPerProbe: ProbeClock = () => (charged += COARSEST_TICK_MS);
+      const result = checkRuleTiming(rule, oneTickPerProbe);
+
+      expect(result.worstMs).toBeGreaterThanOrEqual(BUDGET_MS);
+      expect(result.corroboratedMs).toBe(COARSEST_TICK_MS);
+      expect(
+        result.verdict,
+        'one tick is what a benign rule gets for being unlucky with the timer, not evidence it ' +
+          'did any work. Caching that disables a rule the user installed, permanently.',
+      ).toBe('uncorroborated');
+    } finally {
+      stalled.mockRestore();
+    }
+  });
+
+  it('still corroborates when that same coarse clock charges two ticks', () => {
+    // The control for the case above, and the other half of what makes the
+    // constant's placement load-bearing: quarantine has to stay REACHABLE on a
+    // coarse clock, or a Windows host could never cache a verdict at all.
+    const rule = regexRule('ZZQTICK2[0-9]{6}');
+    let reads = 0;
+    const stalled = vi.spyOn(performance, 'now').mockImplementation(() => reads++ * BUDGET_MS * 2);
+    try {
+      let charged = 0;
+      const twoTicksPerProbe: ProbeClock = () => (charged += 2 * COARSEST_TICK_MS);
+      const result = checkRuleTiming(rule, twoTicksPerProbe);
+
+      expect(result.corroboratedMs).toBe(2 * COARSEST_TICK_MS);
+      expect(result.verdict).toBe('over-budget');
+    } finally {
+      stalled.mockRestore();
+    }
+  });
+
   // A genuinely catastrophic pattern must still be quarantinable on a real
   // clock — the control for every case above. If corroboration ever stopped
   // succeeding on real work, the two stalled-clock cases would still pass and


### PR DESCRIPTION
## What

`CORROBORATION_FLOOR_MS` decides whether a wall-budget breach may be **cached as a permanent quarantine** — the one detection decision the machine reaches on its own, and the one whose error is unrecoverable without `aka detections unquarantine`.

It is a millisecond threshold, so it is only as meaningful as the clock underneath it. Every number in the comment justifying it was taken where `process.threadCpuUsage()` resolves to **0.001ms**.

## The clock is not universal

Windows credits a whole scheduler tick to whichever thread was running at the timer interrupt. Measured on the CI runner: **16.0000ms** (the `Runner facts` step #467 adds prints it).

On that host the corroborating reading is not "how much CPU the probe burned" but "how many timer interrupts it was running at". The measured separation the constant sits in — 0.2–7.7ms of stalled-benign work against 44.5ms for the cheapest genuine breach — collapses onto a lattice of **0, 16, 32**.

## 20ms survives, for a reason nothing had written down

It sits **between one tick and two**:

- a benign rule can be charged at most one tick (16ms) and still not corroborate, because 16 < 20;
- a genuine breach crosses two (32ms) and does, because 32 ≥ 20.

So the usable range on such a host is `ONE TICK < floor <= TWO TICKS` — far narrower than the measured separation suggests, and invisible inside it. The 4ms of margin on the lower side was holding up an unrecoverable outcome, undocumented.

**The hazard is a plausible-looking edit.** A share of 0.16 or less still reads as conservative and is still comfortably below every catastrophic measurement in the comment — and it puts the floor at or under one tick, at which point *any* benign rule whose probe merely straddles a timer interrupt reads as a full tick of corroborating work and is quarantined for ever. That is the exact false accusation the corroboration split exists to refuse. Every existing test compares against `CORROBORATION_FLOOR_MS` symbolically, so all of them stay green through it.

## Three cases, two of them behavioural

| case | holds |
| --- | --- |
| the floor exceeds one tick of the coarsest supported clock | the lower end, directly |
| a benign rule charged **one whole tick** still reads `uncorroborated` | the lower end, by consequence |
| the same coarse clock charging **two ticks** still reaches `over-budget` | the upper end — quarantine must stay reachable on that host at all |

The third is the control: without it a floor raised out of reach would pass the first two while making the product unable to cache any verdict on Windows.

## Verified by mutation

| `CPU_CORROBORATION_SHARE` | floor | result |
| --- | --- | --- |
| 0.16 | 16ms (== one tick) | **2 failed** |
| 0.10 | 10ms | **2 failed** |
| 0.35 | 35ms (> two ticks) | **1 failed** |
| 0.2 (unchanged) | 20ms | 13 passed |

## No behaviour changes

The constant is where it was. What is new is that moving it now has to answer for a clock 16,000× coarser than the one it was chosen on.

## Related

- #467 — the `Runner facts` step that measured the tick.
- #474 — the same clock, reached through a different door: it made a test control report a provably quadratic pass as LINEAR.