### PR TITLE
fix(web-ui): stop removing a temp home the store is still open in

### DIFF
--- a/web-ui/app/lib/db.ts
+++ b/web-ui/app/lib/db.ts
@@ -25,3 +25,29 @@ export function db(): LocalDatabase {
   store.__akaDb = database;
   return database;
 }
+
+/**
+ * Release the store this module holds, if it holds one.
+ *
+ * Exported for the one caller that needs it: a test suite REMOVING the directory
+ * the store lives in. Windows refuses to delete a file another handle holds open
+ * (EPERM) where POSIX unlinks it and carries on, so a suite that redirects the
+ * home, renders a page and then removes that home again cannot do so while this
+ * module still holds the store it opened there. See test/helpers/temp-home.ts.
+ *
+ * Nothing in the request path calls this: the singleton above is deliberate and
+ * production never moves its home.
+ */
+export function closeStore(): void {
+  const held = store.__akaDb;
+  if (!held) return;
+  // Cleared BEFORE the close, so a close that throws cannot leave a handle
+  // nobody can reach still recorded as the live one.
+  store.__akaDb = undefined;
+  try {
+    held.close();
+  } catch {
+    // Cleanup: already closed, or a close that failed. Neither leaves the caller
+    // anything useful to do.
+  }
+}

--- a/web-ui/test/actions/connection.test.ts
+++ b/web-ui/test/actions/connection.test.ts
@@ -1,14 +1,5 @@
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  statSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type * as Persistence from '@akasecurity/persistence';
@@ -19,7 +10,7 @@ import {
   readWorkspaceSettings,
 } from '@akasecurity/persistence';
 import { isAttached, isHistorySyncConsentValid } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   attachToControlPlane,
@@ -27,6 +18,7 @@ import {
   saveSettings,
 } from '../../app/(app)/settings/actions.ts';
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { tempHomes } from '../helpers/temp-home.ts';
 
 // The attach/detach pair, and the input guard in front of all three settings
 // actions.
@@ -107,6 +99,11 @@ vi.mock('@akasecurity/persistence', async (importActual) => {
   };
 });
 
+// Homes are removed when this FILE finishes, not after each test: the store
+// app/lib/db.ts opens under them stays open, and Windows will not delete a
+// directory a handle still holds. See the helper.
+const newHome = tempHomes('aka-web-connection-');
+
 let home: string;
 
 const ENDPOINT = 'https://aka.acme.internal';
@@ -130,17 +127,13 @@ function credential(): { endpoint: string; apiKey: string; specVersion: number }
 }
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'aka-web-connection-'));
+  home = newHome();
   osHome.dir = home;
   whoami.reject = null;
   whoami.calls = [];
   writeFailure.error = null;
   writeFailure.onCall = null;
   backgroundSync.uninstallCalls = [];
-});
-
-afterEach(() => {
-  rmSync(home, { recursive: true, force: true });
 });
 
 describe('attachToControlPlane', () => {

--- a/web-ui/test/actions/settings.test.ts
+++ b/web-ui/test/actions/settings.test.ts
@@ -1,14 +1,14 @@
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { readWorkspaceSettings } from '@akasecurity/persistence';
 import type { SaveSettingsInput } from '@akasecurity/schema';
 import { HISTORY_SYNC_PAYLOAD_VERSION, VAULT_CONSENT_VERSION } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest';
 
 import { saveSettings } from '../../app/(app)/settings/actions.ts';
+import { tempHomes } from '../helpers/temp-home.ts';
 
 // `saveSettings` is the web surface that records and revokes the vault-consent
 // grant. The grant must always be stamped server-side ('on' has no input path
@@ -28,6 +28,11 @@ vi.mock('node:os', async (importActual) => {
 });
 vi.mock('next/cache', () => ({ revalidatePath: () => undefined }));
 
+// Homes are removed when this FILE finishes, not after each test: the store
+// app/lib/db.ts opens under them stays open, and Windows will not delete a
+// directory a handle still holds. See the helper.
+const newHome = tempHomes('aka-web-settings-');
+
 let home: string;
 
 function settingsFile(): string {
@@ -39,12 +44,8 @@ function rawSettings(): string {
 }
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'aka-web-settings-'));
+  home = newHome();
   osHome.dir = home;
-});
-
-afterEach(() => {
-  rmSync(home, { recursive: true, force: true });
 });
 
 const ENDPOINT = 'https://plane.example.com';

--- a/web-ui/test/actions/sync-now.test.ts
+++ b/web-ui/test/actions/sync-now.test.ts
@@ -1,6 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type * as LocalOps from '@akasecurity/local-ops';
@@ -13,7 +12,7 @@ import {
   writeControlPlaneCredential,
 } from '@akasecurity/persistence';
 import { HISTORY_SYNC_PAYLOAD_VERSION } from '@akasecurity/schema';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { syncNow } from '../../app/(app)/settings/actions.ts';
 import {
@@ -24,6 +23,7 @@ import {
   SYNC_PAUSED,
   SYNC_SPAWN_FAILED,
 } from '../../app/lib/action-refusals.ts';
+import { tempHomes } from '../helpers/temp-home.ts';
 
 // `syncNow` is the only action on this surface that starts a PROCESS, and the
 // three things worth asserting about it all follow from that: it must not start
@@ -56,6 +56,11 @@ vi.mock('@akasecurity/local-ops', async (importActual) => {
     },
   };
 });
+
+// Homes are removed when this FILE finishes, not after each test: the store
+// app/lib/db.ts opens under them stays open, and Windows will not delete a
+// directory a handle still holds. See the helper.
+const newHome = tempHomes('aka-web-sync-now-');
 
 let home: string;
 
@@ -100,14 +105,10 @@ function openBreaker(openedAtMs: number): void {
 }
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'aka-web-sync-now-'));
+  home = newHome();
   osHome.dir = home;
   spawn.bases = [];
   spawn.result = { started: true };
-});
-
-afterEach(() => {
-  rmSync(home, { recursive: true, force: true });
 });
 
 describe('syncNow', () => {

--- a/web-ui/test/helpers/temp-home.test.ts
+++ b/web-ui/test/helpers/temp-home.test.ts
@@ -1,0 +1,95 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const TEST_ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * Every `afterEach` body in a file, as source text.
+ *
+ * Brace-matched from the hook's opening `{` rather than regexed to the first
+ * `}`, so a nested block inside the hook does not end it early. Crude on
+ * purpose: this guard reads source rather than running it, and a reader should
+ * be able to see exactly how much it can and cannot see.
+ */
+/** Every `*.test.ts` under `dir`, recursively. Plain node:fs — a guard that
+ * needed a dependency to read the tree would be one more thing to keep. */
+function testFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...testFiles(full));
+    else if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.test.tsx')) out.push(full);
+  }
+  return out;
+}
+
+function afterEachBodies(source: string): string[] {
+  const bodies: string[] = [];
+  for (
+    let at = source.indexOf('afterEach(');
+    at !== -1;
+    at = source.indexOf('afterEach(', at + 1)
+  ) {
+    const open = source.indexOf('{', at);
+    if (open === -1) continue;
+    let depth = 0;
+    for (let i = open; i < source.length; i += 1) {
+      if (source[i] === '{') depth += 1;
+      else if (source[i] === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          bodies.push(source.slice(open, i + 1));
+          break;
+        }
+      }
+    }
+  }
+  return bodies;
+}
+
+describe('a suite that redirects the home', () => {
+  // The bug this pins, in full: anything these suites render opens the local
+  // store under whichever home was current, and app/lib/db.ts holds that handle
+  // for the process. A per-test removal of that directory is silently fine on
+  // POSIX — the files are unlinked and the open handle keeps serving them — and
+  // refused outright on Windows, where rmSync raises EPERM and the suite fails
+  // in its own teardown naming a cleanup line and no test.
+  //
+  // Only the FIRST suite in a worker to open a store can fail that way, so the
+  // failure moves between files as import order changes. That is exactly why
+  // this is a guard and not a fix in one suite.
+  it('never removes a directory tree from an afterEach', () => {
+    const files = testFiles(TEST_ROOT);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = readFileSync(file, 'utf-8');
+      // Only suites that redirect the home can put a store inside a temp tree.
+      if (!source.includes('homedir: () =>')) continue;
+      for (const body of afterEachBodies(source)) {
+        if (/rmSync\([^)]*recursive:\s*true/.test(body)) {
+          offenders.push(file.slice(TEST_ROOT.length));
+        }
+      }
+    }
+
+    // The exit, named in the failure rather than left for the reader to find.
+    expect(
+      offenders,
+      'Remove the tree when the FILE finishes instead, via tempHomes() in ' +
+        'test/helpers/temp-home.ts — it releases the store first, in the same hook. ' +
+        'See akasecurity/ai-tc#486.',
+    ).toEqual([]);
+  });
+
+  it('has suites that actually redirect it, so the scan above is not vacuous', () => {
+    // Without this the guard passes just as well on a tree where nothing matches
+    // its precondition — which is how a guard stops guarding without going red.
+    const files = testFiles(TEST_ROOT);
+    const redirecting = files.filter((f) => readFileSync(f, 'utf-8').includes('homedir: () =>'));
+    expect(redirecting.length).toBeGreaterThan(10);
+  });
+});

--- a/web-ui/test/helpers/temp-home.ts
+++ b/web-ui/test/helpers/temp-home.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterAll } from 'vitest';
+
+/**
+ * Temp directories for a suite that redirects `homedir()`, removed when the FILE
+ * finishes rather than after each test.
+ *
+ * Anything such a suite renders opens the local store under whichever home was
+ * current, and `app/lib/db.ts` holds that handle for the life of the process.
+ * Removing the directory while it is still held is invisible on POSIX — the
+ * files are unlinked and the open handle goes on serving them — and an outright
+ * refusal on Windows, where `rmSync` raises EPERM and the suite fails in its own
+ * teardown, naming a cleanup line and no test.
+ *
+ * Deferring to `afterAll` is what makes hook ORDER stop mattering: the store is
+ * released and the directories removed inside one hook, in that order. Splitting
+ * them across two hooks does not work — vitest's `sequence.hooks` defaults to
+ * `stack`, so a suite's own `afterEach` runs BEFORE one a setup file registered,
+ * and the removal would still go first.
+ *
+ * Every test still gets its own directory, so isolation is unchanged. All that
+ * moves is when the bytes go away.
+ */
+/**
+ * Let go of the store `app/lib/db.ts` holds, so the directory it lives in can be
+ * removed.
+ *
+ * Dynamic, and only ever called from a teardown: a static import would load that
+ * module — and @akasecurity/persistence beneath it — before a suite's own
+ * `vi.mock('node:os')` is installed, so persistence would bind the real
+ * homedir() and every redirect in the file would quietly stop working.
+ */
+export async function releaseLocalStore(): Promise<void> {
+  const { closeStore } = await import('../../app/lib/db.ts');
+  closeStore();
+}
+
+export function tempHomes(prefix: string): () => string {
+  const made: string[] = [];
+
+  afterAll(async () => {
+    // Released first, then removed — one hook, explicit order.
+    await releaseLocalStore();
+    for (const dir of made.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  return () => {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    made.push(dir);
+    return dir;
+  };
+}

--- a/web-ui/test/lib/close-store.test.ts
+++ b/web-ui/test/lib/close-store.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { openLocalDatabase } from '@akasecurity/persistence';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { closeStore, db } from '../../app/lib/db.ts';
+
+/** The module's cache, reached the way the module itself reaches it. */
+const cache = globalThis as unknown as { __akaDb?: unknown };
+
+const dirs: string[] = [];
+function tempStoreDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'aka-close-store-'));
+  dirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  closeStore();
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// `closeStore()` is the whole mechanism behind test/helpers/temp-home.ts: the
+// directories are removed only once it has run. A close that quietly failed to
+// release the handle would leave the teardown green here and the Windows leg red,
+// which is precisely the failure this change exists to remove — so the assertions
+// below are about the HANDLE, not about the function returning.
+describe('closeStore', () => {
+  it('actually closes the handle, rather than merely forgetting it', async () => {
+    // The load-bearing one. A body of `store.__akaDb = undefined` with no close
+    // passes every other case in this file and ships the original bug.
+    const held = openLocalDatabase(join(tempStoreDir(), 'data'));
+    cache.__akaDb = held;
+
+    // `transaction()` opens a real SQLite transaction on the handle, so it is
+    // the one surface here that cannot answer on a closed one. The read paths
+    // are fail-open by design and would return the same either way, which is
+    // exactly why they cannot tell a release from a dropped reference.
+    await expect(held.transaction(() => 1)).resolves.toBe(1);
+
+    closeStore();
+
+    expect(cache.__akaDb).toBeUndefined();
+    await expect(held.transaction(() => 1)).rejects.toThrow();
+  });
+
+  it('leaves nothing cached, so the next db() has to open its own', () => {
+    const held = openLocalDatabase(join(tempStoreDir(), 'data'));
+    cache.__akaDb = held;
+
+    closeStore();
+    // Not asserted through db() itself: that would resolve a path this test does
+    // not control and open a store under the real home. An empty cache is the
+    // precondition db() reads, and it is the part this function owns.
+    expect(cache.__akaDb).toBeUndefined();
+    expect(db).toBeTypeOf('function');
+  });
+
+  it('calls close on the handle it lets go of', () => {
+    // The narrowest statement of the same property, with no store involved: a
+    // body that only cleared the cache would satisfy every assertion in this
+    // file except this one and the transaction above.
+    let closed = false;
+    cache.__akaDb = {
+      close() {
+        closed = true;
+      },
+    };
+
+    closeStore();
+
+    expect(closed).toBe(true);
+    expect(cache.__akaDb).toBeUndefined();
+  });
+
+  it('is a no-op when nothing is held', () => {
+    // The teardown runs after EVERY test, including the many that never open a
+    // store. Throwing there would turn one suite's red into the whole file's.
+    expect(cache.__akaDb).toBeUndefined();
+    expect(() => {
+      closeStore();
+      closeStore();
+    }).not.toThrow();
+  });
+
+  it('clears the cache even when the close itself throws', () => {
+    // Cleanup must not strand a dead handle as the live one: whatever went wrong
+    // with this close, the next db() has to be free to open a working store.
+    cache.__akaDb = {
+      close() {
+        throw new Error('already closed');
+      },
+    };
+
+    expect(() => {
+      closeStore();
+    }).not.toThrow();
+    expect(cache.__akaDb).toBeUndefined();
+  });
+});

--- a/web-ui/test/pages/settings-page.test.ts
+++ b/web-ui/test/pages/settings-page.test.ts
@@ -1,6 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
 import type * as NodeOs from 'node:os';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import type * as Persistence from '@akasecurity/persistence';
@@ -10,11 +8,12 @@ import {
   writeControlPlaneCredential,
 } from '@akasecurity/persistence';
 import type { ComponentProps, ReactElement } from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import SettingsPage from '../../app/(app)/settings/page.tsx';
 import { SettingsClient } from '../../app/(app)/settings/SettingsClient.tsx';
 import { expectNoEchoOf } from '../helpers/no-echo.ts';
+import { tempHomes } from '../helpers/temp-home.ts';
 
 type ReadEffectiveArgs = Parameters<typeof Persistence.readEffectiveSettings>;
 
@@ -62,6 +61,11 @@ vi.mock('@akasecurity/persistence', async (importActual) => {
 
 const NOW = '2026-02-02T00:00:00.000Z';
 
+// Homes are removed when this FILE finishes, not after each test: the store
+// app/lib/db.ts opens under them stays open, and Windows will not delete a
+// directory a handle still holds. See the helper.
+const newHome = tempHomes('aka-settings-page-');
+
 let home: string;
 
 /** The AKA home inside the redirected HOME — what every writer here takes as
@@ -69,14 +73,10 @@ let home: string;
 const akaHome = (): string => join(home, '.aka');
 
 beforeEach(() => {
-  home = mkdtempSync(join(tmpdir(), 'aka-settings-page-'));
+  home = newHome();
   osHome.dir = home;
   managedSource.calls = 0;
   managedSource.override = null;
-});
-
-afterEach(() => {
-  rmSync(home, { recursive: true, force: true });
 });
 
 type ClientProps = ComponentProps<typeof SettingsClient>;

--- a/web-ui/test/pages/updates-page.test.ts
+++ b/web-ui/test/pages/updates-page.test.ts
@@ -9,6 +9,8 @@ import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import { Children, isValidElement } from 'react';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { releaseLocalStore } from '../helpers/temp-home.ts';
+
 // The Updates route derives ONE line per component and hands it to a confirm
 // dialog that introduces it with "This runs the following command on this
 // machine". For the CLI that line depends on how this copy was installed, and
@@ -75,7 +77,11 @@ beforeEach(() => {
   osHome.dir = tempDir('aka-web-updates-home-');
 });
 
-afterAll(() => {
+afterAll(async () => {
+  // The store app/lib/db.ts opened under one of these homes is still held, and
+  // Windows will not remove a directory a handle has open. Removing at afterAll
+  // was already right; releasing first is what makes it work there too.
+  await releaseLocalStore();
   for (const dir of temps) rmSync(dir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
Closes #486.

`app/lib/db.ts` holds the store it opens for the life of the process, and the suites here redirect `homedir()` to a directory they remove again. Anything such a suite renders opens that store under the current home, so the removal runs with a handle still inside it.

POSIX unlinks the files and the open handle goes on serving them, which is why this was invisible. Windows refuses outright, and the suite fails in its own teardown naming a cleanup line and no test:

```
Error: EPERM, Permission denied: \\?\C:\...\Temp\aka-settings-page-XXXXXX
  { errno: 1, code: 'EPERM', syscall: 'rm' }
  ❯ test/pages/settings-page.test.ts:79:3
```

## Why this is a helper and a guard, not a fix in one suite

Only the **first** suite in a worker to open a store leaves a handle in its own home; every later one removes a home with nothing open in it. So exactly one test in one file fails, and **which one moves with import order**. Fixing the suite that happens to be red today just relocates the failure.

Verified rather than assumed — a probe inside `db()` during the failing suite prints the directory it opens:

```
db() opened: /var/folders/.../T/aka-settings-page-VWSBAP/.aka/data
```

and a second probe in that suite's own `afterEach` shows the handle still held for tests 5 through 11, never 1 through 4.

## The shape

`tempHomes()` hands out the same per-test directory and defers every removal to one `afterAll` that releases the store first. **One hook, explicit order** — splitting the release and the removal across two hooks does not work, because `sequence.hooks` defaults to `stack` and a suite's own `afterEach` runs *before* one a setup file registered. I measured that before abandoning it:

```
6 held_at_rmSync=false
5 held_at_rmSync=true
```

Isolation is unchanged: each test still gets its own home. All that moves is when the bytes go away.

Five suites removed their home (`settings-page`, `updates-page`, `sync-now`, `settings`, `connection`); the rest never did. `updates-page` already removed at `afterAll` and only needed the release.

## The one production change

`closeStore()`, additive. It clears the cache **before** the close, so a close that throws cannot leave a dead handle recorded as the live one. `db()` itself is untouched.

Deliberately **not** keying `db()`'s memo on the resolved path: that fixes the separate cross-home reuse but costs a cold open on every store-touching test, on the slowest leg. Measured on this package's own `openLocalDatabase`:

| | p50 |
| --- | ---: |
| cold open (fresh dir — migrations + seed) | 15.7 ms |
| warm reopen | 2.1 ms |

That is a separate change with its own tradeoff, and it belongs in its own PR.

## Tests

`test/helpers/temp-home.test.ts` fails the package when a suite that redirects the home removes a tree from an `afterEach`, names the offending file and names the exit. It carries a non-vacuity case (>10 files must redirect) so it cannot quietly stop guarding. Verified by reintroducing the removal to `settings-page`: red, naming the file.

`test/lib/close-store.test.ts` covers `closeStore()` behaviourally — added in review, after the reliability lens correctly pointed out that the load-bearing mechanism had no test and the teardown would only have gone red if it *threw*, not if it failed to release.

Note for anyone asserting on a released handle: `purgeSampleData()` and the read paths are **fail-open** and answer identically on a closed handle. `transaction()` is the one surface that rejects. (`UNSAFE_TEST_ONLY_RAW_HANDLE` is not re-exported from the package root, so it resolves to `undefined` here.)

### Mutation evidence

| mutation | result |
| --- | ---: |
| clears the cache but never calls `close` | **2 red** |
| closes but leaves the dead handle cached | **5 red** |
| drops the try/catch around the close | **1 red** |
| a suite reintroduces the per-test removal | **guard red**, names the file |

## Verification

```
pnpm --filter @akasecurity/web-ui test    876 passed (876), 56 files
turbo lint typecheck --filter=web-ui      22 tasks, clean
```

Run `pnpm --filter @akasecurity/web-ui build:worker` first — without `dist/scan-worker.js`, four unrelated cases fail on the missing artifact on `main` too.