### PR TITLE
ci: grow the clock probe until it has an answer to print

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,7 +768,12 @@ jobs:
           # POSIX reports microseconds; Windows charges whole scheduler ticks to
           # whichever thread was running at the interrupt, so a guard measuring a
           # few milliseconds of work here is reading the clock rather than the work.
-          "smallest non-zero threadCpuUsage deltas, ms: $(node -e "const seen = new Set(); for (let i = 0; i < 2000; i += 1) { const a = process.threadCpuUsage(); let x = 0; for (let j = 0; j < 5000; j += 1) x += j; const b = process.threadCpuUsage(); const d = (b.user + b.system - a.user - a.system) / 1000; if (d > 0) seen.add(d); } const v = [...seen].sort((p, q) => p - q); process.stdout.write(v.length === 0 ? 'no non-zero delta in 2000 tries' : v.slice(0, 4).map((m) => m.toFixed(4)).join(', '))")"
+          #
+          # The busy loop GROWS until a delta appears, because a loop sized for a
+          # microsecond clock reads zero on a coarse one for ever — and "no delta"
+          # would then be printed by exactly the clock this line exists to size. The
+          # accumulator is read so V8 cannot drop the loop and report the same thing.
+          "smallest non-zero threadCpuUsage deltas, ms: $(node -e "const read = () => { const t = process.threadCpuUsage(); return (t.user + t.system) / 1000; }; let out = 'no non-zero delta up to 134217728 adds per try'; for (let work = 1000; work <= 134217728; work *= 8) { const seen = new Set(); let sink = 0; for (let i = 0; i < 64 && seen.size < 8; i += 1) { const a = read(); for (let j = 0; j < work; j += 1) sink += j; const d = read() - a; if (d > 0 && sink >= 0) seen.add(d); } if (seen.size > 0) { const v = [...seen].sort((p, q) => p - q); out = v.slice(0, 4).map((m) => m.toFixed(4)).join(', ') + ' (at ' + work + ' adds per try)'; break; } } process.stdout.write(out)")"
           "total RAM MB: $([math]::Round($os.TotalVisibleMemorySize / 1KB))"
           "free RAM MB:  $([math]::Round($os.FreePhysicalMemory / 1KB))"
           Get-PSDrive -PSProvider FileSystem |


### PR DESCRIPTION
Follow-up to #467, which merged before this landed on its branch.

## What

The `Runner facts` step's thread-CPU clock probe could not answer in the regime it exists to measure. Its work was fixed at 5,000 adds per try, so a clock coarser than the whole run printed `no non-zero delta in 2000 tries` — which is exactly what the clock being sized prints, making the reading ambiguous precisely where it matters.

Demonstrated against a `threadCpuUsage` quantized to a 16ms tick:

| probe | prints |
| --- | --- |
| before | `no non-zero delta in 2000 tries` |
| after | `16.0000 (at 64000 adds per try)` |

## How

The inner bound grows ×8 until a delta appears — the shape #474's probe uses, and for the same reason — and the work level is printed beside the deltas, so the reading says what it was taken at. The accumulator is now read as well, so V8 cannot drop the loop and print the same empty answer for an unrelated reason.

On an arm64 Mac it still answers at the first level: `0.0030, 0.0040, 0.0040, 0.0050 (at 1000 adds per try)`.

Raised in review on #467 by pmontiel-git; both points were correct.