### PR TITLE
feat(dashboard-ui): one search field with a clear button, for both dashboards

### DIFF
--- a/packages/dashboard-ui/src/activity/SessionListView.tsx
+++ b/packages/dashboard-ui/src/activity/SessionListView.tsx
@@ -8,15 +8,9 @@ import type { ActivitySessionSummary, Harness } from '@akasecurity/schema';
 import { Button, cn, Skeleton } from '@akasecurity/ui-kit';
 
 import { relativeTime } from '../lib/relativeTime.ts';
-import {
-  BranchIcon,
-  ClockIcon,
-  ListIcon,
-  RepoIcon,
-  SearchIcon,
-  ShieldCheckIcon,
-} from '../shared/icons.tsx';
+import { BranchIcon, ClockIcon, ListIcon, RepoIcon, ShieldCheckIcon } from '../shared/icons.tsx';
 import { Provider } from '../shared/Provider.tsx';
+import { SearchField } from '../shared/SearchField.tsx';
 import { WidgetError } from '../shared/widget-state.tsx';
 import { Metric, StatusDot } from './atoms.tsx';
 import { durationLabel, groupSessionsByDay } from './format.ts';
@@ -173,18 +167,15 @@ export function SessionListView({
   return (
     <div className="flex h-full min-h-0 flex-col">
       <div className="shrink-0 border-b border-border p-3">
-        <div className="mb-2 flex h-8.5 items-center gap-2 rounded-lg border border-border-field bg-surface-2 px-2.5 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40">
-          <SearchIcon aria-hidden focusable={false} className="size-3.5 shrink-0 text-text-3" />
-          <input
-            value={query}
-            onChange={(e) => {
-              onQuery(e.target.value);
-            }}
-            placeholder="Search sessions & events…"
-            aria-label="Search sessions and events"
-            className="min-w-0 flex-1 bg-transparent text-sm text-text placeholder:text-text-3 focus:outline-hidden"
-          />
-        </div>
+        <SearchField
+          value={query}
+          onValueChange={onQuery}
+          label="Search sessions and events"
+          placeholder="Search sessions & events…"
+          surface="card"
+          className="mb-2 h-8.5 px-2.5"
+          iconClassName="size-3.5"
+        />
         <HarnessSelect
           value={harness}
           onChange={onHarness}

--- a/packages/dashboard-ui/src/detections/DetectionsListView.tsx
+++ b/packages/dashboard-ui/src/detections/DetectionsListView.tsx
@@ -7,7 +7,8 @@
 import type { DetectionListItem } from '@akasecurity/schema';
 import { Card } from '@akasecurity/ui-kit';
 
-import { ArrowUpIcon, SearchIcon } from '../shared/icons.tsx';
+import { ArrowUpIcon } from '../shared/icons.tsx';
+import { SearchField } from '../shared/SearchField.tsx';
 import { OriginBadge, PolicyTag, UpdateBadge } from './atoms.tsx';
 import { PLACEHOLDER_POLICY } from './meta.ts';
 import type { DetectionPolicyFloor } from './policy-floor.ts';
@@ -114,22 +115,14 @@ export function DetectionsListView({
   return (
     <Card className="flex flex-col overflow-hidden shadow-sm">
       <div className="border-b border-border p-3">
-        <div className="relative">
-          <SearchIcon
-            aria-hidden
-            focusable={false}
-            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3"
-          />
-          <input
-            value={query}
-            onChange={(ev) => {
-              onQueryChange(ev.target.value);
-            }}
-            spellCheck={false}
-            placeholder="Search detections…"
-            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
-          />
-        </div>
+        <SearchField
+          value={query}
+          onValueChange={onQueryChange}
+          label="Search detections"
+          placeholder="Search detections…"
+          surface="card"
+          className="h-9"
+        />
         <div className="mt-2.5 flex flex-wrap gap-1.5">
           {filterTabs.map(([k, lbl]) => {
             const on = filter === k;

--- a/packages/dashboard-ui/src/findings/FindingTypesListView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingTypesListView.tsx
@@ -187,6 +187,11 @@ export function FindingTypesListView({
           onValueChange={onQueryChange}
           label="Search finding types"
           placeholder="Search types…"
+          // Named because the Findings page reaches this and FindingsToolbarView.
+          // The two are mutually exclusive today — this renders on the grouped
+          // view, that one on flat/files — so this is insurance rather than a
+          // fix; web-ui/test/search-field-labels.test.ts errs toward naming.
+          clearLabel="Clear type search"
           surface="card"
           className="h-9"
         />

--- a/packages/dashboard-ui/src/findings/FindingTypesListView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingTypesListView.tsx
@@ -29,7 +29,8 @@ import {
 } from '@akasecurity/ui-kit';
 import type { ReactNode } from 'react';
 
-import { KeyIcon, SearchIcon } from '../shared/icons.tsx';
+import { KeyIcon } from '../shared/icons.tsx';
+import { SearchField } from '../shared/SearchField.tsx';
 import { CATEGORY_ICON_FALLBACK, categoryLabel, categoryStyle, SEVERITIES } from './meta.ts';
 
 /**
@@ -181,24 +182,14 @@ export function FindingTypesListView({
   return (
     <Card className="flex h-full flex-col overflow-hidden shadow-sm">
       <div className="border-b border-border p-3">
-        <div className="relative">
-          <SearchIcon
-            aria-hidden
-            focusable={false}
-            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3"
-          />
-          <input
-            type="text"
-            aria-label="Search finding types"
-            value={query}
-            onChange={(ev) => {
-              onQueryChange(ev.target.value);
-            }}
-            spellCheck={false}
-            placeholder="Search types…"
-            className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
-          />
-        </div>
+        <SearchField
+          value={query}
+          onValueChange={onQueryChange}
+          label="Search finding types"
+          placeholder="Search types…"
+          surface="card"
+          className="h-9"
+        />
         <SeverityFilter
           counts={severityCounts}
           selected={selectedSeverities}

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -3,8 +3,9 @@
 import type { FindingFacets, FindingProvider } from '@akasecurity/schema';
 import { cn, Popover, PopoverContent, PopoverTrigger } from '@akasecurity/ui-kit';
 
-import { CheckIcon, ChevronDownIcon, SearchIcon } from '../shared/icons.tsx';
+import { CheckIcon, ChevronDownIcon } from '../shared/icons.tsx';
 import { PROVIDERS } from '../shared/Provider.tsx';
+import { SearchField } from '../shared/SearchField.tsx';
 import { FINDING_STATUS_META, FINDING_STATUSES, type FindingsFilters, SEVERITIES } from './meta.ts';
 
 const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
@@ -159,19 +160,14 @@ export function FindingsToolbarView({
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <div className="relative w-64">
-        <SearchIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3" />
-        <input
-          type="text"
-          aria-label="Search findings"
-          placeholder="Search findings…"
-          value={query}
-          onChange={(e) => {
-            onQueryChange(e.target.value);
-          }}
-          className="h-9 w-full rounded-lg border border-border-field bg-surface pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
-        />
-      </div>
+      <SearchField
+        value={query}
+        onValueChange={onQueryChange}
+        label="Search findings"
+        placeholder="Search findings…"
+        surface="canvas"
+        className="h-9 w-64"
+      />
       <MultiSelectFilter
         label="Severity"
         options={severityOptions}

--- a/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
+++ b/packages/dashboard-ui/src/findings/FindingsToolbarView.tsx
@@ -165,6 +165,8 @@ export function FindingsToolbarView({
         onValueChange={onQueryChange}
         label="Search findings"
         placeholder="Search findings…"
+        // See FindingTypesListView — same page, same reason.
+        clearLabel="Clear findings search"
         surface="canvas"
         className="h-9 w-64"
       />

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -38,7 +38,7 @@ export {
 export { PageHead } from './shared/PageHead.tsx';
 export { Provider, type ProviderId, type ProviderMeta, PROVIDERS } from './shared/Provider.tsx';
 export { ScrubbedValue } from './shared/ScrubbedValue.tsx';
-export { SearchField } from './shared/SearchField.tsx';
+export { type FieldSurface, SearchField } from './shared/SearchField.tsx';
 export {
   type StatTone,
   type SummaryStatItem,

--- a/packages/dashboard-ui/src/index.ts
+++ b/packages/dashboard-ui/src/index.ts
@@ -38,6 +38,7 @@ export {
 export { PageHead } from './shared/PageHead.tsx';
 export { Provider, type ProviderId, type ProviderMeta, PROVIDERS } from './shared/Provider.tsx';
 export { ScrubbedValue } from './shared/ScrubbedValue.tsx';
+export { SearchField } from './shared/SearchField.tsx';
 export {
   type StatTone,
   type SummaryStatItem,

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -142,6 +142,11 @@ export function InventoryNav(props: InventoryNavProps) {
           onValueChange={onQuery}
           label="Search assets"
           placeholder="Search assets…"
+          // Named, not defaulted: ProjectPane renders a second search field
+          // beside this one whenever a project is selected, and two buttons
+          // both called "Clear search" say nothing about which field each
+          // empties. web-ui/test/search-field-labels.test.ts holds the pair.
+          clearLabel="Clear asset search"
           surface="card"
           className="h-8.5"
         />

--- a/packages/dashboard-ui/src/inventory/InventoryNav.tsx
+++ b/packages/dashboard-ui/src/inventory/InventoryNav.tsx
@@ -17,6 +17,7 @@ import { Badge, Card, cn, SegmentedControl, SegmentedControlItem } from '@akasec
 import { useMemo } from 'react';
 
 import { Provider } from '../shared/Provider.tsx';
+import { SearchField } from '../shared/SearchField.tsx';
 import { AccessBar, EmptyState, FlagChips, TrustPill, VisBadge } from './chips.tsx';
 import {
   ASSET_META,
@@ -136,20 +137,14 @@ export function InventoryNav(props: InventoryNavProps) {
           )}
         </div>
 
-        <div className="relative">
-          <Ico
-            name="search"
-            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3"
-          />
-          <input
-            value={query}
-            onChange={(e) => {
-              onQuery(e.target.value);
-            }}
-            placeholder="Search assets…"
-            className="h-8.5 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
-          />
-        </div>
+        <SearchField
+          value={query}
+          onValueChange={onQuery}
+          label="Search assets"
+          placeholder="Search assets…"
+          surface="card"
+          className="h-8.5"
+        />
 
         <SegmentedControl
           className="mt-3 flex w-full"

--- a/packages/dashboard-ui/src/inventory/ProjectPane.tsx
+++ b/packages/dashboard-ui/src/inventory/ProjectPane.tsx
@@ -168,6 +168,9 @@ function SearchBox({ proj, query, onQueryChange }: ProjectPaneProps) {
       onValueChange={onQueryChange}
       label={`Search files in ${proj.name}`}
       placeholder={`Search files in ${proj.name}…`}
+      // Named for the same reason InventoryNav's is — the two render side by
+      // side, so the default would name both identically.
+      clearLabel={`Clear file search in ${proj.name}`}
       surface="card"
       className="h-9 w-70 shrink-0"
     />

--- a/packages/dashboard-ui/src/inventory/ProjectPane.tsx
+++ b/packages/dashboard-ui/src/inventory/ProjectPane.tsx
@@ -26,6 +26,7 @@ import {
 } from '@akasecurity/ui-kit';
 import { Fragment } from 'react';
 
+import { SearchField } from '../shared/SearchField.tsx';
 import { AccessBar, AccessControl, AccessLabel, OriginTag, VisBadge } from './chips.tsx';
 import { ACCESS, ACCESS_ORDER, fmtDateTime, rationale } from './data.ts';
 import { Ico } from './Ico.tsx';
@@ -162,29 +163,14 @@ export function ProjectPane(props: ProjectPaneProps) {
 
 function SearchBox({ proj, query, onQueryChange }: ProjectPaneProps) {
   return (
-    <div className="relative w-70 shrink-0">
-      <Ico name="search" className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-text-3" />
-      <input
-        value={query}
-        onChange={(e) => {
-          onQueryChange(e.target.value);
-        }}
-        placeholder={`Search files in ${proj.name}…`}
-        className="h-9 w-full rounded-lg border border-border-field bg-surface-2 pl-9 pr-8 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
-      />
-      {query && (
-        <button
-          type="button"
-          aria-label="Clear search"
-          onClick={() => {
-            onQueryChange('');
-          }}
-          className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 text-text-3 hover:text-text"
-        >
-          <Ico name="x" className="size-3.5" />
-        </button>
-      )}
-    </div>
+    <SearchField
+      value={query}
+      onValueChange={onQueryChange}
+      label={`Search files in ${proj.name}`}
+      placeholder={`Search files in ${proj.name}…`}
+      surface="card"
+      className="h-9 w-70 shrink-0"
+    />
   );
 }
 

--- a/packages/dashboard-ui/src/shared/SearchField.tsx
+++ b/packages/dashboard-ui/src/shared/SearchField.tsx
@@ -1,0 +1,146 @@
+'use client';
+// The one search box both products render. Every search surface in the OSS
+// dashboard and the enterprise dashboard goes through this, so the things a
+// search box owes its user are decided once rather than once per call site:
+//
+//  - a CLEAR affordance, shown only while there is something to clear, on a
+//    target big enough to hit;
+//  - Escape as its keyboard equal, so clearing is not a Tab away;
+//  - a focus indicator that survives the input suppressing its own outline;
+//  - focus that stays put when the clear button removes itself.
+//
+// Props-driven and bundler-agnostic like the rest of this package — the host
+// owns the query state (debounced, URL-backed or plain local) and this renders it.
+import { cn } from '@akasecurity/ui-kit';
+import { useRef } from 'react';
+
+import { SearchIcon, XIcon } from './icons.tsx';
+
+/**
+ * What the field is sitting ON, which is the only thing that decides its fill:
+ * a fill equal to the surface under it leaves the border drawing a rectangle
+ * against its own colour. `card` covers Card, DialogContent and SheetContent
+ * (all `bg-surface`); `canvas` is the page itself, where `--color-canvas` and
+ * `--color-surface-2` are the same hex in light and a `bg-surface-2` field
+ * would have no fill of its own.
+ */
+export type FieldSurface = 'card' | 'canvas';
+
+/**
+ * The edge and the fill, resolved from that one choice rather than retyped per
+ * call site. `border-border-field` is the edge: `border-border` measures 1.26:1
+ * light and 1.42:1 dark, under the 3:1 a control boundary is asked for.
+ * theme/field-boundary.test.ts pins both halves here.
+ */
+const SURFACE_CLASS: Record<FieldSurface, string> = {
+  card: 'rounded-lg border border-border-field bg-surface-2',
+  canvas: 'rounded-lg border border-border-field bg-surface',
+};
+
+export function SearchField({
+  value,
+  onValueChange,
+  label,
+  placeholder,
+  surface,
+  className,
+  iconClassName,
+  clearLabel = 'Clear search',
+}: {
+  value: string;
+  onValueChange: (next: string) => void;
+  /**
+   * The input's accessible name. Required rather than defaulted: a page with
+   * two search boxes needs them told apart, and a default would name both.
+   */
+  label: string;
+  placeholder: string;
+  /** Which surface the field sits on — see `FieldSurface`. */
+  surface: FieldSurface;
+  /**
+   * This field's own GEOMETRY, and only that — `h-9`, `w-64`, `flex-1`,
+   * `shrink-0`, a margin. The edge and the fill come from `surface`, so a call
+   * site cannot put one of them back on `border-border` by hand.
+   */
+  className?: string;
+  /** Sizes the leading glyph where a denser control wants a smaller one. */
+  iconClassName?: string;
+  /**
+   * Overridden where "search" is not what the box is called — the accessible
+   * name of a control that appears and disappears should say what it clears.
+   */
+  clearLabel?: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const clear = () => {
+    onValueChange('');
+    // Clearing unmounts the button, and a focused element that disappears drops
+    // focus to <body> — which strands a keyboard user at the top of the
+    // document. Hand it back to the input, which is where they were and where
+    // they want to keep typing. Harmless when Escape got here: focus is already
+    // on the input.
+    inputRef.current?.focus();
+  };
+
+  return (
+    // The focus ring sits HERE rather than on the input, so it wraps the whole
+    // control — glyph, text and clear button — and so it is still drawn while
+    // the input suppresses its own outline. An input that suppresses the native
+    // outline and puts nothing back is a control whose focus is invisible.
+    <div
+      className={cn(
+        'flex items-center gap-2 px-3 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
+        SURFACE_CLASS[surface],
+        className,
+      )}
+    >
+      <SearchIcon
+        aria-hidden
+        focusable={false}
+        className={cn('size-4 shrink-0 text-text-3', iconClassName)}
+      />
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(ev) => {
+          onValueChange(ev.target.value);
+        }}
+        onKeyDown={(ev) => {
+          // `type="search"` would give this natively, but it also injects a
+          // second, browser-drawn clear button beside ours. So the type stays
+          // `text` and the shortcut is supplied here — otherwise clearing costs
+          // a keyboard user a Tab where a pointer user gets one click.
+          if (ev.key === 'Escape' && value !== '') {
+            // Nothing above this listens for Escape today; stopping it here
+            // keeps a later Dialog or Sheet ancestor from also closing on the
+            // keystroke that was meant for the field.
+            ev.preventDefault();
+            ev.stopPropagation();
+            clear();
+          }
+        }}
+        // A query is a proper noun about as often as it is a word; the red
+        // underline under a rule id or a hostname is noise either way.
+        spellCheck={false}
+        placeholder={placeholder}
+        aria-label={label}
+        className="min-w-0 flex-1 bg-transparent text-sm text-text placeholder:text-text-3 focus:outline-hidden"
+      />
+      {value !== '' && (
+        <button
+          type="button"
+          aria-label={clearLabel}
+          onClick={clear}
+          // `size-6` is the target, `size-3.5` the glyph inside it: WCAG 2.5.8
+          // asks for 24x24 CSS px, and a button sized to its own icon is 14.
+          // The field is h-8.5 at its densest, so 24 fits without growing it.
+          className="grid size-6 shrink-0 cursor-pointer place-items-center rounded text-text-3 hover:text-text focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          <XIcon aria-hidden focusable={false} className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/dashboard-ui/src/shared/SearchField.tsx
+++ b/packages/dashboard-ui/src/shared/SearchField.tsx
@@ -59,15 +59,26 @@ export function SearchField({
   surface: FieldSurface;
   /**
    * This field's own GEOMETRY, and only that — `h-9`, `w-64`, `flex-1`,
-   * `shrink-0`, a margin. The edge and the fill come from `surface`, so a call
-   * site cannot put one of them back on `border-border` by hand.
+   * `shrink-0`, a margin.
+   *
+   * A `border-*` or `bg-*` token passed here does NOT take effect: the merge
+   * below puts `surface` last and tailwind-merge is last-wins, so the edge and
+   * the fill are not reachable from a call site. That is a property of the
+   * merge ORDER rather than of this sentence — see the comment on the `cn`
+   * call, which is where it is decided and where it can be undone.
    */
   className?: string;
   /** Sizes the leading glyph where a denser control wants a smaller one. */
   iconClassName?: string;
   /**
-   * Overridden where "search" is not what the box is called — the accessible
-   * name of a control that appears and disappears should say what it clears.
+   * The clear button's accessible name.
+   *
+   * It defaults, and the default is safe only while ONE search field is on the
+   * page: two fields both taking it leaves a screen-reader user hearing "Clear
+   * search, button" twice with nothing saying which field each one empties.
+   * That is the same ambiguity `label` is required to prevent, one control
+   * over, so a page rendering two fields must pass this on both.
+   * web-ui/test/search-field-labels.test.ts derives which pages those are.
    */
   clearLabel?: string;
 }) {
@@ -91,8 +102,19 @@ export function SearchField({
     <div
       className={cn(
         'flex items-center gap-2 px-3 focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
-        SURFACE_CLASS[surface],
+        // `className` sits BEFORE the surface, and the order is the whole of
+        // what makes the `className` docblock true. `cn` is tailwind-merge,
+        // which resolves a conflict LAST-WINS — so with the surface last, a
+        // call site passing `border-border` or `bg-surface` loses to it rather
+        // than replacing it. Geometry is unaffected either way, because it
+        // conflicts with nothing in either of the other two strings.
+        //
+        // Reordering these two lines silently puts the edge back in the call
+        // site's hands, and no rendered assertion in this repo would notice:
+        // `surface="card"` stays intact, so the call-site table still passes.
+        // theme/field-boundary.test.ts pins the order for that reason.
         className,
+        SURFACE_CLASS[surface],
       )}
     >
       <SearchIcon

--- a/packages/dashboard-ui/test/shared/SearchField.test.tsx
+++ b/packages/dashboard-ui/test/shared/SearchField.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+//
+// The clear button is why this suite needs a DOM. Its properties are all about
+// what happens AFTER a click — the callback, the re-render, and where focus
+// lands once the button has removed itself — and a server render sees none of
+// them. The environment is opted into per file, as this package's
+// vitest.config.ts asks.
+import { act, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SearchField } from '../../src/shared/SearchField.tsx';
+
+/**
+ * A host that owns the query the way every real call site does — controlled,
+ * with the field rendering what the parent last set. Clearing is only
+ * observable through a re-render, so a test that passed a fixed `value` would
+ * assert on markup the clear could never change.
+ */
+function Host({
+  initial,
+  onChange,
+  clearLabel,
+}: {
+  initial: string;
+  onChange?: (next: string) => void;
+  clearLabel?: string;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <SearchField
+      value={value}
+      onValueChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+      label="Search assets"
+      placeholder="Search assets…"
+      surface="card"
+      {...(clearLabel === undefined ? {} : { clearLabel })}
+    />
+  );
+}
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement('div');
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  // Unmounted here rather than at the end of a body: a failing assertion would
+  // skip an in-body teardown and leave a live root (and a focused element) in
+  // the document for every case after it.
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+const input = (): HTMLInputElement => {
+  const el = container.querySelector('input');
+  if (el === null) throw new Error('no input rendered');
+  return el;
+};
+const clearButton = (): HTMLButtonElement | null => container.querySelector('button');
+
+function mount(props: Parameters<typeof Host>[0]): void {
+  act(() => {
+    root.render(<Host {...props} />);
+  });
+}
+
+describe('SearchField', () => {
+  // The affordance half. Both directions are asserted: a control that is always
+  // there is as wrong as one that never is, and only the empty case can show
+  // that the button's presence is a function of the value at all.
+  it('offers nothing to clear while the box is empty', () => {
+    mount({ initial: '' });
+    expect(clearButton()).toBeNull();
+  });
+
+  it('offers a clear button once there is a term', () => {
+    mount({ initial: 'aws' });
+    expect(clearButton()?.getAttribute('aria-label')).toBe('Clear search');
+  });
+
+  it('names the clear button after what it clears when the host says so', () => {
+    mount({ initial: 'aws', clearLabel: 'Clear model search' });
+    expect(clearButton()?.getAttribute('aria-label')).toBe('Clear model search');
+  });
+
+  it('reports the empty term and empties the box', () => {
+    const onChange = vi.fn();
+    mount({ initial: 'aws', onChange });
+
+    act(() => {
+      clearButton()?.click();
+    });
+
+    expect(onChange).toHaveBeenCalledWith('');
+    expect(input().value).toBe('');
+    // The button is gone with the term it cleared — the first case's property,
+    // reached the other way round.
+    expect(clearButton()).toBeNull();
+  });
+
+  // The property the button's own disappearance puts at risk. A focused element
+  // that unmounts drops focus to <body>, which strands a keyboard user at the
+  // top of the document with the search they were editing behind them.
+  it('hands focus back to the input after clearing', () => {
+    mount({ initial: 'aws' });
+
+    const button = clearButton();
+    act(() => {
+      button?.focus();
+    });
+    // The positive control: without it, an implementation that never moves
+    // focus would read the same as one that moves it correctly, because focus
+    // would have been on the input the whole time.
+    expect(document.activeElement).toBe(button);
+
+    act(() => {
+      button?.click();
+    });
+
+    expect(document.activeElement).toBe(input());
+  });
+
+  // Escape is the clear button's keyboard equal. Without it the pointer
+  // affordance is one click and the keyboard one is a Tab away, which is the
+  // gap `type="search"` would have closed natively had it not also drawn a
+  // second clear button of the browser's own.
+  it('clears on Escape', () => {
+    const onChange = vi.fn();
+    mount({ initial: 'aws', onChange });
+
+    act(() => {
+      input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+
+    expect(onChange).toHaveBeenCalledWith('');
+    expect(input().value).toBe('');
+  });
+
+  // An empty box has nothing to clear, so Escape there belongs to whatever is
+  // above — a Dialog or Sheet that closes on it. Swallowing it unconditionally
+  // would trap the user inside a modal whose search box happens to have focus.
+  it('leaves Escape alone while the box is empty', () => {
+    const onChange = vi.fn();
+    mount({ initial: '', onChange });
+
+    const ev = new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true });
+    act(() => {
+      input().dispatchEvent(ev);
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(ev.defaultPrevented).toBe(false);
+  });
+
+  // WCAG 2.5.8 asks for 24x24 CSS px. jsdom does no layout, so the size is
+  // asserted through the utility that sets it: a button sized to its own
+  // `size-3.5` glyph is 14x14, which is what this exists to stop coming back.
+  it('gives the clear button a target bigger than its glyph', () => {
+    mount({ initial: 'aws' });
+    expect(clearButton()?.className).toContain('size-6');
+  });
+
+  // The input's accessible name comes from `label`, never from the placeholder —
+  // a placeholder is not an accessible name, and it is gone from the screen the
+  // moment anything is typed.
+  it('names the input from its label rather than its placeholder', () => {
+    const html = renderToStaticMarkup(
+      <SearchField
+        value=""
+        onValueChange={vi.fn()}
+        label="Search finding types"
+        placeholder="Search types…"
+        surface="card"
+      />,
+    );
+    expect(html).toContain('aria-label="Search finding types"');
+    expect(html).toContain('placeholder="Search types…"');
+  });
+});

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -27,8 +27,18 @@ import { describe, expect, it } from 'vitest';
 // The SEARCH fields are no longer hand-rolled — all six render `SearchField`
 // (shared/SearchField.tsx), and BOTH halves live there: the focus rule, and the
 // edge/fill pair, which `SURFACE_CLASS` resolves from a `surface` prop naming
-// what the field sits on. A call site can no longer put either back on
-// `border-border` by hand, because it never spells them.
+// what the field sits on.
+//
+// A call site cannot put either back on `border-border`, and the reason is the
+// MERGE ORDER rather than the absence of a spelling — `className` is a prop, so
+// a call site can always spell a `border-*` token; what stops it taking effect
+// is that `cn` (tailwind-merge) is last-wins and the surface goes in last. That
+// distinction is not pedantic: the two lines were the other way round when this
+// suite was written, under which `className="border-border"` DID replace the
+// edge, and every assertion in this file passed anyway — the call-site table
+// reads `surface="card"`, which a hostile className leaves untouched, and the
+// edge/fill cases read the component, which it never changes. So the order is
+// pinned below, as the one fact the rest of this file's design rests on.
 //
 // So the six are pinned in ONE place now, and the call-site table below asserts
 // a different thing: which surface each one declares. That is still a per-site
@@ -243,6 +253,18 @@ describe('the field boundary this package draws by hand', () => {
   // theme.css's closing paragraph.
   it('every search field: keeps a focus indicator', () => {
     expect(read(SHARED_FIELD)).toMatch(focusPattern(SHARED_FOCUS));
+  });
+
+  // The order the paragraph above rests on, asserted rather than described.
+  //
+  // Matched as ONE regex spanning both arguments rather than as two `indexOf`
+  // comparisons, so it also fails if something is inserted between them. What
+  // it must catch is the swap: `SURFACE_CLASS[surface]` appearing BEFORE
+  // `className` in the same `cn(...)` call, which is a one-line edit that
+  // reopens the hole with every other assertion here green.
+  it('every search field: merges the surface AFTER className, so the edge wins', () => {
+    expect(read(SHARED_FIELD)).toMatch(/className,\s*SURFACE_CLASS\[surface\],/);
+    expect(read(SHARED_FIELD)).not.toMatch(/SURFACE_CLASS\[surface\],\s*className,/);
   });
 
   // The edge and fill halves, now asserted where they are spelled rather than at

--- a/packages/dashboard-ui/test/theme/field-boundary.test.ts
+++ b/packages/dashboard-ui/test/theme/field-boundary.test.ts
@@ -14,16 +14,32 @@ import { describe, expect, it } from 'vitest';
 // which is compliant and reads as a floating outline.
 //
 // ui-kit's `Input` and `SelectTrigger` carry both in one place, pinned by
-// border-field.test.ts there. The controls below are hand-rolled — a search
-// wrapper around a `bg-transparent` input, a DropdownMenu trigger — so each
-// spells the pair itself and nothing was pinning any of them. That is not a
-// hypothetical gap: five of these six sat on `border-border` while ui-kit's two
-// were correct, and two were missed by a survey that went looking for the other
-// four. Neither miss was about size — `InventoryNav` is `h-8.5` like
-// `SessionListView` and was found. What hid them was SHAPE: SessionListView puts
-// its border on a WRAPPER around a `bg-transparent` input, so a search for
-// bordered `<input>` elements never saw it, and HarnessSelect puts its border
-// COLOUR behind a conditional, so a search for the literal pairing missed that.
+// border-field.test.ts there. The controls below are not those primitives, so
+// each is pinned here. That is not a hypothetical gap: five of the six sat on
+// `border-border` while ui-kit's two were correct, and two were missed by a
+// survey that went looking for the other four. Neither miss was about size —
+// `InventoryNav` is `h-8.5` like `SessionListView` and was found. What hid them
+// was SHAPE: SessionListView put its border on a WRAPPER around a
+// `bg-transparent` input, so a search for bordered `<input>` elements never saw
+// it, and HarnessSelect puts its border COLOUR behind a conditional, so a search
+// for the literal pairing missed that.
+//
+// The SEARCH fields are no longer hand-rolled — all six render `SearchField`
+// (shared/SearchField.tsx), and BOTH halves live there: the focus rule, and the
+// edge/fill pair, which `SURFACE_CLASS` resolves from a `surface` prop naming
+// what the field sits on. A call site can no longer put either back on
+// `border-border` by hand, because it never spells them.
+//
+// So the six are pinned in ONE place now, and the call-site table below asserts
+// a different thing: which surface each one declares. That is still a per-site
+// decision — what makes a fill wrong is the fill of the thing UNDER it, which
+// the component cannot see.
+//
+// Centralizing buys one assertion where there were five and opens one hole in
+// exchange: a call site that goes back to spelling its own `<input>` keeps a
+// correct-looking `surface` fragment while losing the edge, fill and ring
+// together. `renders through the shared field` below is what closes it, and it
+// is the reason the shared half may be asserted once.
 //
 // Both premises these assertions rest on are RESOLVED rather than restated: the
 // container fill is read from ui-kit's `card.tsx`, and the canvas collision from
@@ -115,70 +131,94 @@ function focusPattern(fragment: string): RegExp {
   );
 }
 
+/**
+ * What each call site DECLARES, which is the half that cannot move into the
+ * shared component: the surface it sits on. `shared` says the control renders
+ * through SearchField — whose edge, fill and focus rule are asserted once,
+ * below — rather than spelling an input of its own.
+ */
 const FIELDS: {
   file: string;
   control: string;
   on: 'a Card' | 'the page canvas';
+  /** The `surface` value this call site must declare, or its own edge fragment. */
   edge: string;
-  /** The whole focus treatment, pinned as one fragment — see the loop below. */
-  focus: string;
+  shared: boolean;
+  /** The whole focus treatment, for the controls that still own one. */
+  focus?: string;
   alsoContains?: string;
 }[] = [
   {
     file: 'findings/FindingsToolbarView.tsx',
     control: 'the findings search',
     on: 'the page canvas',
-    edge: 'rounded-lg border border-border-field bg-surface pl-9 pr-3',
-    focus:
-      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
+    edge: 'surface="canvas"',
+    shared: true,
+  },
+  {
+    file: 'findings/FindingTypesListView.tsx',
+    control: 'the finding-types search',
+    on: 'a Card',
+    edge: 'surface="card"',
+    shared: true,
   },
   {
     file: 'detections/DetectionsListView.tsx',
     control: 'the detections search',
     on: 'a Card',
-    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
-    focus:
-      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
+    edge: 'surface="card"',
+    shared: true,
   },
   {
     file: 'inventory/InventoryNav.tsx',
     control: 'the assets search',
     on: 'a Card',
-    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-3',
-    focus:
-      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
+    edge: 'surface="card"',
+    shared: true,
   },
   {
     file: 'inventory/ProjectPane.tsx',
     control: 'the project-files search',
     on: 'a Card',
-    edge: 'rounded-lg border border-border-field bg-surface-2 pl-9 pr-8',
-    focus:
-      'focus:border-primary focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
+    edge: 'surface="card"',
+    shared: true,
   },
   {
     file: 'activity/SessionListView.tsx',
     control: 'the sessions search',
     on: 'a Card',
-    // The border sits on the WRAPPER: the input inside it is bg-transparent, so
-    // this element is the whole visible control and carries both decisions.
-    edge: 'rounded-lg border border-border-field bg-surface-2 px-2.5',
-    focus: 'focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40',
+    edge: 'surface="card"',
+    shared: true,
   },
   {
     file: 'activity/HarnessSelect.tsx',
     control: 'the harness filter',
     on: 'a Card',
-    // Its border COLOUR is conditional — border-border-field at rest, primary
-    // once a subset is chosen — so the fragment carries the fill and the shape,
-    // and the resting colour is pinned as the CONDITIONAL below, not as a token.
+    // The one control here that is still hand-rolled, so it spells the pair
+    // itself. Its border COLOUR is conditional — border-border-field at rest,
+    // primary once a subset is chosen — so the fragment carries the fill and the
+    // shape, and the resting colour is pinned as the CONDITIONAL below, not as a
+    // token.
     edge: 'rounded-lg border bg-surface-2 px-2.5',
+    shared: false,
     alsoContains: "all ? 'border-border-field'",
     focus: 'focus:outline-hidden focus-visible:ring-2 focus-visible:ring-primary/40',
   },
 ];
 
-describe('the hand-rolled field boundary', () => {
+/**
+ * The shared field's own two decisions, in their one home. The edge and fill are
+ * read as the `SURFACE_CLASS` entry each `surface` resolves to, so the table
+ * above pins WHICH surface a call site picked and this pins what that MEANS.
+ */
+const SHARED_FIELD = 'shared/SearchField.tsx';
+const SHARED_FOCUS = 'focus-within:border-primary focus-within:ring-2 focus-within:ring-primary/40';
+const SHARED_EDGE: Record<'a Card' | 'the page canvas', string> = {
+  'a Card': "card: 'rounded-lg border border-border-field bg-surface-2'",
+  'the page canvas': "canvas: 'rounded-lg border border-border-field bg-surface'",
+};
+
+describe('the field boundary this package draws by hand', () => {
   // The FOCUS half. Pinned separately from `edge` because it lives at the far end
   // of the class string and one control expresses it through `focus-within` on a
   // wrapper rather than `focus`/`focus-visible` on the control itself.
@@ -201,23 +241,81 @@ describe('the hand-rolled field boundary', () => {
   // Nor does it assert anything under FORCED COLORS, where the ring's box-shadow
   // and the focused border colour are both discarded — see `focusPattern` and
   // theme.css's closing paragraph.
+  it('every search field: keeps a focus indicator', () => {
+    expect(read(SHARED_FIELD)).toMatch(focusPattern(SHARED_FOCUS));
+  });
+
+  // The edge and fill halves, now asserted where they are spelled rather than at
+  // six call sites. Both surfaces are pinned, because a `surface` declared by a
+  // call site says nothing on its own until this says what it resolves to.
+  for (const [on, entry] of Object.entries(SHARED_EDGE)) {
+    it(`every search field on ${on}: an edge that clears 3:1 and a fill a step off it`, () => {
+      expect(read(SHARED_FIELD)).toContain(entry);
+    });
+
+    it(`every search field on ${on}: its edge is not back on the ordinary border`, () => {
+      expect(read(SHARED_FIELD)).not.toContain(
+        entry.replace('border-border-field', 'border-border'),
+      );
+    });
+  }
+
+  // The fill half, which no token search can express: what makes a fill wrong is
+  // the fill of the thing UNDER it, which is not in the class string. Both
+  // container fills are RESOLVED — ui-kit's Card, and the canvas/surface-2
+  // same-hex identity in theme.css — so the day either stops holding, this stops
+  // asserting a collision that no longer exists.
+  for (const [on, entry] of Object.entries(SHARED_EDGE)) {
+    it(`every search field on ${on}: its fill is not the same as ${on}`, () => {
+      const container = on === 'a Card' ? cardFill() : canvasCollisionFill();
+      expect(entry, `${on}: no bg-surface* token in its class`).toMatch(/\bbg-surface(?:-\d)?\b/);
+      expect(read(SHARED_FIELD)).not.toContain(entry.replace(/\bbg-surface(?:-\d)?\b/, container));
+    });
+  }
+
+  // What lets the assertion above stand for six controls. Without it a call site
+  // could go back to its own `<input>`, keep an edge fragment this file still
+  // matches, and lose the ring with every test here green — which is the
+  // five-into-one trade stated in the header, paid for.
+  for (const { file, control, shared, edge } of FIELDS) {
+    if (!shared) continue;
+    it(`${control}: renders through the shared field`, () => {
+      // Matched as ONE element rather than as two independent substring hits:
+      // `<SearchField` somewhere and `surface="card"` somewhere else is also
+      // satisfied by a hand-rolled input beside an unrelated tag, which is the
+      // join this case exists to hold.
+      expect(read(file)).toMatch(
+        new RegExp(`<SearchField\\b[^>]*${edge.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 's'),
+      );
+    });
+  }
+
   for (const { file, control, focus } of FIELDS) {
-    it(`${control}: keeps a focus indicator`, () => {
+    if (focus === undefined) continue;
+    it(`${control}: keeps a focus indicator of its own`, () => {
       expect(read(file)).toMatch(focusPattern(focus));
     });
   }
 
+  // For a shared control this asserts WHICH surface it declares; for the one
+  // hand-rolled control it asserts the pair spelled in place.
   for (const { file, control, on, edge, alsoContains } of FIELDS) {
-    it(`${control}: an edge that clears 3:1 and a fill a step off ${on}`, () => {
+    it(`${control}: declares the surface it sits on (${on})`, () => {
       const source = read(file);
       expect(source).toContain(edge);
       if (alsoContains !== undefined) expect(source).toContain(alsoContains);
     });
   }
 
-  // The edge half. Built by swapping this control's own edge token back, so it
-  // matches the field and never the card or divider beside it.
-  for (const { file, control, edge } of FIELDS) {
+  // The edge and fill halves for the control that still spells them itself.
+  // Scoped to `shared: false` because a shared control's `edge` is the surface it
+  // DECLARES — it carries no colour token to swap, and the negatives that matter
+  // for it are asserted against SHARED_FIELD above.
+  //
+  // Built by swapping this control's own edge token back, so it matches the field
+  // and never the card or divider beside it.
+  for (const { file, control, edge, shared } of FIELDS) {
+    if (shared) continue;
     const collided = edge.replace('border-border-field', 'border-border');
     if (collided === edge) continue; // HarnessSelect: colour is pinned via alsoContains
     it(`${control}: its edge is not back on the ordinary border`, () => {
@@ -225,11 +323,8 @@ describe('the hand-rolled field boundary', () => {
     });
   }
 
-  // The fill half, which no token search can express: what makes a fill wrong is
-  // the fill of the thing UNDER it, which is not in the class string. Both
-  // container fills are resolved — ui-kit's Card, and the canvas/surface-2
-  // same-hex identity in theme.css.
-  for (const { file, control, on, edge } of FIELDS) {
+  for (const { file, control, on, edge, shared } of FIELDS) {
+    if (shared) continue;
     it(`${control}: its fill is not the same as ${on}`, () => {
       const container = on === 'a Card' ? cardFill() : canvasCollisionFill();
       // The fill token is DERIVED from this control's own edge fragment, by the

--- a/web-ui/app/(app)/data-shares/DataSharesClient.tsx
+++ b/web-ui/app/(app)/data-shares/DataSharesClient.tsx
@@ -6,6 +6,7 @@ import {
   DataSharesTableView,
   NeedsReviewListView,
   NeedsReviewStripView,
+  SearchField,
   type ShareSelection,
 } from '@akasecurity/dashboard-ui';
 import type {
@@ -187,18 +188,14 @@ export function DataSharesClient({
             {/* Shrinks before it wraps: flex-1 grows it to fill the row up to
                 max-w-80, and it shrinks to min-w-48 as the kind tabs beside it
                 (which don't shrink — see DataSharesKindTabsView) take more. */}
-            <div className="flex h-9 min-w-48 max-w-80 flex-1 items-center gap-2 rounded-lg border border-border bg-surface-2 px-3">
-              <SearchIcon aria-hidden focusable={false} className="size-4 shrink-0 text-text-3" />
-              <input
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                }}
-                placeholder="Search destinations, URLs & call sites…"
-                aria-label="Search data shares"
-                className="min-w-0 flex-1 bg-transparent text-sm text-text placeholder:text-text-3 focus:outline-none"
-              />
-            </div>
+            <SearchField
+              value={query}
+              onValueChange={setQuery}
+              label="Search data shares"
+              placeholder="Search destinations, URLs & call sites…"
+              surface="canvas"
+              className="h-9 min-w-48 max-w-80 flex-1"
+            />
           </div>
           <Card className="flex min-h-112 flex-1 flex-col overflow-hidden">
             {activeGroup ? (

--- a/web-ui/test/data-shares/data-shares-client-render.test.ts
+++ b/web-ui/test/data-shares/data-shares-client-render.test.ts
@@ -190,4 +190,81 @@ describe('DataSharesClient', () => {
       }),
     ).not.toThrow();
   });
+
+  // The search box. This page's copy of it had drifted from the one the
+  // enterprise dashboard renders on all three of the decisions a field makes,
+  // and the drift was invisible: the package that pins every other field in the
+  // product (@akasecurity/dashboard-ui's theme/field-boundary.test.ts) reads its
+  // own src/ and cannot see this file.
+  //
+  // Asserted on the RENDERED class string rather than on the source, because the
+  // three decisions have two owners now — the edge and the fill are this page's
+  // to choose, the focus ring is the shared field's — and only the composed
+  // output shows them arriving together.
+  describe('the search box', () => {
+    /**
+     * The ONE class attribute belonging to the search field's own wrapper, found
+     * by walking back from the input that carries its accessible name.
+     *
+     * Joining every class attribute on the page would have been enough to go red
+     * today, and wrong: the assertions below would then match a fragment on any
+     * card, chip or button this page grows later, while the field itself sat on
+     * the wrong edge. The subject has to be the element under test.
+     */
+    const fieldClasses = (html: string): string[] => {
+      const at = html.indexOf('aria-label="Search data shares"');
+      expect(at, "no element carries the search box's accessible name").toBeGreaterThan(-1);
+      // The wrapper is the nearest `<div class="…">` BEFORE that input: the
+      // input's own class attribute follows its aria-label, the wrapper's
+      // precedes it. `<div` rather than any element because the leading search
+      // glyph is an `<svg class="size-4 …">` sitting between the two, and a
+      // match on any tag picks the GLYPH — which reads as a red test for the
+      // right reason while actually measuring the wrong element.
+      const wrappers = [...html.slice(0, at).matchAll(/<div[^>]*\sclass="([^"]*)"/g)];
+      const last = wrappers.at(-1);
+      expect(last, 'the search input is not inside a classed wrapper').toBeDefined();
+      // Split into TOKENS rather than returned as one string: `toContain` on a
+      // string is a substring test, and `bg-surface` is a PREFIX of
+      // `bg-surface-2` — so a field that declared the wrong surface satisfied a
+      // `bg-surface` assertion outright. On an array `toContain` is exact.
+      return (last?.[1] ?? '').split(/\s+/).filter(Boolean);
+    };
+
+    // `border-border` measures 1.26:1 light and 1.42:1 dark, under the 3:1 a
+    // control boundary is asked for; `bg-surface-2` is the canvas's own fill in
+    // light, so a field carrying it has no fill of its own. This box sat on both.
+    it('carries an edge that clears 3:1 and a fill off the page canvas', () => {
+      const classes = fieldClasses(render());
+      expect(classes).toContain('border-border-field');
+      expect(classes).not.toContain('border-border');
+      // `--color-canvas` and `--color-surface-2` are the same hex in light, so
+      // this is the one fill a canvas-level field must not take.
+      expect(classes).toContain('bg-surface');
+      expect(classes).not.toContain('bg-surface-2');
+    });
+
+    // The input suppresses its own outline, so without this the box showed
+    // nothing at all on focus — not a weak indicator, none.
+    it('keeps a focus indicator', () => {
+      const classes = fieldClasses(render());
+      for (const token of [
+        'focus-within:border-primary',
+        'focus-within:ring-2',
+        'focus-within:ring-primary/40',
+      ]) {
+        expect(classes).toContain(token);
+      }
+    });
+
+    // Both directions: a control that is always there is as wrong as one that
+    // never is, and the empty case is the only one that can show the button's
+    // presence is a function of the term at all.
+    it('offers nothing to clear while there is no term', () => {
+      expect(render()).not.toContain('Clear search');
+    });
+
+    it('offers a clear button once a term is active', () => {
+      expect(render({ q: 'okta' })).toContain('aria-label="Clear search"');
+    });
+  });
 });

--- a/web-ui/test/search-field-labels.test.ts
+++ b/web-ui/test/search-field-labels.test.ts
@@ -1,0 +1,120 @@
+import { readdirSync, readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// Two `SearchField`s on one page must not give their clear buttons the same
+// accessible name.
+//
+// `label` is a REQUIRED prop for exactly this reason — a page with two search
+// boxes needs them told apart, and a default would name both. `clearLabel` is
+// not required, and its default reintroduced the ambiguity one control over:
+// the Inventory page renders `InventoryNav` and, once a project is selected,
+// `ProjectPane` side by side, and both clear buttons came out as "Clear
+// search". A screen-reader user listing buttons heard it twice with nothing
+// saying which field each one empties, and the two fields are the two halves of
+// that page — so guessing wrong throws away the wrong query (WCAG 4.1.2).
+//
+// This lives in web-ui rather than beside the component because the property is
+// about REACHABILITY: which fields land on one page is a fact about the app's
+// composition, and `@akasecurity/dashboard-ui` cannot see it. The component's
+// own suite pins the button; this pins the pairing.
+//
+// It is DERIVED rather than a list of known pages. A hand-listed pair would go
+// stale the first time a page grew a second search field, which is the failure
+// this exists to catch.
+
+const ROOT = new URL('../../', import.meta.url);
+const SOURCE_DIRS = ['packages/dashboard-ui/src', 'web-ui/app'];
+
+/** Every `.tsx` under a directory, recursively. */
+function tsxFiles(dir: URL): URL[] {
+  const out: URL[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    // A trailing slash is what makes `new URL` treat the segment as a
+    // directory rather than replacing the last path component.
+    if (entry.isDirectory()) out.push(...tsxFiles(new URL(`${entry.name}/`, dir)));
+    else if (entry.name.endsWith('.tsx')) out.push(new URL(entry.name, dir));
+  }
+  return out;
+}
+
+const ALL = SOURCE_DIRS.flatMap((d) => tsxFiles(new URL(`${d}/`, ROOT))).map((url) => ({
+  path: url.pathname.slice(ROOT.pathname.length),
+  source: readFileSync(url, 'utf8'),
+}));
+
+/**
+ * A file that renders a search field, the components it exports (which is how
+ * another file reaches it), and the `clearLabel` each of its fields declares —
+ * `null` where it takes the default.
+ *
+ * The label is compared as the EXPRESSION TEXT, not as a rendered string: two
+ * different expressions are presumed to name two different things, which is the
+ * most a source scan can honestly claim.
+ */
+const renderers = ALL.filter((f) => f.source.includes('<SearchField')).map((f) => ({
+  path: f.path,
+  // `m[1]` is typed `string | undefined` because TS cannot know the group
+  // matched; a capturing group that did match always yields a string, so the
+  // filter narrows rather than discards.
+  exports: [...f.source.matchAll(/export function (\w+)/g)]
+    .map((m) => m[1])
+    .filter((name): name is string => name !== undefined),
+  clearLabels: [...f.source.matchAll(/<SearchField\b[\s\S]*?\/>/g)].map((el) => {
+    const named = /\bclearLabel=(\{[\s\S]*?\}|"[^"]*")/.exec(el[0]);
+    return named?.[1] ?? null;
+  }),
+}));
+
+/** A path's last segment. `split` always yields one element; `at(-1)` does not say so. */
+const basename = (path: string): string => path.slice(path.lastIndexOf('/') + 1);
+
+/** Which renderers a page file reaches: its own fields, plus those it composes. */
+function reachedBy(file: (typeof ALL)[number]) {
+  return renderers.filter(
+    (r) =>
+      r.path === file.path || r.exports.some((name) => new RegExp(`<${name}\\b`).test(file.source)),
+  );
+}
+
+describe('a page with two search fields names both clear buttons', () => {
+  // The premise. If this stops finding renderers the assertions below hold
+  // vacuously, and a page could grow a colliding pair with this file green.
+  it('finds the search fields to reason about', () => {
+    expect(renderers.length).toBeGreaterThanOrEqual(6);
+    expect(renderers.flatMap((r) => r.clearLabels).length).toBe(renderers.length);
+  });
+
+  // Deliberately an OVER-approximation: this asks whether two fields are
+  // reachable from one page, not whether they are mounted at the same instant.
+  // Findings reaches two that are mutually exclusive today — `FindingsToolbarView`
+  // renders on the flat/files views and `FindingTypesListView` on the grouped one
+  // — so its distinct names are insurance rather than a fix. Modelling which JSX
+  // branches can be live together is the fragile alternative, and a wrong model
+  // is worse than a conservative one: this errs toward naming a button.
+  const pages = ALL.map((f) => ({ file: f, reached: reachedBy(f) })).filter(
+    (p) => p.reached.length > 1,
+  );
+
+  it('finds the pages that reach more than one', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  for (const { file, reached } of pages) {
+    const where = reached.map((r) => basename(r.path)).join(' + ');
+
+    it(`${basename(file.path)} (${where}): every clear button is named`, () => {
+      for (const r of reached) {
+        expect(
+          r.clearLabels,
+          `${r.path} renders beside another search field, so its clear button cannot take the default name`,
+        ).not.toContain(null);
+      }
+    });
+
+    it(`${basename(file.path)} (${where}): no two share a name`, () => {
+      const labels = reached.flatMap((r) => r.clearLabels);
+      expect(new Set(labels).size, `duplicate clearLabel among ${where}`).toBe(labels.length);
+    });
+  }
+});


### PR DESCRIPTION
Every search surface had to be told apart by hand, and only one of seven carried a clear button. This adds `SearchField` and routes them all through it, so what a search box owes its user is decided once.

## What changed

**`packages/dashboard-ui/src/shared/SearchField.tsx`** — the shared composite:

- a **clear button**, shown only while there is a term, on a `size-6` target (WCAG 2.5.8 asks for 24×24; a button sized to its own `size-3.5` glyph is 14);
- **Escape** as its keyboard equal, so clearing is not a Tab away. `type="search"` would give this natively but also draws a second clear button of the browser's own, so the type stays `text` and the shortcut is supplied. Escape on an *empty* box is deliberately left alone — a Dialog or Sheet above it closes on that key;
- a **`focus-within` ring** on the wrapper, so it covers glyph, text and button and is still drawn while the input suppresses its own outline;
- **focus handed back to the input** when the button unmounts — otherwise it drops to `<body>` and strands a keyboard user at the top of the document;
- a required **`surface: 'card' | 'canvas'`** prop resolving the edge and fill. A call site spells geometry only (`h-9`, `w-64`, `flex-1`), so it cannot put either back on a low-contrast border by hand, and omitting the prop fails the build.

**Seven call sites** move onto it: sessions, finding types, findings, detections, assets, project files, data shares.

## Defects this fixes

- **Data Shares was wrong on all three decisions a field makes** — `border-border` for its edge, `bg-surface-2` for its fill (the canvas's own fill in light, so the field had none of its own), and no focus rule at all, so focusing it changed nothing on screen. The package that pins every other field reads its own `src/` and cannot see `web-ui`, which is how it drifted.
- **Detections, assets and project files had no accessible name** — only a placeholder, which is not one.
- **The one pre-existing clear button dropped focus** to `<body>`, and was a 22×22 target.

## Verification

`field-boundary.test.ts` now pins the edge, fill and ring **once** in the shared component, plus which surface each call site declares — matched within the `<SearchField …>` element rather than as two independent substring hits, so a hand-rolled input beside an unrelated tag no longer satisfies it.

Each new assertion was mutation-tested — break the guarded behaviour, confirm red for its own reason, restore, confirm green:

| mutation | red |
|---|---|
| `size-6` removed from the clear button | target case only |
| Escape handler removed | `clears on Escape` only |
| Escape unguarded on an empty box | `leaves Escape alone while the box is empty` only |
| shared card edge → `border-border` | both card cases |
| Data Shares declares `card` | its edge case only |
| focus ring removed | focus case, in both packages |

Two defects surfaced while writing those guards and are fixed: an anchor that picked the leading search **glyph** rather than the field wrapper, and `toContain` on a string being a substring test where `bg-surface` is a prefix of `bg-surface-2` — under which a field declaring the wrong surface passed. Assertions are on token arrays now.

Measured in the running dashboard rather than inferred — `document.querySelector` + `getBoundingClientRect` on the live page:

```
{"button":{"w":24,"h":24},"field":36,"wcag_24":true}
{"before":"okta","after":"","clearButtonGone":true,"focusStillInField":true}
```

Gates, each run in full:

```
pnpm format:check   → All matched files use Prettier code style!
pnpm lint           → Tasks: 26 successful, 26 total  ·  Portability check passed
pnpm typecheck      → Tasks: 26 successful, 26 total
pnpm --filter @akasecurity/dashboard-ui test   → Tests  613 passed (613)
pnpm --filter web-ui test                      → Tests  880 passed (880)
pnpm --filter @akasecurity/eslint-config test  → Tests  1497 passed (1497)
```

Also walked by hand against a real local store: Data Shares, Detections, Activity, Findings (both views) and Inventory. `ProjectPane` renders only when a project is selected and that store has no project rows, so it is covered by tests and typecheck rather than by eye.

## Note

`@akasecurity/dashboard-ui` is consumed by the other dashboard too, so its search fields move onto `SearchField` as well — tracked separately, and it needs this to land first.