### PR TITLE
feat(plugin-sdk): let processText declare a field it cannot rewrite

### DIFF
--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -133,7 +133,7 @@ export {
 } from './rule-packs.ts';
 export type { RuleProbeGateway, RuleProber } from './rule-quarantine.ts';
 export { filterUnsafeRules, quarantineRule, ruleProbeKey } from './rule-quarantine.ts';
-export type { CaptureOptions, PluginRuntime } from './runtime.ts';
+export type { CaptureOptions, DecisionOptions, PluginRuntime } from './runtime.ts';
 export { createPluginRuntime } from './runtime.ts';
 export type { ExceptionWriter, SuppressionEntry } from './suppressions.ts';
 export { applySetupTriageSuppressions, THIRTY_DAYS_MS } from './suppressions.ts';

--- a/packages/plugin-sdk/src/runtime.ts
+++ b/packages/plugin-sdk/src/runtime.ts
@@ -678,8 +678,17 @@ export function createPluginRuntime(
   // `context` scopes appliesTo-tagged rules to the text's language when a file
   // path is known (the worktree scan); hook-path prompts pass none and run the
   // full ruleset.
-  async function processText(text: string, context?: ScanContext): Promise<CaptureResult> {
-    return (await evaluate(text, context, {})).decision;
+  //
+  // `opts.rewritable` is the same per-field flag `capture` takes, forwarded to
+  // the same resolution — a caller that inspects a field it cannot rewrite gets
+  // the degraded action whether or not it goes on to persist an event. Omitted,
+  // it is `true`, so every existing caller is unchanged.
+  async function processText(
+    text: string,
+    context?: ScanContext,
+    opts: DecisionOptions = {},
+  ): Promise<CaptureResult> {
+    return (await evaluate(text, context, {}, opts.rewritable)).decision;
   }
 
   async function capture(input: CaptureInput, opts: CaptureOptions = {}): Promise<CaptureResult> {
@@ -878,18 +887,12 @@ export function createPluginRuntime(
   return { processText, capture, rulesetFingerprint, scanIsolationDegraded, close };
 }
 
-// Persistence policy for capture(): 'always' records an event for every call
-// (the live hook path, so the activity timeline is complete); 'with-findings'
-// records only when something was detected (the historical backfill).
-// `dedupe: 'content-hash'` marks the capture as re-runnable bulk ingest so the
-// gateway drops content it has already recorded (fresh event ids on a re-run
-// would otherwise duplicate rows). Never set it on the live hook path.
-export interface CaptureOptions {
-  persist?: 'always' | 'with-findings';
-  dedupe?: 'content-hash';
-  // Grant ids already spent by this capture's own pointer crossing (see
-  // ExceptionEvalContext.preAuthorizedGrantIds).
-  preAuthorizedGrantIds?: readonly string[];
+// What the CALLER can do about the decision, as opposed to what the runtime
+// does with it. Held apart from `CaptureOptions` because it shapes the ACTION
+// rather than the write, so both decision paths take it: `capture` takes these
+// plus its persistence options, and `processText` — which writes no event —
+// takes only these.
+export interface DecisionOptions {
   // Whether the CALLER can carry out a redaction on this text. Default true.
   //
   // Set false for a field the host offers no way to rewrite — Antigravity's
@@ -906,11 +909,25 @@ export interface CaptureOptions {
   rewritable?: boolean;
 }
 
+// Persistence policy for capture(): 'always' records an event for every call
+// (the live hook path, so the activity timeline is complete); 'with-findings'
+// records only when something was detected (the historical backfill).
+// `dedupe: 'content-hash'` marks the capture as re-runnable bulk ingest so the
+// gateway drops content it has already recorded (fresh event ids on a re-run
+// would otherwise duplicate rows). Never set it on the live hook path.
+export interface CaptureOptions extends DecisionOptions {
+  persist?: 'always' | 'with-findings';
+  dedupe?: 'content-hash';
+  // Grant ids already spent by this capture's own pointer crossing (see
+  // ExceptionEvalContext.preAuthorizedGrantIds).
+  preAuthorizedGrantIds?: readonly string[];
+}
+
 export interface PluginRuntime {
   // Enforcement decision + best-effort blocked-detection bookkeeping (the
   // short-lived approve-flow ledger, when a fingerprint key is available);
   // no event write.
-  processText(text: string, context?: ScanContext): Promise<CaptureResult>;
+  processText(text: string, context?: ScanContext, opts?: DecisionOptions): Promise<CaptureResult>;
   // Decision + persist (event with masked content + N masked findings).
   capture(input: CaptureInput, opts?: CaptureOptions): Promise<CaptureResult>;
   // Fingerprint of the effective ruleset, for scan-ledger invalidation.

--- a/packages/plugin-sdk/test/runtime.test.ts
+++ b/packages/plugin-sdk/test/runtime.test.ts
@@ -1009,6 +1009,53 @@ describe('capture() — CaptureResult.findingKeys (scanner re-scan resolver hook
   });
 });
 
+// The fixtures both `rewritable` suites below drive. Shared rather than copied
+// so the processText suite cannot quietly diverge from the capture suite it
+// claims parity with: a policy or marker changed here moves both at once.
+function redactBundle(): PolicyBundle {
+  const b = bundle();
+  b.policies = [
+    {
+      id: randomUUID(),
+      scope: 'global',
+      target: { ruleId: 'test/secret-marker' },
+      action: 'redact',
+      enabled: true,
+    },
+  ];
+  return b;
+}
+
+// A capture whose worst action and whose lost redact DIFFER: the Block comes
+// from the secret marker's own policy, never from the fallback.
+function mixedBundle(): PolicyBundle {
+  const b = bundle();
+  b.policies = [
+    {
+      id: randomUUID(),
+      scope: 'global',
+      target: { ruleId: 'test/secret-marker' },
+      action: 'block',
+      enabled: true,
+    },
+    {
+      id: randomUUID(),
+      scope: 'global',
+      target: { ruleId: 'test/pii-marker' },
+      action: 'redact',
+      enabled: true,
+    },
+  ];
+  return b;
+}
+
+const MIXED = 'SECRET_MARKER and PII_MARKER together';
+
+const settingsWith = (fallback: 'monitor' | 'warn' | 'block'): WorkspaceSettings => ({
+  ...settings('redact'),
+  redactFallback: fallback,
+});
+
 // A redact the caller cannot carry out (CaptureOptions.rewritable: false).
 //
 // Antigravity's PreToolUse has no `updatedInput` at all, and Codex and Claude
@@ -1019,25 +1066,6 @@ describe('capture() — CaptureResult.findingKeys (scanner re-scan resolver hook
 // blocked-detections ledger — so the audit trail cannot claim a masking that
 // never happened.
 describe('a redact the caller cannot carry out', () => {
-  function redactBundle(): PolicyBundle {
-    const b = bundle();
-    b.policies = [
-      {
-        id: randomUUID(),
-        scope: 'global',
-        target: { ruleId: 'test/secret-marker' },
-        action: 'redact',
-        enabled: true,
-      },
-    ];
-    return b;
-  }
-
-  const settingsWith = (fallback: 'monitor' | 'warn' | 'block'): WorkspaceSettings => ({
-    ...settings('redact'),
-    redactFallback: fallback,
-  });
-
   it('still redacts in place when the caller CAN rewrite (the control)', async () => {
     // Without this the cases below would pass on a runtime that had simply
     // stopped redacting anything.
@@ -1238,29 +1266,6 @@ describe('a redact the caller cannot carry out', () => {
   // So this pair is the whole guard on the producing layer. Replacing the fold
   // with the capture's `worst` — the boolean semantics this field replaced —
   // leaves the other 633 cases green and fails only the first of these.
-  function mixedBundle(): PolicyBundle {
-    const b = bundle();
-    b.policies = [
-      {
-        id: randomUUID(),
-        scope: 'global',
-        target: { ruleId: 'test/secret-marker' },
-        action: 'block',
-        enabled: true,
-      },
-      {
-        id: randomUUID(),
-        scope: 'global',
-        target: { ruleId: 'test/pii-marker' },
-        action: 'redact',
-        enabled: true,
-      },
-    ];
-    return b;
-  }
-
-  const MIXED = 'SECRET_MARKER and PII_MARKER together';
-
   it('names what the LOST redact became, not what the capture did', async () => {
     // A deny that reports `redactDegradedTo: 'block'` explains itself by naming
     // a fallback the workspace never set — here the workspace set `warn`, and
@@ -1293,6 +1298,98 @@ describe('a redact the caller cannot carry out', () => {
 
     expect(out.action).toBe('block');
     expect(out.redactDegradedTo).toBe('block');
+    await runtime.close();
+  });
+});
+
+// The same flag, on the path that writes nothing.
+//
+// `capture` resolves the action and then persists a row; `processText` resolves
+// it and returns. A caller that inspects a field it cannot rewrite while
+// keeping its own audit trail reaches the degrade only through here, and before
+// this option it could not reach it at all: it received the undegraded `redact`
+// and had to apply `redactFallback` itself — a second implementation of the one
+// enforcement rule, which is exactly what resolving it inside the runtime
+// exists to prevent.
+//
+// Note what the caller can read back on this path. `actionTaken` lives on the
+// PERSISTED finding rows, which this path never builds, so `action` and
+// `redactDegradedTo` are the whole record of what happened — which is why the
+// pair at the bottom matters more here than it does on capture.
+describe('processText carries the rewritable flag', () => {
+  it('redacts in place when the option is OMITTED (the neutral-plumbing control)', async () => {
+    // The whole claim that this option changes nothing for the callers that
+    // already exist. The three `surfaced-redact` sites pass no options; a
+    // default of false here would silently degrade every one of them.
+    const runtime = createPluginRuntime(fakeGateway(redactBundle()), settingsWith('warn'));
+    const out = await runtime.processText('here is SECRET_MARKER');
+    expect(out.action).toBe('redact');
+    expect(out.text).not.toContain('SECRET_MARKER');
+    await runtime.close();
+  });
+
+  it.each([
+    ['warn', 'warn'],
+    ['monitor', 'log'],
+    ['block', 'block'],
+  ] as const)('degrades to the configured fallback: %s', async (fallback, expected) => {
+    // Parity with capture's arms, through the same fixtures: the resolution
+    // belongs to the runtime, so which entry point reached it must not matter.
+    const runtime = createPluginRuntime(fakeGateway(redactBundle()), settingsWith(fallback));
+    const out = await runtime.processText('here is SECRET_MARKER', undefined, {
+      rewritable: false,
+    });
+    expect(out.action).toBe(expected);
+    await runtime.close();
+  });
+
+  it('returns the value UNMASKED when the fallback lands below redact', async () => {
+    // The honest half of a degrade: nothing was stripped, so the text handed
+    // back is the text that came in. A caller that forwarded `out.text`
+    // believing it masked would ship the raw value while its own log said warn.
+    const runtime = createPluginRuntime(fakeGateway(redactBundle()), settingsWith('warn'));
+    const out = await runtime.processText('here is SECRET_MARKER', undefined, {
+      rewritable: false,
+    });
+    expect(out.text).toContain('SECRET_MARKER');
+    await runtime.close();
+  });
+
+  it('resolves per CALL, not per runtime', async () => {
+    // The mutation this seam invites: `redactFallback` is a closure variable on
+    // the runtime, so parking `rewritable` beside it reads as a simplification
+    // and passes every case above. Two calls on ONE runtime, either order, is
+    // what separates a forwarded argument from a hoisted one.
+    const runtime = createPluginRuntime(fakeGateway(redactBundle()), settingsWith('block'));
+    const degraded = await runtime.processText('here is SECRET_MARKER', undefined, {
+      rewritable: false,
+    });
+    const rewritten = await runtime.processText('here is SECRET_MARKER');
+    expect(degraded.action).toBe('block');
+    expect(rewritten.action).toBe('redact');
+    await runtime.close();
+  });
+
+  it('names what the LOST redact became, not what the call did', async () => {
+    // The field that tells "policy said warn" from "policy said redact and I
+    // could not carry it out". Here the deny comes from the secret marker's own
+    // Block policy while the workspace set warn, so the two genuinely differ
+    // and only a fold over the degraded findings answers.
+    const runtime = createPluginRuntime(fakeGateway(mixedBundle()), settingsWith('warn'));
+    const out = await runtime.processText(MIXED, undefined, { rewritable: false });
+    expect(out.action).toBe('block');
+    expect(out.redactDegradedTo).toBe('warn');
+    await runtime.close();
+  });
+
+  it('leaves redactDegradedTo ABSENT when the caller can rewrite', async () => {
+    // The control on the case above: a runtime that stamped the field
+    // unconditionally would satisfy it while telling every ordinary caller that
+    // a redact it actually carried out was really a degrade.
+    const runtime = createPluginRuntime(fakeGateway(mixedBundle()), settingsWith('warn'));
+    const out = await runtime.processText(MIXED);
+    expect(out.action).toBe('block');
+    expect(out.redactDegradedTo).toBeUndefined();
     await runtime.close();
   });
 });


### PR DESCRIPTION
The other half of the seam #438 opened. `capture` can say "I cannot rewrite this field"; `processText` cannot, and there is no reason for the asymmetry — the resolution both would reach already lives in the shared `evaluate`.

## The gap

#438 put the degrade in the one place the action is resolved: a `redact` on a field the caller cannot rewrite becomes `settings.redactFallback` inside `actionForFinding`, so the decision, `findings.actionTaken` and the blocked-detections ledger cannot disagree about what was enforced. `evaluate` takes the flag. `capture` passes it.

`processText` does not, and it is the entry point with no way to ask for it. A caller inspecting a field it cannot rewrite gets the undegraded `redact` back and has to apply `redactFallback` itself — which is a second implementation of the rule, in the caller, exactly the shape #438's own comment says resolving it inside the runtime exists to prevent:

> Doing it in the hook instead is what left an escalated deny recorded as 'redact'.

## The change

```
-  async function processText(text: string, context?: ScanContext) {
-    return (await evaluate(text, context, {})).decision;
+  async function processText(text, context?, opts: DecisionOptions = {}) {
+    return (await evaluate(text, context, {}, opts.rewritable)).decision;
```

`rewritable` moves onto a **`DecisionOptions`** interface that `CaptureOptions` extends. One definition, one doc comment, and the split says what the two kinds of option are: `DecisionOptions` shapes the ACTION, `CaptureOptions` adds what to do about the WRITE — which is why the path that writes nothing takes only the first. `CaptureOptions` is structurally unchanged; the type is exported so a caller can name it.

## Why this is neutral

Omitted, the flag is `true`. There are three `processText` call sites in the tree, all `surfaced-redact.ts`:

| site | reads |
|---|---|
| `plugins/antigravity/src/remediation/surfaced-redact.ts:172` | `.findings` |
| `plugins/codex/src/remediation/surfaced-redact.ts:172` | `.findings` |
| `plugins/claude-code/src/remediation/surfaced-redact.ts:269` | `.findings` |

None passes options and none reads `.action`, `.text` or `.redactDegradedTo`. `decide` returns `findings` in full whatever the flag says — the flag moves `actionTaken` and the collapse, never the list — so all three are byte-identical.

## What a caller can read back here

Worth stating, because it differs from `capture` and shaped the tests: `actionTaken` lives on the **persisted** finding rows, which this path never builds. So on `processText` the whole record of a degrade is `action` plus `redactDegradedTo`. That pair is the reason #438 made the field an action rather than a boolean, and this is the path where it carries the most.

## Tests

Six cases, driving the real runtime through the fixtures the capture suite now shares (`redactBundle`, `mixedBundle`, `settingsWith` lifted to module scope so the two suites cannot diverge — same fixtures, different entry point):

| case | pins |
|---|---|
| omitted option is the control | the neutral claim above — a default of `false` would silently degrade all three existing sites |
| the three fallback arms | parity with capture's: `warn`→warn, `monitor`→log, `block`→block |
| unmasked text below redact | nothing was stripped, so `.text` is what came in — a caller forwarding it must not believe otherwise |
| resolves per CALL | two calls on one runtime, opposite flags |
| `redactDegradedTo` names the LOST redact | mixed bundle: `action` is block from the secret marker's own policy while the workspace set `warn` |
| absent when the caller can rewrite | the control on the pair |

### Mutation evidence

Each mutation applied for real against the suite, not read off the diff:

| mutation | result |
|---|---|
| `processText` never forwards `opts.rewritable` | **6 red** (three arms, unmasked, per-call, degradedTo) |
| the option defaults to `false` instead of `true` | **4 red** — the omitted-option control, per-call, the absent control, and the pre-existing `picks redact over warn` case |
| the flag is hoisted onto the runtime instead of forwarded | **1 red** — `resolves per CALL`, and nothing else |

The third is the one this seam invites: `redactFallback` is already a closure variable on the runtime, so parking `rewritable` beside it reads as a simplification and passes every other case.

## Verification

```
pnpm --filter @akasecurity/plugin-sdk test      648 passed (41 files), thresholds met
turbo run test --filter='./plugins/*'           19 tasks, all passed
pnpm typecheck                                  26 tasks + root, clean
pnpm lint                                       26 tasks + root + portability, clean
```