### PR TITLE
test(codex,antigravity): pin the sweep's narrowness on both hosts

### DIFF
--- a/plugins/antigravity/test/remediation/redact.test.ts
+++ b/plugins/antigravity/test/remediation/redact.test.ts
@@ -358,6 +358,31 @@ describe('redactLeakedKeys', () => {
       expect(readFileSync(live, 'utf8')).toBe('in flight');
     });
 
+    it('never removes a sibling it did not name', () => {
+      const file = join(rolloutRoot, 'bystanders.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // Everything the sweep must walk past. Without this case the two checks
+      // that make it narrow — the artifact prefix and the digits-only pid — are
+      // prose: deleting either leaves every other case in this file green, so
+      // the sweep would widen to any `*.aka-redact.tmp` in the directory and
+      // take a neighbour's bytes with it.
+      const bystanders = [
+        // The pid-free shape: nothing this module mints.
+        `${file}.aka-redact.tmp`,
+        `${file}.notapid.aka-redact.tmp`,
+        `${file}. 7.aka-redact.tmp`,
+        // A temp belonging to a DIFFERENT artifact in the same directory.
+        tempName(join(rolloutRoot, 'other.jsonl'), DEAD_PID),
+        // The suffix has to end the name, not merely appear in it.
+        `${tempName(file, DEAD_PID)}.bak`,
+      ];
+      for (const path of bystanders) writeFileSync(path, 'not ours');
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      for (const path of bystanders) expect(existsSync(path)).toBe(true);
+    });
+
     it('refuses to publish through a symlink planted at its temp path', (ctx) => {
       if (process.platform === 'win32') {
         ctx.skip('unprivileged symlink creation is not available on Windows');

--- a/plugins/codex/test/remediation/redact.test.ts
+++ b/plugins/codex/test/remediation/redact.test.ts
@@ -358,6 +358,31 @@ describe('redactLeakedKeys', () => {
       expect(readFileSync(live, 'utf8')).toBe('in flight');
     });
 
+    it('never removes a sibling it did not name', () => {
+      const file = join(rolloutRoot, 'bystanders.jsonl');
+      writeFileSync(file, `leaked ${ROLLOUT_KEY} here`);
+      // Everything the sweep must walk past. Without this case the two checks
+      // that make it narrow — the artifact prefix and the digits-only pid — are
+      // prose: deleting either leaves every other case in this file green, so
+      // the sweep would widen to any `*.aka-redact.tmp` in the directory and
+      // take a neighbour's bytes with it.
+      const bystanders = [
+        // The pid-free shape: nothing this module mints.
+        `${file}.aka-redact.tmp`,
+        `${file}.notapid.aka-redact.tmp`,
+        `${file}. 7.aka-redact.tmp`,
+        // A temp belonging to a DIFFERENT artifact in the same directory.
+        tempName(join(rolloutRoot, 'other.jsonl'), DEAD_PID),
+        // The suffix has to end the name, not merely appear in it.
+        `${tempName(file, DEAD_PID)}.bak`,
+      ];
+      for (const path of bystanders) writeFileSync(path, 'not ours');
+
+      redactLeakedKeys([{ where: { filePath: file }, rawValue: ROLLOUT_KEY }], scope);
+
+      for (const path of bystanders) expect(existsSync(path)).toBe(true);
+    });
+
     it('refuses to publish through a symlink planted at its temp path', (ctx) => {
       if (process.platform === 'win32') {
         ctx.skip('unprivileged symlink creation is not available on Windows');


### PR DESCRIPTION
Follow-up to #472, which merged before this landed on its branch.

## What

The redact hardening ported five of claude-code's six sweep cases to codex and antigravity and missed the one that holds the other two. Reproduced on `main` before fixing, on **both** hosts:

| mutation to `sweepStrandedTemps` | result |
| --- | --- |
| delete the digits-only pid check | **16/16 green** |
| drop `name.startsWith(prefix)` — sweep any `*.aka-redact.tmp` in the directory | **16/16 green** |

So the docblock's two strongest claims — that the sweep removes only names this module mints, and only siblings of *this* artifact — were prose on those two hosts while being behaviour on claude-code.

## Why it is worth a case rather than a comment

The failure it prevents is unrecoverable in the direction that matters. A sweep that deletes too widely takes a neighbouring run's bytes, and the neighbour is by construction a file full of secrets somebody is mid-way through redacting.

## The case

`never removes a sibling it did not name`, ported verbatim in shape: it plants the pid-free form, a `.notapid.` name, a `. 7.` name, a dead-pid temp belonging to a **different** artifact in the same directory, and a `.bak`-suffixed one, then requires all five to survive.

## Verified

| mutation | before | after |
| --- | --- | --- |
| digits-only pid check deleted | 16/16 green | **1 failed** on both hosts |
| artifact-prefix check dropped | 16/16 green | **1 failed** on both hosts |
| `lstat` regular-file guard dropped | — | **1 failed** on both hosts |

17/17 per host; full suites 519 and 537 green. **No source change** — the sweep was already correct; nothing there said so.

Raised in review on #472 by pmontiel-git, on both host copies.