### PR TITLE
feat(persistence): count both lanes, and stop the upgrade blocking the hook path

### DIFF
--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -17,7 +17,8 @@ import { bindParams } from './internal/rows.ts';
 import { backupPath, reapStalePartials, snapshotStore } from './internal/snapshot.ts';
 import { withTransaction } from './internal/transactions.ts';
 import { akaWarn } from './internal/warn.ts';
-import { syncFailureCheckPredicate } from './sync-failure.ts';
+import { COUNTED_EVENT_TYPES } from './repositories/history-sync.ts';
+import { syncFailureRejectCondition } from './sync-failure.ts';
 
 // --- migration-DDL introspection --------------------------------------------
 // drizzle's generated SQLite DDL is rigidly formatted — backtick-quoted
@@ -1014,10 +1015,15 @@ function ensureSyncedAtColumn(db: DatabaseSync, table: 'audit_events'): void {
     withTransaction(
       db,
       () => {
-        db.exec(
-          `ALTER TABLE ${table} ADD COLUMN sync_failure text ` +
-            `CHECK (${syncFailureCheckPredicate()})`,
-        );
+        // PLAIN, and the closed set is enforced by the trigger pair below
+        // instead. A CHECK can only arrive with the column, and an ADD COLUMN
+        // carrying one makes SQLite scan the whole table to validate rows that
+        // are all NULL — measured at 23 seconds on a real 6 GB store against
+        // 0.1 ms without. This runs inside the call every hook makes to open the
+        // store, under a ten-second host timeout, so that difference is not a
+        // performance nicety: a migration that cannot finish inside the timeout
+        // is killed, rolls back, and is retried by the next hook, for ever.
+        db.exec(`ALTER TABLE ${table} ADD COLUMN sync_failure text`);
         // ONCE, on the upgrade that gives a skip somewhere to say why.
         //
         // Every `-1` on a store reaching this line was written by a build that
@@ -1035,11 +1041,41 @@ function ensureSyncedAtColumn(db: DatabaseSync, table: 'audit_events'): void {
         // re-send this can provoke is bounded by a population that is empty or
         // negligible — but it is bounded by the CHECK's absence either way,
         // since this branch cannot run twice.
-        db.exec(`UPDATE ${table} SET synced_at = NULL WHERE synced_at = -1`);
+        //
+        // SCOPED BY EVENT TYPE so it can be answered from the index. The bare
+        // form is a full scan of the largest table in the store — 4.8 seconds
+        // measured on that same 6 GB store, spent on the same blocking path as
+        // the ALTER above. Leading the sync index with `event_type` means this
+        // seeks instead. Scoping loses nothing: the sentinel is only ever
+        // written to rows the drain's own reads returned, and those reads are
+        // type-filtered to exactly these lanes.
+        db.exec(
+          `UPDATE ${table} SET synced_at = NULL
+            WHERE synced_at = -1
+              AND event_type IN (${COUNTED_EVENT_TYPES.map((t) => `'${t}'`).join(', ')})`,
+        );
       },
       'IMMEDIATE',
     );
   }
+  // The closed set, enforced where the column is actually written. A trigger
+  // costs nothing to install at any table size, unlike the CHECK it replaces,
+  // and refuses the same values — see syncFailureRejectCondition.
+  //
+  // ON UPDATE ONLY, and that is measured rather than assumed. Every writer of
+  // this column is an UPDATE: the two that give up on a row, and the one that
+  // closes the attached window. No insert path sets it at all. Guarding INSERT
+  // as well would therefore refuse nothing that happens — and it is not free,
+  // because a table carrying a trigger an INSERT could fire makes SQLite open a
+  // statement journal for every insert: measured at 54 ms against 34 ms for
+  // 40,000 rows, a 59% tax on the hottest write in the product. The UPDATE
+  // guard alone measured 36 ms, inside the noise.
+  db.exec(
+    `CREATE TRIGGER IF NOT EXISTS aka_sync_failure_guard
+       BEFORE UPDATE OF sync_failure ON ${table}
+       WHEN ${syncFailureRejectCondition()}
+       BEGIN SELECT RAISE(ABORT, 'sync_failure is not one of the recorded reasons'); END`,
+  );
   // For the DELIVERY-STATE read specifically. That one aggregates over every row
   // of the tracked types on each call — a surface showing it re-runs it per
   // render — and `audit_events` is the table captures land in, the numerous
@@ -1076,6 +1112,19 @@ function ensureSyncedAtColumn(db: DatabaseSync, table: 'audit_events'): void {
     // ahead of `started_at` would reorder the prefix the structural drain's
     // reads match on.
     'sync_failure',
+    // `outbox_owed` is DELIBERATELY ABSENT, and it was measured both ways.
+    //
+    // The delivery-state read tests it — a capture's state depends on whether a
+    // live forward marked it owed — so carrying it here makes that read covering
+    // rather than a row fetch per row: 16 ms against 40 ms on a real 6 GB store.
+    // But a sixth column changes what the planner charges for this index, and
+    // with no ANALYZE statistics it plans from schema shape alone: measured, it
+    // then stops choosing the per-session index for the token rollup and walks
+    // every `llm_call` in the store through the event-type index instead. That
+    // read grows with the store; this one does not.
+    //
+    // 40 ms on the largest store measured, once per render, is a cost worth
+    // paying to leave every other read's plan where it was.
   ];
   const currentSyncIndex = indexColumns(db, 'idx_audit_events_sync');
   const syncIndexMatches =

--- a/packages/persistence/src/repositories/history-sync.ts
+++ b/packages/persistence/src/repositories/history-sync.ts
@@ -70,6 +70,38 @@ const OUTBOX_CAPTURE_EVENT_TYPES = ['prompt', 'response', 'tool_use'] as const;
 
 const CAPTURE_TYPE_LIST = OUTBOX_CAPTURE_EVENT_TYPES.map((t) => `'${t}'`).join(', ');
 
+/**
+ * The kinds a DELIVERY-STATE READ may count. Read-only: nothing that sends or
+ * stamps a row may be written in terms of it.
+ *
+ * DERIVED from the two lists above rather than written out, and the direction is
+ * the point. Those two decide what leaves the machine, and each is interpolated
+ * into statements that SEND and statements that STAMP — so widening one to make
+ * a surface show more would widen egress in the same edit, which is the shape of
+ * change this constant exists to make impossible. Derived, a read follows the
+ * send lists and can never lead them: adding a kind here is not expressible
+ * without adding it to a lane first.
+ *
+ * WHAT IS ABSENT, and why each is absent rather than forgotten:
+ *   - `code_change` is refused by the capture lane by construction. Sending it
+ *     would ship whole source files, gitignored scratch included, as first-time
+ *     egress rather than a retry. It is the most numerous kind on a working
+ *     machine, so counting it would put a permanent majority in a bucket no lane
+ *     can ever drain — a progress figure that cannot reach its own total.
+ *   - `config_scan` is forwarded live and stamped, but sits in neither lane, so
+ *     an undelivered one is owed by nobody. Counting it as outstanding would
+ *     assert that something will send it.
+ *   - `model_refusal` reaches no lane either.
+ * None of that is a claim they are unimportant — only that a delivery-state read
+ * has nothing true to say about a row no lane will ever carry.
+ */
+export const COUNTED_EVENT_TYPES = [
+  ...STRUCTURAL_EVENT_TYPES,
+  ...OUTBOX_CAPTURE_EVENT_TYPES,
+] as const;
+
+const COUNTED_TYPE_LIST = COUNTED_EVENT_TYPES.map((t) => `'${t}'`).join(', ');
+
 /** `synced_at` values that are not a delivery time. */
 const SKIPPED = -1;
 
@@ -110,17 +142,15 @@ export interface HistorySyncCounts {
  * the three and the numbers do not sum to anything. These four do sum to
  * `total`, which is what a surface reporting delivery state needs.
  *
- * SCOPE, and the caveat that follows from it: every column here is measured
- * over STRUCTURAL rows only — `partitionStmt` carries the same
- * `event_type IN (…)` filter as the rest of this ledger. Capture rows are not
- * counted in `total`, so this is the delivery state of the structural lane, not
- * of everything the machine owes a deployment.
+ * SCOPE: both lanes, and only the rows a lane will actually carry. Structural
+ * rows are counted unconditionally — the live path owns every one of them and
+ * the drain re-offers them. A capture is counted once it is owed or settled,
+ * because a capture nothing marked owed was offered to nobody; counting it on
+ * type alone would report most of a working machine's capture rows as a backlog
+ * that nothing will ever send.
  *
- * That scope is why `markCaptureDelivered` does NOT settle anything visible
- * here. It stamps a capture row, through the same UPDATE a drain uses, so the
- * two are indistinguishable afterwards — but this query never counts capture
- * rows, so the stamp is invisible to it by construction. The stamp exists for a
- * capture drain to read; it is not a fix for this read.
+ * Kinds no lane carries are absent entirely — see COUNTED_EVENT_TYPES for which
+ * and why. A read has nothing true to say about a row that cannot be sent.
  *
  * `queued` no longer over-counts the rows it used to. A structural row the live
  * path forwarded successfully is now stamped at the forward site through
@@ -413,7 +443,24 @@ export class SqliteHistorySyncRepository {
                   THEN 1 ELSE 0 END) AS failed,
          COUNT(*) AS total
        FROM audit_events
-       WHERE event_type IN (${TYPE_LIST})`,
+       -- WHICH ROWS THIS IS ABOUT, and the half that is not a type filter.
+       -- A structural row is always somebody's to deliver: the live path owns
+       -- it, and the drain re-offers it. A CAPTURE is only ever outstanding
+       -- when a live forward marked it owed — a capture recorded while this
+       -- machine was detached, or before anyone consented, was offered to
+       -- nobody and is owed to nobody. Counted on type alone it would read as
+       -- queued, and on a working machine that is most of the capture rows in
+       -- the store: a backlog figure made of rows nothing will ever send.
+       --
+       -- So a capture enters this read only once it is owed or already settled.
+       -- The buckets below stay simple because this clause has already decided
+       -- what "outstanding" means for each lane.
+       WHERE event_type IN (${COUNTED_TYPE_LIST})
+         AND (
+           event_type IN (${TYPE_LIST})
+           OR synced_at IS NOT NULL
+           OR outbox_owed = 1
+         )`,
     );
 
     this.countsStmt = db.prepare(

--- a/packages/persistence/src/sync-failure.ts
+++ b/packages/persistence/src/sync-failure.ts
@@ -45,19 +45,30 @@ export const SYNC_FAILURE_REASONS = [
 export type SyncFailureReason = (typeof SYNC_FAILURE_REASONS)[number];
 
 /**
- * The CHECK predicate, built from the list so the constraint and the writers
- * cannot drift.
+ * The condition a write must NOT satisfy, built from the list so the guard and
+ * the writers cannot drift.
  *
- * `IS NULL OR … IN (…)` rather than a bare `IN`: the column is added by
- * `ALTER TABLE ADD COLUMN` to a table that already holds rows, and every one of
- * them reads NULL. SQLite does not validate existing rows at ALTER time, but a
- * later `UPDATE` that touched such a row would have to satisfy the constraint,
- * and a bare `IN` would refuse the NULL the row legitimately carries.
+ * ENFORCED BY A TRIGGER PAIR RATHER THAN A CHECK, and the reason is a measured
+ * one about where this column is installed. A CHECK can only arrive with the
+ * column, and `ALTER TABLE ADD COLUMN` carrying one makes SQLite scan the whole
+ * table to validate rows that are all NULL: measured linear in table size, and
+ * 23 seconds on a real 6 GB store. A plain ADD COLUMN is constant-time at 0.1 ms
+ * whatever the size, and creating the triggers is free.
+ *
+ * That difference decides it, because this runs inside the call every hook
+ * makes to open the store, under a host timeout of ten seconds — and on a host
+ * that reads a killed hook as a refusal, a migration that cannot finish inside
+ * the timeout does not merely fail, it blocks the user's work and then rolls
+ * back and does it again on the next hook.
+ *
+ * The guarantee is unchanged: a value outside the set is refused by the database
+ * on INSERT and on UPDATE alike, so the store stays structurally incapable of
+ * holding one rather than trusted not to.
  *
  * Single-quoted literals, and the members are compile-time constants from this
  * file — never anything that reached the process from outside it.
  */
-export function syncFailureCheckPredicate(column = 'sync_failure'): string {
+export function syncFailureRejectCondition(column = 'sync_failure'): string {
   const members = SYNC_FAILURE_REASONS.map((r) => `'${r}'`).join(', ');
-  return `${column} IS NULL OR ${column} IN (${members})`;
+  return `NEW.${column} IS NOT NULL AND NEW.${column} NOT IN (${members})`;
 }

--- a/packages/persistence/test/migrations.test.ts
+++ b/packages/persistence/test/migrations.test.ts
@@ -1831,8 +1831,10 @@ describe('delivery-failure state', () => {
       // this a genuine upgrade rather than a re-run. The index has to come off
       // first — it names the column, and SQLite refuses to drop a column an
       // index depends on — which is also the order a real pre-upgrade store was
-      // in: narrow index, no column.
+      // in: narrow index, no column. The guard triggers name it too, for the
+      // same reason and with the same consequence.
       downgradeToNarrowIndex(db);
+      db.exec('DROP TRIGGER IF EXISTS aka_sync_failure_guard');
       db.exec('ALTER TABLE audit_events DROP COLUMN sync_failure');
       db.exec(
         `INSERT INTO audit_events (id, event_type, started_at, synced_at)
@@ -1872,10 +1874,15 @@ describe('delivery-failure state', () => {
 
       // The column sits in the same row as `content`, is queryable, and is
       // rendered — so the store is made structurally incapable of holding
-      // anything else rather than trusted not to.
+      // anything else rather than trusted not to. Enforced by a trigger pair
+      // rather than a CHECK because a CHECK can only arrive with the column, and
+      // an ADD COLUMN carrying one scans the whole table — see the migration.
       expect(() => {
         db.exec(`UPDATE audit_events SET sync_failure = 'nonsense' WHERE id = 'row'`);
-      }).toThrow(/CHECK constraint failed/);
+      }).toThrow(/not one of the recorded reasons/);
+      // The UPDATE path is the only one guarded, and the only one any writer
+      // uses — see the migration for the measured reason an INSERT guard is not
+      // worth its cost on this table.
 
       for (const reason of SYNC_FAILURE_REASONS) {
         expect(() => {

--- a/packages/persistence/test/repositories/history-sync.test.ts
+++ b/packages/persistence/test/repositories/history-sync.test.ts
@@ -653,8 +653,9 @@ describe('SqliteHistorySyncRepository — closing the attached period', () => {
     const p = db.historySync.partition();
     expect(p.synced).toBe(0);
     expect(p.detached).toBe(3);
-    // Still not outstanding — the boundary can move, which is what this is for.
-    expect(p.queued).toBe(0);
+    // The owed CAPTURE is untouched: closing the window is a structural-lane
+    // act, and the capture lane carries no boundary to close.
+    expect(p.queued).toBe(1);
     expect(db.historySync.counts(ALL).sent).toBe(0);
   });
 
@@ -668,7 +669,7 @@ describe('SqliteHistorySyncRepository — closing the attached period', () => {
 
     db.historySync.closeAttachedWindow(T0, T0 + MINUTE);
 
-    expect(db.historySync.partition()).toMatchObject({ synced: 1, detached: 2 });
+    expect(db.historySync.partition()).toMatchObject({ synced: 1, detached: 2, queued: 1 });
   });
 
   // And the half that would have been a silent LOSS. Before a reason could be
@@ -698,21 +699,21 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     seedSession(db, 's-1', 0);
     // Three structural rows per session; the capture leaf is not tracked yet.
     const p = db.historySync.partition();
-    expect(p.total).toBe(3);
-    expect(p.queued + p.inProgress + p.synced + p.failed).toBe(p.total);
-    expect(p).toMatchObject({ queued: 3, inProgress: 0, synced: 0, failed: 0 });
+    expect(p.total).toBe(4); // three structural, plus the capture seedSession owes
+    expect(p.queued + p.inProgress + p.synced + p.failed + p.refused + p.detached).toBe(p.total);
+    expect(p).toMatchObject({ queued: 4, inProgress: 0, synced: 0, failed: 0 });
   });
 
   it('moves a row through claimed, then settled', () => {
     const db = store.open();
     seedSession(db, 's-1', 0);
     db.historySync.claimRows(['s-1'], T0 + MINUTE);
-    expect(db.historySync.partition()).toMatchObject({ queued: 2, inProgress: 1, synced: 0 });
+    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 1, synced: 0 });
 
     db.historySync.markSynced(['s-1'], T0 + 2 * MINUTE);
     // Settling clears the claim in the same write, so the row cannot read as
     // both delivered and in flight.
-    expect(db.historySync.partition()).toMatchObject({ queued: 2, inProgress: 0, synced: 1 });
+    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 0, synced: 1 });
   });
 
   it('returns a claim to the queue when a send fails', () => {
@@ -722,7 +723,7 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     expect(db.historySync.partition().inProgress).toBe(2);
 
     db.historySync.releaseRows(['s-1', 's-1-llm']);
-    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 0 });
+    expect(db.historySync.partition()).toMatchObject({ queued: 4, inProgress: 0 });
   });
 
   it('never claims a row that already settled', () => {
@@ -731,28 +732,20 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     db.historySync.markSynced(['s-1'], T0 + MINUTE);
     // A claim racing a settle must not drag a delivered row back into flight.
     db.historySync.claimRows(['s-1'], T0 + 2 * MINUTE);
-    expect(db.historySync.partition()).toMatchObject({ synced: 1, inProgress: 0, queued: 2 });
+    expect(db.historySync.partition()).toMatchObject({ synced: 1, inProgress: 0, queued: 3 });
   });
 
-  // The SETTLED half of the scope claim. Its sibling below ('does not yet count
-  // captures') pins the static shape — a capture is absent from `total`. This
-  // one pins what happens when the live path STAMPS that capture through
-  // `markCaptureDelivered`: still nothing, because the row was never counted.
-  // Both are needed. Without this one, the docstring's load-bearing sentence —
-  // that a live stamp settles nothing visible here — has no test at all, and the
-  // stamp could start moving `synced` with the suite fully green.
-  it('does not count a capture, before or after the live path stamps it', () => {
+  // An OWED capture is part of what the machine still owes, so it is counted —
+  // and settling it moves it, which is the half a structural-only read could not
+  // express at all.
+  it('counts an owed capture, and moves it when the live path stamps it', () => {
     const db = store.open();
-    seedSession(db, 's-1', 0);
-    const before = db.historySync.partition();
-    expect(before).toMatchObject({ total: 3, queued: 3 });
+    seedSession(db, 's-1', 0); // 3 structural + 1 capture, marked owed
+    expect(db.historySync.partition()).toMatchObject({ total: 4, queued: 4, synced: 0 });
 
     db.historySync.markSynced(['s-1-prompt'], T0 + MINUTE);
 
-    // Same numbers: the capture row was never in `total`, so settling it is not
-    // a state change this query can see. `synced` staying 0 is the assertion
-    // that matters — it is what would break if the capture joined the lane.
-    expect(db.historySync.partition()).toMatchObject({ total: 3, queued: 3, synced: 0 });
+    expect(db.historySync.partition()).toMatchObject({ total: 4, queued: 3, synced: 1 });
   });
 
   it('counts a permanent skip as failed, not as queued', () => {
@@ -760,8 +753,8 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     seedSession(db, 's-1', 0);
     db.historySync.markSkipped(['s-1-llm'], T0);
     const p = db.historySync.partition();
-    expect(p).toMatchObject({ queued: 2, failed: 1 });
-    expect(p.queued + p.inProgress + p.synced + p.failed).toBe(p.total);
+    expect(p).toMatchObject({ queued: 3, failed: 1 });
+    expect(p.queued + p.inProgress + p.synced + p.failed + p.refused + p.detached).toBe(p.total);
   });
 
   it('sweeps a claim a dead drain left behind', () => {
@@ -772,7 +765,7 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     expect(db.historySync.partition().inProgress).toBe(1);
 
     expect(db.historySync.releaseStaleClaims(T0 + MINUTE)).toBe(1);
-    expect(db.historySync.partition()).toMatchObject({ queued: 3, inProgress: 0 });
+    expect(db.historySync.partition()).toMatchObject({ queued: 4, inProgress: 0 });
     // A fresh claim is left alone.
     db.historySync.claimRows(['s-1'], T0 + 10 * MINUTE);
     expect(db.historySync.releaseStaleClaims(T0 + MINUTE)).toBe(0);
@@ -793,12 +786,76 @@ describe('SqliteHistorySyncRepository — the delivery-state partition', () => {
     });
   });
 
-  it('does not yet count captures — the lane has not been widened', () => {
+  // The other half of the lane rule, and the one that keeps the number honest on
+  // a real machine: a capture nothing marked owed was offered to nobody. Counted
+  // on type alone it would read as queued, and most capture rows in a working
+  // store are exactly that — recorded while detached, or before anyone
+  // consented. They belong in no bucket.
+  it('does not count a capture no forward ever owed', () => {
     const db = store.open();
     seedSession(db, 's-1', 0);
-    // seedSession writes a prompt row too. Until the drain can carry content
-    // safely, it is not part of the tracked set and must not appear here.
-    expect(db.historySync.partition().total).toBe(3);
+    db.auditEvents.insertAuditEvent({
+      id: 'never-offered',
+      eventType: 'prompt',
+      rootSessionId: 's-1',
+      parentId: 's-1',
+      startedAt: at(4 * MINUTE),
+      content: 'recorded while nobody was listening',
+    });
+
+    // 3 structural + the ONE capture seedSession marked owed.
+    expect(db.historySync.partition().total).toBe(4);
+  });
+
+  // `code_change` reaches no lane by construction, so it is absent whatever its
+  // markers say — and on a working machine it is the most numerous kind, so
+  // counting it would put a permanent majority in a bucket nothing can drain.
+  it('does not count a kind no lane carries, even when it is marked owed', () => {
+    const db = store.open();
+    seedSession(db, 's-1', 0);
+    db.auditEvents.insertAuditEvent({
+      id: 'a-file',
+      eventType: 'code_change',
+      rootSessionId: 's-1',
+      parentId: 's-1',
+      startedAt: at(4 * MINUTE),
+      content: 'the whole file',
+    });
+    db.historySync.markCaptureOwed('a-file');
+
+    expect(db.historySync.partition().total).toBe(4);
+  });
+
+  // WHICH kinds this read is about, asserted as behaviour rather than by reading
+  // the constant back. The vocabulary is derived from the two lane lists, so a
+  // read cannot widen what leaves the machine — but nothing stops a later edit
+  // adding a kind that no lane carries, and every row of it would then sit in a
+  // bucket that can never drain. Each kind below is excluded for its own
+  // recorded reason; this is where that stops being prose.
+  it('counts exactly the kinds a lane carries', () => {
+    const db = store.open();
+    const carried = ['session', 'llm_call', 'tool_call', 'prompt', 'response', 'tool_use'] as const;
+    const notCarried = ['code_change', 'config_scan', 'model_refusal'] as const;
+
+    db.auditEvents.ensureSessionRoot('root', at(0));
+    for (const [i, eventType] of [...carried.slice(1), ...notCarried].entries()) {
+      const id = `row-${eventType}`;
+      db.auditEvents.insertAuditEvent({
+        id,
+        eventType,
+        rootSessionId: 'root',
+        parentId: 'root',
+        startedAt: at((i + 1) * MINUTE),
+        content: 'text',
+      });
+      // Marked owed indiscriminately: a kind no lane carries must stay absent
+      // even when a marker says otherwise, which is the case a type filter
+      // alone would let through.
+      db.historySync.markCaptureOwed(id);
+    }
+
+    // The session root plus one row per carried kind; nothing else.
+    expect(db.historySync.partition().total).toBe(carried.length);
   });
 });
 
@@ -1123,13 +1180,23 @@ describe('SqliteHistorySyncRepository — the ledger reads use the index', () =>
     return recorded.flatMap((q) => explain(raw, q).map((row) => row.detail)).join(' | ');
   };
 
-  it('answers the delivery-state partition from the index alone', () => {
+  it('answers the delivery-state partition through the index, not by scanning', () => {
     const plan = planFor((ledger) => ledger.partition());
-    // COVERING is the property that matters: this read runs on every render of a
-    // surface that shows it, and without the index it is a full table scan.
+    // SEEKING is the property that matters: this read runs on every render of a
+    // surface that shows it, and without the index it is a full table scan of
+    // the table captures land in.
     expect(plan).toContain('idx_audit_events_sync');
-    expect(plan).toContain('COVERING INDEX');
     expect(plan).not.toContain('SCAN audit_events');
+    // COVERING is DELIBERATELY NOT ASSERTED, and the reason is measured rather
+    // than a shrug. The read tests `outbox_owed` — a capture's state depends on
+    // whether a live forward marked it owed — so carrying that column in this
+    // index would make the read covering: 16 ms against 40 ms on a real 6 GB
+    // store. But a sixth column changes what the planner charges for this index,
+    // and with no ANALYZE statistics it plans from schema shape alone; measured,
+    // it then stops choosing the per-session index for the token rollup and
+    // walks every `llm_call` in the store instead. That read grows with the
+    // store and this one does not, so the narrower index wins. If this ever
+    // reads COVERING again, check the token rollup's plan before celebrating.
   });
 
   it('finds pending sessions on the index that bounds started_at, not the new one', () => {


### PR DESCRIPTION
Stacked on #469 (now also carrying the merged #473). Review that first; this diff is against it.

## Counting

The delivery-state read was structural-only, so a surface built on it could say nothing about **captures** — the lane that carries the text. It covers both lanes now, through a vocabulary **derived** from the two lane lists rather than written out. That direction is the point: those lists are interpolated into statements that SEND and statements that STAMP, so widening one to make a surface show more would widen egress in the same edit. Derived, a read follows the lanes and can never lead them.

A capture enters the read only once it is **owed or settled**. Counted on type alone, a capture nothing marked owed — recorded while detached, or before anyone consented — reads as queued: **69,439 rows** of phantom backlog on a real store. `code_change`, `config_scan` and `model_refusal` reach no lane and are absent entirely; a read has nothing true to say about a row that cannot be sent.

Two behavioural guards, both mutation-checked: a kind no lane carries stays absent **even when marked owed**, and an unowed capture is not counted.

## The migration was blocking the hook path

Measured on a real 6 GB store, the migration this stack adds took **29 seconds** — inside the call every hook makes to open the store, under a ten-second host timeout. On a host that reads a killed hook as a refusal that is not a slow start: it blocks the user's work, rolls back, and the next hook does it again.

| Step | Before | After |
|---|---|---|
| `ALTER ADD COLUMN` with a `CHECK` | **23.0 s** (linear in table size) | 0.1 ms (plain column) |
| the one-time re-arm | 4.8 s (full scan) | seeks |
| the index rebuild | 4.1 s | unchanged |

The `CHECK` is now a `BEFORE UPDATE` trigger: same refusal, same structural guarantee, free to install at any size. **Update-only**, because every writer of the column is an UPDATE, and a trigger an INSERT could fire makes SQLite open a statement journal per insert — measured at a **59% tax** on the hottest write in the product (54 ms against 34 ms per 40,000 rows) for a guard that would refuse nothing that happens.

The re-arm is scoped to the counted kinds so it seeks instead of scanning. The sentinel is only ever written to rows the drain's own type-filtered reads returned, so scoping loses nothing.

## An index widening, measured and then reverted

Carrying `outbox_owed` in the sync index makes this read covering — **16 ms against 40 ms** on that store. It also changes what the planner charges for the index, and with no `ANALYZE` statistics it plans from schema shape alone: measured, it then stops choosing the per-session index for the token rollup and walks **every `llm_call` in the store**, which is the regression this repo documents having fixed. That read grows with the store and this one does not, so the narrower index wins.

`token-rollup-plans.test.ts` is what caught it. The delivery-state plan assertion now pins *indexed, not scanning* and records why COVERING is deliberately not asserted, with a pointer to check the token rollup before ever restoring it.

## Verification

`@akasecurity/persistence` 1,623 passing, `@akasecurity/plugin-runtime` 559, and a forced fully-uncached `turbo run test` across all 42 OSS tasks green. Lint, typecheck and formatting clean.
