### PR TITLE
fix(schema): type contentExpiredAt as TTime, like every other time column

### DIFF
--- a/packages/schema/src/drizzle/base-rows.ts
+++ b/packages/schema/src/drizzle/base-rows.ts
@@ -143,7 +143,19 @@ export interface BaseAuditEventRow<TTime = number> {
   // When local body expiry cleared `content`, if it did — the difference
   // between "expired" and "never carried a body", which `content IS NULL`
   // alone cannot express.
-  contentExpiredAt: number | null;
+  //
+  // `TTime | null`, like `endedAt` four lines up, NOT `number | null`. It is a
+  // time column, and every other one in this interface is generic so a dialect
+  // can carry its own representation — SQLite epoch-millis here, `timestamptz`
+  // in the Postgres mirror. Pinned to `number` it is unmirrorable: the mirror
+  // must either store a time as a bare integer, alone among its time columns,
+  // or fail to adhere.
+  //
+  // This file's own adherence guard cannot catch that, which is why it is worth
+  // a comment: `TTime` DEFAULTS to `number` here, so `number | null` and
+  // `TTime | null` are the same type for SQLite and the guard passes either way.
+  // Only a consumer instantiating `TTime = Date` can tell them apart.
+  contentExpiredAt: TTime | null;
   attributes: string | null;
   inputTokens: number | null;
   outputTokens: number | null;

--- a/packages/schema/test/drizzle/time-columns-generic.test.ts
+++ b/packages/schema/test/drizzle/time-columns-generic.test.ts
@@ -1,0 +1,64 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type {
+  BaseAuditEventRow,
+  BaseEventRow,
+  BaseInstalledPackRow,
+  BaseInventoryRow,
+  BasePolicyRow,
+  BaseSourceProjectRow,
+} from '../../src/drizzle/base-rows.ts';
+
+// Every time column in a base row must be spelled `TTime`, never `number`.
+//
+// The base interfaces are generic so each dialect can carry its own
+// representation of an instant: SQLite stores epoch-millis and instantiates
+// `TTime = number`, while the Postgres mirror stores `timestamptz` and
+// instantiates `TTime = Date`. A time column pinned to `number` is unmirrorable
+// — the mirror must either store an instant as a bare integer, alone among its
+// time columns, or fail to adhere.
+//
+// WHY THIS IS A SEPARATE FILE FROM adherence.test.ts, AND NOT REDUNDANT WITH IT.
+// That suite compares the SQLite tables against these interfaces at the DEFAULT
+// instantiation, where `TTime` IS `number` — so `contentExpiredAt: number | null`
+// and `contentExpiredAt: TTime | null` are the SAME TYPE to it and it passes
+// either way. It is structurally incapable of seeing this class of mistake, and
+// it did not: `contentExpiredAt` shipped pinned to `number`, with every OSS gate
+// green, and surfaced only when a downstream consumer instantiated `TTime = Date`
+// and found one column that would not move with it.
+//
+// So this file instantiates the OTHER dialect. Asserting `Date` where the
+// default would give `number` is what makes a pinned column fail here: a
+// `number`-pinned field stays `number` under `<Date>` and the assertion reds.
+describe('base row time columns follow their dialect', () => {
+  it('audit events: every instant moves with TTime', () => {
+    expectTypeOf<BaseAuditEventRow<Date>['startedAt']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseAuditEventRow<Date>['endedAt']>().toEqualTypeOf<Date | null>();
+    // The one this file was written for.
+    expectTypeOf<BaseAuditEventRow<Date>['contentExpiredAt']>().toEqualTypeOf<Date | null>();
+  });
+
+  it('events: every instant moves with TTime', () => {
+    expectTypeOf<BaseEventRow<Date>['occurredAt']>().toEqualTypeOf<Date>();
+  });
+
+  it('policies, packs, inventory and projects: every instant moves with TTime', () => {
+    expectTypeOf<BasePolicyRow<Date>['createdAt']>().toEqualTypeOf<Date>();
+    expectTypeOf<BasePolicyRow<Date>['updatedAt']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseInstalledPackRow<Date>['createdAt']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseInstalledPackRow<Date>['updatedAt']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseInventoryRow<Date>['firstSeen']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseInventoryRow<Date>['lastSeen']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseSourceProjectRow<Date>['firstSeen']>().toEqualTypeOf<Date>();
+    expectTypeOf<BaseSourceProjectRow<Date>['lastSeen']>().toEqualTypeOf<Date>();
+  });
+
+  // The control. If `TTime` stopped being threaded at all — the interfaces made
+  // non-generic, say — every assertion above would still need to fail for the
+  // right reason rather than because the type argument was ignored. A field that
+  // is genuinely NOT a time column must stay put under `<Date>`.
+  it('a non-time column does not move with TTime', () => {
+    expectTypeOf<BaseAuditEventRow<Date>['content']>().toEqualTypeOf<string | null>();
+    expectTypeOf<BaseAuditEventRow<Date>['inputTokens']>().toEqualTypeOf<number | null>();
+  });
+});


### PR DESCRIPTION
`BaseAuditEventRow<TTime = number>` declares its instants generically so each dialect can carry its own representation — SQLite epoch-millis, Postgres `timestamptz`. `contentExpiredAt` shipped pinned to a concrete `number | null`, four lines below `endedAt: TTime | null` in the same interface.

```ts
startedAt: TTime;
endedAt: TTime | null;
severity: string | null;
priority: string | null;
content: string | null;
contentHash: string | null;
contentExpiredAt: number | null;   // <- the only time column that is not TTime
```

## Why it matters

A consumer instantiating `TTime = Date` gets one column that will not move with the dialect, so a Postgres mirror of this table has to either store an instant as a bare integer — alone among its time columns — or fail to adhere. That is not hypothetical; it is how this was found.

## Why no OSS gate caught it

`adherence.test.ts` compares the SQLite tables against these interfaces at the **default** instantiation, where `TTime` **is** `number`. So `number | null` and `TTime | null` are the same type to it, and it passes either way — it is structurally incapable of seeing this class of mistake. Verified rather than assumed: with the defect reintroduced, that suite still reports `Tests 10 passed`.

## The guard

`time-columns-generic.test.ts` instantiates the **other** dialect, which is the only way to tell the two spellings apart: a `number`-pinned field stays `number` under `<Date>` and the assertion reds.

It carries a **non-time control** (`content`, `inputTokens`) so that if `TTime` ever stopped being threaded at all, the time assertions would still have to fail for the right reason rather than because the type argument was being ignored.

**One thing worth knowing about how it is enforced**, because it surprised me: `expectTypeOf` is a compile-time assertion and is inert under `vitest run`. Re-injecting the defect leaves this suite reporting `Tests 4 passed`; it is `tsc --noEmit` — the package `typecheck` — that evaluates it:

```
$ pnpm --filter @akasecurity/schema typecheck      # with the defect
test/drizzle/time-columns-generic.test.ts(38,79): error TS2344:
  Type 'Date | null' does not satisfy the constraint
  '"Expected: null, Actual: number" | ...'

$ pnpm --filter @akasecurity/schema typecheck      # restored
0 errors
```

That matches how `adherence.test.ts` is enforced, and both run in CI via the workspace typecheck. It also caught a real mistake in my own first draft of this file — a `BaseInstalledPackRow['installedAt']` that does not exist.

## Verification

```
pnpm format:check                             clean
pnpm lint                                     26/26 tasks  ·  portability clean
pnpm typecheck                                26/26 tasks
pnpm --filter @akasecurity/schema test        943 passed
pnpm --filter @akasecurity/persistence test   1717 passed | 2 skipped
```

No behaviour change: `TTime` defaults to `number`, so every existing OSS consumer resolves to exactly the type it had.